### PR TITLE
RUMM-340 Add thread safety to Tracing API

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */; };
 		61AD4E3824531500006E34EA /* DataFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3724531500006E34EA /* DataFormat.swift */; };
 		61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3924534075006E34EA /* TracingFeatureTests.swift */; };
+		61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */; };
 		61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */; };
 		61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */; };
 		61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */; };
@@ -159,9 +160,9 @@
 		61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */; };
 		61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */; };
 		61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
+		61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917CE2464270500E6C631 /* EncodableValueTests.swift */; };
 		61E917D12465423600E6C631 /* DDTracerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D02465423600E6C631 /* DDTracerConfiguration.swift */; };
 		61E917D3246546BF00E6C631 /* DDTracerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D2246546BF00E6C631 /* DDTracerConfigurationTests.swift */; };
-		61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917CE2464270500E6C631 /* EncodableValueTests.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		9E08587A242519FF001A3583 /* NetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E085879242519FF001A3583 /* NetworkPathMonitor.swift */; };
@@ -394,6 +395,7 @@
 		61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingFeatureMocks.swift; sourceTree = "<group>"; };
 		61AD4E3724531500006E34EA /* DataFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataFormat.swift; sourceTree = "<group>"; };
 		61AD4E3924534075006E34EA /* TracingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingFeatureTests.swift; sourceTree = "<group>"; };
+		61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDGeneratorTests.swift; sourceTree = "<group>"; };
 		61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendLogsFixtureViewController.swift; sourceTree = "<group>"; };
 		61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendTracesFixtureViewController.swift; sourceTree = "<group>"; };
 		61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsHelpers.swift; sourceTree = "<group>"; };
@@ -429,9 +431,9 @@
 		61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFileOutputTests.swift; sourceTree = "<group>"; };
 		61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDataMatcher.swift; sourceTree = "<group>"; };
 		61E45ED02451A8730061DAC7 /* SpanMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanMatcher.swift; sourceTree = "<group>"; };
+		61E917CE2464270500E6C631 /* EncodableValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodableValueTests.swift; sourceTree = "<group>"; };
 		61E917D02465423600E6C631 /* DDTracerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerConfiguration.swift; sourceTree = "<group>"; };
 		61E917D2246546BF00E6C631 /* DDTracerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerConfigurationTests.swift; sourceTree = "<group>"; };
-		61E917CE2464270500E6C631 /* EncodableValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodableValueTests.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		9E085879242519FF001A3583 /* NetworkPathMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPathMonitor.swift; sourceTree = "<group>"; };
@@ -1005,6 +1007,7 @@
 			isa = PBXGroup;
 			children = (
 				61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */,
+				61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */,
 			);
 			path = UUIDs;
 			sourceTree = "<group>";
@@ -1546,6 +1549,7 @@
 				61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */,
 				61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */,
 				61133C592423990D00786299 /* FilesOrchestratorTests.swift in Sources */,
+				61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */,
 				61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */,
 				61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */,
 				61133C6C2423990D00786299 /* SwiftExtensions.swift in Sources */,

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -54,7 +54,10 @@ public class DDTracer: Tracer {
 
     internal init(spanOutput: SpanOutput) {
         self.spanOutput = spanOutput
-        self.queue = DispatchQueue(label: "com.datadoghq.tracer", qos: .userInteractive)
+        self.queue = DispatchQueue(
+            label: "com.datadoghq.tracer",
+            target: .global(qos: .userInteractive)
+        )
     }
 
     // MARK: - Open Tracing interface

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -10,6 +10,8 @@ import Foundation
 public class DDTracer: Tracer {
     /// Writes `Span` objects to output.
     private let spanOutput: SpanOutput
+    /// Queue ensuring thread-safety of the `DDTracer` and `DDSpan` operations.
+    internal let queue: DispatchQueue
 
     // MARK: - Initialization
 
@@ -52,6 +54,7 @@ public class DDTracer: Tracer {
 
     internal init(spanOutput: SpanOutput) {
         self.spanOutput = spanOutput
+        self.queue = DispatchQueue(label: "com.datadoghq.tracer", qos: .userInteractive)
     }
 
     // MARK: - Open Tracing interface

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -85,7 +85,10 @@ public class Logger {
 
     init(logOutput: LogOutput, identifier: String) {
         self.logOutput = logOutput
-        self.queue = DispatchQueue(label: "com.datadoghq.logger-\(identifier)", qos: .userInteractive)
+        self.queue = DispatchQueue(
+            label: "com.datadoghq.logger-\(identifier)",
+            target: .global(qos: .userInteractive)
+        )
     }
 
     // MARK: - Logging

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -23,10 +23,6 @@ internal struct SpanBuilder {
     private let tagsJSONEncoder: JSONEncoder = .default()
 
     func createSpan(from ddspan: DDSpan, finishTime: Date) throws -> Span {
-        guard let context = ddspan.context.dd else {
-            throw InternalError(description: "`SpanBuilder` inconsistency - unrecognized span context.")
-        }
-
         let jsonStringEncodedTags = Dictionary(
             uniqueKeysWithValues: ddspan.tags.map { name, value in
                 (name, JSONStringEncodableValue(value, encodedUsing: tagsJSONEncoder))
@@ -34,9 +30,9 @@ internal struct SpanBuilder {
         )
 
         return Span(
-            traceID: context.traceID,
-            spanID: context.spanID,
-            parentID: context.parentSpanID,
+            traceID: ddspan.ddContext.traceID,
+            spanID: ddspan.ddContext.spanID,
+            parentID: ddspan.ddContext.parentSpanID,
             operationName: ddspan.operationName,
             serviceName: serviceName,
             resource: ddspan.operationName, // TODO: RUMM-400 use `resourceName`: `resource: ddspan.resourceName ?? ddspan.operationName`

--- a/Sources/Datadog/Tracing/UUIDs/TracingUUIDGenerator.swift
+++ b/Sources/Datadog/Tracing/UUIDs/TracingUUIDGenerator.swift
@@ -13,7 +13,7 @@ internal protocol TracingUUIDGenerator {
 internal struct DefaultTracingUUIDGenerator: TracingUUIDGenerator {
     func generateUnique() -> TracingUUID {
        // TODO: RUMM-333 Add boundaries to trace & span ID generation, keeping in mind that `0` is reserved (ref: DDTracer.java#L600)
-       // TODO: RUMM-340 Consider thread safety
+       // NOTE: RUMM-340 Consider thread safety if the generation will depend on local state
        return TracingUUID(rawValue: .random(in: 1...UInt64.max))
    }
 }

--- a/Sources/Datadog/Tracing/Utils/Warnings.swift
+++ b/Sources/Datadog/Tracing/Utils/Warnings.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// Returns `true` if the warning was raised. `false` otherwise.
 internal func warn(if condition: @autoclosure () -> Bool, message: String) -> Bool {
-    if condition() { // TODO: RUMM-340 Consider thread safety
+    if condition() {
         userLogger.warn(message)
         return true
     } else {

--- a/Tests/DatadogTests/Datadog/Mocks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/FoundationMocks.swift
@@ -105,7 +105,13 @@ extension String {
     }
 
     static func mockRandom(length: Int = 10) -> String {
-        let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 "
+        return mockRandom(
+            among: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ",
+            length: length
+        )
+    }
+
+    static func mockRandom(among characters: String, length: Int = 10) -> String {
         return String((0..<length).map { _ in characters.randomElement()! })
     }
 

--- a/Tests/DatadogTests/Datadog/Tracing/UUIDs/TracingUUIDGeneratorTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/UUIDs/TracingUUIDGeneratorTests.swift
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class TracingUUIDGeneratorTests: XCTestCase {
+    func testUUIDGenerationIsThreadSafe() {
+        let generator = DefaultTracingUUIDGenerator()
+        var generatedUUIDs: [TracingUUID] = []
+        let queue = DispatchQueue(label: "uuid-array-sync")
+
+        DispatchQueue.concurrentPerform(iterations: 1_000) { iteration in
+            let uuid = generator.generateUnique()
+            queue.async { generatedUUIDs.append(uuid) }
+        }
+
+        queue.sync { } // wait for all UUIDs in the array
+
+        XCTAssertEqual(generatedUUIDs.count, 1_000)
+    }
+}


### PR DESCRIPTION
### What and why?

📮 This PR adds additional thread-safety to `public` APIs exposed by Tracing feature.

### How?

I added unit test to randomly and call various public APIs from concurrent threads. Later, fixed all the crashes and Thread Sanitizer issues by using synchronization queue inside `DDTracer`.

This is a counterpart to thread safety done in logging feature, where the `Logger` owns a `DispatchQueue` used to synchronize its public interface.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
