### PR TITLE
RUMM-422 Disable network info by default in tracing

### DIFF
--- a/Datadog/Example/AppDelegate.swift
+++ b/Datadog/Example/AppDelegate.swift
@@ -48,7 +48,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Register global tracer
         Global.sharedTracer = DDTracer.initialize(
             configuration: DDTracer.Configuration(
-                serviceName: appConfig.serviceName
+                serviceName: appConfig.serviceName,
+                sendNetworkInfo: true
             )
         )
 

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -41,6 +41,9 @@ public class DDTracer: Tracer {
 
     internal convenience init(tracingFeature: TracingFeature, tracerConfiguration: Configuration) {
         let serviceName = tracerConfiguration.serviceName ?? tracingFeature.configuration.serviceName
+        let networkConnectionInfoProvider = tracerConfiguration.sendNetworkInfo ? tracingFeature.networkConnectionInfoProvider : nil
+        let carrierInfoProvider = tracerConfiguration.sendNetworkInfo ? tracingFeature.carrierInfoProvider : nil
+
         self.init(
             spanOutput: SpanFileOutput(
                 spanBuilder: SpanBuilder(
@@ -48,8 +51,8 @@ public class DDTracer: Tracer {
                     environment: tracingFeature.configuration.environment,
                     serviceName: serviceName,
                     userInfoProvider: tracingFeature.userInfoProvider,
-                    networkConnectionInfoProvider: tracingFeature.networkConnectionInfoProvider,
-                    carrierInfoProvider: tracingFeature.carrierInfoProvider
+                    networkConnectionInfoProvider: networkConnectionInfoProvider,
+                    carrierInfoProvider: carrierInfoProvider
                 ),
                 fileWriter: tracingFeature.storage.writer
             ),
@@ -61,8 +64,8 @@ public class DDTracer: Tracer {
                         serviceName: serviceName,
                         loggerName: "trace",
                         userInfoProvider: tracingFeature.userInfoProvider,
-                        networkConnectionInfoProvider: tracingFeature.networkConnectionInfoProvider,
-                        carrierInfoProvider: tracingFeature.carrierInfoProvider
+                        networkConnectionInfoProvider: networkConnectionInfoProvider,
+                        carrierInfoProvider: carrierInfoProvider
                     ),
                     fileWriter: tracingFeature.loggingFeatureStorage.writer
                 )

--- a/Sources/Datadog/DDTracerConfiguration.swift
+++ b/Sources/Datadog/DDTracerConfiguration.swift
@@ -12,10 +12,21 @@ extension DDTracer {
         /// The service name that will appear in traces (if not provided or `nil`, the SDK default `serviceName` will be used).
         public var serviceName: String?
 
+        /// Enriches traces with network connection info.
+        /// This means: reachability status, connection type, mobile carrier name and many more will be added to every span and span logs.
+        /// For full list of network info attributes see `NetworkConnectionInfo` and `CarrierInfo`.
+        /// - Parameter enabled: `false` by default
+        public var sendNetworkInfo: Bool
+
         /// Initializes the Datadog Tracer configuration.
         /// - Parameter serviceName: the service name that will appear in traces (if not provided or `nil`, the SDK default `serviceName` will be used).
-        public init(serviceName: String? = nil) {
+        /// - Parameter sendNetworkInfo: adds network connection info to every span and span logs (`false` by default).
+        public init(
+            serviceName: String? = nil,
+            sendNetworkInfo: Bool = false
+        ) {
             self.serviceName = serviceName
+            self.sendNetworkInfo = sendNetworkInfo
         }
     }
 }

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -16,10 +16,10 @@ internal struct SpanBuilder {
     let serviceName: String
     /// Shared user info provider.
     let userInfoProvider: UserInfoProvider
-    /// Shared network connection info provider.
-    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType // TODO: RUMM-422 Make `nil` if network info is disabled for tracer
-    /// Shared mobile carrier info provider.
-    let carrierInfoProvider: CarrierInfoProviderType
+    /// Shared network connection info provider (or `nil` if disabled for given tracer).
+    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType?
+    /// Shared mobile carrier info provider (or `nil` if disabled for given tracer).
+    let carrierInfoProvider: CarrierInfoProviderType?
 
     /// Encodes tag `Span` tag values as JSON string
     private let tagsJSONEncoder: JSONEncoder = .default()
@@ -43,8 +43,8 @@ internal struct SpanBuilder {
             isError: false, // TODO: RUMM-401 use error flag from `ddspan`
             tracerVersion: sdkVersion,
             applicationVersion: applicationVersion,
-            networkConnectionInfo: networkConnectionInfoProvider.current,
-            mobileCarrierInfo: carrierInfoProvider.current,
+            networkConnectionInfo: networkConnectionInfoProvider?.current,
+            mobileCarrierInfo: carrierInfoProvider?.current,
             userInfo: userInfoProvider.value,
             tags: jsonStringEncodedTags
         )

--- a/Tests/DatadogTests/Datadog/DDTracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerConfigurationTests.swift
@@ -40,7 +40,9 @@ class DDTracerConfigurationTests: XCTestCase {
     }
 
     func testDefaultTracer() {
-        let tracer = DDTracer.initialize(configuration: .init()).dd
+        let tracer = DDTracer.initialize(
+            configuration: .init()
+        ).dd
 
         guard let spanBuilder = (tracer.spanOutput as? SpanFileOutput)?.spanBuilder else {
             XCTFail()
@@ -52,9 +54,8 @@ class DDTracerConfigurationTests: XCTestCase {
         XCTAssertEqual(spanBuilder.environment, "tests")
         XCTAssertEqual(spanBuilder.serviceName, "service-name")
         XCTAssertTrue(spanBuilder.userInfoProvider === feature.userInfoProvider)
-        // TODO: RUMM-422 Assert `.networkConnectionInfoProvider` and `.carrierInfoProvider` are `nil` by default:
-        XCTAssertNotNil(spanBuilder.networkConnectionInfoProvider)
-        XCTAssertNotNil(spanBuilder.carrierInfoProvider)
+        XCTAssertNil(spanBuilder.networkConnectionInfoProvider)
+        XCTAssertNil(spanBuilder.carrierInfoProvider)
 
         guard let tracingLogBuilder = (tracer.logOutput.loggingOutput as? LogFileOutput)?.logBuilder else {
             XCTFail()
@@ -66,14 +67,16 @@ class DDTracerConfigurationTests: XCTestCase {
         XCTAssertEqual(tracingLogBuilder.serviceName, "service-name")
         XCTAssertEqual(tracingLogBuilder.loggerName, "trace")
         XCTAssertTrue(tracingLogBuilder.userInfoProvider === feature.userInfoProvider)
-        // TODO: RUMM-422 Assert `.networkConnectionInfoProvider` and `.carrierInfoProvider` are `nil` by default:
-        XCTAssertTrue(tracingLogBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
-        XCTAssertTrue(tracingLogBuilder.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
+        XCTAssertNil(tracingLogBuilder.networkConnectionInfoProvider)
+        XCTAssertNil(tracingLogBuilder.carrierInfoProvider)
     }
 
     func testCustomizedTracer() {
         let tracer = DDTracer.initialize(
-            configuration: .init(serviceName: "custom-service-name")
+            configuration: .init(
+                serviceName: "custom-service-name",
+                sendNetworkInfo: true
+            )
         ).dd
 
         guard let spanBuilder = (tracer.spanOutput as? SpanFileOutput)?.spanBuilder else {

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -24,9 +24,9 @@ class DDTracerTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Sending spans
+    // MARK: - Customizing DDTracer
 
-    func testSendingMinimalSpan() throws {
+    func testSendingSpanWithDefaultTracer() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWorkingFeatureWith(
             server: server,
@@ -42,7 +42,7 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer.initialize(configuration: .init()).dd
+        let tracer = DDTracer.initialize(configuration: .init())
 
         let span = tracer.startSpan(operationName: "operation")
         span.finish(at: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5))
@@ -65,16 +65,6 @@ class DDTracerTests: XCTestCase {
               "meta.tracer.version": "\(sdkVersion)",
               "meta.version": "1.0.0",
               "meta._dd.source": "ios",
-              "meta.network.client.available_interfaces": "wifi",
-              "meta.network.client.is_constrained": "0",
-              "meta.network.client.is_expensive": "1",
-              "meta.network.client.reachability": "yes",
-              "meta.network.client.sim_carrier.allows_voip": "0",
-              "meta.network.client.sim_carrier.iso_country": "abc",
-              "meta.network.client.sim_carrier.name": "abc",
-              "meta.network.client.sim_carrier.technology": "LTE",
-              "meta.network.client.supports_ipv4": "1",
-              "meta.network.client.supports_ipv6": "1",
               "metrics._top_level": 1,
               "metrics._sampling_priority_v1": 1
             }
@@ -83,6 +73,43 @@ class DDTracerTests: XCTestCase {
         }
         """) // TOOD: RUMM-422 Network info is not send by default with spans
     }
+
+    func testSendingSpanWithCustomizedTracer() throws {
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        TracingFeature.instance = .mockWorkingFeatureWith(
+            server: server,
+            directory: temporaryDirectory
+        )
+        defer { TracingFeature.instance = nil }
+
+        let tracer = DDTracer.initialize(
+            configuration: .init(
+                serviceName: "custom-service-name",
+                sendNetworkInfo: true
+            )
+        )
+
+        let span = tracer.startSpan(operationName: .mockAny())
+        span.finish()
+
+        let spanMatcher = try server.waitAndReturnSpanMatchers(count: 1)[0]
+
+        XCTAssertEqual(try spanMatcher.serviceName(), "custom-service-name")
+        XCTAssertNoThrow(try spanMatcher.meta.networkAvailableInterfaces())
+        XCTAssertNoThrow(try spanMatcher.meta.networkConnectionIsExpensive())
+        XCTAssertNoThrow(try spanMatcher.meta.networkReachability())
+        XCTAssertNoThrow(try spanMatcher.meta.mobileNetworkCarrierAllowsVoIP())
+        XCTAssertNoThrow(try spanMatcher.meta.mobileNetworkCarrierISOCountryCode())
+        XCTAssertNoThrow(try spanMatcher.meta.mobileNetworkCarrierName())
+        XCTAssertNoThrow(try spanMatcher.meta.mobileNetworkCarrierRadioTechnology())
+        XCTAssertNoThrow(try spanMatcher.meta.networkConnectionSupportsIPv4())
+        XCTAssertNoThrow(try spanMatcher.meta.networkConnectionSupportsIPv6())
+        if #available(iOS 13.0, *) {
+            XCTAssertNoThrow(try spanMatcher.meta.networkConnectionIsConstrained())
+        }
+    }
+
+    // MARK: - Sending Customized Spans
 
     func testSendingCustomizedSpan() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -241,7 +241,9 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer.initialize(configuration: .init()).dd
+        let tracer = DDTracer.initialize(
+            configuration: .init(sendNetworkInfo: true)
+        ).dd
 
         // simulate entering cellular service range
         carrierInfoProvider.set(
@@ -284,7 +286,9 @@ class DDTracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        let tracer = DDTracer.initialize(configuration: .init()).dd
+        let tracer = DDTracer.initialize(
+            configuration: .init(sendNetworkInfo: true)
+        ).dd
 
         // simulate reachable network
         networkConnectionInfoProvider.set(

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -23,9 +23,9 @@ class LoggerTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Sending logs
+    // MARK: - Customizing Logger
 
-    func testSendingMinimalLogWithDefaultLogger() throws {
+    func testSendingLogWithDefaultLogger() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
             server: server,
@@ -59,7 +59,7 @@ class LoggerTests: XCTestCase {
         """)
     }
 
-    func testSendingMinimalLogWithCustomizedLogger() throws {
+    func testSendingLogWithCustomizedLogger() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
             server: server,
@@ -91,6 +91,8 @@ class LoggerTests: XCTestCase {
             logMatcher.assertValue(forKeyPath: "network.client.is_constrained", isTypeOf: Bool.self)
         }
     }
+
+    // MARK: - Sending Customized Logs
 
     func testSendingLogsWithDifferentDates() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))


### PR DESCRIPTION
### What and why?

📦 Same as for `Logger`, the network information attached to `Span` and `Span` logs is now disabled by default for `DDTracer`.

### How?

The `sendNetworkInfo` option is added to `DDTracer.Configuration`:

```swift
DDTracer.Configuration(
   serviceName: ...,
   sendNetworkInfo: true
)
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
