### PR TITLE
RUMM-506 Prevent malforming payload due to I/O exception 

### DIFF
--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
   s.module_name  = "Datadog"
-  s.version      = "1.2.1"
+  s.version      = "1.2.2"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKObjc"
   s.module_name  = "DatadogObjc"
-  s.version      = "1.2.1"
+  s.version      = "1.2.2"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/Sources/Datadog/Core/Persistence/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/FileWriter.swift
@@ -42,9 +42,9 @@ internal final class FileWriter {
                     try write(data)
                 }
             } else {
+                let atomicData = commaSeparatorData + data
                 try file.append { write in
-                    try write(commaSeparatorData)
-                    try write(data)
+                    try write(atomicData)
                 }
             }
         } catch {

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// SDK version associated with logs.
 /// Should be synced with SDK releases.
-internal let sdkVersion = "1.2.1"
+internal let sdkVersion = "1.2.2"
 
 /// Datadog SDK configuration object.
 public class Datadog {

--- a/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
@@ -60,11 +60,11 @@ class FileWriterTests: XCTestCase {
                 - succeed on `fileHandle.seekToEndOfFile()` to prepare the file for the second `writer.write(value:)`
                 - throw an `I/O exception` for `fileHandle.write(_:)` for the second write
              */
-            afterSucceedingCallsCounts: 3 // will succeed on writing `validValue1` and `,` separator but will fail on `validValue2`
+            afterSucceedingCallsCounts: 3
         )
 
         writer.write(value: ["key1": "value1"]) // first write (2 calls to `ObjcExceptionHandler`)
-        writer.write(value: ["key2": "value2"]) // second write (3 calls to `ObjcExceptionHandler`)
+        writer.write(value: ["key2": "value2"]) // second write (2 calls to `ObjcExceptionHandler`, where the latter fails)
 
         waitForWritesCompletion(on: queue, thenFulfill: expectation)
         waitForExpectations(timeout: 1, handler: nil)

--- a/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
@@ -54,14 +54,13 @@ class FileWriterTests: XCTestCase {
         objcExceptionHandler = ObjcExceptionHandlerDeferredMock(
             throwingError: ErrorMock("I/O exception"),
             /*
-                Following the logic in `FileWriter` and `File`, the 4 comes from:
-                - succeed on `fileHandle.seekToEndOfFile()` to prepare the file for the first `writer.write(value:)`
+                Following the logic in `FileWriter` and `File`, the 3 comes from:
+                - succeed on `fileHandle.seekToEndOfFile()` to prepare the file for the first write
                 - succeed on `fileHandle.write(_:)` for `writer.write(value: ["key1": "value1"])`
                 - succeed on `fileHandle.seekToEndOfFile()` to prepare the file for the second `writer.write(value:)`
-                - succeed on `fileHandle.write(_:)` when writing separator data for `["key2": "value2"]` in `writer.write(value: ["key2": "value2"])`
-                - throw an `I/O exception` when writing actual `["key2": "value2"]` data in `writer.write(value: ["key2": "value2"])`
+                - throw an `I/O exception` for `fileHandle.write(_:)` for the second write
              */
-            afterSucceedingCallsCounts: 4 // will succeed on writing `validValue1` and `,` separator but will fail on `validValue2`
+            afterSucceedingCallsCounts: 3 // will succeed on writing `validValue1` and `,` separator but will fail on `validValue2`
         )
 
         writer.write(value: ["key1": "value1"]) // first write (2 calls to `ObjcExceptionHandler`)

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogPrivateMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogPrivateMocks.swift
@@ -21,3 +21,26 @@ class ObjcExceptionHandlerMock: ObjcExceptionHandler {
         throw error
     }
 }
+
+/// An `ObjcExceptionHandler` which results with no error for the first `afterTimes` number of calls.
+/// Throws given `throwingError` for all other calls.
+class ObjcExceptionHandlerDeferredMock: ObjcExceptionHandler {
+    private let succeedingCallsCounts: Int
+    private var currentCallsCount = 0
+
+    let error: Error
+
+    init(throwingError: Error, afterSucceedingCallsCounts succeedingCallsCounts: Int) {
+        self.error = throwingError
+        self.succeedingCallsCounts = succeedingCallsCounts
+    }
+
+    override func rethrowToSwift(tryBlock: @escaping () -> Void) throws {
+        if currentCallsCount >= succeedingCallsCounts {
+            throw error
+        } else {
+            tryBlock()
+        }
+        currentCallsCount += 1
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogPrivateMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogPrivateMocks.swift
@@ -44,3 +44,23 @@ class ObjcExceptionHandlerDeferredMock: ObjcExceptionHandler {
         currentCallsCount += 1
     }
 }
+
+/// An `ObjcExceptionHandler` which throws given error with given probability.
+class ObjcExceptionHandlerNonDeterministicMock: ObjcExceptionHandler {
+    private let probability: Int
+    let error: Error
+
+    /// Probability should be described as a number between `0` and `1`
+    init(throwingError: Error, withProbability probability: Double) {
+        self.error = throwingError
+        self.probability = Int(probability * 1_000)
+    }
+
+    override func rethrowToSwift(tryBlock: @escaping () -> Void) throws {
+        if Int.random(in: 0...1_000) < probability {
+            throw error
+        } else {
+            tryBlock()
+        }
+    }
+}


### PR DESCRIPTION
### What and why?

🐛  Some payloads send from SDK were malformed.

The reason was not performing writes atomically:
```swift
// pseudo-code

let separatorData = ",".utf8Data
try writer.write(separatorData)
try writer.write(logData)
```
In rare cases, when the `I/O` exception was thrown for the second write, it was leaving the file's content malformed.

### How?

The fix is to perform atomic writes:
```swift
// pseudo-code

let logWithSeparatorData = ",".utf8Data + logData
try writer.write(logWithSeparatorData)
```

The red unit test for payload malformation was added, then it was made green with a fix.

### Later improvements

The `File` interface is not resistant for this sort of bugs, as it doesn't perform transactional write even if it looks like:
```swift
// FileTests.swift

try file.append { write in
    try write(Data([0x42, 0x42, 0x42, 0x42, 0x42])) // 5 bytes
    try write(Data([0x41, 0x41, 0x41, 0x41, 0x41])) // 5 bytes
}
```

As this requires additional refactoring, to not impact the hotfix scope, I will open a separate PR changing the `WritableFile` interface from:
```swift
func append(transaction: ((Data) throws -> Void) throws -> Void) throws
```
to simply:
```swift
func append(data Data) throws
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
