### PR TITLE
RUMM-300 Method swizzling

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -160,11 +160,15 @@
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */; };
+		9E544A4D24752A8900E83072 /* URLSessionSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */; };
+		9E544A4F24753C6E00E83072 /* MethodSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */; };
+		9E544A5124753DDE00E83072 /* MethodSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */; };
 		9E58E8DF24615B89008E5063 /* ISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8DE24615B89008E5063 /* ISO8601DateFormatter.swift */; };
 		9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8E024615C75008E5063 /* JSONEncoder.swift */; };
 		9E58E8E324615EDA008E5063 /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8E224615EDA008E5063 /* EncodingTests.swift */; };
 		9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */; };
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9EB47B92247443FA004F90BE /* URLSessionSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -384,12 +388,16 @@
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionsTests.swift; sourceTree = "<group>"; };
+		9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlerTests.swift; sourceTree = "<group>"; };
+		9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzler.swift; sourceTree = "<group>"; };
+		9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzlerTests.swift; sourceTree = "<group>"; };
 		9E58E8DE24615B89008E5063 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
 		9E58E8E024615C75008E5063 /* JSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
 		9E58E8E224615EDA008E5063 /* EncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingTests.swift; sourceTree = "<group>"; };
 		9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcExceptionHandler.m; sourceTree = "<group>"; };
 		9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjcExceptionHandler.h; sourceTree = "<group>"; };
 		9E9EB37624468CE90002C80B /* Datadog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Datadog.modulemap; sourceTree = "<group>"; };
+		9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzler.swift; sourceTree = "<group>"; };
 		9EF49F1624476FBD004F2CA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9EF49F17244770AD004F2CA0 /* DatadogIntegrationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogIntegrationTests.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -995,6 +1003,8 @@
 			children = (
 				61C5A87C24509A0C00DA608C /* Casting.swift */,
 				61C5A87D24509A0C00DA608C /* Warnings.swift */,
+				9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */,
+				9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1035,6 +1045,8 @@
 				61C5A89B24509C1100DA608C /* UUID.swift */,
 				61C5A89A24509C1100DA608C /* WarningsTests.swift */,
 				61C5A89C24509C1100DA608C /* Casting.swift */,
+				9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */,
+				9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1408,6 +1420,7 @@
 				61C5A88924509A0C00DA608C /* DDSpanContext.swift in Sources */,
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
+				9E544A4F24753C6E00E83072 /* MethodSwizzler.swift in Sources */,
 				61133BEA2423979B00786299 /* LogConsoleOutput.swift in Sources */,
 				61C5A8A624509FAA00DA608C /* SpanEncoder.swift in Sources */,
 				61C5A88E24509A1F00DA608C /* DDTracer.swift in Sources */,
@@ -1437,6 +1450,7 @@
 				61133BCE2423979B00786299 /* BatteryStatusProvider.swift in Sources */,
 				61133BD52423979B00786299 /* DataUploadConditions.swift in Sources */,
 				612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */,
+				9EB47B92247443FA004F90BE /* URLSessionSwizzler.swift in Sources */,
 				61133BE92423979B00786299 /* LogOutput.swift in Sources */,
 				61C5A88524509A0C00DA608C /* DDNoOps.swift in Sources */,
 				61C5A88624509A0C00DA608C /* TracingUUIDGenerator.swift in Sources */,
@@ -1463,6 +1477,7 @@
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
 				61133C622423990D00786299 /* InternalLoggersTests.swift in Sources */,
 				61133C582423990D00786299 /* FileWriterTests.swift in Sources */,
+				9E544A4D24752A8900E83072 /* URLSessionSwizzlerTests.swift in Sources */,
 				61E917D3246546BF00E6C631 /* DDTracerConfigurationTests.swift in Sources */,
 				61C5A89D24509C1100DA608C /* DDSpanTests.swift in Sources */,
 				61133C672423990D00786299 /* LogConsoleOutputTests.swift in Sources */,
@@ -1490,6 +1505,7 @@
 				61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */,
 				61133C592423990D00786299 /* FilesOrchestratorTests.swift in Sources */,
 				61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */,
+				9E544A5124753DDE00E83072 /* MethodSwizzlerTests.swift in Sources */,
 				61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */,
 				61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */,
 				61133C6C2423990D00786299 /* SwiftExtensions.swift in Sources */,

--- a/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
+++ b/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
@@ -15,7 +15,7 @@ internal struct NetworkConnectionInfo {
         /// The network might be reachable after trying.
         case maybe
         /// The network is not reachable.
-        case no // swiftlint:disable:this identifier_name
+        case no
     }
 
     /// Network connection interfaces.

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -64,7 +64,7 @@ public class Datadog {
     public static var verbosityLevel: LogLevel? = nil
 
     public static func setUserInfo(
-        id: String? = nil, // swiftlint:disable:this identifier_name
+        id: String? = nil,
         name: String? = nil,
         email: String? = nil
     ) {

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -13,10 +13,10 @@ extension Datadog {
         public enum LogsEndpoint {
             /// US based servers.
             /// Sends logs to [app.datadoghq.com](https://app.datadoghq.com/).
-            case us // swiftlint:disable:this identifier_name
+            case us
             /// Europe based servers.
             /// Sends logs to [app.datadoghq.eu](https://app.datadoghq.eu/).
-            case eu // swiftlint:disable:this identifier_name
+            case eu
             /// User-defined server.
             case custom(url: String)
 
@@ -33,10 +33,10 @@ extension Datadog {
         public enum TracesEndpoint {
             /// US based servers.
             /// Sends traces to [app.datadoghq.com](https://app.datadoghq.com/).
-            case us // swiftlint:disable:this identifier_name
+            case us
             /// Europe based servers.
             /// Sends traces to [app.datadoghq.eu](https://app.datadoghq.eu/).
-            case eu // swiftlint:disable:this identifier_name
+            case eu
             /// User-defined server.
             case custom(url: String)
 

--- a/Sources/Datadog/Logs/Attributes/UserInfo.swift
+++ b/Sources/Datadog/Logs/Attributes/UserInfo.swift
@@ -22,7 +22,7 @@ internal class UserInfoProvider {
 
 /// Information about the user.
 internal struct UserInfo {
-    let id: String? // swiftlint:disable:this identifier_name
+    let id: String?
     let name: String?
     let email: String?
 }

--- a/Sources/Datadog/Tracing/Utils/MethodSwizzler.swift
+++ b/Sources/Datadog/Tracing/Utils/MethodSwizzler.swift
@@ -1,0 +1,89 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal enum SwizzlingError: LocalizedError {
+    case unknown
+    case classIsNotNSObjectSubclass(className: String)
+    case methodNotFound(selector: String, className: String)
+    case methodWasNotSwizzled(selector: String, className: String)
+}
+
+internal class MethodSwizzler {
+    static let shared = MethodSwizzler()
+
+    private let queue = DispatchQueue(label: "com.datadoghq.methodSwizzlerQueue", target: DispatchQueue.global(qos: .userInteractive))
+    private var implementationCache = [String: IMP]()
+
+    func currentImplementation<TypedIMP>(of selector: Selector, in klass: AnyClass) throws -> TypedIMP {
+        try queue.sync {
+            let foundMethod = try method(with: selector, in: klass)
+            return unsafeBitCast(method_getImplementation(foundMethod), to: TypedIMP.self)
+        }
+    }
+
+    func swizzle(selector: Selector, in klass: AnyClass, with implementation: IMP) throws {
+        try queue.sync {
+            if !isKindOfNSObject(klass) {
+                throw SwizzlingError.classIsNotNSObjectSubclass(className: NSStringFromClass(klass))
+            }
+            let foundMethod = try method(with: selector, in: klass)
+            let cacheKey = methodIdentifier(foundMethod, in: klass)
+            if implementationCache[cacheKey] == nil {
+                implementationCache[cacheKey] = method_getImplementation(foundMethod)
+            }
+            method_setImplementation(foundMethod, implementation)
+        }
+    }
+
+    func unswizzle(selector: Selector, in klass: AnyClass) throws {
+        try queue.sync {
+            let foundMethod = try method(with: selector, in: klass)
+            let cacheKey = methodIdentifier(foundMethod, in: klass)
+            guard let originalImp = implementationCache[cacheKey] else {
+                throw SwizzlingError.methodWasNotSwizzled(selector: NSStringFromSelector(selector), className: NSStringFromClass(klass))
+            }
+            method_setImplementation(foundMethod, originalImp)
+            implementationCache[cacheKey] = nil
+        }
+    }
+
+    private func method(with selector: Selector, in klass: AnyClass) throws -> Method {
+        var methodsCount: UInt32 = 0
+        guard let methods: UnsafeMutablePointer<Method> = class_copyMethodList(klass, withUnsafeMutablePointer(to: &methodsCount) { $0 }) else {
+            throw SwizzlingError.methodNotFound(selector: NSStringFromSelector(selector), className: NSStringFromClass(klass))
+        }
+        defer {
+            free(methods)
+        }
+        for index in 0..<Int(methodsCount) {
+            let method = methods.advanced(by: index).pointee
+            if method_getName(method) == selector {
+                return method
+            }
+        }
+        throw SwizzlingError.methodNotFound(selector: NSStringFromSelector(selector), className: NSStringFromClass(klass))
+    }
+
+    private func methodIdentifier(_ method: Method, in klass: AnyClass) -> String {
+        let klassName = NSStringFromClass(klass)
+        let methodName = NSStringFromSelector(method_getName(method))
+        return "\(klassName)|||\(methodName)"
+    }
+
+    private func isKindOfNSObject(_ klass: AnyClass) -> Bool {
+        let NSObjectClassName: String = NSStringFromClass(NSObject.self)
+        var head: AnyClass? = klass
+        while let headClass = head {
+            if NSStringFromClass(headClass) == NSObjectClassName {
+                return true
+            }
+            head = class_getSuperclass(head)
+        }
+        return false
+    }
+}

--- a/Sources/Datadog/Tracing/Utils/URLSessionSwizzler.swift
+++ b/Sources/Datadog/Tracing/Utils/URLSessionSwizzler.swift
@@ -1,0 +1,104 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+// TODO: RUMM-300 plug DDTracer into swizzled methods
+
+internal class URLSessionSwizzler {
+    static let subjectClass = URLSession.self
+
+    private typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
+
+    static let sel_DataTaskWithURL = #selector(URLSession.dataTask(with:) as (URLSession) -> (URL) -> URLSessionDataTask)
+    static let sel_DataTaskWithRequest = #selector(URLSession.dataTask(with:) as (URLSession) -> (URLRequest) -> URLSessionDataTask)
+    static let sel_DataTaskWithURLCompletion = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping CompletionHandler) -> URLSessionDataTask)
+    static let sel_DataTaskWithRequestCompletion = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping CompletionHandler) -> URLSessionDataTask)
+
+    private static let swizzler = MethodSwizzler.shared
+
+    private typealias DataTaskWithURL_C = @convention(c) (AnyObject, Selector, URL) -> URLSessionDataTask
+    private typealias DataTaskWithURL_Block = @convention(block) (AnyObject, URL) -> URLSessionDataTask
+    private typealias DataTaskWithRequest_C = @convention(c) (AnyObject, Selector, URLRequest) -> URLSessionDataTask
+    private typealias DataTaskWithRequest_Block = @convention(block) (AnyObject, URLRequest) -> URLSessionDataTask
+
+    private typealias DataTaskWithURLCompletion_C = @convention(c) (AnyObject, Selector, URL, @escaping CompletionHandler) -> URLSessionDataTask
+    private typealias DataTaskWithURLCompletion_Block = @convention(block) (AnyObject, URL, @escaping CompletionHandler) -> URLSessionDataTask
+    private typealias DataTaskWithRequestCompletion_C = @convention(c) (AnyObject, Selector, URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
+    private typealias DataTaskWithRequestCompletion_Block = @convention(block) (AnyObject, URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
+
+    static func swizzle() throws {
+        try swizzleDataTaskWithURL()
+        try swizzleDataTaskWithRequest()
+        try swizzleDataTaskWithURLCompletionHandler()
+        try swizzleDataTaskWithRequestCompletionHandler()
+    }
+
+    static func unswizzle() throws {
+        try swizzler.unswizzle(selector: sel_DataTaskWithURL, in: subjectClass)
+        try swizzler.unswizzle(selector: sel_DataTaskWithRequest, in: subjectClass)
+        try swizzler.unswizzle(selector: sel_DataTaskWithURLCompletion, in: subjectClass)
+        try swizzler.unswizzle(selector: sel_DataTaskWithRequestCompletion, in: subjectClass)
+    }
+
+    static func swizzleDataTaskWithURL() throws {
+        // typealiases cannot be generic as C/block conventions don't support generics
+        // note that _Block doesn't have Selector parameter
+        typealias TypedIMP = DataTaskWithURL_C
+        typealias TypedBlockIMP = DataTaskWithURL_Block
+
+        let sel = sel_DataTaskWithURL
+        let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
+
+        let newImpBlock: TypedBlockIMP = { [impSelector = sel] impSelf, impURL -> URLSessionDataTask in
+            return typedOriginalImp(impSelf, impSelector, impURL)
+        }
+        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
+        try swizzler.swizzle(selector: sel, in: subjectClass, with: newImp)
+    }
+
+    static func swizzleDataTaskWithRequest() throws {
+        typealias TypedIMP = DataTaskWithRequest_C
+        typealias TypedBlockIMP = DataTaskWithRequest_Block
+
+        let sel = sel_DataTaskWithRequest
+        let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
+
+        let newImpBlock: TypedBlockIMP = { [impSelector = sel] impSelf, impURLRequest -> URLSessionDataTask in
+            return typedOriginalImp(impSelf, impSelector, impURLRequest)
+        }
+        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
+        try swizzler.swizzle(selector: sel, in: subjectClass, with: newImp)
+    }
+
+    static func swizzleDataTaskWithURLCompletionHandler() throws {
+        typealias TypedIMP = DataTaskWithURLCompletion_C
+        typealias TypedBlockIMP = DataTaskWithURLCompletion_Block
+
+        let sel = sel_DataTaskWithURLCompletion
+        let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
+
+        let newImpBlock: TypedBlockIMP = { [impSelector = sel] impSelf, impURL, impCompletion -> URLSessionDataTask in
+            return typedOriginalImp(impSelf, impSelector, impURL, impCompletion)
+        }
+        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
+        try swizzler.swizzle(selector: sel, in: subjectClass, with: newImp)
+    }
+
+    static func swizzleDataTaskWithRequestCompletionHandler() throws {
+        typealias TypedIMP = DataTaskWithRequestCompletion_C
+        typealias TypedBlockIMP = DataTaskWithRequestCompletion_Block
+
+        let sel = sel_DataTaskWithRequestCompletion
+        let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
+
+        let newImpBlock: TypedBlockIMP = { [impSelector = sel] impSelf, impURLRequest, impCompletion -> URLSessionDataTask in
+            return typedOriginalImp(impSelf, impSelector, impURLRequest, impCompletion)
+        }
+        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
+        try swizzler.swizzle(selector: sel, in: subjectClass, with: newImp)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/MethodSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/MethodSwizzlerTests.swift
@@ -1,0 +1,163 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+@objcMembers
+private class EmptySubclass: BaseClass { }
+
+@objcMembers
+private class BaseClass: NSObject {
+    static let returnValue = "this is base class"
+
+    func methodToSwizzle() -> String {
+        return Self.returnValue
+    }
+}
+
+@objcMembers
+private class NonNSObjectSubclass {
+    static let returnValue = "this is base class"
+
+    func methodToSwizzle() -> String {
+        return Self.returnValue
+    }
+}
+
+private class ThirdPartySwizzler {
+    private var originalIMP: IMP? = nil
+    private let selector: Selector = #selector(BaseClass.methodToSwizzle)
+    private let targetClass: AnyClass = BaseClass.self
+
+    func swizzleMethodToSwizzle() {
+        typealias TypedIMP = @convention(c) (AnyObject, Selector) -> String
+        typealias TypedBlockIMP = @convention(block) (AnyObject) -> String
+
+        let method: Method = class_getInstanceMethod(targetClass, selector)!
+        let currentMethodImp: IMP = method_getImplementation(method)
+        self.originalIMP = currentMethodImp
+
+        let typedMethodImp: TypedIMP = unsafeBitCast(currentMethodImp, to: TypedIMP.self)
+        let newBlockImp: TypedBlockIMP = { [originalImp = typedMethodImp, impSel = selector] impSelf -> String in
+            let originalRetVal = originalImp(impSelf, impSel)
+            return originalRetVal + "...3rd party swizzled"
+        }
+        let newImp = imp_implementationWithBlock(newBlockImp)
+        method_setImplementation(method, newImp)
+    }
+
+    deinit {
+        let method: Method = class_getInstanceMethod(targetClass, selector)!
+        method_setImplementation(method, self.originalIMP!)
+    }
+}
+
+class MethodSwizzlerTests: XCTestCase {
+    private let swizzler = MethodSwizzler.shared
+
+    func testSimpleSwizzling() {
+        typealias TypedIMP = @convention(c) (AnyObject, Selector) -> String
+        typealias TypedBlockIMP = @convention(block) (AnyObject) -> String
+
+        let sel = #selector(BaseClass.methodToSwizzle as (BaseClass) -> () -> String)
+        let swizzledReturnValue = "this is swizzled imp"
+        let newBlockImp: TypedBlockIMP = { impSelf -> String in
+            return swizzledReturnValue
+        }
+        let newImp = imp_implementationWithBlock(newBlockImp)
+
+        let obj = BaseClass()
+
+        XCTAssertNoThrow(try swizzler.swizzle(selector: sel, in: BaseClass.self, with: newImp))
+        XCTAssertEqual(obj.perform(sel)?.takeUnretainedValue() as? String, swizzledReturnValue)
+    }
+
+    func testUnswizzling() {
+        typealias TypedIMP = @convention(c) (AnyObject, Selector) -> String
+        typealias TypedBlockIMP = @convention(block) (AnyObject) -> String
+
+        let sel = #selector(BaseClass.methodToSwizzle as (BaseClass) -> () -> String)
+        let swizzledReturnValue = "this is swizzled imp"
+        let newBlockImp: TypedBlockIMP = { impSelf -> String in
+            return swizzledReturnValue
+        }
+        let newImp = imp_implementationWithBlock(newBlockImp)
+
+        try! swizzler.swizzle(selector: sel, in: BaseClass.self, with: newImp)
+
+        let obj = BaseClass()
+
+        XCTAssertNoThrow(try swizzler.unswizzle(selector: sel, in: BaseClass.self))
+        XCTAssertEqual(obj.perform(sel)?.takeUnretainedValue() as? String, BaseClass.returnValue)
+    }
+
+    func testSwizzleSuperclassMethod() {
+        typealias TypedIMP = @convention(c) (AnyObject, Selector) -> String
+        typealias TypedBlockIMP = @convention(block) (AnyObject) -> String
+
+        let klass: AnyClass = EmptySubclass.self
+        let sel = #selector(EmptySubclass.methodToSwizzle as (EmptySubclass) -> () -> String)
+        let swizzledReturnValue = "this is swizzled imp"
+        let newBlockImp: TypedBlockIMP = { impSelf -> String in
+            return swizzledReturnValue
+        }
+        let newImp = imp_implementationWithBlock(newBlockImp)
+
+        do {
+            try swizzler.swizzle(selector: sel, in: klass, with: newImp)
+        } catch SwizzlingError.methodNotFound(let unfoundSelector, let searchedClassName) {
+            XCTAssertEqual(unfoundSelector, NSStringFromSelector(sel))
+            XCTAssertEqual(searchedClassName, NSStringFromClass(klass))
+        } catch {
+            XCTAssertNil(error)
+        }
+    }
+
+    func testSwizzleNonNSObjectSubclass() {
+        typealias TypedIMP = @convention(c) (AnyObject, Selector) -> String
+        typealias TypedBlockIMP = @convention(block) (AnyObject) -> String
+
+        let klass: AnyClass = NonNSObjectSubclass.self
+        let sel = #selector(NonNSObjectSubclass.methodToSwizzle as (NonNSObjectSubclass) -> () -> String)
+        let swizzledReturnValue = "this is swizzled imp"
+        let newBlockImp: TypedBlockIMP = { impSelf -> String in
+            return swizzledReturnValue
+        }
+        let newImp = imp_implementationWithBlock(newBlockImp)
+
+        do {
+            try swizzler.swizzle(selector: sel, in: klass, with: newImp)
+        } catch SwizzlingError.classIsNotNSObjectSubclass(let className) {
+            XCTAssertEqual(className, NSStringFromClass(klass))
+        } catch {
+            XCTAssertNil(error)
+        }
+    }
+
+    func testThirdPartySwizzling() {
+        typealias TypedIMP = @convention(c) (AnyObject, Selector) -> String
+        typealias TypedBlockIMP = @convention(block) (AnyObject) -> String
+
+        let sel = #selector(BaseClass.methodToSwizzle as (BaseClass) -> () -> String)
+        let swizzledReturnValue = "this is swizzled imp"
+        let newBlockImp: TypedBlockIMP = { impSelf -> String in
+            return swizzledReturnValue
+        }
+        let newImp = imp_implementationWithBlock(newBlockImp)
+
+        let obj = BaseClass()
+
+        try! swizzler.swizzle(selector: sel, in: BaseClass.self, with: newImp)
+
+        let thirdPartySwizzler = ThirdPartySwizzler()
+        thirdPartySwizzler.swizzleMethodToSwizzle()
+
+        let returnValue: String = obj.perform(sel)?.takeUnretainedValue() as! String
+        XCTAssertNotEqual(returnValue, swizzledReturnValue)
+        XCTAssert(returnValue.contains(swizzledReturnValue))
+    }
+}

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/MethodSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/MethodSwizzlerTests.swift
@@ -64,16 +64,15 @@ class MethodSwizzlerTests: XCTestCase {
         typealias TypedBlockIMP = @convention(block) (AnyObject) -> String
 
         let sel = #selector(BaseClass.methodToSwizzle as (BaseClass) -> () -> String)
-        let swizzledReturnValue = "this is swizzled imp"
         let newBlockImp: TypedBlockIMP = { impSelf -> String in
-            return swizzledReturnValue
+            return .mockAny()
         }
         let newImp = imp_implementationWithBlock(newBlockImp)
 
         let obj = BaseClass()
 
         XCTAssertNoThrow(try swizzler.swizzle(selector: sel, in: BaseClass.self, with: newImp))
-        XCTAssertEqual(obj.perform(sel)?.takeUnretainedValue() as? String, swizzledReturnValue)
+        XCTAssertEqual(obj.perform(sel)?.takeUnretainedValue() as? String, String.mockAny())
     }
 
     func testUnswizzling() {
@@ -81,9 +80,8 @@ class MethodSwizzlerTests: XCTestCase {
         typealias TypedBlockIMP = @convention(block) (AnyObject) -> String
 
         let sel = #selector(BaseClass.methodToSwizzle as (BaseClass) -> () -> String)
-        let swizzledReturnValue = "this is swizzled imp"
         let newBlockImp: TypedBlockIMP = { impSelf -> String in
-            return swizzledReturnValue
+            return .mockAny()
         }
         let newImp = imp_implementationWithBlock(newBlockImp)
 
@@ -101,19 +99,18 @@ class MethodSwizzlerTests: XCTestCase {
 
         let klass: AnyClass = EmptySubclass.self
         let sel = #selector(EmptySubclass.methodToSwizzle as (EmptySubclass) -> () -> String)
-        let swizzledReturnValue = "this is swizzled imp"
         let newBlockImp: TypedBlockIMP = { impSelf -> String in
-            return swizzledReturnValue
+            return .mockAny()
         }
         let newImp = imp_implementationWithBlock(newBlockImp)
 
-        do {
-            try swizzler.swizzle(selector: sel, in: klass, with: newImp)
-        } catch SwizzlingError.methodNotFound(let unfoundSelector, let searchedClassName) {
+        XCTAssertThrowsError(try swizzler.swizzle(selector: sel, in: klass, with: newImp), "Method should NOT be found") { error in
+            guard case SwizzlingError.methodNotFound(let unfoundSelector, let searchedClassName) = error else {
+                XCTFail("Expected `SwizzlingError.methodNotFound`: \(error)")
+                return
+            }
             XCTAssertEqual(unfoundSelector, NSStringFromSelector(sel))
             XCTAssertEqual(searchedClassName, NSStringFromClass(klass))
-        } catch {
-            XCTAssertNil(error)
         }
     }
 
@@ -123,18 +120,17 @@ class MethodSwizzlerTests: XCTestCase {
 
         let klass: AnyClass = NonNSObjectSubclass.self
         let sel = #selector(NonNSObjectSubclass.methodToSwizzle as (NonNSObjectSubclass) -> () -> String)
-        let swizzledReturnValue = "this is swizzled imp"
         let newBlockImp: TypedBlockIMP = { impSelf -> String in
-            return swizzledReturnValue
+            return .mockAny()
         }
         let newImp = imp_implementationWithBlock(newBlockImp)
 
-        do {
-            try swizzler.swizzle(selector: sel, in: klass, with: newImp)
-        } catch SwizzlingError.classIsNotNSObjectSubclass(let className) {
+        XCTAssertThrowsError(try swizzler.swizzle(selector: sel, in: klass, with: newImp), "Method should NOT be found") { error in
+            guard case SwizzlingError.classIsNotNSObjectSubclass(let className) = error else {
+                XCTFail("Expected `SwizzlingError.classIsNotNSObjectSubclass`: \(error)")
+                return
+            }
             XCTAssertEqual(className, NSStringFromClass(klass))
-        } catch {
-            XCTAssertNil(error)
         }
     }
 
@@ -143,9 +139,8 @@ class MethodSwizzlerTests: XCTestCase {
         typealias TypedBlockIMP = @convention(block) (AnyObject) -> String
 
         let sel = #selector(BaseClass.methodToSwizzle as (BaseClass) -> () -> String)
-        let swizzledReturnValue = "this is swizzled imp"
         let newBlockImp: TypedBlockIMP = { impSelf -> String in
-            return swizzledReturnValue
+            return .mockAny()
         }
         let newImp = imp_implementationWithBlock(newBlockImp)
 
@@ -157,7 +152,7 @@ class MethodSwizzlerTests: XCTestCase {
         thirdPartySwizzler.swizzleMethodToSwizzle()
 
         let returnValue: String = obj.perform(sel)?.takeUnretainedValue() as! String
-        XCTAssertNotEqual(returnValue, swizzledReturnValue)
-        XCTAssert(returnValue.contains(swizzledReturnValue))
+        XCTAssertNotEqual(returnValue, String.mockAny())
+        XCTAssert(returnValue.contains(String.mockAny()))
     }
 }

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/URLSessionSwizzlerTests.swift
@@ -1,0 +1,113 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+// TODO: RUMM-300 plug DDTracer into swizzled methods
+
+class URLSessionSwizzlerTests: XCTestCase {
+    func test_swizzleDataTaskWithURL() {
+        defer {
+            try! MethodSwizzler.shared.unswizzle(
+                selector: URLSessionSwizzler.sel_DataTaskWithURL,
+                in: URLSessionSwizzler.subjectClass
+            )
+        }
+
+        let session = URLSession(configuration: .default)
+
+        XCTAssertNoThrow(try URLSessionSwizzler.swizzleDataTaskWithURL())
+
+        let url = URL(string: "http://foo.bar")!
+        let task = session.dataTask(with: url)
+
+        XCTAssertEqual(task.originalRequest?.url, url)
+    }
+
+    func test_unswizzleDataTaskWithURL() {
+        let session = URLSession(configuration: .default)
+
+        XCTAssertNoThrow(try URLSessionSwizzler.swizzleDataTaskWithURL())
+
+        let url = URL(string: "http://foo.bar")!
+        let task = session.dataTask(with: url)
+
+        XCTAssertEqual(task.originalRequest?.url, url)
+
+        try! MethodSwizzler.shared.unswizzle(
+            selector: URLSessionSwizzler.sel_DataTaskWithURL,
+            in: URLSessionSwizzler.subjectClass
+        )
+
+        let unswizzledTask = session.dataTask(with: url)
+        XCTAssertEqual(unswizzledTask.originalRequest?.url, url)
+    }
+
+    func test_swizzleDataTaskWithRequest() {
+        defer {
+            try! MethodSwizzler.shared.unswizzle(
+                selector: URLSessionSwizzler.sel_DataTaskWithRequest,
+                in: URLSessionSwizzler.subjectClass
+            )
+        }
+
+        let session = URLSession(configuration: .default)
+
+        XCTAssertNoThrow(try URLSessionSwizzler.swizzleDataTaskWithRequest())
+
+        let url = URL(string: "http://foo.bar")!
+        let request = URLRequest(url: url)
+        let task = session.dataTask(with: request)
+
+        XCTAssertEqual(task.originalRequest?.url, url)
+    }
+
+    func test_swizzleDataTaskWithURLCompletion() {
+        defer {
+            try! MethodSwizzler.shared.unswizzle(
+                selector: URLSessionSwizzler.sel_DataTaskWithURLCompletion,
+                in: URLSessionSwizzler.subjectClass
+            )
+        }
+
+        let session = URLSession(configuration: .default)
+
+        XCTAssertNoThrow(try URLSessionSwizzler.swizzleDataTaskWithURLCompletionHandler())
+
+        let asyncExpc = expectation(description: "completion handler expectation")
+        let url = URL(string: "http://foo.bar")!
+        let task = session.dataTask(with: url) { _,_,_ in asyncExpc.fulfill() }
+
+        XCTAssertEqual(task.originalRequest?.url, url)
+
+        task.resume()
+        wait(for: [asyncExpc], timeout: 0.1)
+    }
+
+    func test_swizzleDataTaskWithRequestCompletion() {
+        defer {
+            try! MethodSwizzler.shared.unswizzle(
+                selector: URLSessionSwizzler.sel_DataTaskWithRequestCompletion,
+                in: URLSessionSwizzler.subjectClass
+            )
+        }
+
+        let session = URLSession(configuration: .default)
+
+        XCTAssertNoThrow(try URLSessionSwizzler.swizzleDataTaskWithRequestCompletionHandler())
+
+        let asyncExpc = expectation(description: "completion handler expectation")
+        let url = URL(string: "http://foo.bar")!
+        let request = URLRequest(url: url)
+        let task = session.dataTask(with: request) { _,_,_ in asyncExpc.fulfill() }
+
+        XCTAssertEqual(task.originalRequest?.url, url)
+
+        task.resume()
+        wait(for: [asyncExpc], timeout: 0.1)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/URLSessionSwizzlerTests.swift
@@ -13,7 +13,7 @@ class URLSessionSwizzlerTests: XCTestCase {
     func test_swizzleDataTaskWithURL() {
         defer {
             try! MethodSwizzler.shared.unswizzle(
-                selector: URLSessionSwizzler.sel_DataTaskWithURL,
+                selector: URLSessionSwizzler.Selectors.DataTaskWithURL,
                 in: URLSessionSwizzler.subjectClass
             )
         }
@@ -39,7 +39,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         XCTAssertEqual(task.originalRequest?.url, url)
 
         try! MethodSwizzler.shared.unswizzle(
-            selector: URLSessionSwizzler.sel_DataTaskWithURL,
+            selector: URLSessionSwizzler.Selectors.DataTaskWithURL,
             in: URLSessionSwizzler.subjectClass
         )
 
@@ -50,7 +50,7 @@ class URLSessionSwizzlerTests: XCTestCase {
     func test_swizzleDataTaskWithRequest() {
         defer {
             try! MethodSwizzler.shared.unswizzle(
-                selector: URLSessionSwizzler.sel_DataTaskWithRequest,
+                selector: URLSessionSwizzler.Selectors.DataTaskWithRequest,
                 in: URLSessionSwizzler.subjectClass
             )
         }
@@ -69,7 +69,7 @@ class URLSessionSwizzlerTests: XCTestCase {
     func test_swizzleDataTaskWithURLCompletion() {
         defer {
             try! MethodSwizzler.shared.unswizzle(
-                selector: URLSessionSwizzler.sel_DataTaskWithURLCompletion,
+                selector: URLSessionSwizzler.Selectors.DataTaskWithURLCompletion,
                 in: URLSessionSwizzler.subjectClass
             )
         }
@@ -91,7 +91,7 @@ class URLSessionSwizzlerTests: XCTestCase {
     func test_swizzleDataTaskWithRequestCompletion() {
         defer {
             try! MethodSwizzler.shared.unswizzle(
-                selector: URLSessionSwizzler.sel_DataTaskWithRequestCompletion,
+                selector: URLSessionSwizzler.Selectors.DataTaskWithRequestCompletion,
                 in: URLSessionSwizzler.subjectClass
             )
         }

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -119,7 +119,7 @@ internal class LogMatcher: JSONDataMatcher {
     }
 
     func assertUserInfo(equals userInfo: (id: String?, name: String?, email: String?)?, file: StaticString = #file, line: UInt = #line) {
-        if let id = userInfo?.id { // swiftlint:disable:this identifier_name
+        if let id = userInfo?.id {
             assertValue(forKey: JSONKey.userId, equals: id, file: file, line: line)
         } else {
             assertNoValue(forKey: JSONKey.userId, file: file, line: line)

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -30,7 +30,6 @@ whitelist_rules: # we enable lint rules explicitly - only the ones listed below 
   - force_try
   - force_unwrapping
   - function_default_parameter_at_end
-  # - identifier_name
   - implicitly_unwrapped_optional
   - last_where
   - leading_whitespace

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -30,7 +30,7 @@ whitelist_rules: # we enable lint rules explicitly - only the ones listed below 
   - force_try
   - force_unwrapping
   - function_default_parameter_at_end
-  - identifier_name
+  # - identifier_name
   - implicitly_unwrapped_optional
   - last_where
   - leading_whitespace

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -25,7 +25,6 @@ whitelist_rules: # we enable lint rules explicitly - only the ones listed below 
   - first_where
   - for_where
   - function_default_parameter_at_end
-  - identifier_name
   - implicitly_unwrapped_optional
   - last_where
   - leading_whitespace


### PR DESCRIPTION
### What and why?

We needed to change the behavior of `URLSession` instances so that our users will be able to trace network calls automatically.

We considered 3 different solutions, this is the 3rd one.

### How?

#### `URLProtocol`

A custom `URLProtocol` allows us to detect new network requests, change them and detect when the operation is finished.

However, `URLProtocol` isn't designed to be an observer; it needs to do the actual work by starting the operation. If our custom protocol claims responsibility for a given request, we can't use default protocols (such as `HTTPURLProtocol`) anymore.

#### `NSProxy` approach

https://github.com/DataDog/dd-sdk-ios/pull/91

```swift
let tracedSession = URLSession.traced(session)
```

`URLSession.traced(:)` takes an actual `URLSession` instance, wraps it into a proxy type (eg: `DDURLSessionProxy`) and `unsafeBitcast` it to `URLSession`.
Returned value is `DDURLSessionProxy` at runtime although it is `URLSession` at compile-time.

1. This approach requires `unsafeBitcast`
2. Adds many extra redirections to ObjC message forwarding
3. Doesn't work with `URLSession.shared`

#### `isa` swizzling

https://github.com/DataDog/dd-sdk-ios/pull/108

This solutions is safe and it works. However, it is considered too complex to read/understand/maintain

#### Method swizzling ✅ 

This PR implements `MethodSwizzler`
This is thought to be the simplest working solution to our problem.

⚠️ ⚠️ ⚠️ It still requires `unsafeBitcast` in order to call original method implementation in the swizzled implementation, this is based on an assumption how Swift makes method calls and that might be subject to change. We should keep an eye on it

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
