### PR TITLE
RUMM-298 Write spans to file

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -113,6 +113,15 @@
 		61C5A89F24509C1100DA608C /* UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A89B24509C1100DA608C /* UUID.swift */; };
 		61C5A8A024509C1100DA608C /* Casting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A89C24509C1100DA608C /* Casting.swift */; };
 		61C5A8A224509CAB00DA608C /* OpenTracing.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61C5A8732450989E00DA608C /* OpenTracing.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		61C5A8A624509FAA00DA608C /* SpanEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A424509FAA00DA608C /* SpanEncoder.swift */; };
+		61C5A8A724509FAA00DA608C /* SpanBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A524509FAA00DA608C /* SpanBuilder.swift */; };
+		61E45BCF2450A6EC00F2C652 /* UUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BCE2450A6EC00F2C652 /* UUIDTests.swift */; };
+		61E45BD22450F65B00F2C652 /* SpanBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BD12450F65B00F2C652 /* SpanBuilderTests.swift */; };
+		61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */; };
+		61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */; };
+		61E45ECF2451A8630061DAC7 /* JSONDataMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */; };
+		61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
+		61E45ED22451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E085879242519FF001A3583 /* NetworkPathMonitor.swift */; };
@@ -305,6 +314,13 @@
 		61C5A89A24509C1100DA608C /* WarningsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WarningsTests.swift; sourceTree = "<group>"; };
 		61C5A89B24509C1100DA608C /* UUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUID.swift; sourceTree = "<group>"; };
 		61C5A89C24509C1100DA608C /* Casting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Casting.swift; sourceTree = "<group>"; };
+		61C5A8A424509FAA00DA608C /* SpanEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanEncoder.swift; sourceTree = "<group>"; };
+		61C5A8A524509FAA00DA608C /* SpanBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanBuilder.swift; sourceTree = "<group>"; };
+		61E45BCE2450A6EC00F2C652 /* UUIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UUIDTests.swift; sourceTree = "<group>"; };
+		61E45BD12450F65B00F2C652 /* SpanBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanBuilderTests.swift; sourceTree = "<group>"; };
+		61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFileOutputTests.swift; sourceTree = "<group>"; };
+		61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDataMatcher.swift; sourceTree = "<group>"; };
+		61E45ED02451A8730061DAC7 /* SpanMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanMatcher.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		9E085879242519FF001A3583 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
@@ -732,7 +748,9 @@
 		61133C422423990D00786299 /* Matchers */ = {
 			isa = PBXGroup;
 			children = (
+				61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */,
 				61133C432423990D00786299 /* LogMatcher.swift */,
+				61E45ED02451A8730061DAC7 /* SpanMatcher.swift */,
 			);
 			path = Matchers;
 			sourceTree = "<group>";
@@ -767,12 +785,13 @@
 			isa = PBXGroup;
 			children = (
 				61C5A88F24509AA700DA608C /* TracingFeature.swift */,
-				61C5A87824509A0C00DA608C /* DDSpan.swift */,
 				61C5A87924509A0C00DA608C /* DDNoOps.swift */,
-				61C5A87A24509A0C00DA608C /* Utils */,
+				61C5A87824509A0C00DA608C /* DDSpan.swift */,
 				61C5A87E24509A0C00DA608C /* DDSpanContext.swift */,
+				61C5A8A324509FAA00DA608C /* Span */,
 				61C5A87F24509A0C00DA608C /* SpanOutputs */,
 				61C5A88224509A0C00DA608C /* Propagation */,
+				61C5A87A24509A0C00DA608C /* Utils */,
 			);
 			path = Tracing;
 			sourceTree = "<group>";
@@ -808,6 +827,8 @@
 			isa = PBXGroup;
 			children = (
 				61C5A89824509C1100DA608C /* DDSpanTests.swift */,
+				61E45BD02450F64100F2C652 /* Span */,
+				61E45BE3245196D500F2C652 /* SpanOutputs */,
 				61C5A89924509C1100DA608C /* Utils */,
 			);
 			path = Tracing;
@@ -816,11 +837,37 @@
 		61C5A89924509C1100DA608C /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				61C5A89A24509C1100DA608C /* WarningsTests.swift */,
 				61C5A89B24509C1100DA608C /* UUID.swift */,
+				61C5A89A24509C1100DA608C /* WarningsTests.swift */,
 				61C5A89C24509C1100DA608C /* Casting.swift */,
+				61E45BCE2450A6EC00F2C652 /* UUIDTests.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		61C5A8A324509FAA00DA608C /* Span */ = {
+			isa = PBXGroup;
+			children = (
+				61C5A8A424509FAA00DA608C /* SpanEncoder.swift */,
+				61C5A8A524509FAA00DA608C /* SpanBuilder.swift */,
+			);
+			path = Span;
+			sourceTree = "<group>";
+		};
+		61E45BD02450F64100F2C652 /* Span */ = {
+			isa = PBXGroup;
+			children = (
+				61E45BD12450F65B00F2C652 /* SpanBuilderTests.swift */,
+			);
+			path = Span;
+			sourceTree = "<group>";
+		};
+		61E45BE3245196D500F2C652 /* SpanOutputs */ = {
+			isa = PBXGroup;
+			children = (
+				61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */,
+			);
+			path = SpanOutputs;
 			sourceTree = "<group>";
 		};
 		9E2FB279244766CF001C9B7B /* DatadogIntegrationTests */ = {
@@ -1140,6 +1187,7 @@
 				61133BCF2423979B00786299 /* FileWriter.swift in Sources */,
 				61133BCC2423979B00786299 /* MobileDevice.swift in Sources */,
 				9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */,
+				61C5A8A724509FAA00DA608C /* SpanBuilder.swift in Sources */,
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
 				9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
@@ -1148,6 +1196,7 @@
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
 				61133BEA2423979B00786299 /* LogConsoleOutput.swift in Sources */,
+				61C5A8A624509FAA00DA608C /* SpanEncoder.swift in Sources */,
 				61C5A88E24509A1F00DA608C /* DDTracer.swift in Sources */,
 				61133BE32423979B00786299 /* UserInfo.swift in Sources */,
 				61133BE02423979B00786299 /* Datadog.swift in Sources */,
@@ -1190,6 +1239,7 @@
 			files = (
 				61C5A8A024509C1100DA608C /* Casting.swift in Sources */,
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
+				61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */,
 				61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */,
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
@@ -1217,6 +1267,7 @@
 				61133C692423990D00786299 /* LogFileOutputTests.swift in Sources */,
 				61133C682423990D00786299 /* LogUtilityOutputsTests.swift in Sources */,
 				61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */,
+				61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */,
 				61133C592423990D00786299 /* FilesOrchestratorTests.swift in Sources */,
 				61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */,
 				61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */,
@@ -1224,6 +1275,8 @@
 				61133C492423990D00786299 /* DDLoggerBuilderTests.swift in Sources */,
 				61133C4B2423990D00786299 /* DDLoggerTests.swift in Sources */,
 				61C5A89624509BF600DA608C /* DDTracerTests.swift in Sources */,
+				61E45BD22450F65B00F2C652 /* SpanBuilderTests.swift in Sources */,
+				61E45BCF2450A6EC00F2C652 /* UUIDTests.swift in Sources */,
 				61133C482423990D00786299 /* DDDatadogTests.swift in Sources */,
 				61133C4F2423990D00786299 /* DatadogObjcMocks.swift in Sources */,
 				61133C522423990D00786299 /* FoundationMocks.swift in Sources */,
@@ -1234,6 +1287,7 @@
 				61133C652423990D00786299 /* LogBuilderTests.swift in Sources */,
 				61C5A89424509BD700DA608C /* DatadogTracingMocks.swift in Sources */,
 				61133C642423990D00786299 /* LoggerTests.swift in Sources */,
+				61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */,
 				61133C4E2423990D00786299 /* UIKitMocks.swift in Sources */,
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
 				61133C552423990D00786299 /* BatteryStatusProviderTests.swift in Sources */,
@@ -1257,12 +1311,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61E45ECF2451A8630061DAC7 /* JSONDataMatcher.swift in Sources */,
 				9EF49F1024476D96004F2CA0 /* BenchmarkTests.swift in Sources */,
 				9EF49F1124476D96004F2CA0 /* IntegrationTests.swift in Sources */,
 				9EF49F1224476D96004F2CA0 /* LoggingBenchmarkTests.swift in Sources */,
 				9EA6A539244897A900621535 /* LoggingIOBenchmarkTests.swift in Sources */,
 				9EF49F1324476D96004F2CA0 /* LoggingIntegrationTests.swift in Sources */,
 				9EF49F1424476DD6004F2CA0 /* LogMatcher.swift in Sources */,
+				61E45ED22451A8730061DAC7 /* SpanMatcher.swift in Sources */,
 				9EA6A53E24489DC800621535 /* TestsDirectory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Datadog/Core/Upload/DataUploader.swift
+++ b/Sources/Datadog/Core/Upload/DataUploader.swift
@@ -13,8 +13,8 @@ internal class UploadURLProvider {
 
     private var queryItems: [URLQueryItem] {
         // batch_time
-        let currentTimeMillis = dateProvider.currentDate().currentTimeMillis
-        let batchTimeQueryItem = URLQueryItem(name: "batch_time", value: "\(currentTimeMillis)")
+        let timestamp = dateProvider.currentDate().timeIntervalSince1970.toMilliseconds
+        let batchTimeQueryItem = URLQueryItem(name: "batch_time", value: "\(timestamp)")
         // ddsource
         let ddSourceQueryItem = URLQueryItem(name: "ddsource", value: "mobile")
 

--- a/Sources/Datadog/Logs/Log/LogBuilder.swift
+++ b/Sources/Datadog/Logs/Log/LogBuilder.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Builds `Log` representation as it was received from the user (without sanitization).
+/// Builds `Log` representation (for later serialization) from data received from user.
 internal struct LogBuilder {
     /// App information context.
     let appContext: AppContext

--- a/Sources/Datadog/Tracing/DDNoOps.swift
+++ b/Sources/Datadog/Tracing/DDNoOps.swift
@@ -13,13 +13,13 @@ private struct DDNoopGlobals {
     static let context = DDNoopSpanContext()
 }
 
-internal struct DDNoopTracer: Tracer {
+internal struct DDNoopTracer: OpenTracing.Tracer {
     func extract(reader: FormatReader) -> SpanContext? { DDNoopGlobals.context }
     func inject(spanContext: SpanContext, writer: FormatWriter) {}
-    func startSpan(operationName: String, references: [Reference]?, tags: [String: Codable]?, startTime: Date?) -> Span { DDNoopGlobals.span }
+    func startSpan(operationName: String, references: [Reference]?, tags: [String: Codable]?, startTime: Date?) -> OpenTracing.Span { DDNoopGlobals.span }
 }
 
-internal struct DDNoopSpan: Span {
+internal struct DDNoopSpan: OpenTracing.Span {
     var context: SpanContext { DDNoopGlobals.context }
     func tracer() -> Tracer { DDNoopGlobals.tracer }
     func setOperationName(_ operationName: String) {}
@@ -30,6 +30,6 @@ internal struct DDNoopSpan: Span {
     func setTag(key: String, value: Codable) {}
 }
 
-internal struct DDNoopSpanContext: SpanContext {
+internal struct DDNoopSpanContext: OpenTracing.SpanContext {
     func forEachBaggageItem(callback: (String, String) -> Bool) {}
 }

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -7,7 +7,7 @@
 import OpenTracing
 import Foundation
 
-internal class DDSpan: Span {
+internal class DDSpan: OpenTracing.Span {
     private(set) var operationName: String
     private(set) var tags: [String: Codable]
     internal let startTime: Date
@@ -15,20 +15,23 @@ internal class DDSpan: Span {
     /// The `Tracer` which created this span.
     private let issuingTracer: DDTracer
 
-    init(tracer: DDTracer, operationName: String, parentSpanContext: DDSpanContext?, tags: [String: Codable], startTime: Date) {
+    init(
+        tracer: DDTracer,
+        context: DDSpanContext,
+        operationName: String,
+        startTime: Date,
+        tags: [String: Codable]
+    ) {
         self.issuingTracer = tracer
+        self.context = context
         self.operationName = operationName
-        self.tags = tags
         self.startTime = startTime
-        self.context = DDSpanContext(
-            traceID: parentSpanContext?.traceID ?? .generateUnique(),
-            spanID: .generateUnique()
-        )
+        self.tags = tags
     }
 
     // MARK: - Open Tracing interface
 
-    let context: SpanContext
+    let context: OpenTracing.SpanContext
 
     func tracer() -> Tracer {
         return issuingTracer

--- a/Sources/Datadog/Tracing/DDSpanContext.swift
+++ b/Sources/Datadog/Tracing/DDSpanContext.swift
@@ -6,9 +6,13 @@
 
 import OpenTracing
 
-internal struct DDSpanContext: SpanContext {
+internal struct DDSpanContext: OpenTracing.SpanContext {
+    /// This span's trace ID.
     let traceID: TracingUUID
+    /// This span ID.
     let spanID: TracingUUID
+    /// The ID of the parent span or `nil` if this span is the root span.
+    let parentSpanID: TracingUUID?
 
     // MARK: - Open Tracing interface
 

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Builds `Span` representation (for later serialization) from `DDSpan`.
+internal struct SpanBuilder {
+    /// App information context.
+    let appContext: AppContext
+    /// Service name to encode in span.
+    let serviceName: String
+    /// Shared user info provider.
+    let userInfoProvider: UserInfoProvider
+    /// Shared network connection info provider.
+    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
+    /// Shared mobile carrier info provider.
+    let carrierInfoProvider: CarrierInfoProviderType
+
+    func createSpan(from ddspan: DDSpan, finishTime: Date) throws -> Span {
+        guard let context = ddspan.context.dd else {
+            throw InternalError(description: "`SpanBuilder` inconsistency - unrecognized span context.")
+        }
+
+        return Span(
+            traceID: context.traceID,
+            spanID: context.spanID,
+            parentID: context.parentSpanID,
+            operationName: ddspan.operationName,
+            serviceName: serviceName,
+            resource: ddspan.operationName, // TODO: RUMM-400 use `resourceName`: `resource: ddspan.resourceName ?? ddspan.operationName`
+            startTime: ddspan.startTime,
+            duration: finishTime.timeIntervalSince(ddspan.startTime),
+            isError: false, // TODO: RUMM-401 use error flag from `ddspan`
+            tracerVersion: sdkVersion,
+            applicationVersion: getApplicationVersion(),
+            networkConnectionInfo: networkConnectionInfoProvider.current,
+            mobileCarrierInfo: carrierInfoProvider.current,
+            userInfo: userInfoProvider.value
+        )
+    }
+
+    // TODO: RUMM-299 Consider sharing `getApplicationVersion` between `SpanBuilder` and `LogBuilder` when tests are ready
+    private func getApplicationVersion() -> String {
+        if let shortVersion = appContext.bundleShortVersion {
+            return shortVersion
+        } else if let version = appContext.bundleVersion {
+            return version
+        } else {
+            return ""
+        }
+    }
+}

--- a/Sources/Datadog/Tracing/Span/SpanEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEncoder.swift
@@ -1,0 +1,150 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// `Encodable` representation of span.
+internal struct Span: Encodable {
+    let traceID: TracingUUID
+    let spanID: TracingUUID
+    let parentID: TracingUUID?
+    let operationName: String
+    let serviceName: String
+    let resource: String
+    let startTime: Date
+    let duration: TimeInterval
+    let isError: Bool
+
+    // MARK: - Meta
+
+    let tracerVersion: String
+    let applicationVersion: String
+    let networkConnectionInfo: NetworkConnectionInfo?
+    let mobileCarrierInfo: CarrierInfo?
+    let userInfo: UserInfo
+
+    func encode(to encoder: Encoder) throws {
+        try SpanEncoder().encode(self, to: encoder)
+    }
+}
+
+/// Encodes `Span` to given encoder.
+internal struct SpanEncoder {
+    /// Coding keys for permanent `Log` attributes.
+    enum StaticCodingKeys: String, CodingKey {
+        case traceID = "trace_id"
+        case spanID = "span_id"
+        case parentID = "parent_id"
+        case operationName = "name"
+        case serviceName = "service"
+        case resource
+        case type
+        case startTime = "start"
+        case duration
+        case isError = "error"
+
+        // MARK: - Metrics
+
+        case isRootSpan = "metrics._top_level"
+
+        // MARK: - Meta
+
+        case source = "meta._dd.source"
+
+        // MARK: - Application info
+
+        case applicationVersion = "meta.application.version"
+
+        // MARK: - Tracer info
+
+        case tracerVersion = "meta.tracer.version"
+
+        // MARK: - User info
+
+        case userId = "meta.usr.id"
+        case userName = "meta.usr.name"
+        case userEmail = "meta.usr.email"
+
+        // MARK: - Network connection info
+
+        case networkReachability = "meta.network.client.reachability"
+        case networkAvailableInterfaces = "meta.network.client.available_interfaces"
+        case networkConnectionSupportsIPv4 = "meta.network.client.supports_ipv4"
+        case networkConnectionSupportsIPv6 = "meta.network.client.supports_ipv6"
+        case networkConnectionIsExpensive = "meta.network.client.is_expensive"
+        case networkConnectionIsConstrained = "meta.network.client.is_constrained"
+
+        // MARK: - Mobile carrier info
+
+        case mobileNetworkCarrierName = "meta.network.client.sim_carrier.name"
+        case mobileNetworkCarrierISOCountryCode = "meta.network.client.sim_carrier.iso_country"
+        case mobileNetworkCarrierRadioTechnology = "meta.network.client.sim_carrier.technology"
+        case mobileNetworkCarrierAllowsVoIP = "meta.network.client.sim_carrier.allows_voip"
+    }
+
+    func encode(_ span: Span, to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: StaticCodingKeys.self)
+        try container.encode(span.traceID.toHexadecimalString, forKey: .traceID)
+        try container.encode(span.spanID.toHexadecimalString, forKey: .spanID)
+
+        let parentSpanID = span.parentID ?? TracingUUID(rawValue: 0) // 0 is a reserved ID for a root span (ref: DDTracer.java#L600)
+        try container.encode(parentSpanID.toHexadecimalString, forKey: .parentID)
+
+        try container.encode(span.operationName, forKey: .operationName)
+        try container.encode(span.serviceName, forKey: .serviceName)
+        try container.encode(span.resource, forKey: .resource)
+        try container.encode("custom", forKey: .type)
+
+        try container.encode(span.startTime.timeIntervalSince1970.toNanoseconds, forKey: .startTime)
+        try container.encode(span.duration.toNanoseconds, forKey: .duration)
+
+        let isError = span.isError ? 1 : 0
+        try container.encode(isError, forKey: .isError)
+
+        // Encode `metrics.*`
+        if span.parentID == nil {
+            try container.encode(1, forKey: .isRootSpan)
+        }
+
+        // TODO: RUMM-402 Encode custom metrics from `DDSpan` (coding key: `metrics.*`)
+
+        // Encode `meta.*`
+        try container.encode("mobile", forKey: .source)
+        try container.encode(span.tracerVersion, forKey: .tracerVersion)
+        try container.encode(span.applicationVersion, forKey: .applicationVersion)
+
+        // TODO: RUMM-299 Consider sharing `userInfo` encoding between `SpanEncoder` and `LogEncoder` when tests are ready
+        try span.userInfo.id.ifNotNil { try container.encode($0, forKey: .userId) }
+        try span.userInfo.name.ifNotNil { try container.encode($0, forKey: .userName) }
+        try span.userInfo.email.ifNotNil { try container.encode($0, forKey: .userEmail) }
+
+        // TODO: RUMM-299 Consider sharing `networkConnectionInfo` encoding between `SpanEncoder` and `LogEncoder` when tests are ready
+        if let networkConnectionInfo = span.networkConnectionInfo {
+            try container.encode(networkConnectionInfo.reachability, forKey: .networkReachability)
+            try container.encode(networkConnectionInfo.availableInterfaces, forKey: .networkAvailableInterfaces)
+            try container.encode(networkConnectionInfo.supportsIPv4, forKey: .networkConnectionSupportsIPv4)
+            try container.encode(networkConnectionInfo.supportsIPv6, forKey: .networkConnectionSupportsIPv6)
+            try container.encode(networkConnectionInfo.isExpensive, forKey: .networkConnectionIsExpensive)
+            try networkConnectionInfo.isConstrained.ifNotNil {
+                try container.encode($0, forKey: .networkConnectionIsConstrained)
+            }
+        }
+
+        // TODO: RUMM-299 Consider sharing `mobileCarrierInfo` encoding between `SpanEncoder` and `LogEncoder` when tests are ready
+        if let carrierInfo = span.mobileCarrierInfo {
+            try carrierInfo.carrierName.ifNotNil {
+                try container.encode($0, forKey: .mobileNetworkCarrierName)
+            }
+            try carrierInfo.carrierISOCountryCode.ifNotNil {
+                try container.encode($0, forKey: .mobileNetworkCarrierISOCountryCode)
+            }
+            try container.encode(carrierInfo.radioAccessTechnology, forKey: .mobileNetworkCarrierRadioTechnology)
+            try container.encode(carrierInfo.carrierAllowsVOIP, forKey: .mobileNetworkCarrierAllowsVoIP)
+        }
+
+        // TODO: RUMM-403 Encode custom meta (including `span.tags`) from `DDSpan` (coding key: `meta.*`)
+    }
+}

--- a/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
+++ b/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
@@ -8,7 +8,15 @@ import Foundation
 
 /// `SpanOutput` which saves spans to file.
 internal struct SpanFileOutput: SpanOutput {
-    func write(span: DDSpan, finishTime: Date) {
-        // TODO: RUMM-298 Write spans to file
+    let spanBuilder: SpanBuilder
+    let fileWriter: FileWriter
+
+    func write(ddspan: DDSpan, finishTime: Date) {
+        do {
+            let span = try spanBuilder.createSpan(from: ddspan, finishTime: finishTime)
+            fileWriter.write(value: span)
+        } catch {
+            userLogger.error("🔥 Failed to build span: \(error)")
+        }
     }
 }

--- a/Sources/Datadog/Tracing/SpanOutputs/SpanOutput.swift
+++ b/Sources/Datadog/Tracing/SpanOutputs/SpanOutput.swift
@@ -8,5 +8,5 @@ import Foundation
 
 /// Type writting spans to some destination.
 internal protocol SpanOutput {
-    func write(span: DDSpan, finishTime: Date)
+    func write(ddspan: DDSpan, finishTime: Date)
 }

--- a/Sources/Datadog/Tracing/Utils/UUID.swift
+++ b/Sources/Datadog/Tracing/Utils/UUID.swift
@@ -12,10 +12,14 @@ internal struct TracingUUID: Equatable {
     let rawValue: UInt64
 
     static func generateUnique() -> TracingUUID {
-        // TODO: RUMM-333 Add boundaries to trace & span ID generation
+        // TODO: RUMM-333 Add boundaries to trace & span ID generation, keeping in mind that `0` is reserved (ref: DDTracer.java#L600)
         return TracingUUID(
-            rawValue: .random(in: UInt64.min...UInt64.max)
+            rawValue: .random(in: 1...UInt64.max)
         )
+    }
+
+    var toHexadecimalString: String {
+        return String(rawValue, radix: 16, uppercase: true)
     }
 }
 

--- a/Sources/Datadog/Utils/SwiftExtensions.swift
+++ b/Sources/Datadog/Utils/SwiftExtensions.swift
@@ -16,18 +16,31 @@ extension Optional {
     }
 }
 
-// MARK: - Date
+// MARK: - TimeInterval
 
-extension Date {
+extension TimeInterval {
     // NOTE: RUMM-182 counterpart of currentTimeMillis in Java
     // https://docs.oracle.com/javase/7/docs/api/java/lang/System.html#currentTimeMillis()
-    var currentTimeMillis: UInt64 {
+    var toMilliseconds: UInt64 {
         do {
-            let miliseconds = self.timeIntervalSince1970 * 1_000
+            let miliseconds = self * 1_000
             return try UInt64(withReportingOverflow: miliseconds)
         } catch {
-            userLogger.error("🔥 Failed to convert timestamp: \(error)")
-            developerLogger?.error("🔥 Failed to convert timestamp: \(error)")
+            userLogger.error("🔥 Failed to convert `\(self)` time interval in milliseconds: \(error)")
+            developerLogger?.error("🔥 Failed to convert `\(self)` time interval in milliseconds: \(error)")
+            return UInt64.max
+        }
+    }
+
+    /// Returns `TimeInterval` represented in nanoseconds.
+    /// Note: as `TimeInterval` yields sub-millisecond precision the nanoseconds precission will be lost.
+    var toNanoseconds: UInt64 {
+        do {
+            let nanoseconds = self * 1_000_000_000
+            return try UInt64(withReportingOverflow: nanoseconds)
+        } catch {
+            userLogger.error("🔥 Failed to convert `\(self)` time interval in nanoseconds: \(error)")
+            developerLogger?.error("🔥 Failed to convert `\(self)` time interval in nanoseconds: \(error)")
             return UInt64.max
         }
     }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
@@ -34,8 +34,8 @@ class SpanOutputMock: SpanOutput {
 
     var recorded: Recorded? = nil
 
-    func write(span: DDSpan, finishTime: Date) {
-        recorded = Recorded(span: span, finishTime: finishTime)
+    func write(ddspan: DDSpan, finishTime: Date) {
+        recorded = Recorded(span: ddspan, finishTime: finishTime)
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/SpansMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SpansMocks.swift
@@ -12,6 +12,24 @@ A collection of mocks for `DDSpan` objects.
 It follows the mocking conventions described in `FoundationMocks.swift`.
  */
 
+extension DDSpanContext {
+    static func mockAny() -> DDSpanContext {
+        return mockWith()
+    }
+
+    static func mockWith(
+        traceID: TracingUUID = .mockAny(),
+        spanID: TracingUUID = .mockAny(),
+        parentSpanID: TracingUUID? = .mockAny()
+    ) -> DDSpanContext {
+        return DDSpanContext(
+            traceID: traceID,
+            spanID: spanID,
+            parentSpanID: parentSpanID
+        )
+    }
+}
+
 extension DDSpan {
     static func mockAny() -> DDSpan {
         return mockWith()
@@ -19,17 +37,39 @@ extension DDSpan {
 
     static func mockWith(
         tracer: DDTracer = .mockNoOp(),
+        context: DDSpanContext = .mockAny(),
         operationName: String = .mockAny(),
-        parentSpanContext: DDSpanContext? = nil,
-        tags: [String: Codable] = [:],
-        startTime: Date = .mockAny()
+        startTime: Date = .mockAny(),
+        tags: [String: Codable] = [:]
     ) -> DDSpan {
         return DDSpan(
             tracer: tracer,
+            context: context,
             operationName: operationName,
-            parentSpanContext: parentSpanContext,
-            tags: tags,
-            startTime: startTime
+            startTime: startTime,
+            tags: tags
+        )
+    }
+}
+
+extension SpanBuilder {
+    static func mockAny() -> SpanBuilder {
+        return mockWith()
+    }
+
+    static func mockWith(
+        appContext: AppContext = .mockAny(),
+        serviceName: String = .mockAny(),
+        userInfoProvider: UserInfoProvider = .mockAny(),
+        networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockAny(),
+        carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
+    ) -> SpanBuilder {
+        return SpanBuilder(
+            appContext: appContext,
+            serviceName: serviceName,
+            userInfoProvider: userInfoProvider,
+            networkConnectionInfoProvider: networkConnectionInfoProvider,
+            carrierInfoProvider: carrierInfoProvider
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class SpanBuilderTests: XCTestCase {
+    func testItBuildsBasicSpan() throws {
+        let builder: SpanBuilder = .mockWith(
+            serviceName: "test-service-name"
+        )
+        let span = try builder.createSpan(
+            from: .mockWith(
+                context: .mockWith(traceID: 1, spanID: 2, parentSpanID: 1),
+                operationName: "operation-name",
+                startTime: .mockDecember15th2019At10AMUTC()
+            ),
+            finishTime: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5)
+        )
+
+        XCTAssertEqual(span.traceID, 1)
+        XCTAssertEqual(span.spanID, 2)
+        XCTAssertEqual(span.parentID, 1)
+        XCTAssertEqual(span.operationName, "operation-name")
+        XCTAssertEqual(span.serviceName, "test-service-name")
+        XCTAssertEqual(span.resource, "operation-name") // TODO: RUMM-400 Add separate test for the case when `ddspan.resourceName != nil`
+        XCTAssertEqual(span.startTime, .mockDecember15th2019At10AMUTC())
+        XCTAssertEqual(span.duration, 0.50, accuracy: 0.01)
+        XCTAssertFalse(span.isError) // TODO: RUMM-401 Add separate test for the case when `ddspan.isError == true`
+        XCTAssertEqual(span.tracerVersion, sdkVersion)
+    }
+
+    func testItSetsApplicationVersionAttribute() throws {
+        func createSpanUsing(appContext: AppContext) throws -> Span {
+            let builder: SpanBuilder = .mockWith(appContext: appContext)
+            return try builder.createSpan(
+                from: .mockAny(),
+                finishTime: .mockAny()
+            )
+        }
+
+        // When only `bundle.version` is available
+        var span = try createSpanUsing(appContext: .mockWith(bundleVersion: "version", bundleShortVersion: nil))
+        XCTAssertEqual(span.applicationVersion, "version")
+
+        // When only `bundle.shortVersion` is available
+        span = try createSpanUsing(appContext: .mockWith(bundleVersion: nil, bundleShortVersion: "shortVersion"))
+        XCTAssertEqual(span.applicationVersion, "shortVersion")
+
+        // When both `bundle.version` and `bundle.shortVersion` are available
+        span = try createSpanUsing(appContext: .mockWith(bundleVersion: "version", bundleShortVersion: "shortVersion"))
+        XCTAssertEqual(span.applicationVersion, "shortVersion")
+
+        // When neither of `bundle.version` and `bundle.shortVersion` is available
+        span = try createSpanUsing(appContext: .mockWith(bundleVersion: nil, bundleShortVersion: nil))
+        XCTAssertEqual(span.applicationVersion, "")
+    }
+}

--- a/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
@@ -1,0 +1,90 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class SpanFileOutputTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        temporaryDirectory.create()
+    }
+
+    override func tearDown() {
+        temporaryDirectory.delete()
+        super.tearDown()
+    }
+
+    // TODO: RUMM-299 Change to `testItWritesSpanToFileAsJSON()` and move JSON assertions to `DDTracerTests` once upload is done
+    func testWrittingSpanWithNoParent() throws {
+        let queue = DispatchQueue(label: "any")
+        let output = SpanFileOutput(
+            spanBuilder: .mockWith(
+                appContext: .mockWith(bundleVersion: "1.0.0")
+            ),
+            fileWriter: .mockWrittingToSingleFile(in: temporaryDirectory, on: queue)
+        )
+
+        let ddspan: DDSpan = .mockWith(
+            context: .mockWith(
+                traceID: 29,
+                spanID: 1,
+                parentSpanID: nil
+            ),
+            operationName: "operation",
+            startTime: .mockDecember15th2019At10AMUTC()
+        )
+
+        output.write(ddspan: ddspan, finishTime: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5))
+
+        queue.sync {} // wait on writter queue
+
+        let fileData = try temporaryDirectory.files()[0].read()
+        let matcher = try SpanMatcher.fromJSONObjectData(fileData)
+        matcher.assertTraceID(equals: "1D")
+        matcher.assertSpanID(equals: "1")
+        matcher.assertParentSpanID(equals: "0")
+        matcher.assertOperationName(equals: "operation")
+        matcher.assertStartTime(equals: Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toNanoseconds)
+        matcher.assertDuration(equals: 0.5.toNanoseconds)
+        matcher.assertValue(forKey: SpanMatcher.JSONKey.applicationVersion, equals: "1.0.0")
+    }
+
+    // TODO: RUMM-299 Delete this test as this will be asserted in `DDTracerTests` once upload is done
+    func testWrittingSpanWithParent() throws {
+        let queue = DispatchQueue(label: "any")
+        let output = SpanFileOutput(
+            spanBuilder: .mockWith(
+                appContext: .mockWith(bundleVersion: "1.0.0")
+            ),
+            fileWriter: .mockWrittingToSingleFile(in: temporaryDirectory, on: queue)
+        )
+
+        let ddspan: DDSpan = .mockWith(
+            context: .mockWith(
+                traceID: 29,
+                spanID: 1,
+                parentSpanID: 318
+            ),
+            operationName: "operation",
+            startTime: .mockDecember15th2019At10AMUTC()
+        )
+
+        output.write(ddspan: ddspan, finishTime: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5))
+
+        queue.sync {} // wait on writter queue
+
+        let fileData = try temporaryDirectory.files()[0].read()
+        let matcher = try SpanMatcher.fromJSONObjectData(fileData)
+        matcher.assertTraceID(equals: "1D")
+        matcher.assertSpanID(equals: "1")
+        matcher.assertParentSpanID(equals: "13E")
+        matcher.assertOperationName(equals: "operation")
+        matcher.assertStartTime(equals: Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toNanoseconds)
+        matcher.assertDuration(equals: 0.5.toNanoseconds)
+        matcher.assertValue(forKey: SpanMatcher.JSONKey.applicationVersion, equals: "1.0.0")
+    }
+}

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/Casting.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/Casting.swift
@@ -7,6 +7,14 @@
 import OpenTracing
 @testable import Datadog
 
+/*
+ NOTE: The casting methods defined here do shadow the ones defined in `Datadog.Casting`.
+ The difference is that here in tests we do force unwrapping (`as!`), whereas in `Datadog` we do `as?` with a warning.
+
+ This is needed for expressiveness in testing, where i.e. `XCTAssertNil(span.context.dd?.parentID)` may give a false positive
+ without considering if the `parentID` is `nil`. Using `span.context.dd.parentID` mitigates it.
+ */
+
 // swiftlint:disable identifier_name
 internal extension OpenTracing.Tracer {
     var dd: DDTracer { self as! DDTracer }
@@ -14,5 +22,9 @@ internal extension OpenTracing.Tracer {
 
 internal extension OpenTracing.Span {
     var dd: DDSpan { self as! DDSpan }
+}
+
+internal extension OpenTracing.SpanContext {
+    var dd: DDSpanContext { self as! DDSpanContext }
 }
 // swiftlint:enable identifier_name

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/UUIDTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/UUIDTests.swift
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class UUIDTests: XCTestCase {
+    func testToHexadecimalStringConversion() {
+        XCTAssertEqual(TracingUUID(rawValue: 0).toHexadecimalString, "0")
+        XCTAssertEqual(TracingUUID(rawValue: 1).toHexadecimalString, "1")
+        XCTAssertEqual(TracingUUID(rawValue: 15).toHexadecimalString, "F")
+        XCTAssertEqual(TracingUUID(rawValue: 16).toHexadecimalString, "10")
+        XCTAssertEqual(TracingUUID(rawValue: 123).toHexadecimalString, "7B")
+        XCTAssertEqual(TracingUUID(rawValue: 123_456).toHexadecimalString, "1E240")
+        XCTAssertEqual(TracingUUID(rawValue: .max).toHexadecimalString, "FFFFFFFFFFFFFFFF")
+    }
+}

--- a/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
@@ -7,22 +7,41 @@
 import XCTest
 @testable import Datadog
 
-class DateExtensionTests: XCTestCase {
-    func testCurrentMillis() {
+class TimeIntervalExtensionTests: XCTestCase {
+    func testTimeIntervalSince1970InMilliseconds() {
         let date15Dec2019 = Date.mockDecember15th2019At10AMUTC()
-        XCTAssertEqual(date15Dec2019.currentTimeMillis, 1_576_404_000_000)
+        XCTAssertEqual(date15Dec2019.timeIntervalSince1970.toMilliseconds, 1_576_404_000_000)
 
         let dateAdvanced = date15Dec2019 + 9.999
-        XCTAssertEqual(dateAdvanced.currentTimeMillis, 1_576_404_009_999)
+        XCTAssertEqual(dateAdvanced.timeIntervalSince1970.toMilliseconds, 1_576_404_009_999)
 
         let dateAgo = date15Dec2019 - 0.001
-        XCTAssertEqual(dateAgo.currentTimeMillis, 1_576_403_999_999)
+        XCTAssertEqual(dateAgo.timeIntervalSince1970.toMilliseconds, 1_576_403_999_999)
 
         let overflownDate = Date(timeIntervalSinceReferenceDate: .greatestFiniteMagnitude)
-        XCTAssertEqual(overflownDate.currentTimeMillis, UInt64.max)
+        XCTAssertEqual(overflownDate.timeIntervalSince1970.toMilliseconds, UInt64.max)
 
         let uInt64MaxDate = Date(timeIntervalSinceReferenceDate: TimeInterval(UInt64.max))
-        XCTAssertEqual(uInt64MaxDate.currentTimeMillis, UInt64.max)
+        XCTAssertEqual(uInt64MaxDate.timeIntervalSince1970.toMilliseconds, UInt64.max)
+    }
+
+    func testTimeIntervalSince1970InNanoseconds() {
+        let date15Dec2019 = Date.mockDecember15th2019At10AMUTC()
+        XCTAssertEqual(date15Dec2019.timeIntervalSince1970.toNanoseconds, 1_576_404_000_000_000_000)
+
+        // As `TimeInterval` yields sub-millisecond precision this rounds up to the nearest millisecond:
+        let dateAdvanced = date15Dec2019 + 9.999_999_999
+        XCTAssertEqual(dateAdvanced.timeIntervalSince1970.toNanoseconds, 1_576_404_010_000_000_000)
+
+        // As `TimeInterval` yields sub-millisecond precision this rounds up to the nearest millisecond:
+        let dateAgo = date15Dec2019 - 0.000_000_001
+        XCTAssertEqual(dateAgo.timeIntervalSince1970.toNanoseconds, 1_576_404_000_000_000_000)
+
+        let overflownDate = Date(timeIntervalSinceReferenceDate: .greatestFiniteMagnitude)
+        XCTAssertEqual(overflownDate.timeIntervalSince1970.toNanoseconds, UInt64.max)
+
+        let uInt64MaxDate = Date(timeIntervalSinceReferenceDate: TimeInterval(UInt64.max))
+        XCTAssertEqual(uInt64MaxDate.timeIntervalSince1970.toNanoseconds, UInt64.max)
     }
 }
 

--- a/Tests/DatadogTests/Matchers/JSONDataMatcher.swift
+++ b/Tests/DatadogTests/Matchers/JSONDataMatcher.swift
@@ -1,0 +1,114 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import XCTest
+
+/// Provides set of assertions for single JSON object or collection of JSON objects.
+/// Note: this file is individually referenced by integration tests project, so no dependency on other source files should be introduced.
+internal class JSONDataMatcher {
+    let json: [String: Any]
+
+    // MARK: - Initialization
+
+    class func fromJSONObjectData<M: JSONDataMatcher>(_ data: Data, file: StaticString = #file, line: UInt = #line) throws -> M {
+        return M(from: try data.toJSONObject(file: file, line: line))
+    }
+
+    class func fromArrayOfJSONObjectsData<M: JSONDataMatcher>(_ data: Data, file: StaticString = #file, line: UInt = #line) throws -> [M] {
+        return try data.toArrayOfJSONObjects(file: file, line: line)
+            .map { jsonObject in M(from: jsonObject) }
+    }
+
+    required init(from jsonObject: [String: Any]) {
+        self.json = jsonObject
+    }
+
+    // MARK: Full match
+
+    func assertItFullyMatches(jsonString: String, file: StaticString = #file, line: UInt = #line) throws {
+        let thisJSON = json as NSDictionary
+        let theirJSON = try jsonString.data(using: .utf8)!.toJSONObject() as NSDictionary // swiftlint:disable:this force_unwrapping
+
+        XCTAssertEqual(thisJSON, theirJSON, file: file, line: line)
+    }
+
+    // MARK: - Generic matches
+
+    func assertValue<T: Equatable>(forKey key: String, equals value: T, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(json[key] as? T, value, file: file, line: line)
+    }
+
+    func assertNoValue(forKey key: String, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertNil(json[key], file: file, line: line)
+    }
+
+    func assertValue<T: Equatable>(forKeyPath keyPath: String, equals value: T, file: StaticString = #file, line: UInt = #line) {
+        let dictionary = json as NSDictionary
+        let dictionaryValue = dictionary.value(forKeyPath: keyPath)
+        guard let jsonValue = dictionaryValue as? T else {
+            XCTFail("Value at key path `\(keyPath)` is not of type `\(type(of: value))`: \(String(describing: dictionaryValue))", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(jsonValue, value, file: file, line: line)
+    }
+
+    func assertNoValue(forKeyPath keyPath: String, file: StaticString = #file, line: UInt = #line) {
+        let dictionary = json as NSDictionary
+        XCTAssertNil(dictionary.value(forKeyPath: keyPath), file: file, line: line)
+    }
+
+    func assertValue<T: Equatable>(
+        forKeyPath keyPath: String,
+        matches matcherClosure: (T) -> Bool,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let dictionary = json as NSDictionary
+        let dictionaryValue = dictionary.value(forKeyPath: keyPath)
+        guard let jsonValue = dictionaryValue as? T else {
+            XCTFail(
+                "Can't cast value at key path `\(keyPath)` to expected type: \(String(describing: dictionaryValue))",
+                file: file,
+                line: line
+            )
+            return
+        }
+
+        XCTAssertTrue(matcherClosure(jsonValue), file: file, line: line)
+    }
+
+    func assertValue<T>(
+        forKeyPath keyPath: String,
+        isTypeOf type: T.Type,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let dictionary = json as NSDictionary
+        let dictionaryValue = dictionary.value(forKeyPath: keyPath)
+        XCTAssertTrue((dictionaryValue as? T) != nil, file: file, line: line)
+    }
+}
+
+private extension Data {
+    func toArrayOfJSONObjects(file: StaticString = #file, line: UInt = #line) throws -> [[String: Any]] {
+        guard let jsonArray = try? JSONSerialization.jsonObject(with: self, options: []) as? [[String: Any]] else {
+            XCTFail("Cannot decode array of JSON objects from data.", file: file, line: line)
+            return []
+        }
+
+        return jsonArray
+    }
+
+    func toJSONObject(file: StaticString = #file, line: UInt = #line) throws -> [String: Any] {
+        guard let jsonObject = try? JSONSerialization.jsonObject(with: self, options: []) as? [String: Any] else {
+            XCTFail("Cannot decode JSON object from given data.", file: file, line: line)
+            return [:]
+        }
+
+        return jsonObject
+    }
+}

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -6,9 +6,9 @@
 
 import XCTest
 
-/// Provides set of assertions for Log JSON object.
+/// Provides set of assertions for single `Log` JSON object or collection of `[Log]`.
 /// Note: this file is individually referenced by integration tests project, so no dependency on other source files should be introduced.
-struct LogMatcher {
+internal class LogMatcher: JSONDataMatcher {
     private static let dateFormatter = ISO8601DateFormatter()
 
     /// Log JSON keys.
@@ -57,30 +57,14 @@ struct LogMatcher {
     /// Allowed values for `network.client.reachability` attribute.
     static let allowedNetworkReachabilityValues: Set<String> = ["yes", "no", "maybe"]
 
-    private let json: [String: Any]
-
     // MARK: - Initialization
 
-    static func fromJSONObjectData(_ data: Data) throws -> LogMatcher {
-        return self.init(from: try data.toJSONObject())
+    class func fromJSONObjectData(_ data: Data, file: StaticString = #file, line: UInt = #line) throws -> LogMatcher {
+        return try super.fromJSONObjectData(data, file: file, line: line)
     }
 
-    static func fromArrayOfJSONObjectsData(_ data: Data) throws -> [LogMatcher] {
-        return try data.toArrayOfJSONObjects()
-            .map { jsonObject in self.init(from: jsonObject) }
-    }
-
-    private init(from jsonObject: [String: Any]) {
-        self.json = jsonObject
-    }
-
-    // MARK: Full match
-
-    func assertItFullyMatches(jsonString: String, file: StaticString = #file, line: UInt = #line) throws {
-        let thisJSON = json as NSDictionary
-        let theirJSON = try jsonString.data(using: .utf8)!.toJSONObject() as NSDictionary // swiftlint:disable:this force_unwrapping
-
-        XCTAssertEqual(thisJSON, theirJSON, file: file, line: line)
+    class func fromArrayOfJSONObjectsData(_ data: Data, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
+        return try super.fromArrayOfJSONObjectsData(data, file: file, line: line)
     }
 
     // MARK: Partial matches
@@ -170,81 +154,5 @@ struct LogMatcher {
         let logTags = Set(tagsString.split(separator: ",").map { String($0) })
 
         XCTAssertEqual(matcherTags, logTags, file: file, line: line)
-    }
-
-    // MARK: - Generic matches
-
-    func assertValue<T: Equatable>(forKey key: String, equals value: T, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(json[key] as? T, value, file: file, line: line)
-    }
-
-    func assertNoValue(forKey key: String, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertNil(json[key], file: file, line: line)
-    }
-
-    func assertValue<T: Equatable>(forKeyPath keyPath: String, equals value: T, file: StaticString = #file, line: UInt = #line) {
-        let dictionary = json as NSDictionary
-        let dictionaryValue = dictionary.value(forKeyPath: keyPath)
-        guard let jsonValue = dictionaryValue as? T else {
-            XCTFail("Value at key path `\(keyPath)` is not of type `\(type(of: value))`: \(String(describing: dictionaryValue))", file: file, line: line)
-            return
-        }
-        XCTAssertEqual(jsonValue, value, file: file, line: line)
-    }
-
-    func assertNoValue(forKeyPath keyPath: String, file: StaticString = #file, line: UInt = #line) {
-        let dictionary = json as NSDictionary
-        XCTAssertNil(dictionary.value(forKeyPath: keyPath), file: file, line: line)
-    }
-
-    func assertValue<T: Equatable>(
-        forKeyPath keyPath: String,
-        matches matcherClosure: (T) -> Bool,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        let dictionary = json as NSDictionary
-        let dictionaryValue = dictionary.value(forKeyPath: keyPath)
-        guard let jsonValue = dictionaryValue as? T else {
-            XCTFail(
-                "Can't cast value at key path `\(keyPath)` to expected type: \(String(describing: dictionaryValue))",
-                file: file,
-                line: line
-            )
-            return
-        }
-
-        XCTAssertTrue(matcherClosure(jsonValue), file: file, line: line)
-    }
-
-    func assertValue<T>(
-        forKeyPath keyPath: String,
-        isTypeOf type: T.Type,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        let dictionary = json as NSDictionary
-        let dictionaryValue = dictionary.value(forKeyPath: keyPath)
-        XCTAssertTrue((dictionaryValue as? T) != nil, file: file, line: line)
-    }
-}
-
-private extension Data {
-    func toArrayOfJSONObjects(file: StaticString = #file, line: UInt = #line) throws -> [[String: Any]] {
-        guard let jsonArray = try? JSONSerialization.jsonObject(with: self, options: []) as? [[String: Any]] else {
-            XCTFail("Cannot decode array of JSON objects from data.", file: file, line: line)
-            return []
-        }
-
-        return jsonArray
-    }
-
-    func toJSONObject(file: StaticString = #file, line: UInt = #line) throws -> [String: Any] {
-        guard let jsonObject = try? JSONSerialization.jsonObject(with: self, options: []) as? [String: Any] else {
-            XCTFail("Cannot decode JSON object from given data.", file: file, line: line)
-            return [:]
-        }
-
-        return jsonObject
     }
 }

--- a/Tests/DatadogTests/Matchers/SpanMatcher.swift
+++ b/Tests/DatadogTests/Matchers/SpanMatcher.swift
@@ -1,0 +1,130 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Provides set of assertions for single `Span` JSON object or collection of `[Span]`.
+/// Note: this file is individually referenced by integration tests project, so no dependency on other source files should be introduced.
+internal class SpanMatcher: JSONDataMatcher {
+    /// Span JSON keys.
+    struct JSONKey {
+        static let traceID = "trace_id"
+        static let spanID = "span_id"
+        static let parentID = "parent_id"
+        static let operationName = "name"
+        static let serviceName = "service"
+        static let resource = "resource"
+        static let type = "type"
+        static let startTime = "start"
+        static let duration = "duration"
+        static let isError = "error"
+
+        // MARK: - Metrics
+
+        static let isRootSpan = "metrics._top_level"
+
+        // MARK: - Meta
+
+        static let source = "meta._dd.source"
+
+        // MARK: - Application info
+
+        static let applicationVersion = "meta.application.version"
+
+        // MARK: - Tracer info
+
+        static let tracerVersion = "meta.tracer.version"
+
+        // MARK: - User info
+
+        static let userId = "meta.usr.id"
+        static let userName = "meta.usr.name"
+        static let userEmail = "meta.usr.email"
+
+        // MARK: - Network connection info
+
+        static let networkReachability = "meta.network.client.reachability"
+        static let networkAvailableInterfaces = "meta.network.client.available_interfaces"
+        static let networkConnectionSupportsIPv4 = "meta.network.client.supports_ipv4"
+        static let networkConnectionSupportsIPv6 = "meta.network.client.supports_ipv6"
+        static let networkConnectionIsExpensive = "meta.network.client.is_expensive"
+        static let networkConnectionIsConstrained = "meta.network.client.is_constrained"
+
+        // MARK: - Mobile carrier info
+
+        static let mobileNetworkCarrierName = "meta.network.client.sim_carrier.name"
+        static let mobileNetworkCarrierISOCountryCode = "meta.network.client.sim_carrier.iso_country"
+        static let mobileNetworkCarrierRadioTechnology = "meta.network.client.sim_carrier.technology"
+        static let mobileNetworkCarrierAllowsVoIP = "meta.network.client.sim_carrier.allows_voip"
+    }
+
+    /// Allowed values for `network.client.available_interfaces` attribute.
+    static let allowedNetworkAvailableInterfacesValues: Set<String> = ["wifi", "wiredEthernet", "cellular", "loopback", "other"]
+    /// Allowed values for `network.client.reachability` attribute.
+    static let allowedNetworkReachabilityValues: Set<String> = ["yes", "no", "maybe"]
+
+    // MARK: - Initialization
+
+    class func fromJSONObjectData(_ data: Data, file: StaticString = #file, line: UInt = #line) throws -> SpanMatcher {
+        return try super.fromJSONObjectData(data, file: file, line: line)
+    }
+
+    class func fromArrayOfJSONObjectsData(_ data: Data, file: StaticString = #file, line: UInt = #line) throws -> [SpanMatcher] {
+        return try super.fromArrayOfJSONObjectsData(data, file: file, line: line)
+    }
+
+    // MARK: Partial matches
+
+    func assertTraceID(equals traceIDString: String, file: StaticString = #file, line: UInt = #line) {
+        assertValue(forKey: JSONKey.traceID, equals: traceIDString, file: file, line: line)
+    }
+
+    func assertSpanID(equals spanIDString: String, file: StaticString = #file, line: UInt = #line) {
+        assertValue(forKey: JSONKey.spanID, equals: spanIDString, file: file, line: line)
+    }
+
+    func assertParentSpanID(equals parentSpanIDString: String, file: StaticString = #file, line: UInt = #line) {
+        assertValue(forKey: JSONKey.parentID, equals: parentSpanIDString, file: file, line: line)
+    }
+
+    func assertOperationName(equals operationName: String, file: StaticString = #file, line: UInt = #line) {
+        assertValue(forKey: JSONKey.operationName, equals: operationName, file: file, line: line)
+    }
+
+    func assertServiceName(equals serviceName: String, file: StaticString = #file, line: UInt = #line) {
+        assertValue(forKey: JSONKey.serviceName, equals: serviceName, file: file, line: line)
+    }
+
+    func assertResource(equals resource: String, file: StaticString = #file, line: UInt = #line) {
+        assertValue(forKey: JSONKey.resource, equals: resource, file: file, line: line)
+    }
+
+    func assertStartTime(equals timeIntervalSince1970InNanoseconds: UInt64, file: StaticString = #file, line: UInt = #line) {
+        assertValue(forKey: JSONKey.startTime, equals: timeIntervalSince1970InNanoseconds, file: file, line: line)
+    }
+
+    func assertDuration(equals timeIntervalInNanoseconds: UInt64, file: StaticString = #file, line: UInt = #line) {
+        assertValue(forKey: JSONKey.duration, equals: timeIntervalInNanoseconds, file: file, line: line)
+    }
+
+    func assertUserInfo(equals userInfo: (id: String?, name: String?, email: String?)?, file: StaticString = #file, line: UInt = #line) {
+        if let id = userInfo?.id { // swiftlint:disable:this identifier_name
+            assertValue(forKey: JSONKey.userId, equals: id, file: file, line: line)
+        } else {
+            assertNoValue(forKey: JSONKey.userId, file: file, line: line)
+        }
+        if let name = userInfo?.name {
+            assertValue(forKey: JSONKey.userName, equals: name, file: file, line: line)
+        } else {
+            assertNoValue(forKey: JSONKey.userName, file: file, line: line)
+        }
+        if let email = userInfo?.email {
+            assertValue(forKey: JSONKey.userEmail, equals: email, file: file, line: line)
+        } else {
+            assertNoValue(forKey: JSONKey.userEmail, file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
### What and why?

🚚 This PR enables writing OT spans to files. Later, those files will be uploaded to Datadog backend 🚀.

### How?

The Tracing architecture for spans serialization follows the one already done for Logging.

`Log` serialization:
* `LogFileOutput` bundles `LogBuilder` and `FileWriter`;
* `LogBuilder` creates the `Log: Encodable` object;
* `FileWriter` writes the `Log` to underlying file.

`Span` serialization:
* `SpanFileOutput` bundles `SpanBuilder` and `FileWriter`;
* `SpanBuilder` creates the `Span: Encodable` object;
* `FileWriter` writes the `Span` to underlying file.

Both `Log` and `Span` implement custom serialization in `LogEncoder` and `SpanEncoder`. Serialized span looks like this:

```json
{
  "trace_id": "1D",
  "span_id": "1",
  "parent_id": "13E",
  "name": "operation",
  "duration": 500000000,
  "type": "custom",
  "service": "abc",
  "error": 0,
  "start": 1576404000000000000,
  "resource": "operation",
  "meta.network.client.sim_carrier.name": "abc",
  "meta.network.client.available_interfaces": ["wifi"],
  "meta.network.client.sim_carrier.iso_country": "abc",
  "meta.network.client.is_expensive": true,
  "meta.network.client.sim_carrier.technology": "LTE",
  "meta.network.client.reachability": "maybe",
  "meta.network.client.supports_ipv4": true,
  "meta.network.client.supports_ipv6": true,
  "meta.network.client.sim_carrier.allows_voip": false,
  "meta.network.client.is_constrained": true,
  "meta._dd.source": "mobile",
  "meta.application.version": "1.0.0",
  "meta.tracer.version": "1.1.0"
}
```

**Notes on testing**: 
* To make assertions on serialized `Data`, we used to use `LogMatcher`. Now, generic logic was extracted to base `JSONDataMatcher` and reused among `LogMatcher` and `SpanMatcher`.
* Some important tests on `Span` JSON format will be added after upload part is finished. This is to balance number of unit tests - instead of testing full format in writting components, we can test it comprehensively with the upload feature (exactly as it is done for logs, where JSON format is tested in `LoggerTests` - with assertions on data delivered to mock server).

**Notes on implementation**: 
* This implementation doesn't yet pass the `DDSpan` to `SpanFileOutput` when `span.finish()` is called - this requires parts of the upload stack to be present, so will be done together with the upload feature.
* Because both Logging and Tracing write/upload stacks are similar, some code can be reused (like `getApplicationVersion()` in builders or `UserInfo` encoding in encoders). Appropriate `TODO` comments were left to do this after we have more comprehensive unit tests for Tracing feature.
* Some assumptions about the JSON format were taken from [SpanSerializer.kt](https://github.com/DataDog/dd-sdk-android/blob/master/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt), [DDTracer.java](https://github.com/DataDog/dd-sdk-android/blob/master/dd-sdk-android/src/main/java/datadog/opentracing/DDTracer.java) and other components from [`dd-sdk-android`](https://github.com/DataDog/dd-sdk-android).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
