### PR TITLE
RUMM-478 Skip sanitization of log attributes created by Tracing

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcbaselines/61441C6724619FE4003D8BB8.xcbaseline/7C373BCE-2B91-4706-AD99-F9FD342891D3.plist
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcbaselines/61441C6724619FE4003D8BB8.xcbaseline/7C373BCE-2B91-4706-AD99-F9FD342891D3.plist
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>LoggingBenchmarkTests</key>
+		<dict>
+			<key>testCreatingOneLog()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>7.45e-05</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+					<key>maxPercentRelativeStandardDeviation</key>
+					<real>30</real>
+				</dict>
+			</dict>
+			<key>testCreatingOneLogWithAttributes()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.000116</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+					<key>maxPercentRelativeStandardDeviation</key>
+					<real>30</real>
+				</dict>
+			</dict>
+			<key>testCreatingOneLogWithTags()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>7.79e-05</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+					<key>maxPercentRelativeStandardDeviation</key>
+					<real>30</real>
+				</dict>
+			</dict>
+		</dict>
+		<key>LoggingStorageBenchmarkTests</key>
+		<dict>
+			<key>testReadingLogsFromDisc()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00161</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+					<key>maxPercentRelativeStandardDeviation</key>
+					<real>30</real>
+				</dict>
+			</dict>
+			<key>testWrittingLogsOnDisc()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00487</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+					<key>maxPercentRelativeStandardDeviation</key>
+					<real>30</real>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcbaselines/61441C6724619FE4003D8BB8.xcbaseline/Info.plist
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcbaselines/61441C6724619FE4003D8BB8.xcbaseline/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>7C373BCE-2B91-4706-AD99-F9FD342891D3</key>
+		<dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone10,6</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphoneos</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sources/Datadog/FeaturesIntegration/LoggingForTracingAdapter.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingForTracingAdapter.swift
@@ -33,17 +33,15 @@ internal struct LoggingForTracingAdapter {
         )
     }
 
+    internal struct TracingAttributes {
+        static let traceID = "dd.trace_id"
+        static let spanID = "dd.span_id"
+    }
+
     /// Bridges logs created by Tracing feature to Logging feature's output.
     internal struct AdaptedLogOutput {
         private struct Constants {
             static let defaultLogMessage = "Span event"
-        }
-
-        private struct TracingAttributes {
-            static let traceID = "dd.trace_id"
-            static let spanID = "dd.span_id"
-
-            // TODO: RUMM-478 Add tracing log attributes to the list of reserved log attributes in `LogSanitizer`
         }
 
         /// Actual `LogOutput` bridged to `LoggingFeature`.

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -263,7 +263,13 @@ public class Logger {
             return self.loggerTags
         }
 
-        logOutput.writeLogWith(level: level, message: message, date: date, attributes: combinedAttributes, tags: tags)
+        logOutput.writeLogWith(
+            level: level,
+            message: message,
+            date: date,
+            attributes: LogAttributes(userAttributes: combinedAttributes, internalAttributes: nil),
+            tags: tags
+        )
     }
 
     // MARK: - Logger.Builder

--- a/Sources/Datadog/Logging/Log/LogBuilder.swift
+++ b/Sources/Datadog/Logging/Log/LogBuilder.swift
@@ -23,9 +23,9 @@ internal struct LogBuilder {
     /// Shared mobile carrier info provider (or `nil` if disabled for given logger).
     let carrierInfoProvider: CarrierInfoProviderType?
 
-    func createLogWith(level: LogLevel, message: String, date: Date, attributes: [String: Encodable], tags: Set<String>) -> Log {
+    func createLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) -> Log {
         let encodableAttributes = Dictionary(
-            uniqueKeysWithValues: attributes.map { name, value in (name, EncodableValue(value)) }
+            uniqueKeysWithValues: attributes.userAttributes.map { name, value in (name, EncodableValue(value)) }
         )
 
         return Log(

--- a/Sources/Datadog/Logging/Log/LogBuilder.swift
+++ b/Sources/Datadog/Logging/Log/LogBuilder.swift
@@ -24,10 +24,6 @@ internal struct LogBuilder {
     let carrierInfoProvider: CarrierInfoProviderType?
 
     func createLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) -> Log {
-        let encodableAttributes = Dictionary(
-            uniqueKeysWithValues: attributes.userAttributes.map { name, value in (name, EncodableValue(value)) }
-        )
-
         return Log(
             date: date,
             status: logStatus(for: level),
@@ -41,7 +37,7 @@ internal struct LogBuilder {
             userInfo: userInfoProvider.value,
             networkConnectionInfo: networkConnectionInfoProvider?.current,
             mobileCarrierInfo: carrierInfoProvider?.current,
-            attributes: !encodableAttributes.isEmpty ? encodableAttributes : nil,
+            attributes: attributes,
             tags: !tags.isEmpty ? Array(tags) : nil
         )
     }

--- a/Sources/Datadog/Logging/Log/LogSanitizer.swift
+++ b/Sources/Datadog/Logging/Log/LogSanitizer.swift
@@ -12,7 +12,10 @@ internal struct LogSanitizer {
         /// Attribute names reserved for Datadog.
         /// If any of those is used by the user, the attribute will be ignored.
         static let reservedAttributeNames: Set<String> = [
-            "host", "message", "status", "service", "source", "error.message", "error.stack", "ddtags"
+            "host", "message", "status", "service", "source", "error.message", "error.stack", "ddtags",
+            OTLogFields.errorKind,
+            LoggingForTracingAdapter.TracingAttributes.traceID,
+            LoggingForTracingAdapter.TracingAttributes.spanID,
         ]
         /// Maximum number of nested levels in attribute name. E.g. `person.address.street` has 3 levels.
         /// If attribute name exceeds this number, extra levels are escaped by using `_` character (`one.two.(...).nine.ten_eleven_twelve`).

--- a/Sources/Datadog/Logging/Log/LogSanitizer.swift
+++ b/Sources/Datadog/Logging/Log/LogSanitizer.swift
@@ -60,19 +60,22 @@ internal struct LogSanitizer {
 
     // MARK: - Attributes sanitization
 
-    private func sanitize(attributes rawAttributes: [String: EncodableValue]?) -> [String: EncodableValue]? {
-        if let rawAttributes = rawAttributes {
-            var attributes = removeInvalidAttributes(rawAttributes)
-            attributes = removeReservedAttributes(attributes)
-            attributes = sanitizeAttributeNames(attributes)
-            attributes = limitToMaxNumberOfAttributes(attributes)
-            return attributes
-        } else {
-            return nil
-        }
+    private func sanitize(attributes rawAttributes: LogAttributes) -> LogAttributes {
+        // Sanitizes only `userAttributes`, `internalAttributes` remain untouched
+        var userAttributes = rawAttributes.userAttributes
+        userAttributes = removeInvalidAttributes(userAttributes)
+        userAttributes = removeReservedAttributes(userAttributes)
+        userAttributes = sanitizeAttributeNames(userAttributes)
+        let userAttributesLimit = Constraints.maxNumberOfAttributes - (rawAttributes.internalAttributes?.count ?? 0)
+        userAttributes = limitToMaxNumberOfAttributes(userAttributes, limit: userAttributesLimit)
+
+        return LogAttributes(
+            userAttributes: userAttributes,
+            internalAttributes: rawAttributes.internalAttributes
+        )
     }
 
-    private func removeInvalidAttributes(_ attributes: [String: EncodableValue]) -> [String: EncodableValue] {
+    private func removeInvalidAttributes(_ attributes: [String: Encodable]) -> [String: Encodable] {
         // Attribute name cannot be empty
         return attributes.filter { attribute in
             if attribute.key.isEmpty {
@@ -83,7 +86,7 @@ internal struct LogSanitizer {
         }
     }
 
-    private func removeReservedAttributes(_ attributes: [String: EncodableValue]) -> [String: EncodableValue] {
+    private func removeReservedAttributes(_ attributes: [String: Encodable]) -> [String: Encodable] {
         return attributes.filter { attribute in
             if Constraints.reservedAttributeNames.contains(attribute.key) {
                 userLogger.error("'\(attribute.key)' is a reserved attribute name. This attribute will be ignored.")
@@ -93,8 +96,8 @@ internal struct LogSanitizer {
         }
     }
 
-    private func sanitizeAttributeNames(_ attributes: [String: EncodableValue]) -> [String: EncodableValue] {
-        let sanitizedAttributes: [(String, EncodableValue)] = attributes.map { name, value in
+    private func sanitizeAttributeNames(_ attributes: [String: Encodable]) -> [String: Encodable] {
+        let sanitizedAttributes: [(String, Encodable)] = attributes.map { name, value in
             let sanitizedName = sanitize(attributeName: name)
             if sanitizedName != name {
                 userLogger.error("Attribute '\(name)' was modified to '\(sanitizedName)' to match Datadog constraints.")
@@ -121,9 +124,9 @@ internal struct LogSanitizer {
         return sanitized
     }
 
-    private func limitToMaxNumberOfAttributes(_ attributes: [String: EncodableValue]) -> [String: EncodableValue] {
-        // Only `Constants.maxNumberOfAttributes` of attributes are allowed.
-        if attributes.count > Constraints.maxNumberOfAttributes {
+    private func limitToMaxNumberOfAttributes(_ attributes: [String: Encodable], limit: Int) -> [String: Encodable] {
+        // Only `limit` number of attributes are allowed.
+        if attributes.count > limit {
             let extraAttributesCount = attributes.count - Constraints.maxNumberOfAttributes
             userLogger.error("Number of attributes exceeds the limit of \(Constraints.maxNumberOfAttributes). \(extraAttributesCount) attribute(s) will be ignored.")
             return Dictionary(uniqueKeysWithValues: attributes.dropLast(extraAttributesCount))

--- a/Sources/Datadog/Logging/LogOutputs/LogConsoleOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogConsoleOutput.swift
@@ -37,7 +37,7 @@ internal struct LogConsoleOutput: LogOutput {
         self.printingFunction = printingFunction
     }
 
-    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: [String: Encodable], tags: Set<String>) {
+    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) {
         let log = logBuilder.createLogWith(level: level, message: message, date: date, attributes: attributes, tags: tags)
         printingFunction(formatter.format(log: log))
     }

--- a/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
@@ -11,7 +11,7 @@ internal struct LogFileOutput: LogOutput {
     let logBuilder: LogBuilder
     let fileWriter: FileWriter
 
-    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: [String: Encodable], tags: Set<String>) {
+    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) {
         let log = logBuilder.createLogWith(level: level, message: message, date: date, attributes: attributes, tags: tags)
         fileWriter.write(value: log)
     }

--- a/Sources/Datadog/Logging/LogOutputs/LogOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogOutput.swift
@@ -6,7 +6,14 @@
 
 import Foundation
 
+internal struct LogAttributes {
+    /// Log attributes received from the user. They are subject for sanitization.
+    let userAttributes: [String: Encodable]
+    /// Log attributes added internally by the SDK. They are not a subject for sanitization.
+    let internalAttributes: [String: Encodable]?
+}
+
 /// Type writting logs to some destination.
 internal protocol LogOutput {
-    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: [String: Encodable], tags: Set<String>)
+    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>)
 }

--- a/Sources/Datadog/Logging/LogOutputs/LogUtilityOutputs.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogUtilityOutputs.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// `LogOutput` which does nothing.
 internal struct NoOpLogOutput: LogOutput {
-    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: [String: Encodable], tags: Set<String>) {}
+    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) {}
 }
 
 /// Combines one or more `LogOutputs` into one.
@@ -19,7 +19,7 @@ internal struct CombinedLogOutput: LogOutput {
         self.combinedOutputs = outputs
     }
 
-    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: [String: Encodable], tags: Set<String>) {
+    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) {
         combinedOutputs.forEach { $0.writeLogWith(level: level, message: message, date: date, attributes: attributes, tags: tags) }
     }
 }
@@ -28,7 +28,7 @@ internal struct ConditionalLogOutput: LogOutput {
     let conditionedOutput: LogOutput
     let condition: (LogLevel) -> Bool
 
-    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: [String: Encodable], tags: Set<String>) {
+    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) {
         if condition(level) {
             conditionedOutput.writeLogWith(level: level, message: message, date: date, attributes: attributes, tags: tags)
         }

--- a/Tests/DatadogBenchmarkTests/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/LoggingStorageBenchmarkTests.swift
@@ -96,7 +96,10 @@ class LoggingStorageBenchmarkTests: XCTestCase {
                 isConstrained: false
             ),
             mobileCarrierInfo: nil,
-            attributes: ["attribute": EncodableValue("value")],
+            attributes: LogAttributes(
+                userAttributes: ["user.attribute": "value"],
+                internalAttributes: ["internal.attribute": "value"]
+            ),
             tags: ["tag:value"]
         )
     }

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/LoggingForTracingAdapterTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/LoggingForTracingAdapterTests.swift
@@ -27,11 +27,15 @@ class LoggingForTracingAdapterTests: XCTestCase {
             level: .info,
             message: "hello",
             date: .mockDecember15th2019At10AMUTC(),
-            attributes: [
-                "custom field": 123,
-                "dd.span_id": "2",
-                "dd.trace_id": "1"
-            ]
+            attributes: LogAttributes(
+                userAttributes: [
+                    "custom field": 123,
+                ],
+                internalAttributes: [
+                    "dd.span_id": "2",
+                    "dd.trace_id": "1"
+                ]
+            )
         )
 
         XCTAssertEqual(loggingOutput.recordedLog, expectedLog)
@@ -85,11 +89,15 @@ class LoggingForTracingAdapterTests: XCTestCase {
             level: .info,
             message: "Span event", // default message is used.
             date: .mockDecember15th2019At10AMUTC(),
-            attributes: [
-                "custom field": 123,
-                "dd.span_id": "2",
-                "dd.trace_id": "1"
-            ]
+            attributes: LogAttributes(
+                userAttributes: [
+                    "custom field": 123,
+                ],
+                internalAttributes: [
+                    "dd.span_id": "2",
+                    "dd.trace_id": "1"
+                ]
+            )
         )
 
         XCTAssertEqual(loggingOutput.recordedLog, expectedLog)

--- a/Tests/DatadogTests/Datadog/Logging/Log/LogBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/Log/LogBuilderTests.swift
@@ -18,7 +18,7 @@ class LogBuilderTests: XCTestCase {
             level: .debug,
             message: "debug message",
             date: .mockDecember15th2019At10AMUTC(),
-            attributes: ["attribute": "value"],
+            attributes: .mockWith(userAttributes: ["attribute": "value"]),
             tags: ["tag"]
         )
 
@@ -31,19 +31,19 @@ class LogBuilderTests: XCTestCase {
         XCTAssertEqual(log.tags, ["tag"])
         XCTAssertEqual(log.attributes, ["attribute": EncodableValue("value")])
         XCTAssertEqual(
-            builder.createLogWith(level: .info, message: "", date: .mockAny(), attributes: [:], tags: []).status, .info
+            builder.createLogWith(level: .info, message: "", date: .mockAny(), attributes: .mockAny(), tags: []).status, .info
         )
         XCTAssertEqual(
-            builder.createLogWith(level: .notice, message: "", date: .mockAny(), attributes: [:], tags: []).status, .notice
+            builder.createLogWith(level: .notice, message: "", date: .mockAny(), attributes: .mockAny(), tags: []).status, .notice
         )
         XCTAssertEqual(
-            builder.createLogWith(level: .warn, message: "", date: .mockAny(), attributes: [:], tags: []).status, .warn
+            builder.createLogWith(level: .warn, message: "", date: .mockAny(), attributes: .mockAny(), tags: []).status, .warn
         )
         XCTAssertEqual(
-            builder.createLogWith(level: .error, message: "", date: .mockAny(), attributes: [:], tags: []).status, .error
+            builder.createLogWith(level: .error, message: "", date: .mockAny(), attributes: .mockAny(), tags: []).status, .error
         )
         XCTAssertEqual(
-            builder.createLogWith(level: .critical, message: "", date: .mockAny(), attributes: [:], tags: []).status, .critical
+            builder.createLogWith(level: .critical, message: "", date: .mockAny(), attributes: .mockAny(), tags: []).status, .critical
         )
     }
 
@@ -53,13 +53,13 @@ class LogBuilderTests: XCTestCase {
         expectation.expectedFulfillmentCount = 3
 
         DispatchQueue.main.async {
-            let log = builder.createLogWith(level: .debug, message: "", date: .mockAny(), attributes: [:], tags: [])
+            let log = builder.createLogWith(level: .debug, message: "", date: .mockAny(), attributes: .mockAny(), tags: [])
             XCTAssertEqual(log.threadName, "main")
             expectation.fulfill()
         }
 
         DispatchQueue.global(qos: .default).async {
-            let log = builder.createLogWith(level: .debug, message: "", date: .mockAny(), attributes: [:], tags: [])
+            let log = builder.createLogWith(level: .debug, message: "", date: .mockAny(), attributes: .mockAny(), tags: [])
             XCTAssertEqual(log.threadName, "background")
             expectation.fulfill()
         }
@@ -69,7 +69,7 @@ class LogBuilderTests: XCTestCase {
             defer { Thread.current.name = previousName } // reset it as this thread might be picked by `.global(qos: .default)`
 
             Thread.current.name = "custom-thread-name"
-            let log = builder.createLogWith(level: .debug, message: "", date: .mockAny(), attributes: [:], tags: [])
+            let log = builder.createLogWith(level: .debug, message: "", date: .mockAny(), attributes: .mockAny(), tags: [])
             XCTAssertEqual(log.threadName, "custom-thread-name")
             expectation.fulfill()
         }

--- a/Tests/DatadogTests/Datadog/Logging/Log/LogBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/Log/LogBuilderTests.swift
@@ -29,7 +29,7 @@ class LogBuilderTests: XCTestCase {
         XCTAssertEqual(log.serviceName, "test-service-name")
         XCTAssertEqual(log.loggerName, "test-logger-name")
         XCTAssertEqual(log.tags, ["tag"])
-        XCTAssertEqual(log.attributes, ["attribute": EncodableValue("value")])
+        XCTAssertEqual(log.attributes.userAttributes as? [String: String], ["attribute": "value"])
         XCTAssertEqual(
             builder.createLogWith(level: .info, message: "", date: .mockAny(), attributes: .mockAny(), tags: []).status, .info
         )

--- a/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
@@ -10,91 +10,118 @@ import XCTest
 class LogSanitizerTests: XCTestCase {
     // MARK: - Attributes sanitization
 
-    func testWhenAttributeUsesReservedName_itIsIgnored() {
+    func testWhenUserAttributeUsesReservedName_itIsIgnored() {
         let log = Log.mockWith(
-            attributes: [
-                // reserved attributes:
-                "host": .mockAny(),
-                "message": .mockAny(),
-                "status": .mockAny(),
-                "service": .mockAny(),
-                "source": .mockAny(),
-                "error.message": .mockAny(),
-                "error.stack": .mockAny(),
-                "ddtags": .mockAny(),
+            attributes: .mockWith(
+                userAttributes: [
+                    // reserved attributes:
+                    "host": mockValue(),
+                    "message": mockValue(),
+                    "status": mockValue(),
+                    "service": mockValue(),
+                    "source": mockValue(),
+                    "error.message": mockValue(),
+                    "error.stack": mockValue(),
+                    "ddtags": mockValue(),
 
-                // valid attributes:
-                "attribute1": .mockAny(),
-                "attribute2": .mockAny(),
-                "date": .mockAny(),
-            ]
+                    // valid attributes:
+                    "attribute1": mockValue(),
+                    "attribute2": mockValue(),
+                    "date": mockValue(),
+                ]
+            )
         )
 
         let sanitized = LogSanitizer().sanitize(log: log)
 
-        XCTAssertEqual(sanitized.attributes?.count, 3)
-        XCTAssertNotNil(sanitized.attributes?["attribute1"])
-        XCTAssertNotNil(sanitized.attributes?["attribute2"])
-        XCTAssertNotNil(sanitized.attributes?["date"])
+        XCTAssertEqual(sanitized.attributes.userAttributes.count, 3)
+        XCTAssertNotNil(sanitized.attributes.userAttributes["attribute1"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["attribute2"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["date"])
     }
 
-    func testWhenAttributeNameExceeds10NestedLevels_itIsEscapedByUnderscore() {
+    func testWhenUserAttributeNameExceeds10NestedLevels_itIsEscapedByUnderscore() {
         let log = Log.mockWith(
-            attributes: [
-                "one": .mockAny(),
-                "one.two": .mockAny(),
-                "one.two.three": .mockAny(),
-                "one.two.three.four": .mockAny(),
-                "one.two.three.four.five": .mockAny(),
-                "one.two.three.four.five.six": .mockAny(),
-                "one.two.three.four.five.six.seven": .mockAny(),
-                "one.two.three.four.five.six.seven.eight": .mockAny(),
-                "one.two.three.four.five.six.seven.eight.nine": .mockAny(),
-                "one.two.three.four.five.six.seven.eight.nine.ten": .mockAny(),
-                "one.two.three.four.five.six.seven.eight.nine.ten.eleven": .mockAny(),
-                "one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": .mockAny(),
-            ]
+            attributes: .mockWith(
+                userAttributes: [
+                    "one": mockValue(),
+                    "one.two": mockValue(),
+                    "one.two.three": mockValue(),
+                    "one.two.three.four": mockValue(),
+                    "one.two.three.four.five": mockValue(),
+                    "one.two.three.four.five.six": mockValue(),
+                    "one.two.three.four.five.six.seven": mockValue(),
+                    "one.two.three.four.five.six.seven.eight": mockValue(),
+                    "one.two.three.four.five.six.seven.eight.nine": mockValue(),
+                    "one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+                    "one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+                    "one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+                ]
+            )
         )
 
         let sanitized = LogSanitizer().sanitize(log: log)
 
-        XCTAssertEqual(sanitized.attributes?.count, 12)
-        XCTAssertNotNil(sanitized.attributes?["one"])
-        XCTAssertNotNil(sanitized.attributes?["one.two"])
-        XCTAssertNotNil(sanitized.attributes?["one.two.three"])
-        XCTAssertNotNil(sanitized.attributes?["one.two.three.four"])
-        XCTAssertNotNil(sanitized.attributes?["one.two.three.four.five"])
-        XCTAssertNotNil(sanitized.attributes?["one.two.three.four.five.six"])
-        XCTAssertNotNil(sanitized.attributes?["one.two.three.four.five.six.seven"])
-        XCTAssertNotNil(sanitized.attributes?["one.two.three.four.five.six.seven.eight"])
-        XCTAssertNotNil(sanitized.attributes?["one.two.three.four.five.six.seven.eight.nine.ten"])
-        XCTAssertNotNil(sanitized.attributes?["one.two.three.four.five.six.seven.eight.nine.ten_eleven"])
-        XCTAssertNotNil(sanitized.attributes?["one.two.three.four.five.six.seven.eight.nine.ten_eleven_twelve"])
+        XCTAssertEqual(sanitized.attributes.userAttributes.count, 12)
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine.ten"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine.ten_eleven"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine.ten_eleven_twelve"])
     }
 
-    func testWhenAttributeNameIsInvalid_itIsIgnored() {
+    func testWhenUserAttributeNameIsInvalid_itIsIgnored() {
         let log = Log.mockWith(
-            attributes: [
-                "valid-name": .mockAny(),
-                "": .mockAny(), // invalid name
-            ]
+            attributes: .mockWith(
+                userAttributes: [
+                    "valid-name": mockValue(),
+                    "": mockValue(), // invalid name
+                ]
+            )
         )
 
         let sanitized = LogSanitizer().sanitize(log: log)
 
-        XCTAssertEqual(sanitized.attributes?.count, 1)
-        XCTAssertNotNil(sanitized.attributes?["valid-name"])
+        XCTAssertEqual(sanitized.attributes.userAttributes.count, 1)
+        XCTAssertNotNil(sanitized.attributes.userAttributes["valid-name"])
     }
 
-    func testWhenNumberOfAttributesExceedsLimit_itDropsExtraOnes() {
-        let mockAttributes = (0...1_000).map { index in ("attribute-\(index)", EncodableValue.mockAny()) }
+    func testWhenNumberOfUserAttributesExceedsLimit_itDropsExtraOnes() {
+        let mockAttributes = (0...1_000).map { index in ("attribute-\(index)", mockValue()) }
         let log = Log.mockWith(
-            attributes: Dictionary(uniqueKeysWithValues: mockAttributes)
+            attributes: .mockWith(
+                userAttributes: Dictionary(uniqueKeysWithValues: mockAttributes)
+            )
         )
 
         let sanitized = LogSanitizer().sanitize(log: log)
 
-        XCTAssertEqual(sanitized.attributes?.count, LogSanitizer.Constraints.maxNumberOfAttributes)
+        XCTAssertEqual(sanitized.attributes.userAttributes.count, LogSanitizer.Constraints.maxNumberOfAttributes)
+    }
+
+    func testInternalAttributesAreNotSanitized() {
+        let log = Log.mockWith(
+            attributes: .mockWith(
+                internalAttributes: [
+                    // reserved attributes:
+                    LoggingForTracingAdapter.TracingAttributes.traceID: mockValue(),
+                    LoggingForTracingAdapter.TracingAttributes.spanID: mockValue(),
+
+                    // custom attribute:
+                    "attribute1": mockValue(),
+                ]
+            )
+        )
+
+        let sanitized = LogSanitizer().sanitize(log: log)
+
+        XCTAssertEqual(sanitized.attributes.internalAttributes?.count, 3)
     }
 
     // MARK: - Tags sanitization
@@ -171,5 +198,11 @@ class LogSanitizerTests: XCTestCase {
         let sanitized = LogSanitizer().sanitize(log: log)
 
         XCTAssertEqual(sanitized.tags?.count, LogSanitizer.Constraints.maxNumberOfTags)
+    }
+
+    // MARK: - Private
+
+    private func mockValue() -> String {
+        return .mockAny()
     }
 }

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogConsoleOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogConsoleOutputTests.swift
@@ -18,7 +18,7 @@ class LogConsoleOutputTests: XCTestCase {
             timeZone: .UTC,
             printingFunction: { messagePrinted = $0 }
         )
-        output1.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: [:], tags: [])
+        output1.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
         XCTAssertEqual(messagePrinted, "10:00:00.000 [INFO] Info message.")
 
         let output2 = LogConsoleOutput(
@@ -27,7 +27,7 @@ class LogConsoleOutputTests: XCTestCase {
             timeZone: .UTC,
             printingFunction: { messagePrinted = $0 }
         )
-        output2.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: [:], tags: [])
+        output2.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
         XCTAssertEqual(messagePrinted, "🐶 10:00:00.000 [INFO] Info message.")
     }
 
@@ -40,7 +40,7 @@ class LogConsoleOutputTests: XCTestCase {
             timeZone: .EET,
             printingFunction: { messagePrinted = $0 }
         )
-        output.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: [:], tags: [])
+        output.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
         XCTAssertEqual(messagePrinted, "12:00:00.000 [INFO] Info message.")
     }
 
@@ -53,7 +53,7 @@ class LogConsoleOutputTests: XCTestCase {
             timeZone: .mockAny(),
             printingFunction: { messagePrinted = $0 }
         )
-        output1.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: [:], tags: [])
+        output1.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
         try LogMatcher.fromJSONObjectData(messagePrinted.utf8Data)
             .assertMessage(equals: "Info message.")
 
@@ -63,7 +63,7 @@ class LogConsoleOutputTests: XCTestCase {
             timeZone: .mockAny(),
             printingFunction: { messagePrinted = $0 }
         )
-        output2.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: [:], tags: [])
+        output2.writeLogWith(level: .info, message: "Info message.", date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
         XCTAssertTrue(messagePrinted.hasPrefix("🐶 → "))
         try LogMatcher.fromJSONObjectData(messagePrinted.removingPrefix("🐶 → ").utf8Data)
             .assertMessage(equals: "Info message.")

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
@@ -37,12 +37,12 @@ class LogFileOutputTests: XCTestCase {
             )
         )
 
-        output.writeLogWith(level: .info, message: "log message 1", date: .mockAny(), attributes: [:], tags: [])
+        output.writeLogWith(level: .info, message: "log message 1", date: .mockAny(), attributes: .mockAny(), tags: [])
         queue.sync {} // wait on writter queue
 
         fileCreationDateProvider.advance(bySeconds: 1)
 
-        output.writeLogWith(level: .info, message: "log message 2", date: .mockAny(), attributes: [:], tags: [])
+        output.writeLogWith(level: .info, message: "log message 2", date: .mockAny(), attributes: .mockAny(), tags: [])
         queue.sync {} // wait on writter queue
 
         let log1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogUtilityOutputsTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogUtilityOutputsTests.swift
@@ -14,7 +14,7 @@ class CombinedLogOutputTests: XCTestCase {
         let output3 = LogOutputMock()
 
         let combinedOutput = CombinedLogOutput(combine: [output1, output2, output3])
-        combinedOutput.writeLogWith(level: .info, message: "info message", date: .mockDecember15th2019At10AMUTC(), attributes: [:], tags: [])
+        combinedOutput.writeLogWith(level: .info, message: "info message", date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
 
         XCTAssertEqual(output1.recordedLog, .init(level: .info, message: "info message", date: .mockDecember15th2019At10AMUTC()))
         XCTAssertEqual(output2.recordedLog, .init(level: .info, message: "info message", date: .mockDecember15th2019At10AMUTC()))
@@ -25,13 +25,13 @@ class CombinedLogOutputTests: XCTestCase {
         let output1 = LogOutputMock()
         let conditionalOutput1 = ConditionalLogOutput(conditionedOutput: output1) { _ in true }
 
-        conditionalOutput1.writeLogWith(level: .info, message: "info message", date: .mockDecember15th2019At10AMUTC(), attributes: [:], tags: [])
+        conditionalOutput1.writeLogWith(level: .info, message: "info message", date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
         XCTAssertEqual(output1.recordedLog, .init(level: .info, message: "info message", date: .mockDecember15th2019At10AMUTC()))
 
         let output2 = LogOutputMock()
         let conditionalOutput2 = ConditionalLogOutput(conditionedOutput: output2) { _ in false }
 
-        conditionalOutput2.writeLogWith(level: .info, message: "info message", date: .mockAny(), attributes: [:], tags: [])
+        conditionalOutput2.writeLogWith(level: .info, message: "info message", date: .mockAny(), attributes: .mockAny(), tags: [])
         XCTAssertNil(output2.recordedLog)
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -144,30 +144,46 @@ extension LogBuilder {
     }
 }
 
+extension LogAttributes: Equatable {
+    static func mockAny() -> LogAttributes {
+        return mockWith()
+    }
+
+    static func mockWith(
+        userAttributes: [String: Encodable] = [:],
+        internalAttributes: [String: Encodable]? = nil
+    ) -> LogAttributes {
+        return LogAttributes(
+            userAttributes: userAttributes,
+            internalAttributes: internalAttributes
+        )
+    }
+
+    public static func == (lhs: LogAttributes, rhs: LogAttributes) -> Bool {
+        let lhsUserAttributesSorted = lhs.userAttributes.sorted { $0.key < $1.key }
+        let rhsUserAttributesSorted = rhs.userAttributes.sorted { $0.key < $1.key }
+
+        let lhsInternalAttributesSorted = lhs.internalAttributes?.sorted { $0.key < $1.key }
+        let rhsInternalAttributesSorted = rhs.internalAttributes?.sorted { $0.key < $1.key }
+
+        return String(describing: lhsUserAttributesSorted) == String(describing: rhsUserAttributesSorted)
+            && String(describing: lhsInternalAttributesSorted) == String(describing: rhsInternalAttributesSorted)
+    }
+}
+
 /// `LogOutput` recording received logs.
 class LogOutputMock: LogOutput {
     struct RecordedLog: Equatable {
         var level: LogLevel
         var message: String
         var date: Date
-        var attributes: [String: Encodable] = [:]
+        var attributes = LogAttributes(userAttributes: [:], internalAttributes: nil)
         var tags: Set<String> = []
-
-        static func == (lhs: RecordedLog, rhs: RecordedLog) -> Bool {
-            let lhsAttributesSorted = lhs.attributes.sorted { $0.key < $1.key }
-            let rhsAttributesSorted = rhs.attributes.sorted { $0.key < $1.key }
-
-            return lhs.level == rhs.level
-                && lhs.message == rhs.message
-                && lhs.date == rhs.date
-                && String(describing: lhsAttributesSorted) == String(describing: rhsAttributesSorted)
-                && lhs.tags == rhs.tags
-        }
     }
 
     var recordedLog: RecordedLog? = nil
 
-    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: [String: Encodable], tags: Set<String>) {
+    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) {
         recordedLog = RecordedLog(level: level, message: message, date: date, attributes: attributes, tags: tags)
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -88,7 +88,7 @@ extension Log {
         userInfo: UserInfo = .mockAny(),
         networkConnectionInfo: NetworkConnectionInfo = .mockAny(),
         mobileCarrierInfo: CarrierInfo? = .mockAny(),
-        attributes: [String: EncodableValue]? = nil,
+        attributes: LogAttributes = .mockAny(),
         tags: [String]? = nil
     ) -> Log {
         return Log(


### PR DESCRIPTION
### What and why?

📦 The SDK [performs sanitization](https://github.com/DataDog/dd-sdk-ios/blob/master/Sources/Datadog/Logging/Log/LogSanitizer.swift) for `Log` attributes created by the user. This includes list of reserved attributes, that get removed when given by the user. This PR adds `dd.trace_id` and `dd.span_id` to that list.

### How?

The reason why it was not done in #117 is that this includes additional refactoring. It is the subject of this PR.

The `LogOutput` was not differentiating if the attribute comes from the user, or is set internally by the `LoggingForTracingAdapter`:
```swift
internal protocol LogOutput {
    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: [String: Encodable], tags: Set<String>)
}
```

This is now changed by introducing `LogAttributes` type:
```swift
internal struct LogAttributes {
    /// Log attributes received from the user. They are subject for sanitization.
    let userAttributes: [String: Encodable]
    /// Log attributes added internally by the SDK. They are not a subject for sanitization.
    let internalAttributes: [String: Encodable]?
}

internal protocol LogOutput {
    func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>)
}
```

The `.userAttributes` are considered and `.internalAttributes` are skipped for sanitization.

### Benchmarks

I tested it with benchmarks - no impact, but in theory it should be even more performant, as more logic is now moved to `LogEncoder`, which runs on the background thread.

I also include benchmark baselines for my iPhone X deleted in #63, as a reference point for future changes.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
