### PR TITLE
RUMM-293 Create OT Tracer foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.build
 /.swiftpm
 xcuserdata/
+Carthage/

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "DataDog/opentracing-swift" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "DataDog/opentracing-swift" "0aa614e30b3cc01f7b26200480fe9b2d08945189"

--- a/Datadog.podspec
+++ b/Datadog.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
   
   s.source_files = "Sources/Datadog/**/*.swift"
+  s.dependency 'OpenTracingSwift'
 end

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		611409A8242CC07D00316215 /* DDTracerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409A7242CC07D00316215 /* DDTracerTests.swift */; };
 		611409AA242CC08B00316215 /* DatadogTracingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409A9242CC08B00316215 /* DatadogTracingMocks.swift */; };
 		611409AC242CC10400316215 /* OpenTracing.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		611409AF242CCE1E00316215 /* DDSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409AE242CCE1E00316215 /* DDSpanTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -253,6 +254,7 @@
 		6114099F242CC03000316215 /* DDSpanContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDSpanContext.swift; sourceTree = "<group>"; };
 		611409A7242CC07D00316215 /* DDTracerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDTracerTests.swift; sourceTree = "<group>"; };
 		611409A9242CC08B00316215 /* DatadogTracingMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogTracingMocks.swift; sourceTree = "<group>"; };
+		611409AE242CCE1E00316215 /* DDSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -527,6 +529,7 @@
 				611409A7242CC07D00316215 /* DDTracerTests.swift */,
 				61133C212423990D00786299 /* Core */,
 				61133C392423990D00786299 /* Logs */,
+				611409AD242CCDE600316215 /* Traces */,
 				61133C352423990D00786299 /* Utils */,
 			);
 			path = Datadog;
@@ -679,6 +682,14 @@
 				6114099E242CC03000316215 /* UUID.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		611409AD242CCDE600316215 /* Traces */ = {
+			isa = PBXGroup;
+			children = (
+				611409AE242CCE1E00316215 /* DDSpanTests.swift */,
+			);
+			path = Traces;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -910,6 +921,7 @@
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
 				61133C622423990D00786299 /* InternalLoggersTests.swift in Sources */,
 				61133C582423990D00786299 /* FileWriterTests.swift in Sources */,
+				611409AF242CCE1E00316215 /* DDSpanTests.swift in Sources */,
 				61133C672423990D00786299 /* LogConsoleOutputTests.swift in Sources */,
 				61133C4C2423990D00786299 /* LogsMocks.swift in Sources */,
 				61133C542423990D00786299 /* NetworkConnectionInfoProviderTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -91,6 +91,13 @@
 		61140995242CBED700316215 /* OpenTracing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; };
 		61140996242CBED700316215 /* OpenTracing.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61140998242CBF4A00316215 /* OpenTracing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; };
+		611409A0242CC03000316215 /* DDTracer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61140999242CC02F00316215 /* DDTracer.swift */; };
+		611409A1242CC03000316215 /* DDSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114099B242CC03000316215 /* DDSpan.swift */; };
+		611409A2242CC03000316215 /* DDNoOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114099C242CC03000316215 /* DDNoOps.swift */; };
+		611409A3242CC03000316215 /* UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114099E242CC03000316215 /* UUID.swift */; };
+		611409A4242CC03000316215 /* DDSpanContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114099F242CC03000316215 /* DDSpanContext.swift */; };
+		611409A8242CC07D00316215 /* DDTracerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409A7242CC07D00316215 /* DDTracerTests.swift */; };
+		611409AA242CC08B00316215 /* DatadogTracingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409A9242CC08B00316215 /* DatadogTracingMocks.swift */; };
 		611409AC242CC10400316215 /* OpenTracing.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -239,6 +246,13 @@
 		61133C472423990D00786299 /* DatadogExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogExtensions.swift; sourceTree = "<group>"; };
 		9E085879242519FF001A3583 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
 		61140994242CBED700316215 /* OpenTracing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenTracing.framework; path = ../Carthage/Build/iOS/OpenTracing.framework; sourceTree = "<group>"; };
+		61140999242CC02F00316215 /* DDTracer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDTracer.swift; sourceTree = "<group>"; };
+		6114099B242CC03000316215 /* DDSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDSpan.swift; sourceTree = "<group>"; };
+		6114099C242CC03000316215 /* DDNoOps.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDNoOps.swift; sourceTree = "<group>"; };
+		6114099E242CC03000316215 /* UUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUID.swift; sourceTree = "<group>"; };
+		6114099F242CC03000316215 /* DDSpanContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDSpanContext.swift; sourceTree = "<group>"; };
+		611409A7242CC07D00316215 /* DDTracerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDTracerTests.swift; sourceTree = "<group>"; };
+		611409A9242CC08B00316215 /* DatadogTracingMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogTracingMocks.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -313,10 +327,12 @@
 			isa = PBXGroup;
 			children = (
 				61133BBB2423979B00786299 /* Datadog.swift */,
-				61133BB62423979B00786299 /* Logger.swift */,
 				61133BB52423979B00786299 /* DatadogConfiguration.swift */,
+				61133BB62423979B00786299 /* Logger.swift */,
+				61140999242CC02F00316215 /* DDTracer.swift */,
 				61133B9E2423979B00786299 /* Core */,
 				61133BBC2423979B00786299 /* Logs */,
+				6114099A242CC03000316215 /* Traces */,
 				61133BB72423979B00786299 /* Utils */,
 			);
 			name = Datadog;
@@ -506,8 +522,9 @@
 			children = (
 				61133C192423990D00786299 /* Mocks */,
 				61133C412423990D00786299 /* DatadogTests.swift */,
-				61133C382423990D00786299 /* LoggerTests.swift */,
 				61133C372423990D00786299 /* DatadogConfigurationTests.swift */,
+				61133C382423990D00786299 /* LoggerTests.swift */,
+				611409A7242CC07D00316215 /* DDTracerTests.swift */,
 				61133C212423990D00786299 /* Core */,
 				61133C392423990D00786299 /* Logs */,
 				61133C352423990D00786299 /* Utils */,
@@ -523,6 +540,7 @@
 				61133C1C2423990D00786299 /* UIKitMocks.swift */,
 				61133C1D2423990D00786299 /* DatadogObjcMocks.swift */,
 				61133C1F2423990D00786299 /* DatadogMocks.swift */,
+				611409A9242CC08B00316215 /* DatadogTracingMocks.swift */,
 				61133C202423990D00786299 /* FoundationMocks.swift */,
 			);
 			path = Mocks;
@@ -642,6 +660,25 @@
 				61140994242CBED700316215 /* OpenTracing.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6114099A242CC03000316215 /* Traces */ = {
+			isa = PBXGroup;
+			children = (
+				6114099B242CC03000316215 /* DDSpan.swift */,
+				6114099F242CC03000316215 /* DDSpanContext.swift */,
+				6114099C242CC03000316215 /* DDNoOps.swift */,
+				6114099D242CC03000316215 /* Utils */,
+			);
+			path = Traces;
+			sourceTree = "<group>";
+		};
+		6114099D242CC03000316215 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				6114099E242CC03000316215 /* UUID.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -830,11 +867,14 @@
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
 				61133BEA2423979B00786299 /* LogConsoleOutput.swift in Sources */,
 				61133BE32423979B00786299 /* UserInfo.swift in Sources */,
+				611409A2242CC03000316215 /* DDNoOps.swift in Sources */,
 				61133BE02423979B00786299 /* Datadog.swift in Sources */,
 				61133BCB2423979B00786299 /* CarrierInfoProvider.swift in Sources */,
 				61133BD62423979B00786299 /* DataUploader.swift in Sources */,
 				61133BE52423979B00786299 /* LogBuilder.swift in Sources */,
 				61133BD42423979B00786299 /* FileReader.swift in Sources */,
+				611409A1242CC03000316215 /* DDSpan.swift in Sources */,
+				611409A0242CC03000316215 /* DDTracer.swift in Sources */,
 				61133BD32423979B00786299 /* File.swift in Sources */,
 				61133BE72423979B00786299 /* LogUtilityOutputs.swift in Sources */,
 				61133BDA2423979B00786299 /* HTTPHeaders.swift in Sources */,
@@ -845,7 +885,9 @@
 				61133BCD2423979B00786299 /* NetworkConnectionInfoProvider.swift in Sources */,
 				61133BE42423979B00786299 /* LogEncoder.swift in Sources */,
 				61133BD82423979B00786299 /* HTTPClient.swift in Sources */,
+				611409A4242CC03000316215 /* DDSpanContext.swift in Sources */,
 				61133BDB2423979B00786299 /* DatadogConfiguration.swift in Sources */,
+				611409A3242CC03000316215 /* UUID.swift in Sources */,
 				61133BE22423979B00786299 /* LogsPersistenceStrategy.swift in Sources */,
 				61133BCE2423979B00786299 /* BatteryStatusProvider.swift in Sources */,
 				61133BD52423979B00786299 /* DataUploadConditions.swift in Sources */,
@@ -861,6 +903,8 @@
 			files = (
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,
+				611409A8242CC07D00316215 /* DDTracerTests.swift in Sources */,
+				61133C502423990D00786299 /* NetworkMocks.swift in Sources */,
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
 				61133C512423990D00786299 /* DatadogMocks.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
@@ -888,6 +932,7 @@
 				61133C4B2423990D00786299 /* DDLoggerTests.swift in Sources */,
 				61133C482423990D00786299 /* DDDatadogTests.swift in Sources */,
 				61133C4F2423990D00786299 /* DatadogObjcMocks.swift in Sources */,
+				611409AA242CC08B00316215 /* DatadogTracingMocks.swift in Sources */,
 				61133C522423990D00786299 /* FoundationMocks.swift in Sources */,
 				61133C5B2423990D00786299 /* DirectoryTests.swift in Sources */,
 				61133C562423990D00786299 /* CarrierInfoProviderTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -88,6 +88,10 @@
 		61133C702423993200786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61133C712423993200786299 /* Datadog.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E085879242519FF001A3583 /* NetworkPathMonitor.swift */; };
+		61140995242CBED700316215 /* OpenTracing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; };
+		61140996242CBED700316215 /* OpenTracing.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		61140998242CBF4A00316215 /* OpenTracing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; };
+		611409AC242CC10400316215 /* OpenTracing.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,6 +128,27 @@
 				61133C712423993200786299 /* Datadog.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61140997242CBED700316215 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				61140996242CBED700316215 /* OpenTracing.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		611409AB242CC0F900316215 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				611409AC242CC10400316215 /* OpenTracing.framework in CopyFiles */,
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -213,6 +238,7 @@
 		61133C462423990D00786299 /* TestsDirectory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestsDirectory.swift; sourceTree = "<group>"; };
 		61133C472423990D00786299 /* DatadogExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogExtensions.swift; sourceTree = "<group>"; };
 		9E085879242519FF001A3583 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
+		61140994242CBED700316215 /* OpenTracing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenTracing.framework; path = ../Carthage/Build/iOS/OpenTracing.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -220,6 +246,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61140995242CBED700316215 /* OpenTracing.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,6 +255,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61133B8C242393DE00786299 /* Datadog.framework in Frameworks */,
+				61140998242CBF4A00316215 /* OpenTracing.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -611,6 +639,7 @@
 		61133C6F2423993200786299 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				61140994242CBED700316215 /* OpenTracing.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -646,6 +675,7 @@
 				61133B7F242393DE00786299 /* Frameworks */,
 				61133B80242393DE00786299 /* Resources */,
 				61133C772423A4C300786299 /* ⚙️ Run linter */,
+				61140997242CBED700316215 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -663,6 +693,7 @@
 				61133B87242393DE00786299 /* Sources */,
 				61133B88242393DE00786299 /* Frameworks */,
 				61133B89242393DE00786299 /* Resources */,
+				611409AB242CC0F900316215 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -1031,6 +1062,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/Datadog/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1055,6 +1090,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/Datadog/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1077,6 +1116,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/DatadogTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1099,6 +1142,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/DatadogTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		611409B2242CEFB400316215 /* SpanOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B1242CEFB400316215 /* SpanOutput.swift */; };
 		611409B4242CF03300316215 /* SpanFileOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B3242CF03300316215 /* SpanFileOutput.swift */; };
 		611409B6242CF44500316215 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B5242CF44500316215 /* Utils.swift */; };
+		611409B8242D098700316215 /* SpansMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B7242D098700316215 /* SpansMocks.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -261,6 +262,7 @@
 		611409B1242CEFB400316215 /* SpanOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanOutput.swift; sourceTree = "<group>"; };
 		611409B3242CF03300316215 /* SpanFileOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFileOutput.swift; sourceTree = "<group>"; };
 		611409B5242CF44500316215 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		611409B7242D098700316215 /* SpansMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpansMocks.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -545,6 +547,7 @@
 			isa = PBXGroup;
 			children = (
 				61133C1A2423990D00786299 /* LogsMocks.swift */,
+				611409B7242D098700316215 /* SpansMocks.swift */,
 				61133C1B2423990D00786299 /* CoreTelephonyMocks.swift */,
 				61133C1C2423990D00786299 /* UIKitMocks.swift */,
 				61133C1D2423990D00786299 /* DatadogObjcMocks.swift */,
@@ -932,6 +935,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
+				611409B8242D098700316215 /* SpansMocks.swift in Sources */,
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,
 				611409A8242CC07D00316215 /* DDTracerTests.swift in Sources */,
 				61133C502423990D00786299 /* NetworkMocks.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -100,6 +100,9 @@
 		611409AA242CC08B00316215 /* DatadogTracingMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409A9242CC08B00316215 /* DatadogTracingMocks.swift */; };
 		611409AC242CC10400316215 /* OpenTracing.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		611409AF242CCE1E00316215 /* DDSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409AE242CCE1E00316215 /* DDSpanTests.swift */; };
+		611409B2242CEFB400316215 /* SpanOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B1242CEFB400316215 /* SpanOutput.swift */; };
+		611409B4242CF03300316215 /* SpanFileOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B3242CF03300316215 /* SpanFileOutput.swift */; };
+		611409B6242CF44500316215 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B5242CF44500316215 /* Utils.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -255,6 +258,9 @@
 		611409A7242CC07D00316215 /* DDTracerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDTracerTests.swift; sourceTree = "<group>"; };
 		611409A9242CC08B00316215 /* DatadogTracingMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogTracingMocks.swift; sourceTree = "<group>"; };
 		611409AE242CCE1E00316215 /* DDSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanTests.swift; sourceTree = "<group>"; };
+		611409B1242CEFB400316215 /* SpanOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanOutput.swift; sourceTree = "<group>"; };
+		611409B3242CF03300316215 /* SpanFileOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFileOutput.swift; sourceTree = "<group>"; };
+		611409B5242CF44500316215 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -671,6 +677,7 @@
 				6114099B242CC03000316215 /* DDSpan.swift */,
 				6114099F242CC03000316215 /* DDSpanContext.swift */,
 				6114099C242CC03000316215 /* DDNoOps.swift */,
+				611409B0242CEF8A00316215 /* SpanOutputs */,
 				6114099D242CC03000316215 /* Utils */,
 			);
 			path = Traces;
@@ -688,8 +695,18 @@
 			isa = PBXGroup;
 			children = (
 				611409AE242CCE1E00316215 /* DDSpanTests.swift */,
+				611409B5242CF44500316215 /* Utils.swift */,
 			);
 			path = Traces;
+			sourceTree = "<group>";
+		};
+		611409B0242CEF8A00316215 /* SpanOutputs */ = {
+			isa = PBXGroup;
+			children = (
+				611409B1242CEFB400316215 /* SpanOutput.swift */,
+				611409B3242CF03300316215 /* SpanFileOutput.swift */,
+			);
+			path = SpanOutputs;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -877,6 +894,7 @@
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
 				61133BEA2423979B00786299 /* LogConsoleOutput.swift in Sources */,
+				611409B4242CF03300316215 /* SpanFileOutput.swift in Sources */,
 				61133BE32423979B00786299 /* UserInfo.swift in Sources */,
 				611409A2242CC03000316215 /* DDNoOps.swift in Sources */,
 				61133BE02423979B00786299 /* Datadog.swift in Sources */,
@@ -894,6 +912,7 @@
 				61133BD12423979B00786299 /* FilesOrchestrator.swift in Sources */,
 				61133BE12423979B00786299 /* LogsUploadStrategy.swift in Sources */,
 				61133BCD2423979B00786299 /* NetworkConnectionInfoProvider.swift in Sources */,
+				611409B2242CEFB400316215 /* SpanOutput.swift in Sources */,
 				61133BE42423979B00786299 /* LogEncoder.swift in Sources */,
 				61133BD82423979B00786299 /* HTTPClient.swift in Sources */,
 				611409A4242CC03000316215 /* DDSpanContext.swift in Sources */,
@@ -940,6 +959,7 @@
 				61133C592423990D00786299 /* FilesOrchestratorTests.swift in Sources */,
 				61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */,
 				61133C6C2423990D00786299 /* SwiftExtensions.swift in Sources */,
+				611409B6242CF44500316215 /* Utils.swift in Sources */,
 				61133C492423990D00786299 /* DDLoggerBuilderTests.swift in Sources */,
 				61133C4B2423990D00786299 /* DDLoggerTests.swift in Sources */,
 				61133C482423990D00786299 /* DDDatadogTests.swift in Sources */,

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
-all: dependencies xcodeproj-httpservermock templates examples benchmark
-.PHONY : examples
+all: tools dependencies xcodeproj-httpservermock templates examples benchmark
+.PHONY : examples tools
 
-dependencies:
-		@echo "⚙️  Validating dependencies..."
+tools:
+		@echo "⚙️  Installing tools..."
 		@brew list swiftlint &>/dev/null || brew install swiftlint
 		@echo "OK 👌"
+
+dependencies:
+		@echo "⚙️  Installing dependencies..."
+		@carthage bootstrap --platform iOS
+		@echo "OK 👌"	
 
 xcodeproj-httpservermock:
 		@echo "⚙️  Generating 'HTTPServerMock.xcodeproj'..."

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/DataDog/opentracing-swift.git",
         "state": {
           "branch": "master",
-          "revision": "0aa614e30b3cc01f7b26200480fe9b2d08945189",
+          "revision": "bdd65d768aa41a58a78e00d3401cacc352dfc406",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "OpenTracing",
+        "repositoryURL": "https://github.com/DataDog/opentracing-swift.git",
+        "state": {
+          "branch": "master",
+          "revision": "0aa614e30b3cc01f7b26200480fe9b2d08945189",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -16,16 +16,17 @@ let package = Package(
             targets: ["DatadogObjc"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/DataDog/opentracing-swift.git", .branch("master")),
     ],
     targets: [
         .target(
             name: "Datadog",
-            dependencies: []),
+            dependencies: ["OpenTracing"]),
         .target(
             name: "DatadogObjc",
             dependencies: ["Datadog"]),
         .testTarget(
             name: "DatadogTests",
-            dependencies: ["Datadog", "DatadogObjc"]),
+            dependencies: ["Datadog", "DatadogObjc", "OpenTracing"]),
     ]
 )

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -7,8 +7,13 @@
 import OpenTracing
 
 public class DDTracer: Tracer {
+    /// Writes `Span` objects to output.
+    private let spanOutput: SpanOutput
+
     // TODO: RUMM-332 Consider builder pattern to initialize the tracer
-    public init() {}
+    internal init(spanOutput: SpanOutput) {
+        self.spanOutput = spanOutput
+    }
 
     // MARK: - Open Tracing interface
 
@@ -30,7 +35,7 @@ public class DDTracer: Tracer {
         return nil
     }
 
-    // MARK: - Internal
+    // MARK: - Private Open Tracing helpers
 
     private func startSpanOrThrow(operationName: String, references: [Reference]?, tags: [String: Codable]?, startTime: Date?) throws -> Span {
         guard let datadog = Datadog.instance else {
@@ -44,5 +49,11 @@ public class DDTracer: Tracer {
             parentSpanContext: parentSpanContext,
             startTime: startTime ?? datadog.dateProvider.currentDate()
         )
+    }
+
+    // MARK: - Internal
+
+    func write(span: DDSpan, finishTime: Date) {
+        spanOutput.write(span: span, finishTime: finishTime)
     }
 }

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -5,6 +5,7 @@
  */
 
 import OpenTracing
+import Foundation
 
 public class DDTracer: Tracer {
     /// Writes `Span` objects to output.

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -54,7 +54,7 @@ public class DDTracer: Tracer {
 
     // MARK: - Internal
 
-    func write(span: DDSpan, finishTime: Date) {
+    internal func write(span: DDSpan, finishTime: Date) {
         spanOutput.write(span: span, finishTime: finishTime)
     }
 }

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import OpenTracing
+
+public class DDTracer: Tracer {
+    // TODO: RUMM-332 Consider builder pattern to initialize the tracer
+    public init() {}
+
+    // MARK: - Open Tracing interface
+
+    public func startSpan(operationName: String, references: [Reference]? = nil, tags: [String: Codable]? = nil, startTime: Date? = nil) -> Span {
+        do {
+            return try startSpanOrThrow(operationName: operationName, references: references, tags: tags, startTime: startTime)
+        } catch {
+            consolePrint("🔥 \(error)")
+            return DDNoopSpan()
+        }
+    }
+
+    public func inject(spanContext: SpanContext, writer: FormatWriter) {
+        // TODO: RUMM-292
+    }
+
+    public func extract(reader: FormatReader) -> SpanContext? {
+        // TODO: RUMM-292
+        return nil
+    }
+
+    // MARK: - Internal
+
+    private func startSpanOrThrow(operationName: String, references: [Reference]?, tags: [String: Codable]?, startTime: Date?) throws -> Span {
+        guard let datadog = Datadog.instance else {
+            throw ProgrammerError(description: "`Datadog.initialize()` must be called prior to `startSpan(...)`.")
+        }
+
+        let parentSpanContext = references?.compactMap { $0.context as? DDSpanContext }.last
+        return DDSpan(
+            tracer: self,
+            operationName: operationName,
+            parentSpanContext: parentSpanContext,
+            startTime: startTime ?? datadog.dateProvider.currentDate()
+        )
+    }
+}

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -158,17 +158,17 @@ public class Datadog {
 internal typealias AppContext = Datadog.AppContext
 
 /// An exception thrown due to programmer error when calling SDK public API.
-/// It make the SDK non-functional and print the error to developer in debugger console..
+/// It makes the SDK non-functional and print the error to developer in debugger console..
 /// When thrown, check if configuration passed to `Datadog.initialize(...)` is correct
-/// and if you not call any other SDK methods before it returns.
+/// and if you do not call any other SDK methods before it returns.
 internal struct ProgrammerError: Error, CustomStringConvertible {
     init(description: String) { self.description = "Datadog SDK usage error: \(description)" }
     let description: String
 }
 
 /// An exception thrown internally by SDK.
-/// It is always handled by SDK and never passed to the user until `Datadog.verbosity` is set (then it might be printed in debugger console).
-/// `InternalError` might be thrown due to SDK internal inconsistency or external issues (e.g.  I/O errors). The SDK
+/// It is always handled by SDK (keeps it functional) and never passed to the user until `Datadog.verbosity` is set (then it might be printed in debugger console).
+/// `InternalError` might be thrown due to programmer error (API misuse) or SDK internal inconsistency or external issues (e.g.  I/O errors). The SDK
 /// should always recover from that failures.
 internal struct InternalError: Error, CustomStringConvertible {
     let description: String

--- a/Sources/Datadog/Traces/DDNoOps.swift
+++ b/Sources/Datadog/Traces/DDNoOps.swift
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import OpenTracing
+
+private struct DDNoopGlobals {
+    static let tracer = DDNoopTracer()
+    static let span = DDNoopSpan()
+    static let context = DDNoopSpanContext()
+}
+
+internal struct DDNoopTracer: Tracer {
+    func extract(reader: FormatReader) -> SpanContext? { DDNoopGlobals.context }
+    func inject(spanContext: SpanContext, writer: FormatWriter) {}
+    func startSpan(operationName: String, references: [Reference]?, tags: [String: Codable]?, startTime: Date?) -> Span { DDNoopGlobals.span }
+}
+
+internal struct DDNoopSpan: Span {
+    var context: SpanContext { DDNoopGlobals.context }
+    func tracer() -> Tracer { DDNoopGlobals.tracer }
+    func setOperationName(_ operationName: String) {}
+    func finish(at time: Date) {}
+    func log(fields: [String: Codable], timestamp: Date) {}
+    func baggageItem(withKey key: String) -> String? { nil }
+    func setBaggageItem(key: String, value: String) {}
+    func setTag(key: String, value: Codable) {}
+}
+
+internal struct DDNoopSpanContext: SpanContext {
+    func forEachBaggageItem(callback: (String, String) -> Bool) {}
+}

--- a/Sources/Datadog/Traces/DDNoOps.swift
+++ b/Sources/Datadog/Traces/DDNoOps.swift
@@ -5,6 +5,7 @@
  */
 
 import OpenTracing
+import Foundation
 
 private struct DDNoopGlobals {
     static let tracer = DDNoopTracer()

--- a/Sources/Datadog/Traces/DDSpan.swift
+++ b/Sources/Datadog/Traces/DDSpan.swift
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import OpenTracing
+
+internal class DDSpan: Span {
+    /// The `Tracer` which created this span.
+    let issuingTracer: DDTracer
+    let operationName: String
+    let startTime: Date
+
+    init(tracer: DDTracer, operationName: String, parentSpanContext: DDSpanContext?, startTime: Date) {
+        self.issuingTracer = tracer
+        self.operationName = operationName
+        self.startTime = startTime
+        self.context = DDSpanContext(
+            traceID: parentSpanContext?.traceID ?? .generateUnique(),
+            spanID: .generateUnique()
+        )
+    }
+
+    // MARK: - Open Tracing interface
+
+    let context: SpanContext
+
+    func tracer() -> Tracer {
+        return issuingTracer
+    }
+
+    func setOperationName(_ operationName: String) {
+        // TODO: RUMM-293
+    }
+
+    func setTag(key: String, value: Codable) {
+        // TODO: RUMM-292
+    }
+
+    func setBaggageItem(key: String, value: String) {
+        // TODO: RUMM-292
+    }
+
+    func baggageItem(withKey key: String) -> String? {
+        // TODO: RUMM-292
+        return nil
+    }
+
+    func finish(at time: Date) {
+        // TODO: RUMM-293
+    }
+
+    func log(fields: [String: Codable], timestamp: Date) {
+        // TODO: RUMM-292
+    }
+}

--- a/Sources/Datadog/Traces/DDSpan.swift
+++ b/Sources/Datadog/Traces/DDSpan.swift
@@ -8,9 +8,9 @@ import OpenTracing
 
 internal class DDSpan: Span {
     /// The `Tracer` which created this span.
-    let issuingTracer: DDTracer
-    let operationName: String
-    let startTime: Date
+    internal let issuingTracer: DDTracer
+    private(set) var operationName: String
+    internal let startTime: Date
 
     init(tracer: DDTracer, operationName: String, parentSpanContext: DDSpanContext?, startTime: Date) {
         self.issuingTracer = tracer
@@ -31,7 +31,7 @@ internal class DDSpan: Span {
     }
 
     func setOperationName(_ operationName: String) {
-        // TODO: RUMM-293
+        self.operationName = operationName
     }
 
     func setTag(key: String, value: Codable) {

--- a/Sources/Datadog/Traces/DDSpan.swift
+++ b/Sources/Datadog/Traces/DDSpan.swift
@@ -5,6 +5,7 @@
  */
 
 import OpenTracing
+import Foundation
 
 internal class DDSpan: Span {
     private(set) var operationName: String

--- a/Sources/Datadog/Traces/DDSpanContext.swift
+++ b/Sources/Datadog/Traces/DDSpanContext.swift
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import OpenTracing
+
+internal struct DDSpanContext: SpanContext {
+    let traceID: TracingUUID
+    let spanID: TracingUUID
+
+    // MARK: - Open Tracing interface
+
+    func forEachBaggageItem(callback: (String, String) -> Bool) {
+        // TODO: RUMM-292
+    }
+}

--- a/Sources/Datadog/Traces/SpanOutputs/SpanFileOutput.swift
+++ b/Sources/Datadog/Traces/SpanOutputs/SpanFileOutput.swift
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// `SpanOutput` which saves spans to file.
+internal struct SpanFileOutput: SpanOutput {
+    func write(span: DDSpan, finishTime: Date) {
+        // TODO: RUMM-298 Write spans to file
+    }
+}

--- a/Sources/Datadog/Traces/SpanOutputs/SpanOutput.swift
+++ b/Sources/Datadog/Traces/SpanOutputs/SpanOutput.swift
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Type writting spans to some destination.
+internal protocol SpanOutput {
+    func write(span: DDSpan, finishTime: Date)
+}

--- a/Sources/Datadog/Traces/Utils/UUID.swift
+++ b/Sources/Datadog/Traces/Utils/UUID.swift
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct TracingUUID: Equatable {
+    /// The unique integer (64-bit unsigned) ID of the trace containing this span.
+    /// - See also: [Datadog API Reference - Send Traces](https://docs.datadoghq.com/api/?lang=bash#send-traces)
+    let rawValue: UInt64
+
+    static func generateUnique() -> TracingUUID {
+        // TODO: RUMM-333 Add boundaries to trace & span ID generation
+        return TracingUUID(
+            rawValue: .random(in: UInt64.min...UInt64.max)
+        )
+    }
+}
+
+internal typealias TraceID = TracingUUID
+internal typealias SpanID = TracingUUID

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import OpenTracing
+@testable import Datadog
+
+class DDTracerTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        XCTAssertNil(Datadog.instance)
+    }
+
+    override func tearDown() {
+        XCTAssertNil(Datadog.instance)
+        super.tearDown()
+    }
+
+    func testItStartsSpanWithNoParent() {
+        let dateProvider = RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+        Datadog.instance = .mockNoOpWith(dateProvider: dateProvider)
+        defer { Datadog.instance = nil }
+
+        let tracer = DDTracer()
+        let span = tracer.startSpan(operationName: "operation") as? DDSpan
+
+        XCTAssertTrue(span?.tracer() as? DDTracer === tracer)
+        XCTAssertEqual(span?.operationName, "operation")
+        XCTAssertEqual(span?.startTime, .mockDecember15th2019At10AMUTC())
+    }
+
+    func testItStartsSpanWithParent() {
+        let dateProvider = RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+        Datadog.instance = .mockNoOpWith(dateProvider: dateProvider)
+        defer { Datadog.instance = nil }
+
+        let tracer = DDTracer()
+        let parentSpan = tracer.startSpan(operationName: "operation 1") as? DDSpan
+        let span = tracer.startSpan(operationName: "operation 2", childOf: parentSpan?.context) as? DDSpan
+
+        XCTAssertTrue(span?.tracer() as? DDTracer === tracer)
+        XCTAssertEqual(span?.operationName, "operation 2")
+        XCTAssertEqual(span?.startTime, .mockDecember15th2019At10AMUTC())
+        XCTAssertEqual((span?.context as? DDSpanContext)?.traceID, (parentSpan?.context as? DDSpanContext)?.traceID)
+        XCTAssertNotEqual((span?.context as? DDSpanContext)?.spanID, (parentSpan?.context as? DDSpanContext)?.spanID)
+    }
+
+    // MARK: - Initialization
+
+    // TODO: RUMM-339 Move this test to obj-c wrapper tests, similarly to what we do for `DDLoggerBuilderTests`
+    func testGivenDatadogNotInitialized_whenUsingTracer_itPrintsError() {
+        let printFunction = PrintFunctionMock()
+        consolePrint = printFunction.print
+        defer { consolePrint = { print($0) } }
+
+        XCTAssertNil(Datadog.instance)
+
+        let tracer = DDTracer()
+        let fixtures: [(() -> Void, String)] = [
+            ({ _ = tracer.startSpan(operationName: .mockAny()) }, "`Datadog.initialize()` must be called prior to `startSpan(...)`.")
+        ]
+
+        fixtures.forEach { tracerMethod, expectedConsoleError in
+            tracerMethod()
+            XCTAssertEqual(printFunction.printedMessage, "🔥 Datadog SDK usage error: \(expectedConsoleError)")
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -64,7 +64,8 @@ class DDTracerTests: XCTestCase {
 
         let tracer = DDTracer(spanOutput: SpanOutputMock())
         let fixtures: [(() -> Void, String)] = [
-            ({ _ = tracer.startSpan(operationName: .mockAny()) }, "`Datadog.initialize()` must be called prior to `startSpan(...)`.")
+            ({ _ = tracer.startSpan(operationName: .mockAny()) },
+             "`Datadog.initialize()` must be called prior to `startSpan(...)`."),
         ]
 
         fixtures.forEach { tracerMethod, expectedConsoleError in

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -412,7 +412,8 @@ class LoggerTests: XCTestCase {
     // MARK: - Thread safety
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
-        Datadog.instance = .mockNeverPerformingUploads()
+        Datadog.instance = .mockNoOp()
+        defer { Datadog.instance = nil }
         let logger = Logger.builder.build()
 
         DispatchQueue.concurrentPerform(iterations: 900) { iteration in
@@ -432,7 +433,5 @@ class LoggerTests: XCTestCase {
                 break
             }
         }
-
-        Datadog.instance = nil
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
@@ -63,15 +63,6 @@ class RelativeDateProvider: DateProvider {
 // MARK: - Files orchestration
 
 extension WritableFileConditions {
-    static func mockAny() -> WritableFileConditions {
-        return WritableFileConditions(
-            maxDirectorySize: 0,
-            maxFileSize: 0,
-            maxFileAgeForWrite: 0,
-            maxNumberOfUsesOfFile: 0
-        )
-    }
-
     /// Write conditions causing `FilesOrchestrator` to always pick the same file for writting.
     static func mockWriteToSingleFile() -> WritableFileConditions {
         return WritableFileConditions(
@@ -94,10 +85,6 @@ extension WritableFileConditions {
 }
 
 extension ReadableFileConditions {
-    static func mockAny() -> ReadableFileConditions {
-        return ReadableFileConditions(minFileAgeForRead: 0, maxFileAgeForRead: 0)
-    }
-
     /// Read conditions causing `FilesOrchestrator` to pick all files for reading, no matter of their creation time.
     static func mockReadAllFiles() -> ReadableFileConditions {
         return ReadableFileConditions(
@@ -108,11 +95,19 @@ extension ReadableFileConditions {
 }
 
 extension FilesOrchestrator {
-    static func mockAny() -> FilesOrchestrator {
+    static func mockNoOp() -> FilesOrchestrator {
         return FilesOrchestrator(
             directory: temporaryDirectory,
-            writeConditions: .mockAny(),
-            readConditions: .mockAny(),
+            writeConditions: WritableFileConditions(
+                maxDirectorySize: 0,
+                maxFileSize: 0,
+                maxFileAgeForWrite: 0,
+                maxNumberOfUsesOfFile: 0
+            ),
+            readConditions: ReadableFileConditions(
+                minFileAgeForRead: 0,
+                maxFileAgeForRead: 0
+            ),
             dateProvider: SystemDateProvider()
         )
     }
@@ -139,9 +134,9 @@ extension FilesOrchestrator {
 }
 
 extension FileWriter {
-    static func mockAny() -> FileWriter {
+    static func mockNoOp() -> FileWriter {
         return FileWriter(
-            orchestrator: .mockAny(),
+            orchestrator: .mockNoOp(),
             queue: .global(),
             maxWriteSize: 0
         )
@@ -161,9 +156,9 @@ extension FileWriter {
 }
 
 extension FileReader {
-    static func mockAny() -> FileReader {
+    static func mockNoOp() -> FileReader {
         return FileReader(
-            orchestrator: .mockAny(),
+            orchestrator: .mockNoOp(),
             queue: .global()
         )
     }
@@ -256,10 +251,6 @@ extension BatteryStatus {
 
 struct BatteryStatusProviderMock: BatteryStatusProviderType {
     let current: BatteryStatus
-
-    static func mockAny() -> BatteryStatusProviderMock {
-        return BatteryStatusProviderMock(current: .mockAny())
-    }
 
     static func mockWith(status: BatteryStatus) -> BatteryStatusProviderMock {
         return BatteryStatusProviderMock(current: status)
@@ -425,10 +416,20 @@ extension DataUploadDelay {
 }
 
 extension DataUploadConditions {
-    static func mockAny() -> DataUploadConditions {
+    static func mockNeverPerformingUploads() -> DataUploadConditions {
         return DataUploadConditions(
-            batteryStatus: BatteryStatusProviderMock.mockAny(),
-            networkConnectionInfo: NetworkConnectionInfoProviderMock.mockAny()
+            batteryStatus: BatteryStatusProviderMock(
+                current: .mockWith(
+                    state: .unplugged,
+                    level: 0.01,
+                    isLowPowerModeEnabled: true
+                )
+            ),
+            networkConnectionInfo: NetworkConnectionInfoProviderMock.mockWith(
+                networkConnectionInfo: .mockWith(
+                    reachability: .no
+                )
+            )
         )
     }
 
@@ -462,15 +463,15 @@ extension DataUploader {
 }
 
 extension DataUploadWorker {
-    static func mockAny() -> DataUploadWorker {
+    static func mockNoOp() -> DataUploadWorker {
         return .mockWith()
     }
 
     static func mockWith(
         queue: DispatchQueue = .global(),
-        fileReader: FileReader = .mockAny(),
+        fileReader: FileReader = .mockNoOp(),
         dataUploader: DataUploader = .mockAny(),
-        uploadConditions: DataUploadConditions = .mockAny(),
+        uploadConditions: DataUploadConditions = .mockNeverPerformingUploads(),
         delay: DataUploadDelay = .mockAny()
     ) -> DataUploadWorker {
         return DataUploadWorker(
@@ -493,8 +494,8 @@ extension DataUploadWorker {
 }
 
 extension LogsPersistenceStrategy {
-    static func mockAny() -> LogsPersistenceStrategy {
-        return LogsPersistenceStrategy(writer: .mockAny(), reader: .mockAny())
+    static func mockNeverWrittingLogs() -> LogsPersistenceStrategy {
+        return LogsPersistenceStrategy(writer: .mockNoOp(), reader: .mockNoOp())
     }
 
     /// Mocks persistence strategy where:
@@ -519,10 +520,6 @@ extension LogsPersistenceStrategy {
 }
 
 extension LogsUploadStrategy {
-    static func mockAny() -> LogsUploadStrategy {
-        return LogsUploadStrategy(uploadWorker: .mockAny())
-    }
-
     static func mockNeverPerformingUploads() -> LogsUploadStrategy {
         return LogsUploadStrategy(
             uploadWorker: .mockNeverPerformingUploads()
@@ -659,16 +656,15 @@ extension Datadog.Configuration {
 }
 
 extension Datadog {
-    static func mockNeverPerformingUploads() -> Datadog {
-        return .mockWith(
-            logsUploadStrategy: .mockNeverPerformingUploads()
-        )
+    /// Mocks no-op `Datadog` instance (no writes, no uploads).
+    static func mockNoOp() -> Datadog {
+        return .mockNoOpWith()
     }
 
-    static func mockWith(
+    static func mockNoOpWith(
         appContext: AppContext = .mockAny(),
-        logsPersistenceStrategy: LogsPersistenceStrategy = .mockAny(),
-        logsUploadStrategy: LogsUploadStrategy = .mockAny(),
+        logsPersistenceStrategy: LogsPersistenceStrategy = .mockNeverWrittingLogs(),
+        logsUploadStrategy: LogsUploadStrategy = .mockNeverPerformingUploads(),
         dateProvider: DateProvider = SystemDateProvider(),
         userInfoProvider: UserInfoProvider = .mockAny(),
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockAny(),

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
@@ -22,3 +22,9 @@ extension TracingUUID {
         return TracingUUID(rawValue: rawValue)
     }
 }
+
+extension DDTracer {
+    static func mockNoOp() -> DDTracer {
+        return DDTracer()
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import XCTest
+@testable import Datadog
+
+/*
+A collection of SDK object mocks for Tracing.
+It follows the mocking conventions described in `FoundationMocks.swift`.
+ */
+
+extension TracingUUID {
+    static func mockAny() -> TracingUUID {
+        return .generateUnique()
+    }
+
+    static func mock(_ rawValue: UInt64) -> TracingUUID {
+        return TracingUUID(rawValue: rawValue)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
@@ -23,8 +23,24 @@ extension TracingUUID {
     }
 }
 
+// MARK: - Integration
+
+/// `SpanOutput` recording received spans.
+class SpanOutputMock: SpanOutput {
+    struct Recorded {
+        let span: DDSpan
+        let finishTime: Date
+    }
+
+    var recorded: Recorded? = nil
+
+    func write(span: DDSpan, finishTime: Date) {
+        recorded = Recorded(span: span, finishTime: finishTime)
+    }
+}
+
 extension DDTracer {
     static func mockNoOp() -> DDTracer {
-        return DDTracer()
+        return DDTracer(spanOutput: SpanOutputMock())
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/LogsMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LogsMocks.swift
@@ -8,7 +8,7 @@ import Foundation
 @testable import Datadog
 
 /*
-A collection of mocks for Logs objects.
+A collection of mocks for `Log` objects.
 It follows the mocking conventions described in `FoundationMocks.swift`.
  */
 

--- a/Tests/DatadogTests/Datadog/Mocks/SpansMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SpansMocks.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+@testable import Datadog
+
+/*
+A collection of mocks for `DDSpan` objects.
+It follows the mocking conventions described in `FoundationMocks.swift`.
+ */
+
+extension DDSpan {
+    static func mockWith(
+        tracer: DDTracer = .mockNoOp(),
+        operationName: String = .mockAny(),
+        parentSpanContext: DDSpanContext? = nil,
+        startTime: Date = .mockAny()
+    ) -> DDSpan {
+        return DDSpan(
+            tracer: tracer,
+            operationName: operationName,
+            parentSpanContext: parentSpanContext,
+            startTime: startTime
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/Traces/DDSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/Traces/DDSpanTests.swift
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class DDSpanTests: XCTestCase {
+    func testSettingOperationName() {
+        let span = DDSpan(tracer: .mockNoOp(), operationName: "initial", parentSpanContext: nil, startTime: .mockAny())
+        span.setOperationName("new")
+        XCTAssertEqual(span.operationName, "new")
+    }
+}

--- a/Tests/DatadogTests/Datadog/Traces/Utils.swift
+++ b/Tests/DatadogTests/Datadog/Traces/Utils.swift
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import OpenTracing
+@testable import Datadog
+
+// MARK: - OT to DD casting
+
+// swiftlint:disable identifier_name
+extension OpenTracing.SpanContext {
+    var dd: DDSpanContext {
+        return self as! DDSpanContext
+    }
+}
+// swiftlint:enable identifier_name

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -13,7 +13,7 @@ class InternalLoggersTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        Datadog.instance = .mockNeverPerformingUploads()
+        Datadog.instance = .mockNoOp()
         printedMessages = []
         userLogger = createSDKUserLogger(
             consolePrintFunction: { [weak self] in self?.printedMessages.append($0) },

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerBuilderTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerBuilderTests.swift
@@ -68,7 +68,8 @@ class DDLoggerBuilderTests: XCTestCase {
     }
 
     func testUsingDifferentOutputs() throws {
-        Datadog.instance = .mockNeverPerformingUploads()
+        Datadog.instance = .mockNoOp()
+        defer { Datadog.instance = nil }
 
         assertThat(
             logger: {
@@ -145,8 +146,6 @@ class DDLoggerBuilderTests: XCTestCase {
             }(),
             usesOutput: NoOpLogOutput.self
         )
-
-        try Datadog.deinitializeOrThrow()
     }
 
     // MARK: - Initialization

--- a/dependency-manager-tests/carthage/Makefile
+++ b/dependency-manager-tests/carthage/Makefile
@@ -4,12 +4,7 @@ else
 		GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 endif
 
-EXPECTED_FRAMEWORKS := \
-	Carthage/Build/iOS/Datadog.framework \
-	Carthage/Build/iOS/DatadogObjc.framework \
-	Carthage/Build/iOS/OpenTracing.framework
-
-FRAMEWORKS_MISSING := $(shell $(foreach framework,$(EXPECTED_FRAMEWORKS),test -e "$(framework)" || echo "$(framework)";))
+PWD := $(shell pwd)
 
 test:
 		@echo "⚙️  Testing Carthage for remote branch: '${GIT_BRANCH}'..."
@@ -17,12 +12,10 @@ test:
 		@rm -rf Carthage/
 
 		@echo "🧪 Run 'carthage update'"
-		carthage update
+		@carthage update
 
-		@echo "🧪 Check if expected frameworks exist"
-ifneq ($(FRAMEWORKS_MISSING),)
-	@echo "🔥 Frameworks missing: $(FRAMEWORKS_MISSING)"
-	@echo "🧪 FAILED"
-	@false
-endif
+		@echo "🧪 Check if expected frameworks exist in $(PWD)/Carthage/Build/iOS"
+		@[ -e "Carthage/Build/iOS/Datadog.framework" ] && echo "Datadog.framework - OK" || { echo "Datadog.framework - missing"; false; }
+		@[ -e "Carthage/Build/iOS/DatadogObjc.framework" ] && echo "DatadogObjc.framework - OK" || { echo "DatadogObjc.framework - missing"; false; }
+		@[ -e "Carthage/Build/iOS/OpenTracing.framework" ] && echo "OpenTracing.framework - OK" || { echo "OpenTracing.framework - missing"; false; }
 		@echo "🧪 SUCCEEDED"

--- a/dependency-manager-tests/carthage/Makefile
+++ b/dependency-manager-tests/carthage/Makefile
@@ -4,9 +4,25 @@ else
 		GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 endif
 
+EXPECTED_FRAMEWORKS := \
+	Carthage/Build/iOS/Datadog.framework \
+	Carthage/Build/iOS/DatadogObjc.framework \
+	Carthage/Build/iOS/OpenTracing.framework
+
+FRAMEWORKS_MISSING := $(shell $(foreach framework,$(EXPECTED_FRAMEWORKS),test -e "$(framework)" || echo "$(framework)";))
+
 test:
 		@echo "⚙️  Testing Carthage for remote branch: '${GIT_BRANCH}'..."
 		@sed "s|REMOTE_GIT_BRANCH|${GIT_BRANCH}|g" Cartfile.src > Cartfile
-		rm -rf Carthage/
+		@rm -rf Carthage/
+
+		@echo "🧪 Run 'carthage update'"
 		carthage update
-		@echo "OK 👌"
+
+		@echo "🧪 Check if expected frameworks exist"
+ifneq ($(FRAMEWORKS_MISSING),)
+	@echo "🔥 Frameworks missing: $(FRAMEWORKS_MISSING)"
+	@echo "🧪 FAILED"
+	@false
+endif
+		@echo "🧪 SUCCEEDED"

--- a/examples/iOS-app-example-cocoapods/Podfile
+++ b/examples/iOS-app-example-cocoapods/Podfile
@@ -2,5 +2,7 @@ platform :ios, '12.0'
 
 target 'iOS-app-example-cocoapods' do
   use_frameworks!
+  # Here we need to point to our fork as up-to-date `opentracing/opentracing-swift`'s podspec is not pushed to pod trunk
+  pod 'OpenTracingSwift', :git => 'https://github.com/DataDog/opentracing-swift'
   pod 'Datadog', path: '../..'
 end


### PR DESCRIPTION
### What and why?

📦 This PR introduces a foundation for implementing OT Tracer for Datadog.

Following [Open Tracing Specification](https://github.com/opentracing/specification/blob/master/specification.md), it addresses following behaviours:
* `Tracer`: Start a new `Span`;
* `Span`: Overwrite the operation name;
* `Span`: Finish the `Span`;
* `NoopTracer` no-op implementation of `OpenTracing.Tracer`.

### How?

1/ Carthage support was added to [our fork](https://github.com/DataDog/opentracing-swift) of [`opentracing-swift`](https://github.com/opentracing/opentracing-swift).
2/ `OpenTracing.framework` was linked to both `Datadog` and `DatadogTests`.
3/ `DDTracer`, `DDSpan` and few other OT types were implemented.

When implementing `DDTracer`, I followed similar architecture to what we use for `Logger`, so:
* `DDTracer` produces `DDSpan` which is written to `tracer.spanOutput`(`SpanFileOutput`).
* Later we might add console output for debugging 🚀 (as we do for `Logger`).

### 💡 Linking 3rd party dependency to `DatadogTests`

As I struggled a bit on linking `OpenTracing.framework` to `DatadogTests`, I leave this instruction for future reference:

**Linking to `Datadog` target**
1/ Drag `X.framework` from `Carthage/Build/iOS` and drop on `Datadog` > General > Frameworks and Libraries.
2/ Point `Datadog` > Build Setting > Framework Search Paths to `Carthage/Build/iOS`.
3/ Verify that `X.framework` is present in both `Datadog` > Build Phases > "Link Binary With Libraries" and "Embed Frameworks" phases

**Linking to `DatadogTests` target**
1/ Point `DatadogTests` > Build Setting > Framework Search Paths to `Carthage/Build/iOS`.
2/ Add `X.framework` to `DatadogTests` > Build Phases > "Link Binary With Libraries".
3/ Add "Copy Files" build phase to `DatadogTests` and set it to copy `X.framework` to `Frameworks` destination.

When doing above steps, limit number of drag & drops from `Carthage/Build/iOS` folder and always prefer `+` button in Xcode UI. After all, verify that `X.framework` is not duplicated anywhere in project navigator (there should be only one reference).

### ~~⚠️ CI note~~

~~This PR is targeting `tracing` branch and it is not possible to make its build green without first delivering `RUMM-283` ticket to store CI configuration in the repo. As `tracing` is a development branch for now, I'd suggest to merge this PR even if it's red, and then do "`RUMM-344` Fix CI builds for `tracing` branch" after `RUMM-283`.~~

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
