### PR TITLE
RUMM-403 Add tags to span

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
 		61E917D12465423600E6C631 /* DDTracerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D02465423600E6C631 /* DDTracerConfiguration.swift */; };
 		61E917D3246546BF00E6C631 /* DDTracerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D2246546BF00E6C631 /* DDTracerConfigurationTests.swift */; };
+		61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917CE2464270500E6C631 /* EncodableValueTests.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E085879242519FF001A3583 /* NetworkPathMonitor.swift */; };
@@ -427,6 +428,7 @@
 		61E45ED02451A8730061DAC7 /* SpanMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanMatcher.swift; sourceTree = "<group>"; };
 		61E917D02465423600E6C631 /* DDTracerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerConfiguration.swift; sourceTree = "<group>"; };
 		61E917D2246546BF00E6C631 /* DDTracerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerConfigurationTests.swift; sourceTree = "<group>"; };
+		61E917CE2464270500E6C631 /* EncodableValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodableValueTests.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		9E085879242519FF001A3583 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
@@ -784,6 +786,7 @@
 				61133C222423990D00786299 /* System */,
 				61133C272423990D00786299 /* Persistence */,
 				61133C2E2423990D00786299 /* Upload */,
+				61E917CD246426E000E6C631 /* Utils */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1102,6 +1105,14 @@
 				61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */,
 			);
 			path = SpanOutputs;
+			sourceTree = "<group>";
+		};
+		61E917CD246426E000E6C631 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				61E917CE2464270500E6C631 /* EncodableValueTests.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		9E47010324471027000073A4 /* include */ = {
@@ -1505,6 +1516,7 @@
 				61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */,
 				61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */,
 				61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */,
+				61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */,
 				61133C4C2423990D00786299 /* LogsMocks.swift in Sources */,
 				61133C542423990D00786299 /* NetworkConnectionInfoProviderTests.swift in Sources */,
 				61133C4A2423990D00786299 /* DDConfigurationTests.swift in Sources */,

--- a/Datadog/Example/IntegrationTestFixtures/SendLogsFixtureViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendLogsFixtureViewController.swift
@@ -16,6 +16,7 @@ internal class SendLogsFixtureViewController: UIViewController {
 
         logger.addAttribute(forKey: "logger-attribute1", value: "string value")
         logger.addAttribute(forKey: "logger-attribute2", value: 1_000)
+        logger.addAttribute(forKey: "some-url", value: URL(string: "https://example.com/image.png")!)
 
         logger.debug("debug message", attributes: ["attribute": "value"])
         logger.info("info message", attributes: ["attribute": "value"])

--- a/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
@@ -22,6 +22,8 @@ internal class SendTracesFixtureViewController: UIViewController {
             operationName: "data downloading",
             childOf: viewAppearingSpan.context
         )
+        dataDownloadingSpan.setTag(key: "data.kind", value: "image")
+        dataDownloadingSpan.setTag(key: "data.url", value: URL(string: "https://example.com/image.png")!)
 
         downloadSomeData { [weak self] data in
             dataDownloadingSpan.finish()

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -20,7 +20,7 @@ internal struct SpanBuilder {
     let carrierInfoProvider: CarrierInfoProviderType
 
     /// Encodes tag `Span` tag values as JSON string
-    private let tagsJSONEncoder = JSONEncoder()
+    private let tagsJSONEncoder: JSONEncoder = .default()
 
     func createSpan(from ddspan: DDSpan, finishTime: Date) throws -> Span {
         guard let context = ddspan.context.dd else {
@@ -60,5 +60,17 @@ internal struct SpanBuilder {
         } else {
             return ""
         }
+    }
+}
+
+extension JSONEncoder {
+    // NOTE: RUMM-403 This will conflict with `JSONEncoder.default` after merging `master` into `tracing`.
+    // Use `master's` one and remove this extension.
+    static func `default`() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        if #available(iOS 13.0, OSX 10.15, *) {
+            encoder.outputFormatting = [.withoutEscapingSlashes]
+        }
+        return encoder
     }
 }

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -19,10 +19,19 @@ internal struct SpanBuilder {
     /// Shared mobile carrier info provider.
     let carrierInfoProvider: CarrierInfoProviderType
 
+    /// Encodes tag `Span` tag values as JSON string
+    private let tagsJSONEncoder = JSONEncoder()
+
     func createSpan(from ddspan: DDSpan, finishTime: Date) throws -> Span {
         guard let context = ddspan.context.dd else {
             throw InternalError(description: "`SpanBuilder` inconsistency - unrecognized span context.")
         }
+
+        let jsonStringEncodedTags = Dictionary(
+            uniqueKeysWithValues: ddspan.tags.map { name, value in
+                (name, JSONStringEncodableValue(value, encodedUsing: tagsJSONEncoder))
+            }
+        )
 
         return Span(
             traceID: context.traceID,
@@ -38,7 +47,8 @@ internal struct SpanBuilder {
             applicationVersion: getApplicationVersion(),
             networkConnectionInfo: networkConnectionInfoProvider.current,
             mobileCarrierInfo: carrierInfoProvider.current,
-            userInfo: userInfoProvider.value
+            userInfo: userInfoProvider.value,
+            tags: jsonStringEncodedTags
         )
     }
 

--- a/Sources/Datadog/Tracing/Span/SpanEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEncoder.swift
@@ -134,7 +134,6 @@ internal struct SpanEncoder {
         try encodeDefaultMeta(span, to: &container)
 
         var customAttributesContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        // TODO: RUMM-402 Encode custom metrics from `DDSpan` (coding key: `metrics.*`)
         try encodeCustomMeta(span, to: &customAttributesContainer)
     }
 

--- a/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
@@ -63,6 +63,7 @@ class LoggingIntegrationTests: IntegrationTests {
                     "logger-attribute1": "string value",
                     "logger-attribute2": 1_000,
                     "attribute": "value",
+                    "some-url": "https://example.com/image.png"
                 ]
             )
             matcher.assertTags(equal: ["build_configuration:release", "tag1:tag-value", "tag2"])

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -52,6 +52,10 @@ class TracingIntegrationTests: IntegrationTests {
         XCTAssertNil(try? spanMatchers[1].metrics.isRootSpan())
         XCTAssertEqual(try spanMatchers[2].metrics.isRootSpan(), 1)
 
+        // "downloading" span's tags
+        XCTAssertEqual(try spanMatchers[0].meta.custom(keyPath: "meta.data.kind"), "image")
+        XCTAssertEqual(try spanMatchers[0].meta.custom(keyPath: "meta.data.url"), "https://example.com/image.png")
+
         try spanMatchers.forEach { matcher in
             XCTAssertGreaterThan(try matcher.startTime(), testBeginTimeInNanoseconds)
             XCTAssertLessThan(try matcher.startTime(), testEndTimeInNanoseconds)

--- a/Tests/DatadogTests/Datadog/Core/Utils/EncodableValueTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Utils/EncodableValueTests.swift
@@ -1,0 +1,81 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class EncodableValueTests: XCTestCase {
+    func testItEncodesDifferentEncodableValues() throws {
+        let encoder = JSONEncoder()
+
+        XCTAssertEqual(
+            try encoder.encode(EncodableValue("string")).utf8String,
+            #""string""#
+        )
+        XCTAssertEqual(
+            try encoder.encode(EncodableValue(123)).utf8String,
+            #"123"#
+        )
+        XCTAssertEqual(
+            try encoder.encode(EncodableValue(["a", "b", "c"])).utf8String,
+            #"["a","b","c"]"#
+        )
+        XCTAssertEqual(
+            try encoder.encode(EncodableValue(URL(string: "https://example.com/image.png")!)).utf8String,
+            #""https:\/\/example.com\/image.png""#
+        )
+        struct Foo: Encodable {
+            let bar = "bar_"
+            let bizz = "bizz_"
+        }
+        XCTAssertEqual(
+            try encoder.encode(EncodableValue(Foo())).utf8String,
+            #"{"bar":"bar_","bizz":"bizz_"}"#
+        )
+    }
+}
+
+class JSONStringEncodableValueTests: XCTestCase {
+    func testItEncodesDifferentEncodableValuesAsString() throws {
+        let encoder = JSONEncoder()
+
+        XCTAssertEqual(
+            try encoder.encode(JSONStringEncodableValue("string", encodedUsing: JSONEncoder())).utf8String,
+            #""string""#
+        )
+        XCTAssertEqual(
+            try encoder.encode(JSONStringEncodableValue(123, encodedUsing: JSONEncoder())).utf8String,
+            #""123""#
+        )
+        XCTAssertEqual(
+            try encoder.encode(JSONStringEncodableValue(["a", "b", "c"], encodedUsing: JSONEncoder())).utf8String,
+            #""[\"a\",\"b\",\"c\"]""#
+        )
+        XCTAssertEqual(
+            try encoder.encode(
+                JSONStringEncodableValue(URL(string: "https://example.com/image.png")!, encodedUsing: JSONEncoder())
+            ).utf8String,
+            #""https:\/\/example.com\/image.png""#
+        )
+        struct Foo: Encodable {
+            let bar = "bar_"
+            let bizz = "bizz_"
+        }
+        XCTAssertEqual(
+            try encoder.encode(JSONStringEncodableValue(Foo(), encodedUsing: JSONEncoder())).utf8String,
+            #""{\"bar\":\"bar_\",\"bizz\":\"bizz_\"}""#
+        )
+    }
+
+    func testWhenValueCannotBeEncoded_itThrowsErrorDuringEncoderInvocation() {
+        let encoder = JSONEncoder()
+        let value = JSONStringEncodableValue(FailingEncodableMock(errorMessage: "ops..."), encodedUsing: JSONEncoder())
+
+        XCTAssertThrowsError(try encoder.encode(value)) { error in
+            XCTAssertEqual((error as? ErrorMock)?.description, "ops...")
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -108,8 +108,6 @@ class DDTracerTests: XCTestCase {
         XCTAssertEqual(try spanMatcher.duration(), 500_000_000)
         XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.tag1"), "string value")
         XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.tag2"), "123")
-
-        // TODO: RUMM-402 assert custom `metrics.*`
     }
 
     func testSendingSpanWithParent() throws {

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -301,6 +301,9 @@ class LoggerTests: XCTestCase {
         // nested string literal
         logger.addAttribute(forKey: "nested.string", value: "hello")
 
+        // URL
+        logger.addAttribute(forKey: "url", value: URL(string: "https://example.com/image.png")!)
+
         logger.info("message")
 
         let logMatcher = try server.waitAndReturnLogMatchers(count: 1)[0]
@@ -316,6 +319,8 @@ class LoggerTests: XCTestCase {
         logMatcher.assertValue(forKeyPath: "person.age", equals: 30)
         logMatcher.assertValue(forKeyPath: "person.nationality", equals: "Polish")
         logMatcher.assertValue(forKeyPath: "nested.string", equals: "hello")
+        /// URLs are encoded explicitly as `String` - see the comment in `EncodableValue`
+        logMatcher.assertValue(forKeyPath: "url", equals: "https://example.com/image.png")
     }
 
     func testSendingMessageAttributes() throws {

--- a/Tests/DatadogTests/Matchers/JSONDataMatcher.swift
+++ b/Tests/DatadogTests/Matchers/JSONDataMatcher.swift
@@ -22,7 +22,8 @@ internal class JSONDataMatcher {
 
     func assertItFullyMatches(jsonString: String, file: StaticString = #file, line: UInt = #line) throws {
         let thisJSON = json as NSDictionary
-        let theirJSON = try jsonString.data(using: .utf8)!.toJSONObject() as NSDictionary // swiftlint:disable:this force_unwrapping
+        let theirJSON = try jsonString.data(using: .utf8)!
+            .toJSONObject(file: file, line: line) as NSDictionary // swiftlint:disable:this force_unwrapping
 
         XCTAssertEqual(thisJSON, theirJSON, file: file, line: line)
     }

--- a/Tests/DatadogTests/Matchers/SpanMatcher.swift
+++ b/Tests/DatadogTests/Matchers/SpanMatcher.swift
@@ -125,6 +125,8 @@ internal class SpanMatcher {
         func mobileNetworkCarrierISOCountryCode()  throws -> String { try matcher.meta(forKeyPath: "meta.network.client.sim_carrier.iso_country") }
         func mobileNetworkCarrierRadioTechnology() throws -> String { try matcher.meta(forKeyPath: "meta.network.client.sim_carrier.technology") }
         func mobileNetworkCarrierAllowsVoIP()      throws -> String { try matcher.meta(forKeyPath: "meta.network.client.sim_carrier.allows_voip") }
+
+        func custom(keyPath: String) throws -> String { try matcher.meta(forKeyPath: keyPath) }
     }
 
     /// Allowed values for `meta.network.client.available_interfaces` attribute.


### PR DESCRIPTION
### What and why?

🚚 This PR adds support to `Span` tags. Tags can be specified when starting the span:
```swift
let span = tracer.startSpan(..., tags: ["foo": "bar"], ...)
```
or anytime on the `Span` object:
```swift
span.setTag(key: "number", value: 10)
```

Tag consist of a `String` key and value which can be any `Codable` type - `String`, `Int`, `URL`, custom `Codable` structure etc.

### How?

APM API enforces that all tags are encoded as `span.meta.*` JSON attributes **with `String` values**. This means that whatever `Codable` we get from the user, we must translate it into `String`.

This `Codable` → `String` translation happens in `JSONStringEncodableValue`. It turns `Codable` values into their JSON string representation. Given this:
```swift
span.setTag(key: "string", value: "abc")
span.setTag(key: "number", value: 1)
span.setTag(key: "boolean", value: true)
span.setTag(key: "person", value: Person(name: "foo", surname: "bar"))
```
are values are sent as `String`. This is how they are rendered at [app.datadoghq.com](https://app.datadoghq.com):

<img width="325" alt="Screenshot 2020-05-07 at 20 35 20" src="https://user-images.githubusercontent.com/2358722/81331867-86451f00-90a2-11ea-8b71-f4b39169bf0a.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
