### PR TITLE
RUMM-346 Add Cocoa Pods dependency manager test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,7 @@ test-spm:
 # Tests if current branch ships a valid Carthage project.
 test-carthage:
 		@cd dependency-manager-tests/carthage && $(MAKE)
+
+# Tests if current branch ships a valid Cocoapods project.
+test-cocoapods:
+		@cd dependency-manager-tests/cocoapods && $(MAKE)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,7 +15,10 @@ workflows:
     - run_integration_tests
     - run_benchmarks
     - check_dependency_managers
-    - check_example_projects
+    # I disable it for now, as this would require supporting local pod installation
+    # of `DatadogSDK.podspec` in CP example project. This effort will be lost as in `RUMM-334`
+    # we're going to re-do sample apps layout and not use local pod anymore.
+    # - check_example_projects
     - _deploy_artifacts
 
   _make_dependencies:
@@ -140,6 +143,14 @@ workflows:
             #!/usr/bin/env bash
             set -e
             make test-spm ci=true
+    - xcode-test:
+        title: Run SPMProject UITests
+        inputs:
+        - scheme: SPMProject
+        - is_clean_build: 'yes'
+        - cache_level: none
+        - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/spm/SPMProject.xcodeproj"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPMProject-ui-tests.html"
     - script@1.1.6:
         title: Test Carthage compatibility
         inputs:
@@ -147,6 +158,22 @@ workflows:
             #!/usr/bin/env bash
             set -e
             make test-carthage ci=true
+    # TODO: RUMM-334 add UITests for Carthage project
+    - script@1.1.6:
+        title: Test Cocoapods compatibility
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make test-cocoapods ci=true
+    - xcode-test:
+        title: Run CPProject UITests
+        inputs:
+        - scheme: CPProject
+        - is_clean_build: 'yes'
+        - cache_level: none
+        - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/cocoapods/CPProject.xcworkspace"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CPProject-ui-tests.html"
 
   check_example_projects:
     description: |-

--- a/dependency-manager-tests/cocoapods/.gitignore
+++ b/dependency-manager-tests/cocoapods/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+/Pods
+
+# Ignore `Podfile.lock` and `Podfile` as they will be re-created for every test run.
+Podfile.lock
+Podfile

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
@@ -1,0 +1,533 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		61C363932436318E00C4D4E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363922436318E00C4D4E6 /* AppDelegate.swift */; };
+		61C363952436318E00C4D4E6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363942436318E00C4D4E6 /* SceneDelegate.swift */; };
+		61C363972436318E00C4D4E6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363962436318E00C4D4E6 /* ViewController.swift */; };
+		61C3639A2436318E00C4D4E6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61C363982436318E00C4D4E6 /* Main.storyboard */; };
+		61C3639F2436319000C4D4E6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61C3639D2436319000C4D4E6 /* LaunchScreen.storyboard */; };
+		61C363AA2436319000C4D4E6 /* CPProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363A92436319000C4D4E6 /* CPProjectUITests.swift */; };
+		BFBE2FE9FE6CA40F0A6B154A /* Pods_CPProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A18949628C7A45A21789F71F /* Pods_CPProject.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		61C363A62436319000C4D4E6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61C363872436318E00C4D4E6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 61C3638E2436318E00C4D4E6;
+			remoteInfo = CPProject;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		5AD49F84C2EA2EE5CB99586F /* Pods-CPProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject.debug.xcconfig"; path = "Target Support Files/Pods-CPProject/Pods-CPProject.debug.xcconfig"; sourceTree = "<group>"; };
+		61C3638F2436318E00C4D4E6 /* CPProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CPProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		61C363922436318E00C4D4E6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		61C363942436318E00C4D4E6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		61C363962436318E00C4D4E6 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		61C363992436318E00C4D4E6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		61C3639E2436319000C4D4E6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		61C363A02436319000C4D4E6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		61C363A52436319000C4D4E6 /* CPProjectUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CPProjectUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		61C363A92436319000C4D4E6 /* CPProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CPProjectUITests.swift; sourceTree = "<group>"; };
+		61C363AB2436319000C4D4E6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A18949628C7A45A21789F71F /* Pods_CPProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7DE97263B77DC87F0FC27F0 /* Pods-CPProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject.release.xcconfig"; path = "Target Support Files/Pods-CPProject/Pods-CPProject.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		61C3638C2436318E00C4D4E6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BFBE2FE9FE6CA40F0A6B154A /* Pods_CPProject.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61C363A22436319000C4D4E6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0157255130C038561709B7CF /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				5AD49F84C2EA2EE5CB99586F /* Pods-CPProject.debug.xcconfig */,
+				C7DE97263B77DC87F0FC27F0 /* Pods-CPProject.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		61C363862436318E00C4D4E6 = {
+			isa = PBXGroup;
+			children = (
+				61C363912436318E00C4D4E6 /* CPProject */,
+				61C363A82436319000C4D4E6 /* CPProjectUITests */,
+				61C363902436318E00C4D4E6 /* Products */,
+				0157255130C038561709B7CF /* Pods */,
+				A0508E6A3FA3F45E84391D24 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		61C363902436318E00C4D4E6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				61C3638F2436318E00C4D4E6 /* CPProject.app */,
+				61C363A52436319000C4D4E6 /* CPProjectUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		61C363912436318E00C4D4E6 /* CPProject */ = {
+			isa = PBXGroup;
+			children = (
+				61C363922436318E00C4D4E6 /* AppDelegate.swift */,
+				61C363942436318E00C4D4E6 /* SceneDelegate.swift */,
+				61C363962436318E00C4D4E6 /* ViewController.swift */,
+				61C363982436318E00C4D4E6 /* Main.storyboard */,
+				61C3639D2436319000C4D4E6 /* LaunchScreen.storyboard */,
+				61C363A02436319000C4D4E6 /* Info.plist */,
+			);
+			path = CPProject;
+			sourceTree = "<group>";
+		};
+		61C363A82436319000C4D4E6 /* CPProjectUITests */ = {
+			isa = PBXGroup;
+			children = (
+				61C363A92436319000C4D4E6 /* CPProjectUITests.swift */,
+				61C363AB2436319000C4D4E6 /* Info.plist */,
+			);
+			path = CPProjectUITests;
+			sourceTree = "<group>";
+		};
+		A0508E6A3FA3F45E84391D24 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A18949628C7A45A21789F71F /* Pods_CPProject.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		61C3638E2436318E00C4D4E6 /* CPProject */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 61C363AE2436319000C4D4E6 /* Build configuration list for PBXNativeTarget "CPProject" */;
+			buildPhases = (
+				B5E3E8D262C8003866F38F23 /* [CP] Check Pods Manifest.lock */,
+				61C3638B2436318E00C4D4E6 /* Sources */,
+				61C3638C2436318E00C4D4E6 /* Frameworks */,
+				61C3638D2436318E00C4D4E6 /* Resources */,
+				E9D5FEEB347D68D026118CC9 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CPProject;
+			productName = CPProject;
+			productReference = 61C3638F2436318E00C4D4E6 /* CPProject.app */;
+			productType = "com.apple.product-type.application";
+		};
+		61C363A42436319000C4D4E6 /* CPProjectUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 61C363B12436319000C4D4E6 /* Build configuration list for PBXNativeTarget "CPProjectUITests" */;
+			buildPhases = (
+				61C363A12436319000C4D4E6 /* Sources */,
+				61C363A22436319000C4D4E6 /* Frameworks */,
+				61C363A32436319000C4D4E6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				61C363A72436319000C4D4E6 /* PBXTargetDependency */,
+			);
+			name = CPProjectUITests;
+			productName = CPProjectUITests;
+			productReference = 61C363A52436319000C4D4E6 /* CPProjectUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		61C363872436318E00C4D4E6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1140;
+				LastUpgradeCheck = 1140;
+				ORGANIZATIONNAME = Datadog;
+				TargetAttributes = {
+					61C3638E2436318E00C4D4E6 = {
+						CreatedOnToolsVersion = 11.4;
+					};
+					61C363A42436319000C4D4E6 = {
+						CreatedOnToolsVersion = 11.4;
+						TestTargetID = 61C3638E2436318E00C4D4E6;
+					};
+				};
+			};
+			buildConfigurationList = 61C3638A2436318E00C4D4E6 /* Build configuration list for PBXProject "CPProject" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 61C363862436318E00C4D4E6;
+			productRefGroup = 61C363902436318E00C4D4E6 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				61C3638E2436318E00C4D4E6 /* CPProject */,
+				61C363A42436319000C4D4E6 /* CPProjectUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		61C3638D2436318E00C4D4E6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61C3639F2436319000C4D4E6 /* LaunchScreen.storyboard in Resources */,
+				61C3639A2436318E00C4D4E6 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61C363A32436319000C4D4E6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		B5E3E8D262C8003866F38F23 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-CPProject-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E9D5FEEB347D68D026118CC9 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CPProject/Pods-CPProject-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CPProject/Pods-CPProject-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CPProject/Pods-CPProject-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		61C3638B2436318E00C4D4E6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61C363972436318E00C4D4E6 /* ViewController.swift in Sources */,
+				61C363932436318E00C4D4E6 /* AppDelegate.swift in Sources */,
+				61C363952436318E00C4D4E6 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61C363A12436319000C4D4E6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61C363AA2436319000C4D4E6 /* CPProjectUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		61C363A72436319000C4D4E6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 61C3638E2436318E00C4D4E6 /* CPProject */;
+			targetProxy = 61C363A62436319000C4D4E6 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		61C363982436318E00C4D4E6 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				61C363992436318E00C4D4E6 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		61C3639D2436319000C4D4E6 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				61C3639E2436319000C4D4E6 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		61C363AC2436319000C4D4E6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		61C363AD2436319000C4D4E6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		61C363AF2436319000C4D4E6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5AD49F84C2EA2EE5CB99586F /* Pods-CPProject.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = CPProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProject;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		61C363B02436319000C4D4E6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C7DE97263B77DC87F0FC27F0 /* Pods-CPProject.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = CPProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProject;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		61C363B22436319000C4D4E6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = CPProjectUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProjectUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = CPProject;
+			};
+			name = Debug;
+		};
+		61C363B32436319000C4D4E6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = CPProjectUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProjectUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = CPProject;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		61C3638A2436318E00C4D4E6 /* Build configuration list for PBXProject "CPProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				61C363AC2436319000C4D4E6 /* Debug */,
+				61C363AD2436319000C4D4E6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		61C363AE2436319000C4D4E6 /* Build configuration list for PBXNativeTarget "CPProject" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				61C363AF2436319000C4D4E6 /* Debug */,
+				61C363B02436319000C4D4E6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		61C363B12436319000C4D4E6 /* Build configuration list for PBXNativeTarget "CPProjectUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				61C363B22436319000C4D4E6 /* Debug */,
+				61C363B32436319000C4D4E6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 61C363872436318E00C4D4E6 /* Project object */;
+}

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:CPProject.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/xcshareddata/xcschemes/CPProject.xcscheme
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/xcshareddata/xcschemes/CPProject.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "61C3638E2436318E00C4D4E6"
+               BuildableName = "CPProject.app"
+               BlueprintName = "CPProject"
+               ReferencedContainer = "container:CPProject.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "61C363A42436319000C4D4E6"
+               BuildableName = "CPProjectUITests.xctest"
+               BlueprintName = "CPProjectUITests"
+               ReferencedContainer = "container:CPProject.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61C3638E2436318E00C4D4E6"
+            BuildableName = "CPProject.app"
+            BlueprintName = "CPProject"
+            ReferencedContainer = "container:CPProject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61C3638E2436318E00C4D4E6"
+            BuildableName = "CPProject.app"
+            BlueprintName = "CPProject"
+            ReferencedContainer = "container:CPProject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/dependency-manager-tests/cocoapods/CPProject.xcworkspace/contents.xcworkspacedata
+++ b/dependency-manager-tests/cocoapods/CPProject.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:CPProject.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/dependency-manager-tests/cocoapods/CPProject.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/dependency-manager-tests/cocoapods/CPProject.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/dependency-manager-tests/cocoapods/CPProject/AppDelegate.swift
+++ b/dependency-manager-tests/cocoapods/CPProject/AppDelegate.swift
@@ -1,0 +1,23 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    }
+}

--- a/dependency-manager-tests/cocoapods/CPProject/Base.lproj/LaunchScreen.storyboard
+++ b/dependency-manager-tests/cocoapods/CPProject/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/dependency-manager-tests/cocoapods/CPProject/Base.lproj/Main.storyboard
+++ b/dependency-manager-tests/cocoapods/CPProject/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/dependency-manager-tests/cocoapods/CPProject/Info.plist
+++ b/dependency-manager-tests/cocoapods/CPProject/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/dependency-manager-tests/cocoapods/CPProject/SceneDelegate.swift
+++ b/dependency-manager-tests/cocoapods/CPProject/SceneDelegate.swift
@@ -1,0 +1,30 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+    }
+}

--- a/dependency-manager-tests/cocoapods/CPProject/ViewController.swift
+++ b/dependency-manager-tests/cocoapods/CPProject/ViewController.swift
@@ -1,0 +1,24 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import UIKit
+import Datadog
+
+class ViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        Datadog.initialize(
+            appContext: .init(),
+            configuration: Datadog.Configuration
+                .builderUsing(clientToken: "abc")
+                .build()
+        )
+
+        let logger = Logger.builder.build()
+        logger.info("It works")
+    }
+}

--- a/dependency-manager-tests/cocoapods/CPProjectUITests/CPProjectUITests.swift
+++ b/dependency-manager-tests/cocoapods/CPProjectUITests/CPProjectUITests.swift
@@ -1,0 +1,20 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import XCTest
+
+class CPProjectUITests: XCTestCase {
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func testExample() throws {
+        let app = XCUIApplication()
+        app.launch()
+    }
+}

--- a/dependency-manager-tests/cocoapods/CPProjectUITests/Info.plist
+++ b/dependency-manager-tests/cocoapods/CPProjectUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/dependency-manager-tests/cocoapods/Makefile
+++ b/dependency-manager-tests/cocoapods/Makefile
@@ -1,0 +1,13 @@
+ifdef ci
+		GIT_BRANCH := ${BITRISE_GIT_BRANCH}
+else
+		GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+endif
+
+test:
+		@echo "⚙️  Testing Cocoapods for remote branch: '${GIT_BRANCH}'..."
+		@sed "s|REMOTE_GIT_BRANCH|${GIT_BRANCH}|g" Podfile.src > Podfile
+		rm -rf Pods/
+		rm -rf Podfile.lock
+		pod update
+		@echo "OK 👌"

--- a/dependency-manager-tests/cocoapods/Podfile.src
+++ b/dependency-manager-tests/cocoapods/Podfile.src
@@ -1,0 +1,6 @@
+platform :ios, '12.0'
+
+target 'CPProject' do
+  use_frameworks!
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :branch => 'REMOTE_GIT_BRANCH'
+end

--- a/dependency-manager-tests/spm/Makefile
+++ b/dependency-manager-tests/spm/Makefile
@@ -7,8 +7,4 @@ endif
 test:
 		@echo "⚙️  Testing SPM for remote branch: '${GIT_BRANCH}'..."
 		@sed -i "" "s|branch = *.;|branch = ${GIT_BRANCH};|g" SPMProject.xcodeproj/project.pbxproj
-		@xcodebuild -project SPMProject.xcodeproj \
-			-scheme "SPMProjectUITests" \
-        	   	-destination 'platform=iOS Simulator,name=iPhone 11' \
-        	   	test
 		@echo "OK 👌"


### PR DESCRIPTION
### What and why?

📦 This PR adds Cocoa Pods installation test.

### How?

`make test-cocoapods` sources `Podfile.src` by injecting current git branch name, then `pod update` is called. After this, Bitrise runs UITests for this `CPProject.xcworkspace`.

I also update `SPMProject` to run UITests from `bitrise.yml` instead of `xcodebuild` in `Makefile`. This has few benefits:
- cleaner build log on Bitrise thanks to `xcpretty`;
- `SPMProject-ui-test` artifact is exported on Bitrise;
- build-related logic is centralized in single place (`bitrise.yml`).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
