### PR TITLE
RUMM-163 Limit the size of logs folder

### DIFF
--- a/Sources/Datadog/Logs/LogsPersistenceStrategy.swift
+++ b/Sources/Datadog/Logs/LogsPersistenceStrategy.swift
@@ -8,6 +8,9 @@ internal struct LogsPersistenceStrategy {
         /// Maximum size of batched logs in single file (in bytes).
         /// If last written file is too big to append next log data, new file is created.
         static let maxBatchSize: UInt64 = 4 * 1_024 * 1_024 // 4MB
+        /// Maximum size of the log files directory.
+        /// If this size is exceeded, log files are being deleted (starting from the oldest one) until this limit is met again.
+        static let maxSizeOfLogsDirectory: UInt64 = 128 * maxBatchSize // 512 MB
         /// Maximum age of logs file for file reuse (in seconds).
         /// If last written file is older than this, new file is created to store next log data.
         static let maxFileAgeForWrite: TimeInterval = 4.75
@@ -27,6 +30,7 @@ internal struct LogsPersistenceStrategy {
 
     /// Default write conditions for `FilesOrchestrator`.
     static let defaultWriteConditions = WritableFileConditions(
+        maxDirectorySize: LogsPersistenceStrategy.Constants.maxSizeOfLogsDirectory,
         maxFileSize: LogsPersistenceStrategy.Constants.maxBatchSize,
         maxFileAgeForWrite: LogsPersistenceStrategy.Constants.maxFileAgeForWrite,
         maxNumberOfUsesOfFile: LogsPersistenceStrategy.Constants.maxLogsPerBatch

--- a/Tests/DatadogTests/Core/Persistence/FileWriterTests.swift
+++ b/Tests/DatadogTests/Core/Persistence/FileWriterTests.swift
@@ -78,7 +78,7 @@ class FileWriterTests: XCTestCase {
         }
 
         waitForWritesCompletion(on: queue, thenFulfill: expectation)
-        waitForExpectations(timeout: 10) // 10 seconds is an arbitrary timeout
+        waitForExpectations(timeout: 20) // 20 seconds is an arbitrary timeout
 
         XCTAssertGreaterThan(try temporaryDirectory.allFiles().count, 1)
     }

--- a/Tests/DatadogTests/Mocks/DatadogMocks.swift
+++ b/Tests/DatadogTests/Mocks/DatadogMocks.swift
@@ -55,6 +55,7 @@ extension WritableFileConditions {
     /// Write conditions causing `FilesOrchestrator` to always pick the same file for writting.
     static func mockWriteToSingleFile() -> WritableFileConditions {
         return WritableFileConditions(
+            maxDirectorySize: .max,
             maxFileSize: .max,
             maxFileAgeForWrite: .greatestFiniteMagnitude,
             maxNumberOfUsesOfFile: .max
@@ -64,6 +65,7 @@ extension WritableFileConditions {
     /// Write conditions causing `FilesOrchestrator` to create new file for each write.
     static func mockWriteToNewFileEachTime() -> WritableFileConditions {
         return WritableFileConditions(
+            maxDirectorySize: .max,
             maxFileSize: .max,
             maxFileAgeForWrite: .greatestFiniteMagnitude,
             maxNumberOfUsesOfFile: 1

--- a/Tests/DatadogTests/Mocks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Mocks/FoundationMocks.swift
@@ -36,8 +36,8 @@ extension Data {
         return Data(repeating: byte, count: count)
     }
 
-    static func mock(ofSize size: Int) -> Data {
-        return mockRepeating(byte: 0x41, times: size)
+    static func mock(ofSize size: UInt64) -> Data {
+        return mockRepeating(byte: 0x41, times: Int(size))
     }
 }
 


### PR DESCRIPTION
🚚 This PR adds two constraints on log files folder:
* It's maximum allowed size is `512MB`. If this size is exceeded, files above that limit are deleted starting from the oldest one.
* Files older than `18 hours` are considered obsolete and get deleted. This check is performed as part of upload worker job (when reading files).