### PR TITLE
RUMM-305 Make command fails at fresh install

### DIFF
--- a/tools/xcode-templates/install-xcode-templates.sh
+++ b/tools/xcode-templates/install-xcode-templates.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 
 if [ ! -f "Package.swift" ]; then
-    echo "\`install-xcode-templates.sh\` must be run in repository root folder: \`./tools/xcode-templates/install-xcode-templates.sh\`"; exit 1
+    echo "\`install-xcode-templates.sh\` must be run in repository root folder: \`./tools/xcode-templates/install-xcode-templates.sh\`"
+    exit 1
 fi
 
 XCODE_LOCATION=$(xcode-select -p)
-XCODE_TEMPLATES_LOCATION="$XCODE_LOCATION/Library/Xcode/Templates/File Templates/"
+
+SOURCE_TEMPLATES_LOCATION="./tools/xcode-templates/Datadog/"
+TARGET_TEMPLATES_LOCATION="$HOME/Library/Developer/Xcode/Templates/File Templates/Datadog"
 
 if [ -z "$XCODE_LOCATION" ]; then
 	echo "🔥 Failed to install Xcode templates - cannot determine Xcode installation with \`xcode-select -p\`."
 	exit 1
 fi
 
-rm -r "$XCODE_TEMPLATES_LOCATION/Datadog" 2> /dev/null
-cp -R "./tools/xcode-templates/Datadog" "$XCODE_TEMPLATES_LOCATION"
+rm -r "$TARGET_TEMPLATES_LOCATION" 2> /dev/null
+mkdir -p "$TARGET_TEMPLATES_LOCATION"
+cp -R "$SOURCE_TEMPLATES_LOCATION" "$TARGET_TEMPLATES_LOCATION"
+
+echo "✅ Datadog templates copied to: $TARGET_TEMPLATES_LOCATION"
+
+exit 0

--- a/tools/xcode-templates/install-xcode-templates.sh
+++ b/tools/xcode-templates/install-xcode-templates.sh
@@ -5,15 +5,8 @@ if [ ! -f "Package.swift" ]; then
     exit 1
 fi
 
-XCODE_LOCATION=$(xcode-select -p)
-
 SOURCE_TEMPLATES_LOCATION="./tools/xcode-templates/Datadog/"
 TARGET_TEMPLATES_LOCATION="$HOME/Library/Developer/Xcode/Templates/File Templates/Datadog"
-
-if [ -z "$XCODE_LOCATION" ]; then
-	echo "🔥 Failed to install Xcode templates - cannot determine Xcode installation with \`xcode-select -p\`."
-	exit 1
-fi
 
 rm -r "$TARGET_TEMPLATES_LOCATION" 2> /dev/null
 mkdir -p "$TARGET_TEMPLATES_LOCATION"


### PR DESCRIPTION
### What and why?

This PR fixes the error occurring during `make all` with fresh-installed Xcode

```
make all
...
Installing Xcode templates...
./tools/xcode-templates/install-xcode-templates.sh
cp: /Applications/Xcode.app/{...redacted...}/Datadog: Permission denied
```

### How?

Installation directory for Xcode templates are changed
• from: `/Applications/Xcode/...`
• to: `$HOME/Library/Xcode/...`

This fixes permission issues
Also, templates stay even Xcode gets updated

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
