### PR TITLE
RMM-500 Bump sdk version to `1.3.0-beta1`

### DIFF
--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
   s.module_name  = "Datadog"
-  s.version      = "1.2.2"
+  s.version      = "1.3.0-beta1"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKObjc"
   s.module_name  = "DatadogObjc"
-  s.version      = "1.2.2"
+  s.version      = "1.3.0-beta1"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// SDK version associated with logs.
 /// Should be synced with SDK releases.
-internal let sdkVersion = "1.2.2-tracing-alpha2"
+internal let sdkVersion = "1.3.0-beta1"
 
 /// Datadog SDK configuration object.
 public class Datadog {


### PR DESCRIPTION
### What and why?

📦 This PR bumps the SDK version to `1.3.0-beta1` so we can release tracing `-beta1`.

### How?

I bumped both `sdkVersion` and `.podspecs`, although `.podspecs` won't be pushed to `pod trunk` until it's official `1.3.0`. Also, I'm going to create a `pre-release` tag.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
