### PR TITLE
RUMM-408 Change `ddsource` to `ios` for traces

### DIFF
--- a/Sources/Datadog/Core/Upload/DataUploader.swift
+++ b/Sources/Datadog/Core/Upload/DataUploader.swift
@@ -11,7 +11,7 @@ internal class UploadURLProvider {
     private let urlWithClientToken: URL
     private let queryItemProviders: [QueryItemProvider]
 
-    struct QueryItemProvider {
+    class QueryItemProvider {
         let value: () -> URLQueryItem
 
         /// Creates `batch_time=...` query item adding current timestamp (in milliseconds) to the URL.
@@ -26,6 +26,10 @@ internal class UploadURLProvider {
         static func ddsource() -> QueryItemProvider {
             let queryItem = URLQueryItem(name: "ddsource", value: Datadog.Constants.ddsource)
             return QueryItemProvider { queryItem }
+        }
+
+        private init(value: @escaping () -> URLQueryItem) {
+            self.value = value
         }
     }
 

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -105,7 +105,10 @@ public class Datadog {
             httpClient: httpClient,
             logsUploadURLProvider: UploadURLProvider(
                 urlWithClientToken: validConfiguration.logsUploadURLWithClientToken,
-                dateProvider: dateProvider
+                queryItems: [
+                    .ddsource(),
+                    .batchTime(using: dateProvider)
+                ]
             ),
             dateProvider: dateProvider,
             userInfoProvider: userInfoProvider,
@@ -121,7 +124,9 @@ public class Datadog {
             httpClient: httpClient,
             tracesUploadURLProvider: UploadURLProvider(
                 urlWithClientToken: validConfiguration.tracesUploadURLWithClientToken,
-                dateProvider: dateProvider
+                queryItems: [
+                    .batchTime(using: dateProvider)
+                ]
             ),
             dateProvider: dateProvider,
             tracingUUIDGenerator: DefaultTracingUUIDGenerator(),

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -105,7 +105,7 @@ public class Datadog {
             httpClient: httpClient,
             logsUploadURLProvider: UploadURLProvider(
                 urlWithClientToken: validConfiguration.logsUploadURLWithClientToken,
-                queryItems: [
+                queryItemProviders: [
                     .ddsource(),
                     .batchTime(using: dateProvider)
                 ]
@@ -124,7 +124,7 @@ public class Datadog {
             httpClient: httpClient,
             tracesUploadURLProvider: UploadURLProvider(
                 urlWithClientToken: validConfiguration.tracesUploadURLWithClientToken,
-                queryItems: [
+                queryItemProviders: [
                     .batchTime(using: dateProvider)
                 ]
             ),

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -7,6 +7,11 @@
 import Foundation
 
 extension Datadog {
+    internal struct Constants {
+        /// Value for `ddsource` send by different features.
+        static let ddsource = "ios"
+    }
+
     /// Datadog SDK configuration.
     public struct Configuration {
         /// Determines server to which logs are sent.

--- a/Sources/Datadog/Tracing/Span/SpanEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEncoder.swift
@@ -149,7 +149,7 @@ internal struct SpanEncoder {
     /// Encodes default `meta.*` attributes
     private func encodeDefaultMeta(_ span: Span, to container: inout KeyedEncodingContainer<StaticCodingKeys>) throws {
         // NOTE: RUMM-299 only string values are supported for `meta.*` attributes
-        try container.encode("mobile", forKey: .source)
+        try container.encode(Datadog.Constants.ddsource, forKey: .source)
         try container.encode(span.tracerVersion, forKey: .tracerVersion)
         try container.encode(span.applicationVersion, forKey: .applicationVersion)
 

--- a/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
@@ -25,7 +25,9 @@ class LoggingIntegrationTests: IntegrationTests {
         // Assert requests
         let recordedRequests = try serverSession.getRecordedPOSTRequests()
         recordedRequests.forEach { request in
-            XCTAssertTrue(request.path.contains("/ui-tests-client-token?ddsource=ios"))
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309/ui-tests-client-token?ddsource=ios&batch_time=1589969230153`
+            let pathRegexp = #"^(.*)(/ui-tests-client-token\?ddsource=ios&batch_time=)([0-9]+)$"#
+            XCTAssertNotNil(request.path.range(of: pathRegexp, options: .regularExpression, range: nil, locale: nil))
             XCTAssertTrue(request.httpHeaders.contains("Content-Type: application/json"))
         }
 

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -26,7 +26,9 @@ class TracingIntegrationTests: IntegrationTests {
         // Assert requests
         let recordedRequests = try serverSession.getRecordedPOSTRequests()
         recordedRequests.forEach { request in
-            XCTAssertTrue(request.path.contains("/ui-tests-client-token?ddsource=mobile"))
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309/ui-tests-client-token?batch_time=1589969230153`
+            let pathRegexp = #"^(.*)(/ui-tests-client-token\?batch_time=)([0-9]+)$"#
+            XCTAssertNotNil(request.path.range(of: pathRegexp, options: .regularExpression, range: nil, locale: nil))
             XCTAssertTrue(request.httpHeaders.contains("Content-Type: text/plain;charset=UTF-8"))
         }
 
@@ -66,7 +68,7 @@ class TracingIntegrationTests: IntegrationTests {
             XCTAssertEqual(try matcher.isError(), 0)
             XCTAssertEqual(try matcher.environment(), "integration")
 
-            XCTAssertEqual(try matcher.meta.source(), "mobile")
+            XCTAssertEqual(try matcher.meta.source(), "ios")
             XCTAssertEqual(try matcher.meta.tracerVersion().split(separator: ".").count, 3)
             XCTAssertEqual(try matcher.meta.applicationVersion(), "1.0")
 

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 class DataUploadURLProviderTests: XCTestCase {
     func testDDSourceQueryItem() {
-        let item: UploadURLProvider.QueryItem = .ddsource()
+        let item: UploadURLProvider.QueryItemProvider = .ddsource()
 
         XCTAssertEqual(item.value().name, "ddsource")
         XCTAssertEqual(item.value().value, "ios")
@@ -17,7 +17,7 @@ class DataUploadURLProviderTests: XCTestCase {
 
     func testBatchTimeQueryItem() {
         let dateProvider = RelativeDateProvider(using: Date.mockDecember15th2019At10AMUTC())
-        let item: UploadURLProvider.QueryItem = .batchTime(using: dateProvider)
+        let item: UploadURLProvider.QueryItemProvider = .batchTime(using: dateProvider)
 
         XCTAssertEqual(item.value().name, "batch_time")
         XCTAssertEqual(item.value().value, "1576404000000")
@@ -29,7 +29,7 @@ class DataUploadURLProviderTests: XCTestCase {
     func testItBuildsValidURLUsingNoQueryItems() throws {
         let urlProvider = UploadURLProvider(
             urlWithClientToken: URL(string: "https://api.example.com/v1/endpoint/abc")!,
-            queryItems: []
+            queryItemProviders: []
         )
 
         XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?"))
@@ -39,7 +39,7 @@ class DataUploadURLProviderTests: XCTestCase {
         let dateProvider = RelativeDateProvider(using: Date.mockDecember15th2019At10AMUTC())
         let urlProvider = UploadURLProvider(
             urlWithClientToken: URL(string: "https://api.example.com/v1/endpoint/abc")!,
-            queryItems: [.ddsource(), .batchTime(using: dateProvider)]
+            queryItemProviders: [.ddsource(), .batchTime(using: dateProvider)]
         )
 
         XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=ios&batch_time=1576404000000"))

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -65,7 +65,7 @@ class DDTracerTests: XCTestCase {
               "type": "custom",
               "meta.tracer.version": "\(sdkVersion)",
               "meta.version": "1.0.0",
-              "meta._dd.source": "mobile",
+              "meta._dd.source": "ios",
               "meta.network.client.available_interfaces": "wifi",
               "meta.network.client.is_constrained": "0",
               "meta.network.client.is_expensive": "1",

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
@@ -355,7 +355,7 @@ extension UploadURLProvider {
     static func mockAny() -> UploadURLProvider {
         return UploadURLProvider(
             urlWithClientToken: URL(string: "https://app.example.com/v2/api?abc-def-ghi")!,
-            dateProvider: RelativeDateProvider(using: Date.mockDecember15th2019At10AMUTC())
+            queryItems: []
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
@@ -355,7 +355,7 @@ extension UploadURLProvider {
     static func mockAny() -> UploadURLProvider {
         return UploadURLProvider(
             urlWithClientToken: URL(string: "https://app.example.com/v2/api?abc-def-ghi")!,
-            queryItems: []
+            queryItemProviders: []
         )
     }
 }


### PR DESCRIPTION
### What and why?

📦 This is #111's counterpart for Tracing feature. We change `ddsource` span attribute's value from `mobile` to `ios`.

### How?

The difference between Logging and Tracing in context of `ddsource` is that:
* for logs, the `ddsource` is sent as HTTP query `?ddsource=ios`,
* for spans, the `ddsource` is encoded as `meta._dd.source` json attribute.

This PR makes the upload URL query items customizable and provides different items for each feature. It also centralizes the `ddsource` value declaration to `Datadog.Constants.ddsource`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
