### PR TITLE
RUMM-265 Network info can be added optionally

### DIFF
--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -242,6 +242,7 @@ public class Logger {
     public class Builder {
         private var serviceName: String = "ios"
         private var loggerName: String?
+        private var sendNetworkInfo: Bool = false
         private var useFileOutput = true
         private var useConsoleLogFormat: ConsoleLogFormat?
 
@@ -256,6 +257,15 @@ public class Logger {
         /// - Parameter loggerName: the logger custom name (default value is set to main bundle identifier)
         public func set(loggerName: String) -> Builder {
             self.loggerName = loggerName
+            return self
+        }
+
+        /// Enriches logs with network connection info.
+        /// This means: reachability status, connection type, mobile carrier name and many more will be added to each log.
+        /// For full list of network info attributes see `NetworkConnectionInfo` and `CarrierInfo`.
+        /// - Parameter enabled: `false` by default
+        public func sendNetworkInfo(_ enabled: Bool) -> Builder {
+            sendNetworkInfo = true
             return self
         }
 
@@ -316,8 +326,8 @@ public class Logger {
                 loggerName: loggerName ?? datadog.appContext.bundleIdentifier ?? "",
                 dateProvider: datadog.dateProvider,
                 userInfoProvider: datadog.userInfoProvider,
-                networkConnectionInfoProvider: datadog.networkConnectionInfoProvider,
-                carrierInfoProvider: datadog.carrierInfoProvider
+                networkConnectionInfoProvider: sendNetworkInfo ? datadog.networkConnectionInfoProvider : nil,
+                carrierInfoProvider: sendNetworkInfo ? datadog.carrierInfoProvider : nil
             )
 
             switch (useFileOutput, useConsoleLogFormat) {

--- a/Sources/Datadog/Logs/Log/LogBuilder.swift
+++ b/Sources/Datadog/Logs/Log/LogBuilder.swift
@@ -18,9 +18,9 @@ internal struct LogBuilder {
     let dateProvider: DateProvider
     /// Shared user info provider.
     let userInfoProvider: UserInfoProvider
-    /// Shared network connection info provider.
-    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
-    /// Shared mobile carrier info provider (or `nil` if not available on current platform).
+    /// Shared network connection info provider (or `nil` if disabled for given logger).
+    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType?
+    /// Shared mobile carrier info provider (or `nil` if not available on current platform or disabled for given logger).
     let carrierInfoProvider: CarrierInfoProviderType?
 
     func createLogWith(level: LogLevel, message: String, attributes: [String: Encodable], tags: Set<String>) -> Log {
@@ -38,7 +38,7 @@ internal struct LogBuilder {
             threadName: getCurrentThreadName(),
             applicationVersion: getApplicationVersion(),
             userInfo: userInfoProvider.value,
-            networkConnectionInfo: networkConnectionInfoProvider.current,
+            networkConnectionInfo: networkConnectionInfoProvider?.current,
             mobileCarrierInfo: carrierInfoProvider?.current,
             attributes: !encodableAttributes.isEmpty ? encodableAttributes : nil,
             tags: !tags.isEmpty ? Array(tags) : nil

--- a/Sources/Datadog/Logs/Log/LogEncoder.swift
+++ b/Sources/Datadog/Logs/Log/LogEncoder.swift
@@ -26,7 +26,7 @@ internal struct Log: Encodable {
     let threadName: String
     let applicationVersion: String
     let userInfo: UserInfo
-    let networkConnectionInfo: NetworkConnectionInfo
+    let networkConnectionInfo: NetworkConnectionInfo?
     let mobileCarrierInfo: CarrierInfo?
     let attributes: [String: EncodableValue]?
     let tags: [String]?
@@ -110,13 +110,15 @@ internal struct LogEncoder {
         try log.userInfo.email.ifNotNil { try container.encode($0, forKey: .userEmail) }
 
         // Encode network info
-        try container.encode(log.networkConnectionInfo.reachability, forKey: .networkReachability)
-        try container.encode(log.networkConnectionInfo.availableInterfaces, forKey: .networkAvailableInterfaces)
-        try container.encode(log.networkConnectionInfo.supportsIPv4, forKey: .networkConnectionSupportsIPv4)
-        try container.encode(log.networkConnectionInfo.supportsIPv6, forKey: .networkConnectionSupportsIPv6)
-        try container.encode(log.networkConnectionInfo.isExpensive, forKey: .networkConnectionIsExpensive)
-        try log.networkConnectionInfo.isConstrained.ifNotNil {
-            try container.encode($0, forKey: .networkConnectionIsConstrained)
+        if let networkConnectionInfo = log.networkConnectionInfo {
+            try container.encode(networkConnectionInfo.reachability, forKey: .networkReachability)
+            try container.encode(networkConnectionInfo.availableInterfaces, forKey: .networkAvailableInterfaces)
+            try container.encode(networkConnectionInfo.supportsIPv4, forKey: .networkConnectionSupportsIPv4)
+            try container.encode(networkConnectionInfo.supportsIPv6, forKey: .networkConnectionSupportsIPv6)
+            try container.encode(networkConnectionInfo.isExpensive, forKey: .networkConnectionIsExpensive)
+            try networkConnectionInfo.isConstrained.ifNotNil {
+                try container.encode($0, forKey: .networkConnectionIsConstrained)
+            }
         }
 
         // Encode mobile carrier info

--- a/Sources/DatadogObjc/Logger+objc.swift
+++ b/Sources/DatadogObjc/Logger+objc.swift
@@ -129,6 +129,10 @@ public class DDLoggerBuilder: NSObject {
         _ = sdkBuilder.set(loggerName: loggerName)
     }
 
+    public func sendNetworkInfo(_ enabled: Bool) {
+        _ = sdkBuilder.sendNetworkInfo(enabled)
+    }
+
     public func sendLogsToDatadog(_ enabled: Bool) {
         _ = sdkBuilder.sendLogsToDatadog(enabled)
     }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -373,51 +373,6 @@ class LoggerTests: XCTestCase {
             .destroy()
     }
 
-    // MARK: - Customizing outputs
-
-    func testUsingDifferentOutputs() throws {
-        Datadog.instance = .mockNeverPerformingUploads()
-
-        assertThat(
-            logger: Logger.builder.build(),
-            usesOutput: LogFileOutput.self
-        )
-        assertThat(
-            logger: Logger.builder.sendLogsToDatadog(true).build(),
-            usesOutput: LogFileOutput.self
-        )
-        assertThat(
-            logger: Logger.builder.sendLogsToDatadog(false).build(),
-            usesOutput: NoOpLogOutput.self
-        )
-        assertThat(
-            logger: Logger.builder.printLogsToConsole(true).build(),
-            usesCombinedOutputs: [LogFileOutput.self, LogConsoleOutput.self]
-        )
-        assertThat(
-            logger: Logger.builder.sendLogsToDatadog(true).printLogsToConsole(true).build(),
-            usesCombinedOutputs: [LogFileOutput.self, LogConsoleOutput.self]
-        )
-        assertThat(
-            logger: Logger.builder.sendLogsToDatadog(false).printLogsToConsole(true).build(),
-            usesOutput: LogConsoleOutput.self
-        )
-        assertThat(
-            logger: Logger.builder.printLogsToConsole(false).build(),
-            usesOutput: LogFileOutput.self
-        )
-        assertThat(
-            logger: Logger.builder.sendLogsToDatadog(true).printLogsToConsole(false).build(),
-            usesOutput: LogFileOutput.self
-        )
-        assertThat(
-            logger: Logger.builder.sendLogsToDatadog(false).printLogsToConsole(false).build(),
-            usesOutput: NoOpLogOutput.self
-        )
-
-        try Datadog.deinitializeOrThrow()
-    }
-
     // MARK: - Sending logs with different network and battery conditions
 
     func testGivenBadBatteryConditions_itDoesntTryToSendLogs() throws {
@@ -452,39 +407,5 @@ class LoggerTests: XCTestCase {
             .waitUntil(numberOfLogsSent: 1)
             .verifyNoLogsSent()
             .destroy()
-    }
-
-    // MARK: - Initialization
-
-    func testGivenDatadogNotInitialized_whenBuildingLogger_itPrintsError() {
-        let printFunction = PrintFunctionMock()
-        consolePrint = printFunction.print
-        defer { consolePrint = { print($0) } }
-
-        XCTAssertNil(Datadog.instance)
-
-        let logger = Logger.builder.build()
-        XCTAssertEqual(
-            printFunction.printedMessage,
-            "🔥 Datadog SDK usage error: `Datadog.initialize()` must be called prior to `Logger.builder.build()`."
-        )
-        assertThat(logger: logger, usesOutput: NoOpLogOutput.self)
-    }
-
-    // MARK: - Helpers
-
-    private func assertThat(logger: Logger, usesOutput outputType: LogOutput.Type, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertTrue(type(of: logger.logOutput) == outputType, file: file, line: line)
-    }
-
-    private func assertThat(logger: Logger, usesCombinedOutputs outputTypes: [LogOutput.Type], file: StaticString = #file, line: UInt = #line) {
-        if let combinedOutputs = (logger.logOutput as? CombinedLogOutput)?.combinedOutputs {
-            XCTAssertEqual(outputTypes.count, combinedOutputs.count, file: file, line: line)
-            outputTypes.forEach { outputType in
-                XCTAssertTrue(combinedOutputs.contains { type(of: $0) == outputType }, file: file, line: line)
-            }
-        } else {
-            XCTFail(file: file, line: line)
-        }
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
@@ -874,6 +874,12 @@ class DatadogInstanceMock {
         return self
     }
 
+    /// Verifies given block without running `run()` and `wait()`.
+    func verifyBlock(closure: @escaping () throws -> Void) throws -> DatadogInstanceMock {
+        try closure()
+        return self
+    }
+
     func destroy() throws {
         try Datadog.deinitializeOrThrow()
     }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
@@ -311,7 +311,7 @@ extension NetworkConnectionInfo {
 }
 
 class NetworkConnectionInfoProviderMock: NetworkConnectionInfoProviderType {
-    let current: NetworkConnectionInfo
+    var current: NetworkConnectionInfo
 
     init(networkConnectionInfo: NetworkConnectionInfo) {
         self.current = networkConnectionInfo

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerBuilderTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerBuilderTests.swift
@@ -1,0 +1,187 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+@testable import DatadogObjc
+
+class DDLoggerBuilderTests: XCTestCase {
+    private let appContext: AppContext = .mockWith(bundleIdentifier: "com.datadog.sdk-unit-tests")
+    private let networkConnectionInfoProvider: NetworkConnectionInfoProviderMock = .mockAny()
+    private let carrierInfoProvider: CarrierInfoProviderMock = .mockAny()
+
+    // MARK: - Default logger
+
+    func testBuildingDefaultLogger() throws {
+        try DatadogInstanceMock.builder
+            .with(appContext: appContext)
+            .with(networkConnectionInfoProvider: networkConnectionInfoProvider)
+            .with(carrierInfoProvider: carrierInfoProvider)
+            .initialize()
+            .verifyBlock {
+                let logger = DDLogger.builder().build().sdkLogger
+
+                guard let logBuilder = (logger.logOutput as? LogFileOutput)?.logBuilder else {
+                    XCTFail()
+                    return
+                }
+
+                XCTAssertEqual(logBuilder.serviceName, "ios")
+                XCTAssertEqual(logBuilder.loggerName, "com.datadog.sdk-unit-tests")
+                XCTAssertNil(logBuilder.networkConnectionInfoProvider)
+                XCTAssertNil(logBuilder.carrierInfoProvider)
+            }
+            .destroy()
+    }
+
+    // MARK: - Customized logger
+
+    func testBuildingCustomizedLogger() throws {
+        try DatadogInstanceMock.builder
+            .with(appContext: appContext)
+            .with(networkConnectionInfoProvider: networkConnectionInfoProvider)
+            .with(carrierInfoProvider: carrierInfoProvider)
+            .initialize()
+            .verifyBlock {
+                let builder = DDLogger.builder()
+                _ = builder.set(serviceName: "custom service name")
+                _ = builder.set(loggerName: "custom logger name")
+                _ = builder.sendNetworkInfo(true)
+
+                let objcLogger = builder.build()
+                let logger = objcLogger.sdkLogger
+
+                guard let logBuilder = (logger.logOutput as? LogFileOutput)?.logBuilder else {
+                    XCTFail()
+                    return
+                }
+
+                XCTAssertEqual(logBuilder.serviceName, "custom service name")
+                XCTAssertEqual(logBuilder.loggerName, "custom logger name")
+                XCTAssertNotNil(logBuilder.networkConnectionInfoProvider)
+                XCTAssertNotNil(logBuilder.carrierInfoProvider)
+            }
+            .destroy()
+    }
+
+    func testUsingDifferentOutputs() throws {
+        Datadog.instance = .mockNeverPerformingUploads()
+
+        assertThat(
+            logger: {
+                let builder = DDLogger.builder()
+                return builder.build()
+            }(),
+            usesOutput: LogFileOutput.self
+        )
+        assertThat(
+            logger: {
+                let builder = DDLogger.builder()
+                _ = builder.sendLogsToDatadog(true)
+                return builder.build()
+            }(),
+            usesOutput: LogFileOutput.self
+        )
+        assertThat(
+            logger: {
+                let builder = DDLogger.builder()
+                _ = builder.sendLogsToDatadog(false)
+                return builder.build()
+            }(),
+            usesOutput: NoOpLogOutput.self
+        )
+        assertThat(
+            logger: {
+                let builder = DDLogger.builder()
+                _ = builder.printLogsToConsole(true)
+                return builder.build()
+            }(),
+            usesCombinedOutputs: [LogFileOutput.self, LogConsoleOutput.self]
+        )
+        assertThat(
+            logger: {
+                let builder = DDLogger.builder()
+                _ = builder.printLogsToConsole(false)
+                return builder.build()
+            }(),
+            usesOutput: LogFileOutput.self
+        )
+        assertThat(
+            logger: {
+                let builder = DDLogger.builder()
+                _ = builder.sendLogsToDatadog(true)
+                _ = builder.printLogsToConsole(true)
+                return builder.build()
+            }(),
+            usesCombinedOutputs: [LogFileOutput.self, LogConsoleOutput.self]
+        )
+        assertThat(
+            logger: {
+                let builder = DDLogger.builder()
+                _ = builder.sendLogsToDatadog(false)
+                _ = builder.printLogsToConsole(true)
+                return builder.build()
+            }(),
+            usesOutput: LogConsoleOutput.self
+        )
+        assertThat(
+            logger: {
+                let builder = DDLogger.builder()
+                _ = builder.sendLogsToDatadog(true)
+                _ = builder.printLogsToConsole(false)
+                return builder.build()
+            }(),
+            usesOutput: LogFileOutput.self
+        )
+        assertThat(
+            logger: {
+                let builder = DDLogger.builder()
+                _ = builder.sendLogsToDatadog(false)
+                _ = builder.printLogsToConsole(false)
+                return builder.build()
+            }(),
+            usesOutput: NoOpLogOutput.self
+        )
+
+        try Datadog.deinitializeOrThrow()
+    }
+
+    // MARK: - Initialization
+
+    func testGivenDatadogNotInitialized_whenBuildingLogger_itPrintsError() {
+        let printFunction = PrintFunctionMock()
+        consolePrint = printFunction.print
+        defer { consolePrint = { print($0) } }
+
+        XCTAssertNil(Datadog.instance)
+
+        let logger = DDLogger.builder().build()
+        XCTAssertEqual(
+            printFunction.printedMessage,
+            "🔥 Datadog SDK usage error: `Datadog.initialize()` must be called prior to `Logger.builder.build()`."
+        )
+        assertThat(logger: logger, usesOutput: NoOpLogOutput.self)
+    }
+
+    // MARK: - Helpers
+
+    private func assertThat(logger objcLogger: DDLogger, usesOutput outputType: LogOutput.Type, file: StaticString = #file, line: UInt = #line) {
+        let logger = objcLogger.sdkLogger
+        XCTAssertTrue(type(of: logger.logOutput) == outputType, file: file, line: line)
+    }
+
+    private func assertThat(logger objcLogger: DDLogger, usesCombinedOutputs outputTypes: [LogOutput.Type], file: StaticString = #file, line: UInt = #line) {
+        let logger = objcLogger.sdkLogger
+        if let combinedOutputs = (logger.logOutput as? CombinedLogOutput)?.combinedOutputs {
+            XCTAssertEqual(outputTypes.count, combinedOutputs.count, file: file, line: line)
+            outputTypes.forEach { outputType in
+                XCTAssertTrue(combinedOutputs.contains { type(of: $0) == outputType }, file: file, line: line)
+            }
+        } else {
+            XCTFail(file: file, line: line)
+        }
+    }
+}

--- a/Tests/DatadogTests/Helpers/TestsDirectory.swift
+++ b/Tests/DatadogTests/Helpers/TestsDirectory.swift
@@ -20,10 +20,6 @@ func obtainUniqueTemporaryDirectory() -> Directory {
 /// The subfolder does not exist and can be created and deleted by calling `.create()` and `.delete()`.
 let temporaryDirectory = obtainUniqueTemporaryDirectory()
 
-/// References logs directory for current platform.
-/// For integration tests it is necessary to make sure this directory is deleted each time so tests are run in clean state.
-let logsDirectory = try! Directory(withSubdirectoryPath: LogsPersistenceStrategy.Constants.logFilesSubdirectory)
-
 /// Extends `Directory` with set of utilities for convenient work with files in tests.
 /// Provides handy methods to create / delete files and directires.
 extension Directory {

--- a/instrumented-tests/Integration/IntegrationTests/LoggingIntegrationTests.swift
+++ b/instrumented-tests/Integration/IntegrationTests/LoggingIntegrationTests.swift
@@ -30,6 +30,7 @@ class LoggingIntegrationTests: IntegrationTests {
         let logger = Logger.builder
             .set(serviceName: "service-name")
             .set(loggerName: "logger-name")
+            .sendNetworkInfo(true)
             .build()
 
         // Send logs


### PR DESCRIPTION
### What and why?

🚚 This PR adds `sendNetworkInfo(_ enabled: Bool)` to the `Logger.Builder`. Before, the network info was always associated with logs. Now it's `false` by default.

### How?

* New method was added to `Logger.Builder` public API - both Swift and Objective-C.
* I added additional set of unit tests for different `Logger` states - note, that I moved some existing tests from Swift API to Objective-C surface for wider coverage.
* Integration tests were updated.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
