### PR TITLE
Fixing layout for import in public doc

### DIFF
--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -74,7 +74,7 @@ Datadog.initialize(
     {{% /tab %}}
     {{< /tabs >}}
 
-     When writing your application, you can enable development logs. All internal messages in the library with a priority equal to  or higher than the provided level are then logged to console logs.
+     When writing your application, you can enable development logs. All internal messages in the library with a priority equal to or higher than the provided level are then logged to console logs.
 
     ```swift
     Datadog.verbosityLevel = .debug

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -74,7 +74,7 @@ Datadog.initialize(
     {{% /tab %}}
     {{< /tabs >}}
 
-     When writing your application, you can enable development logs. All internal messages in the library with a priority equal to   or higher than the provided level are then logged to console logs.
+     When writing your application, you can enable development logs. All internal messages in the library with a priority equal to  or higher than the provided level are then logged to console logs.
 
     ```swift
     Datadog.verbosityLevel = .debug
@@ -189,4 +189,3 @@ logger.removeAttribute("device-model")
 [3]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
 [4]: https://docs.datadoghq.com/logs/processing/attributes_naming_convention/
 [5]: https://docs.datadoghq.com/tagging/
-

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -70,11 +70,11 @@ Datadog.initialize(
     {{% /tab %}}
     {{< /tabs >}}
 
-When writing your application, you can enable development logs. All internal messages in the library with a priority equal to or higher than the provided level are then logged to console logs.
+     When writing your application, you can enable development logs. All internal messages in the library with a priority equal to   or higher than the provided level are then logged to console logs.
 
-```swift
+    ```swift
     Datadog.verbosityLevel = .debug
-```
+    ```
 
 3. Configure the iOS Logger:
 

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -21,6 +21,8 @@ You can use [CocoaPods][6] to install `dd-sdk-ios`:
 pod 'DatadogSDK'
 ```
 
+[6]: https://cocoapods.org/
+
     {{% /tab %}}
     {{% tab "Swift Package Manager (SPM)" %}}
 
@@ -36,6 +38,8 @@ You can use [Carthage][7] to install `dd-sdk-ios`:
 ```
 github "DataDog/dd-sdk-ios"
 ```
+
+[7]: https://github.com/Carthage/Carthage
 
     {{% /tab %}}
     {{< /tabs >}}
@@ -185,5 +189,4 @@ logger.removeAttribute("device-model")
 [3]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
 [4]: https://docs.datadoghq.com/logs/processing/attributes_naming_convention/
 [5]: https://docs.datadoghq.com/tagging/
-[6]: https://cocoapods.org/
-[7]: https://github.com/Carthage/Carthage
+


### PR DESCRIPTION
### What and why?

Fixes layout of doc for the public doc: https://github.com/DataDog/documentation/pull/7044