### PR TITLE
RUMM-290 Make `Logger` tags and attributes thread safe

### DIFF
--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -42,11 +42,11 @@ internal class DataUploadWorker {
 
     private func scheduleNextUpload(after delay: TimeInterval) {
         queue.asyncAfter(deadline: .now() + delay) { [weak self] in
-            developerLogger?.info("⏳ Checking for next batch...")
-
             guard let self = self else {
                 return
             }
+
+            developerLogger?.info("⏳ Checking for next batch...")
 
             let isSystemReady = self.uploadConditions.canPerformUpload()
             let nextBatch = isSystemReady ? self.fileReader.readNextBatch() : nil

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -80,9 +80,12 @@ public class Logger {
     private var loggerAttributes: [String: Encodable] = [:]
     /// Taggs associated with every log.
     private var loggerTags: Set<String> = []
+    /// Queue ensuring thread-safety of the `Logger`. It synchronizes tags and attributes mutation.
+    private let queue: DispatchQueue
 
-    init(logOutput: LogOutput) {
+    init(logOutput: LogOutput, queue: DispatchQueue) {
         self.logOutput = logOutput
+        self.queue = queue
     }
 
     // MARK: - Logging
@@ -150,14 +153,18 @@ public class Logger {
     ///   - value: any value that conforms to `Encodable`. See `AttributeValue` documentation
     ///   for information about nested encoding containers limitation.
     public func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
-        loggerAttributes[key] = value
+        queue.async {
+            self.loggerAttributes[key] = value
+        }
     }
 
     /// Removes the custom attribute from all future logs sent by this logger.
     /// Previous logs won't lose this attribute if they were created prior to this call.
     /// - Parameter key: key for the attribute that will be removed.
     public func removeAttribute(forKey key: AttributeKey) {
-        loggerAttributes.removeValue(forKey: key)
+        queue.async {
+            self.loggerAttributes.removeValue(forKey: key)
+        }
     }
 
     // MARK: - Tags
@@ -177,8 +184,10 @@ public class Logger {
     /// - Parameter key: key for the tag
     /// - Parameter value: value of the tag
     public func addTag(withKey key: String, value: String) {
-        let prefix = "\(key):"
-        loggerTags.insert("\(prefix)\(value)")
+        queue.async {
+            let prefix = "\(key):"
+            self.loggerTags.insert("\(prefix)\(value)")
+        }
     }
 
     /// Remove all tags with the given key from all future logs sent by this logger.
@@ -186,8 +195,10 @@ public class Logger {
     ///
     /// - Parameter key: key of the tag to remove
     public func removeTag(withKey key: String) {
-        let prefix = "\(key):"
-        loggerTags = loggerTags.filter { !$0.hasPrefix(prefix) }
+        queue.async {
+            let prefix = "\(key):"
+            self.loggerTags = self.loggerTags.filter { !$0.hasPrefix(prefix) }
+        }
     }
 
     /// Adds a tag to all future logs sent by this logger.
@@ -203,7 +214,9 @@ public class Logger {
     ///
     /// - Parameter tag: value of the tag
     public func add(tag: String) {
-        loggerTags.insert(tag)
+        queue.async {
+            self.loggerTags.insert(tag)
+        }
     }
 
     /// Removes a tag from all future logs sent by this logger.
@@ -211,17 +224,24 @@ public class Logger {
     ///
     /// - Parameter tag: value of the tag to remove
     public func remove(tag: String) {
-        loggerTags.remove(tag)
+        queue.async {
+            self.loggerTags.remove(tag)
+        }
     }
 
     // MARK: - Private
 
     private func log(level: LogLevel, message: String, messageAttributes: [String: Encodable]?) {
-        let combinedAttributes = loggerAttributes.merging(messageAttributes ?? [:]) { _, messageAttributeValue in
-            return messageAttributeValue // use message attribute when the same key appears also in logger attributes
+        let combinedAttributes = queue.sync {
+            return self.loggerAttributes.merging(messageAttributes ?? [:]) { _, messageAttributeValue in
+                return messageAttributeValue // use message attribute when the same key appears also in logger attributes
+            }
+        }
+        let tags = queue.sync {
+            return self.loggerTags
         }
 
-        logOutput.writeLogWith(level: level, message: message, attributes: combinedAttributes, tags: loggerTags)
+        logOutput.writeLogWith(level: level, message: message, attributes: combinedAttributes, tags: tags)
     }
 
     // MARK: - Logger.Builder
@@ -307,7 +327,10 @@ public class Logger {
                 return try buildOrThrow()
             } catch {
                 consolePrint("🔥 \(error)")
-                return Logger(logOutput: NoOpLogOutput())
+                return Logger(
+                    logOutput: NoOpLogOutput(),
+                    queue: DispatchQueue(label: "com.datadoghq.logger-noop")
+                )
             }
         }
 
@@ -316,14 +339,17 @@ public class Logger {
                 throw ProgrammerError(description: "`Datadog.initialize()` must be called prior to `Logger.builder.build()`.")
             }
 
-            return Logger(logOutput: resolveLogsOutput(using: datadog))
+            return Logger(
+                logOutput: resolveLogsOutput(using: datadog),
+                queue: resolveSynchronizationQueue(using: datadog)
+            )
         }
 
         private func resolveLogsOutput(using datadog: Datadog) -> LogOutput {
             let logBuilder = LogBuilder(
                 appContext: datadog.appContext,
                 serviceName: serviceName,
-                loggerName: loggerName ?? datadog.appContext.bundleIdentifier ?? "",
+                loggerName: resolveLoggerName(using: datadog),
                 dateProvider: datadog.dateProvider,
                 userInfoProvider: datadog.userInfoProvider,
                 networkConnectionInfoProvider: sendNetworkInfo ? datadog.networkConnectionInfoProvider : nil,
@@ -357,6 +383,15 @@ public class Logger {
             case (false, nil):
                 return NoOpLogOutput()
             }
+        }
+
+        private func resolveLoggerName(using datadog: Datadog) -> String {
+            return loggerName ?? datadog.appContext.bundleIdentifier ?? ""
+        }
+
+        private func resolveSynchronizationQueue(using datadog: Datadog) -> DispatchQueue {
+            let loggerName = resolveLoggerName(using: datadog)
+            return DispatchQueue(label: "com.datadoghq.logger-\(loggerName)", qos: .userInteractive)
         }
     }
 }

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -83,9 +83,9 @@ public class Logger {
     /// Queue ensuring thread-safety of the `Logger`. It synchronizes tags and attributes mutation.
     private let queue: DispatchQueue
 
-    init(logOutput: LogOutput, queue: DispatchQueue) {
+    init(logOutput: LogOutput, identifier: String) {
         self.logOutput = logOutput
-        self.queue = queue
+        self.queue = DispatchQueue(label: "com.datadoghq.logger-\(identifier)", qos: .userInteractive)
     }
 
     // MARK: - Logging
@@ -329,7 +329,7 @@ public class Logger {
                 consolePrint("🔥 \(error)")
                 return Logger(
                     logOutput: NoOpLogOutput(),
-                    queue: DispatchQueue(label: "com.datadoghq.logger-noop")
+                    identifier: "no-op"
                 )
             }
         }
@@ -341,7 +341,7 @@ public class Logger {
 
             return Logger(
                 logOutput: resolveLogsOutput(using: datadog),
-                queue: resolveSynchronizationQueue(using: datadog)
+                identifier: resolveLoggerName(using: datadog)
             )
         }
 
@@ -387,11 +387,6 @@ public class Logger {
 
         private func resolveLoggerName(using datadog: Datadog) -> String {
             return loggerName ?? datadog.appContext.bundleIdentifier ?? ""
-        }
-
-        private func resolveSynchronizationQueue(using datadog: Datadog) -> DispatchQueue {
-            let loggerName = resolveLoggerName(using: datadog)
-            return DispatchQueue(label: "com.datadoghq.logger-\(loggerName)", qos: .userInteractive)
         }
     }
 }

--- a/Sources/Datadog/Utils/InternalLoggers.swift
+++ b/Sources/Datadog/Utils/InternalLoggers.swift
@@ -48,10 +48,7 @@ internal func createSDKDeveloperLogger(
         timeFormatter: timeFormatter
     )
 
-    return Logger(
-        logOutput: consoleOutput,
-        queue: DispatchQueue(label: "com.datadoghq.logger-sdk-dev")
-    )
+    return Logger(logOutput: consoleOutput, identifier: "sdk-developer")
 }
 
 internal func createSDKUserLogger(
@@ -60,10 +57,7 @@ internal func createSDKUserLogger(
     timeFormatter: DateFormatter = LogConsoleOutput.shortTimeFormatter()
 ) -> Logger {
     guard let datadog = Datadog.instance else {
-        return Logger(
-            logOutput: NoOpLogOutput(),
-            queue: DispatchQueue(label: "com.datadoghq.logger-noop")
-        )
+        return Logger(logOutput: NoOpLogOutput(), identifier: "no-op")
     }
 
     let consoleOutput = LogConsoleOutput(
@@ -85,6 +79,6 @@ internal func createSDKUserLogger(
         logOutput: ConditionalLogOutput(conditionedOutput: consoleOutput) { logLevel in
             logLevel.rawValue >= (Datadog.verbosityLevel?.rawValue ?? .max)
         },
-        queue: DispatchQueue(label: "com.datadoghq.logger-sdk-user")
+        identifier: "sdk-user"
     )
 }

--- a/Sources/Datadog/Utils/InternalLoggers.swift
+++ b/Sources/Datadog/Utils/InternalLoggers.swift
@@ -48,7 +48,10 @@ internal func createSDKDeveloperLogger(
         timeFormatter: timeFormatter
     )
 
-    return Logger(logOutput: consoleOutput)
+    return Logger(
+        logOutput: consoleOutput,
+        queue: DispatchQueue(label: "com.datadoghq.logger-sdk-dev")
+    )
 }
 
 internal func createSDKUserLogger(
@@ -57,7 +60,10 @@ internal func createSDKUserLogger(
     timeFormatter: DateFormatter = LogConsoleOutput.shortTimeFormatter()
 ) -> Logger {
     guard let datadog = Datadog.instance else {
-        return Logger(logOutput: NoOpLogOutput())
+        return Logger(
+            logOutput: NoOpLogOutput(),
+            queue: DispatchQueue(label: "com.datadoghq.logger-noop")
+        )
     }
 
     let consoleOutput = LogConsoleOutput(
@@ -78,6 +84,7 @@ internal func createSDKUserLogger(
     return Logger(
         logOutput: ConditionalLogOutput(conditionedOutput: consoleOutput) { logLevel in
             logLevel.rawValue >= (Datadog.verbosityLevel?.rawValue ?? .max)
-        }
+        },
+        queue: DispatchQueue(label: "com.datadoghq.logger-sdk-user")
     )
 }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
@@ -69,10 +69,7 @@ class FileWriterTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = Logger(
-            logOutput: output,
-            queue: DispatchQueue(label: "com.datadoghq.logger-sdk-user")
-        )
+        userLogger = Logger(logOutput: output, identifier: "sdk-user")
 
         let writer = FileWriter(
             orchestrator: .mockWriteToSingleFile(in: temporaryDirectory),

--- a/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
@@ -69,7 +69,10 @@ class FileWriterTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = Logger(logOutput: output)
+        userLogger = Logger(
+            logOutput: output,
+            queue: DispatchQueue(label: "com.datadoghq.logger-sdk-user")
+        )
 
         let writer = FileWriter(
             orchestrator: .mockWriteToSingleFile(in: temporaryDirectory),

--- a/Tests/DatadogTests/Datadog/Mocks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/FoundationMocks.swift
@@ -195,21 +195,28 @@ private class URLSessionDataTaskReferences {
 /// Records requests passed to `URLSessionMock`.
 class URLSessionRequestRecorder {
     private var requests: [URLRequest] = []
+    private let queue = DispatchQueue(label: "queue-URLSessionRequestRecorder-\(UUID().uuidString)")
 
     /// Closure called immediately after new request is recorded.
     var onNewRequest: ((URLRequest) -> Void)?
 
     func record(request: URLRequest) {
-        requests.append(request)
-        onNewRequest?(request)
+        queue.async {
+            self.requests.append(request)
+            self.onNewRequest?(request)
+        }
     }
 
     var requestsSent: [URLRequest] {
-        requests
+        queue.sync {
+            requests
+        }
     }
 
     func containsRequestWith(body: Data) -> Bool {
-        return requests.contains { $0.httpBody == body }
+        queue.sync {
+            requests.contains { $0.httpBody == body }
+        }
     }
 }
 


### PR DESCRIPTION
### What and why?

📦 This fixes #47 

`Logger` tags and attributes were not thread safe, so when mutated parallelly by different threads, the SDK was resulting with a crash on `loggerTags` and `loggerAttributes` access.

### How?

I added basic thread safety using logger-specific `DispatchQueue` with `.sync {}` (writes) and `.async {}` (reads) synchronization.

Following this great [post from Matt Gallagher](http://www.cocoawithlove.com/blog/2016/06/02/threads-and-mutexes.html) this might be not the most performant way of synchronization, but I checked benchmark results and they are still acceptable:

<img width="843" alt="Screenshot 2020-03-17 at 18 48 48" src="https://user-images.githubusercontent.com/2358722/76886719-774fa680-6881-11ea-9ec1-2cd63b3d8bc6.png">

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
