### PR TITLE
RUMM-468 Add public api to enable / disable features

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
@@ -54,7 +54,8 @@
       </CodeCoverageTargets>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61133B8A242393DE00786299"

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -92,7 +92,20 @@ public class Datadog {
         let networkConnectionInfoProvider = NetworkConnectionInfoProvider()
         let carrierInfoProvider = CarrierInfoProvider()
 
-        // Initialize features:
+        // First, initialize internal loggers:
+
+        let internalLoggerConfiguration = InternalLoggerConfiguration(
+            applicationVersion: validConfiguration.applicationVersion,
+            environment: validConfiguration.environment,
+            userInfoProvider: userInfoProvider,
+            networkConnectionInfoProvider: networkConnectionInfoProvider,
+            carrierInfoProvider: carrierInfoProvider
+        )
+
+        userLogger = createSDKUserLogger(configuration: internalLoggerConfiguration)
+        developerLogger = createSDKDeveloperLogger(configuration: internalLoggerConfiguration)
+
+        // Then, initialize features:
 
         let httpClient = HTTPClient()
         let mobileDevice = MobileDevice.current
@@ -155,10 +168,15 @@ public class Datadog {
             throw ProgrammerError(description: "Attempted to stop SDK before it was initialized.")
         }
 
-        // Deinitialize features:
+        // First, reset internal loggers:
+        userLogger = createNoOpSDKUserLogger()
+        developerLogger = nil
 
+        // Then, deinitialize features:
         LoggingFeature.instance = nil
         TracingFeature.instance = nil
+
+        // Deinitialize `Datadog`:
         Datadog.instance = nil
     }
 }

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -94,7 +94,15 @@ extension Datadog {
 
             // MARK: - Features Configuration
 
-            /// Enables the logging feature.
+            /// Enables or disables the logging feature.
+            ///
+            /// This option is meant to opt-out from using Datadog Logging entirely, no matter of your environment or build configuration. If you need to
+            /// disable logging only for certain scenarios (e.g. in `DEBUG` build configuration), use `sendLogsToDatadog(false)` available
+            /// on `Logger.Builder`.
+            ///
+            /// If `enableLogging(false)` is set, the SDK won't instantiate underlying resources required for
+            /// running the logging feature. This will give you additional performance optimization if you only use tracing, but not logging.
+            ///
             /// - Parameter enabled: `true` by default
             public func enableLogging(_ enabled: Bool) -> Builder {
                 // TODO: RUMM-468 Describe the impact on Logging for Tracing integration in this method comment

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -103,17 +103,26 @@ extension Datadog {
             /// If `enableLogging(false)` is set, the SDK won't instantiate underlying resources required for
             /// running the logging feature. This will give you additional performance optimization if you only use tracing, but not logging.
             ///
+            /// **NOTE**: If you use logging for tracing (`span.log(fields:)`) keep the logging feature enabled. Otherwise the logs
+            /// you send for `span` objects won't be delivered to Datadog.
+            ///
             /// - Parameter enabled: `true` by default
             public func enableLogging(_ enabled: Bool) -> Builder {
-                // TODO: RUMM-468 Describe the impact on Logging for Tracing integration in this method comment
                 self.loggingEnabled = enabled
                 return self
             }
 
-            /// Enables the tracing feature.
+            /// Enables or disables the tracing feature.
+            ///
+            /// This option is meant to opt-out from using Datadog Tracing entirely, no matter of your environment or build configuration. If you need to
+            /// disable tracing only for certain scenarios (e.g. in `DEBUG` build configuration), do not set `OpenTracing.Global.sharedTracer` to `DDTracer`,
+            /// and your app will be using the no-op tracer instance provided by `OpenTracing`.
+            ///
+            /// If `enableTracing(false)` is set, the SDK won't instantiate underlying resources required for
+            /// running the tracing feature. This will give you additional performance optimization if you only use logging, but not tracing.
+            ///
             /// - Parameter enabled: `true` by default
             public func enableTracing(_ enabled: Bool) -> Builder {
-                // TODO: RUMM-468 Describe the impact on Global.sharedTracer
                 self.tracingEnabled = enabled
                 return self
             }

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -55,10 +55,12 @@ extension Datadog {
         }
 
         internal let clientToken: String
+        internal let environment: String
+        internal var loggingEnabled: Bool
+        internal var tracingEnabled: Bool
         internal let logsEndpoint: LogsEndpoint
         internal let tracesEndpoint: TracesEndpoint
         internal let serviceName: String?
-        internal let environment: String
 
         /// Creates configuration builder and sets client token.
         /// - Parameter clientToken: client token obtained on Datadog website.
@@ -79,14 +81,36 @@ extension Datadog {
         public class Builder {
             internal let clientToken: String
             internal let environment: String
-            internal var serviceName: String? = nil
+            internal var loggingEnabled = true
+            internal var tracingEnabled = true
             internal var logsEndpoint: LogsEndpoint = .us
             internal var tracesEndpoint: TracesEndpoint = .us
+            internal var serviceName: String? = nil
 
             internal init(clientToken: String, environment: String) {
                 self.clientToken = clientToken
                 self.environment = environment
             }
+
+            // MARK: - Features Configuration
+
+            /// Enables the logging feature.
+            /// - Parameter enabled: `true` by default
+            public func enableLogging(_ enabled: Bool) -> Builder {
+                // TODO: RUMM-468 Describe the impact on Logging for Tracing integration in this method comment
+                self.loggingEnabled = enabled
+                return self
+            }
+
+            /// Enables the tracing feature.
+            /// - Parameter enabled: `true` by default
+            public func enableTracing(_ enabled: Bool) -> Builder {
+                // TODO: RUMM-468 Describe the impact on Global.sharedTracer
+                self.tracingEnabled = enabled
+                return self
+            }
+
+            // MARK: - Endpoints Configuration
 
             /// Sets the server endpoint to which logs are sent.
             /// - Parameter logsEndpoint: server endpoint (default value is `LogsEndpoint.us`)
@@ -102,6 +126,8 @@ extension Datadog {
                 return self
             }
 
+            // MARK: - Other Settings
+
             /// Sets the default service name associated with data send to Datadog.
             /// NOTE: The `serviceName` can be also overwriten by each `Logger` instance.
             /// - Parameter serviceName: the service name (default value is set to application bundle identifier)
@@ -114,10 +140,12 @@ extension Datadog {
             public func build() -> Configuration {
                 return Configuration(
                     clientToken: clientToken,
+                    environment: environment,
+                    loggingEnabled: loggingEnabled,
+                    tracingEnabled: tracingEnabled,
                     logsEndpoint: logsEndpoint,
                     tracesEndpoint: tracesEndpoint,
-                    serviceName: serviceName,
-                    environment: environment
+                    serviceName: serviceName
                 )
             }
         }

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -344,7 +344,11 @@ public class Logger {
 
         private func buildOrThrow() throws -> Logger {
             guard let loggingFeature = LoggingFeature.instance else {
-                throw ProgrammerError(description: "`Datadog.initialize()` must be called prior to `Logger.builder.build()`.")
+                throw ProgrammerError(
+                    description: Datadog.instance == nil
+                        ? "`Datadog.initialize()` must be called prior to `Logger.builder.build()`."
+                        : "`Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."
+                )
             }
 
             return Logger(

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -111,7 +111,7 @@ internal class DDSpan: OpenTracing.Span {
             return
         }
         logFields.append(fields)
-        ddTracer.writeLog(withSpanContext: ddContext, fields: fields, date: timestamp)
+        ddTracer.writeLog(for: self, fields: fields, date: timestamp)
     }
 
     // MARK: - Private

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -23,7 +23,9 @@ internal final class TracingFeature {
 
     // MARK: - Integration With Other Features
 
-    let loggingFeatureAdapter: LoggingForTracingAdapter
+    /// Integration with Logging feature, which enables the `span.log()` functionality.
+    /// Equals `nil` if Logging feature is disabled.
+    let loggingFeatureAdapter: LoggingForTracingAdapter?
 
     // MARK: - Dependencies
 
@@ -120,7 +122,7 @@ internal final class TracingFeature {
         directory: Directory,
         configuration: Datadog.ValidConfiguration,
         performance: PerformancePreset,
-        loggingFeatureAdapter: LoggingForTracingAdapter,
+        loggingFeatureAdapter: LoggingForTracingAdapter?,
         mobileDevice: MobileDevice,
         httpClient: HTTPClient,
         tracesUploadURLProvider: UploadURLProvider,

--- a/Sources/Datadog/Utils/InternalLoggers.swift
+++ b/Sources/Datadog/Utils/InternalLoggers.swift
@@ -6,21 +6,35 @@
 
 import Foundation
 
+/// Necessary configuration to instantiate `developerLogger` and `userLogger`.
+internal struct InternalLoggerConfiguration {
+    let applicationVersion: String
+    let environment: String
+    let userInfoProvider: UserInfoProvider
+    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
+    let carrierInfoProvider: CarrierInfoProviderType
+}
+
 /// Global SDK `Logger` using console output.
 /// This logger is meant for debugging purposes during SDK development, hence **it should print useful information to SDK developer**.
 /// It is only instantiated when `DD_SDK_DEVELOPMENT` compilation condition is set for `Datadog` target.
 /// Some information posted with `developerLogger` may be also passed to `userLogger` with `.debug()` level to help SDK users
 /// understand why the SDK is not operating.
-internal var developerLogger = createSDKDeveloperLogger()
+///
+/// This `Logger` may be instantited on above conditions as soon as the SDK is initialized.
+internal var developerLogger: Logger? = nil
 
 /// Global SDK `Logger` using console output.
 /// This logger is meant for debugging purposes when using SDK, hence **it should print useful information to SDK user**.
 /// It is only used when `Datadog.verbosityLevel` value is set.
 /// Every information posted to user should be properly classified (most commonly `.debug()` or `.error()`) according to
 /// its context: does the message pop up due to user error or user's app environment error? or is it SDK error?
-internal var userLogger = createSDKUserLogger()
+///
+/// This no-op `Logger` gets replaced with working instance as soon as the SDK is initialized.
+internal var userLogger = createNoOpSDKUserLogger()
 
 internal func createSDKDeveloperLogger(
+    configuration: InternalLoggerConfiguration,
     consolePrintFunction: @escaping (String) -> Void = { consolePrint($0) },
     dateProvider: DateProvider = SystemDateProvider(),
     timeZone: TimeZone = .current
@@ -29,19 +43,15 @@ internal func createSDKDeveloperLogger(
         return nil
     }
 
-    guard let loggingFeature = LoggingFeature.instance else {
-        return nil
-    }
-
     let consoleOutput = LogConsoleOutput(
         logBuilder: LogBuilder(
-            applicationVersion: loggingFeature.configuration.applicationVersion,
-            environment: loggingFeature.configuration.environment,
+            applicationVersion: configuration.applicationVersion,
+            environment: configuration.environment,
             serviceName: "sdk-developer",
             loggerName: "sdk-developer",
-            userInfoProvider: loggingFeature.userInfoProvider,
-            networkConnectionInfoProvider: loggingFeature.networkConnectionInfoProvider,
-            carrierInfoProvider: loggingFeature.carrierInfoProvider
+            userInfoProvider: configuration.userInfoProvider,
+            networkConnectionInfoProvider: configuration.networkConnectionInfoProvider,
+            carrierInfoProvider: configuration.carrierInfoProvider
         ),
         format: .shortWith(prefix: "🐶 → "),
         timeZone: timeZone,
@@ -55,24 +65,29 @@ internal func createSDKDeveloperLogger(
     )
 }
 
+internal func createNoOpSDKUserLogger() -> Logger {
+    return Logger(
+        logOutput: NoOpLogOutput(),
+        dateProvider: SystemDateProvider(),
+        identifier: "no-op"
+    )
+}
+
 internal func createSDKUserLogger(
+    configuration: InternalLoggerConfiguration,
     consolePrintFunction: @escaping (String) -> Void = { consolePrint($0) },
     dateProvider: DateProvider = SystemDateProvider(),
     timeZone: TimeZone = .current
 ) -> Logger {
-    guard let loggingFeature = LoggingFeature.instance else {
-        return Logger(logOutput: NoOpLogOutput(), dateProvider: SystemDateProvider(), identifier: "no-op")
-    }
-
     let consoleOutput = LogConsoleOutput(
         logBuilder: LogBuilder(
-            applicationVersion: loggingFeature.configuration.applicationVersion,
-            environment: loggingFeature.configuration.environment,
+            applicationVersion: configuration.applicationVersion,
+            environment: configuration.environment,
             serviceName: "sdk-user",
             loggerName: "sdk-user",
-            userInfoProvider: loggingFeature.userInfoProvider,
-            networkConnectionInfoProvider: loggingFeature.networkConnectionInfoProvider,
-            carrierInfoProvider: loggingFeature.carrierInfoProvider
+            userInfoProvider: configuration.userInfoProvider,
+            networkConnectionInfoProvider: configuration.networkConnectionInfoProvider,
+            carrierInfoProvider: configuration.carrierInfoProvider
         ),
         format: .shortWith(prefix: "[DATADOG SDK] 🐶 → "),
         timeZone: timeZone,

--- a/Tests/DatadogTests/Datadog/DDTracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerConfigurationTests.swift
@@ -57,7 +57,7 @@ class DDTracerConfigurationTests: XCTestCase {
         XCTAssertNil(spanBuilder.networkConnectionInfoProvider)
         XCTAssertNil(spanBuilder.carrierInfoProvider)
 
-        guard let tracingLogBuilder = (tracer.logOutput.loggingOutput as? LogFileOutput)?.logBuilder else {
+        guard let tracingLogBuilder = (tracer.logOutput?.loggingOutput as? LogFileOutput)?.logBuilder else {
             XCTFail()
             return
         }
@@ -92,7 +92,7 @@ class DDTracerConfigurationTests: XCTestCase {
         XCTAssertTrue(spanBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
         XCTAssertTrue(spanBuilder.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
 
-        guard let tracingLogBuilder = (tracer.logOutput.loggingOutput as? LogFileOutput)?.logBuilder else {
+        guard let tracingLogBuilder = (tracer.logOutput?.loggingOutput as? LogFileOutput)?.logBuilder else {
             XCTFail()
             return
         }
@@ -104,44 +104,5 @@ class DDTracerConfigurationTests: XCTestCase {
         XCTAssertTrue(tracingLogBuilder.userInfoProvider === feature.userInfoProvider)
         XCTAssertTrue(tracingLogBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
         XCTAssertTrue(tracingLogBuilder.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
-    }
-}
-
-class DDTracerErrorTests: XCTestCase {
-    func testGivenDatadogNotInitialized_whenInitializingTracer_itPrintsError() {
-        let printFunction = PrintFunctionMock()
-        consolePrint = printFunction.print
-        defer { consolePrint = { print($0) } }
-
-        XCTAssertNil(Datadog.instance)
-
-        let tracer = DDTracer.initialize(configuration: .init())
-        XCTAssertEqual(
-            printFunction.printedMessage,
-            "🔥 Datadog SDK usage error: `Datadog.initialize()` must be called prior to `DDTracer.initialize()`."
-        )
-        XCTAssertTrue(tracer is DDNoopTracer)
-    }
-
-    func testGivenDatadogNotInitialized_whenUsingTracer_itPrintsError() {
-        let printFunction = PrintFunctionMock()
-        consolePrint = printFunction.print
-        defer { consolePrint = { print($0) } }
-
-        XCTAssertNil(Datadog.instance)
-
-        let tracer = DDTracer(
-            spanOutput: SpanOutputMock(),
-            logOutput: .init(loggingOutput: LogOutputMock())
-        )
-        let fixtures: [(() -> Void, String)] = [
-            ({ _ = tracer.startSpan(operationName: .mockAny()) },
-             "`Datadog.initialize()` must be called prior to `startSpan(...)`."),
-        ]
-
-        fixtures.forEach { tracerMethod, expectedConsoleError in
-            tracerMethod()
-            XCTAssertEqual(printFunction.printedMessage, "🔥 Datadog SDK usage error: \(expectedConsoleError)")
-        }
     }
 }

--- a/Tests/DatadogTests/Datadog/DDTracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerConfigurationTests.swift
@@ -25,6 +25,7 @@ class DDTracerConfigurationTests: XCTestCase {
                 serviceName: "service-name",
                 environment: "tests"
             ),
+            loggingFeature: .mockNoOp(temporaryDirectory: temporaryDirectory),
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider
         )

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationTests.swift
@@ -13,17 +13,24 @@ class DatadogConfigurationTests: XCTestCase {
     func testDefaultConfiguration() {
         let defaultConfiguration = Configuration.builderUsing(clientToken: "abcd", environment: "tests").build()
         XCTAssertEqual(defaultConfiguration.clientToken, "abcd")
-        XCTAssertEqual(defaultConfiguration.logsEndpoint.url, "https://mobile-http-intake.logs.datadoghq.com/v1/input/")
         XCTAssertEqual(defaultConfiguration.environment, "tests")
+        XCTAssertTrue(defaultConfiguration.loggingEnabled)
+        XCTAssertTrue(defaultConfiguration.tracingEnabled)
+        XCTAssertEqual(defaultConfiguration.logsEndpoint.url, "https://mobile-http-intake.logs.datadoghq.com/v1/input/")
+        XCTAssertEqual(defaultConfiguration.tracesEndpoint.url, "https://public-trace-http-intake.logs.datadoghq.com/v1/input/")
         XCTAssertNil(defaultConfiguration.serviceName)
     }
 
     func testCustomConfiguration() {
         let configuration = Configuration.builderUsing(clientToken: "abcd", environment: "tests")
             .set(serviceName: "service-name")
+            .enableLogging(false)
+            .enableTracing(false)
             .build()
         XCTAssertEqual(configuration.clientToken, "abcd")
         XCTAssertEqual(configuration.environment, "tests")
+        XCTAssertFalse(configuration.loggingEnabled)
+        XCTAssertFalse(configuration.tracingEnabled)
         XCTAssertEqual(configuration.serviceName, "service-name")
     }
 

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -78,7 +78,8 @@ class DatadogTests: XCTestCase {
         Datadog.initialize(appContext: .mockAny(), configuration: validConfiguration)
 
         XCTAssertNotNil(Datadog.instance)
-        XCTAssertNoThrow(try Datadog.deinitializeOrThrow())
+
+        try Datadog.deinitializeOrThrow()
     }
 
     func testGivenInvalidConfiguration_whenInitializing_itPrintsError() throws {

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -48,15 +48,9 @@ class AppContextTests: XCTestCase {
 
 class DatadogTests: XCTestCase {
     private var printFunction: PrintFunctionMock! // swiftlint:disable:this implicitly_unwrapped_optional
-    private let validConfiguration = Datadog.Configuration(
-        clientToken: "abc-def",
-        environment: "tests",
-        loggingEnabled: true,
-        tracingEnabled: true,
-        logsEndpoint: .us,
-        tracesEndpoint: .us,
-        serviceName: "service-name"
-    )
+    private var configurationBuilder: Datadog.Configuration.Builder {
+        Datadog.Configuration.builderUsing(clientToken: "abc-def", environment: "tests")
+    }
 
     override func setUp() {
         super.setUp()
@@ -75,7 +69,7 @@ class DatadogTests: XCTestCase {
     // MARK: - Initializing with configuration
 
     func testGivenValidConfiguration_itCanBeInitialized() throws {
-        Datadog.initialize(appContext: .mockAny(), configuration: validConfiguration)
+        Datadog.initialize(appContext: .mockAny(), configuration: configurationBuilder.build())
 
         XCTAssertNotNil(Datadog.instance)
 
@@ -93,9 +87,9 @@ class DatadogTests: XCTestCase {
         XCTAssertNil(Datadog.instance)
     }
 
-    func testWhenInitializedMoreThanOnce_itPrintsError() throws {
-        Datadog.initialize(appContext: .mockAny(), configuration: validConfiguration)
-        Datadog.initialize(appContext: .mockAny(), configuration: validConfiguration)
+    func testGivenValidConfiguration_whenInitializedMoreThanOnce_itPrintsError() throws {
+        Datadog.initialize(appContext: .mockAny(), configuration: configurationBuilder.build())
+        Datadog.initialize(appContext: .mockAny(), configuration: configurationBuilder.build())
 
         XCTAssertEqual(
             printFunction.printedMessage,
@@ -105,9 +99,55 @@ class DatadogTests: XCTestCase {
         try Datadog.deinitializeOrThrow()
     }
 
+    // MARK: - Toggling features
+
+    func testEnablingAndDisablingFeatures() throws {
+        func verify(configuration: Datadog.Configuration, verificationBlock: () -> Void) throws {
+            Datadog.initialize(appContext: .mockAny(), configuration: configuration)
+            verificationBlock()
+            try Datadog.deinitializeOrThrow()
+        }
+
+        try verify(configuration: configurationBuilder.build()) {
+            // verify features:
+            XCTAssertNotNil(LoggingFeature.instance)
+            XCTAssertNotNil(TracingFeature.instance)
+            // verify integrations:
+            XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
+        }
+        try verify(configuration: configurationBuilder.enableLogging(false).build()) {
+            // verify features:
+            XCTAssertNil(LoggingFeature.instance)
+            XCTAssertNotNil(TracingFeature.instance)
+            // verify integrations:
+            XCTAssertNil(TracingFeature.instance?.loggingFeatureAdapter)
+        }
+        try verify(configuration: configurationBuilder.enableTracing(false).build()) {
+            // verify features:
+            XCTAssertNotNil(LoggingFeature.instance)
+            XCTAssertNil(TracingFeature.instance)
+        }
+        try verify(configuration: configurationBuilder.enableLogging(false).enableTracing(false).build()) {
+            // verify features:
+            XCTAssertNil(LoggingFeature.instance)
+            XCTAssertNil(TracingFeature.instance)
+        }
+    }
+
     // MARK: - Defaults
 
     func testDefaultVerbosityLevel() {
         XCTAssertNil(Datadog.verbosityLevel)
+    }
+
+    func testDefaultUserInfo() throws {
+        Datadog.initialize(appContext: .mockAny(), configuration: configurationBuilder.build())
+
+        XCTAssertNotNil(Datadog.instance?.userInfoProvider.value)
+        XCTAssertNil(Datadog.instance?.userInfoProvider.value.id)
+        XCTAssertNil(Datadog.instance?.userInfoProvider.value.email)
+        XCTAssertNil(Datadog.instance?.userInfoProvider.value.name)
+
+        try Datadog.deinitializeOrThrow()
     }
 }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -50,10 +50,12 @@ class DatadogTests: XCTestCase {
     private var printFunction: PrintFunctionMock! // swiftlint:disable:this implicitly_unwrapped_optional
     private let validConfiguration = Datadog.Configuration(
         clientToken: "abc-def",
+        environment: "tests",
+        loggingEnabled: true,
+        tracingEnabled: true,
         logsEndpoint: .us,
         tracesEndpoint: .us,
-        serviceName: "service-name",
-        environment: "tests"
+        serviceName: "service-name"
     )
 
     override func setUp() {

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -120,23 +120,6 @@ class LoggerBuilderTests: XCTestCase {
     }
 }
 
-class LoggerBuilderErrorTests: XCTestCase {
-    func testGivenDatadogNotInitialized_whenBuildingLogger_itPrintsError() {
-        let printFunction = PrintFunctionMock()
-        consolePrint = printFunction.print
-        defer { consolePrint = { print($0) } }
-
-        XCTAssertNil(Datadog.instance)
-
-        let logger = Logger.builder.build()
-        XCTAssertEqual(
-            printFunction.printedMessage,
-            "🔥 Datadog SDK usage error: `Datadog.initialize()` must be called prior to `Logger.builder.build()`."
-        )
-        assertThat(logger: logger, usesOutput: NoOpLogOutput.self)
-    }
-}
-
 // MARK: - Helpers
 
 private func assertThat(logger: Logger, usesOutput outputType: LogOutput.Type, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogMocks.swift
@@ -395,17 +395,21 @@ extension Datadog.Configuration {
 
     static func mockWith(
         clientToken: String = .mockAny(),
+        environment: String = .mockAny(),
+        loggingEnabled: Bool = false,
+        tracingEnabled: Bool = false,
         logsEndpoint: LogsEndpoint = .us,
         tracesEndpoint: TracesEndpoint = .us,
-        serviceName: String? = .mockAny(),
-        environment: String = .mockAny()
+        serviceName: String? = .mockAny()
     ) -> Datadog.Configuration {
         return Datadog.Configuration(
             clientToken: clientToken,
+            environment: environment,
+            loggingEnabled: loggingEnabled,
+            tracingEnabled: tracingEnabled,
             logsEndpoint: logsEndpoint,
             tracesEndpoint: tracesEndpoint,
-            serviceName: serviceName,
-            environment: environment
+            serviceName: serviceName
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogTracingMocks.swift
@@ -58,10 +58,21 @@ class SpanOutputMock: SpanOutput {
 }
 
 extension DDTracer {
-    static func mockNoOp() -> DDTracer {
+    static func mockAny() -> DDTracer {
+        return mockWith()
+    }
+
+    static func mockWith(
+        spanOutput: SpanOutput = SpanOutputMock(),
+        logOutput: LoggingForTracingAdapter.AdaptedLogOutput = .init(loggingOutput: LogOutputMock()),
+        dateProvider: DateProvider = SystemDateProvider(),
+        tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator()
+    ) -> DDTracer {
         return DDTracer(
-            spanOutput: SpanOutputMock(),
-            logOutput: .init(loggingOutput: LogOutputMock())
+            spanOutput: spanOutput,
+            logOutput: logOutput,
+            dateProvider: dateProvider,
+            tracingUUIDGenerator: tracingUUIDGenerator
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/SpansMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SpansMocks.swift
@@ -36,7 +36,7 @@ extension DDSpan {
     }
 
     static func mockWith(
-        tracer: DDTracer = .mockNoOp(),
+        tracer: DDTracer = .mockAny(),
         context: DDSpanContext = .mockAny(),
         operationName: String = .mockAny(),
         startTime: Date = .mockAny(),

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -9,12 +9,11 @@
 extension TracingFeature {
     /// Mocks feature instance which performs no writes and no uploads.
     static func mockNoOp(temporaryDirectory: Directory) -> TracingFeature {
-        let noOpLoggingFeature = LoggingFeature.mockNoOp(temporaryDirectory: temporaryDirectory)
         return TracingFeature(
             directory: temporaryDirectory,
             configuration: .mockAny(),
             performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp),
-            loggingFeatureAdapter: LoggingForTracingAdapter(loggingFeature: noOpLoggingFeature),
+            loggingFeatureAdapter: nil,
             mobileDevice: .mockAny(),
             httpClient: .mockAny(),
             tracesUploadURLProvider: .mockAny(),
@@ -39,9 +38,7 @@ extension TracingFeature {
             storagePerformance: .writeEachObjectToNewFileAndReadAllFiles,
             uploadPerformance: .veryQuick
         ),
-        loggingFeature: LoggingFeature = .mockNoOp(
-            temporaryDirectory: temporaryDirectory
-        ),
+        loggingFeature: LoggingFeature? = nil,
         mobileDevice: MobileDevice = .mockWith(
             currentBatteryStatus: {
                 // Mock full battery, so it doesn't rely on battery condition for the upload
@@ -68,7 +65,7 @@ extension TracingFeature {
             directory: directory,
             configuration: configuration,
             performance: performance,
-            loggingFeatureAdapter: LoggingForTracingAdapter(loggingFeature: loggingFeature),
+            loggingFeatureAdapter: loggingFeature.flatMap { LoggingForTracingAdapter(loggingFeature: $0) },
             mobileDevice: mobileDevice,
             httpClient: HTTPClient(session: server.urlSession),
             tracesUploadURLProvider: tracesUploadURLProvider,

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
@@ -11,7 +11,7 @@ class SpanBuilderTests: XCTestCase {
     func testBuildingBasicSpan() throws {
         let builder: SpanBuilder = .mockWith(serviceName: "test-service-name")
         let ddspan = DDSpan(
-            tracer: .mockNoOp(),
+            tracer: .mockAny(),
             context: .mockWith(traceID: 1, spanID: 2, parentSpanID: 1),
             operationName: "operation-name",
             startTime: .mockDecember15th2019At10AMUTC(),

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -8,118 +8,153 @@ import XCTest
 @testable import Datadog
 
 class InternalLoggersTests: XCTestCase {
-    private var printedMessages: [String]! // swiftlint:disable:this implicitly_unwrapped_optional
-    private var userLogger: Logger! // swiftlint:disable:this implicitly_unwrapped_optional
+    private let internalLoggerConfigurationMock = InternalLoggerConfiguration(
+        applicationVersion: .mockAny(),
+        environment: .mockAny(),
+        userInfoProvider: UserInfoProvider.mockAny(),
+        networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
+        carrierInfoProvider: CarrierInfoProviderMock.mockAny()
+    )
 
-    override func setUp() {
-        super.setUp()
-        temporaryDirectory.create()
-        LoggingFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
-        printedMessages = []
-        userLogger = createSDKUserLogger(
-            consolePrintFunction: { [weak self] in self?.printedMessages.append($0) },
-            dateProvider: RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC()),
-            timeZone: .UTC
+    // MARK: - User Logger
+
+    func testWhenSDKIsNotInitialized_itUsesNoOpUserLogger() {
+        XCTAssertTrue(userLogger.logOutput is NoOpLogOutput)
+    }
+
+    func testGivenDefaultSDKConfiguration_whenInitialized_itUsesWorkingUserLogger() throws {
+        let defaultSDKConfiguration = Datadog.Configuration.builderUsing(clientToken: "abc", environment: "test").build()
+        Datadog.initialize(appContext: .mockAny(), configuration: defaultSDKConfiguration)
+        XCTAssertTrue((userLogger.logOutput as? ConditionalLogOutput)?.conditionedOutput is LogConsoleOutput)
+        try Datadog.deinitializeOrThrow()
+    }
+
+    func testGivenLoggingFeatureDisabled_whenSDKisInitialized_itUsesWorkingUserLogger() throws {
+        Datadog.initialize(appContext: .mockAny(), configuration: .mockWith(loggingEnabled: false))
+        XCTAssertTrue((userLogger.logOutput as? ConditionalLogOutput)?.conditionedOutput is LogConsoleOutput)
+        try Datadog.deinitializeOrThrow()
+    }
+
+    func testUserLoggerPrintsMessagesAboveGivenVerbosityLevel() {
+        var printedMessages: [String] = []
+
+        let userLogger = createSDKUserLogger(
+            configuration: internalLoggerConfigurationMock,
+            consolePrintFunction: { printedMessages.append($0) },
+            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
+            timeZone: .EET
         )
-    }
 
-    override func tearDown() {
-        printedMessages = nil
-        userLogger = nil
-        Datadog.verbosityLevel = nil
-        LoggingFeature.instance = nil
-        temporaryDirectory.delete()
-        super.tearDown()
-    }
+        let expectedMessages = [
+            "[DATADOG SDK] 🐶 → 12:00:00.000 [DEBUG] message",
+            "[DATADOG SDK] 🐶 → 12:00:00.000 [INFO] message",
+            "[DATADOG SDK] 🐶 → 12:00:00.000 [NOTICE] message",
+            "[DATADOG SDK] 🐶 → 12:00:00.000 [WARN] message",
+            "[DATADOG SDK] 🐶 → 12:00:00.000 [ERROR] message",
+            "[DATADOG SDK] 🐶 → 12:00:00.000 [CRITICAL] message"
+        ]
 
-    // MARK: - `userLogger`
-
-    private func logMessageUsingAllLevels(_ message: String) {
-        userLogger.debug(message)
-        userLogger.info(message)
-        userLogger.notice(message)
-        userLogger.warn(message)
-        userLogger.error(message)
-        userLogger.critical(message)
-    }
-
-    private let expectedMessages = [
-        "[DATADOG SDK] 🐶 → 10:00:00.000 [DEBUG] message",
-        "[DATADOG SDK] 🐶 → 10:00:00.000 [INFO] message",
-        "[DATADOG SDK] 🐶 → 10:00:00.000 [NOTICE] message",
-        "[DATADOG SDK] 🐶 → 10:00:00.000 [WARN] message",
-        "[DATADOG SDK] 🐶 → 10:00:00.000 [ERROR] message",
-        "[DATADOG SDK] 🐶 → 10:00:00.000 [CRITICAL] message"
-    ]
-
-    func testUserLoggerDoesNothingWithDefaultVerbosityLevel() {
         XCTAssertNil(Datadog.verbosityLevel)
-        logMessageUsingAllLevels("message")
+        logMessageUsingAllLevels("message", with: userLogger)
         XCTAssertEqual(printedMessages, [])
-    }
 
-    func testUserLoggerPrintsWithVerbosityLevel_debug() {
+        printedMessages = []
         Datadog.verbosityLevel = .debug
-        logMessageUsingAllLevels("message")
+        logMessageUsingAllLevels("message", with: userLogger)
         XCTAssertEqual(printedMessages, Array(expectedMessages[0..<expectedMessages.count]))
-    }
 
-    func testUserLoggerPrintsWithVerbosityLevel_info() {
+        printedMessages = []
         Datadog.verbosityLevel = .info
-        logMessageUsingAllLevels("message")
+        logMessageUsingAllLevels("message", with: userLogger)
         XCTAssertEqual(printedMessages, Array(expectedMessages[1..<expectedMessages.count]))
-    }
 
-    func testUserLoggerPrintsWithVerbosityLevel_notice() {
+        printedMessages = []
         Datadog.verbosityLevel = .notice
-        logMessageUsingAllLevels("message")
+        logMessageUsingAllLevels("message", with: userLogger)
         XCTAssertEqual(printedMessages, Array(expectedMessages[2..<expectedMessages.count]))
-    }
 
-    func testUserLoggerPrintsWithVerbosityLevel_warn() {
+        printedMessages = []
         Datadog.verbosityLevel = .warn
-        logMessageUsingAllLevels("message")
+        logMessageUsingAllLevels("message", with: userLogger)
         XCTAssertEqual(printedMessages, Array(expectedMessages[3..<expectedMessages.count]))
-    }
 
-    func testUserLoggerPrintsWithVerbosityLevel_error() {
+        printedMessages = []
         Datadog.verbosityLevel = .error
-        logMessageUsingAllLevels("message")
+        logMessageUsingAllLevels("message", with: userLogger)
         XCTAssertEqual(printedMessages, Array(expectedMessages[4..<expectedMessages.count]))
-    }
 
-    func testUserLoggerPrintsWithVerbosityLevel_critical() {
+        printedMessages = []
         Datadog.verbosityLevel = .critical
-        logMessageUsingAllLevels("message")
+        logMessageUsingAllLevels("message", with: userLogger)
         XCTAssertEqual(printedMessages, Array(expectedMessages[5..<expectedMessages.count]))
+
+        Datadog.verbosityLevel = nil
     }
 
-    // MARK: - `developerLogger`
+    // MARK: - SDK Developer Logger
 
-    func testWhenCompileNotForDevelopment_DeveloperLoggerIsNotAvailable() {
+    func testGivenSDKCompiledNotForDevelopment_whenSDKIsInitialized_developerLoggerIsNotAvailable() {
         let originalValue = CompilationConditions.isSDKCompiledForDevelopment
         defer { CompilationConditions.isSDKCompiledForDevelopment = originalValue }
 
-        CompilationConditions.isSDKCompiledForDevelopment = false
-
-        XCTAssertNil(createSDKDeveloperLogger())
+        XCTAssertNil(developerLogger)
     }
 
-    func testWhenCompileForDevelopment_DeveloperLoggerIsAvailable() {
+    func testGivenSDKCompiledForDevelopment_whenSDKIsInitialized_developerLoggerIsAvailable() throws {
         let originalValue = CompilationConditions.isSDKCompiledForDevelopment
         defer { CompilationConditions.isSDKCompiledForDevelopment = originalValue }
-        var printedMessage: String?
+
+        Datadog.initialize(appContext: .mockAny(), configuration: .mockAny())
+        XCTAssertNotNil(developerLogger)
+        try Datadog.deinitializeOrThrow()
+    }
+
+    func testGivenSDKCompiledForDevelopment_whenLoggingFeatureIsDisabled_developerLoggerIsAvailable() throws {
+        let originalValue = CompilationConditions.isSDKCompiledForDevelopment
+        defer { CompilationConditions.isSDKCompiledForDevelopment = originalValue }
+
+        Datadog.initialize(appContext: .mockAny(), configuration: .mockWith(loggingEnabled: false))
+        XCTAssertNotNil(developerLogger)
+        try Datadog.deinitializeOrThrow()
+    }
+
+    func testDeveloperLoggerPrintsAllMessages() {
+        let originalValue = CompilationConditions.isSDKCompiledForDevelopment
+        defer { CompilationConditions.isSDKCompiledForDevelopment = originalValue }
+
+        var printedMessages: [String] = []
 
         CompilationConditions.isSDKCompiledForDevelopment = true
 
         let developerLogger = createSDKDeveloperLogger(
-            consolePrintFunction: { printedMessage = $0 },
+            configuration: internalLoggerConfigurationMock,
+            consolePrintFunction: { printedMessages.append($0) },
             dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
-            timeZone: .UTC
+            timeZone: .EET
         )
-        developerLogger?.info("It works.")
 
-        XCTAssertNotNil(developerLogger)
-        XCTAssertEqual(printedMessage, "🐶 → 10:00:00.000 [INFO] It works.")
+        let expectedMessages = [
+            "🐶 → 12:00:00.000 [DEBUG] message",
+            "🐶 → 12:00:00.000 [INFO] message",
+            "🐶 → 12:00:00.000 [NOTICE] message",
+            "🐶 → 12:00:00.000 [WARN] message",
+            "🐶 → 12:00:00.000 [ERROR] message",
+            "🐶 → 12:00:00.000 [CRITICAL] message"
+        ]
+
+        logMessageUsingAllLevels("message", with: developerLogger!)
+
+        XCTAssertEqual(printedMessages, expectedMessages)
+    }
+
+    // MARK: - Helpers
+
+    private func logMessageUsingAllLevels(_ message: String, with logger: Logger) {
+        logger.debug(message)
+        logger.info(message)
+        logger.notice(message)
+        logger.warn(message)
+        logger.error(message)
+        logger.critical(message)
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR adds two public methods to toggle logging and tracing features:
```swift
/// Enables or disables the logging feature.
///
/// This option is meant to opt-out from using Datadog Logging entirely, no matter of your environment or build configuration. If you need to
/// disable logging only for certain scenarios (e.g. in `DEBUG` build configuration), use `sendLogsToDatadog(false)` available
/// on `Logger.Builder`.
///
/// If `enableLogging(false)` is set, the SDK won't instantiate underlying resources required for
/// running the logging feature. This will give you additional performance optimization if you only use tracing, but not logging.
///
/// **NOTE**: If you use logging for tracing (`span.log(fields:)`) keep the logging feature enabled. Otherwise the logs
/// you send for `span` objects won't be delivered to Datadog.
///
/// - Parameter enabled: `true` by default
public func enableLogging(_ enabled: Bool) -> Builder

/// Enables or disables the tracing feature.
///
/// This option is meant to opt-out from using Datadog Tracing entirely, no matter of your environment or build configuration. If you need to
/// disable tracing only for certain scenarios (e.g. in `DEBUG` build configuration), do not set `OpenTracing.Global.sharedTracer` to `DDTracer`,
/// and your app will be using the no-op tracer instance provided by `OpenTracing`.
///
/// If `enableTracing(false)` is set, the SDK won't instantiate underlying resources required for
/// running the tracing feature. This will give you additional performance optimization if you only use logging, but not tracing.
///
/// - Parameter enabled: `true` by default
public func enableTracing(_ enabled: Bool) -> Builder
```

### How?

Internally, the feature status is determined by its `.instance` optional, so:
```swift
let loggingEnabled = LoggingFeature.instance != nil
let tracingEnabled = TracingFeature.instance != nil
```
It's simple, and powerful, as we expect non-optional feature instances in appropriate places, making the error handling and consistency consideration super simple, e.g. this reads as `TracingFeature` depends optionally on `LoggingFeature`:
```swift
internal final class TracingFeature {
    let loggingFeatureAdapter: LoggingForTracingAdapter?
}
```
but this:
```swift
internal struct LoggingForTracingAdapter {
    private let loggingFeature: LoggingFeature
}
```
means that `LoggingForTracingAdapter` requires the logging feature to be enabled.

All possible API misuses were covered with user-facing error messages:
* if `Logger` is instantiated with logging feature disabled;
* if `DDTracer` is instantiated with tracing feature disabled;
* if `span.log(fields:)` is used with logging feature disabled.

Also, because playing with global components (`.instance`, `consolePrint`, `userLogger`, ...) might be error prone in unit tests, I enabled "Randomize execution order" for tests target. This way, if we introduce flakiness due to global state inconsistency, we will be able to spot it early and fix.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
