### PR TITLE
RUMM-486 Run CI tests on all supported iOS versions

### DIFF
--- a/tools/all-platform-tests/bitrise-test-all-platforms.yml
+++ b/tools/all-platform-tests/bitrise-test-all-platforms.yml
@@ -1,0 +1,149 @@
+---
+format_version: '8'
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+project_type: other
+
+# Stack specification:
+# https://github.com/bitrise-io/bitrise.io/blob/master/system_reports/osx-xcode-11.5.x.log
+#
+# This stack is configured for the `trigger_all_platform_tests` workflow
+# defined in Workflow Editor on Bitrise.io
+#
+# To properly use this stack, environment variables need to be picked up carefully:
+# - SIMULATOR_DEVICE - pick one listed in `== Device Types ==`
+# - SIMULATOR_OS_VERSION - pick one listed in `== Runtimes ==`
+
+app:
+  envs:
+  - PROJECT_PATH: Datadog.xcworkspace
+  - PROJECT_SCHEME: Datadog
+
+workflows:
+  run_all:
+    after_run:
+    - _make_dependencies
+    - _run_unit_tests_iOS12.0
+    - _run_unit_tests_iOS12.1
+    - _run_unit_tests_iOS12.2
+    - _run_unit_tests_iOS12.4
+    - _run_unit_tests_iOS13.0
+    - _run_unit_tests_iOS13.1
+    - _run_unit_tests_iOS13.2
+    - _run_unit_tests_iOS13.3
+    - _run_unit_tests_iOS13.4
+    - _run_unit_tests_iOS13.5
+    - _deploy_artifacts
+
+  # Platform-specific workflows:
+
+  _run_unit_tests_iOS12.0:
+    envs:
+    - SIMULATOR_DEVICE: iPhone X
+    - SIMULATOR_OS_VERSION: '12.0'
+    after_run:
+    - _run_unit_tests
+
+  _run_unit_tests_iOS12.1:
+    envs:
+    - SIMULATOR_DEVICE: iPhone X
+    - SIMULATOR_OS_VERSION: '12.1'
+    after_run:
+    - _run_unit_tests
+
+  _run_unit_tests_iOS12.2:
+    envs:
+    - SIMULATOR_DEVICE: iPhone X
+    - SIMULATOR_OS_VERSION: '12.2'
+    after_run:
+    - _run_unit_tests
+
+  _run_unit_tests_iOS12.4:
+    envs:
+    - SIMULATOR_DEVICE: iPhone X
+    - SIMULATOR_OS_VERSION: '12.4'
+    after_run:
+    - _run_unit_tests
+
+  _run_unit_tests_iOS13.0:
+    envs:
+    - SIMULATOR_DEVICE: iPhone 11
+    - SIMULATOR_OS_VERSION: '13.0'
+    after_run:
+    - _run_unit_tests
+
+  _run_unit_tests_iOS13.1:
+    envs:
+    - SIMULATOR_DEVICE: iPhone 11
+    - SIMULATOR_OS_VERSION: '13.1'
+    after_run:
+    - _run_unit_tests
+
+  _run_unit_tests_iOS13.2:
+    envs:
+    - SIMULATOR_DEVICE: iPhone 11
+    - SIMULATOR_OS_VERSION: '13.2'
+    after_run:
+    - _run_unit_tests
+
+  _run_unit_tests_iOS13.3:
+    envs:
+    - SIMULATOR_DEVICE: iPhone 11
+    - SIMULATOR_OS_VERSION: '13.3'
+    after_run:
+    - _run_unit_tests
+
+  _run_unit_tests_iOS13.4:
+    envs:
+    - SIMULATOR_DEVICE: iPhone 11
+    - SIMULATOR_OS_VERSION: '13.4'
+    after_run:
+    - _run_unit_tests
+
+  _run_unit_tests_iOS13.5:
+    envs:
+    - SIMULATOR_DEVICE: iPhone 11
+    - SIMULATOR_OS_VERSION: '13.5'
+    after_run:
+    - _run_unit_tests
+
+  # Platform-agnostic workflows:
+
+  _make_dependencies:
+    description: |-
+        Does `make dependencies` to prepare source code in repo for building and testing.
+    steps:
+    - script@1.1.6:
+        title: Do `make dependencies`.
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make dependencies
+
+  _deploy_artifacts:
+    description: |-
+        Uploads artifacts to associate them with build log on Bitrise.io.
+    steps:
+    - deploy-to-bitrise-io: {}
+
+  _run_unit_tests:
+    steps:
+    - script@1.1.6:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            echo "+------------------------------------------------------------------------------+"
+            printf '| %-78s |\n' "🧪 Runing unit tests for ${PROJECT_SCHEME} on ${SIMULATOR_DEVICE} (${SIMULATOR_OS_VERSION})"
+            echo "+------------------------------------------------------------------------------+"
+    - xcode-test@2.4.5:
+        title: Run unit tests for given platform
+        is_always_run: true # continue next tests if some failed
+        inputs:
+        - project_path: $PROJECT_PATH
+        - scheme: $PROJECT_SCHEME
+        - simulator_device: $SIMULATOR_DEVICE
+        - simulator_os_version: $SIMULATOR_OS_VERSION
+        - is_clean_build: 'no'
+        - should_retry_test_on_fail: 'yes' # retry once to mitigate flakiness
+        - generate_code_coverage_files: 'yes'
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests-${PROJECT_SCHEME}-${SIMULATOR_DEVICE} (${SIMULATOR_OS_VERSION}).html"


### PR DESCRIPTION
### What and why?

📦 This PR adds CI configuration to run tests on as many iOS versions as possible. Right now the trigger is fully manual, and a branch must be scheduled to run with `trigger_all_platform_tests` on Bitrise:

<img width="599" alt="Screenshot 2020-06-22 at 14 31 14" src="https://user-images.githubusercontent.com/2358722/85288231-b4858f00-b495-11ea-9ce6-a14e85e6c7b9.png">

The automation is a distinct thing and will come with a next PR.

### How?

I created a separate `bitrise-test-all-platforms.yml` CI configuration, which runs tests on all key `device` + `iOS version` configurations for [given Bitrise stack](https://github.com/bitrise-io/bitrise.io/blob/master/system_reports/osx-xcode-11.5.x.log).

Unfortunatelly, Bitrise comes with a limitation - we can only use devices and runtimes provided by the stack. This means, for [osx-xcode-11.5.x.log](https://github.com/bitrise-io/bitrise.io/blob/master/system_reports/osx-xcode-11.5.x.log) we can only automate:
```
iOS 12.0
iOS 12.1
iOS 12.2
iOS 12.4
iOS 13.0
iOS 13.1
iOS 13.2
iOS 13.3
iOS 13.4
iOS 13.5
```

#### Limitations

The [osx-xcode-11.5.x.log](https://github.com/bitrise-io/bitrise.io/blob/master/system_reports/osx-xcode-11.5.x.log) stack bundles `Xcode 11.5` and is missing `iOS 12.3` and all `iOS 11.x`.

The highest stack which provides `iOS 11.x` is [osx-xcode-11.3.x.log](https://github.com/bitrise-io/bitrise.io/blob/master/system_reports/osx-xcode-11.3.x.log), but this comes with `Xcode 11.3`, which uses the `iphoneSDK` version not compatible with our codebase:

<img width="1135" alt="Screenshot 2020-06-19 at 17 47 50" src="https://user-images.githubusercontent.com/2358722/85288920-de8b8100-b496-11ea-846c-d1b7aa5c9425.png">

This could be overcome with conditional code compilation. However, given that the market penetration of `iOS 11.0` is very low ([unknown in official report](https://developer.apple.com/support/app-store/), [negligible in 3rd party reports](https://david-smith.org/iosversionstats/)), struggling with compiler checks on daily basis is IMO not worth it. We can run `iOS 11` tests locally for key features.

Another workaround would be to download necessary simulators, but Bitrise doesn't expose such API and their [answer is "use what's available or change the stack"](https://discuss.bitrise.io/t/xcode-10-stack-does-not-include-ios-9-3/6262).

#### Execution

The whole job takes ~20 minutes to run unit tests on given 10 versions of `iOS`:

<img width="1505" alt="Screenshot 2020-06-22 at 14 58 14" src="https://user-images.githubusercontent.com/2358722/85290146-d03e6480-b498-11ea-800e-c8b7f00c4764.png">

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
