### PR TITLE
RUMM-346 DatadogPrivate module is hidden from public

### DIFF
--- a/Datadog.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Datadog.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Datadog/DatadogPrivate/module.modulemap
+++ b/Datadog/DatadogPrivate/module.modulemap
@@ -1,14 +1,1 @@
-/*
- Module Map Language reference: https://clang.llvm.org/docs/Modules.html#module-map-language
- */
-module _Datadog_Private {
-    /*
-     Each header exported from here must be also exposed to each dependency manager separately:
-     - For Carthage, add it to "Datadog > Build Phases > Headers > Project".
-     - For SPM, import it from `include/SPMHeaders.h`.
-     - Cocoapods `.podspec` is already configured to read this `module.modulemap`.
-     */
 
-    header "ObjcExceptionHandler.h"
-    export *
-}

--- a/Datadog/DatadogPrivate/module.private.modulemap
+++ b/Datadog/DatadogPrivate/module.private.modulemap
@@ -1,0 +1,14 @@
+/*
+ Module Map Language reference: https://clang.llvm.org/docs/Modules.html#module-map-language
+ */
+module _Datadog_Private {
+    /*
+     Each header exported from here must be also exposed to each dependency manager separately:
+     - For Carthage, add it to "Datadog > Build Phases > Headers > Project".
+     - For SPM, import it from `include/SPMHeaders.h`.
+     - Cocoapods `.podspec` is already configured to read this `module.modulemap`.
+     */
+
+    header "ObjcExceptionHandler.h"
+    export *
+}

--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -18,10 +18,8 @@ Pod::Spec.new do |s|
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
   
-  s.source_files = "Sources/Datadog/**/*.swift", "Datadog/DatadogPrivate/*.{h,m}"
-  s.public_header_files = "Datadog/TargetSupport/**/*.h"
-  s.private_header_files = "Datadog/DatadogPrivate/*.h"
-  s.preserve_paths = "Datadog/DatadogPrivate/module.modulemap"
+  s.source_files = "Sources/Datadog/**/*.swift", "Datadog/DatadogPrivate/*.m"
+  s.preserve_paths = "Datadog/DatadogPrivate/*.{modulemap,h}"
   s.pod_target_xcconfig = { 
     "SWIFT_INCLUDE_PATHS" => "$(PODS_ROOT)/DatadogSDK/Datadog/DatadogPrivate/** $(PODS_TARGET_SRCROOT)/DatadogSDK/Datadog/DatadogPrivate/**"
   }


### PR DESCRIPTION
### What and why?

DDPrivate module is created to use ObjC from Swift

### How?

It is not intended for public use
We used private.modulemap to hide it from public

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
