### PR TITLE
RUMM-319 Fix tests flakiness

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <CodeCoverageTargets>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
@@ -27,7 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
       <CodeCoverageTargets>

--- a/Sources/Datadog/Logs/Attributes/UserInfo.swift
+++ b/Sources/Datadog/Logs/Attributes/UserInfo.swift
@@ -8,7 +8,16 @@ import Foundation
 
 /// Shared user info provider.
 internal class UserInfoProvider {
-    var value = UserInfo(id: nil, name: nil, email: nil)
+    /// Ensures thread-safe access to `UserInfo`.
+    /// `UserInfo` can be mutated by any user thread with `Datadog.setUserInfo(id:name:email:)` - at the same
+    /// time it might be accessed by different queues running in the SDK.
+    private let queue = DispatchQueue(label: "com.datadoghq.user-info-provider", qos: .userInteractive)
+    private var current = UserInfo(id: nil, name: nil, email: nil)
+
+    var value: UserInfo {
+        set { queue.async { self.current = newValue } }
+        get { queue.sync { self.current } }
+    }
 }
 
 /// Information about the user.

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -28,8 +28,8 @@ class LoggerTests: XCTestCase {
     func testSendingMinimalLogWithDefaultLogger() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
             server: server,
+            directory: temporaryDirectory,
             appContext: .mockWith(
                 bundleIdentifier: "com.datadoghq.ios-sdk",
                 bundleVersion: "1.0.0",
@@ -60,8 +60,8 @@ class LoggerTests: XCTestCase {
     func testSendingLogWithCustomizedLogger() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
-            server: server
+            server: server,
+            directory: temporaryDirectory
         )
         defer { LoggingFeature.instance = nil }
 
@@ -93,8 +93,8 @@ class LoggerTests: XCTestCase {
     func testSendingLogsWithDifferentLevels() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
-            server: server
+            server: server,
+            directory: temporaryDirectory
         )
         defer { LoggingFeature.instance = nil }
 
@@ -124,8 +124,8 @@ class LoggerTests: XCTestCase {
         )
         defer { Datadog.instance = nil }
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
             server: server,
+            directory: temporaryDirectory,
             userInfoProvider: Datadog.instance!.userInfoProvider
         )
         defer { LoggingFeature.instance = nil }
@@ -155,8 +155,8 @@ class LoggerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let carrierInfoProvider = CarrierInfoProviderMock(carrierInfo: nil)
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
             server: server,
+            directory: temporaryDirectory,
             carrierInfoProvider: carrierInfoProvider
         )
         defer { LoggingFeature.instance = nil }
@@ -166,19 +166,19 @@ class LoggerTests: XCTestCase {
             .build()
 
         // simulate entering cellular service range
-        carrierInfoProvider.current = .mockWith(
-            carrierName: "Carrier",
-            carrierISOCountryCode: "US",
-            carrierAllowsVOIP: true,
-            radioAccessTechnology: .LTE
+        carrierInfoProvider.set(
+            current: .mockWith(
+                carrierName: "Carrier",
+                carrierISOCountryCode: "US",
+                carrierAllowsVOIP: true,
+                radioAccessTechnology: .LTE
+            )
         )
 
         logger.debug("message")
 
-        server.waitForNextRequests(count: 1)
-
         // simulate leaving cellular service range
-        carrierInfoProvider.current = nil
+        carrierInfoProvider.set(current: nil)
 
         logger.debug("message")
 
@@ -196,8 +196,8 @@ class LoggerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let networkConnectionInfoProvider = NetworkConnectionInfoProviderMock.mockAny()
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
             server: server,
+            directory: temporaryDirectory,
             networkConnectionInfoProvider: networkConnectionInfoProvider
         )
         defer { LoggingFeature.instance = nil }
@@ -207,35 +207,35 @@ class LoggerTests: XCTestCase {
             .build()
 
         // simulate reachable network
-        networkConnectionInfoProvider.current = .mockWith(
-            reachability: .yes,
-            availableInterfaces: [.wifi, .cellular],
-            supportsIPv4: true,
-            supportsIPv6: true,
-            isExpensive: false,
-            isConstrained: false
+        networkConnectionInfoProvider.set(
+            current: .mockWith(
+                reachability: .yes,
+                availableInterfaces: [.wifi, .cellular],
+                supportsIPv4: true,
+                supportsIPv6: true,
+                isExpensive: false,
+                isConstrained: false
+            )
         )
 
         logger.debug("message")
-
-        server.waitForNextRequests(count: 1)
 
         // simulate unreachable network
-        networkConnectionInfoProvider.current = .mockWith(
-            reachability: .no,
-            availableInterfaces: [],
-            supportsIPv4: false,
-            supportsIPv6: false,
-            isExpensive: false,
-            isConstrained: false
+        networkConnectionInfoProvider.set(
+            current: .mockWith(
+                reachability: .no,
+                availableInterfaces: [],
+                supportsIPv4: false,
+                supportsIPv6: false,
+                isExpensive: false,
+                isConstrained: false
+            )
         )
 
         logger.debug("message")
 
-        server.waitForNextRequests(count: 0)
-
         // put the network back online so last log can be send
-        networkConnectionInfoProvider.current = .mockWith(reachability: .yes)
+        networkConnectionInfoProvider.set(current: .mockWith(reachability: .yes))
 
         let logMatchers = try server.waitAndReturnLogMatchers(count: 2)
         logMatchers[0].assertValue(forKeyPath: "network.client.reachability", equals: "yes")
@@ -258,8 +258,8 @@ class LoggerTests: XCTestCase {
     func testSendingLoggerAttributesOfDifferentEncodableValues() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
-            server: server
+            server: server,
+            directory: temporaryDirectory
         )
         defer { LoggingFeature.instance = nil }
 
@@ -321,8 +321,8 @@ class LoggerTests: XCTestCase {
     func testSendingMessageAttributes() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
-            server: server
+            server: server,
+            directory: temporaryDirectory
         )
         defer { LoggingFeature.instance = nil }
 
@@ -354,8 +354,8 @@ class LoggerTests: XCTestCase {
     func testSendingTags() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
-            server: server
+            server: server,
+            directory: temporaryDirectory
         )
         defer { LoggingFeature.instance = nil }
 
@@ -393,8 +393,8 @@ class LoggerTests: XCTestCase {
     func testGivenBadBatteryConditions_itDoesNotTryToSendLogs() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
             server: server,
+            directory: temporaryDirectory,
             appContext: .mockWith(
                 mobileDevice: .mockWith(
                     currentBatteryStatus: { () -> MobileDevice.BatteryStatus in
@@ -408,14 +408,14 @@ class LoggerTests: XCTestCase {
         let logger = Logger.builder.build()
         logger.debug("message")
 
-        server.waitForNextRequests(count: 0)
+        server.waitAndAssertNoRequestsSent()
     }
 
     func testGivenNoNetworkConnection_itDoesNotTryToSendLogs() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
             server: server,
+            directory: temporaryDirectory,
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
                 networkConnectionInfo: .mockWith(reachability: .no)
             )
@@ -425,16 +425,20 @@ class LoggerTests: XCTestCase {
         let logger = Logger.builder.build()
         logger.debug("message")
 
-        server.waitForNextRequests(count: 0)
+        server.waitAndAssertNoRequestsSent()
     }
 
     // MARK: - Thread safety
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
-        LoggingFeature.instance = .mockNoOp()
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        LoggingFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
         defer { LoggingFeature.instance = nil }
 
-        let logger = Logger.builder.build()
+        let logger = Logger.builder
+            .sendLogsToDatadog(false)
+            .printLogsToConsole(false)
+            .build()
 
         DispatchQueue.concurrentPerform(iterations: 900) { iteration in
             let modulo = iteration % 3
@@ -453,5 +457,7 @@ class LoggerTests: XCTestCase {
                 break
             }
         }
+
+        server.waitAndAssertNoRequestsSent()
     }
 }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -175,6 +175,8 @@ class LoggerTests: XCTestCase {
 
         logger.debug("message")
 
+        server.waitForNextRequests(count: 1)
+
         // simulate leaving cellular service range
         carrierInfoProvider.current = nil
 
@@ -216,6 +218,8 @@ class LoggerTests: XCTestCase {
 
         logger.debug("message")
 
+        server.waitForNextRequests(count: 1)
+
         // simulate unreachable network
         networkConnectionInfoProvider.current = .mockWith(
             reachability: .no,
@@ -227,6 +231,8 @@ class LoggerTests: XCTestCase {
         )
 
         logger.debug("message")
+
+        server.waitForNextRequests(count: 0)
 
         // put the network back online so last log can be send
         networkConnectionInfoProvider.current = .mockWith(reachability: .yes)
@@ -402,11 +408,7 @@ class LoggerTests: XCTestCase {
         let logger = Logger.builder.build()
         logger.debug("message")
 
-        let requests = server.waitAndReturnRequests(
-            count: 0,
-            timeout: PerformancePreset.mockUnitTestsPerformancePreset().defaultLogsUploadDelay * 10
-        )
-        XCTAssertEqual(requests.count, 0)
+        server.waitForNextRequests(count: 0)
     }
 
     func testGivenNoNetworkConnection_itDoesNotTryToSendLogs() throws {
@@ -423,11 +425,7 @@ class LoggerTests: XCTestCase {
         let logger = Logger.builder.build()
         logger.debug("message")
 
-        let requests = server.waitAndReturnRequests(
-            count: 0,
-            timeout: PerformancePreset.mockUnitTestsPerformancePreset().defaultLogsUploadDelay * 10
-        )
-        XCTAssertEqual(requests.count, 0)
+        server.waitForNextRequests(count: 0)
     }
 
     // MARK: - Thread safety

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
@@ -73,10 +73,10 @@ extension PerformancePreset {
             maxFileAgeForRead: 0,
             maxLogsPerBatch: 0,
             maxLogSize: 0,
-            initialLogsUploadDelay: 0,
-            defaultLogsUploadDelay: 0,
-            minLogsUploadDelay: 0,
-            maxLogsUploadDelay: 0,
+            initialLogsUploadDelay: .distantFuture,
+            defaultLogsUploadDelay: .distantFuture,
+            minLogsUploadDelay: .distantFuture,
+            maxLogsUploadDelay: .distantFuture,
             logsUploadDelayDecreaseFactor: 1
         )
     }
@@ -310,11 +310,24 @@ extension NetworkConnectionInfo {
 }
 
 class NetworkConnectionInfoProviderMock: NetworkConnectionInfoProviderType {
-    var current: NetworkConnectionInfo
+    private let queue = DispatchQueue(label: "com.datadoghq.NetworkConnectionInfoProviderMock")
+    private var _current: NetworkConnectionInfo
 
     init(networkConnectionInfo: NetworkConnectionInfo) {
-        self.current = networkConnectionInfo
+        _current = networkConnectionInfo
     }
+
+    func set(current: NetworkConnectionInfo) {
+        queue.async { self._current = current }
+    }
+
+    // MARK: - NetworkConnectionInfoProviderType
+
+    var current: NetworkConnectionInfo {
+        queue.sync { _current }
+    }
+
+    // MARK: - Mocking
 
     static func mockAny() -> NetworkConnectionInfoProviderMock {
         return mockWith()
@@ -352,11 +365,24 @@ extension CarrierInfo {
 }
 
 class CarrierInfoProviderMock: CarrierInfoProviderType {
-    var current: CarrierInfo?
+    private let queue = DispatchQueue(label: "com.datadoghq.CarrierInfoProviderMock")
+    private var _current: CarrierInfo?
 
     init(carrierInfo: CarrierInfo?) {
-        self.current = carrierInfo
+        _current = carrierInfo
     }
+
+    func set(current: CarrierInfo?) {
+        queue.async { self._current = current }
+    }
+
+    // MARK: - CarrierInfoProviderType
+
+    var current: CarrierInfo? {
+        queue.sync { _current }
+    }
+
+    // MARK: - Mocking
 
     static func mockAny() -> CarrierInfoProviderMock {
         return mockWith()

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -118,30 +118,75 @@ class ServerMock {
     fileprivate func record(newRequest: URLRequest) {
         queue.async {
             self.requests.append(newRequest)
-            self.waitingExpectation?.fulfill()
+            self.waitForNextRequestsExpectation?.fulfill()
+            self.waitAndReturnRequestsExpectation?.fulfill()
         }
     }
 
     private var requests: [URLRequest] = []
-    private var waitingExpectation: XCTestExpectation?
+    private var waitForNextRequestsExpectation: XCTestExpectation?
+    private var waitAndReturnRequestsExpectation: XCTestExpectation?
 
-    /// Waits until given number of request callbacks is completed and returns that requests.
+    // MARK: - Waiting for next requests
+
+    /// Waits until given number of request callbacks is completed (after this call on this instance of `ServerMock`).
+    /// Passing no `timeout` will result with picking the recommended timeout for unit tests.
+    /// Pass `count: 0` to wait and expect no request is made expected time.
     /// Calling this method guarantees also that no callbacks are leaked inside `URLSession`, which prevents tests flakiness.
-    func waitAndReturnRequests(count: Int, timeout: TimeInterval = 1, file: StaticString = #file, line: UInt = #line) -> [URLRequest] {
-        precondition(waitingExpectation == nil, "The `ServerMock` is already waiting.")
+    func waitForNextRequests(count: UInt, timeout: TimeInterval? = nil, file: StaticString = #file, line: UInt = #line) {
+        precondition(waitForNextRequestsExpectation == nil, "The `ServerMock` is already waiting on `waitForNextRequestsExpectation`.")
 
-        let expectation = XCTestExpectation(description: "Receive \(count) requests.")
+        let expectation = XCTestExpectation(description: "Receive \(count) next requests.")
         if count > 0 {
-            expectation.expectedFulfillmentCount = count
+            expectation.expectedFulfillmentCount = Int(count)
         } else {
             expectation.isInverted = true
         }
 
         queue.sync {
-            self.waitingExpectation = expectation
+            self.waitForNextRequestsExpectation = expectation
+        }
+
+        let timeout = timeout ?? recommendedTimeoutFor(numberOfRequestsMade: max(count, 1))
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+
+        queue.sync {
+            self.waitForNextRequestsExpectation = nil
+        }
+
+        switch result {
+        case .completed:
+            break
+        case .incorrectOrder, .interrupted:
+            fatalError("Can't happen.")
+        case .timedOut:
+            XCTFail("Exceeded timeout of \(timeout)s with not receiving \(count) expected requests.", file: file, line: line)
+            return
+        case .invertedFulfillment:
+            XCTFail("Received more than \(count) expected requests.", file: file, line: line)
+            return
+        @unknown default:
+            fatalError()
+        }
+    }
+
+    // MARK: - Waiting for total number of requests
+
+    /// Waits until given number of request callbacks is completed (in total for this instance of `ServerMock`) and returns that requests.
+    /// Passing no `timeout` will result with picking the recommended timeout for unit tests.
+    /// Calling this method guarantees also that no callbacks are leaked inside `URLSession`, which prevents tests flakiness.
+    func waitAndReturnRequests(count: UInt, timeout: TimeInterval? = nil, file: StaticString = #file, line: UInt = #line) -> [URLRequest] {
+        precondition(waitAndReturnRequestsExpectation == nil, "The `ServerMock` is already waiting on `waitAndReturnRequests`.")
+
+        let expectation = XCTestExpectation(description: "Receive \(count) total requests.")
+        expectation.expectedFulfillmentCount = Int(count)
+
+        queue.sync {
+            self.waitAndReturnRequestsExpectation = expectation
             self.requests.forEach { _ in expectation.fulfill() } // fulfill already recorded
         }
 
+        let timeout = timeout ?? recommendedTimeoutFor(numberOfRequestsMade: count)
         let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
 
         switch result {
@@ -153,7 +198,7 @@ class ServerMock {
             XCTFail("Exceeded timeout of \(timeout)s with receiving \(requests.count) out of \(count) expected requests.", file: file, line: line)
             // Return array of dummy requests, so the crash will happen leter in the test code, properly
             // printing the above error.
-            return Array(repeating: .mockAny(), count: count)
+            return Array(repeating: .mockAny(), count: Int(count))
         case .invertedFulfillment:
             XCTFail("\(requests.count) requests were sent, but not expected.", file: file, line: line)
             // Return array of dummy requests, so the crash will happen leter in the test code, properly
@@ -166,14 +211,17 @@ class ServerMock {
         return queue.sync { requests }
     }
 
-    /// Waits until given number of request callbacks is completed.
+    /// Waits until given number of request callbacks is completed (in total for this instance of `ServerMock`).
+    /// Passing no `timeout` will result with picking the recommended timeout for unit tests.
     /// Calling this method guarantees that no callbacks are leaked inside `URLSession`, which prevents tests flakiness.
-    func waitFor(requestsCompletion requestsCount: Int, timeout: TimeInterval = 1, file: StaticString = #file, line: UInt = #line) {
-        _ = waitAndReturnRequests(count: requestsCount, timeout: 1)
+    func waitFor(requestsCompletion requestsCount: UInt, timeout: TimeInterval? = nil, file: StaticString = #file, line: UInt = #line) {
+        _ = waitAndReturnRequests(count: requestsCount, timeout: timeout)
     }
 
+    // MARK: - Utils
+
     /// Returns recommended timeout for delivering given number of requests if `.mockUnitTestsPerformancePreset()` is used for upload.
-    func recommendedTimeoutFor(numberOfRequestsMade: Int) -> TimeInterval {
+    func recommendedTimeoutFor(numberOfRequestsMade: UInt) -> TimeInterval {
         let performancePresetForTests: PerformancePreset = .mockUnitTestsPerformancePreset()
         // Set the timeout to 40 times more than expected.
         // In `RUMM-311` we observed 0.66% of flakiness for 150 test runs on CI with arbitrary value of `20`.
@@ -184,7 +232,7 @@ class ServerMock {
 // MARK: - Logging feature helpers
 
 extension ServerMock {
-    func waitAndReturnLogMatchers(count: Int, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
+    func waitAndReturnLogMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
         try waitAndReturnRequests(
             count: count,
             timeout: recommendedTimeoutFor(numberOfRequestsMade: count),

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -13,7 +13,8 @@ class InternalLoggersTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        LoggingFeature.instance = .mockNoOp()
+        temporaryDirectory.create()
+        LoggingFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
         printedMessages = []
         userLogger = createSDKUserLogger(
             consolePrintFunction: { [weak self] in self?.printedMessages.append($0) },
@@ -27,6 +28,7 @@ class InternalLoggersTests: XCTestCase {
         userLogger = nil
         Datadog.verbosityLevel = nil
         LoggingFeature.instance = nil
+        temporaryDirectory.delete()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -26,8 +26,8 @@ class DDLoggerTests: XCTestCase {
     func testSendingLogWithCustomizedLogger() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
-            server: server
+            server: server,
+            directory: temporaryDirectory
         )
         defer { LoggingFeature.instance = nil }
 
@@ -48,8 +48,8 @@ class DDLoggerTests: XCTestCase {
     func testSendingLogsWithDifferentLevels() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
-            server: server
+            server: server,
+            directory: temporaryDirectory
         )
         defer { LoggingFeature.instance = nil }
 
@@ -76,8 +76,8 @@ class DDLoggerTests: XCTestCase {
     func testSendingLoggerAttributes() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
-            directory: temporaryDirectory,
-            server: server
+            server: server,
+            directory: temporaryDirectory
         )
         defer { LoggingFeature.instance = nil }
 

--- a/Tests/DatadogTests/Helpers/TestsDirectory.swift
+++ b/Tests/DatadogTests/Helpers/TestsDirectory.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import XCTest
 @testable import Datadog
 
 /// Creates `Directory` pointing to unique subfolder in `/var/folders/`.
@@ -28,23 +29,23 @@ let logsDirectory = try! obtainLoggingFeatureDirectory()
 /// Provides handy methods to create / delete files and directires.
 extension Directory {
     /// Creates empty directory with given attributes .
-    func create(attributes: [FileAttributeKey: Any]? = nil) {
+    func create(attributes: [FileAttributeKey: Any]? = nil, file: StaticString = #file, line: UInt = #line) {
         do {
             try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: attributes)
             let initialFilesCount = try files().count
-            precondition(initialFilesCount == 0) // ensure it's empty
+            XCTAssert(initialFilesCount == 0, "🔥 `TestsDirectory` is not empty: \(url)", file: file, line: line)
         } catch {
-            fatalError("🔥 Failed to create `TestsDirectory`: \(error)")
+            XCTFail("🔥 Failed to create `TestsDirectory`: \(error)", file: file, line: line)
         }
     }
 
     /// Deletes entire directory with its content.
-    func delete() {
+    func delete(file: StaticString = #file, line: UInt = #line) {
         if FileManager.default.fileExists(atPath: url.path) {
             do {
                 try FileManager.default.removeItem(at: url)
             } catch {
-                fatalError("🔥 Failed to delete `TestsDirectory`: \(error)")
+                XCTFail("🔥 Failed to delete `TestsDirectory`: \(error)", file: file, line: line)
             }
         }
     }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,15 +10,29 @@ workflows:
   push_to_any_branch:
     after_run:
     - _make_dependencies
-    - run_linter
+    # - run_linter
     - run_unit_tests
-    - run_integration_tests
-    - check_dependency_managers
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests # 10x
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests
+    - run_unit_tests
+    # - run_integration_tests
+    # - check_dependency_managers
     # I disable it for now, as this would require supporting local pod installation
     # of `DatadogSDK.podspec` in CP example project. This effort will be lost as in `RUMM-334`
     # we're going to re-do sample apps layout and not use local pod anymore.
     # - check_example_projects
-    - _deploy_artifacts
+    # - _deploy_artifacts
 
   _make_dependencies:
     description: |-
@@ -76,23 +90,24 @@ workflows:
         inputs:
         - scheme: Datadog
         - simulator_device: iPhone 11
-        - is_clean_build: 'yes'
-        - generate_code_coverage_files: 'yes'
+        - is_clean_build: 'no'
+        - generate_code_coverage_files: 'no'
         - project_path: Datadog.xcworkspace
-        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests.html"
-    - script@1.1.6:
-        title: Generate HTTPServerMock.xcodeproj
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -e
-            make xcodeproj-httpservermock
-    - xcode-test-mac:
-        title: Run unit tests for HTTPServerMock.xcodeproj - macOS
-        inputs:
-        - scheme: HTTPServerMock-Package
-        - destination: platform=OS X,arch=x86_64
-        - project_path: instrumented-tests/http-server-mock/HTTPServerMock.xcodeproj
+        - output_tool: xcodebuild
+        # - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests.html"
+    # - script@1.1.6:
+    #     title: Generate HTTPServerMock.xcodeproj
+    #     inputs:
+    #     - content: |-
+    #         #!/usr/bin/env bash
+    #         set -e
+    #         make xcodeproj-httpservermock
+    # - xcode-test-mac:
+    #     title: Run unit tests for HTTPServerMock.xcodeproj - macOS
+    #     inputs:
+    #     - scheme: HTTPServerMock-Package
+    #     - destination: platform=OS X,arch=x86_64
+    #     - project_path: instrumented-tests/http-server-mock/HTTPServerMock.xcodeproj
 
   run_integration_tests:
     description: |-


### PR DESCRIPTION
### What and why?

🧪  This PR fixes tests flakiness in #84 

### How?

In unit test, we need to mutate`CarrierInfoProviderMock` and `NetworkConnectionInfoProviderMock` from the main thread while SDK reads them on a background queue. I added additional queues to synchronize write / read operations on that mocks.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
