### PR TITLE
RUMM-333 Set boundaries for trace and span ID generation

### DIFF
--- a/Sources/Datadog/Tracing/UUIDs/TracingUUIDGenerator.swift
+++ b/Sources/Datadog/Tracing/UUIDs/TracingUUIDGenerator.swift
@@ -11,9 +11,25 @@ internal protocol TracingUUIDGenerator {
 }
 
 internal struct DefaultTracingUUIDGenerator: TracingUUIDGenerator {
+    /// Lower boundary of `TracingUUID`.
+    /// `0` is reserved for historical reason: 0 == "unset", ref: dd-trace-java:DDId.java.
+    internal static let min: UInt64 = 1
+    /// Upper boundary of `TracingUUID`.
+    /// It equals to `2 ^ 63 - 1` because some tracers can't handle the `2 ^ 64 -1` range, ref: dd-trace-java:DDId.java.
+    internal static let max = UInt64.max >> 1
+
+    internal let min: UInt64
+    internal let max: UInt64
+
+    init(
+        lowerBoundary: UInt64 = DefaultTracingUUIDGenerator.min,
+        upperBoundary: UInt64 = DefaultTracingUUIDGenerator.max
+    ) {
+        self.min = lowerBoundary
+        self.max = upperBoundary
+    }
+
     func generateUnique() -> TracingUUID {
-       // TODO: RUMM-333 Add boundaries to trace & span ID generation, keeping in mind that `0` is reserved (ref: DDTracer.java#L600)
-       // NOTE: RUMM-340 Consider thread safety if the generation will depend on local state
-       return TracingUUID(rawValue: .random(in: 1...UInt64.max))
+        return TracingUUID(rawValue: .random(in: min...max))
    }
 }

--- a/Sources/Datadog/Tracing/UUIDs/TracingUUIDGenerator.swift
+++ b/Sources/Datadog/Tracing/UUIDs/TracingUUIDGenerator.swift
@@ -11,25 +11,18 @@ internal protocol TracingUUIDGenerator {
 }
 
 internal struct DefaultTracingUUIDGenerator: TracingUUIDGenerator {
-    /// Lower boundary of `TracingUUID`.
-    /// `0` is reserved for historical reason: 0 == "unset", ref: dd-trace-java:DDId.java.
-    internal static let min: UInt64 = 1
-    /// Upper boundary of `TracingUUID`.
-    /// It equals to `2 ^ 63 - 1` because some tracers can't handle the `2 ^ 64 -1` range, ref: dd-trace-java:DDId.java.
-    internal static let max = UInt64.max >> 1
+    /// Describes the lower and upper boundary of tracing ID generation.
+    /// * Lower: starts with `1` as `0` is reserved for historical reason: 0 == "unset", ref: dd-trace-java:DDId.java.
+    /// * Upper: equals to `2 ^ 63 - 1` as some tracers can't handle the `2 ^ 64 -1` range, ref: dd-trace-java:DDId.java.
+    internal static let defaultGenerationRange = (1...UInt64.max >> 1)
 
-    internal let min: UInt64
-    internal let max: UInt64
+    internal let range: ClosedRange<UInt64>
 
-    init(
-        lowerBoundary: UInt64 = DefaultTracingUUIDGenerator.min,
-        upperBoundary: UInt64 = DefaultTracingUUIDGenerator.max
-    ) {
-        self.min = lowerBoundary
-        self.max = upperBoundary
+    init(range: ClosedRange<UInt64> = Self.defaultGenerationRange) {
+        self.range = range
     }
 
     func generateUnique() -> TracingUUID {
-        return TracingUUID(rawValue: .random(in: min...max))
+        return TracingUUID(rawValue: .random(in: range))
    }
 }

--- a/Tests/DatadogTests/Datadog/Tracing/UUIDs/TracingUUIDGeneratorTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/UUIDs/TracingUUIDGeneratorTests.swift
@@ -10,12 +10,12 @@ import XCTest
 class TracingUUIDGeneratorTests: XCTestCase {
     func testDefaultGenerationBoundaries() {
         let generator = DefaultTracingUUIDGenerator()
-        XCTAssertEqual(generator.min, 1)
-        XCTAssertEqual(generator.max, 9_223_372_036_854_775_807) // 2 ^ 63 -1
+        XCTAssertEqual(generator.range.lowerBound, 1)
+        XCTAssertEqual(generator.range.upperBound, 9_223_372_036_854_775_807) // 2 ^ 63 -1
     }
 
     func testItGeneratesUUIDsFromGivenBoundaries() {
-        let generator = DefaultTracingUUIDGenerator(lowerBoundary: 10, upperBoundary: 15)
+        let generator = DefaultTracingUUIDGenerator(range: 10...15)
         var generatedUUIDs: Set<UInt64> = []
 
         (0..<1_000).forEach { _ in


### PR DESCRIPTION
### What and why?

📦 This PR adds boundaries to the generated `trace_id` and `span_id` so it stays compatible with Datadog infrastructure.

### How?

Following the [dd-trace-java/DDId.java](https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-api/src/main/java/datadog/trace/api/DDId.java) implementation, the boundaries are:
* the `id` should be higher or equal `1`,
* the `id` should be less or equal `2 ^ 63 - 1`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
