### PR TITLE
RUMM-484 URLSessionHooks implemented

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		9E58E8E324615EDA008E5063 /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8E224615EDA008E5063 /* EncodingTests.swift */; };
 		9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */; };
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9E97A2FF247844F800C50BC5 /* URLSessionHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E97A2FE247844F800C50BC5 /* URLSessionHooks.swift */; };
 		9EB47B92247443FA004F90BE /* URLSessionSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */; };
 /* End PBXBuildFile section */
 
@@ -398,6 +399,7 @@
 		9E58E8E224615EDA008E5063 /* EncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingTests.swift; sourceTree = "<group>"; };
 		9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcExceptionHandler.m; sourceTree = "<group>"; };
 		9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjcExceptionHandler.h; sourceTree = "<group>"; };
+		9E97A2FE247844F800C50BC5 /* URLSessionHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHooks.swift; sourceTree = "<group>"; };
 		9E9EB37624468CE90002C80B /* Datadog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Datadog.modulemap; sourceTree = "<group>"; };
 		9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzler.swift; sourceTree = "<group>"; };
 		9EF49F1624476FBD004F2CA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1008,6 +1010,7 @@
 				61C5A87D24509A0C00DA608C /* Warnings.swift */,
 				9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */,
 				9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */,
+				9E97A2FE247844F800C50BC5 /* URLSessionHooks.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1420,6 +1423,7 @@
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
+				9E97A2FF247844F800C50BC5 /* URLSessionHooks.swift in Sources */,
 				61C5A88924509A0C00DA608C /* DDSpanContext.swift in Sources */,
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		9E544A4D24752A8900E83072 /* URLSessionSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */; };
 		9E544A4F24753C6E00E83072 /* MethodSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */; };
 		9E544A5124753DDE00E83072 /* MethodSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */; };
+		9E56C64F2481954D001ED01A /* ThirdPartySwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E56C64E2481954D001ED01A /* ThirdPartySwizzler.swift */; };
 		9E58E8DF24615B89008E5063 /* ISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8DE24615B89008E5063 /* ISO8601DateFormatter.swift */; };
 		9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8E024615C75008E5063 /* JSONEncoder.swift */; };
 		9E58E8E324615EDA008E5063 /* EncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8E224615EDA008E5063 /* EncodingTests.swift */; };
@@ -391,6 +392,7 @@
 		9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlerTests.swift; sourceTree = "<group>"; };
 		9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzler.swift; sourceTree = "<group>"; };
 		9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzlerTests.swift; sourceTree = "<group>"; };
+		9E56C64E2481954D001ED01A /* ThirdPartySwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartySwizzler.swift; sourceTree = "<group>"; };
 		9E58E8DE24615B89008E5063 /* ISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateFormatter.swift; sourceTree = "<group>"; };
 		9E58E8E024615C75008E5063 /* JSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
 		9E58E8E224615EDA008E5063 /* EncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingTests.swift; sourceTree = "<group>"; };
@@ -853,6 +855,7 @@
 				61133C452423990D00786299 /* SwiftExtensions.swift */,
 				61133C462423990D00786299 /* TestsDirectory.swift */,
 				61133C472423990D00786299 /* DatadogExtensions.swift */,
+				9E56C64E2481954D001ED01A /* ThirdPartySwizzler.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1467,6 +1470,7 @@
 			files = (
 				61C5A8A024509C1100DA608C /* Casting.swift in Sources */,
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
+				9E56C64F2481954D001ED01A /* ThirdPartySwizzler.swift in Sources */,
 				61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */,
 				61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */,
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -90,10 +90,9 @@ public class DDTracer: Tracer {
         let parentSpanContext = references?.compactMap { $0.context.dd }.last
         return DDSpan(
             tracer: self,
-            context: DDSpanContext(
-                traceID: parentSpanContext?.traceID ?? tracingFeature.tracingUUIDGenerator.generateUnique(),
-                spanID: tracingFeature.tracingUUIDGenerator.generateUnique(),
-                parentSpanID: parentSpanContext?.spanID
+            context: createSpanContext(
+                with: tracingFeature,
+                parentSpanContext: parentSpanContext
             ),
             operationName: operationName,
             startTime: startTime ?? tracingFeature.dateProvider.currentDate(),
@@ -103,7 +102,20 @@ public class DDTracer: Tracer {
 
     // MARK: - Internal
 
+    internal func createSpanContext(with tracingFeature: TracingFeature, parentSpanContext: DDSpanContext? = nil) -> DDSpanContext {
+        return DDSpanContext(
+            traceID: parentSpanContext?.traceID ?? tracingFeature.tracingUUIDGenerator.generateUnique(),
+            spanID: tracingFeature.tracingUUIDGenerator.generateUnique(),
+            parentSpanID: parentSpanContext?.spanID
+        )
+    }
+
     internal func write(span: DDSpan, finishTime: Date) {
         spanOutput.write(ddspan: span, finishTime: finishTime)
+    }
+
+    // TODO: RUMM-452 Placeholder implementation
+    internal func startSpan(with context: DDSpanContext) -> DDSpan? {
+        return nil
     }
 }

--- a/Sources/Datadog/Tracing/Utils/MethodSwizzler.swift
+++ b/Sources/Datadog/Tracing/Utils/MethodSwizzler.swift
@@ -6,56 +6,118 @@
 
 import Foundation
 
-internal enum SwizzlingError: LocalizedError {
-    case unknown
-    case classIsNotNSObjectSubclass(className: String)
+internal enum SwizzlingError: LocalizedError, Equatable {
     case methodNotFound(selector: String, className: String)
+    case methodIsAlreadySwizzled(selector: String, targetClassName: String, swizzledClassName: String)
     case methodWasNotSwizzled(selector: String, className: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .methodNotFound(let selector, let className):
+            return "\(selector) is not found in \(className)"
+        case .methodIsAlreadySwizzled(let selector, let targetClassName, let swizzledClassName):
+            return "\(selector) of \(targetClassName) is already swizzled in \(swizzledClassName)"
+        case .methodWasNotSwizzled(let selector, let className):
+            return "\(selector) in \(className) was not swizzled, thus cannot be unswizzled"
+        }
+    }
 }
 
 internal class MethodSwizzler {
-    static let shared = MethodSwizzler()
+    private typealias FoundMethod = (method: Method, klass: AnyClass)
 
-    private let queue = DispatchQueue(label: "com.datadoghq.methodSwizzlerQueue", target: DispatchQueue.global(qos: .userInteractive))
+    static let shared = MethodSwizzler()
+    private init() { }
     private var implementationCache = [String: IMP]()
 
     func currentImplementation<TypedIMP>(of selector: Selector, in klass: AnyClass) throws -> TypedIMP {
-        try queue.sync {
-            let foundMethod = try method(with: selector, in: klass)
-            return unsafeBitCast(method_getImplementation(foundMethod), to: TypedIMP.self)
+        return try sync {
+            let found = try findMethodRecursively(with: selector, in: klass)
+            return unsafeBitCast(method_getImplementation(found.method), to: TypedIMP.self)
+        }
+    }
+
+    func originalImplementation<TypedIMP>(of selector: Selector, in klass: AnyClass) throws -> TypedIMP {
+        return try sync {
+            let found = try findMethodRecursively(with: selector, in: klass)
+            let cacheKey = methodIdentifier(for: found)
+            let originalImp: IMP = implementationCache[cacheKey] ?? method_getImplementation(found.method)
+            return unsafeBitCast(originalImp, to: TypedIMP.self)
         }
     }
 
     func swizzle(selector: Selector, in klass: AnyClass, with implementation: IMP) throws {
-        try queue.sync {
-            if !isKindOfNSObject(klass) {
-                throw SwizzlingError.classIsNotNSObjectSubclass(className: NSStringFromClass(klass))
+        try sync {
+            assert(isKindOfNSObject(klass), "\(klass) is not NSObject subclass: swizzling may not work!")
+            let found = try findMethodRecursively(with: selector, in: klass)
+            set(newIMP: implementation, for: found)
+        }
+    }
+
+    func swizzleIfNonSwizzled(
+        selector: Selector,
+        in klass: AnyClass,
+        with implementation: @autoclosure () throws -> IMP
+    ) throws {
+        try sync {
+            let found = try findMethodRecursively(with: selector, in: klass)
+            let methodID = methodIdentifier(for: found)
+            if implementationCache[methodID] != nil {
+                throw SwizzlingError.methodIsAlreadySwizzled(
+                    selector: NSStringFromSelector(selector),
+                    targetClassName: NSStringFromClass(klass),
+                    swizzledClassName: NSStringFromClass(found.klass)
+                )
             }
-            let foundMethod = try method(with: selector, in: klass)
-            let cacheKey = methodIdentifier(foundMethod, in: klass)
-            if implementationCache[cacheKey] == nil {
-                implementationCache[cacheKey] = method_getImplementation(foundMethod)
-            }
-            method_setImplementation(foundMethod, implementation)
+            assert(isKindOfNSObject(found.klass), "\(klass) is not NSObject subclass: swizzling may not work!")
+            set(newIMP: try implementation(), for: found)
         }
     }
 
     func unswizzle(selector: Selector, in klass: AnyClass) throws {
-        try queue.sync {
-            let foundMethod = try method(with: selector, in: klass)
-            let cacheKey = methodIdentifier(foundMethod, in: klass)
+        return try sync {
+            let found = try findMethodRecursively(with: selector, in: klass)
+            let cacheKey = methodIdentifier(for: found)
             guard let originalImp = implementationCache[cacheKey] else {
                 throw SwizzlingError.methodWasNotSwizzled(selector: NSStringFromSelector(selector), className: NSStringFromClass(klass))
             }
-            method_setImplementation(foundMethod, originalImp)
+            method_setImplementation(found.method, originalImp)
             implementationCache[cacheKey] = nil
         }
     }
 
-    private func method(with selector: Selector, in klass: AnyClass) throws -> Method {
+    // MARK: - Private methods
+
+    private func sync<T>(block: () throws -> T) throws -> T {
+        objc_sync_enter(self)
+        defer { objc_sync_exit(self) }
+        return try block()
+    }
+
+    private func set(newIMP: IMP, for found: FoundMethod) {
+        let cacheKey = methodIdentifier(for: found)
+        if implementationCache[cacheKey] == nil {
+            implementationCache[cacheKey] = method_getImplementation(found.method)
+        }
+        method_setImplementation(found.method, newIMP)
+    }
+
+    private func findMethodRecursively(with selector: Selector, in klass: AnyClass) throws -> FoundMethod {
+        var headKlass: AnyClass? = klass
+        while let someKlass = headKlass {
+            if let foundMethod = findMethod(with: selector, in: someKlass) {
+                return (method: foundMethod, klass: someKlass)
+            }
+            headKlass = class_getSuperclass(headKlass)
+        }
+        throw SwizzlingError.methodNotFound(selector: NSStringFromSelector(selector), className: NSStringFromClass(klass))
+    }
+
+    private func findMethod(with selector: Selector, in klass: AnyClass) -> Method? {
         var methodsCount: UInt32 = 0
-        guard let methods: UnsafeMutablePointer<Method> = class_copyMethodList(klass, withUnsafeMutablePointer(to: &methodsCount) { $0 }) else {
-            throw SwizzlingError.methodNotFound(selector: NSStringFromSelector(selector), className: NSStringFromClass(klass))
+        let methodsCountPtr = withUnsafeMutablePointer(to: &methodsCount) { $0 }
+        guard let methods: UnsafeMutablePointer<Method> = class_copyMethodList(klass, methodsCountPtr) else {
+            return nil
         }
         defer {
             free(methods)
@@ -66,13 +128,25 @@ internal class MethodSwizzler {
                 return method
             }
         }
-        throw SwizzlingError.methodNotFound(selector: NSStringFromSelector(selector), className: NSStringFromClass(klass))
+        return nil
     }
 
-    private func methodIdentifier(_ method: Method, in klass: AnyClass) -> String {
-        let klassName = NSStringFromClass(klass)
-        let methodName = NSStringFromSelector(method_getName(method))
-        return "\(klassName)|||\(methodName)"
+    private static let separator = "|||"
+    private func methodIdentifier(for found: FoundMethod) -> String {
+        let klassName = NSStringFromClass(found.klass)
+        let methodName = NSStringFromSelector(method_getName(found.method))
+        return "\(klassName)\(Self.separator)\(methodName)"
+    }
+
+    private func classSelectorPair(from methodIdentifier: String) -> (klass: AnyClass, selector: Selector)? {
+        let classSelectorPair = methodIdentifier.components(separatedBy: Self.separator)
+        if classSelectorPair.count == 2,
+            let klass = NSClassFromString(classSelectorPair[0]) {
+            let selector = NSSelectorFromString(classSelectorPair[1])
+            return (klass: klass, selector: selector)
+        } else {
+            return nil
+        }
     }
 
     private func isKindOfNSObject(_ klass: AnyClass) -> Bool {
@@ -86,4 +160,18 @@ internal class MethodSwizzler {
         }
         return false
     }
+
+    // MARK: - DEBUG only
+
+    // TODO: RUMM-452 only for unit tests?
+    #if DEBUG
+    func unswizzleALL() {
+        let cachedKeys: [String] = Array(implementationCache.keys)
+        for key in cachedKeys {
+            if let classSelPair = classSelectorPair(from: key) {
+                try? unswizzle(selector: classSelPair.selector, in: classSelPair.klass)
+            }
+        }
+    }
+    #endif
 }

--- a/Sources/Datadog/Tracing/Utils/URLSessionHooks.swift
+++ b/Sources/Datadog/Tracing/Utils/URLSessionHooks.swift
@@ -1,0 +1,69 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import OpenTracing
+
+// TODO: RUMM-452 URLSessionHooks has incomplete whitelisting implementation
+
+internal enum URLSessionHooks {
+    static func tracingRequestInterceptor(domainWhitelist: Set<URL>, tracingFeature: TracingFeature) -> RequestInterceptor {
+        let domainStrings = Set(domainWhitelist.compactMap { $0.domain })
+        assert(domainStrings.count != domainWhitelist.count, "\(domainWhitelist) contains invalid domain(s)")
+
+        return { originalRequest -> InterceptionResult? in
+            guard let domain = originalRequest.url?.domain,
+                domainStrings.contains(domain),
+                let sharedTracer = Global.sharedTracer as? DDTracer else {
+                    return nil
+            }
+            let spanContext = sharedTracer.createSpanContext(with: tracingFeature)
+            let headersWriter = DDHTTPHeadersWriter()
+            headersWriter.inject(spanContext: spanContext)
+            let tracingHeaders = headersWriter.tracePropagationHTTPHeaders
+            let httpHeaders = tracingHeaders.merging(originalRequest.allHTTPHeaderFields ?? [:]) { _, originalHeader -> String in
+                return originalHeader
+            }
+            var modifiedRequest = originalRequest
+            modifiedRequest.allHTTPHeaderFields = httpHeaders
+
+            let observer: TaskObserver = tracingTaskObserver(
+                tracer: sharedTracer,
+                createdSpanContext: spanContext
+            )
+            return (request: modifiedRequest, taskPayload: observer)
+        }
+    }
+
+    private static func tracingTaskObserver(tracer: DDTracer, createdSpanContext: DDSpanContext) -> TaskObserver {
+        var previousEvent: TaskObservationEvent? = nil
+        var startedSpan: OpenTracing.Span? = nil
+        let observer: TaskObserver = { observedEvent in
+            let previousEventValue = previousEvent?.rawValue ?? Int.min
+            if observedEvent.rawValue <= previousEventValue {
+                return
+            }
+            previousEvent = observedEvent
+
+            switch observedEvent {
+            case .starting:
+                startedSpan = tracer.startSpan(with: createdSpanContext)
+            case .completed:
+                startedSpan?.finish()
+            }
+        }
+        return observer
+    }
+}
+
+private extension URL {
+    var domain: String? {
+        if let scheme = self.scheme, let host = self.host {
+            return scheme + "://" + host
+        }
+        return nil
+    }
+}

--- a/Sources/Datadog/Tracing/Utils/URLSessionSwizzler.swift
+++ b/Sources/Datadog/Tracing/Utils/URLSessionSwizzler.swift
@@ -6,102 +6,167 @@
 
 import Foundation
 
-// TODO: RUMM-300 plug DDTracer into swizzled methods
+// hook into URLSessionTask creation
+internal typealias RequestInterceptor = (URLRequest) -> InterceptionResult?
 
-internal class URLSessionSwizzler {
-    enum Selectors {
-        static let DataTaskWithURL = #selector(URLSession.dataTask(with:) as (URLSession) -> (URL) -> URLSessionDataTask)
-        static let DataTaskWithRequest = #selector(URLSession.dataTask(with:) as (URLSession) -> (URLRequest) -> URLSessionDataTask)
-        static let DataTaskWithURLCompletion = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping CompletionHandler) -> URLSessionDataTask)
-        static let DataTaskWithRequestCompletion = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping CompletionHandler) -> URLSessionDataTask)
+// modifying URLRequest for task creation, observer block to run at resume/completion
+internal typealias InterceptionResult = (request: URLRequest, taskPayload: TaskObserver)
+internal typealias TaskObserver = (TaskObservationEvent) -> Void
+internal enum TaskObservationEvent: Int, Equatable {
+    case starting
+    case completed
+}
+
+internal func swizzleURLSession(interceptor: @escaping RequestInterceptor) throws {
+    do {
+        try URLSessionSwizzler.DataTask_URL_Completion.swizzle(interceptor: interceptor)
+        try URLSessionSwizzler.DataTask_Request_Completion.swizzle(interceptor: interceptor)
+    } catch {
+        try URLSessionSwizzler.DataTask_URL_Completion.unswizzle()
+        try URLSessionSwizzler.DataTask_Request_Completion.unswizzle()
+        throw error
     }
+}
 
+// MARK: - Private
+
+private enum URLSessionSwizzler {
     typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
-    enum TypedIMPs {
-        typealias DataTaskWithURL = @convention(c) (URLSession, Selector, URL) -> URLSessionDataTask
-        typealias DataTaskWithRequest = @convention(c) (URLSession, Selector, URLRequest) -> URLSessionDataTask
-        typealias DataTaskWithURLCompletion = @convention(c) (URLSession, Selector, URL, @escaping CompletionHandler) -> URLSessionDataTask
-        typealias DataTaskWithURLRequestCompletion = @convention(c) (URLSession, Selector, URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
-    }
-    enum TypedBlocks {
-        typealias DataTaskWithURL = @convention(block) (URLSession, URL) -> URLSessionDataTask
-        typealias DataTaskWithRequest = @convention(block) (URLSession, URLRequest) -> URLSessionDataTask
-        typealias DataTaskWithURLCompletion = @convention(block) (URLSession, URL, @escaping CompletionHandler) -> URLSessionDataTask
-        typealias DataTaskWithRequestCompletion = @convention(block) (URLSession, URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
-    }
 
     static let subjectClass = URLSession.self
-    private static let swizzler = MethodSwizzler.shared
+    static let swizzler = MethodSwizzler.shared
 
-    static func swizzle() throws {
-        try swizzleDataTaskWithURL()
-        try swizzleDataTaskWithRequest()
-        try swizzleDataTaskWithURLCompletionHandler()
-        try swizzleDataTaskWithRequestCompletionHandler()
-    }
+    enum DataTask_URL_Completion {
+        static let selector = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping CompletionHandler) -> URLSessionDataTask)
+        typealias TypedIMP = @convention(c) (URLSession, Selector, URL, @escaping CompletionHandler) -> URLSessionDataTask
+        typealias TypedBlockIMP = @convention(block) (URLSession, URL, @escaping CompletionHandler) -> URLSessionDataTask
 
-    static func unswizzle() throws {
-        try swizzler.unswizzle(selector: Selectors.DataTaskWithURL, in: subjectClass)
-        try swizzler.unswizzle(selector: Selectors.DataTaskWithRequest, in: subjectClass)
-        try swizzler.unswizzle(selector: Selectors.DataTaskWithURLCompletion, in: subjectClass)
-        try swizzler.unswizzle(selector: Selectors.DataTaskWithRequestCompletion, in: subjectClass)
-    }
-
-    static func swizzleDataTaskWithURL() throws {
-        // typealiases cannot be generic as C/block conventions don't support generics
-        // note that _Block doesn't have Selector parameter
-        typealias TypedIMP = TypedIMPs.DataTaskWithURL
-        typealias TypedBlockIMP = TypedBlocks.DataTaskWithURL
-        let sel = Selectors.DataTaskWithURL
-
-        let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
-
-        let newImpBlock: TypedBlockIMP = { [impSelector = sel] impSelf, impURL -> URLSessionDataTask in
-            return typedOriginalImp(impSelf, impSelector, impURL)
+        static func swizzle(interceptor: @escaping RequestInterceptor) throws {
+            try swizzler.swizzle(selector: selector, in: subjectClass, with: newIMP(using: interceptor))
         }
-        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
-        try swizzler.swizzle(selector: sel, in: subjectClass, with: newImp)
+
+        static func unswizzle() throws {
+            try swizzler.unswizzle(selector: selector, in: subjectClass)
+        }
+
+        private static func newIMP(using interceptor: @escaping RequestInterceptor) throws -> IMP {
+            let sel = selector
+            let redirectedSel = DataTask_Request_Completion.selector
+            let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
+            let typedRedirectedImp: DataTask_Request_Completion.TypedIMP
+            typedRedirectedImp = try swizzler.originalImplementation(of: redirectedSel, in: subjectClass)
+
+            let newImpBlock: TypedBlockIMP = { impSelf, impURL, impCompletion -> URLSessionDataTask in
+                if let interceptionResult = interceptor(impSelf.urlRequest(with: impURL)) {
+                    weak var blockTask: URLSessionDataTask? = nil
+                    let modifiedCompletion: CompletionHandler = { origData, origResponse, origError in
+                        impCompletion(origData, origResponse, origError)
+                        blockTask?.payload?(.completed)
+                    }
+                    let task = typedRedirectedImp(impSelf, sel, interceptionResult.request, modifiedCompletion)
+                    // TODO: RUMM-452 report error?
+                    try? Resume.swizzle(in: task)
+                    task.payload = interceptionResult.taskPayload
+                    blockTask = task
+                    return task
+                }
+
+                return typedOriginalImp(impSelf, sel, impURL, impCompletion)
+            }
+            let newImp: IMP = imp_implementationWithBlock(newImpBlock)
+            return newImp
+        }
     }
 
-    static func swizzleDataTaskWithRequest() throws {
-        typealias TypedIMP = TypedIMPs.DataTaskWithRequest
-        typealias TypedBlockIMP = TypedBlocks.DataTaskWithRequest
-        let sel = Selectors.DataTaskWithRequest
+    enum DataTask_Request_Completion {
+        static let selector = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping CompletionHandler) -> URLSessionDataTask)
+        typealias TypedIMP = @convention(c) (URLSession, Selector, URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
+        typealias TypedBlockIMP = @convention(block) (URLSession, URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
 
-        let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
-
-        let newImpBlock: TypedBlockIMP = { [impSelector = sel] impSelf, impURLRequest -> URLSessionDataTask in
-            return typedOriginalImp(impSelf, impSelector, impURLRequest)
+        static func swizzle(interceptor: @escaping RequestInterceptor) throws {
+            try swizzler.swizzle(selector: selector, in: subjectClass, with: newIMP(using: interceptor))
         }
-        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
-        try swizzler.swizzle(selector: sel, in: subjectClass, with: newImp)
+
+        static func unswizzle() throws {
+            try swizzler.unswizzle(selector: selector, in: subjectClass)
+        }
+
+        private static func newIMP(using interceptor: @escaping RequestInterceptor) throws -> IMP {
+            let sel = selector
+            let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
+
+            let newImpBlock: TypedBlockIMP = { impSelf, impURLRequest, impCompletion -> URLSessionDataTask in
+                if let interceptionResult = interceptor(impURLRequest) {
+                    weak var blockTask: URLSessionDataTask? = nil
+
+                    // swizzled completion handler
+                    let modifiedCompletion: CompletionHandler = { origData, origResponse, origError in
+                        // unswizzled completion handler
+                        impCompletion(origData, origResponse, origError)
+                        blockTask?.payload?(.completed)
+                    }
+
+                    let task = typedOriginalImp(impSelf, sel, interceptionResult.request, modifiedCompletion)
+                    // TODO: RUMM-452 report error?
+                    try? Resume.swizzle(in: task)
+                    task.payload = interceptionResult.taskPayload
+                    blockTask = task
+                    return task
+                }
+                return typedOriginalImp(impSelf, sel, impURLRequest, impCompletion)
+            }
+            let newImp: IMP = imp_implementationWithBlock(newImpBlock)
+            return newImp
+        }
     }
 
-    static func swizzleDataTaskWithURLCompletionHandler() throws {
-        typealias TypedIMP = TypedIMPs.DataTaskWithURLCompletion
-        typealias TypedBlockIMP = TypedBlocks.DataTaskWithURLCompletion
-        let sel = Selectors.DataTaskWithURLCompletion
+    enum Resume {
+        static let selector = #selector(URLSessionTask.resume)
+        typealias TypedIMP = @convention(c) (URLSessionTask, Selector) -> Void
+        typealias TypedBlockIMP = @convention(block) (URLSessionTask) -> Void
 
-        let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
-
-        let newImpBlock: TypedBlockIMP = { [impSelector = sel] impSelf, impURL, impCompletion -> URLSessionDataTask in
-            return typedOriginalImp(impSelf, impSelector, impURL, impCompletion)
+        static func swizzle(in task: URLSessionTask) throws {
+            guard let taskClass = object_getClass(task) else {
+                // TODO: RUMM-452 report error?
+                // InternalError(description: "Task \(task), has no class, is passed to \(#function)")
+                return
+            }
+            // NOTE: RUMM-452 We will probably not need to swizzle tasks every time
+            // swizzleIfNonSwizzled lets us perform swizzling in given class if not done before
+            try swizzler.swizzleIfNonSwizzled(
+                selector: selector,
+                in: taskClass,
+                with: newIMP_resume(for: taskClass)
+            )
         }
-        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
-        try swizzler.swizzle(selector: sel, in: subjectClass, with: newImp)
+
+        private static func newIMP_resume(for klass: AnyClass) throws -> IMP {
+            let typedOriginalImp: TypedIMP
+            typedOriginalImp = try swizzler.currentImplementation(of: selector, in: klass)
+            let newImpBlock: TypedBlockIMP = { impSelf in
+                impSelf.payload?(.starting)
+                return typedOriginalImp(impSelf, selector)
+            }
+            return imp_implementationWithBlock(newImpBlock)
+        }
     }
+}
 
-    static func swizzleDataTaskWithRequestCompletionHandler() throws {
-        typealias TypedIMP = TypedIMPs.DataTaskWithURLRequestCompletion
-        typealias TypedBlockIMP = TypedBlocks.DataTaskWithRequestCompletion
-        let sel = Selectors.DataTaskWithRequestCompletion
+private extension URLSession {
+    func urlRequest(with url: URL) -> URLRequest {
+        return URLRequest(
+            url: url,
+            cachePolicy: configuration.requestCachePolicy,
+            timeoutInterval: configuration.timeoutIntervalForRequest
+        )
+    }
+}
 
-        let typedOriginalImp: TypedIMP = try swizzler.currentImplementation(of: sel, in: subjectClass)
-
-        let newImpBlock: TypedBlockIMP = { [impSelector = sel] impSelf, impURLRequest, impCompletion -> URLSessionDataTask in
-            return typedOriginalImp(impSelf, impSelector, impURLRequest, impCompletion)
-        }
-        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
-        try swizzler.swizzle(selector: sel, in: subjectClass, with: newImp)
+// payload is executed in task.resume() and completion
+private extension URLSessionTask {
+    private static var payloadAssociationKey: UInt8 = 0
+    var payload: TaskObserver? {
+        get { objc_getAssociatedObject(self, &Self.payloadAssociationKey) as? TaskObserver }
+        set { objc_setAssociatedObject(self, &Self.payloadAssociationKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
     }
 }

--- a/Tests/DatadogTests/Helpers/ThirdPartySwizzler.swift
+++ b/Tests/DatadogTests/Helpers/ThirdPartySwizzler.swift
@@ -1,0 +1,213 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+private typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void
+private extension URLSession {
+    @objc
+    func thirdPartySwizzled_dataTaskURL(_ url: URL, completion: @escaping CompletionHandler) -> URLSessionDataTask {
+        NotificationCenter.default.post(name: ExchangingThirdPartySwizzler.swizzleNotification_dataTask_URL, object: nil)
+        return thirdPartySwizzled_dataTaskURL(url, completion: completion)
+    }
+    @objc
+    func thirdPartySwizzled_dataTaskRequest(_ request: URLRequest, completion: @escaping CompletionHandler) -> URLSessionDataTask {
+        NotificationCenter.default.post(name: ExchangingThirdPartySwizzler.swizzleNotification_dataTask_request, object: nil)
+        return thirdPartySwizzled_dataTaskRequest(request, completion: completion)
+    }
+}
+private extension URLSessionTask {
+    @objc
+    func swizzled_resume() {
+        NotificationCenter.default.post(name: ExchangingThirdPartySwizzler.swizzleNotification_resume, object: nil)
+    }
+}
+
+class ExchangingThirdPartySwizzler {
+    fileprivate static let swizzleNotification_dataTask_URL = Notification.Name("swizzledDataTaskWithURLNotification")
+    fileprivate static let swizzleNotification_dataTask_request = Notification.Name("swizzledDataTaskWithRequestNotification")
+    fileprivate static let swizzleNotification_resume = Notification.Name("resumeNotification")
+
+    private static let targetClass: AnyClass = URLSession.self
+    private var taskTargetClass: AnyClass?
+
+    private let selector_url_completion: Selector = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping CompletionHandler) -> URLSessionDataTask)
+    private let swizzle_selector_url_completion: Selector = #selector(URLSession.thirdPartySwizzled_dataTaskURL(_:completion:))
+
+    private let selector_request_completion: Selector = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping CompletionHandler) -> URLSessionDataTask)
+    private let swizzle_selector_request_completion: Selector = #selector(URLSession.thirdPartySwizzled_dataTaskRequest(_:completion:))
+
+    private let selector_resume: Selector = #selector(URLSessionTask.resume)
+    private let swizzle_selector_resume: Selector = #selector(URLSessionTask.swizzled_resume)
+
+    private var observer_dataTask_url_completion: NSObjectProtocol? = nil
+    private var observer_dataTask_request_completion: NSObjectProtocol? = nil
+    private var observer_resume: NSObjectProtocol? = nil
+
+    private var cached_origIMP_dataTask_URL: IMP? = nil
+    private var cached_swizzleIMP_dataTask_URL: IMP? = nil
+
+    private var cached_origIMP_dataTask_request: IMP? = nil
+    private var cached_swizzleIMP_dataTask_request: IMP? = nil
+
+    private var cached_origIMP_resume: IMP? = nil
+    private var cached_swizzleIMP_resume: IMP? = nil
+
+    func swizzle_dataTask_url_completion(expectation: XCTestExpectation?) {
+        let origMethod = class_getInstanceMethod(Self.targetClass, selector_url_completion)!
+        cached_origIMP_dataTask_URL = method_getImplementation(origMethod)
+
+        let swizzledMethod = class_getInstanceMethod(Self.targetClass, swizzle_selector_url_completion)!
+        cached_swizzleIMP_dataTask_URL = method_getImplementation(swizzledMethod)
+
+        method_setImplementation(origMethod, cached_swizzleIMP_dataTask_URL!)
+        method_setImplementation(swizzledMethod, cached_origIMP_dataTask_URL!)
+
+        observer_dataTask_url_completion = NotificationCenter.default.addObserver(
+            forName: Self.swizzleNotification_dataTask_URL,
+            object: nil,
+            queue: nil
+        ) { _ in
+            expectation?.fulfill()
+        }
+    }
+
+    func swizzle_dataTask_request_completion(expectation: XCTestExpectation?) {
+        let origMethod = class_getInstanceMethod(Self.targetClass, selector_request_completion)!
+        cached_origIMP_dataTask_request = method_getImplementation(origMethod)
+
+        let swizzledMethod = class_getInstanceMethod(Self.targetClass, swizzle_selector_request_completion)!
+        cached_swizzleIMP_dataTask_request = method_getImplementation(swizzledMethod)
+
+        method_setImplementation(origMethod, cached_swizzleIMP_dataTask_request!)
+        method_setImplementation(swizzledMethod, cached_origIMP_dataTask_request!)
+
+        observer_dataTask_request_completion = NotificationCenter.default.addObserver(
+            forName: Self.swizzleNotification_dataTask_request,
+            object: nil,
+            queue: nil
+        ) { _ in
+            expectation?.fulfill()
+        }
+    }
+
+    func swizzle_resume(_ task: URLSessionTask, expectation: XCTestExpectation?) {
+        let taskClass: AnyClass = object_getClass(task)!
+        taskTargetClass = taskClass
+        let origMethod = class_getInstanceMethod(taskClass, selector_resume)!
+        cached_origIMP_resume = method_getImplementation(origMethod)
+
+        let swizzledMethod = class_getInstanceMethod(taskClass, swizzle_selector_resume)!
+        cached_swizzleIMP_resume = method_getImplementation(swizzledMethod)
+
+        method_setImplementation(origMethod, cached_swizzleIMP_resume!)
+        method_setImplementation(swizzledMethod, cached_origIMP_resume!)
+
+        observer_resume = NotificationCenter.default.addObserver(
+            forName: Self.swizzleNotification_resume,
+            object: nil,
+            queue: nil
+        ) { _ in
+            expectation?.fulfill()
+        }
+    }
+
+    func unswizzle() {
+        if let someOrigIMP = cached_origIMP_dataTask_URL,
+            let someSwizzleIMP = cached_swizzleIMP_dataTask_URL {
+            method_setImplementation(
+                class_getInstanceMethod(Self.targetClass, selector_url_completion)!,
+                someOrigIMP
+            )
+            method_setImplementation(
+                class_getInstanceMethod(Self.targetClass, swizzle_selector_url_completion)!,
+                someSwizzleIMP
+            )
+        }
+        if let someOrigIMP = cached_origIMP_dataTask_request,
+            let someSwizzleIMP = cached_swizzleIMP_dataTask_request {
+            method_setImplementation(
+                class_getInstanceMethod(Self.targetClass, selector_request_completion)!,
+                someOrigIMP
+            )
+            method_setImplementation(
+                class_getInstanceMethod(Self.targetClass, swizzle_selector_request_completion)!,
+                someSwizzleIMP
+            )
+        }
+        if let someTargetClass = taskTargetClass,
+            let someOrigIMP = cached_origIMP_resume,
+            let someSwizzleIMP = cached_swizzleIMP_resume {
+            method_setImplementation(
+                class_getInstanceMethod(someTargetClass, selector_resume)!,
+                someOrigIMP
+            )
+            method_setImplementation(
+                class_getInstanceMethod(someTargetClass, swizzle_selector_resume)!,
+                someSwizzleIMP
+            )
+        }
+    }
+}
+
+/*
+
+class DirectThirdPartySwizzler {
+    private var origIMP_URL: IMP? = nil
+    private var origIMP_request: IMP? = nil
+
+    func swizzle_dataTask_url_completion(expectation: XCTestExpectation) {
+        typealias TypedIMP = @convention(c) (URLSession, Selector, URL, @escaping CompletionHandler) -> URLSessionDataTask
+        typealias TypedBlockIMP = @convention(block) (URLSession, URL, @escaping CompletionHandler) -> URLSessionDataTask
+
+        let sel = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping CompletionHandler) -> URLSessionDataTask)
+        let method = class_getInstanceMethod(URLSession.self, sel)!
+        let originalIMP = method_getImplementation(method)
+        let typedOriginalImp = unsafeBitCast(originalIMP, to: TypedIMP.self)
+        origIMP_URL = originalIMP
+
+        let newImpBlock: TypedBlockIMP = { impSelf, impURL, impCompletion -> URLSessionDataTask in
+            expectation.fulfill()
+            return typedOriginalImp(impSelf, sel, impURL, impCompletion)
+        }
+        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
+        method_setImplementation(method, newImp)
+    }
+
+    func swizzle_dataTask_request_completion(expectation: XCTestExpectation) {
+        typealias TypedIMP = @convention(c) (URLSession, Selector, URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
+        typealias TypedBlockIMP = @convention(block) (URLSession, URLRequest, @escaping CompletionHandler) -> URLSessionDataTask
+
+        let sel = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping CompletionHandler) -> URLSessionDataTask)
+        let method = class_getInstanceMethod(URLSession.self, sel)!
+        let originalIMP = method_getImplementation(method)
+        let typedOriginalImp = unsafeBitCast(originalIMP, to: TypedIMP.self)
+        origIMP_request = originalIMP
+
+        let newImpBlock: TypedBlockIMP = { impSelf, impURLRequest, impCompletion -> URLSessionDataTask in
+            expectation.fulfill()
+            return typedOriginalImp(impSelf, sel, impURLRequest, impCompletion)
+        }
+        let newImp: IMP = imp_implementationWithBlock(newImpBlock)
+        method_setImplementation(method, newImp)
+    }
+
+    func unswizzle() {
+        if let someIMP = origIMP_URL {
+            let sel = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URL, @escaping CompletionHandler) -> URLSessionDataTask)
+            let method = class_getInstanceMethod(URLSession.self, sel)!
+            method_setImplementation(method, someIMP)
+        }
+        if let someIMP = origIMP_request {
+            let sel = #selector(URLSession.dataTask(with:completionHandler:) as (URLSession) -> (URLRequest, @escaping CompletionHandler) -> URLSessionDataTask)
+            let method = class_getInstanceMethod(URLSession.self, sel)!
+            method_setImplementation(method, someIMP)
+        }
+    }
+}
+
+*/


### PR DESCRIPTION
### What and why?

Hooks are used to inject tracing methods into URLSession methods

### How?

{PLACEHOLDER}

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
