### PR TITLE
RUMM-474 Upgrade to Xcode 11.5

### DIFF
--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/Shopist/Shopist/Resources/Main.storyboard
+++ b/Shopist/Shopist/Resources/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>


### PR DESCRIPTION
### What and why?

🏄‍♂️ This PR upgrades our toolset to Xcode 11.5.

### How?

In our code - I only upgraded `toolsVersion` in IB files, but on Bitrise, I updated the default stack to use Xcode 11.5. 

I also wanted to declare the stack in the `bitrise.yml` stored in repo, but this [seems to be not possible](https://discuss.bitrise.io/t/trigger-workflow-with-different-stack/10014). I asked Bitrise Support if they plan to handle this (**update:** they said it's not possible and no time-fixed plans to support this).

I made sure both `tracing` and `master` branch are green with the new stack:

<img width="1023" alt="Screenshot 2020-06-02 at 15 04 25" src="https://user-images.githubusercontent.com/2358722/83523367-60b10700-a4e2-11ea-8d98-77aa2271edab.png">


### Review checklist

~~- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)~~
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
