### PR TITLE
RUMM-541 Fix: URLSessionSwizzler in iOS11/12

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
@@ -63,17 +63,6 @@
                BlueprintName = "DatadogTests"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "URLSessionSwizzlerTests/test_dataTask_urlCompletion_alwaysIntercept()">
-               </Test>
-               <Test
-                  Identifier = "URLSessionSwizzlerTests_CustomDelegate/test_dataTask_urlCompletion_alwaysIntercept()">
-               </Test>
-               <Test
-                  Identifier = "URLSessionSwizzlerTests_DefaultConfig/test_dataTask_urlCompletion_alwaysIntercept()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Sources/Datadog/Core/AutoInstrumentation/MethodSwizzler.swift
+++ b/Sources/Datadog/Core/AutoInstrumentation/MethodSwizzler.swift
@@ -35,7 +35,7 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
         return Array(implementationCache.keys)
     }
 
-    init() throws {
+    init() {
         self.implementationCache = [:]
     }
 

--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/MethodSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/MethodSwizzlerTests.swift
@@ -36,7 +36,7 @@ class MethodSwizzlerTests: XCTestCase {
     private let newIMPReturnString: TypedBlockIMPReturnString = { _ in String.mockAny() }
 
     private typealias Swizzler = MethodSwizzler<TypedIMPReturnString, TypedBlockIMPReturnString>
-    private let swizzler = try! Swizzler()
+    private let swizzler = Swizzler()
 
     override func tearDown() {
         super.tearDown()

--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -61,7 +61,11 @@ class URLSessionSwizzlerTests: XCTestCase {
 
         let taskRequest = task.originalRequest!
         XCTAssertEqual(taskRequest.url, mockURL)
-        XCTAssertNil(taskRequest.allHTTPHeaderFields)
+        if #available(iOS 13.0, *) {
+            XCTAssertNil(taskRequest.allHTTPHeaderFields)
+        } else {
+            XCTAssertEqual(taskRequest.allHTTPHeaderFields, modifiedHTTPHeaders + secondModifiedHTTPHeaders)
+        }
 
         wait(
             for: [
@@ -197,7 +201,7 @@ private extension Dictionary where Key == String, Value == String {
         return lhs.merging(rhs) { lhsKey, _ in return lhsKey }
     }
 }
-private extension URLSessionSwizzler {
+extension URLSessionSwizzler {
     func unswizzle() {
         dataTaskWithURL.unswizzle()
         dataTaskwithRequest.unswizzle()


### PR DESCRIPTION
### What and why?

We swizzle `dataTaskWithURL` and `dataTaskWithRequest` as part of auto-instrumentation. 
iOS 11/12 calls `dataTaskWithRequest` FROM `dataTaskWithURL`, that leads to duplicate execution of our swizzled implementation.

This case was not handled ❌ 

### How?

This PR contains 
1. the fix for the problem
2. also some minor refactoring based on https://github.com/DataDog/dd-sdk-ios/pull/139

#### Fix

We didn't need any change in `dataTaskWithRequest` implementation.
Now, in `dataTaskWithURL`, after creating the `task` object we check if `task.originalRequest` has interception headers.
If it has then that means **the task is already intercepted and we should not intercept it once again.**

```swift
/// dataTaskWithURL
let task = currentTypedImp(impSelf, Self.selector, impURL, modifiedCompletion)
if var request = task.originalRequest,
    request.add(newHTTPHeaders: interceptionResult.httpHeaders) {
    /// request.add(...) succeeded -> interception needed
    swizzleResumeAndAddPayload()
} else {
    /// do NOT intercept!
    doNothing()
}
return task
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
