### PR TITLE
RUMM-294 Implement "Inject a `SpanContext` into a carrier" part of OT interface

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "DataDog/opentracing-swift" "0aa614e30b3cc01f7b26200480fe9b2d08945189"
+github "DataDog/opentracing-swift" "bdd65d768aa41a58a78e00d3401cacc352dfc406"

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -87,13 +87,6 @@
 		61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C472423990D00786299 /* DatadogExtensions.swift */; };
 		61133C702423993200786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61133C712423993200786299 /* Datadog.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		616A62D024349BA700D1BE12 /* ObjcExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 616A626924335D4900D1BE12 /* ObjcExceptionHandler.m */; };
-		616A62D62434A3C500D1BE12 /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 616A626A24335D4900D1BE12 /* ObjcExceptionHandler.h */; };
-		61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */; };
-		61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */; };
-		61C3638524361E9200C4D4E6 /* Globals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638424361E9200C4D4E6 /* Globals.swift */; };
-		61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3646F243B5C8300C4D4E6 /* ServerMock.swift */; };
-		9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E085879242519FF001A3583 /* NetworkPathMonitor.swift */; };
 		61140995242CBED700316215 /* OpenTracing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; };
 		61140996242CBED700316215 /* OpenTracing.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61140998242CBF4A00316215 /* OpenTracing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61140994242CBED700316215 /* OpenTracing.framework */; };
@@ -108,8 +101,19 @@
 		611409AF242CCE1E00316215 /* DDSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409AE242CCE1E00316215 /* DDSpanTests.swift */; };
 		611409B2242CEFB400316215 /* SpanOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B1242CEFB400316215 /* SpanOutput.swift */; };
 		611409B4242CF03300316215 /* SpanFileOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B3242CF03300316215 /* SpanFileOutput.swift */; };
-		611409B6242CF44500316215 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B5242CF44500316215 /* Utils.swift */; };
 		611409B8242D098700316215 /* SpansMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611409B7242D098700316215 /* SpansMocks.swift */; };
+		616007DA243F38B0009C2338 /* HTTPHeadersWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616007D9243F38B0009C2338 /* HTTPHeadersWriter.swift */; };
+		616007DC243F3FC1009C2338 /* Warnings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616007DB243F3FC1009C2338 /* Warnings.swift */; };
+		616007DF243F5029009C2338 /* WarningsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616007DE243F5029009C2338 /* WarningsTests.swift */; };
+		616007E1243F517B009C2338 /* Casting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616007E0243F517B009C2338 /* Casting.swift */; };
+		616007E5243F5AAF009C2338 /* UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616007E4243F5AAF009C2338 /* UUID.swift */; };
+		616A62D024349BA700D1BE12 /* ObjcExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 616A626924335D4900D1BE12 /* ObjcExceptionHandler.m */; };
+		616A62D62434A3C500D1BE12 /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 616A626A24335D4900D1BE12 /* ObjcExceptionHandler.h */; };
+		61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */; };
+		61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */; };
+		61C3638524361E9200C4D4E6 /* Globals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638424361E9200C4D4E6 /* Globals.swift */; };
+		61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3646F243B5C8300C4D4E6 /* ServerMock.swift */; };
+		9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E085879242519FF001A3583 /* NetworkPathMonitor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -255,16 +259,6 @@
 		61133C452423990D00786299 /* SwiftExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExtensions.swift; sourceTree = "<group>"; };
 		61133C462423990D00786299 /* TestsDirectory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestsDirectory.swift; sourceTree = "<group>"; };
 		61133C472423990D00786299 /* DatadogExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogExtensions.swift; sourceTree = "<group>"; };
-		61545C9C243DD2610017B6D5 /* module.private.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.private.modulemap; sourceTree = "<group>"; };
-		61545C9D243DD2610017B6D5 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		61545C9F243DD35C0017B6D5 /* SPMHeaders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMHeaders.h; sourceTree = "<group>"; };
-		616A626924335D4900D1BE12 /* ObjcExceptionHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcExceptionHandler.m; sourceTree = "<group>"; };
-		616A626A24335D4900D1BE12 /* ObjcExceptionHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcExceptionHandler.h; sourceTree = "<group>"; };
-		61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcExceptionHandlerTests.swift; sourceTree = "<group>"; };
-		61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogPrivateMocks.swift; sourceTree = "<group>"; };
-		61C3638424361E9200C4D4E6 /* Globals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Globals.swift; sourceTree = "<group>"; };
-		61C3646F243B5C8300C4D4E6 /* ServerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerMock.swift; sourceTree = "<group>"; };
-		9E085879242519FF001A3583 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
 		61140994242CBED700316215 /* OpenTracing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenTracing.framework; path = ../Carthage/Build/iOS/OpenTracing.framework; sourceTree = "<group>"; };
 		61140999242CC02F00316215 /* DDTracer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDTracer.swift; sourceTree = "<group>"; };
 		6114099B242CC03000316215 /* DDSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDSpan.swift; sourceTree = "<group>"; };
@@ -276,8 +270,22 @@
 		611409AE242CCE1E00316215 /* DDSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanTests.swift; sourceTree = "<group>"; };
 		611409B1242CEFB400316215 /* SpanOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanOutput.swift; sourceTree = "<group>"; };
 		611409B3242CF03300316215 /* SpanFileOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFileOutput.swift; sourceTree = "<group>"; };
-		611409B5242CF44500316215 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		611409B7242D098700316215 /* SpansMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpansMocks.swift; sourceTree = "<group>"; };
+		61545C9C243DD2610017B6D5 /* module.private.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.private.modulemap; sourceTree = "<group>"; };
+		61545C9D243DD2610017B6D5 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		61545C9F243DD35C0017B6D5 /* SPMHeaders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SPMHeaders.h; sourceTree = "<group>"; };
+		616007D9243F38B0009C2338 /* HTTPHeadersWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeadersWriter.swift; sourceTree = "<group>"; };
+		616007DB243F3FC1009C2338 /* Warnings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Warnings.swift; sourceTree = "<group>"; };
+		616007DE243F5029009C2338 /* WarningsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningsTests.swift; sourceTree = "<group>"; };
+		616007E0243F517B009C2338 /* Casting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Casting.swift; sourceTree = "<group>"; };
+		616007E4243F5AAF009C2338 /* UUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UUID.swift; sourceTree = "<group>"; };
+		616A626924335D4900D1BE12 /* ObjcExceptionHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcExceptionHandler.m; sourceTree = "<group>"; };
+		616A626A24335D4900D1BE12 /* ObjcExceptionHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcExceptionHandler.h; sourceTree = "<group>"; };
+		61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcExceptionHandlerTests.swift; sourceTree = "<group>"; };
+		61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogPrivateMocks.swift; sourceTree = "<group>"; };
+		61C3638424361E9200C4D4E6 /* Globals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Globals.swift; sourceTree = "<group>"; };
+		61C3646F243B5C8300C4D4E6 /* ServerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerMock.swift; sourceTree = "<group>"; };
+		9E085879242519FF001A3583 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -694,6 +702,47 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		6114099A242CC03000316215 /* Traces */ = {
+			isa = PBXGroup;
+			children = (
+				6114099B242CC03000316215 /* DDSpan.swift */,
+				6114099F242CC03000316215 /* DDSpanContext.swift */,
+				6114099C242CC03000316215 /* DDNoOps.swift */,
+				616007D8243F37F4009C2338 /* Propagation */,
+				611409B0242CEF8A00316215 /* SpanOutputs */,
+				6114099D242CC03000316215 /* Utils */,
+			);
+			path = Traces;
+			sourceTree = "<group>";
+		};
+		6114099D242CC03000316215 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				6114099E242CC03000316215 /* UUID.swift */,
+				616007DB243F3FC1009C2338 /* Warnings.swift */,
+				616007E0243F517B009C2338 /* Casting.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		611409AD242CCDE600316215 /* Traces */ = {
+			isa = PBXGroup;
+			children = (
+				611409AE242CCE1E00316215 /* DDSpanTests.swift */,
+				616007DD243F4FE4009C2338 /* Utils */,
+			);
+			path = Traces;
+			sourceTree = "<group>";
+		};
+		611409B0242CEF8A00316215 /* SpanOutputs */ = {
+			isa = PBXGroup;
+			children = (
+				611409B1242CEFB400316215 /* SpanOutput.swift */,
+				611409B3242CF03300316215 /* SpanFileOutput.swift */,
+			);
+			path = SpanOutputs;
+			sourceTree = "<group>";
+		};
 		61545C9A243DD2610017B6D5 /* include */ = {
 			isa = PBXGroup;
 			children = (
@@ -702,6 +751,23 @@
 				61545C9D243DD2610017B6D5 /* module.modulemap */,
 			);
 			path = include;
+			sourceTree = "<group>";
+		};
+		616007D8243F37F4009C2338 /* Propagation */ = {
+			isa = PBXGroup;
+			children = (
+				616007D9243F38B0009C2338 /* HTTPHeadersWriter.swift */,
+			);
+			path = Propagation;
+			sourceTree = "<group>";
+		};
+		616007DD243F4FE4009C2338 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				616007E4243F5AAF009C2338 /* UUID.swift */,
+				616007DE243F5029009C2338 /* WarningsTests.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		616A626824335D4900D1BE12 /* DatadogPrivate */ = {
@@ -720,44 +786,6 @@
 				61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */,
 			);
 			path = DatadogPrivate;
-			sourceTree = "<group>";
-		};
-		6114099A242CC03000316215 /* Traces */ = {
-			isa = PBXGroup;
-			children = (
-				6114099B242CC03000316215 /* DDSpan.swift */,
-				6114099F242CC03000316215 /* DDSpanContext.swift */,
-				6114099C242CC03000316215 /* DDNoOps.swift */,
-				611409B0242CEF8A00316215 /* SpanOutputs */,
-				6114099D242CC03000316215 /* Utils */,
-			);
-			path = Traces;
-			sourceTree = "<group>";
-		};
-		6114099D242CC03000316215 /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-				6114099E242CC03000316215 /* UUID.swift */,
-			);
-			path = Utils;
-			sourceTree = "<group>";
-		};
-		611409AD242CCDE600316215 /* Traces */ = {
-			isa = PBXGroup;
-			children = (
-				611409AE242CCE1E00316215 /* DDSpanTests.swift */,
-				611409B5242CF44500316215 /* Utils.swift */,
-			);
-			path = Traces;
-			sourceTree = "<group>";
-		};
-		611409B0242CEF8A00316215 /* SpanOutputs */ = {
-			isa = PBXGroup;
-			children = (
-				611409B1242CEFB400316215 /* SpanOutput.swift */,
-				611409B3242CF03300316215 /* SpanFileOutput.swift */,
-			);
-			path = SpanOutputs;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -954,6 +982,7 @@
 				61133BE02423979B00786299 /* Datadog.swift in Sources */,
 				61133BCB2423979B00786299 /* CarrierInfoProvider.swift in Sources */,
 				61133BD62423979B00786299 /* DataUploader.swift in Sources */,
+				616007DA243F38B0009C2338 /* HTTPHeadersWriter.swift in Sources */,
 				61133BE52423979B00786299 /* LogBuilder.swift in Sources */,
 				61133BD42423979B00786299 /* FileReader.swift in Sources */,
 				611409A1242CC03000316215 /* DDSpan.swift in Sources */,
@@ -963,6 +992,7 @@
 				61133BDA2423979B00786299 /* HTTPHeaders.swift in Sources */,
 				61133BE82423979B00786299 /* LogFileOutput.swift in Sources */,
 				61133BD72423979B00786299 /* DataUploadWorker.swift in Sources */,
+				616007E1243F517B009C2338 /* Casting.swift in Sources */,
 				61133BD12423979B00786299 /* FilesOrchestrator.swift in Sources */,
 				61133BE12423979B00786299 /* LogsUploadStrategy.swift in Sources */,
 				61133BCD2423979B00786299 /* NetworkConnectionInfoProvider.swift in Sources */,
@@ -974,6 +1004,7 @@
 				611409A3242CC03000316215 /* UUID.swift in Sources */,
 				61133BE22423979B00786299 /* LogsPersistenceStrategy.swift in Sources */,
 				61133BCE2423979B00786299 /* BatteryStatusProvider.swift in Sources */,
+				616007DC243F3FC1009C2338 /* Warnings.swift in Sources */,
 				61133BD52423979B00786299 /* DataUploadConditions.swift in Sources */,
 				61133BE92423979B00786299 /* LogOutput.swift in Sources */,
 				61133BD92423979B00786299 /* DataUploadDelay.swift in Sources */,
@@ -990,7 +1021,6 @@
 				611409B8242D098700316215 /* SpansMocks.swift in Sources */,
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,
 				611409A8242CC07D00316215 /* DDTracerTests.swift in Sources */,
-				61133C502423990D00786299 /* NetworkMocks.swift in Sources */,
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
 				61133C512423990D00786299 /* DatadogMocks.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
@@ -998,10 +1028,12 @@
 				61133C582423990D00786299 /* FileWriterTests.swift in Sources */,
 				611409AF242CCE1E00316215 /* DDSpanTests.swift in Sources */,
 				61133C672423990D00786299 /* LogConsoleOutputTests.swift in Sources */,
+				616007E5243F5AAF009C2338 /* UUID.swift in Sources */,
 				61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */,
 				61133C4C2423990D00786299 /* LogsMocks.swift in Sources */,
 				61133C542423990D00786299 /* NetworkConnectionInfoProviderTests.swift in Sources */,
 				61133C4A2423990D00786299 /* DDConfigurationTests.swift in Sources */,
+				616007DF243F5029009C2338 /* WarningsTests.swift in Sources */,
 				61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */,
 				61133C602423990D00786299 /* HTTPHeadersTests.swift in Sources */,
 				61133C632423990D00786299 /* DatadogConfigurationTests.swift in Sources */,
@@ -1017,7 +1049,6 @@
 				61133C592423990D00786299 /* FilesOrchestratorTests.swift in Sources */,
 				61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */,
 				61133C6C2423990D00786299 /* SwiftExtensions.swift in Sources */,
-				611409B6242CF44500316215 /* Utils.swift in Sources */,
 				61133C492423990D00786299 /* DDLoggerBuilderTests.swift in Sources */,
 				61133C4B2423990D00786299 /* DDLoggerTests.swift in Sources */,
 				61133C482423990D00786299 /* DDDatadogTests.swift in Sources */,

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -28,11 +28,11 @@ public class DDTracer: Tracer {
     }
 
     public func inject(spanContext: SpanContext, writer: FormatWriter) {
-        // TODO: RUMM-292
+        writer.inject(spanContext: spanContext)
     }
 
     public func extract(reader: FormatReader) -> SpanContext? {
-        // TODO: RUMM-292
+        // TODO: RUMM-385 - we don't need to support it now
         return nil
     }
 
@@ -43,7 +43,7 @@ public class DDTracer: Tracer {
             throw ProgrammerError(description: "`Datadog.initialize()` must be called prior to `startSpan(...)`.")
         }
 
-        let parentSpanContext = references?.compactMap { $0.context as? DDSpanContext }.last
+        let parentSpanContext = references?.compactMap { $0.context.dd }.last
         return DDSpan(
             tracer: self,
             operationName: operationName,

--- a/Sources/Datadog/Traces/DDSpan.swift
+++ b/Sources/Datadog/Traces/DDSpan.swift
@@ -33,28 +33,28 @@ internal class DDSpan: Span {
     }
 
     func setOperationName(_ operationName: String) {
-        guard warnIfFinished("setOperationName(_:)") else {
+        guard !warnIfFinished("setOperationName(_:)") else {
             return
         }
         self.operationName = operationName
     }
 
     func setTag(key: String, value: Codable) {
-        guard warnIfFinished("setTag(key:value:)") else {
+        guard !warnIfFinished("setTag(key:value:)") else {
             return
         }
         // TODO: RUMM-292
     }
 
     func setBaggageItem(key: String, value: String) {
-        guard warnIfFinished("setBaggageItem(key:value:)") else {
+        guard !warnIfFinished("setBaggageItem(key:value:)") else {
             return
         }
         // TODO: RUMM-292
     }
 
     func baggageItem(withKey key: String) -> String? {
-        guard warnIfFinished("baggageItem(withKey:)") else {
+        guard !warnIfFinished("baggageItem(withKey:)") else {
             return nil
         }
         // TODO: RUMM-292
@@ -62,7 +62,7 @@ internal class DDSpan: Span {
     }
 
     func finish(at time: Date) {
-        guard warnIfFinished("finish(at:)") else {
+        guard !warnIfFinished("finish(at:)") else {
             return
         }
         isFinished = true // TODO: RUMM-340 Consider thread safety
@@ -70,7 +70,7 @@ internal class DDSpan: Span {
     }
 
     func log(fields: [String: Codable], timestamp: Date) {
-        guard warnIfFinished("log(fields:timestamp:)") else {
+        guard !warnIfFinished("log(fields:timestamp:)") else {
             return
         }
         // TODO: RUMM-292
@@ -79,11 +79,9 @@ internal class DDSpan: Span {
     // MARK: - Private
 
     private func warnIfFinished(_ methodName: String) -> Bool {
-        if isFinished { // TODO: RUMM-340 Consider thread safety
-            userLogger.warn("🔥 Calling `\(methodName)` on a finished span (\"\(operationName)\") is not allowed.")
-            return false
-        } else {
-            return true
-        }
+        return warn(
+            if: isFinished, // TODO: RUMM-340 Consider thread safety when reading `.isFinished`
+            message: "🔥 Calling `\(methodName)` on a finished span (\"\(operationName)\") is not allowed."
+        )
     }
 }

--- a/Sources/Datadog/Traces/DDSpan.swift
+++ b/Sources/Datadog/Traces/DDSpan.swift
@@ -33,28 +33,28 @@ internal class DDSpan: Span {
     }
 
     func setOperationName(_ operationName: String) {
-        guard !warnIfFinished("setOperationName(_:)") else {
+        if warnIfFinished("setOperationName(_:)") {
             return
         }
         self.operationName = operationName
     }
 
     func setTag(key: String, value: Codable) {
-        guard !warnIfFinished("setTag(key:value:)") else {
+        if warnIfFinished("setTag(key:value:)") {
             return
         }
         // TODO: RUMM-292
     }
 
     func setBaggageItem(key: String, value: String) {
-        guard !warnIfFinished("setBaggageItem(key:value:)") else {
+        if warnIfFinished("setBaggageItem(key:value:)") {
             return
         }
         // TODO: RUMM-292
     }
 
     func baggageItem(withKey key: String) -> String? {
-        guard !warnIfFinished("baggageItem(withKey:)") else {
+        if warnIfFinished("baggageItem(withKey:)") {
             return nil
         }
         // TODO: RUMM-292
@@ -62,7 +62,7 @@ internal class DDSpan: Span {
     }
 
     func finish(at time: Date) {
-        guard !warnIfFinished("finish(at:)") else {
+        if warnIfFinished("finish(at:)") {
             return
         }
         isFinished = true // TODO: RUMM-340 Consider thread safety
@@ -70,7 +70,7 @@ internal class DDSpan: Span {
     }
 
     func log(fields: [String: Codable], timestamp: Date) {
-        guard !warnIfFinished("log(fields:timestamp:)") else {
+        if warnIfFinished("log(fields:timestamp:)") {
             return
         }
         // TODO: RUMM-292

--- a/Sources/Datadog/Traces/Propagation/HTTPHeadersWriter.swift
+++ b/Sources/Datadog/Traces/Propagation/HTTPHeadersWriter.swift
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import OpenTracing
+
+public class DDHTTPHeadersWriter: HTTPHeadersWriter {
+    private struct Constants {
+        static let traceIDField = "x-datadog-trace-id"
+        static let parentSpanIDField = "x-datadog-parent-id"
+        // TODO: RUMM-338 support `x-datadog-sampling-priority`. `dd-trace-ot` reference:
+        // https://github.com/DataDog/dd-trace-java/blob/4ba0ca0f9da748d4018310d026b1a72b607947f1/dd-trace-ot/src/main/java/datadog/opentracing/propagation/DatadogHttpCodec.java#L23
+    }
+
+    /// The `tracePropagationHTTPHeaders` will be used by customers to add additional headers to the
+    /// `URLRequest` in order to propagate the trace to Datadog-OT-instrumented backend.
+    ///
+    /// TODO: revisit in RUMM-386
+    public private(set) var tracePropagationHTTPHeaders: [String: String] = [:]
+
+    public func inject(spanContext: SpanContext) {
+        guard let spanContext = spanContext.dd else {
+            return
+        }
+
+        tracePropagationHTTPHeaders = [
+            Constants.traceIDField: String(spanContext.traceID.rawValue),
+            Constants.parentSpanIDField: String(spanContext.spanID.rawValue)
+        ]
+    }
+}

--- a/Sources/Datadog/Traces/Utils/Casting.swift
+++ b/Sources/Datadog/Traces/Utils/Casting.swift
@@ -5,14 +5,9 @@
  */
 
 import OpenTracing
-@testable import Datadog
-
-// MARK: - OT to DD casting
 
 // swiftlint:disable identifier_name
-extension OpenTracing.SpanContext {
-    var dd: DDSpanContext {
-        return self as! DDSpanContext
-    }
+internal extension OpenTracing.SpanContext {
+    var dd: DDSpanContext? { warnIfCannotCast(value: self) }
 }
 // swiftlint:enable identifier_name

--- a/Sources/Datadog/Traces/Utils/Warnings.swift
+++ b/Sources/Datadog/Traces/Utils/Warnings.swift
@@ -19,7 +19,7 @@ internal func warn(if condition: @autoclosure () -> Bool, message: String) -> Bo
 /// Returns `nil` if the warning was raised. `T` otherwise.
 internal func warnIfCannotCast<T>(value: Any) -> T? {
     guard let castedValue = value as? T else {
-        userLogger.warn("🔥 Using \(type(of: value.self)) while \(T.self) was expected.")
+        userLogger.warn("🔥 Using \(type(of: value as Any)) while \(T.self) was expected.")
         return nil
     }
     return castedValue

--- a/Sources/Datadog/Traces/Utils/Warnings.swift
+++ b/Sources/Datadog/Traces/Utils/Warnings.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Returns `true` if the warning was raised. `false` otherwise.
+internal func warn(if condition: @autoclosure () -> Bool, message: String) -> Bool {
+    if condition() { // TODO: RUMM-340 Consider thread safety
+        userLogger.warn(message)
+        return true
+    } else {
+        return false
+    }
+}
+
+/// Returns `nil` if the warning was raised. `T` otherwise.
+internal func warnIfCannotCast<T>(value: Any) -> T? {
+    guard let castedValue = value as? T else {
+        userLogger.warn("🔥 Using \(type(of: value.self)) while \(T.self) was expected.")
+        return nil
+    }
+    return castedValue
+}

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -48,8 +48,24 @@ class DDTracerTests: XCTestCase {
         span?.finish(at: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
 
         let recorded = spanOutput.recorded
-        XCTAssertEqual(recorded?.span.context.dd.traceID, parentSpan?.context.dd.traceID)
-        XCTAssertNotEqual(recorded?.span.context.dd.spanID, parentSpan?.context.dd.spanID)
+        XCTAssertEqual(recorded?.span.context.dd!.traceID, parentSpan?.context.dd!.traceID)
+        XCTAssertNotEqual(recorded?.span.context.dd!.spanID, parentSpan?.context.dd!.spanID)
+    }
+
+    func testItInjectsSpanContextIntoHTTPHeadersWriter() {
+        let tracer = DDTracer(spanOutput: SpanOutputMock())
+        let spanContext = DDSpanContext(traceID: 1, spanID: 2)
+
+        let httpHeadersWriter = DDHTTPHeadersWriter()
+        XCTAssertEqual(httpHeadersWriter.tracePropagationHTTPHeaders, [:])
+
+        tracer.inject(spanContext: spanContext, writer: httpHeadersWriter)
+
+        let expectedHTTPHeaders = [
+            "x-datadog-trace-id": "1",
+            "x-datadog-parent-id": "2",
+        ]
+        XCTAssertEqual(httpHeadersWriter.tracePropagationHTTPHeaders, expectedHTTPHeaders)
     }
 
     // MARK: - Initialization

--- a/Tests/DatadogTests/Datadog/Mocks/SpansMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SpansMocks.swift
@@ -13,6 +13,10 @@ It follows the mocking conventions described in `FoundationMocks.swift`.
  */
 
 extension DDSpan {
+    static func mockAny() -> DDSpan {
+        return mockWith()
+    }
+
     static func mockWith(
         tracer: DDTracer = .mockNoOp(),
         operationName: String = .mockAny(),

--- a/Tests/DatadogTests/Datadog/Traces/Utils/UUID.swift
+++ b/Tests/DatadogTests/Datadog/Traces/Utils/UUID.swift
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+@testable import Datadog
+
+extension TracingUUID: ExpressibleByIntegerLiteral {
+    public typealias IntegerLiteralType = UInt64
+
+    public init(integerLiteral value: UInt64) {
+        self.init(rawValue: value)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Traces/Utils/WarningsTests.swift
+++ b/Tests/DatadogTests/Datadog/Traces/Utils/WarningsTests.swift
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class WarningsTests: XCTestCase {
+    func testPrintingWarningsOnDifferentConditions() {
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
+
+        let output = LogOutputMock()
+        userLogger = Logger(logOutput: output, identifier: "sdk-user")
+
+        XCTAssertTrue(warn(if: true, message: "message"))
+        XCTAssertEqual(output.recordedLog, .init(level: .warn, message: "message"))
+
+        output.recordedLog = nil
+
+        XCTAssertFalse(warn(if: false, message: "message"))
+        XCTAssertNil(output.recordedLog)
+
+        output.recordedLog = nil
+
+        let failingCast: () -> DDSpan? = { warnIfCannotCast(value: DDNoopSpan()) }
+        XCTAssertNil(failingCast())
+        XCTAssertEqual(output.recordedLog, .init(level: .warn, message: "🔥 Using DDNoopSpan while DDSpan was expected."))
+
+        output.recordedLog = nil
+
+        let succeedingCast: () -> DDSpan? = { warnIfCannotCast(value: DDSpan.mockAny()) }
+        XCTAssertNotNil(succeedingCast())
+        XCTAssertNil(output.recordedLog)
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR implements _"Inject a `SpanContext` into a carrier"_ part of [OT specification](https://github.com/opentracing/specification/blob/master/specification.md#inject-a-spancontext-into-a-carrier).

This means enabling users to pass trace information within HTTP headers to a backend that supports Datadog instrumentation for OT.

### How?

This is what users will need to do in order to propagate trace information:
```swift
import OpenTracing
import Datadog

let request: URLRequest = ...

// ...

let traceHeaders = DDHTTPHeadersWriter()
Global.sharedTracer.inject(spanContext: span, writer: traceHeaders)
request.allHTTPHeaderFields += traceHeaders.tracePropagationHTTPHeaders

// ...

send(request)
```

After this, the HTTP request will be set with those two additional headers:
```
"x-datadog-trace-id": "1",
"x-datadog-parent-id": "2",
```
Where "1" is trace ID and "2" is the ID of the span which instruments this network request.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
