### PR TITLE
RUMM-287 Mark 1.0.0-beta1 release

### DIFF
--- a/Datadog.podspec
+++ b/Datadog.podspec
@@ -1,17 +1,19 @@
-Pod::Spec.new do |spec|
-  spec.name         = "Datadog"
-  spec.version      = "0.0.1"
-  spec.summary      = "Logging and iOS app monitoring using Datadog."
-  spec.description  = <<-DESC
-  Logging and iOS app monitoring using Datadog in Swift.
-                   DESC
-  spec.homepage     = "https://www.datadoghq.com"
-  spec.license            = { :type => "Apache" }
-  spec.authors            = { "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com" }
-  spec.social_media_url   = "https://twitter.com/datadoghq"
-  spec.platform           = :ios, "12.0"
-  spec.swift_version      = '5.1'
-  spec.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git',
-                  :tag => spec.version.to_s }
-  spec.source_files       = "Sources/Datadog/**/*.swift"
+Pod::Spec.new do |s|
+  s.name         = "Datadog"
+  s.version      = "1.0.0-beta1"
+  s.summary      = "Datadog Swift SDK for iOS and macOS."
+  
+  s.homepage     = "https://www.datadoghq.com"
+  s.social_media_url   = "https://twitter.com/datadoghq"
+
+  s.license            = { :type => "Apache" }
+  s.authors            = { "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com" }
+
+  s.swift_version      = '5.1'
+  s.ios.deployment_target = '12.0'
+  s.osx.deployment_target = '10.14'
+
+  s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
+  
+  s.source_files = "Sources/Datadog/**/*.swift"
 end

--- a/DatadogObjc.podspec
+++ b/DatadogObjc.podspec
@@ -1,18 +1,20 @@
-Pod::Spec.new do |spec|
-  spec.name         = "DatadogObjc"
-  spec.version      = "0.0.1"
-  spec.summary      = "Logging and iOS app monitoring using Datadog."
-  spec.description  = <<-DESC
-  Logging and iOS app monitoring using Datadog in Objective-C.
-                   DESC
-  spec.homepage     = "https://www.datadoghq.com"
-  spec.license            = { :type => "Apache" }
-  spec.authors            = { "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com" }
-  spec.social_media_url   = "https://twitter.com/datadoghq"
-  spec.platform           = :ios, "12.0"
-  spec.swift_version      = '5.1'
-  spec.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git',
-                  :tag => spec.version.to_s }
-  spec.source_files       = "Sources/DatadogObjc/**/*.swift"
-  spec.dependency 'Datadog'
+Pod::Spec.new do |s|
+  s.name         = "DatadogObjc"
+  s.version      = "1.0.0-beta1"
+  s.summary      = "Datadog Objective-C SDK for iOS and macOS."
+  
+  s.homepage     = "https://www.datadoghq.com"
+  s.social_media_url   = "https://twitter.com/datadoghq"
+
+  s.license            = { :type => "Apache" }
+  s.authors            = { "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com" }
+
+  s.swift_version      = '5.1'
+  s.ios.deployment_target = '12.0'
+  s.osx.deployment_target = '10.14'
+
+  s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
+
+  s.source_files = "Sources/DatadogObjc/**/*.swift"
+  s.dependency 'Datadog'
 end

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// SDK version associated with logs.
 /// Should be synced with SDK releases.
-internal let sdkVersion = "1.0.0-alpha2"
+internal let sdkVersion = "1.0.0-beta1"
 
 /// Datadog SDK configuration object.
 public class Datadog {


### PR DESCRIPTION
### What and why?

📦 This PR updates Cocoapod podspecs to target pre-release `1.0.0-beta1` tag.

### How?

The `1.0.0-beta1` tag will be created on `master` after this is merged.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
