### PR TITLE
RUMM-494 Hotfix for crash on iOS 11.0 - 11.1

### DIFF
--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
   s.module_name  = "Datadog"
-  s.version      = "1.2.0"
+  s.version      = "1.2.1"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKObjc"
   s.module_name  = "DatadogObjc"
-  s.version      = "1.2.0"
+  s.version      = "1.2.1"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/Sources/Datadog/Core/Utils/ISO8601DateFormatter.swift
+++ b/Sources/Datadog/Core/Utils/ISO8601DateFormatter.swift
@@ -9,7 +9,9 @@ import Foundation
 extension ISO8601DateFormatter {
     static func `default`() -> ISO8601DateFormatter {
         let formatter = ISO8601DateFormatter()
-        formatter.formatOptions.insert(.withFractionalSeconds)
+        if #available(iOS 11.2, *) {
+            formatter.formatOptions.insert(.withFractionalSeconds)
+        }
         return formatter
     }
 

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// SDK version associated with logs.
 /// Should be synced with SDK releases.
-internal let sdkVersion = "1.2.0"
+internal let sdkVersion = "1.2.1"
 
 /// Datadog SDK configuration object.
 public class Datadog {

--- a/Sources/Datadog/Logs/LogOutputs/LogConsoleOutput.swift
+++ b/Sources/Datadog/Logs/LogOutputs/LogConsoleOutput.swift
@@ -16,7 +16,11 @@ internal struct LogConsoleOutput: LogOutput {
     /// Time formatter used for `.short` output format.
     static func shortTimeFormatter(calendar: Calendar = .current, timeZone: TimeZone = .current) -> Formatter {
         let formatter = ISO8601DateFormatter.default()
-        formatter.formatOptions = [.withFractionalSeconds, .withFullTime]
+        if #available(iOS 11.2, *) {
+            formatter.formatOptions = [.withFractionalSeconds, .withFullTime]
+        } else {
+            formatter.formatOptions = [.withFullTime]
+        }
         return formatter
     }
 

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -11,7 +11,9 @@ import XCTest
 struct LogMatcher {
     private static let dateFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
-        formatter.formatOptions.insert(.withFractionalSeconds)
+        if #available(iOS 11.2, *) {
+            formatter.formatOptions.insert(.withFractionalSeconds)
+        }
         return formatter
     }()
 


### PR DESCRIPTION
### What and why?

🔥 Fixes #126 

The `.withFractionalSeconds` used for `ISO8601DateFormatter` results with a crash on `iOS 11.0` and `11.1`. This is [a known bug](https://openradar.appspot.com/35660658), fixed by Apple in `iOS 11.2`.

### How?

Reproduced by running unit tests on `iOS11.1` - it was crashing.

This hotfix drops the millisecond precision on `iOS 11.0-.11.1`, falling back to the behaviour from before `1.2.0`. We will bring the milliseconds support for `iOS 11.0-.11.1` back in `RUMM-494`, within a next release.

With the precision dropped, some time-format related tests fail on `11.1`. Because we don't yet run tests on earlier iOS versions, this doesn't block the workflow. Those tests will be fulfilled in `RUMM-494`, where the precision is added again for `iOS 11.1`.

### Review checklist

~- [] Feature or bugfix MUST have appropriate tests (unit, integration)~
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
