### PR TITLE
RUMM-297 Implement Baggage Item interface

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		61E917D3246546BF00E6C631 /* DDTracerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D2246546BF00E6C631 /* DDTracerConfigurationTests.swift */; };
 		61F1A61A2498A51700075390 /* CoreMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A6192498A51700075390 /* CoreMocks.swift */; };
 		61F1A623249B811200075390 /* Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A622249B811200075390 /* Encoding.swift */; };
+		61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A620249A45E400075390 /* DDSpanContextTests.swift */; };
 		61F8CC092469295500FE2908 /* DatadogConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8CC082469295500FE2908 /* DatadogConfigurationTests.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
@@ -388,6 +389,7 @@
 		61E917D2246546BF00E6C631 /* DDTracerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerConfigurationTests.swift; sourceTree = "<group>"; };
 		61F1A6192498A51700075390 /* CoreMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMocks.swift; sourceTree = "<group>"; };
 		61F1A622249B811200075390 /* Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encoding.swift; sourceTree = "<group>"; };
+		61F1A620249A45E400075390 /* DDSpanContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanContextTests.swift; sourceTree = "<group>"; };
 		61F8CC082469295500FE2908 /* DatadogConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogConfigurationTests.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
@@ -1057,6 +1059,7 @@
 			children = (
 				61AD4E3924534075006E34EA /* TracingFeatureTests.swift */,
 				61C5A89824509C1100DA608C /* DDSpanTests.swift */,
+				61F1A620249A45E400075390 /* DDSpanContextTests.swift */,
 				61E45BD02450F64100F2C652 /* Span */,
 				61E45BE3245196D500F2C652 /* SpanOutputs */,
 				617CEB3A2456BC8200AD4669 /* UUIDs */,
@@ -1538,6 +1541,7 @@
 				61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */,
 				61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */,
 				61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */,
+				61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */,
 				61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */,
 				61133C542423990D00786299 /* NetworkConnectionInfoProviderTests.swift in Sources */,
 				61B558CF2469561C001460D3 /* LoggerBuilderTests.swift in Sources */,

--- a/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendTracesFixtureViewController.swift
@@ -19,6 +19,9 @@ internal class SendTracesFixtureViewController: UIViewController {
 
         viewAppearingSpan = tracer.startSpan(operationName: "view appearing")
 
+        // Set `class: SendTracesFixtureViewController` baggage item on the root span, so it will be propagated to all child spans.
+        viewAppearingSpan.setBaggageItem(key: "class", value: "\(type(of: self))")
+
         let dataDownloadingSpan = tracer.startSpan(
             operationName: "data downloading",
             childOf: viewAppearingSpan.context

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -125,7 +125,7 @@ public class DDTracer: Tracer {
                 traceID: parentSpanContext?.traceID ?? tracingUUIDGenerator.generateUnique(),
                 spanID: tracingUUIDGenerator.generateUnique(),
                 parentSpanID: parentSpanContext?.spanID,
-                baggageItems: BaggageItems(queue: queue, parentSpanItems: parentSpanContext?.baggageItems)
+                baggageItems: BaggageItems(targetQueue: queue, parentSpanItems: parentSpanContext?.baggageItems)
             ),
             operationName: operationName,
             startTime: startTime ?? dateProvider.currentDate(),

--- a/Sources/Datadog/DDTracer.swift
+++ b/Sources/Datadog/DDTracer.swift
@@ -124,7 +124,8 @@ public class DDTracer: Tracer {
             context: DDSpanContext(
                 traceID: parentSpanContext?.traceID ?? tracingUUIDGenerator.generateUnique(),
                 spanID: tracingUUIDGenerator.generateUnique(),
-                parentSpanID: parentSpanContext?.spanID
+                parentSpanID: parentSpanContext?.spanID,
+                baggageItems: BaggageItems(queue: queue, parentSpanItems: parentSpanContext?.baggageItems)
             ),
             operationName: operationName,
             startTime: startTime ?? dateProvider.currentDate(),

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -87,15 +87,14 @@ internal class DDSpan: OpenTracing.Span {
         if warnIfFinished("setBaggageItem(key:value:)") {
             return
         }
-        // TODO: RUMM-292
+        ddContext.baggageItems.set(key: key, value: value)
     }
 
     func baggageItem(withKey key: String) -> String? {
         if warnIfFinished("baggageItem(withKey:)") {
             return nil
         }
-        // TODO: RUMM-292
-        return nil
+        return ddContext.baggageItems.get(key: key)
     }
 
     func finish(at time: Date) {

--- a/Sources/Datadog/Tracing/DDSpanContext.swift
+++ b/Sources/Datadog/Tracing/DDSpanContext.swift
@@ -5,6 +5,7 @@
  */
 
 import OpenTracing
+import Foundation
 
 internal struct DDSpanContext: OpenTracing.SpanContext {
     /// This span's trace ID.

--- a/Sources/Datadog/Tracing/DDSpanContext.swift
+++ b/Sources/Datadog/Tracing/DDSpanContext.swift
@@ -13,10 +13,59 @@ internal struct DDSpanContext: OpenTracing.SpanContext {
     let spanID: TracingUUID
     /// The ID of the parent span or `nil` if this span is the root span.
     let parentSpanID: TracingUUID?
+    /// The baggage items of this span.
+    let baggageItems: BaggageItems
 
     // MARK: - Open Tracing interface
 
     func forEachBaggageItem(callback: (String, String) -> Bool) {
-        // TODO: RUMM-292
+        for (itemKey, itemValue) in baggageItems.all {
+            if callback(itemKey, itemValue) {
+                break
+            }
+        }
+    }
+}
+
+/// Baggage items are used to propagate span information from parent to child. This propagation is
+/// unidirectional and recursive, so the grandchild of a span `A` will contain the `A's` baggage items,
+/// but `A` won't contain items of its descendants.
+internal class BaggageItems {
+    /// Queue used to synchronize `unsafeItems` access.
+    private let queue: DispatchQueue
+    /// Baggage items of the parent `DDSpan` or`nil` for items of the root span.
+    private let parent: BaggageItems?
+
+    /// Unsynchronized baggage items dictionary. Use `queue` to synchronize the access.
+    private var unsafeItems: [String: String] = [:]
+
+    init(queue: DispatchQueue, parentSpanItems: BaggageItems?) {
+        self.queue = queue
+        self.parent = parentSpanItems
+    }
+
+    func set(key: String, value: String) {
+        queue.async { self.unsafeItems[key] = value }
+    }
+
+    func get(key: String) -> String? {
+        queue.sync { self.unsafeItems[key] }
+    }
+
+    var all: [String: String] {
+        queue.sync { self.unsafeAll }
+    }
+
+    /// Returns all baggage items for the span, including its parent items.
+    /// This property is unsafe and should be accessed using `queue`.
+    private var unsafeAll: [String: String] {
+        let parentItems = parent?.unsafeAll ?? [:]
+        let selfItems = unsafeItems
+
+        let allItems = parentItems.merging(selfItems) { _, selfItem -> String in
+            return selfItem
+        }
+
+        return allItems
     }
 }

--- a/Sources/Datadog/Tracing/DDSpanContext.swift
+++ b/Sources/Datadog/Tracing/DDSpanContext.swift
@@ -40,8 +40,8 @@ internal class BaggageItems {
     /// Unsynchronized baggage items dictionary. Use `queue` to synchronize the access.
     private var unsafeItems: [String: String] = [:]
 
-    init(queue: DispatchQueue, parentSpanItems: BaggageItems?) {
-        self.queue = queue
+    init(targetQueue: DispatchQueue, parentSpanItems: BaggageItems?) {
+        self.queue = DispatchQueue(label: "com.datadoghq.BaggageItem", target: targetQueue)
         self.parent = parentSpanItems
     }
 

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -87,6 +87,9 @@ class TracingIntegrationTests: IntegrationTests {
             XCTAssertEqual(try matcher.meta.tracerVersion().split(separator: ".").count, 3)
             XCTAssertEqual(try matcher.meta.applicationVersion(), "1.0")
 
+            // assert baggage item:
+            XCTAssertEqual(try matcher.meta.custom(keyPath: "meta.class"), "SendTracesFixtureViewController")
+
             XCTAssertTrue(
                 SpanMatcher.allowedNetworkReachabilityValues.contains(
                     try matcher.meta.networkReachability()

--- a/Tests/DatadogTests/Datadog/DDTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/DDTracerTests.swift
@@ -143,7 +143,7 @@ class DDTracerTests: XCTestCase {
         XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.tag2"), "123")
     }
 
-    func testSendingSpanWithParent() throws {
+    func testSendingSpanWithParentAndBaggageItems() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWorkingFeatureWith(
             server: server,
@@ -156,6 +156,13 @@ class DDTracerTests: XCTestCase {
         let rootSpan = tracer.startSpan(operationName: "root operation")
         let childSpan = tracer.startSpan(operationName: "child operation", childOf: rootSpan.context)
         let grandchildSpan = tracer.startSpan(operationName: "grandchild operation", childOf: childSpan.context)
+        rootSpan.setBaggageItem(key: "root-item", value: "foo")
+        childSpan.setBaggageItem(key: "child-item", value: "bar")
+        grandchildSpan.setBaggageItem(key: "grandchild-item", value: "bizz")
+
+        grandchildSpan.setTag(key: "overwritten", value: "b") // This value "b" coming from a tag...
+        grandchildSpan.setBaggageItem(key: "overwritten", value: "a") // ... should overwrite this "a" coming from the baggage item.
+
         grandchildSpan.finish()
         childSpan.finish()
         rootSpan.finish()
@@ -171,15 +178,26 @@ class DDTracerTests: XCTestCase {
         XCTAssertEqual(try grandchildMatcher.traceID(), rootSpan.context.dd.traceID.toHexadecimalString)
         XCTAssertEqual(try grandchildMatcher.parentSpanID(), childSpan.context.dd.spanID.toHexadecimalString)
         XCTAssertNil(try? grandchildMatcher.metrics.isRootSpan())
+        XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.root-item"), "foo")
+        XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.child-item"), "bar")
+        XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.grandchild-item"), "bizz")
+        XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.grandchild-item"), "bizz")
+        XCTAssertEqual(try grandchildMatcher.meta.custom(keyPath: "meta.overwritten"), "b", "Tags should have higher priority than baggage items")
 
         XCTAssertEqual(try childMatcher.operationName(), "child operation")
         XCTAssertEqual(try childMatcher.traceID(), rootSpan.context.dd.traceID.toHexadecimalString)
         XCTAssertEqual(try childMatcher.parentSpanID(), rootSpan.context.dd.spanID.toHexadecimalString)
         XCTAssertNil(try? childMatcher.metrics.isRootSpan())
+        XCTAssertEqual(try childMatcher.meta.custom(keyPath: "meta.root-item"), "foo")
+        XCTAssertEqual(try childMatcher.meta.custom(keyPath: "meta.child-item"), "bar")
+        XCTAssertNil(try? childMatcher.meta.custom(keyPath: "meta.grandchild-item"))
 
         XCTAssertEqual(try rootMatcher.operationName(), "root operation")
         XCTAssertEqual(try rootMatcher.parentSpanID(), "0")
         XCTAssertEqual(try rootMatcher.metrics.isRootSpan(), 1)
+        XCTAssertEqual(try rootMatcher.meta.custom(keyPath: "meta.root-item"), "foo")
+        XCTAssertNil(try? rootMatcher.meta.custom(keyPath: "meta.child-item"))
+        XCTAssertNil(try? rootMatcher.meta.custom(keyPath: "meta.grandchild-item"))
 
         // Assert timing constraints
 
@@ -491,7 +509,7 @@ class DDTracerTests: XCTestCase {
 
     func testItInjectsSpanContextIntoHTTPHeadersWriter() {
         let tracer: DDTracer = .mockAny()
-        let spanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: .mockAny())
+        let spanContext = DDSpanContext(traceID: 1, spanID: 2, parentSpanID: .mockAny(), baggageItems: .mockAny())
 
         let httpHeadersWriter = DDHTTPHeadersWriter()
         XCTAssertEqual(httpHeadersWriter.tracePropagationHTTPHeaders, [:])

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -88,12 +88,23 @@ extension DDSpanContext {
     static func mockWith(
         traceID: TracingUUID = .mockAny(),
         spanID: TracingUUID = .mockAny(),
-        parentSpanID: TracingUUID? = .mockAny()
+        parentSpanID: TracingUUID? = .mockAny(),
+        baggageItems: BaggageItems = .mockAny()
     ) -> DDSpanContext {
         return DDSpanContext(
             traceID: traceID,
             spanID: spanID,
-            parentSpanID: parentSpanID
+            parentSpanID: parentSpanID,
+            baggageItems: baggageItems
+        )
+    }
+}
+
+extension BaggageItems {
+    static func mockAny() -> BaggageItems {
+        return BaggageItems(
+            queue: DispatchQueue(label: "com.datadoghq.baggage-items"),
+            parentSpanItems: nil
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -103,7 +103,7 @@ extension DDSpanContext {
 extension BaggageItems {
     static func mockAny() -> BaggageItems {
         return BaggageItems(
-            queue: DispatchQueue(label: "com.datadoghq.baggage-items"),
+            targetQueue: DispatchQueue(label: "com.datadoghq.baggage-items"),
             parentSpanItems: nil
         )
     }

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanContextTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanContextTests.swift
@@ -11,7 +11,7 @@ class DDSpanContextTests: XCTestCase {
     private let queue = DispatchQueue(label: "com.datadoghq.\(#file)")
 
     func testIteratingOverBaggageItems() {
-        let baggageItems = BaggageItems(queue: queue, parentSpanItems: nil)
+        let baggageItems = BaggageItems(targetQueue: queue, parentSpanItems: nil)
         baggageItems.set(key: "k1", value: "v1")
         baggageItems.set(key: "k2", value: "v2")
         baggageItems.set(key: "k3", value: "v3")
@@ -38,8 +38,8 @@ class DDSpanContextTests: XCTestCase {
     }
 
     func testChildItemsOverwriteTheParentItems() {
-        let parentBaggageItems = BaggageItems(queue: queue, parentSpanItems: nil)
-        let childBaggageItems = BaggageItems(queue: queue, parentSpanItems: parentBaggageItems)
+        let parentBaggageItems = BaggageItems(targetQueue: queue, parentSpanItems: nil)
+        let childBaggageItems = BaggageItems(targetQueue: queue, parentSpanItems: parentBaggageItems)
 
         parentBaggageItems.set(key: "foo", value: "a")
         XCTAssertEqual(parentBaggageItems.all["foo"], "a")

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanContextTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanContextTests.swift
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class DDSpanContextTests: XCTestCase {
+    private let queue = DispatchQueue(label: "com.datadoghq.\(#file)")
+
+    func testIteratingOverBaggageItems() {
+        let baggageItems = BaggageItems(queue: queue, parentSpanItems: nil)
+        baggageItems.set(key: "k1", value: "v1")
+        baggageItems.set(key: "k2", value: "v2")
+        baggageItems.set(key: "k3", value: "v3")
+        baggageItems.set(key: "k4", value: "v4")
+
+        let context: DDSpanContext = .mockWith(baggageItems: baggageItems)
+
+        var allItems: [String: String] = [:]
+        var someItems: [String: String] = [:]
+
+        context.forEachBaggageItem { itemKey, itemValue -> Bool in
+            allItems[itemKey] = itemValue
+            return false // never stop the iteration
+        }
+        context.forEachBaggageItem { itemKey, itemValue -> Bool in
+            someItems[itemKey] = itemValue
+            return itemKey == "k2" || itemKey == "k3" // stop the iteration at `k2` or `k3`, whichever comes first
+        }
+
+        let expectedAllItems = ["k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"]
+        XCTAssertEqual(allItems, expectedAllItems)
+        XCTAssertLessThan(someItems.count, expectedAllItems.count)
+        XCTAssertTrue(Set(someItems.keys).isSubset(of: expectedAllItems.keys))
+    }
+
+    func testChildItemsOverwriteTheParentItems() {
+        let parentBaggageItems = BaggageItems(queue: queue, parentSpanItems: nil)
+        let childBaggageItems = BaggageItems(queue: queue, parentSpanItems: parentBaggageItems)
+
+        parentBaggageItems.set(key: "foo", value: "a")
+        XCTAssertEqual(parentBaggageItems.all["foo"], "a")
+        XCTAssertEqual(childBaggageItems.all["foo"], "a")
+
+        childBaggageItems.set(key: "foo", value: "b")
+        XCTAssertEqual(parentBaggageItems.all["foo"], "a")
+        XCTAssertEqual(childBaggageItems.all["foo"], "b")
+    }
+}

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
@@ -33,7 +33,7 @@ class DDSpanTests: XCTestCase {
     func testSettingBaggageItems() {
         let queue = DispatchQueue(label: "com.datadoghq.\(#function)")
         let span: DDSpan = .mockWith(
-            context: .mockWith(baggageItems: BaggageItems(queue: queue, parentSpanItems: nil))
+            context: .mockWith(baggageItems: BaggageItems(targetQueue: queue, parentSpanItems: nil))
         )
 
         XCTAssertEqual(span.ddContext.baggageItems.all, [:])

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
@@ -14,6 +14,8 @@ class DDSpanTests: XCTestCase {
         XCTAssertEqual(span.operationName, "new")
     }
 
+    // MARK: - Tags
+
     func testSettingTag() {
         let span: DDSpan = .mockWith(operationName: "operation")
         XCTAssertEqual(span.tags.count, 0)
@@ -26,7 +28,27 @@ class DDSpanTests: XCTestCase {
         XCTAssertEqual(span.tags["key2"] as? String, "value2")
     }
 
-    func testCallingMethodsOnSpanInstanceAfterItIsFinished() {
+    // MARK: - Baggage Items
+
+    func testSettingBaggageItems() {
+        let queue = DispatchQueue(label: "com.datadoghq.\(#function)")
+        let span: DDSpan = .mockWith(
+            context: .mockWith(baggageItems: BaggageItems(queue: queue, parentSpanItems: nil))
+        )
+
+        XCTAssertEqual(span.ddContext.baggageItems.all, [:])
+
+        span.setBaggageItem(key: "foo", value: "bar")
+        span.setBaggageItem(key: "bizz", value: "buzz")
+
+        XCTAssertEqual(span.baggageItem(withKey: "foo"), "bar")
+        XCTAssertEqual(span.baggageItem(withKey: "bizz"), "buzz")
+        XCTAssertEqual(span.ddContext.baggageItems.all, ["foo": "bar", "bizz": "buzz"])
+    }
+
+    // MARK: - Usage
+
+    func testGivenFinishedSpan_whenCallingItsAPI_itPrintsErrors() {
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }
 


### PR DESCRIPTION
### What and why?

📦 This PR adds implementation to following Open Tracing interfaces:
```swift
// OpenTracing

public protocol Span {
    func setBaggageItem(key: String, value: String)
    func baggageItem(withKey key: String) -> String?
}

public protocol SpanContext {
    func forEachBaggageItem(callback: (_ key: String, _ value: String) -> Bool)
}
```

### How?

The baggage item can be set on `span`:
```swift
span.setBaggageItem(key: "foo", value: "bar")
```
and will be propagated to all it's descendants spans, so given this:
```swift
let childSpan = tracer.startSpan(operationName: ..., childOf: span.context)
let grandchildSpan = tracer.startSpan(operationName: ..., childOf: childSpan.context)
```
both, `childSpan` and `grandchildSpan` will contain the `"foo" : "bar"` baggage item.

Internally, baggage items are encoded as tags, giving tags higher priority when keys are conflicted.

### Example
Here, the `"class": "SendTracesFixtureViewController"` baggage item was set on the "view_appearing" span, but is also available on "data_downloading":

<img width="1096" alt="Screenshot 2020-06-17 at 15 56 11" src="https://user-images.githubusercontent.com/2358722/84908925-5fbccf80-b0b5-11ea-8c90-ede36a8fb25c.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
