### PR TITLE
RUMM-400 Add support to custom `resource.name` span tag

### DIFF
--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -465,15 +465,43 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                     </textField>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bZW-Bh-rsg" userLabel="Vertical gap 10">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iyw-VO-Zma" userLabel="Vertical gap 10">
                                         <rect key="frame" x="0.0" y="202.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="7KZ-J6-u3c"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RESOURCE NAME" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CIm-Y6-2du">
+                                        <rect key="frame" x="0.0" y="212.5" width="384" height="14.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eVC-sE-w0h" userLabel="Vertical gap 5">
+                                        <rect key="frame" x="0.0" y="227" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="5" id="rd9-W8-LSF"/>
+                                        </constraints>
+                                    </view>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter resource name..." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="O6r-wl-sFd">
+                                        <rect key="frame" x="0.0" y="232" width="384" height="44"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="WPr-RI-Egu"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                    </textField>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bZW-Bh-rsg" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="276" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="bGV-Qi-s8z"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Z8K-Vl-XI8">
-                                        <rect key="frame" x="0.0" y="212.5" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="286" width="384" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v8U-xf-I9C">
                                                 <rect key="frame" x="0.0" y="0.0" width="384" height="44"/>
@@ -499,47 +527,47 @@
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ye7-9X-YIS" userLabel="Vertical gap 20">
-                                        <rect key="frame" x="0.0" y="256.5" width="384" height="20"/>
+                                        <rect key="frame" x="0.0" y="330" width="384" height="20"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20" id="3Dl-pf-hL7"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Complex spans hierarchy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GsW-ex-CTl">
-                                        <rect key="frame" x="0.0" y="276.5" width="384" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="350" width="384" height="20.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDC-NL-tAk" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="297" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="370.5" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="efG-2c-Dag"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gMD-8X-YiX" userLabel="Vertical gap 5">
-                                        <rect key="frame" x="0.0" y="307" width="384" height="5"/>
+                                        <rect key="frame" x="0.0" y="380.5" width="384" height="5"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="5" id="GYP-0A-9xf"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ROOT OPERATION NAME" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yh6-Tm-ozZ">
-                                        <rect key="frame" x="0.0" y="312" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="385.5" width="384" height="14.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                         <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lO3-mO-nzb" userLabel="Vertical gap 5">
-                                        <rect key="frame" x="0.0" y="326.5" width="384" height="5"/>
+                                        <rect key="frame" x="0.0" y="400" width="384" height="5"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="5" id="NE8-zr-Vi3"/>
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Enter root operation name..." textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="WdR-er-YSX">
-                                        <rect key="frame" x="0.0" y="331.5" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="405" width="384" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="UTv-Br-F8n"/>
                                         </constraints>
@@ -547,14 +575,14 @@
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                     </textField>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sr3-sx-NOx" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="375.5" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="449" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="eOZ-ue-cej"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="tlp-TM-3R8">
-                                        <rect key="frame" x="0.0" y="385.5" width="384" height="44"/>
+                                        <rect key="frame" x="0.0" y="459" width="384" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="W8c-Yf-ICI">
                                                 <rect key="frame" x="0.0" y="0.0" width="384" height="44"/>
@@ -580,27 +608,27 @@
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bn8-jd-Xrh" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="429.5" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="503" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="GjS-fK-DeF"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONSOLE OUTPUT:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hyc-B5-Er9">
-                                        <rect key="frame" x="0.0" y="439.5" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="513" width="384" height="14.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                         <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uBu-lq-4fT" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="454" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="527.5" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="vfa-Ap-dUP"/>
                                         </constraints>
                                     </view>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RFt-6W-lf2">
-                                        <rect key="frame" x="0.0" y="464" width="384" height="280"/>
+                                        <rect key="frame" x="0.0" y="537.5" width="384" height="206.5"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
@@ -627,6 +655,7 @@
                         <outlet property="sendSingleSpanButton" destination="v8U-xf-I9C" id="7ON-9M-oIL"/>
                         <outlet property="serviceNameTextField" destination="Uja-Qc-xBT" id="2L0-ha-iRO"/>
                         <outlet property="singleSpanOperationNameTextField" destination="1RN-ZZ-Uf5" id="KzN-2e-dpK"/>
+                        <outlet property="singleSpanResourceNameTextField" destination="O6r-wl-sFd" id="GUI-CK-Rc4"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LiQ-0O-emZ" sceneMemberID="firstResponder"/>

--- a/Datadog/Example/Debugging/DebugTracingViewController.swift
+++ b/Datadog/Example/Debugging/DebugTracingViewController.swift
@@ -11,6 +11,7 @@ class DebugTracingViewController: UIViewController {
     @IBOutlet weak var serviceNameTextField: UITextField!
     @IBOutlet weak var isErrorSegmentedControl: UISegmentedControl!
     @IBOutlet weak var singleSpanOperationNameTextField: UITextField!
+    @IBOutlet weak var singleSpanResourceNameTextField: UITextField!
     @IBOutlet weak var sendSingleSpanButton: UIButton!
     @IBOutlet weak var complexSpanOperationNameTextField: UITextField!
     @IBOutlet weak var sendComplexSpanButton: UIButton!
@@ -37,14 +38,22 @@ class DebugTracingViewController: UIViewController {
         singleSpanOperationNameTextField.text!.isEmpty ? "single span" : singleSpanOperationNameTextField.text!
     }
 
+    private var singleSpanResourceName: String? {
+        singleSpanResourceNameTextField.text!.isEmpty ? nil : singleSpanResourceNameTextField.text!
+    }
+
     @IBAction func didTapSendSingleSpan(_ sender: Any) {
         sendSingleSpanButton.disableFor(seconds: 0.5)
 
         let spanName = singleSpanOperationName
+        let resourceName = singleSpanResourceName
         let isError = self.isError
 
         queue1.async {
             let span = Global.sharedTracer.startSpan(operationName: spanName)
+            if let resourceName = resourceName {
+                span.setTag(key: "resource.name", value: resourceName) // TODO: RUMM-390 use public constant
+            }
             if isError {
                 // To only mark the span as an error, use the Open Tracing `error` tag:
                 // span.setTag(key: "error", value: true)

--- a/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
@@ -24,6 +24,7 @@ internal class SendTracesFixtureViewController: UIViewController {
         )
         dataDownloadingSpan.setTag(key: "data.kind", value: "image")
         dataDownloadingSpan.setTag(key: "data.url", value: URL(string: "https://example.com/image.png")!)
+        dataDownloadingSpan.setTag(key: "resource.name", value: "GET /image.png") // TODO: RUMM-390 use public constant
 
         downloadSomeData { [weak self] data in
             // Simulate logging download progress

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -25,10 +25,10 @@ internal struct SpanBuilder {
     private let tagsJSONEncoder: JSONEncoder = .default()
 
     func createSpan(from ddspan: DDSpan, finishTime: Date) throws -> Span {
-        let tagsReducer = SpanTagsReducer.reduce(spanTags: ddspan.tags, logFields: ddspan.logFields)
+        let tagsReducer = SpanTagsReducer(spanTags: ddspan.tags, logFields: ddspan.logFields)
 
         let jsonStringEncodedTags = Dictionary(
-            uniqueKeysWithValues: tagsReducer.spanTags.map { name, value in
+            uniqueKeysWithValues: tagsReducer.reducedSpanTags.map { name, value in
                 (name, JSONStringEncodableValue(value, encodedUsing: tagsJSONEncoder))
             }
         )

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -39,7 +39,7 @@ internal struct SpanBuilder {
             parentID: ddspan.ddContext.parentSpanID,
             operationName: ddspan.operationName,
             serviceName: serviceName,
-            resource: ddspan.operationName, // TODO: RUMM-400 use `resourceName`: `resource: tagsReducer.resourceName ?? ddspan.operationName`
+            resource: tagsReducer.extractedResourceName ?? ddspan.operationName,
             startTime: ddspan.startTime,
             duration: finishTime.timeIntervalSince(ddspan.startTime),
             isError: tagsReducer.extractedIsError ?? false,

--- a/Sources/Datadog/Tracing/Span/SpanTagsReducer.swift
+++ b/Sources/Datadog/Tracing/Span/SpanTagsReducer.swift
@@ -6,11 +6,13 @@
 
 import Foundation
 
-/// Datadog tag keys used to encode information received from the user through `OpenTracingLogFields` and `OpenTracingTagKeys`.
+/// Datadog tag keys used to encode information received from the user through `OpenTracingLogFields`, `OpenTracingTagKeys` or custom fields
+/// supported by Datadog platform.
 private struct DatadogTagKeys {
     static let errorType     = "error.type"
     static let errorMessage  = "error.msg"
     static let errorStack    = "error.stack"
+    static let resourceName  = "resource.name"
 }
 
 /// Reduces `DDSpan` tags and log attributes by extracting values that require separate handling.
@@ -32,6 +34,7 @@ internal struct SpanTagsReducer {
     // MARK: - Extracted Info
 
     private(set) var extractedIsError: Bool? = nil
+    private(set) var extractedResourceName: String? = nil
 
     // MARK: - Reducers
 
@@ -43,7 +46,8 @@ internal struct SpanTagsReducer {
 
     private static let reducers: [(inout SpanTagsReducer) -> Void] = [
         extractErrorFromLogFields,
-        extractErrorFromTags
+        extractErrorFromTags,
+        extractResourceNameFromTags
     ]
 
     private static func extractErrorFromLogFields(_ reducer: inout SpanTagsReducer) {
@@ -64,6 +68,12 @@ internal struct SpanTagsReducer {
     private static func extractErrorFromTags(_ reducer: inout SpanTagsReducer) {
         if reducer.spanTags[OpenTracingTagKeys.error] as? Bool == true {
             reducer.extractedIsError = true
+        }
+    }
+
+    private static func extractResourceNameFromTags(_ reducer: inout SpanTagsReducer) {
+        if let resourceName = reducer.spanTags.removeValue(forKey: DatadogTagKeys.resourceName) as? String {
+            reducer.extractedResourceName = resourceName
         }
     }
 }

--- a/Sources/Datadog/Tracing/Span/SpanTagsReducer.swift
+++ b/Sources/Datadog/Tracing/Span/SpanTagsReducer.swift
@@ -21,59 +21,55 @@ private struct DatadogTagKeys {
 /// and [log fields](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#log-fields-table) given by the user and
 /// transform them into the format used by Datadog. This happens in two ways, by:
 /// - extracting information from `spanTags` and `logFields` to `extracted*` variables,
-/// - reducing the initial `spanTags` collection by removing extracted information.
+/// - reducing the initial `spanTags` collection to `reducedSpanTags` by removing extracted information.
 ///
-/// In result, the `spanTags` will contain only the tags that do NOT require special handling by Datadog and can be send as generic `span.meta.*` JSON values.
+/// In result, the `reducedSpanTags` will contain only the tags that do NOT require special handling by Datadog and can be send as generic `span.meta.*` JSON values.
 /// Values extracted from `spanTags` and `logFields` will be passed to the `Span` encoding process in a type-safe manner.
 internal struct SpanTagsReducer {
-    /// Tags received by the user. This collection may be changed by the `reduce(_:)` function.
-    private(set) var spanTags: [String: Codable]
-    /// Log fieds send by the user for this `DDSpan`. This collection is never mutated, and is only used to extract extra information about the span.
-    private let logFields: [[String: Codable]]
+    /// Tags for generic `span.meta.*` encoding in `Span` JSON.
+    let reducedSpanTags: [String: Codable]
 
     // MARK: - Extracted Info
 
-    private(set) var extractedIsError: Bool? = nil
-    private(set) var extractedResourceName: String? = nil
+    /// Error information requiring a special encoding in `Span` JSON.
+    let extractedIsError: Bool?
+    /// Resource name requiring a special encoding in `Span` JSON.
+    let extractedResourceName: String?
 
-    // MARK: - Reducers
+    // MARK: - Initialization
 
-    internal static func reduce(spanTags: [String: Codable], logFields: [[String: Codable]]) -> SpanTagsReducer {
-        var reducer = SpanTagsReducer(spanTags: spanTags, logFields: logFields)
-        reducers.forEach { reduce in reduce(&reducer) }
-        return reducer
-    }
+    init(spanTags: [String: Codable], logFields: [[String: Codable]]) {
+        var mutableSpanTags = spanTags
 
-    private static let reducers: [(inout SpanTagsReducer) -> Void] = [
-        extractErrorFromLogFields,
-        extractErrorFromTags,
-        extractResourceNameFromTags
-    ]
+        var extractedIsError: Bool? = nil
+        var extractedResourceName: String? = nil
 
-    private static func extractErrorFromLogFields(_ reducer: inout SpanTagsReducer) {
-        for fields in reducer.logFields {
+        // extract error from `logFields`
+        for fields in logFields {
             let isErrorEvent = fields[OpenTracingLogFields.event] as? String == "error"
             let errorKind = fields[OpenTracingLogFields.errorKind] as? String
 
             if isErrorEvent || errorKind != nil {
-                reducer.extractedIsError = true
-                reducer.spanTags[DatadogTagKeys.errorMessage] = fields[OpenTracingLogFields.message] as? String
-                reducer.spanTags[DatadogTagKeys.errorType] = errorKind
-                reducer.spanTags[DatadogTagKeys.errorStack] = fields[OpenTracingLogFields.stack] as? String
-                return // ignore further logs
+                extractedIsError = true
+                mutableSpanTags[DatadogTagKeys.errorMessage] = fields[OpenTracingLogFields.message] as? String
+                mutableSpanTags[DatadogTagKeys.errorType] = errorKind
+                mutableSpanTags[DatadogTagKeys.errorStack] = fields[OpenTracingLogFields.stack] as? String
+                break // ignore next logs
             }
         }
-    }
 
-    private static func extractErrorFromTags(_ reducer: inout SpanTagsReducer) {
-        if reducer.spanTags[OpenTracingTagKeys.error] as? Bool == true {
-            reducer.extractedIsError = true
+        // extract error from `mutableSpanTags`
+        if mutableSpanTags[OpenTracingTagKeys.error] as? Bool == true {
+            extractedIsError = true
         }
-    }
 
-    private static func extractResourceNameFromTags(_ reducer: inout SpanTagsReducer) {
-        if let resourceName = reducer.spanTags.removeValue(forKey: DatadogTagKeys.resourceName) as? String {
-            reducer.extractedResourceName = resourceName
+        // extract resource name from `mutableSpanTags`
+        if let resourceName = mutableSpanTags.removeValue(forKey: DatadogTagKeys.resourceName) as? String {
+            extractedResourceName = resourceName
         }
+
+        self.reducedSpanTags = mutableSpanTags
+        self.extractedIsError = extractedIsError
+        self.extractedResourceName = extractedResourceName
     }
 }

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -123,7 +123,11 @@ class DDTracerTests: XCTestCase {
 
         let span = tracer.startSpan(
             operationName: "operation",
-            tags: ["tag1": "string value"],
+            tags: [
+                "tag1": "string value",
+                "error": true,
+                "resource.name": "GET /foo.png"
+            ],
             startTime: .mockDecember15th2019At10AMUTC()
         )
         span.setTag(key: "tag2", value: 123)
@@ -131,8 +135,10 @@ class DDTracerTests: XCTestCase {
 
         let spanMatcher = try server.waitAndReturnSpanMatchers(count: 1)[0]
         XCTAssertEqual(try spanMatcher.operationName(), "operation")
+        XCTAssertEqual(try spanMatcher.resource(), "GET /foo.png")
         XCTAssertEqual(try spanMatcher.startTime(), 1_576_404_000_000_000_000)
         XCTAssertEqual(try spanMatcher.duration(), 500_000_000)
+        XCTAssertEqual(try spanMatcher.isError(), 1)
         XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.tag1"), "string value")
         XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.tag2"), "123")
     }

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
@@ -24,7 +24,7 @@ class SpanBuilderTests: XCTestCase {
         XCTAssertEqual(span.parentID, 1)
         XCTAssertEqual(span.operationName, "operation-name")
         XCTAssertEqual(span.serviceName, "test-service-name")
-        XCTAssertEqual(span.resource, "operation-name") // TODO: RUMM-400 Add separate test for the case when `ddspan.resourceName != nil`
+        XCTAssertEqual(span.resource, "operation-name")
         XCTAssertEqual(span.startTime, .mockDecember15th2019At10AMUTC())
         XCTAssertEqual(span.duration, 0.50, accuracy: 0.01)
         XCTAssertFalse(span.isError)
@@ -97,6 +97,18 @@ class SpanBuilderTests: XCTestCase {
         // then
         XCTAssertTrue(span.isError)
         XCTAssertEqual(try span.tags.toEquatable(), ["error.type": "Swift error 1"]) // only first error log is captured
+    }
+
+    func testBuildingSpanWithResourceNameTagSet() throws {
+        let builder: SpanBuilder = .mockAny()
+
+        // given
+        let ddspan: DDSpan = .mockWith(tags: ["resource.name": "custom resource name"]) // TODO: RUMM-390 use public constant
+        let span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+
+        // then
+        XCTAssertEqual(span.resource, "custom resource name")
+        XCTAssertEqual(try span.tags.toEquatable(), [:])
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
@@ -99,6 +99,26 @@ class SpanBuilderTests: XCTestCase {
         XCTAssertEqual(try span.tags.toEquatable(), ["error.type": "Swift error 1"]) // only first error log is captured
     }
 
+    func testBuildingSpanWithErrorTagAndErrorLogsSend() throws {
+        let builder: SpanBuilder = .mockAny()
+
+        // given
+        var ddspan: DDSpan = .mockWith(tags: ["error": true])
+        ddspan.log(fields: [OpenTracingLogFields.event: "error"])
+        var span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+
+        // then
+        XCTAssertTrue(span.isError)
+
+        // given
+        ddspan = .mockWith(tags: ["error": false])
+        ddspan.log(fields: [OpenTracingLogFields.event: "error"])
+        span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+
+        // then
+        XCTAssertTrue(span.isError)
+    }
+
     func testBuildingSpanWithResourceNameTagSet() throws {
         let builder: SpanBuilder = .mockAny()
 


### PR DESCRIPTION
### What and why?

📦 This PR adds support to custom `resource.name` tag for `Span`. Doing this, results with a proper value being rendered in the **RESOURCE** column on [app.datadoghq.com](https://app.datadoghq.com):

```swift
span.setTag(key: "resource.name", value: "GET /api/users/123-456")
```

<img width="741" alt="Screenshot 2020-06-01 at 20 27 20" src="https://user-images.githubusercontent.com/2358722/83441809-6c9bbb00-a447-11ea-8134-bc0e3af06d55.png">


### How?

The `resource.name` tag is another example of information received from the user, which requires special encoding (different than `span.meta.*` used for custom tags). To handle `resource.name`, another reducer was added to `SpanTagsReducer` introduced in #120.

Right now, the `resource.name` tag has zero discovery for the user, but this will change in `RUMM-390` where we will think of exposing supported span tags and log fields as `public`.

In addition to unit and integration tests, I also added a new text field to the Example app UI, so we can manually test custom resource names:

![Simulator Screen Shot - iPhone 11 - 2020-06-01 at 20 41 51](https://user-images.githubusercontent.com/2358722/83442492-8ab5eb00-a448-11ea-8ca8-3da011b41b97.png)


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
