### PR TITLE
RUMM-555 Auto-tracing for Objective-C added

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		61F8CC092469295500FE2908 /* DatadogConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8CC082469295500FE2908 /* DatadogConfigurationTests.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
+		9E330A8E24ADE1250031408E /* NSURLSessionBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E330A8D24ADE1250031408E /* NSURLSessionBridge.m */; };
 		9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */; };
 		9E493E1C249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E493E1B249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift */; };
 		9E544A4D24752A8900E83072 /* URLSessionSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */; };
@@ -434,6 +435,9 @@
 		61F8CC082469295500FE2908 /* DatadogConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogConfigurationTests.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
+		9E330A8B24ADE1250031408E /* DatadogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DatadogTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		9E330A8C24ADE1250031408E /* NSURLSessionBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionBridge.h; sourceTree = "<group>"; };
+		9E330A8D24ADE1250031408E /* NSURLSessionBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionBridge.m; sourceTree = "<group>"; };
 		9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionsTests.swift; sourceTree = "<group>"; };
 		9E493E1B249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingAutoInstrumentationTests.swift; sourceTree = "<group>"; };
 		9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlerTests.swift; sourceTree = "<group>"; };
@@ -537,6 +541,7 @@
 			isa = PBXGroup;
 			children = (
 				61133B92242393DE00786299 /* Info.plist */,
+				9E330A8B24ADE1250031408E /* DatadogTests-Bridging-Header.h */,
 			);
 			path = DatadogTests;
 			sourceTree = "<group>";
@@ -1250,6 +1255,8 @@
 			children = (
 				9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */,
 				9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */,
+				9E330A8C24ADE1250031408E /* NSURLSessionBridge.h */,
+				9E330A8D24ADE1250031408E /* NSURLSessionBridge.m */,
 			);
 			path = AutoInstrumentation;
 			sourceTree = "<group>";
@@ -1638,6 +1645,7 @@
 			files = (
 				61C5A8A024509C1100DA608C /* Casting.swift in Sources */,
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
+				9E330A8E24ADE1250031408E /* NSURLSessionBridge.m in Sources */,
 				9E493E1C249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift in Sources */,
 				61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */,
 				61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */,
@@ -1998,6 +2006,7 @@
 			baseConfigurationReference = 615519252461BCE7002A85CF /* Datadog.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = TargetSupport/DatadogTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2008,6 +2017,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
@@ -2019,6 +2030,7 @@
 			baseConfigurationReference = 615519252461BCE7002A85CF /* Datadog.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = TargetSupport/DatadogTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2029,6 +2041,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
@@ -2358,6 +2371,7 @@
 			baseConfigurationReference = 615519252461BCE7002A85CF /* Datadog.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = TargetSupport/DatadogTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2368,6 +2382,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";

--- a/Datadog/TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h
+++ b/Datadog/TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h
@@ -1,0 +1,11 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "NSURLSessionBridge.h"

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -85,6 +85,10 @@ public class DDConfigurationBuilder: NSObject {
         _ = sdkBuilder.set(tracesEndpoint: tracesEndpoint.sdkEndpoint)
     }
 
+    public func set(tracedHosts: Set<String>) {
+        _ = sdkBuilder.set(tracedHosts: tracedHosts)
+    }
+
     public func set(serviceName: String) {
         _ = sdkBuilder.set(serviceName: serviceName)
     }

--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/NSURLSessionBridge.h
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/NSURLSessionBridge.h
@@ -1,0 +1,17 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+#import <Foundation/Foundation.h>
+
+@interface NSURLSessionBridge : NSObject
+
++ (NSURLSessionDataTask *)session:(NSURLSession *)session dataTaskWithURL:(NSURL *)url completionHandler:(void(^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
++ (NSURLSessionDataTask *)session:(NSURLSession *)session dataTaskWithRequest:(NSURLRequest *)request completionHandler:(void(^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
+
++ (id)new NS_UNAVAILABLE;
+- (id)init NS_UNAVAILABLE;
+
+@end

--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/NSURLSessionBridge.m
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/NSURLSessionBridge.m
@@ -1,0 +1,19 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+#import "NSURLSessionBridge.h"
+
+@implementation NSURLSessionBridge
+
++ (NSURLSessionDataTask *)session:(NSURLSession *)session dataTaskWithURL:(NSURL *)url completionHandler:(void(^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+    return [session dataTaskWithURL:url completionHandler:completionHandler];
+}
+
++ (NSURLSessionDataTask *)session:(NSURLSession *)session dataTaskWithRequest:(NSURLRequest *)request completionHandler:(void(^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
+    return [session dataTaskWithRequest:request completionHandler:completionHandler];
+}
+
+@end

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -73,5 +73,9 @@ class DDConfigurationTests: XCTestCase {
         objcBuilder.set(serviceName: "service-name")
         let swiftConfigurationServiceName = objcBuilder.build().sdkConfiguration
         XCTAssertEqual(swiftConfigurationServiceName.serviceName, "service-name")
+
+        objcBuilder.set(tracedHosts: ["example.com"])
+        let swiftConfigurationTracedHosts = objcBuilder.build().sdkConfiguration
+        XCTAssertEqual(swiftConfigurationTracedHosts.tracedHosts, ["example.com"])
     }
 }

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -14,26 +14,33 @@ class DDDatadogTests: XCTestCase {
         super.setUp()
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(LoggingFeature.instance)
+        XCTAssertNil(TracingAutoInstrumentation.instance)
     }
 
     override func tearDown() {
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(LoggingFeature.instance)
+        XCTAssertNil(TracingAutoInstrumentation.instance)
         super.tearDown()
     }
 
     // MARK: - Initializing with configuration
 
     func testItFowardsInitializationToSwift() throws {
+        let configBuilder = DDConfiguration.builder(clientToken: "abcefghi", environment: "tests")
+        configBuilder.set(tracedHosts: ["example.com"])
+
         DDDatadog.initialize(
             appContext: DDAppContext(mainBundle: BundleMock.mockWith(CFBundleExecutable: "app-name")),
-            configuration: DDConfiguration.builder(clientToken: "abcefghi", environment: "tests").build()
+            configuration: configBuilder.build()
         )
 
         XCTAssertNotNil(Datadog.instance)
         XCTAssertEqual(LoggingFeature.instance?.configuration.applicationName, "app-name")
         XCTAssertEqual(LoggingFeature.instance?.configuration.environment, "tests")
+        XCTAssertNotNil(TracingAutoInstrumentation.instance)
 
+        TracingAutoInstrumentation.instance?.swizzler.unswizzle()
         try Datadog.deinitializeOrThrow()
     }
 


### PR DESCRIPTION
### What and why?

`DatadogObjc` needs to provide auto-instrumentation for Tracing as `Datadog` already does

### How?

We provide `set(tracedHosts: Set<String>)` in `DDConfigurationBuilder` interface.
This method sets `tracedHosts` in `Datadog.Configuration` which leads to automatic tracing in given hosts, just as `Datadog` does in Swift

### Edge case 1
#### Passing `nil` parameters to swizzled methods

Unlike in Swift, we can pass `nil` as `url`, `request` and/or `completionHandler` to swizzled methods in ObjC.
Although this never should happen, if that happens the app crashes with only `exc_bad_access`: our users won't even have a clue what went wrong!

We fixed that by changing the method signature in swizzle implementation
```swift
// before
(URLSession, Selector, URL, @escaping CompletionHandler)
// after
(URLSession, Selector, URL?, CompletionHandler?)
```
This change doesn't change the memory layout of those types at runtime, that's why it doesn't crash and works properly ✅ 
For more info and understand memory layout of `Enum` types, you can refer to [Swift source code](https://github.com/apple/swift/blob/master/include/swift/ABI/Enum.h#L48)

### Edge case 2
#### Executing swizzled `resume` more than once

⚠️ This edge case does NOT exist in any known scenarios, that's why I can't add tests for it ⚠️ 

```swift
class FirstSubclass: URLSessionTask { ... }
class SecondSubclass: FirstSubclass { ... }

// 1 - dataTask is called, FirstSubclass instance is returned and its resume is swizzled
let first = session.dataTask(with: someURL, ...) -> FirstSubclass
// 2 - dataTask is called again, SecondSubclass instance is returned and its resume is swizzled
let second = session.dataTask(with: anotherRequest, ...) -> SecondSubclass
// 3 - swizzled resume imp will be executed twice
second.resume() -> first.resume()
```

The fix is simpler than understanding the problem: now we consume payloads so that they can only be used once ✅ 
_(I noticed that case while looking at issues in `InterposeKit`, I can't find the related issue now, I'll put the link once I can)_

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
