### PR TITLE
RUMM-489 TracingRequestInterceptor added

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */; };
+		9E493E1C249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E493E1B249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift */; };
 		9E544A4D24752A8900E83072 /* URLSessionSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */; };
 		9E544A4F24753C6E00E83072 /* MethodSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */; };
 		9E544A5124753DDE00E83072 /* MethodSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */; };
@@ -176,6 +177,7 @@
 		9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */; };
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9EB47B92247443FA004F90BE /* URLSessionSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */; };
+		9ED583A32498C222004CFF2A /* TracingAutoInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED583A22498C222004CFF2A /* TracingAutoInstrumentation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -405,6 +407,7 @@
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionsTests.swift; sourceTree = "<group>"; };
+		9E493E1B249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingAutoInstrumentationTests.swift; sourceTree = "<group>"; };
 		9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlerTests.swift; sourceTree = "<group>"; };
 		9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzler.swift; sourceTree = "<group>"; };
 		9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzlerTests.swift; sourceTree = "<group>"; };
@@ -414,6 +417,7 @@
 		9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjcExceptionHandler.h; sourceTree = "<group>"; };
 		9E9EB37624468CE90002C80B /* Datadog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Datadog.modulemap; sourceTree = "<group>"; };
 		9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzler.swift; sourceTree = "<group>"; };
+		9ED583A22498C222004CFF2A /* TracingAutoInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingAutoInstrumentation.swift; sourceTree = "<group>"; };
 		9EF49F1624476FBD004F2CA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9EF49F17244770AD004F2CA0 /* DatadogIntegrationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogIntegrationTests.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1023,6 +1027,7 @@
 				61C5A87924509A0C00DA608C /* DDNoOps.swift */,
 				61C5A87824509A0C00DA608C /* DDSpan.swift */,
 				61C5A87E24509A0C00DA608C /* DDSpanContext.swift */,
+				9ED583A22498C222004CFF2A /* TracingAutoInstrumentation.swift */,
 				61C5A8A324509FAA00DA608C /* Span */,
 				61C5A87F24509A0C00DA608C /* SpanOutputs */,
 				61C5A88224509A0C00DA608C /* Propagation */,
@@ -1061,6 +1066,7 @@
 		61C5A89724509C1100DA608C /* Tracing */ = {
 			isa = PBXGroup;
 			children = (
+				9E493E1B249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift */,
 				61AD4E3924534075006E34EA /* TracingFeatureTests.swift */,
 				61C5A89824509C1100DA608C /* DDSpanTests.swift */,
 				61F1A620249A45E400075390 /* DDSpanContextTests.swift */,
@@ -1496,6 +1502,7 @@
 				9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */,
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
 				9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */,
+				9ED583A32498C222004CFF2A /* TracingAutoInstrumentation.swift in Sources */,
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
@@ -1550,6 +1557,7 @@
 			files = (
 				61C5A8A024509C1100DA608C /* Casting.swift in Sources */,
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
+				9E493E1C249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift in Sources */,
 				61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */,
 				61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */,
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,

--- a/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
@@ -57,15 +57,17 @@ internal class SendTracesFixtureViewController: UIViewController {
 
         viewAppearingSpan.finish()
 
-        // Step #2: Auto Instrumentation
-        // Send two requests which will be automatically traced as tracing auto-instrumentation is enabled
-        let tracedHost = currentAppConfig().sourceEndpoint.absoluteString
-        let url = URL(string: "\(tracedHost)/dataTaskWithURL")!
-        var request = URLRequest(url: URL(string: "\(tracedHost)/dataTaskWithRequest")!)
-        request.httpMethod = "POST"
+        // Send requests which will be automatically traced as tracing auto-instrumentation is enabled
+        let url = currentAppConfig().arbitraryNetworkURL
+        let request = currentAppConfig().arbitraryNetworkRequest
+        let dnsErrorURL = URL(string: "https://foo.bar")!
+        // Step #2: Auto-instrumentated request with URL to succeed
         URLSession.shared.dataTask(with: url) { _, _, _ in
-            // Step #3
-            URLSession.shared.dataTask(with: request) { _, _, _ in }.resume()
+            // Step #3: Auto-instrumentated request with Request to fail
+            URLSession.shared.dataTask(with: request) { _, _, _ in
+                // Step #4: Auto-instrumentated request to return NSError
+                URLSession.shared.dataTask(with: dnsErrorURL) { _, _, _ in }.resume()
+            }.resume()
         }.resume()
     }
 

--- a/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
@@ -29,6 +29,7 @@ internal class SendTracesFixtureViewController: UIViewController {
         dataDownloadingSpan.setTag(key: "data.url", value: URL(string: "https://example.com/image.png")!)
         dataDownloadingSpan.setTag(key: DDTags.resource, value: "GET /image.png")
 
+        // Step #1: Manual tracing with complex hierarchy
         downloadSomeData { [weak self] data in
             // Simulate logging download progress
             dataDownloadingSpan.log(
@@ -55,6 +56,17 @@ internal class SendTracesFixtureViewController: UIViewController {
         super.viewDidAppear(animated)
 
         viewAppearingSpan.finish()
+
+        // Step #2: Auto Instrumentation
+        // Send two requests which will be automatically traced as tracing auto-instrumentation is enabled
+        let tracedHost = currentAppConfig().sourceEndpoint.absoluteString
+        let url = URL(string: "\(tracedHost)/dataTaskWithURL")!
+        var request = URLRequest(url: URL(string: "\(tracedHost)/dataTaskWithRequest")!)
+        request.httpMethod = "POST"
+        URLSession.shared.dataTask(with: url) { _, _, _ in
+            // Step #3
+            URLSession.shared.dataTask(with: request) { _, _, _ in }.resume()
+        }.resume()
     }
 
     /// Simulates doing an asynchronous work with completion.

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -112,6 +112,7 @@ public class Datadog {
 
         var logging: LoggingFeature?
         var tracing: TracingFeature?
+        var tracingAutoInstrumentation: TracingAutoInstrumentation?
 
         if configuration.loggingEnabled {
             logging = LoggingFeature(
@@ -154,10 +155,13 @@ public class Datadog {
                 networkConnectionInfoProvider: networkConnectionInfoProvider,
                 carrierInfoProvider: carrierInfoProvider
             )
+            tracingAutoInstrumentation = TracingAutoInstrumentation(tracedHosts: configuration.tracedHosts)
         }
 
         LoggingFeature.instance = logging
         TracingFeature.instance = tracing
+        TracingAutoInstrumentation.instance = tracingAutoInstrumentation
+        TracingAutoInstrumentation.instance?.apply()
 
         // Only after all features were initialized with no error thrown:
         self.instance = Datadog(
@@ -182,6 +186,7 @@ public class Datadog {
         // Then, deinitialize features:
         LoggingFeature.instance = nil
         TracingFeature.instance = nil
+        TracingAutoInstrumentation.instance = nil
 
         // Deinitialize `Datadog`:
         Datadog.instance = nil

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -61,7 +61,7 @@ extension Datadog {
         internal let logsEndpoint: LogsEndpoint
         internal let tracesEndpoint: TracesEndpoint
         internal let serviceName: String?
-        internal var tracedHosts = Set<URL>()
+        internal var tracedHosts = Set<String>()
 
         /// Creates configuration builder and sets client token.
         /// - Parameter clientToken: client token obtained on Datadog website.
@@ -87,7 +87,7 @@ extension Datadog {
             internal var logsEndpoint: LogsEndpoint = .us
             internal var tracesEndpoint: TracesEndpoint = .us
             internal var serviceName: String? = nil
-            internal var tracedHosts = Set<URL>()
+            internal var tracedHosts = Set<String>()
 
             internal init(clientToken: String, environment: String) {
                 self.clientToken = clientToken
@@ -131,11 +131,19 @@ extension Datadog {
 
             /// Sets the hosts to be automatically traced.
             ///
-            /// Example, if tracedHosts is ["https://foo.bar"], then every network request such as "https://foo.bar/some/path" will be automatically traced.
-            /// If nil, automatic tracing is disabled.
+            /// Every request made to a traced host and its subdomains will create its Span with related information; _such as url, method, status code, error (if any)_.
+            /// Example, if `tracedHosts` is ["example.com"], then every network request such as the ones below will be automatically traced and generate a span.
+            /// "https://example.com/any/path"
+            /// "https://api.example.com/any/path"
             ///
-            /// - Parameter tracedHosts: `nil` by default
-            public func setTracedHosts(_ tracedHosts: Set<URL>) -> Builder {
+            /// If your backend is also being traced with Datadog agents, you can see the full trace (eg: client>server>database) in your dashboard with our distributed tracing feature.
+            /// A few HTTP headers are injected to auto-traced network requests so that you can see your spans in your backend as well.
+            ///
+            /// If `tracedHosts` is empty, automatic tracing is disabled.
+            /// **IMPORTANT:** Non-empty `tracedHost`s will lead to modifying implementation of some `URLSession` methods, in case your app relies on `URLSession` internals please refer to `URLSessionSwizzler.swift` file for details
+            ///
+            /// - Parameter tracedHosts: empty by default
+            public func set(tracedHosts: Set<String>) -> Builder {
                 self.tracedHosts = tracedHosts
                 return self
             }

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -61,6 +61,7 @@ extension Datadog {
         internal let logsEndpoint: LogsEndpoint
         internal let tracesEndpoint: TracesEndpoint
         internal let serviceName: String?
+        internal var tracedHosts = Set<URL>()
 
         /// Creates configuration builder and sets client token.
         /// - Parameter clientToken: client token obtained on Datadog website.
@@ -86,6 +87,7 @@ extension Datadog {
             internal var logsEndpoint: LogsEndpoint = .us
             internal var tracesEndpoint: TracesEndpoint = .us
             internal var serviceName: String? = nil
+            internal var tracedHosts = Set<URL>()
 
             internal init(clientToken: String, environment: String) {
                 self.clientToken = clientToken
@@ -127,6 +129,17 @@ extension Datadog {
                 return self
             }
 
+            /// Sets the hosts to be automatically traced.
+            ///
+            /// Example, if tracedHosts is ["https://foo.bar"], then every network request such as "https://foo.bar/some/path" will be automatically traced.
+            /// If nil, automatic tracing is disabled.
+            ///
+            /// - Parameter tracedHosts: `nil` by default
+            public func setTracedHosts(_ tracedHosts: Set<URL>) -> Builder {
+                self.tracedHosts = tracedHosts
+                return self
+            }
+
             // MARK: - Endpoints Configuration
 
             /// Sets the server endpoint to which logs are sent.
@@ -162,7 +175,8 @@ extension Datadog {
                     tracingEnabled: tracingEnabled,
                     logsEndpoint: logsEndpoint,
                     tracesEndpoint: tracesEndpoint,
-                    serviceName: serviceName
+                    serviceName: serviceName,
+                    tracedHosts: tracedHosts
                 )
             }
         }

--- a/Sources/Datadog/Tracing/Propagation/HTTPHeadersWriter.swift
+++ b/Sources/Datadog/Tracing/Propagation/HTTPHeadersWriter.swift
@@ -4,10 +4,12 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
+
 public class HTTPHeadersWriter: OTHTTPHeadersWriter {
-    private struct Constants {
-        static let traceIDField = "x-datadog-trace-id"
-        static let parentSpanIDField = "x-datadog-parent-id"
+    private enum Constants: String, CaseIterable {
+        case traceIDField = "x-datadog-trace-id"
+        case parentSpanIDField = "x-datadog-parent-id"
         // TODO: RUMM-338 support `x-datadog-sampling-priority`. `dd-trace-ot` reference:
         // https://github.com/DataDog/dd-trace-java/blob/4ba0ca0f9da748d4018310d026b1a72b607947f1/dd-trace-ot/src/main/java/datadog/opentracing/propagation/DatadogHttpCodec.java#L23
     }
@@ -26,8 +28,16 @@ public class HTTPHeadersWriter: OTHTTPHeadersWriter {
         }
 
         tracePropagationHTTPHeaders = [
-            Constants.traceIDField: String(spanContext.traceID.rawValue),
-            Constants.parentSpanIDField: String(spanContext.spanID.rawValue)
+            Constants.traceIDField.rawValue: String(spanContext.traceID.rawValue),
+            Constants.parentSpanIDField.rawValue: String(spanContext.spanID.rawValue)
         ]
+    }
+
+    internal static func canInject(to request: URLRequest) -> Bool {
+        let containsHeaders: Bool
+        containsHeaders = Constants.allCases.contains { headerKey -> Bool in
+            return request.value(forHTTPHeaderField: headerKey.rawValue) != nil
+        }
+        return !containsHeaders
     }
 }

--- a/Sources/Datadog/Tracing/Span/SpanTagsReducer.swift
+++ b/Sources/Datadog/Tracing/Span/SpanTagsReducer.swift
@@ -6,15 +6,6 @@
 
 import Foundation
 
-/// Datadog tag keys used to encode information received from the user through `OTLogFields`, `OTTagKeys` or custom fields
-/// supported by Datadog platform.
-private struct DatadogTagKeys {
-    static let errorType    = "error.type"
-    static let errorMessage = "error.msg"
-    static let errorStack   = "error.stack"
-    static let resourceName = DDTags.resource
-}
-
 /// Reduces `DDSpan` tags and log attributes by extracting values that require separate handling.
 ///
 /// The responsibility of `SpanTagsReducer` is to capture Open Tracing [tags](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table)
@@ -51,9 +42,9 @@ internal struct SpanTagsReducer {
 
             if isErrorEvent || errorKind != nil {
                 extractedIsError = true
-                mutableSpanTags[DatadogTagKeys.errorMessage] = fields[OTLogFields.message] as? String
-                mutableSpanTags[DatadogTagKeys.errorType] = errorKind
-                mutableSpanTags[DatadogTagKeys.errorStack] = fields[OTLogFields.stack] as? String
+                mutableSpanTags[DDTags.errorMessage] = fields[OTLogFields.message] as? String
+                mutableSpanTags[DDTags.errorType] = errorKind
+                mutableSpanTags[DDTags.errorStack] = fields[OTLogFields.stack] as? String
                 break // ignore next logs
             }
         }
@@ -64,7 +55,7 @@ internal struct SpanTagsReducer {
         }
 
         // extract resource name from `mutableSpanTags`
-        if let resourceName = mutableSpanTags.removeValue(forKey: DatadogTagKeys.resourceName) as? String {
+        if let resourceName = mutableSpanTags.removeValue(forKey: DDTags.resource) as? String {
             extractedResourceName = resourceName
         }
 

--- a/Sources/Datadog/Tracing/TracingAutoInstrumentation.swift
+++ b/Sources/Datadog/Tracing/TracingAutoInstrumentation.swift
@@ -1,0 +1,113 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal class TracingAutoInstrumentation {
+    static var instance: TracingAutoInstrumentation?
+
+    let tracedHosts: Set<URL>
+    let swizzler: URLSessionSwizzler
+
+    init?(tracedHosts: Set<URL>) {
+        if tracedHosts.isEmpty {
+            return nil
+        }
+        do {
+            self.tracedHosts = tracedHosts
+            self.swizzler = try URLSessionSwizzler()
+        } catch {
+            userLogger.warn("🔥 Network requests won't be traced automatically for \(String(describing: tracedHosts)): \(error)")
+            developerLogger?.warn("🔥 Network requests won't be traced automatically for \(String(describing: tracedHosts)): \(error)")
+            return nil
+        }
+    }
+
+    func apply() {
+        let interceptor = TracingRequestInterceptor.build(with: tracedHosts)
+        swizzler.swizzle(using: interceptor)
+    }
+}
+
+internal enum TracingRequestInterceptor {
+    static func build(with tracedHosts: Set<URL>) -> RequestInterceptor {
+        let interceptor: RequestInterceptor = { urlRequest in
+            guard let tracer = Global.sharedTracer as? DDTracer,
+                let someURL = urlRequest.url,
+                tracedHosts.allows(someURL),
+                HTTPHeadersWriter.canInject(to: urlRequest) else {
+                    return nil
+            }
+            let spanContext = tracer.createSpanContext()
+            let headersWriter = HTTPHeadersWriter()
+            headersWriter.inject(spanContext: spanContext)
+            let tracingHeaders = headersWriter.tracePropagationHTTPHeaders
+            var modifiedRequest = urlRequest
+            tracingHeaders.forEach { modifiedRequest.setValue($1, forHTTPHeaderField: $0) }
+
+            let observer: TaskObserver = tracingTaskObserver(tracer: tracer, spanContext: spanContext)
+            return InterceptionResult(modifiedRequest: modifiedRequest, taskObserver: observer)
+        }
+        return interceptor
+    }
+
+    static func tracingTaskObserver(
+        tracer: DDTracer,
+        spanContext: DDSpanContext
+    ) -> TaskObserver {
+        var startedSpan: OTSpan? = nil
+        let observer: TaskObserver = { observedEvent in
+            switch observedEvent {
+            case .starting(let request):
+                if let ongoingSpan = startedSpan {
+                    userLogger.warn("\(String(describing: request)) is starting a new trace but it's already started a trace before: \(ongoingSpan)")
+                    developerLogger?.warn("\(String(describing: request)) is starting a new trace but it's already started a trace before: \(ongoingSpan)")
+                }
+                let span = tracer.startSpan(
+                    spanContext: spanContext,
+                    operationName: "urlsession.request"
+                )
+                let url = request?.url?.absoluteString ?? "unknown_url"
+                let method = request?.httpMethod ?? "unknown_method"
+                span.setTag(key: DDTags.resource, value: url)
+                span.setTag(key: OTTags.httpUrl, value: url)
+                span.setTag(key: OTTags.httpMethod, value: method)
+                startedSpan = span
+            case .completed(let response, let error):
+                guard let completedSpan = startedSpan else {
+                    break
+                }
+                if let statusCode = (response as? HTTPURLResponse)?.statusCode {
+                    completedSpan.setTag(key: OTTags.httpStatusCode, value: statusCode)
+                }
+                if let someError = error {
+                    completedSpan.handleError(someError)
+                }
+                completedSpan.finish()
+            }
+        }
+        return observer
+    }
+}
+
+private extension Set where Element == URL {
+    func allows(_ url: URL) -> Bool {
+        return self.contains {
+            return (url.scheme == $0.scheme) && (url.host == $0.host)
+        }
+    }
+}
+
+private extension OTSpan {
+    func handleError(_ error: Error) {
+        setTag(key: DDTags.errorStack, value: String(describing: error))
+        let nsError = error as NSError
+        let errorKind = "\(nsError.domain) - \(nsError.code)"
+        setTag(key: DDTags.errorType, value: errorKind)
+        let errorMessage = nsError.localizedDescription
+        setTag(key: DDTags.errorMessage, value: errorMessage)
+    }
+}

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -16,13 +16,19 @@ class TracingIntegrationTests: IntegrationTests {
     func testLaunchTheAppAndSendTraces() throws {
         let testBeginTimeInNanoseconds = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
 
+        // Server session recording mock data requests send to `HTTPServerMock`.
+        // Used to inspect trace HTTP headers.
+        let dataSourceServerSession = server.obtainUniqueRecordingSession()
+        // Server session recording spans send to `HTTPServerMock`.
         let tracingServerSession = server.obtainUniqueRecordingSession()
+        // Server session recording logs send to `HTTPServerMock`.
         let loggingServerSession = server.obtainUniqueRecordingSession()
 
         let app = ExampleApplication()
         app.launchWith(
             mockLogsEndpointURL: loggingServerSession.recordingURL,
-            mockTracesEndpointURL: tracingServerSession.recordingURL
+            mockTracesEndpointURL: tracingServerSession.recordingURL,
+            mockSourceEndpointURL: dataSourceServerSession.recordingURL
         )
         app.tapSendTracesForUITests()
 
@@ -44,10 +50,23 @@ class TracingIntegrationTests: IntegrationTests {
         let spanMatchers = try recordedTracingRequests
             .flatMap { request in try SpanMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
 
-        XCTAssertEqual(spanMatchers.count, 3)
+        let autoTracedWithURL = spanMatchers[3]
+        let autoTracedWithRequest = spanMatchers[4]
+
+        let recordedNetworkRequests = try dataSourceServerSession.getRecordedPOSTRequests()
+        XCTAssert(recordedNetworkRequests.count == 1)
+        let traceID = try! autoTracedWithRequest.traceID().hexadecimalNumberToDecimal
+        XCTAssert(recordedNetworkRequests.first!.httpHeaders.contains("x-datadog-trace-id: \(traceID)"), "Trace: \(traceID) Actual: \(recordedNetworkRequests.first!.httpHeaders)")
+        let spanID = try! autoTracedWithRequest.spanID().hexadecimalNumberToDecimal
+        XCTAssert(recordedNetworkRequests.first!.httpHeaders.contains("x-datadog-parent-id: \(spanID)"), "Span: \(spanID) Actual: \(recordedNetworkRequests.first!.httpHeaders)")
+
+        XCTAssertEqual(spanMatchers.count, 5)
         XCTAssertEqual(try spanMatchers[0].operationName(), "data downloading")
         XCTAssertEqual(try spanMatchers[1].operationName(), "data presentation")
         XCTAssertEqual(try spanMatchers[2].operationName(), "view appearing")
+
+        XCTAssertEqual(try autoTracedWithURL.operationName(), "urlsession.request")
+        XCTAssertEqual(try autoTracedWithRequest.operationName(), "urlsession.request")
 
         // All spans share the same `trace_id`
         XCTAssertEqual(try spanMatchers[0].traceID(), try spanMatchers[1].traceID())
@@ -57,9 +76,15 @@ class TracingIntegrationTests: IntegrationTests {
         XCTAssertEqual(try spanMatchers[0].parentSpanID(), try spanMatchers[2].spanID())
         XCTAssertEqual(try spanMatchers[1].parentSpanID(), try spanMatchers[2].spanID())
 
+        // auto-instrumentation generates unique trace ids
+        XCTAssertNotEqual(try autoTracedWithURL.traceID(), try spanMatchers[0].traceID())
+        XCTAssertNotEqual(try autoTracedWithRequest.traceID(), try spanMatchers[0].traceID())
+
         XCTAssertNil(try? spanMatchers[0].metrics.isRootSpan())
         XCTAssertNil(try? spanMatchers[1].metrics.isRootSpan())
         XCTAssertEqual(try spanMatchers[2].metrics.isRootSpan(), 1)
+        XCTAssertEqual(try autoTracedWithURL.metrics.isRootSpan(), 1)
+        XCTAssertEqual(try autoTracedWithRequest.metrics.isRootSpan(), 1)
 
         // "data downloading" span's tags
         XCTAssertEqual(try spanMatchers[0].meta.custom(keyPath: "meta.data.kind"), "image")
@@ -69,11 +94,24 @@ class TracingIntegrationTests: IntegrationTests {
         XCTAssertEqual(try spanMatchers[0].isError(), 0)
         XCTAssertEqual(try spanMatchers[1].isError(), 1)
         XCTAssertEqual(try spanMatchers[2].isError(), 0)
+        XCTAssertEqual(try autoTracedWithURL.isError(), 0)
+        XCTAssertEqual(try autoTracedWithRequest.isError(), 0)
 
         // "data downloading" span has custom resource name
         XCTAssertEqual(try spanMatchers[0].resource(), "GET /image.png")
         XCTAssertEqual(try spanMatchers[1].resource(), try spanMatchers[1].operationName())
         XCTAssertEqual(try spanMatchers[2].resource(), try spanMatchers[2].operationName())
+
+        let baseURL = dataSourceServerSession.recordingURL.absoluteString
+        let targetURL1 = URL(string: "\(baseURL)/dataTaskWithURL")!
+        let targetURL2 = URL(string: "\(baseURL)/dataTaskWithRequest")!
+        XCTAssertEqual(try autoTracedWithURL.resource(), targetURL1.absoluteString)
+        XCTAssertEqual(try autoTracedWithRequest.resource(), targetURL2.absoluteString)
+
+        // assert baggage item:
+        XCTAssertEqual(try spanMatchers[0].meta.custom(keyPath: "meta.class"), "SendTracesFixtureViewController")
+        XCTAssertEqual(try spanMatchers[1].meta.custom(keyPath: "meta.class"), "SendTracesFixtureViewController")
+        XCTAssertEqual(try spanMatchers[2].meta.custom(keyPath: "meta.class"), "SendTracesFixtureViewController")
 
         try spanMatchers.forEach { matcher in
             XCTAssertGreaterThan(try matcher.startTime(), testBeginTimeInNanoseconds)
@@ -86,9 +124,6 @@ class TracingIntegrationTests: IntegrationTests {
             XCTAssertEqual(try matcher.meta.source(), "ios")
             XCTAssertEqual(try matcher.meta.tracerVersion().split(separator: ".").count, 3)
             XCTAssertEqual(try matcher.meta.applicationVersion(), "1.0")
-
-            // assert baggage item:
-            XCTAssertEqual(try matcher.meta.custom(keyPath: "meta.class"), "SendTracesFixtureViewController")
 
             XCTAssertTrue(
                 SpanMatcher.allowedNetworkReachabilityValues.contains(

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -10,15 +10,16 @@ import XCTest
 class ExampleApplication: XCUIApplication {
     /// Launches the app by mocking all feature endpoints with `mockServerURL`.
     func launchWith(mockServerURL: URL) {
-        self.launchWith(mockLogsEndpointURL: mockServerURL, mockTracesEndpointURL: mockServerURL)
+        self.launchWith(mockLogsEndpointURL: mockServerURL, mockTracesEndpointURL: mockServerURL, mockSourceEndpointURL: mockServerURL)
     }
 
     /// Launches the app by mocking feature endpoints separately.
-    func launchWith(mockLogsEndpointURL: URL, mockTracesEndpointURL: URL) {
+    func launchWith(mockLogsEndpointURL: URL, mockTracesEndpointURL: URL, mockSourceEndpointURL: URL) {
         launchArguments = ["IS_RUNNING_UI_TESTS"]
         launchEnvironment = [
             "DD_MOCK_LOGS_ENDPOINT_URL": mockLogsEndpointURL.absoluteString,
-            "DD_MOCK_TRACES_ENDPOINT_URL": mockTracesEndpointURL.absoluteString
+            "DD_MOCK_TRACES_ENDPOINT_URL": mockTracesEndpointURL.absoluteString,
+            "DD_MOCK_SOURCE_ENDPOINT_URL": mockSourceEndpointURL.absoluteString
         ]
         super.launch()
     }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -108,10 +108,15 @@ class DatadogTests: XCTestCase {
             try Datadog.deinitializeOrThrow()
         }
 
+        defer {
+            TracingAutoInstrumentation.instance?.swizzler.unswizzle()
+        }
+
         try verify(configuration: configurationBuilder.build()) {
             // verify features:
             XCTAssertNotNil(LoggingFeature.instance)
             XCTAssertNotNil(TracingFeature.instance)
+            XCTAssertNil(TracingAutoInstrumentation.instance)
             // verify integrations:
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
         }
@@ -119,6 +124,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNil(LoggingFeature.instance)
             XCTAssertNotNil(TracingFeature.instance)
+            XCTAssertNil(TracingAutoInstrumentation.instance)
             // verify integrations:
             XCTAssertNil(TracingFeature.instance?.loggingFeatureAdapter)
         }
@@ -126,11 +132,21 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNotNil(LoggingFeature.instance)
             XCTAssertNil(TracingFeature.instance)
+            XCTAssertNil(TracingAutoInstrumentation.instance)
         }
         try verify(configuration: configurationBuilder.enableLogging(false).enableTracing(false).build()) {
             // verify features:
             XCTAssertNil(LoggingFeature.instance)
             XCTAssertNil(TracingFeature.instance)
+            XCTAssertNil(TracingAutoInstrumentation.instance)
+        }
+        try verify(configuration: configurationBuilder.enableTracing(true).setTracedHosts([URL.mockAny()]).build()) {
+            XCTAssertNotNil(TracingFeature.instance)
+            XCTAssertNotNil(TracingAutoInstrumentation.instance)
+        }
+        try verify(configuration: configurationBuilder.enableTracing(false).setTracedHosts([URL.mockAny()]).build()) {
+            XCTAssertNil(TracingFeature.instance)
+            XCTAssertNil(TracingAutoInstrumentation.instance)
         }
     }
 

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -140,11 +140,21 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(TracingFeature.instance)
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }
-        try verify(configuration: configurationBuilder.enableTracing(true).setTracedHosts([URL.mockAny()]).build()) {
+        try verify(
+            configuration: configurationBuilder
+            .enableTracing(true)
+            .set(tracedHosts: [String.mockAny()])
+            .build()
+        ) {
             XCTAssertNotNil(TracingFeature.instance)
             XCTAssertNotNil(TracingAutoInstrumentation.instance)
         }
-        try verify(configuration: configurationBuilder.enableTracing(false).setTracedHosts([URL.mockAny()]).build()) {
+        try verify(
+            configuration: configurationBuilder
+            .enableTracing(false)
+            .set(tracedHosts: [String.mockAny()])
+            .build()
+        ) {
             XCTAssertNil(TracingFeature.instance)
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }

--- a/Tests/DatadogTests/Datadog/Tracing/TracingAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingAutoInstrumentationTests.swift
@@ -28,26 +28,45 @@ class TracingURLSessionHooksTests: XCTestCase {
         Global.sharedTracer = previousSharedTracer
     }
 
-    let tracedHost = URL(string: "http://foo.bar")!
+    let tracedHost = "foo.bar"
     let tracedRequest = URLRequest(url: URL(string: "http://foo.bar/foo")!)
 
     func testTracedHosts() {
-        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+        let tracedHosts: Set<String> = [tracedHost, "example", "my.app.org"]
+        guard let interceptor = TracingAutoInstrumentation(tracedHosts: tracedHosts)?.interceptor else {
+            XCTFail("Non-empty set of traced hosts should create a TracingAutoInstrumentation instance")
+            return
+        }
 
         XCTAssertNotNil(interceptor(tracedRequest))
 
-        let urlInNonTracedHost = URL(string: "http://www.foo.bar/foo")!
-        XCTAssertNil(interceptor(URLRequest(url: urlInNonTracedHost)))
+        for tracedHost in tracedHosts {
+            let subdomainURLInTracedHost = URL(string: "http://www.\(tracedHost)/foo")!
+            XCTAssertNotNil(interceptor(URLRequest(url: subdomainURLInTracedHost)))
 
-        let complexURLInTracedHost = URL(string: "http://johnny:p4ssw0rd@foo.bar:999/script.ext;param=value?query=value#ref")!
-        XCTAssertNotNil(interceptor(URLRequest(url: complexURLInTracedHost)))
+            let complexURLInTracedHost = URL(string: "http://johnny:p4ssw0rd@\(tracedHost):999/script.ext;param=value?query=value#ref")!
+            XCTAssertNotNil(interceptor(URLRequest(url: complexURLInTracedHost)))
 
-        let differentSchemeInTracedHost = URL(string: "https://foo.bar/foo")!
-        XCTAssertNil(interceptor(URLRequest(url: differentSchemeInTracedHost)))
+            let differentSchemeInTracedHost = URL(string: "https://\(tracedHost)/foo")!
+            XCTAssertNotNil(interceptor(URLRequest(url: differentSchemeInTracedHost)))
+        }
+
+        let nonTracedHost = URL(string: "https://non.traced.host")!
+        XCTAssertNil(interceptor(URLRequest(url: nonTracedHost)))
+
+        let nonEscapedDotURL = URL(string: "https://foo-bar.com")!
+        XCTAssertNil(interceptor(URLRequest(url: nonEscapedDotURL)))
+
+        let extendedTracedHost = URL(string: "https://foo.bar.asd")!
+        XCTAssertNil(interceptor(URLRequest(url: extendedTracedHost)))
+
+        let fileURL = URL(string: "file://some-file")!
+        XCTAssertTrue(fileURL.isFileURL)
+        XCTAssertNil(interceptor(URLRequest(url: fileURL)))
     }
 
     func testTaskObserver() throws {
-        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+        let interceptor = TracingAutoInstrumentation(tracedHosts: [tracedHost])!.interceptor
 
         let interception = interceptor(tracedRequest)
         guard let taskObserver = interception?.taskObserver else {
@@ -67,7 +86,7 @@ class TracingURLSessionHooksTests: XCTestCase {
     }
 
     func testTaskObserver_response() throws {
-        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+        let interceptor = TracingAutoInstrumentation(tracedHosts: [tracedHost])!.interceptor
 
         let interception = interceptor(tracedRequest)
         guard let taskObserver = interception?.taskObserver else {
@@ -78,16 +97,18 @@ class TracingURLSessionHooksTests: XCTestCase {
         taskObserver(.starting(tracedRequest))
         XCTAssertNil(spanRecorder.recorded)
 
-        let response = HTTPURLResponse(url: tracedRequest.url!, statusCode: 999, httpVersion: nil, headerFields: nil)
+        let response = HTTPURLResponse(url: tracedRequest.url!, statusCode: 404, httpVersion: nil, headerFields: nil)
         taskObserver(.completed(response, nil))
         XCTAssertNotNil(spanRecorder.recorded)
 
         let recordedSpanTags = spanRecorder.recorded!.span.tags
-        XCTAssertEqual(recordedSpanTags[OTTags.httpStatusCode] as? Int, 999)
+        XCTAssertEqual(recordedSpanTags[OTTags.httpStatusCode] as? Int, 404)
+        XCTAssertEqual(recordedSpanTags[DDTags.resource] as? String, "404")
+        XCTAssertEqual(recordedSpanTags[OTTags.error] as? Bool, true)
     }
 
     func testTaskObserver_NSError() throws {
-        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+        let interceptor = TracingAutoInstrumentation(tracedHosts: [tracedHost])!.interceptor
 
         let interception = interceptor(tracedRequest)
         guard let taskObserver = interception?.taskObserver else {
@@ -104,13 +125,14 @@ class TracingURLSessionHooksTests: XCTestCase {
         XCTAssertNotNil(spanRecorder.recorded)
 
         let recordedSpanTags = spanRecorder.recorded!.span.tags
+        XCTAssertEqual(recordedSpanTags[OTTags.error] as? Bool, true)
         XCTAssertEqual(recordedSpanTags[DDTags.errorType] as? String, "\(error.domain) - \(error.code)")
         XCTAssertEqual(recordedSpanTags[DDTags.errorMessage] as? String, errorDescription)
         XCTAssertEqual(recordedSpanTags[DDTags.errorStack] as? String, String(describing: error))
     }
 
     func testTaskObserver_wrongOrder() throws {
-        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+        let interceptor = TracingAutoInstrumentation(tracedHosts: [tracedHost])!.interceptor
 
         let interception = interceptor(tracedRequest)
         let taskObserver: TaskObserver! = interception?.taskObserver //swiftlint:disable:this implicitly_unwrapped_optional
@@ -122,14 +144,14 @@ class TracingURLSessionHooksTests: XCTestCase {
     }
 
     func testTaskObserver_duplicateStarts_shouldNotFail() throws {
-        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+        let interceptor = TracingAutoInstrumentation(tracedHosts: [tracedHost])!.interceptor
 
         let interception = interceptor(tracedRequest)
         let taskObserver: TaskObserver! = interception?.taskObserver //swiftlint:disable:this implicitly_unwrapped_optional
 
         taskObserver(.starting(tracedRequest))
 
-        let secondRequest = URLRequest(url: URL(string: "2", relativeTo: tracedHost)!)
+        let secondRequest = URLRequest(url: URL(string: "2", relativeTo: URL(string: tracedHost))!)
         taskObserver(.starting(secondRequest))
         taskObserver(.completed(nil, nil))
 

--- a/Tests/DatadogTests/Datadog/Tracing/TracingAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingAutoInstrumentationTests.swift
@@ -1,0 +1,141 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class TracingAutoInstrumentationTests: XCTestCase {
+    func testFailableInit() {
+        XCTAssertNil(TracingAutoInstrumentation(tracedHosts: []))
+    }
+}
+
+class TracingURLSessionHooksTests: XCTestCase {
+    let spanRecorder = SpanOutputMock()
+    var previousSharedTracer = Global.sharedTracer
+
+    override func setUp() {
+        super.setUp()
+        previousSharedTracer = Global.sharedTracer
+        Global.sharedTracer = DDTracer.mockWith(spanOutput: spanRecorder)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Global.sharedTracer = previousSharedTracer
+    }
+
+    let tracedHost = URL(string: "http://foo.bar")!
+    let tracedRequest = URLRequest(url: URL(string: "http://foo.bar/foo")!)
+
+    func testTracedHosts() {
+        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+
+        XCTAssertNotNil(interceptor(tracedRequest))
+
+        let urlInNonTracedHost = URL(string: "http://www.foo.bar/foo")!
+        XCTAssertNil(interceptor(URLRequest(url: urlInNonTracedHost)))
+
+        let complexURLInTracedHost = URL(string: "http://johnny:p4ssw0rd@foo.bar:999/script.ext;param=value?query=value#ref")!
+        XCTAssertNotNil(interceptor(URLRequest(url: complexURLInTracedHost)))
+
+        let differentSchemeInTracedHost = URL(string: "https://foo.bar/foo")!
+        XCTAssertNil(interceptor(URLRequest(url: differentSchemeInTracedHost)))
+    }
+
+    func testTaskObserver() throws {
+        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+
+        let interception = interceptor(tracedRequest)
+        guard let taskObserver = interception?.taskObserver else {
+            XCTFail("taskObserver should not be nil")
+            return
+        }
+
+        taskObserver(.starting(tracedRequest))
+        XCTAssertNil(spanRecorder.recorded)
+
+        taskObserver(.completed(nil, nil))
+        XCTAssertNotNil(spanRecorder.recorded)
+
+        let recordedSpanTags = spanRecorder.recorded!.span.tags
+        XCTAssertEqual(recordedSpanTags[OTTags.httpUrl] as? String, tracedRequest.url!.absoluteString)
+        XCTAssertEqual(recordedSpanTags[OTTags.httpMethod] as? String, tracedRequest.httpMethod)
+    }
+
+    func testTaskObserver_response() throws {
+        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+
+        let interception = interceptor(tracedRequest)
+        guard let taskObserver = interception?.taskObserver else {
+            XCTFail("taskObserver should not be nil")
+            return
+        }
+
+        taskObserver(.starting(tracedRequest))
+        XCTAssertNil(spanRecorder.recorded)
+
+        let response = HTTPURLResponse(url: tracedRequest.url!, statusCode: 999, httpVersion: nil, headerFields: nil)
+        taskObserver(.completed(response, nil))
+        XCTAssertNotNil(spanRecorder.recorded)
+
+        let recordedSpanTags = spanRecorder.recorded!.span.tags
+        XCTAssertEqual(recordedSpanTags[OTTags.httpStatusCode] as? Int, 999)
+    }
+
+    func testTaskObserver_NSError() throws {
+        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+
+        let interception = interceptor(tracedRequest)
+        guard let taskObserver = interception?.taskObserver else {
+            XCTFail("taskObserver should not be nil")
+            return
+        }
+
+        taskObserver(.starting(tracedRequest))
+        XCTAssertNil(spanRecorder.recorded)
+
+        let errorDescription = "something happened"
+        let error = NSError(domain: "unit-test", code: 123, userInfo: [NSLocalizedDescriptionKey: errorDescription])
+        taskObserver(.completed(nil, error))
+        XCTAssertNotNil(spanRecorder.recorded)
+
+        let recordedSpanTags = spanRecorder.recorded!.span.tags
+        XCTAssertEqual(recordedSpanTags[DDTags.errorType] as? String, "\(error.domain) - \(error.code)")
+        XCTAssertEqual(recordedSpanTags[DDTags.errorMessage] as? String, errorDescription)
+        XCTAssertEqual(recordedSpanTags[DDTags.errorStack] as? String, String(describing: error))
+    }
+
+    func testTaskObserver_wrongOrder() throws {
+        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+
+        let interception = interceptor(tracedRequest)
+        let taskObserver: TaskObserver! = interception?.taskObserver //swiftlint:disable:this implicitly_unwrapped_optional
+
+        for _ in 0...3 {
+            taskObserver(.completed(nil, nil))
+            XCTAssertNil(spanRecorder.recorded)
+        }
+    }
+
+    func testTaskObserver_duplicateStarts_shouldNotFail() throws {
+        let interceptor: RequestInterceptor = TracingRequestInterceptor.build(with: [tracedHost])
+
+        let interception = interceptor(tracedRequest)
+        let taskObserver: TaskObserver! = interception?.taskObserver //swiftlint:disable:this implicitly_unwrapped_optional
+
+        taskObserver(.starting(tracedRequest))
+
+        let secondRequest = URLRequest(url: URL(string: "2", relativeTo: tracedHost)!)
+        taskObserver(.starting(secondRequest))
+        taskObserver(.completed(nil, nil))
+
+        XCTAssertNotNil(spanRecorder.recorded)
+        let recordedSpanTags = spanRecorder.recorded!.span.tags
+        XCTAssertEqual(recordedSpanTags[OTTags.httpUrl] as? String, secondRequest.url!.absoluteString)
+        XCTAssertNotEqual(recordedSpanTags[OTTags.httpUrl] as? String, tracedRequest.url!.absoluteString)
+    }
+}


### PR DESCRIPTION
### What and why?

We need to trace every network request automatically as part of auto-instrumentation feature.
[First](https://github.com/DataDog/dd-sdk-ios/pull/113) and [second](https://github.com/DataDog/dd-sdk-ios/pull/116) parts are already implemented.
This is the last part of tracing auto-instrumentation.

### How?

With previous PRs we implemented a way to inject our custom code into `URLSession` methods.
Now we inject the code to:
1. create&inject tracing headers to network requests
2. create span context at network task creation `dataTaskWithURL/Request`
3. create span at starting network operation `task.resume`

### Review checklist

- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Feature or bugfix MUST have appropriate unit tests
- [x] Feature or bugfix MUST have appropriate integration tests
