### PR TITLE
RUMM-332 Add public initializer for `DDTracer`

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */; };
 		61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */; };
 		61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
+		61E917D12465423600E6C631 /* DDTracerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D02465423600E6C631 /* DDTracerConfiguration.swift */; };
+		61E917D3246546BF00E6C631 /* DDTracerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D2246546BF00E6C631 /* DDTracerConfigurationTests.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E085879242519FF001A3583 /* NetworkPathMonitor.swift */; };
@@ -423,6 +425,8 @@
 		61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFileOutputTests.swift; sourceTree = "<group>"; };
 		61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDataMatcher.swift; sourceTree = "<group>"; };
 		61E45ED02451A8730061DAC7 /* SpanMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanMatcher.swift; sourceTree = "<group>"; };
+		61E917D02465423600E6C631 /* DDTracerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerConfiguration.swift; sourceTree = "<group>"; };
+		61E917D2246546BF00E6C631 /* DDTracerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerConfigurationTests.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		9E085879242519FF001A3583 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
@@ -541,6 +545,7 @@
 				61133BBB2423979B00786299 /* Datadog.swift */,
 				61133BB62423979B00786299 /* Logger.swift */,
 				61C5A88D24509A1F00DA608C /* DDTracer.swift */,
+				61E917D02465423600E6C631 /* DDTracerConfiguration.swift */,
 				61133BB52423979B00786299 /* DatadogConfiguration.swift */,
 				61133B9E2423979B00786299 /* Core */,
 				61133BBC2423979B00786299 /* Logs */,
@@ -744,6 +749,7 @@
 				61133C412423990D00786299 /* DatadogTests.swift */,
 				61133C382423990D00786299 /* LoggerTests.swift */,
 				61C5A89524509BF600DA608C /* DDTracerTests.swift */,
+				61E917D2246546BF00E6C631 /* DDTracerConfigurationTests.swift */,
 				61133C212423990D00786299 /* Core */,
 				61133C392423990D00786299 /* Logs */,
 				61C5A89724509C1100DA608C /* Tracing */,
@@ -1421,6 +1427,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61E917D12465423600E6C631 /* DDTracerConfiguration.swift in Sources */,
 				61133BDE2423979B00786299 /* CompilationConditions.swift in Sources */,
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,
 				61133BDC2423979B00786299 /* Logger.swift in Sources */,
@@ -1492,6 +1499,7 @@
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
 				61133C622423990D00786299 /* InternalLoggersTests.swift in Sources */,
 				61133C582423990D00786299 /* FileWriterTests.swift in Sources */,
+				61E917D3246546BF00E6C631 /* DDTracerConfigurationTests.swift in Sources */,
 				61C5A89D24509C1100DA608C /* DDSpanTests.swift in Sources */,
 				61133C672423990D00786299 /* LogConsoleOutputTests.swift in Sources */,
 				61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */,

--- a/Datadog/Example/AppDelegate.swift
+++ b/Datadog/Example/AppDelegate.swift
@@ -47,7 +47,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Register global tracer
         Global.sharedTracer = DDTracer.initialize(
-            configuration: DDTracer.Configuration()
+            configuration: DDTracer.Configuration(
+                serviceName: appConfig.serviceName
+            )
         )
 
         // Set highest verbosity level to see internal actions made in SDK

--- a/Datadog/Example/AppDelegate.swift
+++ b/Datadog/Example/AppDelegate.swift
@@ -46,7 +46,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .build()
 
         // Register global tracer
-        Global.sharedTracer = DDTracer()
+        Global.sharedTracer = DDTracer.initialize(
+            configuration: DDTracer.Configuration()
+        )
 
         // Set highest verbosity level to see internal actions made in SDK
         Datadog.verbosityLevel = .debug

--- a/Shopist/Shopist/AppDelegate.swift
+++ b/Shopist/Shopist/AppDelegate.swift
@@ -34,7 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .build()
 
         // Register global tracer
-        Global.sharedTracer = DDTracer(tracingFeature: TracingFeature.instance!) // TODO: RUMM-332 Use public `DDTracer` initializer
+        Global.sharedTracer = DDTracer.initialize(configuration: .init(serviceName: appConfig.serviceName))
 
         // Set highest verbosity level to see internal actions made in SDK
         Datadog.verbosityLevel = .debug

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -8,17 +8,6 @@ import OpenTracing
 import Foundation
 
 public class DDTracer: Tracer {
-    /// Datadog Tracer configuration.
-    public struct Configuration {
-        internal let serviceName: String
-
-        /// Initializes the Datadog Tracer configuration.
-        /// - Parameter serviceName: the service name that will appear in traces (if not provided or `nil`, default value is used: "ios").
-        public init(serviceName: String? = nil) {
-            self.serviceName = serviceName ?? Datadog.Configuration.Defaults.serviceName
-        }
-    }
-
     /// Writes `Span` objects to output.
     private let spanOutput: SpanOutput
 
@@ -40,10 +29,13 @@ public class DDTracer: Tracer {
         guard let tracingFeature = TracingFeature.instance else {
             throw ProgrammerError(description: "`Datadog.initialize()` must be called prior to `DDTracer.initialize()`.")
         }
-        return DDTracer(tracingFeature: tracingFeature, tracerConfiguration: configuration)
+        return DDTracer(
+            tracingFeature: tracingFeature,
+            tracerConfiguration: ResolvedConfiguration(tracerConfiguration: configuration)
+        )
     }
 
-    internal convenience init(tracingFeature: TracingFeature, tracerConfiguration: Configuration) {
+    internal convenience init(tracingFeature: TracingFeature, tracerConfiguration: ResolvedConfiguration) {
         self.init(
             spanOutput: SpanFileOutput(
                 spanBuilder: SpanBuilder(

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -31,7 +31,7 @@ public class DDTracer: Tracer {
         do {
             return try initializeOrThrow(configuration: configuration)
         } catch {
-            consolePrint("🔥 \(error)")
+            consolePrint("\(error)")
             return DDNoopTracer()
         }
     }
@@ -68,7 +68,7 @@ public class DDTracer: Tracer {
         do {
             return try startSpanOrThrow(operationName: operationName, references: references, tags: tags, startTime: startTime)
         } catch {
-            consolePrint("🔥 \(error)")
+            consolePrint("\(error)")
             return DDNoopSpan()
         }
     }

--- a/Sources/Datadog/DDTracerConfiguration.swift
+++ b/Sources/Datadog/DDTracerConfiguration.swift
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+extension DDTracer {
+    /// Datadog Tracer configuration.
+    public struct Configuration {
+        /// The service name that will appear in traces (if not provided or `nil`, the SDK default `serviceName` will be used).
+        public var serviceName: String?
+
+        /// Initializes the Datadog Tracer configuration.
+        /// - Parameter serviceName: the service name that will appear in traces (if not provided or `nil`, the SDK default `serviceName` will be used).
+        public init(serviceName: String? = nil) {
+            self.serviceName = serviceName
+        }
+    }
+
+    /// Datadog Tracer configuration resolved with defaults coming from the other source.
+    internal struct ResolvedConfiguration {
+        internal let serviceName: String
+
+        /// TODO: RUMM-409 Defaults should be resolved using `Datadog.instance`. I don't do it now, because the SDK-wide `serviceName`
+        ///  must be first done on `master` branch, then merged to `tracing` and update here.
+        init(tracerConfiguration: Configuration) {
+            self.serviceName = tracerConfiguration.serviceName ?? "ios"
+        }
+    }
+}

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -58,7 +58,7 @@ public class Datadog {
         do {
             try initializeOrThrow(appContext: appContext, configuration: configuration)
         } catch {
-            consolePrint("🔥 \(error)")
+            consolePrint("\(error)")
         }
     }
 
@@ -165,7 +165,7 @@ internal typealias AppContext = Datadog.AppContext
 /// When thrown, check if configuration passed to `Datadog.initialize(...)` is correct
 /// and if you do not call any other SDK methods before it returns.
 internal struct ProgrammerError: Error, CustomStringConvertible {
-    init(description: String) { self.description = "Datadog SDK usage error: \(description)" }
+    init(description: String) { self.description = "🔥 Datadog SDK usage error: \(description)" }
     let description: String
 }
 

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -9,12 +9,6 @@ import Foundation
 extension Datadog {
     /// Datadog SDK configuration.
     public struct Configuration {
-        /// Set of default values for SDK componetns which provide distinct way of initialization (i.e. `Logger` or `DDTracer`).
-        /// NOTE: changing any of this defaults requires corresponding change to public documentation comment.
-        internal struct Defaults {
-            internal static let serviceName: String = "ios"
-        }
-
         /// Determines server to which logs are sent.
         public enum LogsEndpoint {
             /// US based servers.

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -9,6 +9,12 @@ import Foundation
 extension Datadog {
     /// Datadog SDK configuration.
     public struct Configuration {
+        /// Set of default values for SDK componetns which provide distinct way of initialization (i.e. `Logger` or `DDTracer`).
+        /// NOTE: changing any of this defaults requires corresponding change to public documentation comment.
+        internal struct Defaults {
+            internal static let serviceName: String = "ios"
+        }
+
         /// Determines server to which logs are sent.
         public enum LogsEndpoint {
             /// US based servers.

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -326,7 +326,7 @@ public class Logger {
             do {
                 return try buildOrThrow()
             } catch {
-                consolePrint("🔥 \(error)")
+                consolePrint("\(error)")
                 return Logger(
                     logOutput: NoOpLogOutput(),
                     identifier: "no-op"

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -260,7 +260,7 @@ public class Logger {
     ///           .build()
     ///
     public class Builder {
-        private var serviceName: String = "ios"
+        private var serviceName: String = Datadog.Configuration.Defaults.serviceName
         private var loggerName: String?
         private var sendNetworkInfo: Bool = false
         private var useFileOutput = true

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -260,7 +260,7 @@ public class Logger {
     ///           .build()
     ///
     public class Builder {
-        private var serviceName: String = Datadog.Configuration.Defaults.serviceName
+        private var serviceName: String = "ios"
         private var loggerName: String?
         private var sendNetworkInfo: Bool = false
         private var useFileOutput = true

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -56,7 +56,7 @@ class TracingIntegrationTests: IntegrationTests {
             XCTAssertGreaterThan(try matcher.startTime(), testBeginTimeInNanoseconds)
             XCTAssertLessThan(try matcher.startTime(), testEndTimeInNanoseconds)
 
-            XCTAssertEqual(try matcher.serviceName(), "ios")
+            XCTAssertEqual(try matcher.serviceName(), "ui-tests-service-name")
             XCTAssertEqual(try matcher.resource(), try matcher.operationName())
             XCTAssertEqual(try matcher.type(), "custom")
             XCTAssertEqual(try matcher.isError(), 0)

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -22,13 +22,13 @@ class DataUploadURLProviderTests: XCTestCase {
 
     func testWhenClientTokenIsInvalid_itThrowsProgrammerError() {
         XCTAssertThrowsError(try UploadURLProvider(endpointURL: "https://api.example.com/v1/endpoint", clientToken: "", dateProvider: dateProvider)) { error in
-            XCTAssertEqual((error as? ProgrammerError)?.description, "Datadog SDK usage error: `clientToken` cannot be empty.")
+            XCTAssertEqual((error as? ProgrammerError)?.description, "🔥 Datadog SDK usage error: `clientToken` cannot be empty.")
         }
     }
 
     func testWhenEndpointURLIsInvalid_itThrowsProgrammerError() {
         XCTAssertThrowsError(try UploadURLProvider(endpointURL: "", clientToken: "abc", dateProvider: dateProvider)) { error in
-            XCTAssertEqual((error as? ProgrammerError)?.description, "Datadog SDK usage error: `endpointURL` cannot be empty.")
+            XCTAssertEqual((error as? ProgrammerError)?.description, "🔥 Datadog SDK usage error: `endpointURL` cannot be empty.")
         }
     }
 

--- a/Tests/DatadogTests/Datadog/DDTracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerConfigurationTests.swift
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class DDTracerConfigurationTests: XCTestCase {
+    private typealias Configuration = DDTracer.Configuration
+    private typealias ResolvedConfiguration = DDTracer.ResolvedConfiguration
+
+    func testDefaultConfiguration() {
+        func verify(configuration: Configuration) {
+            let resolvedConfiguration = ResolvedConfiguration(tracerConfiguration: configuration)
+
+            XCTAssertEqual(resolvedConfiguration.serviceName, "ios")
+        }
+
+        verify(configuration: Configuration())
+
+        var configuration = Configuration()
+        configuration.serviceName = nil
+        verify(configuration: configuration)
+    }
+
+    func testCustomServiceName() {
+        func verify(configuration: Configuration) {
+            let resolvedConfiguration = ResolvedConfiguration(tracerConfiguration: configuration)
+
+            XCTAssertEqual(resolvedConfiguration.serviceName, "custom")
+        }
+
+        verify(configuration: Configuration(serviceName: "custom"))
+
+        var configuration = Configuration()
+        configuration.serviceName = "custom"
+        verify(configuration: configuration)
+    }
+}

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -8,6 +8,20 @@ import XCTest
 import OpenTracing
 @testable import Datadog
 
+class DDTracerConfigurationTests: XCTestCase {
+    private typealias Configuration = DDTracer.Configuration
+
+    func testDefaultConfiguration() {
+        let defaultConfiguration = Configuration()
+        XCTAssertEqual(defaultConfiguration.serviceName, Datadog.Configuration.Defaults.serviceName)
+    }
+
+    func testCustomConfiguration() {
+        let defaultConfiguration = Configuration(serviceName: "abc")
+        XCTAssertEqual(defaultConfiguration.serviceName, "abc")
+    }
+}
+
 // swiftlint:disable multiline_arguments_brackets
 // swiftlint:disable trailing_closure
 class DDTracerTests: XCTestCase {
@@ -42,7 +56,7 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         let span = tracer.startSpan(operationName: "operation")
         span.finish(at: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5))
@@ -92,7 +106,7 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         let span = tracer.startSpan(operationName: "operation", tags: ["tag1": "value1"], startTime: .mockDecember15th2019At10AMUTC())
         span.finish(at: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5))
@@ -113,7 +127,7 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         let rootSpan = tracer.startSpan(operationName: "root operation")
         let childSpan = tracer.startSpan(operationName: "child operation", childOf: rootSpan.context)
@@ -166,7 +180,7 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         tracer.startSpan(operationName: "span with no user info").finish()
 
@@ -209,7 +223,7 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         // simulate entering cellular service range
         carrierInfoProvider.set(
@@ -252,7 +266,7 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         // simulate reachable network
         networkConnectionInfoProvider.set(
@@ -318,7 +332,7 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         tracer.startSpan(operationName: .mockAny()).finish()
 
@@ -336,7 +350,7 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         tracer.startSpan(operationName: .mockAny()).finish()
 
@@ -362,6 +376,22 @@ class DDTracerTests: XCTestCase {
     }
 
     // MARK: - Initialization
+
+    // TODO: RUMM-339 Move this test to obj-c wrapper tests, similarly to what we do for `DDLoggerBuilderTests`
+    func testGivenDatadogNotInitialized_whenInitializingTracer_itPrintsError() {
+        let printFunction = PrintFunctionMock()
+        consolePrint = printFunction.print
+        defer { consolePrint = { print($0) } }
+
+        XCTAssertNil(Datadog.instance)
+
+        let tracer = DDTracer.initialize(configuration: .init())
+        XCTAssertEqual(
+            printFunction.printedMessage,
+            "🔥 Datadog SDK usage error: `Datadog.initialize()` must be called prior to `DDTracer.initialize()`."
+        )
+        XCTAssertTrue(tracer is DDNoopTracer)
+    }
 
     // TODO: RUMM-339 Move this test to obj-c wrapper tests, similarly to what we do for `DDLoggerBuilderTests`
     func testGivenDatadogNotInitialized_whenUsingTracer_itPrintsError() {

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -8,20 +8,6 @@ import XCTest
 import OpenTracing
 @testable import Datadog
 
-class DDTracerConfigurationTests: XCTestCase {
-    private typealias Configuration = DDTracer.Configuration
-
-    func testDefaultConfiguration() {
-        let defaultConfiguration = Configuration()
-        XCTAssertEqual(defaultConfiguration.serviceName, Datadog.Configuration.Defaults.serviceName)
-    }
-
-    func testCustomConfiguration() {
-        let defaultConfiguration = Configuration(serviceName: "abc")
-        XCTAssertEqual(defaultConfiguration.serviceName, "abc")
-    }
-}
-
 // swiftlint:disable multiline_arguments_brackets
 // swiftlint:disable trailing_closure
 class DDTracerTests: XCTestCase {

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -53,7 +53,7 @@ class TracingFeatureTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         let span = tracer.startSpan(operationName: "operation 1")
         span.finish()
@@ -76,7 +76,7 @@ class TracingFeatureTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         let span = tracer.startSpan(operationName: "operation 1")
         span.finish()
@@ -114,7 +114,7 @@ class TracingFeatureTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer(tracingFeature: TracingFeature.instance!)
+        let tracer = DDTracer.initialize(configuration: .init()).dd
 
         tracer.startSpan(operationName: "operation 1").finish()
         tracer.startSpan(operationName: "operation 2").finish()


### PR DESCRIPTION
### What and why?

📦 This PR adds the `public` way of initializing the `DDTracer`

### How?

Following API was introduced:
```swift
let tracer = DDTracer.initialize(
   configuration: DDTracer.Configuration(
      serviceName: "app-tracer"
   )
)
```

As default `serviceName` will soon (`RUMM-409`) come from `Datadog.Configuration`, the defaults resolution was decoupled to a separate `internal` type:
```swift
ResolvedConfiguration(tracerConfiguration: Configuration)
```
After default service name is provided by `Datadog.Configuration`, it will become:
```swift
ResolvedConfiguration(
    tracerConfiguration: Configuration, 
    defaultConfiguration: datadog.instance.configuration
)
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
