### PR TITLE
RUMM-283 Use `bitrise.yml` from repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
-all: dependencies xcodeproj-httpservermock templates examples benchmark
-.PHONY : examples
+all: tools dependencies xcodeproj-httpservermock templates examples benchmark
+.PHONY : examples tools
 
-dependencies:
-		@echo "⚙️  Validating dependencies..."
+tools:
+		@echo "⚙️  Installing tools..."
 		@brew list swiftlint &>/dev/null || brew install swiftlint
 		@echo "OK 👌"
+
+dependencies:
+ifneq ("$(wildcard ./Cartfile)","")
+		@echo "⚙️  Cartfile found, bootstrapping..."
+		@carthage bootstrap --platform iOS
+else
+		@echo "⚙️  Cartfile not found, ignoring."
+		@echo "OK 👌"	
+endif
 
 xcodeproj-httpservermock:
 		@echo "⚙️  Generating 'HTTPServerMock.xcodeproj'..."

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -16,6 +16,7 @@ workflows:
     - run_benchmarks
     - check_dependency_managers
     - check_example_projects
+    - _deploy_artifacts
 
   _make_dependencies:
     description: |-
@@ -28,6 +29,12 @@ workflows:
             #!/usr/bin/env bash
             set -e
             make dependencies
+
+  _deploy_artifacts:
+    description: |-
+        Uploads artifacts to associate them with build log on Bitrise.io.
+    steps:
+    - deploy-to-bitrise-io: {}
 
   run_linter:
     description: |-
@@ -71,7 +78,6 @@ workflows:
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog/Datadog.xcodeproj
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests.html"
-    - deploy-to-bitrise-io: {}
     - script@1.1.6:
         title: Generate HTTPServerMock.xcodeproj
         inputs:
@@ -85,7 +91,6 @@ workflows:
         - scheme: HTTPServerMock-Package
         - destination: platform=OS X,arch=x86_64
         - project_path: instrumented-tests/http-server-mock/HTTPServerMock.xcodeproj
-    #- deploy-to-bitrise-io: # deploying test artifact from `xcode-test-mac` is not yet supported
 
   run_integration_tests:
     description: |-
@@ -99,7 +104,6 @@ workflows:
         - is_clean_build: 'yes'
         - project_path: instrumented-tests/Integration/Integration.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Integration-tests.html"
-    - deploy-to-bitrise-io: {}
 
   run_benchmarks:
     description: |-
@@ -123,7 +127,6 @@ workflows:
         - is_clean_build: 'yes'
         - project_path: instrumented-tests/Benchmark/Benchmark.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Benchmarks-result.html"
-    - deploy-to-bitrise-io: {}
 
   check_dependency_managers:
     description: |-
@@ -170,7 +173,6 @@ workflows:
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/examples/iOS-app-example-cocoapods/iOS-app-example-cocoapods.xcworkspace"
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Cocoapods-example-ui-tests.html"
-    - deploy-to-bitrise-io: {}
     - xcode-test:
         title: Run SPM's example UITests
         inputs:
@@ -179,4 +181,3 @@ workflows:
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/examples/iOS-app-example-spm/iOS-app-example-spm.xcodeproj"
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPM-example-ui-tests.html"
-    - deploy-to-bitrise-io: {}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,0 +1,182 @@
+---
+format_version: '8'
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+project_type: other
+
+# To customize how workflows are run on different triggers,
+# go to Workflow Editor on Bitrise.io.
+
+workflows:
+  push_to_any_branch:
+    after_run:
+    - _make_dependencies
+    - run_linter
+    - run_unit_tests
+    - run_integration_tests
+    - run_benchmarks
+    - check_dependency_managers
+    - check_example_projects
+
+  _make_dependencies:
+    description: |-
+        Does `make dependencies` to prepare source code in repo for building and testing.
+    steps:
+    - script@1.1.6:
+        title: Do `make dependencies`.
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make dependencies
+
+  run_linter:
+    description: |-
+        Runs swiftlint and license check for all source and test files.
+    steps:
+    - swiftlint@0.4.2:
+        title: Lint Sources/*
+        inputs:
+        - strict: 'yes'
+        - lint_config_file: "$BITRISE_SOURCE_DIR/tools/lint/sources.swiftlint.yml"
+        - linting_path: "$BITRISE_SOURCE_DIR"
+        - reporter: emoji
+    - swiftlint@0.4.2:
+        title: Lint Tests/*
+        is_always_run: true
+        inputs:
+        - strict: 'yes'
+        - linting_path: "$BITRISE_SOURCE_DIR"
+        - lint_config_file: "$BITRISE_SOURCE_DIR/tools/lint/tests.swiftlint.yml"
+        - reporter: emoji
+    - script@1.1.6:
+        title: Check license headers
+        is_always_run: true
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            ./tools/license/check-license.sh
+
+  run_unit_tests:
+    description: |-
+        Runs unit tests for SDK on iOS Simulator.
+        Runs unit tests for HTTPServerMock package on macOS.
+    steps:
+    - xcode-test@2.4.5:
+        title: Run unit tests for Datadog.xcodeproj - iOS Simulator
+        inputs:
+        - scheme: Datadog
+        - simulator_device: iPhone Xs Max
+        - is_clean_build: 'yes'
+        - generate_code_coverage_files: 'yes'
+        - project_path: Datadog/Datadog.xcodeproj
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests.html"
+    - deploy-to-bitrise-io: {}
+    - script@1.1.6:
+        title: Generate HTTPServerMock.xcodeproj
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make xcodeproj-httpservermock
+    - xcode-test-mac:
+        title: Run unit tests for HTTPServerMock.xcodeproj - macOS
+        inputs:
+        - scheme: HTTPServerMock-Package
+        - destination: platform=OS X,arch=x86_64
+        - project_path: instrumented-tests/http-server-mock/HTTPServerMock.xcodeproj
+    #- deploy-to-bitrise-io: # deploying test artifact from `xcode-test-mac` is not yet supported
+
+  run_integration_tests:
+    description: |-
+        Runs integration tests from instrumented Integration.xcworkspace.
+    steps:
+    - xcode-test:
+        title: Run integration tests - Integration.xcworkspace on iOS Simulator
+        inputs:
+        - scheme: Integration
+        - simulator_device: iPhone 11
+        - is_clean_build: 'yes'
+        - project_path: instrumented-tests/Integration/Integration.xcworkspace
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Integration-tests.html"
+    - deploy-to-bitrise-io: {}
+
+  run_benchmarks:
+    description: |-
+        Runs benchmark tests from instrumented Benchmark.xcworkspace.
+        Results are ignored, because we tests are not run on a real device.
+        The aim of this workflow is to only ensure that benchmarks can be run.
+    steps:
+    - script@1.1.6:
+        title: Configure Benchmark.xcworkspace
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            make benchmark
+    - xcode-test:
+        title: Check benchmarks - Benchmark.xcworkspace on iOS Simulator
+        inputs:
+        - scheme: Benchmark
+        - simulator_device: iPhone 11
+        - is_clean_build: 'yes'
+        - project_path: instrumented-tests/Benchmark/Benchmark.xcworkspace
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Benchmarks-result.html"
+    - deploy-to-bitrise-io: {}
+
+  check_dependency_managers:
+    description: |-
+        Uses supported dependency managers to fetch, install and link the SDK
+        to test projects.
+    steps:
+    - script@1.1.6:
+        title: Test SPM compatibility
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make test-spm ci=true
+    - script@1.1.6:
+        title: Test Carthage compatibility
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make test-carthage ci=true
+
+  check_example_projects:
+    description: |-
+        Links SDK to example projects using supported dependency
+        managers (SPM and Cocoapods). With UITests it checks if example apps start with
+        no dylib error.
+    steps:
+    - cocoapods-install:
+        inputs:
+        - is_cache_disabled: 'true'
+        - source_root_path: "$BITRISE_SOURCE_DIR/examples/iOS-app-example-cocoapods"
+    - script@1.1.6:
+        title: Generate fake Client Token
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make examples
+    - xcode-test:
+        title: Run CP's example UITests
+        inputs:
+        - scheme: iOS-app-example-cocoapods
+        - is_clean_build: 'yes'
+        - cache_level: none
+        - project_path: "$BITRISE_SOURCE_DIR/examples/iOS-app-example-cocoapods/iOS-app-example-cocoapods.xcworkspace"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Cocoapods-example-ui-tests.html"
+    - deploy-to-bitrise-io: {}
+    - xcode-test:
+        title: Run SPM's example UITests
+        inputs:
+        - scheme: iOS-app-example-spm
+        - is_clean_build: 'yes'
+        - cache_level: none
+        - project_path: "$BITRISE_SOURCE_DIR/examples/iOS-app-example-spm/iOS-app-example-spm.xcodeproj"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPM-example-ui-tests.html"
+    - deploy-to-bitrise-io: {}


### PR DESCRIPTION
### What and why?

🚚 This PR updates CI configuration to read our workflows from repository. This enables version control for CI setup and allows modeling branch-specific pipelines.

### How?

Following [this article from Bitrise](https://devcenter.bitrise.io/tips-and-tricks/use-bitrise-yml-from-repository/), CI was configured to execute `bitrise run push_to_any_branch` in repository. This launches set of workflows defined in `bitrise.yml`.

It's also possible to test workflows locally, by installing [Bitrise CLI](https://devcenter.bitrise.io/bitrise-cli/index/):
```bash
$ bitrise run <workflow-id>
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
