### PR TITLE
RUMM-292 Cherry pick explitic no-op `Datadog` mocks from `tracing` branch

### DIFF
--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -410,7 +410,8 @@ class LoggerTests: XCTestCase {
     // MARK: - Thread safety
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
-        Datadog.instance = .mockNeverPerformingUploads()
+        Datadog.instance = .mockNoOp()
+        defer { Datadog.instance = nil }
         let logger = Logger.builder.build()
 
         DispatchQueue.concurrentPerform(iterations: 900) { iteration in
@@ -430,7 +431,5 @@ class LoggerTests: XCTestCase {
                 break
             }
         }
-
-        Datadog.instance = nil
     }
 }

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -13,7 +13,7 @@ class InternalLoggersTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        Datadog.instance = .mockNeverPerformingUploads()
+        Datadog.instance = .mockNoOp()
         printedMessages = []
         userLogger = createSDKUserLogger(
             consolePrintFunction: { [weak self] in self?.printedMessages.append($0) },

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerBuilderTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerBuilderTests.swift
@@ -68,7 +68,8 @@ class DDLoggerBuilderTests: XCTestCase {
     }
 
     func testUsingDifferentOutputs() throws {
-        Datadog.instance = .mockNeverPerformingUploads()
+        Datadog.instance = .mockNoOp()
+        defer { Datadog.instance = nil }
 
         assertThat(
             logger: {
@@ -145,8 +146,6 @@ class DDLoggerBuilderTests: XCTestCase {
             }(),
             usesOutput: NoOpLogOutput.self
         )
-
-        try Datadog.deinitializeOrThrow()
     }
 
     // MARK: - Initialization


### PR DESCRIPTION
### What and why?

⚙️ This PR cherry-picks "no-op" mocks for `Datadog` that were created on `tracing` branch. This is to avoid conflicts between `master` and `tracing` when development continuous on both branches.

### How?

I just cherry-pick a commit from `tracing` that modifies mocks available also on `master`.

We need explicit "no-op" mock on `tracing` branch to disable logging feature entirely in unit tests for tracing.

I will rebase `tracing` branch onto `master` after this is merged.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
