### PR TITLE
RUMM-501 Add `DDLogger` typealias to avoid compiler ambiguity

### DIFF
--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -73,6 +73,21 @@ public typealias AttributeKey = String
 ///
 public typealias AttributeValue = Encodable
 
+/// Because `Logger` is a common name widely used across different projects, the `Datadog.Logger` may conflict when
+/// using `Logger.builder`. In such case, following `DDLogger` typealias can be used to avoid compiler ambiguity.
+///
+/// Usage:
+///
+///     import Datadog
+///
+///     // logger reference
+///     var logger: DDLogger!
+///
+///     // instantiate Datadog logger
+///     logger = DDLogger.builder.build()
+///
+public typealias DDLogger = Logger
+
 public class Logger {
     /// Writes `Log` objects to output.
     let logOutput: LogOutput

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -491,7 +491,7 @@ class LoggerTests: XCTestCase {
         server.waitAndAssertNoRequestsSent()
     }
 
-    // MARK: - Usage errors
+    // MARK: - Usage
 
     func testGivenDatadogNotInitialized_whenInitializingLogger_itPrintsError() {
         let printFunction = PrintFunctionMock()
@@ -536,6 +536,10 @@ class LoggerTests: XCTestCase {
         XCTAssertTrue(logger.logOutput is NoOpLogOutput)
 
         try Datadog.deinitializeOrThrow()
+    }
+
+    func testDDLoggerIsLoggerTypealias() {
+        XCTAssertTrue(DDLogger.self == Logger.self)
     }
 }
 // swiftlint:enable multiline_arguments_brackets


### PR DESCRIPTION
### What and why?

🚚 This PR addresses #127 and #142 where compiler ambiguity is reported in projects defining their own `Logger` class.

### How?

A public `DDLogger` typealias is exposed and can be used in projects which define their own `Logger` class.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
