### PR TITLE
RUMM-486 Fix `FileHandle` crash on iOS 13.0-13.3

### DIFF
--- a/Sources/Datadog/Core/Persistence/Files/File.swift
+++ b/Sources/Datadog/Core/Persistence/Files/File.swift
@@ -46,7 +46,18 @@ internal struct File: WritableFile, ReadableFile {
     func append(data: Data) throws {
         let fileHandle = try FileHandle(forWritingTo: url)
 
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.4, *) {
+            /**
+             Even though the `fileHandle.seekToEnd()` should be available since iOS 13.0:
+             ```
+             @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+             public func seekToEnd() throws -> UInt64
+             ```
+             it crashes on iOS Simulators prior to iOS 13.4:
+             ```
+             Symbol not found: _$sSo12NSFileHandleC10FoundationE9seekToEnds6UInt64VyKF
+             ```
+            */
             defer { try? fileHandle.close() }
             try fileHandle.seekToEnd()
             try fileHandle.write(contentsOf: data)
@@ -67,7 +78,18 @@ internal struct File: WritableFile, ReadableFile {
     func read() throws -> Data {
         let fileHandle = try FileHandle(forReadingFrom: url)
 
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.4, *) {
+            /**
+             Even though the `fileHandle.seekToEnd()` should be available since iOS 13.0:
+             ```
+             @available(OSX 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+             public func readToEnd() throws -> Data?
+             ```
+             it crashes on iOS Simulators prior to iOS 13.4:
+             ```
+             Symbol not found: _$sSo12NSFileHandleC10FoundationE9readToEndAC4DataVSgyKF
+             ```
+            */
             defer { try? fileHandle.close() }
             return try fileHandle.readToEnd() ?? Data()
         } else {


### PR DESCRIPTION
### What and why?

📦 The new `FileHandle` throwing API crashes on `iOS 13.0`, `13.1`, `13.2` and `13.3`.

### How?

Even though the [documentation says](https://developer.apple.com/documentation/foundation/filehandle/3516319-seektoend) some of the new `FileHandle` throwing APIs should be available since `iOS 13.0`, they are crashing on versions prior to `13.4`, e.g.:
```
Symbol not found: _$sSo12NSFileHandleC10FoundationE9seekToEnds6UInt64VyKF
Symbol not found: _$sSo12NSFileHandleC10FoundationE9readToEndAC4DataVSgyKF
```

In this PR, I roll back to using the old APIs on versions prior to `13.4`.

I filled a bug report to Apple. 
Radar: https://openradar.appspot.com/radar?id=4998297672482816

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
