### PR TITLE
RUMM-266 Use setUpWithError or tearDownWithError in tests

### DIFF
--- a/Tests/DatadogBenchmarkTests/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/LoggingStorageBenchmarkTests.swift
@@ -15,10 +15,10 @@ class LoggingStorageBenchmarkTests: XCTestCase {
     private var reader: FileReader!
     // swiftlint:enable implicitly_unwrapped_optional
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         self.queue = DispatchQueue(label: "com.datadoghq.benchmark-logs-io", target: .global(qos: .utility))
-        self.directory = try! Directory(withSubdirectoryPath: "logging-benchmark")
+        self.directory = try Directory(withSubdirectoryPath: "logging-benchmark")
 
         let storage = LoggingFeature.Storage(
             directory: directory,
@@ -30,7 +30,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
         self.writer = storage.writer
         self.reader = storage.reader
 
-        XCTAssertTrue(try! directory.files().count == 0)
+        XCTAssertTrue(try directory.files().count == 0)
     }
 
     override func tearDown() {

--- a/Tests/DatadogIntegrationTests/IntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/IntegrationTests.swift
@@ -15,9 +15,9 @@ struct ServerConnectionError: Error {
 class IntegrationTests: XCTestCase {
     private(set) var server: ServerMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
-    override func setUp() {
-        super.setUp()
-        server = try! connectToServer()
+    override func setUpWithError() throws {
+        try super.setUp()
+        server = try connectToServer()
     }
 
     override func tearDownWithError() throws {

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -56,9 +56,9 @@ class TracingIntegrationTests: IntegrationTests {
 
         let recordedNetworkRequests = try dataSourceServerSession.getRecordedPOSTRequests()
         XCTAssert(recordedNetworkRequests.count == 1)
-        let traceID = try! autoTracedWithRequest.traceID().hexadecimalNumberToDecimal
+        let traceID = try autoTracedWithRequest.traceID().hexadecimalNumberToDecimal
         XCTAssert(recordedNetworkRequests.first!.httpHeaders.contains("x-datadog-trace-id: \(traceID)"), "Trace: \(traceID) Actual: \(recordedNetworkRequests.first!.httpHeaders)")
-        let spanID = try! autoTracedWithRequest.spanID().hexadecimalNumberToDecimal
+        let spanID = try autoTracedWithRequest.spanID().hexadecimalNumberToDecimal
         XCTAssert(recordedNetworkRequests.first!.httpHeaders.contains("x-datadog-parent-id: \(spanID)"), "Span: \(spanID) Actual: \(recordedNetworkRequests.first!.httpHeaders)")
         XCTAssert(recordedNetworkRequests.first!.httpHeaders.contains("creation-method: dataTaskWithRequest"))
 

--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -24,11 +24,11 @@ class URLSessionSwizzlerTests: XCTestCase {
     var thirdSwizzler: URLSessionSwizzler!
     // swiftlint:enable implicitly_unwrapped_optional
 
-    override func setUp() {
-        super.setUp()
-        firstSwizzler = try! URLSessionSwizzler()
-        secondSwizzler = try! URLSessionSwizzler()
-        thirdSwizzler = try! URLSessionSwizzler()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        firstSwizzler = try URLSessionSwizzler()
+        secondSwizzler = try URLSessionSwizzler()
+        thirdSwizzler = try URLSessionSwizzler()
     }
 
     override func tearDown() {


### PR DESCRIPTION
### What and why?

Use `setUpWithError()` or `tearDownWithError()` in test setups that can throw, it allows properly handling of errors
Clean all `try!` uses in the test code since can be handled as error instead of crashes

### How?

Just replaced  `setUp()` with `setUpWithError()` and `tearDown()`  with `tearDownWithError()`  in those methods that were using methods that could throw

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
