### PR TITLE
RUMM-341 Fix linter not failing on missing license header

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,14 +39,14 @@ workflows:
     description: |-
         Runs swiftlint and license check for all source and test files.
     steps:
-    - swiftlint@0.4.2:
+    - swiftlint@0.7.0:
         title: Lint Sources/*
         inputs:
         - strict: 'yes'
         - lint_config_file: "$BITRISE_SOURCE_DIR/tools/lint/sources.swiftlint.yml"
         - linting_path: "$BITRISE_SOURCE_DIR"
         - reporter: emoji
-    - swiftlint@0.4.2:
+    - swiftlint@0.7.0:
         title: Lint Tests/*
         is_always_run: true
         inputs:

--- a/tools/license/check-license.sh
+++ b/tools/license/check-license.sh
@@ -8,7 +8,7 @@ IFS=$'\n'
 
 function files {
 	find -E . \
-		-iregex '.*\.(swift|h|m)$' \
+		-iregex '.*\.(swift|h|m|py)$' \
 		-type f \( ! -name "Package.swift" \) \
 		-not -path "*/.build/*" \
 		-not -path "*Pods*" \

--- a/tools/license/check-license.sh
+++ b/tools/license/check-license.sh
@@ -4,21 +4,30 @@ if [ ! -f "Package.swift" ]; then
 	echo "\`check-license.sh\` must be run in repository root folder: \`./tools/license/check-license.sh\`"; exit 1
 fi
 
+IFS=$'\n'
+
 function files {
 	find -E . \
 		-iregex '.*\.(swift|h|m)$' \
 		-type f \( ! -name "Package.swift" \) \
 		-not -path "*/.build/*" \
 		-not -path "*Pods*" \
-		-print0	
+		-not -path "*Carthage/Build/*" \
+		-not -path "*Carthage/Checkouts/*"
 }
 
-files | while IFS= read -r -d '' file; do
-  if ! grep -q "Apache License Version 2.0" "$file"
-  then
-  	echo "No license in $file"
-  	exit 1
-  fi
+FILES_WITH_MISSING_LICENSE=""
+
+for file in $(files); do
+	if ! grep -q "Apache License Version 2.0" "$file"; then
+		FILES_WITH_MISSING_LICENSE="${FILES_WITH_MISSING_LICENSE}\n${file}"
+	fi
 done
 
-exit 0
+if [ -z "$FILES_WITH_MISSING_LICENSE" ]; then
+	echo "✅ All files include the license header"
+	exit 0
+else
+	echo -e "🔥 Missing the license header in files: $FILES_WITH_MISSING_LICENSE"
+	exit 1
+fi


### PR DESCRIPTION
### What and why?

⚙️ The `run_linter` CI job was not failing when license header was not found.

### How?

The `exit 1` was not properly evaluated in `check-license.sh` script. I made the bash script more straightforward by removing the `while` loop nested with pipe operator `|`.

### Review checklist

~~- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
