### PR TITLE
RUMM-408 Change `ddsource` to `ios` for logs

### DIFF
--- a/Sources/Datadog/Core/Upload/DataUploader.swift
+++ b/Sources/Datadog/Core/Upload/DataUploader.swift
@@ -16,7 +16,7 @@ internal class UploadURLProvider {
         let currentTimeMillis = dateProvider.currentDate().currentTimeMillis
         let batchTimeQueryItem = URLQueryItem(name: "batch_time", value: "\(currentTimeMillis)")
         // ddsource
-        let ddSourceQueryItem = URLQueryItem(name: "ddsource", value: "mobile")
+        let ddSourceQueryItem = URLQueryItem(name: "ddsource", value: "ios")
 
         return [ddSourceQueryItem, batchTimeQueryItem]
     }

--- a/Tests/DatadogIntegrationTests/Integration/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/Integration/LoggingIntegrationTests.swift
@@ -53,7 +53,7 @@ class LoggingIntegrationTests: IntegrationTests {
         // Assert
         let recordedRequests = try serverSession.getRecordedPOSTRequests()
         recordedRequests.forEach { request in
-            XCTAssertTrue(request.path.contains("/client-token?ddsource=mobile"))
+            XCTAssertTrue(request.path.contains("/client-token?ddsource=ios"))
         }
 
         let logMatchers = try recordedRequests

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -14,9 +14,9 @@ class DataUploadURLProviderTests: XCTestCase {
             urlWithClientToken: URL(string: "https://api.example.com/v1/endpoint/abc")!,
             dateProvider: dateProvider
         )
-        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=mobile&batch_time=1576404000000"))
+        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=ios&batch_time=1576404000000"))
         dateProvider.advance(bySeconds: 9.999)
-        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=mobile&batch_time=1576404009999"))
+        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=ios&batch_time=1576404009999"))
     }
 }
 


### PR DESCRIPTION
### What and why?

🚚 To unify the "source" concept across different Datadog products, we want to change `ddsource` value from `mobile` to `ios`.

From now, all data send with iOS SDK will be tagged `source=ios` at [app.datadoghq.com](https://app.datadoghq.com/). A corresponding change [was already applied to `dd-sdk-android`](https://github.com/DataDog/dd-sdk-android/pull/239).

### How?

In Logging feature, `source` is send through HTTP query parameter. I just updated the value and corresponding tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
