### PR TITLE
RUMM-437 Encoding doesn't ignore miliseconds anymore

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -97,6 +97,9 @@
 		9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E085879242519FF001A3583 /* NetworkPathMonitor.swift */; };
 		9E2FB2722447660E001C9B7B /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */; };
+		9E58E8DF24615B89008E5063 /* ISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8DE24615B89008E5063 /* ISO8601DateFormatter.swift */; };
+		9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8E024615C75008E5063 /* JSONEncoder.swift */; };
+		9E58E8E324615EDA008E5063 /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8E224615EDA008E5063 /* EncodingTests.swift */; };
 		9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */; };
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9EA6A539244897A900621535 /* LoggingIOBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA6A538244897A900621535 /* LoggingIOBenchmarkTests.swift */; };
@@ -254,6 +257,9 @@
 		9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionsTests.swift; sourceTree = "<group>"; };
 		9E4195742449D739000AB0DB /* app-target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "app-target.xcconfig"; sourceTree = "<group>"; };
 		9E4195752449D739000AB0DB /* unit-tests-target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "unit-tests-target.xcconfig"; sourceTree = "<group>"; };
+		9E58E8DE24615B89008E5063 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
+		9E58E8E024615C75008E5063 /* JSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
+		9E58E8E224615EDA008E5063 /* EncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingTests.swift; sourceTree = "<group>"; };
 		9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcExceptionHandler.m; sourceTree = "<group>"; };
 		9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjcExceptionHandler.h; sourceTree = "<group>"; };
 		9E9EB37624468CE90002C80B /* Datadog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Datadog.modulemap; sourceTree = "<group>"; };
@@ -372,6 +378,8 @@
 			isa = PBXGroup;
 			children = (
 				61133BA02423979B00786299 /* EncodableValue.swift */,
+				9E58E8DE24615B89008E5063 /* ISO8601DateFormatter.swift */,
+				9E58E8E024615C75008E5063 /* JSONEncoder.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -627,6 +635,7 @@
 			children = (
 				61133C362423990D00786299 /* InternalLoggersTests.swift */,
 				9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */,
+				9E58E8E224615EDA008E5063 /* EncodingTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1008,12 +1017,14 @@
 				61133BCF2423979B00786299 /* FileWriter.swift in Sources */,
 				61133BCC2423979B00786299 /* MobileDevice.swift in Sources */,
 				9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */,
+				9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */,
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
 				9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
 				61133BEA2423979B00786299 /* LogConsoleOutput.swift in Sources */,
+				9E58E8DF24615B89008E5063 /* ISO8601DateFormatter.swift in Sources */,
 				61133BE32423979B00786299 /* UserInfo.swift in Sources */,
 				61133BE02423979B00786299 /* Datadog.swift in Sources */,
 				61133BCB2423979B00786299 /* CarrierInfoProvider.swift in Sources */,
@@ -1067,6 +1078,7 @@
 				61133C6A2423990D00786299 /* DatadogTests.swift in Sources */,
 				61133C5E2423990D00786299 /* LogsUploadDelayTests.swift in Sources */,
 				61133C5C2423990D00786299 /* DataUploadWorkerTests.swift in Sources */,
+				9E58E8E324615EDA008E5063 /* EncodingTests.swift in Sources */,
 				61133C692423990D00786299 /* LogFileOutputTests.swift in Sources */,
 				61133C682423990D00786299 /* LogUtilityOutputsTests.swift in Sources */,
 				61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */,

--- a/Sources/Datadog/Core/Persistence/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/FileWriter.swift
@@ -19,11 +19,7 @@ internal final class FileWriter {
     init(orchestrator: FilesOrchestrator, queue: DispatchQueue) {
         self.orchestrator = orchestrator
         self.queue = queue
-        self.jsonEncoder = JSONEncoder()
-        jsonEncoder.dateEncodingStrategy = .iso8601
-        if #available(iOS 13.0, OSX 10.15, *) {
-            jsonEncoder.outputFormatting = [.withoutEscapingSlashes]
-        }
+        self.jsonEncoder = JSONEncoder.default()
     }
 
     // MARK: - Writing data

--- a/Sources/Datadog/Core/Utils/ISO8601DateFormatter.swift
+++ b/Sources/Datadog/Core/Utils/ISO8601DateFormatter.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+extension ISO8601DateFormatter {
+    static func `default`() -> ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions.insert(.withFractionalSeconds)
+        return formatter
+    }
+
+    static var encodingStrategy: JSONEncoder.DateEncodingStrategy {
+        let formatter = Self.default()
+        return .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            let formatted = formatter.string(from: date)
+            try container.encode(formatted)
+        }
+    }
+}

--- a/Sources/Datadog/Core/Utils/JSONEncoder.swift
+++ b/Sources/Datadog/Core/Utils/JSONEncoder.swift
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+extension JSONEncoder {
+    static func `default`() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = ISO8601DateFormatter.encodingStrategy
+        if #available(iOS 13.0, OSX 10.15, *) {
+            encoder.outputFormatting = [.withoutEscapingSlashes]
+        }
+        return encoder
+    }
+}

--- a/Sources/Datadog/Logs/LogOutputs/LogConsoleOutput.swift
+++ b/Sources/Datadog/Logs/LogOutputs/LogConsoleOutput.swift
@@ -14,11 +14,9 @@ internal protocol ConsoleLogFormatter {
 /// `LogOutput` which prints logs to console.
 internal struct LogConsoleOutput: LogOutput {
     /// Time formatter used for `.short` output format.
-    static func shortTimeFormatter(calendar: Calendar = .current, timeZone: TimeZone = .current) -> DateFormatter {
-        let formatter = DateFormatter()
-        formatter.calendar = calendar
-        formatter.timeZone = timeZone
-        formatter.dateFormat = "HH:mm:ss"
+    static func shortTimeFormatter(calendar: Calendar = .current, timeZone: TimeZone = .current) -> Formatter {
+        let formatter = ISO8601DateFormatter.default()
+        formatter.formatOptions = [.withFractionalSeconds, .withFullTime]
         return formatter
     }
 
@@ -30,7 +28,7 @@ internal struct LogConsoleOutput: LogOutput {
         logBuilder: LogBuilder,
         format: Logger.Builder.ConsoleLogFormat,
         printingFunction: @escaping (String) -> Void = { consolePrint($0) },
-        timeFormatter: DateFormatter = LogConsoleOutput.shortTimeFormatter()
+        timeFormatter: Formatter = LogConsoleOutput.shortTimeFormatter()
     ) {
         switch format {
         case .short:
@@ -60,8 +58,7 @@ private struct JSONLogFormatter: ConsoleLogFormatter {
     private let prefix: String
 
     init(prefix: String = "") {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        let encoder = JSONEncoder.default()
         encoder.outputFormatting = .prettyPrinted
         self.encoder = encoder
         self.prefix = prefix
@@ -79,17 +76,17 @@ private struct JSONLogFormatter: ConsoleLogFormatter {
 
 /// Formats log as custom short string.
 private struct ShortLogFormatter: ConsoleLogFormatter {
-    private let timeFormatter: DateFormatter
+    private let timeFormatter: Formatter
     private let prefix: String
 
-    init(timeFormatter: DateFormatter, prefix: String = "") {
+    init(timeFormatter: Formatter, prefix: String = "") {
         self.timeFormatter = timeFormatter
         self.prefix = prefix
     }
 
     func format(log: Log) -> String {
-        let time = timeFormatter.string(from: log.date)
+        let time = timeFormatter.string(for: log.date)
         let status = log.status.rawValue.uppercased()
-        return "\(prefix)\(time) [\(status)] \(log.message)"
+        return "\(prefix)\(time ?? "null") [\(status)] \(log.message)"
     }
 }

--- a/Sources/Datadog/Utils/InternalLoggers.swift
+++ b/Sources/Datadog/Utils/InternalLoggers.swift
@@ -23,7 +23,7 @@ internal var userLogger = createSDKUserLogger()
 internal func createSDKDeveloperLogger(
     consolePrintFunction: @escaping (String) -> Void = { consolePrint($0) },
     dateProvider: DateProvider = SystemDateProvider(),
-    timeFormatter: DateFormatter = LogConsoleOutput.shortTimeFormatter()
+    timeFormatter: Formatter = LogConsoleOutput.shortTimeFormatter()
 ) -> Logger? {
     if CompilationConditions.isSDKCompiledForDevelopment == false {
         return nil
@@ -54,7 +54,7 @@ internal func createSDKDeveloperLogger(
 internal func createSDKUserLogger(
     consolePrintFunction: @escaping (String) -> Void = { consolePrint($0) },
     dateProvider: DateProvider = SystemDateProvider(),
-    timeFormatter: DateFormatter = LogConsoleOutput.shortTimeFormatter()
+    timeFormatter: Formatter = LogConsoleOutput.shortTimeFormatter()
 ) -> Logger {
     guard let loggingFeature = LoggingFeature.instance else {
         return Logger(logOutput: NoOpLogOutput(), identifier: "no-op")

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -51,7 +51,7 @@ class LoggerTests: XCTestCase {
           "logger.name" : "com.datadoghq.ios-sdk",
           "logger.version": "\(sdkVersion)",
           "logger.thread_name" : "main",
-          "date" : "2019-12-15T10:00:00Z",
+          "date" : "2019-12-15T10:00:00.000Z",
           "application.version": "1.0.0"
         }
         """)
@@ -310,8 +310,8 @@ class LoggerTests: XCTestCase {
         logMatcher.assertValue(forKey: "uint-8", equals: UInt8(10))
         logMatcher.assertValue(forKey: "double", equals: 10.5)
         logMatcher.assertValue(forKey: "array-of-int", equals: [1, 2, 3])
-        logMatcher.assertValue(forKeyPath: "dictionary-of-date.date1", equals: "2019-12-15T10:00:00Z")
-        logMatcher.assertValue(forKeyPath: "dictionary-of-date.date2", equals: "2019-12-15T11:00:00Z")
+        logMatcher.assertValue(forKeyPath: "dictionary-of-date.date1", equals: "2019-12-15T10:00:00.000Z")
+        logMatcher.assertValue(forKeyPath: "dictionary-of-date.date2", equals: "2019-12-15T11:00:00.000Z")
         logMatcher.assertValue(forKeyPath: "person.name", equals: "Adam")
         logMatcher.assertValue(forKeyPath: "person.age", equals: 30)
         logMatcher.assertValue(forKeyPath: "person.nationality", equals: "Polish")

--- a/Tests/DatadogTests/Datadog/Logs/LogOutputs/LogConsoleOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logs/LogOutputs/LogConsoleOutputTests.swift
@@ -19,7 +19,7 @@ class LogConsoleOutputTests: XCTestCase {
             timeFormatter: LogConsoleOutput.shortTimeFormatter(calendar: .gregorian, timeZone: .UTC)
         )
         output1.writeLogWith(level: .info, message: "Info message.", attributes: [:], tags: [])
-        XCTAssertEqual(messagePrinted, "10:00:00 [INFO] Info message.")
+        XCTAssertEqual(messagePrinted, "10:00:00.000Z [INFO] Info message.")
 
         let output2 = LogConsoleOutput(
             logBuilder: .mockWith(date: .mockDecember15th2019At10AMUTC()),
@@ -28,7 +28,7 @@ class LogConsoleOutputTests: XCTestCase {
             timeFormatter: LogConsoleOutput.shortTimeFormatter(calendar: .gregorian, timeZone: .UTC)
         )
         output2.writeLogWith(level: .info, message: "Info message.", attributes: [:], tags: [])
-        XCTAssertEqual(messagePrinted, "🐶 10:00:00 [INFO] Info message.")
+        XCTAssertEqual(messagePrinted, "🐶 10:00:00.000Z [INFO] Info message.")
     }
 
     func testItPrintsLogsUsingJSONFormat() throws {

--- a/Tests/DatadogTests/Datadog/Utils/EncodingTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/EncodingTests.swift
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class DateFormatterTests: XCTestCase {
+    func testISO8601FormatWithSubSecondPrecision() throws {
+        let dateFormatter = ISO8601DateFormatter.default()
+
+        let knownDate: Date = .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.123)
+        let formattedDate = dateFormatter.string(from: knownDate)
+
+        XCTAssertEqual(formattedDate, "2019-12-15T10:00:00.123Z")
+    }
+}
+
+class EncodingTests: XCTestCase {
+    func testEncodingDateWithSubSecondPrecision() throws {
+        let jsonEncoder = JSONEncoder.default()
+
+        let knownDate: Date = .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.123)
+        let encodedKnownDate = try jsonEncoder.encode(knownDate)
+
+        let jsonDecoder = JSONDecoder()
+        let knownDateDecodedString = try jsonDecoder.decode(String.self, from: encodedKnownDate)
+
+        XCTAssertEqual(knownDateDecodedString, "2019-12-15T10:00:00.123Z")
+    }
+}

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -44,12 +44,12 @@ class InternalLoggersTests: XCTestCase {
     }
 
     private let expectedMessages = [
-        "[DATADOG SDK] 🐶 → 10:00:00 [DEBUG] message",
-        "[DATADOG SDK] 🐶 → 10:00:00 [INFO] message",
-        "[DATADOG SDK] 🐶 → 10:00:00 [NOTICE] message",
-        "[DATADOG SDK] 🐶 → 10:00:00 [WARN] message",
-        "[DATADOG SDK] 🐶 → 10:00:00 [ERROR] message",
-        "[DATADOG SDK] 🐶 → 10:00:00 [CRITICAL] message"
+        "[DATADOG SDK] 🐶 → 10:00:00.000Z [DEBUG] message",
+        "[DATADOG SDK] 🐶 → 10:00:00.000Z [INFO] message",
+        "[DATADOG SDK] 🐶 → 10:00:00.000Z [NOTICE] message",
+        "[DATADOG SDK] 🐶 → 10:00:00.000Z [WARN] message",
+        "[DATADOG SDK] 🐶 → 10:00:00.000Z [ERROR] message",
+        "[DATADOG SDK] 🐶 → 10:00:00.000Z [CRITICAL] message"
     ]
 
     func testUserLoggerDoesNothingWithDefaultVerbosityLevel() {
@@ -120,6 +120,6 @@ class InternalLoggersTests: XCTestCase {
         developerLogger?.info("It works.")
 
         XCTAssertNotNil(developerLogger)
-        XCTAssertEqual(printedMessage, "🐶 → 10:00:00 [INFO] It works.")
+        XCTAssertEqual(printedMessage, "🐶 → 10:00:00.000Z [INFO] It works.")
     }
 }

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -110,8 +110,8 @@ class DDLoggerTests: XCTestCase {
         logMatcher.assertValue(forKeyPath: "nsnull", isTypeOf: Optional<Any>.self)
         logMatcher.assertValue(forKey: "nsurl", equals: "http://apple.com")
         logMatcher.assertValue(forKey: "nsarray-of-int", equals: [1, 2, 3])
-        logMatcher.assertValue(forKeyPath: "nsdictionary-of-date.date1", equals: "2019-12-15T10:00:00Z")
-        logMatcher.assertValue(forKeyPath: "nsdictionary-of-date.date2", equals: "2019-12-15T11:00:00Z")
+        logMatcher.assertValue(forKeyPath: "nsdictionary-of-date.date1", equals: "2019-12-15T10:00:00.000Z")
+        logMatcher.assertValue(forKeyPath: "nsdictionary-of-date.date2", equals: "2019-12-15T11:00:00.000Z")
     }
 }
 // swiftlint:enable multiline_arguments_brackets

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -9,7 +9,11 @@ import XCTest
 /// Provides set of assertions for Log JSON object.
 /// Note: this file is individually referenced by integration tests project, so no dependency on other source files should be introduced.
 struct LogMatcher {
-    private static let dateFormatter = ISO8601DateFormatter()
+    private static let dateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions.insert(.withFractionalSeconds)
+        return formatter
+    }()
 
     /// Log JSON keys.
     struct JSONKey {


### PR DESCRIPTION
Closes #95 

### What and why?

SDK collects `Log`s and writes them onto disk, then uploads them as raw data
It relies on `JSONEncoder` with `dateEncodingStrategy = .iso8601`
However, it turns out `IS08601` doesn't enforce miliseconds and `JSONEncoder` omits them

```swift
let date = {2020-05-04T18:19:57.109Z}
jsonEncoder.dateEncodingStrategy = .iso8601
jsonEncoder.encode(date) // becomes {2020-05-04T18:19:57Z}
```

The result is very well described in the original issue #95

### How?

There are 2 main solutions:

#### `ISO8601DateFormatter` and `dateEncodingStrategy = .custom`

🍎 Apple recommends using `ISO8601DateFormatter` when dealing with `ISO8601` format.
❌ However, that enforces us to use `dateEncodingStrategy = .custom`
Because the logical strategy option, `.formatted(DateFormatter)`, doesn't accept it as it's not a subclass of `DateFormatter`

#### Customized `DateFormatter` and `dateEncodingStrategy = .formatted`

Although this is not the official way, this method is used in many places/projects.

Basically, we describe the `ISO8601` standard in our own `DateFormatter` instance
Then we pass the instance to `dateEncodingStrategy = .formatted(dateFormatter)`
✅ Now we have miliseconds in the encoded data

## UPDATE:

I turned to the first option: `ISO8601DateFormatter` and `dateEncodingStrategy = .custom`

### Questions?

How can we test **encoding** without making types `Decodable`, since they don't need to be decoded in the main target?

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
