### PR TITLE
RUMM-492 Encode log levels as lowercase strings

### DIFF
--- a/Sources/Datadog/Logging/Log/LogEncoder.swift
+++ b/Sources/Datadog/Logging/Log/LogEncoder.swift
@@ -9,12 +9,12 @@ import Foundation
 /// `Encodable` representation of log. It gets sanitized before encoding.
 internal struct Log: Encodable {
     enum Status: String, Encodable {
-        case debug = "debug"
-        case info = "info"
-        case notice = "notice"
-        case warn = "warn"
-        case error = "error"
-        case critical = "critical"
+        case debug
+        case info
+        case notice
+        case warn
+        case error
+        case critical
     }
 
     let date: Date

--- a/Sources/Datadog/Logging/Log/LogEncoder.swift
+++ b/Sources/Datadog/Logging/Log/LogEncoder.swift
@@ -9,12 +9,12 @@ import Foundation
 /// `Encodable` representation of log. It gets sanitized before encoding.
 internal struct Log: Encodable {
     enum Status: String, Encodable {
-        case debug = "DEBUG"
-        case info = "INFO"
-        case notice = "NOTICE"
-        case warn = "WARN"
-        case error = "ERROR"
-        case critical = "CRITICAL"
+        case debug = "debug"
+        case info = "info"
+        case notice = "notice"
+        case warn = "warn"
+        case error = "error"
+        case critical = "critical"
     }
 
     let date: Date

--- a/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
@@ -39,22 +39,22 @@ class LoggingIntegrationTests: IntegrationTests {
 
         XCTAssertEqual(logMatchers.count, 6)
 
-        logMatchers[0].assertStatus(equals: "DEBUG")
+        logMatchers[0].assertStatus(equals: "debug")
         logMatchers[0].assertMessage(equals: "debug message")
 
-        logMatchers[1].assertStatus(equals: "INFO")
+        logMatchers[1].assertStatus(equals: "info")
         logMatchers[1].assertMessage(equals: "info message")
 
-        logMatchers[2].assertStatus(equals: "NOTICE")
+        logMatchers[2].assertStatus(equals: "notice")
         logMatchers[2].assertMessage(equals: "notice message")
 
-        logMatchers[3].assertStatus(equals: "WARN")
+        logMatchers[3].assertStatus(equals: "warn")
         logMatchers[3].assertMessage(equals: "warn message")
 
-        logMatchers[4].assertStatus(equals: "ERROR")
+        logMatchers[4].assertStatus(equals: "error")
         logMatchers[4].assertMessage(equals: "error message")
 
-        logMatchers[5].assertStatus(equals: "CRITICAL")
+        logMatchers[5].assertStatus(equals: "critical")
         logMatchers[5].assertMessage(equals: "critical message")
 
         logMatchers.forEach { matcher in

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -130,7 +130,7 @@ class TracingIntegrationTests: IntegrationTests {
 
         XCTAssertEqual(logMatchers.count, 1)
 
-        logMatchers[0].assertStatus(equals: "INFO")
+        logMatchers[0].assertStatus(equals: "info")
         logMatchers[0].assertMessage(equals: "download progress")
         logMatchers[0].assertValue(forKey: "progress", equals: 0.99)
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -46,7 +46,7 @@ class LoggerTests: XCTestCase {
         let logMatcher = try server.waitAndReturnLogMatchers(count: 1)[0]
         try logMatcher.assertItFullyMatches(jsonString: """
         {
-          "status" : "DEBUG",
+          "status" : "debug",
           "message" : "message",
           "service" : "default-service-name",
           "logger.name" : "com.datadoghq.ios-sdk",
@@ -133,12 +133,12 @@ class LoggerTests: XCTestCase {
         logger.critical("message")
 
         let logMatchers = try server.waitAndReturnLogMatchers(count: 6)
-        logMatchers[0].assertStatus(equals: "DEBUG")
-        logMatchers[1].assertStatus(equals: "INFO")
-        logMatchers[2].assertStatus(equals: "NOTICE")
-        logMatchers[3].assertStatus(equals: "WARN")
-        logMatchers[4].assertStatus(equals: "ERROR")
-        logMatchers[5].assertStatus(equals: "CRITICAL")
+        logMatchers[0].assertStatus(equals: "debug")
+        logMatchers[1].assertStatus(equals: "info")
+        logMatchers[2].assertStatus(equals: "notice")
+        logMatchers[3].assertStatus(equals: "warn")
+        logMatchers[4].assertStatus(equals: "error")
+        logMatchers[5].assertStatus(equals: "critical")
     }
 
     // MARK: - Sending user info

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -63,12 +63,12 @@ class DDLoggerTests: XCTestCase {
         objcLogger.critical("message")
 
         let logMatchers = try server.waitAndReturnLogMatchers(count: 6)
-        logMatchers[0].assertStatus(equals: "DEBUG")
-        logMatchers[1].assertStatus(equals: "INFO")
-        logMatchers[2].assertStatus(equals: "NOTICE")
-        logMatchers[3].assertStatus(equals: "WARN")
-        logMatchers[4].assertStatus(equals: "ERROR")
-        logMatchers[5].assertStatus(equals: "CRITICAL")
+        logMatchers[0].assertStatus(equals: "debug")
+        logMatchers[1].assertStatus(equals: "info")
+        logMatchers[2].assertStatus(equals: "notice")
+        logMatchers[3].assertStatus(equals: "warn")
+        logMatchers[4].assertStatus(equals: "error")
+        logMatchers[5].assertStatus(equals: "critical")
     }
 
     // MARK: - Sending attributes


### PR DESCRIPTION
### What and why?

📦 With this PR and its counterpart DataDog/dd-sdk-android#288, we're changing log levels send from mobile SDKs to be lowercased strings.

### How?

Internal change to `LogEncoder` and appropriate tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
