### PR TITLE
RUMM-299 Add Tracing integration tests

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -122,6 +122,9 @@
 		61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */; };
 		61AD4E3824531500006E34EA /* DataFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3724531500006E34EA /* DataFormat.swift */; };
 		61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3924534075006E34EA /* TracingFeatureTests.swift */; };
+		61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */; };
+		61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */; };
+		61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */; };
 		61BB2B1B244A185D009F3F56 /* PerformancePreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */; };
 		61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */; };
 		61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */; };
@@ -384,6 +387,9 @@
 		61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingFeatureMocks.swift; sourceTree = "<group>"; };
 		61AD4E3724531500006E34EA /* DataFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataFormat.swift; sourceTree = "<group>"; };
 		61AD4E3924534075006E34EA /* TracingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingFeatureTests.swift; sourceTree = "<group>"; };
+		61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendLogsFixtureViewController.swift; sourceTree = "<group>"; };
+		61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendTracesFixtureViewController.swift; sourceTree = "<group>"; };
+		61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsHelpers.swift; sourceTree = "<group>"; };
 		61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePreset.swift; sourceTree = "<group>"; };
 		61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcExceptionHandlerTests.swift; sourceTree = "<group>"; };
 		61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogPrivateMocks.swift; sourceTree = "<group>"; };
@@ -888,9 +894,10 @@
 			isa = PBXGroup;
 			children = (
 				61441C9C2461A796003D8BB8 /* AppConfig.swift */,
-				61441C9A2461A64F003D8BB8 /* Debugging */,
-				61441C8F2461A648003D8BB8 /* Utils */,
 				61441C0424616DE9003D8BB8 /* AppDelegate.swift */,
+				61441C9A2461A64F003D8BB8 /* Debugging */,
+				61B9ED142461DFEE00C0DCFF /* IntegrationTestFixtures */,
+				61441C8F2461A648003D8BB8 /* Utils */,
 				61441C0A24616DE9003D8BB8 /* Main.storyboard */,
 				61441C0D24616DEC003D8BB8 /* Assets.xcassets */,
 				61441C0F24616DEC003D8BB8 /* LaunchScreen.storyboard */,
@@ -903,6 +910,7 @@
 			children = (
 				61441C3B24617013003D8BB8 /* IntegrationTests.swift */,
 				61441C3C24617013003D8BB8 /* LoggingIntegrationTests.swift */,
+				61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */,
 			);
 			name = DatadogIntegrationTests;
 			path = ../Tests/DatadogIntegrationTests;
@@ -978,6 +986,15 @@
 				61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */,
 			);
 			path = UUIDs;
+			sourceTree = "<group>";
+		};
+		61B9ED142461DFEE00C0DCFF /* IntegrationTestFixtures */ = {
+			isa = PBXGroup;
+			children = (
+				61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */,
+				61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */,
+			);
+			path = IntegrationTestFixtures;
 			sourceTree = "<group>";
 		};
 		61C3637E2436163400C4D4E6 /* DatadogPrivate */ = {
@@ -1539,6 +1556,8 @@
 				61441C982461A649003D8BB8 /* DebugTracingViewController.swift in Sources */,
 				61441C952461A649003D8BB8 /* ConsoleOutputInterceptor.swift in Sources */,
 				61441C972461A649003D8BB8 /* UIViewController+KeyboardControlling.swift in Sources */,
+				61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */,
+				61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */,
 				61441C9D2461A796003D8BB8 /* AppConfig.swift in Sources */,
 				61441C0524616DE9003D8BB8 /* AppDelegate.swift in Sources */,
 				61441C992461A649003D8BB8 /* DebugLoggingViewController.swift in Sources */,
@@ -1551,6 +1570,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61441C4024617013003D8BB8 /* IntegrationTests.swift in Sources */,
+				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,
 				61441C4124617013003D8BB8 /* LoggingIntegrationTests.swift in Sources */,
 				61441C4B24618052003D8BB8 /* SpanMatcher.swift in Sources */,
 				61441C4924618052003D8BB8 /* JSONDataMatcher.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */; };
 		61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */; };
 		61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */; };
+		61B9ED212462089600C0DCFF /* TracingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED202462089600C0DCFF /* TracingIntegrationTests.swift */; };
 		61BB2B1B244A185D009F3F56 /* PerformancePreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */; };
 		61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */; };
 		61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */; };
@@ -390,6 +391,7 @@
 		61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendLogsFixtureViewController.swift; sourceTree = "<group>"; };
 		61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendTracesFixtureViewController.swift; sourceTree = "<group>"; };
 		61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsHelpers.swift; sourceTree = "<group>"; };
+		61B9ED202462089600C0DCFF /* TracingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingIntegrationTests.swift; sourceTree = "<group>"; };
 		61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePreset.swift; sourceTree = "<group>"; };
 		61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcExceptionHandlerTests.swift; sourceTree = "<group>"; };
 		61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogPrivateMocks.swift; sourceTree = "<group>"; };
@@ -910,6 +912,7 @@
 			children = (
 				61441C3B24617013003D8BB8 /* IntegrationTests.swift */,
 				61441C3C24617013003D8BB8 /* LoggingIntegrationTests.swift */,
+				61B9ED202462089600C0DCFF /* TracingIntegrationTests.swift */,
 				61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */,
 			);
 			name = DatadogIntegrationTests;
@@ -1570,6 +1573,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61441C4024617013003D8BB8 /* IntegrationTests.swift in Sources */,
+				61B9ED212462089600C0DCFF /* TracingIntegrationTests.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,
 				61441C4124617013003D8BB8 /* LoggingIntegrationTests.swift in Sources */,
 				61441C4B24618052003D8BB8 /* SpanMatcher.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
@@ -25,7 +25,7 @@
       </PreActions>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Integration"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
@@ -28,7 +28,9 @@
       buildConfiguration = "Integration"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <PreActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
@@ -65,12 +67,22 @@
             </ActionContent>
          </ExecutionAction>
       </PostActions>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "IS_RUNNING_UI_TESTS"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61133B81242393DE00786299"
+            BuildableName = "Datadog.framework"
+            BlueprintName = "Datadog"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61133BEF242397DA00786299"
+            BuildableName = "DatadogObjc.framework"
+            BlueprintName = "DatadogObjc"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -85,7 +97,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Integration"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -94,6 +106,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61441C0124616DE9003D8BB8"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -101,6 +123,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61441C0124616DE9003D8BB8"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Datadog/Example/AppDelegate.swift
+++ b/Datadog/Example/AppDelegate.swift
@@ -25,9 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Initialize Datadog SDK
         Datadog.initialize(
             appContext: .init(),
-            configuration: Datadog.Configuration
-                .builderUsing(clientToken: appConfig.clientToken)
-                .build()
+            configuration: appConfig.datadogConfiguration
         )
 
         // Set user information
@@ -36,6 +34,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Create logger instance
         logger = Logger.builder
             .set(serviceName: appConfig.serviceName)
+            .set(loggerName: "logger-name")
+            .sendNetworkInfo(true)
             .printLogsToConsole(true, usingFormat: .shortWith(prefix: "[iOS App] "))
             .build()
 

--- a/Datadog/Example/AppDelegate.swift
+++ b/Datadog/Example/AppDelegate.swift
@@ -9,6 +9,8 @@ import Datadog
 import OpenTracing
 
 var logger: Logger!
+var tracer: OpenTracing.Tracer { Global.sharedTracer }
+
 let appConfig: AppConfig = currentAppConfig()
 
 @UIApplicationMain

--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -2,12 +2,13 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Features-->
+        <!--Testing-->
         <scene sceneID="2o7-u6-GFX">
             <objects>
                 <tableViewController id="inJ-zN-6Pz" sceneMemberID="viewController">
@@ -16,12 +17,12 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="wle-IX-rUl">
-                            <rect key="frame" x="0.0" y="143" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="286" width="414" height="0.0"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         </view>
                         <sections>
-                            <tableViewSection id="tgY-ka-MYv">
+                            <tableViewSection headerTitle="Debug features:" id="tgY-ka-MYv">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="xoO-Hn-N29" style="IBUITableViewCellStyleDefault" id="2Id-yJ-iEw">
                                         <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
@@ -33,7 +34,7 @@
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Logging" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xoO-Hn-N29">
                                                     <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -53,7 +54,7 @@
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Tracing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NMa-2j-8ux">
                                                     <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -65,13 +66,57 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="UITest scenarios:" id="6Zm-Kj-Vxy">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="cup-8g-amw" style="IBUITableViewCellStyleDefault" id="0R8-Cw-D1v">
+                                        <rect key="frame" x="0.0" y="171" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0R8-Cw-D1v" id="qW4-7f-cXH">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Send logs for UI Tests" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="cup-8g-amw">
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="6cL-Sc-vbm" kind="show" id="65A-jA-yIE"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Mfa-d4-bXd" style="IBUITableViewCellStyleDefault" id="TY6-N9-9Dp">
+                                        <rect key="frame" x="0.0" y="214.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TY6-N9-9Dp" id="1CW-VC-avL">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Send traces for UI Tests" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Mfa-d4-bXd">
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="dQd-PO-4F8" kind="show" id="A9W-uP-Mly"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                         </sections>
                         <connections>
                             <outlet property="dataSource" destination="inJ-zN-6Pz" id="5kv-dC-RIj"/>
                             <outlet property="delegate" destination="inJ-zN-6Pz" id="bp5-F3-8qt"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Features" id="JeY-0H-yif"/>
+                    <navigationItem key="navigationItem" title="Testing" id="JeY-0H-yif"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RfY-1e-1pV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -96,7 +141,7 @@
         <!--Debug Logging View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="DebugLoggingViewController" customModule="Shopist" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="DebugLoggingViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -309,12 +354,12 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-57" y="123"/>
+            <point key="canvasLocation" x="-99" y="-410"/>
         </scene>
         <!--Debug Tracing View Controller-->
         <scene sceneID="qsy-Bu-n9m">
             <objects>
-                <viewController id="FaI-gu-eql" customClass="DebugTracingViewController" customModule="Shopist" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="FaI-gu-eql" customClass="DebugTracingViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="eNX-qG-oNX">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -586,7 +631,65 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LiQ-0O-emZ" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-58" y="785"/>
+            <point key="canvasLocation" x="264" y="252"/>
+        </scene>
+        <!--Send Logs Fixture View Controller-->
+        <scene sceneID="pAJ-JA-qyP">
+            <objects>
+                <viewController id="6cL-Sc-vbm" customClass="SendLogsFixtureViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="uJg-Zj-2p8">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending logs... " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eN3-26-Att">
+                                <rect key="frame" x="146" y="437.5" width="122" height="21"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="eN3-26-Att" firstAttribute="centerY" secondItem="uJg-Zj-2p8" secondAttribute="centerY" id="TYh-qt-WSq"/>
+                            <constraint firstItem="eN3-26-Att" firstAttribute="centerX" secondItem="uJg-Zj-2p8" secondAttribute="centerX" id="bAc-FS-DpA"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="9il-94-ccy"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Obr-1g-kOD"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="8d2-uk-OiR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="259" y="915"/>
+        </scene>
+        <!--Send Traces Fixture View Controller-->
+        <scene sceneID="LEY-wo-4ju">
+            <objects>
+                <viewController id="dQd-PO-4F8" customClass="SendTracesFixtureViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="iEH-Jh-wcF">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending traces... " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OQc-SX-UQJ">
+                                <rect key="frame" x="138" y="437.5" width="138" height="21"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="OQc-SX-UQJ" firstAttribute="centerX" secondItem="iEH-Jh-wcF" secondAttribute="centerX" id="Mme-MH-jDz"/>
+                            <constraint firstItem="OQc-SX-UQJ" firstAttribute="centerY" secondItem="iEH-Jh-wcF" secondAttribute="centerY" id="tS3-bZ-ee7"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="5fD-Q8-BQ1"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="ap5-Ws-Q2y"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6qc-vU-hqo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-309" y="1611"/>
         </scene>
     </scenes>
 </document>

--- a/Datadog/Example/IntegrationTestFixtures/SendLogsFixtureViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendLogsFixtureViewController.swift
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal class SendLogsFixtureViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Send logs
+        logger.addTag(withKey: "tag1", value: "tag-value")
+        logger.add(tag: "tag2")
+
+        logger.addAttribute(forKey: "logger-attribute1", value: "string value")
+        logger.addAttribute(forKey: "logger-attribute2", value: 1_000)
+
+        logger.debug("debug message", attributes: ["attribute": "value"])
+        logger.info("info message", attributes: ["attribute": "value"])
+        logger.notice("notice message", attributes: ["attribute": "value"])
+        logger.warn("warn message", attributes: ["attribute": "value"])
+        logger.error("error message", attributes: ["attribute": "value"])
+        logger.critical("critical message", attributes: ["attribute": "value"])
+    }
+}

--- a/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
@@ -5,9 +5,54 @@
  */
 
 import UIKit
+import OpenTracing
 
 internal class SendTracesFixtureViewController: UIViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    private let backgroundQueue = DispatchQueue(label: "background-queue")
+
+    /// Traces view appearing
+    private var viewAppearingSpan: Span!
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        viewAppearingSpan = tracer.startSpan(operationName: "view appearing", childOf: nil)
+
+        let dataDownloadingSpan = tracer.startSpan(
+            operationName: "data downloading",
+            childOf: viewAppearingSpan.context
+        )
+
+        downloadSomeData { [weak self] data in
+            dataDownloadingSpan.finish()
+
+            guard let self = self else { return }
+
+            let dataPresentationSpan = tracer.startSpan(
+                operationName: "data presentation",
+                childOf: self.viewAppearingSpan.context
+            )
+            self.present(data: data)
+            dataPresentationSpan.finish()
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        viewAppearingSpan.finish()
+    }
+
+    /// Simulates some asynchronous work with completion.
+    private func downloadSomeData(completion: @escaping (Data) -> Void) {
+        backgroundQueue.async {
+            Thread.sleep(forTimeInterval: 0.3)
+            DispatchQueue.main.async { completion(Data()) }
+        }
+    }
+
+    /// Simulates presentation of some data.
+    private func present(data: Data) {
+        Thread.sleep(forTimeInterval: 0.06)
     }
 }

--- a/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal class SendTracesFixtureViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
@@ -31,6 +31,7 @@ class LoggingIntegrationTests: IntegrationTests {
         let recordedRequests = try serverSession.getRecordedPOSTRequests()
         recordedRequests.forEach { request in
             XCTAssertTrue(request.path.contains("/ui-tests-client-token?ddsource=mobile"))
+            XCTAssertTrue(request.httpHeaders.contains("Content-Type: application/json"))
         }
 
         // Assert logs

--- a/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
@@ -14,11 +14,6 @@ class LoggingIntegrationTests: IntegrationTests {
         static let logsDeliveryTime: TimeInterval = 30
     }
 
-    override func setUp() {
-        super.setUp()
-        Springboard().deleteExampleAppIfExists()
-    }
-
     func testLaunchTheAppAndSendLogs() throws {
         let app = ExampleApplication()
         app.launchWith(mockServerURL: serverSession.recordingURL)

--- a/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
@@ -4,48 +4,25 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-@testable import Datadog // TODO RUMM-299 change to regular import after fixtures are moved to host app
 import HTTPServerMock
 import XCTest
 
+// swiftlint:disable trailing_closure
 class LoggingIntegrationTests: IntegrationTests {
     private struct Constants {
         /// Time needed for logs to be uploaded to mock server.
         static let logsDeliveryTime: TimeInterval = 30
     }
 
-    // swiftlint:disable trailing_closure
-    func testLogsAreUploadedToServer() throws {
-        let serverSession = server.obtainUniqueRecordingSession()
+    override func setUp() {
+        super.setUp()
+        Springboard().deleteExampleAppIfExists()
+    }
 
-        // Initialize SDK
-        Datadog.initialize(
-            appContext: .init(mainBundle: Bundle.init(for: type(of: self))),
-            configuration: Datadog.Configuration.builderUsing(clientToken: "client-token")
-                .set(logsEndpoint: .custom(url: serverSession.recordingURL.absoluteString))
-                .build()
-        )
-
-        // Create logger
-        let logger = Logger.builder
-            .set(serviceName: "service-name")
-            .set(loggerName: "logger-name")
-            .sendNetworkInfo(true)
-            .build()
-
-        // Send logs
-        logger.addTag(withKey: "tag1", value: "tag-value")
-        logger.add(tag: "tag2")
-
-        logger.addAttribute(forKey: "logger-attribute1", value: "string value")
-        logger.addAttribute(forKey: "logger-attribute2", value: 1_000)
-
-        logger.debug("debug message", attributes: ["attribute": "value"])
-        logger.info("info message", attributes: ["attribute": "value"])
-        logger.notice("notice message", attributes: ["attribute": "value"])
-        logger.warn("warn message", attributes: ["attribute": "value"])
-        logger.error("error message", attributes: ["attribute": "value"])
-        logger.critical("critical message", attributes: ["attribute": "value"])
+    func testLaunchTheAppAndSendLogs() throws {
+        let app = ExampleApplication()
+        app.launchWith(mockServerURL: serverSession.recordingURL)
+        app.tapSendLogsForUITests()
 
         // Wait for delivery
         Thread.sleep(forTimeInterval: Constants.logsDeliveryTime)
@@ -53,7 +30,7 @@ class LoggingIntegrationTests: IntegrationTests {
         // Assert
         let recordedRequests = try serverSession.getRecordedPOSTRequests()
         recordedRequests.forEach { request in
-            XCTAssertTrue(request.path.contains("/client-token?ddsource=mobile"))
+            XCTAssertTrue(request.path.contains("/ui-tests-client-token?ddsource=mobile"))
         }
 
         let logMatchers = try recordedRequests
@@ -79,7 +56,7 @@ class LoggingIntegrationTests: IntegrationTests {
 
         logMatchers.forEach { matcher in
             matcher.assertDate(matches: { Date().timeIntervalSince($0) < Constants.logsDeliveryTime * 2 })
-            matcher.assertServiceName(equals: "service-name")
+            matcher.assertServiceName(equals: "ui-tests-service-name")
             matcher.assertLoggerName(equals: "logger-name")
             matcher.assertLoggerVersion(matches: { version in version.split(separator: ".").count == 3 })
             matcher.assertApplicationVersion(equals: "1.0")
@@ -91,7 +68,7 @@ class LoggingIntegrationTests: IntegrationTests {
                     "attribute": "value",
                 ]
             )
-            matcher.assertTags(equal: ["tag1:tag-value", "tag2"])
+            matcher.assertTags(equal: ["build_configuration:release", "tag1:tag-value", "tag2"])
 
             matcher.assertValue(
                 forKeyPath: LogMatcher.JSONKey.networkReachability,
@@ -126,5 +103,5 @@ class LoggingIntegrationTests: IntegrationTests {
             #endif
         }
     }
-    // swiftlint:enable trailing_closure
 }
+// swiftlint:enable trailing_closure

--- a/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
@@ -27,12 +27,13 @@ class LoggingIntegrationTests: IntegrationTests {
         // Wait for delivery
         Thread.sleep(forTimeInterval: Constants.logsDeliveryTime)
 
-        // Assert
+        // Assert requests
         let recordedRequests = try serverSession.getRecordedPOSTRequests()
         recordedRequests.forEach { request in
             XCTAssertTrue(request.path.contains("/ui-tests-client-token?ddsource=mobile"))
         }
 
+        // Assert logs
         let logMatchers = try recordedRequests
             .flatMap { request in try LogMatcher.fromArrayOfJSONObjectsData(request.httpBody) }
 

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -32,6 +32,7 @@ class TracingIntegrationTests: IntegrationTests {
         let recordedRequests = try serverSession.getRecordedPOSTRequests()
         recordedRequests.forEach { request in
             XCTAssertTrue(request.path.contains("/ui-tests-client-token?ddsource=mobile"))
+            XCTAssertTrue(request.httpHeaders.contains("Content-Type: text/plain;charset=UTF-8"))
         }
 
         let testEndTimeInNanoseconds = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -13,11 +13,6 @@ class TracingIntegrationTests: IntegrationTests {
         static let tracesDeliveryTime: TimeInterval = 30
     }
 
-    override func setUp() {
-        super.setUp()
-        Springboard().deleteExampleAppIfExists()
-    }
-
     func testLaunchTheAppAndSendTraces() throws {
         let testBeginTimeInNanoseconds = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
 

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -1,0 +1,107 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import HTTPServerMock
+import XCTest
+
+class TracingIntegrationTests: IntegrationTests {
+    private struct Constants {
+        /// Time needed for traces to be uploaded to mock server.
+        static let tracesDeliveryTime: TimeInterval = 30
+    }
+
+    override func setUp() {
+        super.setUp()
+        Springboard().deleteExampleAppIfExists()
+    }
+
+    func testLaunchTheAppAndSendTraces() throws {
+        let testBeginTimeInNanoseconds = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
+
+        let app = ExampleApplication()
+        app.launchWith(mockServerURL: serverSession.recordingURL)
+        app.tapSendTracesForUITests()
+
+        // Wait for delivery
+        Thread.sleep(forTimeInterval: Constants.tracesDeliveryTime)
+
+        // Assert requests
+        let recordedRequests = try serverSession.getRecordedPOSTRequests()
+        recordedRequests.forEach { request in
+            XCTAssertTrue(request.path.contains("/ui-tests-client-token?ddsource=mobile"))
+        }
+
+        let testEndTimeInNanoseconds = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
+
+        // Assert spans
+        let spanMatchers = try recordedRequests
+            .flatMap { request in try SpanMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+
+        XCTAssertEqual(try spanMatchers[0].operationName(), "data downloading")
+        XCTAssertEqual(try spanMatchers[1].operationName(), "data presentation")
+        XCTAssertEqual(try spanMatchers[2].operationName(), "view appearing")
+
+        // they share the same `trace_id`
+        XCTAssertEqual(try spanMatchers[0].traceID(), try spanMatchers[1].traceID())
+        XCTAssertEqual(try spanMatchers[0].traceID(), try spanMatchers[2].traceID())
+
+        // "downloading" and "presentation" are childs of "view appearing"
+        XCTAssertEqual(try spanMatchers[0].parentSpanID(), try spanMatchers[2].spanID())
+        XCTAssertEqual(try spanMatchers[1].parentSpanID(), try spanMatchers[2].spanID())
+
+        XCTAssertNil(try? spanMatchers[0].metrics.isRootSpan())
+        XCTAssertNil(try? spanMatchers[1].metrics.isRootSpan())
+        XCTAssertEqual(try spanMatchers[2].metrics.isRootSpan(), 1)
+
+        try spanMatchers.forEach { matcher in
+            XCTAssertGreaterThan(try matcher.startTime(), testBeginTimeInNanoseconds)
+            XCTAssertLessThan(try matcher.startTime(), testEndTimeInNanoseconds)
+
+            XCTAssertEqual(try matcher.serviceName(), "ios")
+            XCTAssertEqual(try matcher.resource(), try matcher.operationName())
+            XCTAssertEqual(try matcher.type(), "custom")
+            XCTAssertEqual(try matcher.isError(), 0)
+            XCTAssertEqual(try matcher.environment(), "staging")
+
+            XCTAssertEqual(try matcher.meta.source(), "mobile")
+            XCTAssertEqual(try matcher.meta.tracerVersion().split(separator: ".").count, 3)
+            XCTAssertEqual(try matcher.meta.applicationVersion(), "1.0")
+
+            XCTAssertTrue(
+                SpanMatcher.allowedNetworkReachabilityValues.contains(
+                    try matcher.meta.networkReachability()
+                )
+            )
+
+            try matcher.meta.networkAvailableInterfaces().split(separator: "+").forEach { interface in
+                XCTAssertTrue(
+                    SpanMatcher.allowedNetworkAvailableInterfacesValues.contains(String(interface))
+                )
+            }
+
+            XCTAssertTrue(["0", "1"].contains(try matcher.meta.networkConnectionSupportsIPv4()))
+            XCTAssertTrue(["0", "1"].contains(try matcher.meta.networkConnectionSupportsIPv6()))
+            XCTAssertTrue(["0", "1"].contains(try matcher.meta.networkConnectionIsExpensive()))
+            if #available(iOS 13.0, *) {
+                XCTAssertTrue(["0", "1"].contains(try matcher.meta.networkConnectionIsConstrained()))
+            }
+
+            #if targetEnvironment(simulator)
+                // When running on iOS Simulator
+                XCTAssertNil(try? matcher.meta.mobileNetworkCarrierName())
+                XCTAssertNil(try? matcher.meta.mobileNetworkCarrierISOCountryCode())
+                XCTAssertNil(try? matcher.meta.mobileNetworkCarrierRadioTechnology())
+                XCTAssertNil(try? matcher.meta.mobileNetworkCarrierAllowsVoIP())
+            #else
+                // When running on physical device with SIM card registered
+                XCTAssertNotNil(try? matcher.meta.mobileNetworkCarrierName())
+                XCTAssertNotNil(try? matcher.meta.mobileNetworkCarrierISOCountryCode())
+                XCTAssertNotNil(try? matcher.meta.mobileNetworkCarrierRadioTechnology())
+                XCTAssertNotNil(try? matcher.meta.mobileNetworkCarrierAllowsVoIP())
+            #endif
+        }
+    }
+}

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -6,22 +6,6 @@
 
 import XCTest
 
-/// Convenient interface to navigate through iOS springboard.
-class Springboard: XCUIApplication {
-    override init() {
-        super.init(bundleIdentifier: "com.apple.springboard")
-    }
-
-    func deleteExampleAppIfExists() {
-        let icon = icons["Example"]
-        if icon.exists {
-            icon.press(forDuration: 1.3)
-            buttons.element(boundBy: 0).tap() // tap "Delete App" button
-            buttons.element(boundBy: 1).tap() // tap "Delete" button
-        }
-    }
-}
-
 /// Convenient interface to navigate through Example app's main screen.
 class ExampleApplication: XCUIApplication {
     func launchWith(mockServerURL: URL) {

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+
+/// Convenient interface to navigate through iOS springboard.
+class Springboard: XCUIApplication {
+    override init() {
+        super.init(bundleIdentifier: "com.apple.springboard")
+    }
+
+    func deleteExampleAppIfExists() {
+        let icon = icons["Example"]
+        if icon.exists {
+            icon.press(forDuration: 1.3)
+            buttons.element(boundBy: 0).tap() // tap "Delete App" button
+            buttons.element(boundBy: 1).tap() // tap "Delete" button
+        }
+    }
+}
+
+/// Convenient interface to navigate through Example app's main screen.
+class ExampleApplication: XCUIApplication {
+    func launchWith(mockServerURL: URL) {
+        launchArguments = ["IS_RUNNING_UI_TESTS"]
+        launchEnvironment = [
+            "DD_MOCK_SERVER_URL": mockServerURL.absoluteString
+        ]
+        super.launch()
+    }
+
+    func tapSendLogsForUITests() {
+        tables.staticTexts["Send logs for UI Tests"].tap()
+    }
+
+    func tapSendTracesForUITests() {
+        tables.staticTexts["Send traces for UI Tests"].tap()
+    }
+}

--- a/Tests/DatadogTests/Helpers/TestsDirectory.swift
+++ b/Tests/DatadogTests/Helpers/TestsDirectory.swift
@@ -21,10 +21,6 @@ func obtainUniqueTemporaryDirectory() -> Directory {
 /// The subfolder does not exist and can be created and deleted by calling `.create()` and `.delete()`.
 let temporaryDirectory = obtainUniqueTemporaryDirectory()
 
-/// Default URL where logs persist in
-/// logsDirectory.delete() can be useful in tests when logs need to be cleared
-let logsDirectory = try! obtainLoggingFeatureDirectory()
-
 /// Extends `Directory` with set of utilities for convenient work with files in tests.
 /// Provides handy methods to create / delete files and directires.
 extension Directory {

--- a/Tests/DatadogTests/Matchers/SpanMatcher.swift
+++ b/Tests/DatadogTests/Matchers/SpanMatcher.swift
@@ -127,6 +127,11 @@ internal class SpanMatcher {
         func mobileNetworkCarrierAllowsVoIP()      throws -> String { try matcher.meta(forKeyPath: "meta.network.client.sim_carrier.allows_voip") }
     }
 
+    /// Allowed values for `meta.network.client.available_interfaces` attribute.
+    static let allowedNetworkAvailableInterfacesValues: Set<String> = ["wifi", "wiredEthernet", "cellular", "loopback", "other"]
+    /// Allowed values for `meta.network.client.reachability` attribute.
+    static let allowedNetworkReachabilityValues: Set<String> = ["yes", "no", "maybe"]
+
     // MARK: - Private
 
     private func attribute<T: AllowedSpanAttributeValue & Equatable>(forKeyPath keyPath: String) throws -> T {

--- a/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerMock.swift
+++ b/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerMock.swift
@@ -28,13 +28,16 @@ public class ServerMock {
         let path: String
         /// HTTP method of this request.
         let httpMethod: String
+        /// Follow-up path to fetch HTTP headers associated with this request.
+        let httpHeadersInspectionPath: String
         /// Follow-up path to fetch HTTP body associated with this request.
         let httpBodyInspectionPath: String
 
         enum CodingKeys: String, CodingKey {
             case path = "request_path"
             case httpMethod = "request_method"
-            case httpBodyInspectionPath = "inspection_path"
+            case httpHeadersInspectionPath = "headers_inspection_path"
+            case httpBodyInspectionPath = "body_inspection_path"
         }
     }
 
@@ -51,5 +54,12 @@ public class ServerMock {
     internal func getRecordedRequestBody(_ requestInfo: RequestInfo) throws -> Data {
         let bodyURL = baseURL.appendingPathComponent(requestInfo.httpBodyInspectionPath)
         return try Data(contentsOf: bodyURL)
+    }
+
+    /// Fetches HTTP headers of particular request recorded by the server.
+    internal func getRecordedRequestHeaders(_ requestInfo: RequestInfo) throws -> [String] {
+        let headersURL = baseURL.appendingPathComponent(requestInfo.httpHeadersInspectionPath)
+        let headersString = try String(data: Data(contentsOf: headersURL), encoding: .utf8)
+        return headersString?.split(separator: "\r\n").map { String($0) } ?? []
     }
 }

--- a/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerSession.swift
+++ b/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerSession.swift
@@ -12,6 +12,8 @@ public class ServerSession {
     public struct POSTRequestDetails {
         /// Original path of the request, i.e. `/something/1` for `POST /something/1`.
         public let path: String
+        /// Original http headers of this request.
+        public let httpHeaders: [String]
         /// Original body of this request.
         public let httpBody: Data
     }
@@ -37,6 +39,7 @@ public class ServerSession {
             .map { requestInfo in
                 return POSTRequestDetails(
                     path: requestInfo.path,
+                    httpHeaders: try server.getRecordedRequestHeaders(requestInfo),
                     httpBody: try server.getRecordedRequestBody(requestInfo)
                 )
             }


### PR DESCRIPTION
### What and why?

🧪 This PR adds integration test for the Tracing feature.

### How?

It leverages the setup introduced in #97.

`SendTracesFixtureViewController` was added to the `Example` app. The UI tests runner in `TracingIntegrationTests` launches the app and navigates to _"Send traces for UI Tests"_ screen:

![Simulator Screen Shot - iPhone 11 - 2020-05-06 at 11 36 32](https://user-images.githubusercontent.com/2358722/81163143-966bda00-8f8e-11ea-898c-5c95e51c8f26.png)

In that view controller, `viewDidLoad()`, `viewWillAppear()` and `viewDidAppear()` methods are instrumented to generate trace information:

<img width="1106" alt="Screenshot 2020-05-06 at 11 43 49" src="https://user-images.githubusercontent.com/2358722/81163331-de8afc80-8f8e-11ea-8f0e-46b8ad900b58.png">

Trace data is send to the `HTTPServerMock` and asserted in `TracingIntegrationTests `.

Same thing was also done to Logging feature integration test - log fixtures were moved to view controller in `Example` app and only asserted in `LoggingIntegrationTests`.

#### Passing the information from UITest to `Example` app

This of course requires passing the mock server url from the `DatadogIntegrationTests` target to `Example` app. This is done using `XCUITest` tools:
```swift
class ExampleApplication: XCUIApplication {
    func launchWith(mockServerURL: URL) {
        launchArguments = ["IS_RUNNING_UI_TESTS"]
        launchEnvironment = [
            "DD_MOCK_SERVER_URL": mockServerURL.absoluteString
        ]
        super.launch()
    }

    // ...
}
```

Additionally, the `Example` app wipes out its persisted SDK data on each start if `IS_RUNNING_UI_TESTS ` launch argument is present. This guarantees a clean start for each test. 

💡 I also tried deleting the app before each run by making UI Test runner tap and hold the app icon on Springboard, then chose "Delete App" and confirm, however this turned out to be flaky on CI (and also locally) as it required custom `sleep()` calls to wait for iOS popups animation.

#### Extra things done in this PR

Because Logging and Tracing feature use different HTTP headers, I updated the `HTTPServerMock` to also inspect headers passed with each request. This allows for HTTP headers assertions, which was crucial for this PR and will help on testing the upcoming `URLSession` auto-instrumentation feature.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
