### PR TITLE
RUMM-575 URLSessionSwizzlerTests flakiness

### DIFF
--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -9,10 +9,13 @@ import XCTest
 
 class URLSessionSwizzlerTests: XCTestCase {
     /// URL.mockAny() is a valid URL so that it loads actual resource and exceeds expectation timeouts
-    let mockURL = URL(string: "https://foo.bar")!
-    let mockURLRequest = URLRequest(url: URL(string: "https://foo.bar")!)
-    let modifiedURLRequest = URLRequest(url: URL(string: "https://bar.foo")!)
-    let secondModifiedURLRequest = URLRequest(url: URL(string: "https://bar.foo.bar")!)
+    /// We use unsupported URLs so that the task goes through its URLProtocol chain and **immediately** returns with "unsupported URL" error
+    let mockURL = URL(string: "foo://example.com")!
+    let mockURLRequest = URLRequest(url: URL(string: "foo://example.com")!)
+    let modifiedURLRequest = URLRequest(url: URL(string: "bar://example.com")!)
+    let secondModifiedURLRequest = URLRequest(url: URL(string: "bar://foo.example.com")!)
+
+    let timeout = 1.0
 
     var session: URLSession { URLSession.shared }
     // swiftlint:disable implicitly_unwrapped_optional
@@ -63,7 +66,7 @@ class URLSessionSwizzlerTests: XCTestCase {
                 mock2.interceptionExpectation,
                 mock3.interceptionExpectation
             ],
-            timeout: 1
+            timeout: timeout
         )
 
         task.resume()
@@ -78,7 +81,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         ]
         wait(
             for: resumeExpectations,
-            timeout: 1,
+            timeout: timeout,
             enforceOrder: true
         )
     }
@@ -106,7 +109,7 @@ class URLSessionSwizzlerTests: XCTestCase {
                 mock2.interceptionExpectation,
                 mock3.interceptionExpectation
             ],
-            timeout: 1
+            timeout: timeout
         )
 
         task.resume()
@@ -120,7 +123,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         ]
         wait(
             for: resumeExpectations,
-            timeout: 1,
+            timeout: timeout,
             enforceOrder: true
         )
     }


### PR DESCRIPTION
### What and why?

We use URLs such as "https://foo.bar" in those tests.
They don't resolve to a real address, so they only result in DNS queries, not actual HTTPS connections.
However, those DNS queries are actual connections anyway and they cause flakiness in unit tests.
[Origin of the issue](https://github.com/DataDog/dd-sdk-ios/pull/157#discussion_r448234067)

### How?

Now we use unsupported protocols in tests.

Those tasks go through session's `URLProtocol` chain and returns immediately with "unsupported URL" error.
That prevents actual network traffic in unit tests.

#### Alternative how?

We could also use custom `URLProtocol`s to achieve the same result (as we did in other test cases)
but that wouldn't work in case of `URLSession.shared`

#### ⚠️  Note ⚠️ 

If we notice weird behavior in swizzling tests again, we may want to verify if `TracingAutoInstrument.instance.unswizzle()` is properly called in other test cases

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
