### PR TITLE
RUMM-500 Fix pod installation snippet

### DIFF
--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -19,7 +19,7 @@ Send [traces][1] to Datadog from your iOS applications with [Datadog's `dd-sdk-i
 You can use [CocoaPods][4] to install `dd-sdk-ios` and `opentracing-swift`:
 ```
 pod 'OpenTracingSwift', :git => 'https://github.com/DataDog/opentracing-swift'
-pod 'DatadogSDK'
+pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.3.0-beta1'
 ```
 
 [4]: https://cocoapods.org/


### PR DESCRIPTION
### What and why?

📦 Until our contribution in  https://github.com/opentracing/opentracing-swift/pull/11 is considered OR we go with another `.podspec` for our [OT fork](https://github.com/DataDog/opentracing-swift), the classic `pod DatadogSDK` installation will not work. We need a workaround.

### How?

The workaround is to reference `OpenTracingSwift` and `DatadogSDK` using `git` + `tag` syntax in `Podfile`.

@DataDog/documentation - it's purely technical update, nothing to review 🙂.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
