### PR TITLE
RUMM-339 Expose tracing-related configuration for Objective-C

### DIFF
--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -23,6 +23,21 @@ public class DDLogsEndpoint: NSObject {
 }
 
 @objcMembers
+public class DDTracesEndpoint: NSObject {
+    internal let sdkEndpoint: Datadog.Configuration.TracesEndpoint
+
+    internal init(sdkEndpoint: Datadog.Configuration.TracesEndpoint) {
+        self.sdkEndpoint = sdkEndpoint
+    }
+
+    // MARK: - Public
+
+    public static func eu() -> DDTracesEndpoint { .init(sdkEndpoint: .eu) }
+    public static func us() -> DDTracesEndpoint { .init(sdkEndpoint: .us) }
+    public static func custom(url: String) -> DDTracesEndpoint { .init(sdkEndpoint: .custom(url: url)) }
+}
+
+@objcMembers
 public class DDConfiguration: NSObject {
     internal let sdkConfiguration: Datadog.Configuration
 
@@ -49,8 +64,25 @@ public class DDConfigurationBuilder: NSObject {
 
     // MARK: - Public
 
+    @available(*, deprecated, renamed: "set(logsEndpoint:)")
     public func set(endpoint: DDLogsEndpoint) {
-        _ = sdkBuilder.set(logsEndpoint: endpoint.sdkEndpoint)
+        set(logsEndpoint: endpoint)
+    }
+
+    public func enableLogging(_ enabled: Bool) {
+        _ = sdkBuilder.enableLogging(enabled)
+    }
+
+    public func enableTracing(_ enabled: Bool) {
+        _ = sdkBuilder.enableTracing(enabled)
+    }
+
+    public func set(logsEndpoint: DDLogsEndpoint) {
+        _ = sdkBuilder.set(logsEndpoint: logsEndpoint.sdkEndpoint)
+    }
+
+    public func set(tracesEndpoint: DDTracesEndpoint) {
+        _ = sdkBuilder.set(tracesEndpoint: tracesEndpoint.sdkEndpoint)
     }
 
     public func set(serviceName: String) {

--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -106,7 +106,7 @@ class URLSessionSwizzlerTests: XCTestCase {
                 mock2.interceptionExpectation,
                 mock3.interceptionExpectation
             ],
-            timeout: 1
+            timeout: 2
         )
 
         task.resume()
@@ -120,7 +120,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         ]
         wait(
             for: resumeExpectations,
-            timeout: 1,
+            timeout: 2,
             enforceOrder: true
         )
     }

--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -106,7 +106,7 @@ class URLSessionSwizzlerTests: XCTestCase {
                 mock2.interceptionExpectation,
                 mock3.interceptionExpectation
             ],
-            timeout: 2
+            timeout: 1
         )
 
         task.resume()
@@ -120,7 +120,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         ]
         wait(
             for: resumeExpectations,
-            timeout: 2,
+            timeout: 1,
             enforceOrder: true
         )
     }


### PR DESCRIPTION
### What and why?

🚚 This PR exposes new tracing configuration APIs to Objective-C.

### How?

Two APIs were exposed using our way of Objective-C → Swift bridging:
```swift
.enableTracing(_ enabled:)
.set(tracesEndpoint:)
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
