### PR TITLE
RUMM-566 Exclude URLs from auto-tracing

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		9E330A8E24ADE1250031408E /* NSURLSessionBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E330A8D24ADE1250031408E /* NSURLSessionBridge.m */; };
 		9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */; };
 		9E493E1C249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E493E1B249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift */; };
+		9E50B2E424B49DDF00A2CB95 /* URLFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E50B2E324B49DDF00A2CB95 /* URLFilterTests.swift */; };
 		9E544A4D24752A8900E83072 /* URLSessionSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */; };
 		9E544A4F24753C6E00E83072 /* MethodSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */; };
 		9E544A5124753DDE00E83072 /* MethodSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */; };
@@ -195,6 +196,7 @@
 		9ED583A32498C222004CFF2A /* TracingAutoInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED583A22498C222004CFF2A /* TracingAutoInstrumentation.swift */; };
 		E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */; };
 		E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */; };
+		9EFD112C24B32D29003A1A2B /* URLFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFD112B24B32D29003A1A2B /* URLFilter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -442,6 +444,7 @@
 		9E330A8D24ADE1250031408E /* NSURLSessionBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionBridge.m; sourceTree = "<group>"; };
 		9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionsTests.swift; sourceTree = "<group>"; };
 		9E493E1B249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingAutoInstrumentationTests.swift; sourceTree = "<group>"; };
+		9E50B2E324B49DDF00A2CB95 /* URLFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFilterTests.swift; sourceTree = "<group>"; };
 		9E544A4C24752A8900E83072 /* URLSessionSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionSwizzlerTests.swift; sourceTree = "<group>"; };
 		9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzler.swift; sourceTree = "<group>"; };
 		9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzlerTests.swift; sourceTree = "<group>"; };
@@ -456,6 +459,7 @@
 		9EF49F17244770AD004F2CA0 /* DatadogIntegrationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogIntegrationTests.xcconfig; sourceTree = "<group>"; };
 		E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingBenchmarkTests.swift; sourceTree = "<group>"; };
 		E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingStorageBenchmarkTests.swift; sourceTree = "<group>"; };
+		9EFD112B24B32D29003A1A2B /* URLFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFilter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -860,6 +864,7 @@
 			children = (
 				61133C362423990D00786299 /* InternalLoggersTests.swift */,
 				9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */,
+				9E50B2E324B49DDF00A2CB95 /* URLFilterTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1127,6 +1132,7 @@
 			children = (
 				61C5A87C24509A0C00DA608C /* Casting.swift */,
 				61C5A87D24509A0C00DA608C /* Warnings.swift */,
+				9EFD112B24B32D29003A1A2B /* URLFilter.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1600,6 +1606,7 @@
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
+				9EFD112C24B32D29003A1A2B /* URLFilter.swift in Sources */,
 				61C5A88924509A0C00DA608C /* DDSpanContext.swift in Sources */,
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
@@ -1692,6 +1699,7 @@
 				61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */,
 				61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */,
 				61133C592423990D00786299 /* FilesOrchestratorTests.swift in Sources */,
+				9E50B2E424B49DDF00A2CB95 /* URLFilterTests.swift in Sources */,
 				61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */,
 				9E544A5124753DDE00E83072 /* MethodSwizzlerTests.swift in Sources */,
 				61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */,

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -112,7 +112,6 @@ public class Datadog {
 
         var logging: LoggingFeature?
         var tracing: TracingFeature?
-        var tracingAutoInstrumentation: TracingAutoInstrumentation?
 
         if configuration.loggingEnabled {
             logging = LoggingFeature(
@@ -155,12 +154,11 @@ public class Datadog {
                 networkConnectionInfoProvider: networkConnectionInfoProvider,
                 carrierInfoProvider: carrierInfoProvider
             )
-            tracingAutoInstrumentation = TracingAutoInstrumentation(tracedHosts: configuration.tracedHosts)
         }
 
         LoggingFeature.instance = logging
         TracingFeature.instance = tracing
-        TracingAutoInstrumentation.instance = tracingAutoInstrumentation
+        TracingAutoInstrumentation.instance = TracingAutoInstrumentation(with: configuration)
         TracingAutoInstrumentation.instance?.apply()
 
         // Only after all features were initialized with no error thrown:

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -59,7 +59,7 @@ extension Datadog {
         internal var loggingEnabled: Bool
         internal var tracingEnabled: Bool
         internal let logsEndpoint: LogsEndpoint
-        internal let tracesEndpoint: TracesEndpoint
+        internal var tracesEndpoint: TracesEndpoint
         internal let serviceName: String?
         internal var tracedHosts = Set<String>()
 

--- a/Sources/Datadog/Tracing/Utils/URLFilter.swift
+++ b/Sources/Datadog/Tracing/Utils/URLFilter.swift
@@ -1,0 +1,49 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal protocol URLFiltering {
+    func allows(_ url: URL?) -> Bool
+}
+
+internal struct URLFilter: URLFiltering, Equatable {
+    private let excludedURLs: Set<String>
+    private let inclusionRegex: String
+
+    init(includedHosts: Set<String>, excludedURLs: Set<String>) {
+        self.inclusionRegex = Self.buildRegexString(from: includedHosts)
+        self.excludedURLs = excludedURLs
+    }
+
+    func allows(_ url: URL?) -> Bool {
+        guard !excludes(url),
+            let host = url?.host else {
+                return false
+        }
+        let isIncluded = host.range(of: inclusionRegex, options: .regularExpression) != nil
+        return isIncluded
+    }
+
+    private func excludes(_ url: URL?) -> Bool {
+        if let absoluteString = url?.absoluteString {
+            return excludedURLs.contains {
+                absoluteString.starts(with: $0)
+            }
+        }
+        return true
+    }
+
+    /// matches hosts and their subdomains: example.com -> example.com, api.example.com, sub.example.com, etc.
+    private static func buildRegexString(from hosts: Set<String>) -> String {
+        return hosts.map {
+            let escaped = NSRegularExpression.escapedPattern(for: $0)
+            /// pattern = "^(.*\\.)*tracedHost1|^(.*\\.)*tracedHost2|..."
+            return "^(.*\\.)*\(escaped)$"
+        }
+        .joined(separator: "|")
+    }
+}

--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -158,7 +158,7 @@ class URLSessionSwizzlerTests: XCTestCase {
             completionExpectation,
             interceptor.observationCompletedExpectation
         ]
-        wait(for: resumeExpectations, timeout: timeout, enforceOrder: true)
+        wait(for: resumeExpectations, timeout: timeout)
     }
 
     func test_dataTask_requestCompletion_edgeCase_nilCompletion() throws {
@@ -186,7 +186,7 @@ class URLSessionSwizzlerTests: XCTestCase {
             completionExpectation,
             interceptor.observationCompletedExpectation
         ]
-        wait(for: resumeExpectations, timeout: timeout, enforceOrder: true)
+        wait(for: resumeExpectations, timeout: timeout)
     }
 
     func test_dataTask_requestCompletion_edgeCase_nilRequestNilCompletion() throws {

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -140,14 +140,20 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(TracingFeature.instance)
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }
-        try verify(
-            configuration: configurationBuilder
+
+        let autoTracingConfig = configurationBuilder
             .enableTracing(true)
             .set(tracedHosts: [String.mockAny()])
             .build()
-        ) {
+        try verify(configuration: autoTracingConfig) {
             XCTAssertNotNil(TracingFeature.instance)
             XCTAssertNotNil(TracingAutoInstrumentation.instance)
+
+            let urlFilter = TracingAutoInstrumentation.instance?.urlFilter as? URLFilter
+            let expectedURLFilter = TracingAutoInstrumentation(with: autoTracingConfig)?.urlFilter as? URLFilter
+
+            XCTAssertNotNil(urlFilter)
+            XCTAssertEqual(urlFilter, expectedURLFilter)
         }
         try verify(
             configuration: configurationBuilder

--- a/Tests/DatadogTests/Datadog/Utils/URLFilterTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/URLFilterTests.swift
@@ -1,0 +1,58 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class URLFilterTests: XCTestCase {
+    func testTracedHosts() {
+        let included: Set<String> = ["foo.bar", "example", "my.app.org"]
+        let excluded: Set<String> = ["exclude.me", "and.me.too"]
+        let filter = URLFilter(includedHosts: included, excludedURLs: excluded)
+
+        for host in included {
+            let subdomainURL = URL(string: "http://www.\(host)/foo")!
+            XCTAssertTrue(filter.allows(subdomainURL))
+
+            let complexURL = URL(string: "http://johnny:p4ssw0rd@\(host):999/script.ext;param=value?query=value#ref")!
+            XCTAssertTrue(filter.allows(complexURL))
+
+            let differentScheme = URL(string: "https://\(host)/foo")!
+            XCTAssertTrue(filter.allows(differentScheme))
+        }
+
+        let nonIncludedHost = URL(string: "https://non.traced.host")!
+        XCTAssertFalse(filter.allows(nonIncludedHost))
+
+        let nonEscapedDotURL = URL(string: "https://foo-bar.com")!
+        XCTAssertFalse(filter.allows(nonEscapedDotURL))
+
+        let extendedIncludedHost = URL(string: "https://foo.bar.asd")!
+        XCTAssertFalse(filter.allows(extendedIncludedHost))
+
+        let fileURL = URL(string: "file://some-file")!
+        XCTAssertTrue(fileURL.isFileURL)
+        XCTAssertFalse(filter.allows(fileURL))
+    }
+
+    func testExclusionOverrulesInclusion() {
+        let included: Set<String> = ["example.com"]
+        let excluded: Set<String> = ["http://api.example.com"]
+        let filter = URLFilter(includedHosts: included, excludedURLs: excluded)
+
+        let includedURL = URL(string: "http://example.com")!
+        XCTAssertTrue(filter.allows(includedURL))
+
+        let includedSubdomainURL = URL(string: "http://www.example.com")!
+        XCTAssertTrue(filter.allows(includedSubdomainURL))
+
+        let excludedSubdomainURL = URL(string: "http://api.example.com")!
+        XCTAssertFalse(filter.allows(excludedSubdomainURL))
+
+        let excludedSubdomainURLwithPath = URL(string: "http://api.example.com/some/path")!
+        XCTAssertFalse(filter.allows(excludedSubdomainURLwithPath))
+    }
+}


### PR DESCRIPTION
### What and why?

During shipping beta 3, we noticed that we should exclude certain URLs from autoinstrumentation in order to avoid tracing the trace requests.

### How?

`URLFilter` is refactored out from `TracingAutoInstrumentation`
It takes `includedHosts` and `excludedURLs`:
• `includedHosts` include themselves and their subdomains
• `excludedURLs` exclude URLs which contain any of them

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
