### PR TITLE
RUMM-565 Make integration tests execute faster

### DIFF
--- a/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
@@ -21,11 +21,9 @@ class LoggingIntegrationTests: IntegrationTests {
         app.launchWith(mockServerURL: serverSession.recordingURL)
         app.tapSendLogsForUITests()
 
-        // Wait for delivery
-        Thread.sleep(forTimeInterval: Constants.logsDeliveryTime)
+        // Return desired count or timeout
+        let recordedRequests = try serverSession.pullRecordedPOSTRequests(count: 1, timeout: Constants.logsDeliveryTime)
 
-        // Assert requests
-        let recordedRequests = try serverSession.getRecordedPOSTRequests()
         recordedRequests.forEach { request in
             // Example path here: `/36882784-420B-494F-910D-CBAC5897A309/ui-tests-client-token?ddsource=ios&batch_time=1589969230153`
             let pathRegexp = #"^(.*)(/ui-tests-client-token\?ddsource=ios&batch_time=)([0-9]+)$"#

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -32,11 +32,9 @@ class TracingIntegrationTests: IntegrationTests {
         )
         app.tapSendTracesForUITests()
 
-        // Wait for delivery
-        Thread.sleep(forTimeInterval: Constants.dataDeliveryTime)
+        // Return desired count or timeout
+        let recordedTracingRequests = try tracingServerSession.pullRecordedPOSTRequests(count: 1, timeout: Constants.dataDeliveryTime)
 
-        // Assert tracing requests
-        let recordedTracingRequests = try tracingServerSession.getRecordedPOSTRequests()
         recordedTracingRequests.forEach { request in
             // Example path here: `/36882784-420B-494F-910D-CBAC5897A309/ui-tests-client-token?batch_time=1589969230153`
             let pathRegexp = #"^(.*)(/ui-tests-client-token\?batch_time=)([0-9]+)$"#

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -52,7 +52,7 @@ class TracingIntegrationTests: IntegrationTests {
         let autoTracedWithRequest = spanMatchers[4]
         let autoTracedWithError = spanMatchers[5]
 
-        let recordedNetworkRequests = try dataSourceServerSession.getRecordedPOSTRequests()
+        let recordedNetworkRequests = try dataSourceServerSession.pullRecordedPOSTRequests(count: 1, timeout: Constants.dataDeliveryTime)
         XCTAssert(recordedNetworkRequests.count == 1)
         let traceID = try! autoTracedWithRequest.traceID().hexadecimalNumberToDecimal
         XCTAssert(recordedNetworkRequests.first!.httpHeaders.contains("x-datadog-trace-id: \(traceID)"), "Trace: \(traceID) Actual: \(recordedNetworkRequests.first!.httpHeaders)")
@@ -165,7 +165,7 @@ class TracingIntegrationTests: IntegrationTests {
         }
 
         // Assert logs requests
-        let recordedLoggingRequests = try loggingServerSession.getRecordedPOSTRequests()
+        let recordedLoggingRequests = try loggingServerSession.pullRecordedPOSTRequests(count: 1, timeout: Constants.dataDeliveryTime)
 
         // Assert logs
         let logMatchers = try recordedLoggingRequests

--- a/instrumented-tests/http-server-mock/Package.swift
+++ b/instrumented-tests/http-server-mock/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "HTTPServerMock",
+    platforms: [.macOS(.v10_12)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/instrumented-tests/http-server-mock/Tests/HTTPServerMockTests/HTTPServerMockTests.swift
+++ b/instrumented-tests/http-server-mock/Tests/HTTPServerMockTests/HTTPServerMockTests.swift
@@ -114,7 +114,7 @@ final class HTTPServerMockTests: XCTestCase {
         XCTAssertThrowsError(try session.pullRecordedPOSTRequests(count: 2, timeout: timeoutTime)) {
             thrownError = $0
         }
-        XCTAssertTrue( thrownError is ServerSession.Exception, "Unexpected error type: \(type(of: thrownError))")
+        XCTAssertTrue(thrownError is ServerSession.Exception, "Unexpected error type: \(type(of: thrownError))")
     }
 }
 


### PR DESCRIPTION
### What and why?

 This PR avoid waiting more than necessary in integration tests, so can be run faster

### How?

Creates a method in ServerSession to actively check for a fixed number of recorded POST requests. This method waits for a specific number of recorded post requests and returns, or timeouts and returns existing recorded requests 

This method is used in some integration tests that were waiting a fixed time (higher than ecessary)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
