### PR TITLE
RUMM-563 Generate api-surface-swift and api-surface-objc

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,2 +1,4 @@
 Component,Origin,License,Copyright
 import,io.opentracing,MIT,Copyright 2018 LightStep
+import (tools),https://github.com/jpsim/SourceKitten,MIT,Copyright (c) 2014 JP Simard
+import (tools),https://github.com/apple/swift-argument-parser,Apache-2.0,(c) 2020 Apple Inc. and the Swift project authors

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,14 @@ test-carthage:
 test-cocoapods:
 		@cd dependency-manager-tests/cocoapods && $(MAKE)
 
+# Generate api-surface files for Datadog and DatadogObjc.
+api-surface:
+		@cd tools/api-surface/ && swift build --configuration release
+		@echo "Generating api-surface-swift"
+		./tools/api-surface/.build/x86_64-apple-macosx/release/api-surface workspace --workspace-name Datadog.xcworkspace --scheme Datadog --path . > api-surface-swift
+		@echo "Generating api-surface-objc"
+		./tools/api-surface/.build/x86_64-apple-macosx/release/api-surface workspace --workspace-name Datadog.xcworkspace --scheme DatadogObjc --path . > api-surface-objc
+
 bump:
 		@read -p "Enter version number: " version;  \
 		echo "// GENERATED FILE: Do not edit directly\n\ninternal let sdkVersion = \"$$version\"" > Sources/Datadog/Versioning.swift; \

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -1,0 +1,104 @@
+public class DDAppContext: NSObject
+ public init(mainBundle: Bundle)
+ override public init()
+public class DDDatadog: NSObject
+ public static func initialize(appContext: DDAppContext, configuration: DDConfiguration)
+ public static func setVerbosityLevel(_ verbosityLevel: DDSDKVerbosityLevel)
+ public static func verbosityLevel() -> DDSDKVerbosityLevel
+ public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil)
+public class DDLogsEndpoint: NSObject
+ public static func eu() -> DDLogsEndpoint
+ public static func us() -> DDLogsEndpoint
+ public static func custom(url: String) -> DDLogsEndpoint
+public class DDTracesEndpoint: NSObject
+ public static func eu() -> DDTracesEndpoint
+ public static func us() -> DDTracesEndpoint
+ public static func custom(url: String) -> DDTracesEndpoint
+public class DDConfiguration: NSObject
+ public static func builder(clientToken: String, environment: String) -> DDConfigurationBuilder
+public class DDConfigurationBuilder: NSObject
+ public func set(endpoint: DDLogsEndpoint)
+ public func enableLogging(_ enabled: Bool)
+ public func enableTracing(_ enabled: Bool)
+ public func set(logsEndpoint: DDLogsEndpoint)
+ public func set(tracesEndpoint: DDTracesEndpoint)
+ public func set(tracedHosts: Set<String>)
+ public func set(serviceName: String)
+ public func build() -> DDConfiguration
+public enum DDSDKVerbosityLevel: Int
+ case none
+ case debug
+ case info
+ case notice
+ case warn
+ case error
+ case critical
+public class DDLogger: NSObject
+ public func debug(_ message: String)
+ public func debug(_ message: String, attributes: [String: Any])
+ public func info(_ message: String)
+ public func info(_ message: String, attributes: [String: Any])
+ public func notice(_ message: String)
+ public func notice(_ message: String, attributes: [String: Any])
+ public func warn(_ message: String)
+ public func warn(_ message: String, attributes: [String: Any])
+ public func error(_ message: String)
+ public func error(_ message: String, attributes: [String: Any])
+ public func critical(_ message: String)
+ public func critical(_ message: String, attributes: [String: Any])
+ public func addAttribute(forKey key: String, value: Any)
+ public func removeAttribute(forKey key: String)
+ public func addTag(withKey key: String, value: String)
+ public func removeTag(withKey key: String)
+ public func add(tag: String)
+ public func remove(tag: String)
+ public static func builder() -> DDLoggerBuilder
+public class DDLoggerBuilder: NSObject
+ public func set(serviceName: String)
+ public func set(loggerName: String)
+ public func sendNetworkInfo(_ enabled: Bool)
+ public func sendLogsToDatadog(_ enabled: Bool)
+ public func printLogsToConsole(_ enabled: Bool)
+ public func build() -> DDLogger
+public class OTGlobal: NSObject
+ public static func initSharedTracer(_ tracer: OTTracer)
+ public internal(set) static var sharedTracer: OTTracer = noopTracer
+public protocol OTSpan
+ var context: OTSpanContext
+ var tracer: OTTracer
+ func setOperationName(_ operationName: String)
+ func setTag(_ key: String, value: NSString)
+ func setTag(_ key: String, numberValue: NSNumber)
+ func setTag(_ key: String, boolValue: Bool)
+ func log(_ fields: [String: NSObject])
+ func log(_ fields: [String: NSObject], timestamp: Date?)
+ func setBaggageItem(_ key: String, value: String) -> OTSpan
+ func getBaggageItem(_ key: String) -> String?
+ func finish()
+ func finishWithTime(_ finishTime: Date?)
+public protocol OTSpanContext
+ func forEachBaggageItem(_ callback: (_ key: String, _ value: String) -> Bool)
+public let OTFormatHTTPHeaders = "OTFormatHTTPHeaders"
+public protocol OTTracer
+ func startSpan(_ operationName: String) -> OTSpan
+ func startSpan(_ operationName: String, tags: NSDictionary?) -> OTSpan
+ func startSpan(_ operationName: String, childOf parent: OTSpanContext?) -> OTSpan
+ func startSpan(_ operationName: String, childOf parent: OTSpanContext?, tags: NSDictionary?) -> OTSpan
+ func startSpan(_ operationName: String, childOf parent: OTSpanContext?, tags: NSDictionary?, startTime: Date?) -> OTSpan
+ func inject(_ spanContext: OTSpanContext, format: String, carrier: Any) throws
+ func extractWithFormat(_ format: String, carrier: Any) throws
+public class DDTracer: DatadogObjc.OTTracer
+ public static func initialize(configuration: DDTracerConfiguration) -> DatadogObjc.OTTracer
+ public func startSpan(_ operationName: String) -> OTSpan
+ public func startSpan(_ operationName: String, tags: NSDictionary?) -> OTSpan
+ public func startSpan(_ operationName: String, childOf parent: OTSpanContext?) -> OTSpan
+ public func startSpan(_ operationName: String,childOf parent: OTSpanContext?,tags: NSDictionary?) -> OTSpan
+ public func startSpan(_ operationName: String,childOf parent: OTSpanContext?,tags: NSDictionary?,startTime: Date?) -> OTSpan
+ public func inject(_ spanContext: OTSpanContext, format: String, carrier: Any) throws
+ public func extractWithFormat(_ format: String, carrier: Any) throws
+public class DDTracerConfiguration: NSObject
+ override public init()
+ public func set(serviceName: String)
+ public func sendNetworkInfo(_ enabled: Bool)
+public class DDHTTPHeadersWriter: NSObject
+ override public init()

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1,0 +1,140 @@
+public class Datadog
+ public struct AppContext
+  public init(mainBundle: Bundle = Bundle.main)
+ public static func initialize(appContext: AppContext, configuration: Configuration)
+ public static var verbosityLevel: LogLevel? = nil
+ public static func setUserInfo(id: String? = nil,name: String? = nil,email: String? = nil)
+ public struct Configuration
+  public enum LogsEndpoint
+   case us
+   case eu
+   case custom(url: String)
+  public enum TracesEndpoint
+   case us
+   case eu
+   case custom(url: String)
+  public static func builderUsing(clientToken: String, environment: String) -> Builder
+  public class Builder
+   public func enableLogging(_ enabled: Bool) -> Builder
+   public func enableTracing(_ enabled: Bool) -> Builder
+   public func set(tracedHosts: Set<String>) -> Builder
+   public func set(logsEndpoint: LogsEndpoint) -> Builder
+   public func set(tracesEndpoint: TracesEndpoint) -> Builder
+   public func set(serviceName: String) -> Builder
+   public func build() -> Configuration
+public enum LogLevel: Int, Codable
+ case debug
+ case info
+ case notice
+ case warn
+ case error
+ case critical
+public typealias AttributeKey = String
+public typealias AttributeValue = Encodable
+public typealias DDLogger = Logger
+public class Logger
+ public func debug(_ message: String, attributes: [AttributeKey: AttributeValue]? = nil)
+ public func info(_ message: String, attributes: [AttributeKey: AttributeValue]? = nil)
+ public func notice(_ message: String, attributes: [AttributeKey: AttributeValue]? = nil)
+ public func warn(_ message: String, attributes: [AttributeKey: AttributeValue]? = nil)
+ public func error(_ message: String, attributes: [AttributeKey: AttributeValue]? = nil)
+ public func critical(_ message: String, attributes: [AttributeKey: AttributeValue]? = nil)
+ public func addAttribute(forKey key: AttributeKey, value: AttributeValue)
+ public func removeAttribute(forKey key: AttributeKey)
+ public func addTag(withKey key: String, value: String)
+ public func removeTag(withKey key: String)
+ public func add(tag: String)
+ public func remove(tag: String)
+ public static var builder: Builder
+ public class Builder
+  public func set(serviceName: String) -> Builder
+  public func set(loggerName: String) -> Builder
+  public func sendNetworkInfo(_ enabled: Bool) -> Builder
+  public func sendLogsToDatadog(_ enabled: Bool) -> Builder
+  public enum ConsoleLogFormat
+   case short
+   case shortWith(prefix: String)
+   case json
+   case jsonWith(prefix: String)
+  public func printLogsToConsole(_ enabled: Bool, usingFormat format: ConsoleLogFormat = .short) -> Builder
+  public func build() -> Logger
+public struct OTTags
+ public static let component = "component"
+ public static let dbInstance = "db.instance"
+ public static let dbStatement = "db.statement"
+ public static let dbType = "db.type"
+ public static let dbUser = "db.user"
+ public static let error = "error"
+ public static let httpMethod = "http.method"
+ public static let httpStatusCode = "http.status_code"
+ public static let httpUrl = "http.url"
+ public static let messageBusDestination = "message_bus.destination"
+ public static let peerAddress = "peer.address"
+ public static let peerHostname = "peer.hostname"
+ public static let peerIPv4 = "peer.ipv4"
+ public static let peerIPv6 = "peer.ipv6"
+ public static let peerPort = "peer.port"
+ public static let peerService = "peer.service"
+ public static let samplingPriority = "sampling.priority"
+ public static let spanKind = "span.kind"
+public struct OTLogFields
+ public static let errorKind = "error.kind"
+ public static let event = "event"
+ public static let message = "message"
+ public static let stack = "stack"
+public protocol OTFormatReader: OTCustomFormatReader
+public protocol OTFormatWriter: OTCustomFormatWriter
+public protocol OTTextMapReader: OTFormatReader
+public protocol OTTextMapWriter: OTFormatWriter
+public protocol OTHTTPHeadersReader: OTTextMapReader
+public protocol OTHTTPHeadersWriter: OTTextMapWriter
+public protocol OTCustomFormatReader
+ func extract() -> OTSpanContext?
+public protocol OTCustomFormatWriter
+ func inject(spanContext: OTSpanContext)
+public struct Global
+ public static var sharedTracer: OTTracer = DDNoopGlobals.tracer
+public struct OTReference
+ public let type: OTReferenceType
+ public let context: OTSpanContext
+ public static func child(of parent: OTSpanContext) -> OTReference
+ public static func follows(from precedingContext: OTSpanContext) -> OTReference
+public enum OTReferenceType: String
+ case childOf = "CHILD_OF"
+ case followsFrom = "FOLLOWS_FROM"
+public protocol OTSpan
+ var context: OTSpanContext
+ func tracer() -> OTTracer
+ func setOperationName(_ operationName: String)
+ func setTag(key: String, value: Encodable)
+ func log(fields: [String: Encodable], timestamp: Date)
+ func setBaggageItem(key: String, value: String)
+ func baggageItem(withKey key: String) -> String?
+ func finish(at time: Date)
+public extension OTSpan
+ func log(fields: [String: Encodable])
+ func finish()
+public protocol OTSpanContext
+ func forEachBaggageItem(callback: (_ key: String, _ value: String) -> Bool)
+public protocol OTTracer
+ func startSpan(operationName: String,references: [OTReference]?,tags: [String: Encodable]?,startTime: Date?) -> OTSpan
+ func inject(spanContext: OTSpanContext, writer: OTFormatWriter)
+ func extract(reader: OTFormatReader) -> OTSpanContext?
+public extension OTTracer
+ func startSpan(operationName: String,childOf parent: OTSpanContext? = nil,tags: [String: Encodable]? = nil,startTime: Date? = nil) -> OTSpan
+public struct DDTags
+ public static let resource = "resource.name"
+public typealias DDTracer = Tracer
+public class Tracer: OTTracer
+ public static func initialize(configuration: Configuration) -> OTTracer
+ public func startSpan(operationName: String, references: [OTReference]? = nil, tags: [String: Encodable]? = nil, startTime: Date? = nil) -> OTSpan
+ public func inject(spanContext: OTSpanContext, writer: OTFormatWriter)
+ public func extract(reader: OTFormatReader) -> OTSpanContext?
+ public struct Configuration
+  public var serviceName: String?
+  public var sendNetworkInfo: Bool
+  public init(serviceName: String? = nil,sendNetworkInfo: Bool = false)
+public class HTTPHeadersWriter: OTHTTPHeadersWriter
+ public init()
+ public private(set) var tracePropagationHTTPHeaders: [String: String] = [:]
+ public func inject(spanContext: OTSpanContext)

--- a/instrumented-tests/http-server-mock/README.md
+++ b/instrumented-tests/http-server-mock/README.md
@@ -38,3 +38,7 @@ XCTAssertEqual(recordedRequests[0].httpBody, "hello world".data(using: .utf8)!)
 ```
 
 By obtaining separate `ServerSession` with `server.obtainUniqueRecordingSession()` for each test, there is no need to restart the server each time to reset its state. 
+
+## License
+
+[Apache License, v2.0](../../LICENSE)

--- a/instrumented-tests/http-server-mock/Tests/HTTPServerMockTests/HTTPServerMockTests.swift
+++ b/instrumented-tests/http-server-mock/Tests/HTTPServerMockTests/HTTPServerMockTests.swift
@@ -59,10 +59,10 @@ final class HTTPServerMockTests: XCTestCase {
             XCTFail("Failed to connect with the server.")
             return
         }
-        
+
         let server = ServerMock(serverProcess: serverProces)
         let session = server.obtainUniqueRecordingSession()
-        
+
         let initialTime = Date()
         DispatchQueue.global(qos: .userInitiated).async {
             Thread.sleep(forTimeInterval: 0.5)
@@ -85,17 +85,17 @@ final class HTTPServerMockTests: XCTestCase {
         XCTAssertTrue(recordedRequests[1].path.hasSuffix("/resource/2"))
         XCTAssertEqual(recordedRequests[1].httpBody, "2nd request body".data(using: .utf8)!)
     }
-    
+
     func testWhenPullingRecordedPOSTRequestExceedsTimeout_itThrownsAnError() throws {
         let runner = ServerProcessRunner(serverURL: URL(string: "http://127.0.0.1:8000")!)
         guard let serverProces = runner.waitUntilServerIsReachable() else {
             XCTFail("Failed to connect with the server.")
             return
         }
-        
+
         let server = ServerMock(serverProcess: serverProces)
         let session = server.obtainUniqueRecordingSession()
-        
+
         DispatchQueue.global(qos: .userInitiated).async {
             Thread.sleep(forTimeInterval: 2)
             sendPOSTRequestAsynchronouslyTo(
@@ -108,7 +108,7 @@ final class HTTPServerMockTests: XCTestCase {
                 body: "2nd request body".data(using: .utf8)!
             )
         }
-        
+
         let timeoutTime: TimeInterval = 2
         var thrownError: Error?
         XCTAssertThrowsError(try session.pullRecordedPOSTRequests(count: 2, timeout: timeoutTime)) {

--- a/tools/api-surface/.gitignore
+++ b/tools/api-surface/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/

--- a/tools/api-surface/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/tools/api-surface/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/tools/api-surface/Fixtures/.gitignore
+++ b/tools/api-surface/Fixtures/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/

--- a/tools/api-surface/Fixtures/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/tools/api-surface/Fixtures/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/tools/api-surface/Fixtures/Package.swift
+++ b/tools/api-surface/Fixtures/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Fixtures",
+    products: [
+        .library(name: "Fixtures", targets: ["Fixtures"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "Fixtures", dependencies: [])
+    ]
+)

--- a/tools/api-surface/Fixtures/Sources/Fixtures/Fixture1.swift
+++ b/tools/api-surface/Fixtures/Sources/Fixtures/Fixture1.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+/// This is a fixture file used by `api-surface` tests.
+
+import Foundation
+
+public class Car {
+    public enum Manufacturer: String {
+        case manufacturer1
+        case manufacturer2
+        case manufacturer3
+    }
+
+    private let engine = Engine()
+
+    public init(
+        manufacturer: Manufacturer
+    ) {}
+
+    public func startEngine() -> Bool { engine.start() }
+    public func stopEngine() -> Bool { engine.stop() }
+}
+
+internal struct Engine {
+    func start() -> Bool { true }
+    func stop() -> Bool { true }
+}
+
+public extension Car {
+    var price: Int { 100 }
+}

--- a/tools/api-surface/Package.resolved
+++ b/tools/api-surface/Package.resolved
@@ -1,0 +1,70 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Commandant",
+        "repositoryURL": "https://github.com/Carthage/Commandant.git",
+        "state": {
+          "branch": null,
+          "revision": "ab68611013dec67413628ac87c1f29e8427bc8e4",
+          "version": "0.17.0"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "2b1809051b4a65c1d7f5233331daa24572cd7fca",
+          "version": "8.1.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "09b3becb37cb2163919a3842a4c5fa6ec7130792",
+          "version": "2.2.1"
+        }
+      },
+      {
+        "package": "SourceKitten",
+        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
+        "state": {
+          "branch": null,
+          "revision": "77a4dbbb477a8110eb8765e3c44c70fb4929098f",
+          "version": "0.29.0"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "eb51f949cdd0c9d88abba9ce79d37eb7ea1231d0",
+          "version": "0.2.0"
+        }
+      },
+      {
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+        "state": {
+          "branch": null,
+          "revision": "a4931e5c3bafbedeb1601d3bb76bbe835c6d475a",
+          "version": "5.0.1"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
+          "version": "2.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/tools/api-surface/Package.swift
+++ b/tools/api-surface/Package.swift
@@ -5,19 +5,28 @@ import PackageDescription
 
 let package = Package(
     name: "api-surface",
-    platforms: [.macOS(.v10_12)],
+    platforms: [.macOS(.v10_15)],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.2.0"),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", .exact("0.29.0")),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "api-surface",
-            dependencies: []),
+            dependencies: [
+                "APISurfaceCore",
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ]
+        ),
+        .target(
+            name: "APISurfaceCore",
+            dependencies: [
+                .product(name: "SourceKittenFramework", package: "SourceKitten")
+            ]
+        ),
         .testTarget(
             name: "api-surfaceTests",
-            dependencies: ["api-surface"]),
+            dependencies: ["api-surface"]
+        )
     ]
 )

--- a/tools/api-surface/Package.swift
+++ b/tools/api-surface/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "api-surface",
+    platforms: [.macOS(.v10_12)],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "api-surface",
+            dependencies: []),
+        .testTarget(
+            name: "api-surfaceTests",
+            dependencies: ["api-surface"]),
+    ]
+)

--- a/tools/api-surface/README.md
+++ b/tools/api-surface/README.md
@@ -1,3 +1,65 @@
 # api-surface
 
-A command-line utility for generating public API interface for the SDK.
+> A command-line utility for listing public API interface for Swift modules.
+
+This package provides a command-line tool for listing `public` interface of a Swift module.
+
+## Usage
+
+```
+$ api-surface spm --module-name Foo --path ./Foo 
+```
+or
+```
+$ api-surface workspace --workspace-name Foo.xcworkspace --scheme Foo --path .
+```
+Check `api-surface help`  for full overview.
+
+## What is API surface?
+
+API surface is a list of all public APIs exposed from a module. Given following Swift file:
+```swift
+import Foundation
+
+public class Car {
+    public enum Manufacturer: String {
+        case manufacturer1
+        case manufacturer2
+        case manufacturer3
+    }
+
+    private let engine = Engine()
+
+    public init(
+        manufacturer: Manufacturer
+    ) {}
+
+    public func startEngine() -> Bool { engine.start() }
+    public func stopEngine() -> Bool { engine.stop() }
+}
+
+internal struct Engine {
+    func start() -> Bool { true }
+    func stop() -> Bool { true }
+}
+
+public extension Car {
+    var price: Int { 100 }
+}
+```
+It's API surface is:
+```
+public class Car
+ public enum Manufacturer: String
+  case manufacturer1
+  case manufacturer2
+  case manufacturer3
+ public init(manufacturer: Manufacturer)
+ public func startEngine() -> Bool
+ public func stopEngine() -> Bool
+public extension Car
+ var price: Int
+```
+## License
+
+[Apache License, v2.0](../../LICENSE)

--- a/tools/api-surface/README.md
+++ b/tools/api-surface/README.md
@@ -1,0 +1,3 @@
+# api-surface
+
+A command-line utility for generating public API interface for the SDK.

--- a/tools/api-surface/Sources/APISurfaceCore/APISurface.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/APISurface.swift
@@ -1,0 +1,52 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import SourceKittenFramework
+
+public struct APISurfaceError: Error, CustomStringConvertible {
+    public let description: String
+}
+
+public class APISurface {
+    private let moduleInterface: ModuleInterface
+    private let printer = ModuleInterfacePrinter()
+
+    // MARK: - Initialization
+
+    public convenience init(forWorkspaceNamed workspaceName: String, scheme: String, inPath path: String) throws {
+        try self.init(
+            module: Module(
+                xcodeBuildArguments: [
+                    "-workspace", workspaceName,
+                    "-scheme", scheme
+                ],
+                inPath: path
+            )
+        )
+    }
+
+    public convenience init(forSPMModuleNamed spmModuleName: String, inPath path: String) throws {
+        try self.init(
+            module: Module(
+                spmName: spmModuleName,
+                inPath: path
+            )
+        )
+    }
+
+    private init(module: Module?) throws {
+        guard let module = module else {
+            throw APISurfaceError(description: "Failed to generate module interface.")
+        }
+        self.moduleInterface = try ModuleInterface(module: module)
+    }
+
+    // MARK: - Output
+
+    public func print() -> String {
+        printer.print(moduleInterface: moduleInterface)
+    }
+}

--- a/tools/api-surface/Sources/APISurfaceCore/ModuleInterface.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/ModuleInterface.swift
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import SourceKittenFramework
+
+/// A single interface item, e.g.: class or method declaration.
+struct InterfaceItem {
+    /// Code declaration,
+    /// e.g. `class Car` or `case manufacturer1` for enum.
+    let declaration: String
+
+    /// The level of nesting this item,
+    /// e.g. `2` for `struct City` nested in `struct Address`.
+    let nestingLevel: Int
+}
+
+/// An interface of the entire module.
+struct ModuleInterface {
+    /// List of file interfaces in this module.
+    let fileInterfaces: [FileInterface]
+
+    init(module: Module) throws {
+        self.fileInterfaces = try module.docs.map { fileDocs in
+            try FileInterface(docs: fileDocs)
+        }
+    }
+}
+
+/// An interface of a single source file.
+struct FileInterface {
+    /// List of public interface items in this file.
+    let publicInterface: [InterfaceItem]
+
+    fileprivate init(docs: SwiftDocs) throws {
+        self.publicInterface = try getPublicInterfaceItems(from: docs)
+    }
+}

--- a/tools/api-surface/Sources/APISurfaceCore/ModuleInterface.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/ModuleInterface.swift
@@ -8,7 +8,7 @@ import Foundation
 import SourceKittenFramework
 
 /// A single interface item, e.g.: class or method declaration.
-struct InterfaceItem {
+internal struct InterfaceItem {
     /// Code declaration,
     /// e.g. `class Car` or `case manufacturer1` for enum.
     let declaration: String
@@ -19,7 +19,7 @@ struct InterfaceItem {
 }
 
 /// An interface of the entire module.
-struct ModuleInterface {
+internal struct ModuleInterface {
     /// List of file interfaces in this module.
     let fileInterfaces: [FileInterface]
 
@@ -31,7 +31,7 @@ struct ModuleInterface {
 }
 
 /// An interface of a single source file.
-struct FileInterface {
+internal struct FileInterface {
     /// List of public interface items in this file.
     let publicInterface: [InterfaceItem]
 

--- a/tools/api-surface/Sources/APISurfaceCore/Parsing.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/Parsing.swift
@@ -8,7 +8,7 @@ import Foundation
 import SourceKittenFramework
 
 /// Finds public `InterfaceItems` in given `SwiftDocs`.
-func getPublicInterfaceItems(from docs: SwiftDocs) throws -> [InterfaceItem] {
+internal func getPublicInterfaceItems(from docs: SwiftDocs) throws -> [InterfaceItem] {
     let docsJSONObject = toNSDictionary(docs.docsDictionary)
     let docsJSONData = try JSONSerialization.data(
         withJSONObject: docsJSONObject,
@@ -58,7 +58,7 @@ private func recursivelySearchForPublicInterfaceItems(
     recursionLevel: Int = 0
 ) {
     skSubstructures
-        .compactMap({ $0 })
+        .compactMap { $0 }
         .forEach { structure in
             if structure.accessibility == "source.lang.swift.accessibility.public" {
                 if let declaration = structure.declaration {
@@ -85,4 +85,3 @@ private func recursivelySearchForPublicInterfaceItems(
             }
         }
 }
-

--- a/tools/api-surface/Sources/APISurfaceCore/Parsing.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/Parsing.swift
@@ -1,0 +1,88 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import Foundation
+import SourceKittenFramework
+
+/// Finds public `InterfaceItems` in given `SwiftDocs`.
+func getPublicInterfaceItems(from docs: SwiftDocs) throws -> [InterfaceItem] {
+    let docsJSONObject = toNSDictionary(docs.docsDictionary)
+    let docsJSONData = try JSONSerialization.data(
+        withJSONObject: docsJSONObject,
+        options: [.prettyPrinted, .sortedKeys]
+    )
+
+    let skCode = try decoder.decode(SKCode.self, from: docsJSONData)
+
+    var items: [InterfaceItem] = []
+    recursivelySearchForPublicInterfaceItems(in: skCode.substructures, result: &items)
+    return items
+}
+
+// MARK: - Parsing SourceKitten-generated documentation
+
+/// Decodable `SourceKitten's` representation of a file documentation.
+private class SKCode: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case substructures = "key.substructure"
+    }
+
+    let substructures: [SKSubstructure]
+}
+
+/// Decodable `SourceKitten's` representation of a code construct documentation.
+/// Code construct may nest other code constructs.
+private class SKSubstructure: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case accessibility  = "key.accessibility"
+        case declaration    = "key.parsed_declaration"
+        case substructures  = "key.substructure"
+    }
+
+    /// e.g. `source.lang.swift.accessibility.public`
+    let accessibility: String?
+    /// e.g. `public class Car`
+    let declaration: String?
+    let substructures: [SKSubstructure]?
+}
+
+private let decoder = JSONDecoder()
+
+/// Inspects `SKCode` and fills the `result` array with public `InterfaceItems`.
+private func recursivelySearchForPublicInterfaceItems(
+    in skSubstructures: [SKSubstructure],
+    result: inout [InterfaceItem],
+    recursionLevel: Int = 0
+) {
+    skSubstructures
+        .compactMap({ $0 })
+        .forEach { structure in
+            if structure.accessibility == "source.lang.swift.accessibility.public" {
+                if let declaration = structure.declaration {
+                    let item = InterfaceItem(
+                        declaration: declaration,
+                        nestingLevel: recursionLevel
+                    )
+                    result.append(item)
+                }
+            }
+
+            /// Some `substructures` parsed by `SourceKitten` are simple containers without any declaration.
+            let hasDeclaration = structure.declaration != nil
+
+            if let substructures = structure.substructures {
+                // Structures can nest other structures, e.g. `enum` may nest
+                // its `case` substructures. We do head recursion to
+                // list them in the correct order.
+                recursivelySearchForPublicInterfaceItems(
+                    in: substructures,
+                    result: &result,
+                    recursionLevel: recursionLevel + (hasDeclaration ? 1 : 0)
+                )
+            }
+        }
+}
+

--- a/tools/api-surface/Sources/APISurfaceCore/Printing.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/Printing.swift
@@ -7,7 +7,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct ModuleInterfacePrinter {
+internal struct ModuleInterfacePrinter {
     func print(moduleInterface: ModuleInterface) -> String {
         return moduleInterface
             .fileInterfaces
@@ -30,7 +30,7 @@ struct ModuleInterfacePrinter {
             .joined()
 
         let indentation = (0..<interfaceItem.nestingLevel)
-            .map({ _ in " "})
+            .map { _ in " " }
             .joined()
 
         return "\(indentation)\(inlinedDeclaration)"

--- a/tools/api-surface/Sources/APISurfaceCore/Printing.swift
+++ b/tools/api-surface/Sources/APISurfaceCore/Printing.swift
@@ -1,0 +1,38 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import Foundation
+import SourceKittenFramework
+
+struct ModuleInterfacePrinter {
+    func print(moduleInterface: ModuleInterface) -> String {
+        return moduleInterface
+            .fileInterfaces
+            .filter { fileInterface in !fileInterface.publicInterface.isEmpty }
+            .map { fileInterface in self.print(fileInterface: fileInterface) }
+            .joined(separator: "\n")
+    }
+
+    private func print(fileInterface: FileInterface) -> String {
+        return fileInterface
+            .publicInterface
+            .map { self.print(interfaceItem: $0) }
+            .joined(separator: "\n")
+    }
+
+    private func print(interfaceItem: InterfaceItem) -> String {
+        let inlinedDeclaration = interfaceItem.declaration
+            .split(separator: "\n")
+            .map { String($0).removingCommonLeadingWhitespaceFromLines() }
+            .joined()
+
+        let indentation = (0..<interfaceItem.nestingLevel)
+            .map({ _ in " "})
+            .joined()
+
+        return "\(indentation)\(inlinedDeclaration)"
+    }
+}

--- a/tools/api-surface/Sources/api-surface/main.swift
+++ b/tools/api-surface/Sources/api-surface/main.swift
@@ -1,0 +1,7 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+print("Hello, world!")

--- a/tools/api-surface/Sources/api-surface/main.swift
+++ b/tools/api-surface/Sources/api-surface/main.swift
@@ -4,4 +4,65 @@
 * Copyright 2019-2020 Datadog, Inc.
 */
 
-print("Hello, world!")
+import ArgumentParser
+import APISurfaceCore
+
+struct RootCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "api-surface",
+        abstract: "Prints API surface for given Swift module.",
+        subcommands: [
+            SPMSurface.self,
+            WorskspaceSurface.self
+        ]
+    )
+
+    struct SPMSurface: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "spm",
+            abstract: "Prints API surface for given SPM module."
+        )
+
+        @Option(help: "The name of Swift module.")
+        var moduleName: String
+
+        @Option(help: "The path to the folder containing `Package.swift`")
+        var path: String
+
+        func run() {
+            do {
+                let surface = try APISurface(forSPMModuleNamed: moduleName, inPath: path)
+                print(surface.print())
+            } catch {
+                print("Failed to generate api surface: \(error)")
+            }
+        }
+    }
+
+    struct WorskspaceSurface: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "workspace",
+            abstract: "Prints API surface for a module produced by given scheme in given workspace."
+        )
+
+        @Option(help: "The name of the workspace (including extension).")
+        var workspaceName: String
+
+        @Option(help: "The name of the scheme producing a Swift module.")
+        var scheme: String
+
+        @Option(help: "The path to the folder containing workspace file.")
+        var path: String
+
+        func run() {
+            do {
+                let surface = try APISurface(forWorkspaceNamed: workspaceName, scheme: scheme, inPath: path)
+                print(surface.print())
+            } catch {
+                print("Failed to generate api surface: \(error)")
+            }
+        }
+    }
+}
+
+RootCommand.main()

--- a/tools/api-surface/Sources/api-surface/main.swift
+++ b/tools/api-surface/Sources/api-surface/main.swift
@@ -7,7 +7,7 @@
 import ArgumentParser
 import APISurfaceCore
 
-struct RootCommand: ParsableCommand {
+private struct RootCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "api-surface",
         abstract: "Prints API surface for given Swift module.",

--- a/tools/api-surface/Tests/api-surfaceTests/api_surfaceTests.swift
+++ b/tools/api-surface/Tests/api-surfaceTests/api_surfaceTests.swift
@@ -1,0 +1,53 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import XCTest
+import class Foundation.Bundle
+
+final class api_surfaceTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        let fooBinary = productsDirectory.appendingPathComponent("api-surface")
+
+        let process = Process()
+        process.executableURL = fooBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(output, "Hello, world!\n")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/tools/api-surface/Tests/api-surfaceTests/api_surfaceTests.swift
+++ b/tools/api-surface/Tests/api-surfaceTests/api_surfaceTests.swift
@@ -6,22 +6,39 @@
 
 import XCTest
 import class Foundation.Bundle
+@testable import APISurfaceCore
+
+/// API surface for `Fixtures` package
+private let expectedFixturesAPISurface = """
+    public class Car
+     public enum Manufacturer: String
+      case manufacturer1
+      case manufacturer2
+      case manufacturer3
+     public init(manufacturer: Manufacturer)
+     public func startEngine() -> Bool
+     public func stopEngine() -> Bool
+    public extension Car
+     var price: Int
+    """
 
 final class api_surfaceTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
+    func testApiSurfaceCommandLineInterface() throws {
+        // Run `swift build` for `Fixtures` package
+        buildFixturesPackage()
 
-        // Some of the APIs that we use below are available in macOS 10.13 and above.
-        guard #available(macOS 10.13, *) else {
-            return
-        }
+        // Run `api-surface spm --module-name Fixtures --path ./Fixtures`
+        let output = try executeBinary(
+            withArguments: ["spm", "--module-name", "Fixtures", "--path", resolveFixturesPackageFolder().path]
+        )
 
-        let fooBinary = productsDirectory.appendingPathComponent("api-surface")
+        XCTAssertEqual(output, expectedFixturesAPISurface + "\n")
+    }
 
+    private func executeBinary(withArguments arguments: [String]) throws -> String {
         let process = Process()
-        process.executableURL = fooBinary
+        process.executableURL = productsDirectory.appendingPathComponent("api-surface")
+        process.arguments = arguments
 
         let pipe = Pipe()
         process.standardOutput = pipe
@@ -29,25 +46,72 @@ final class api_surfaceTests: XCTestCase {
         try process.run()
         process.waitUntilExit()
 
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: data, encoding: .utf8)
+        let data = pipe.fileHandleForReading.readDataToEndOfFile() 
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}
 
-        XCTAssertEqual(output, "Hello, world!\n")
+final class APISurfaceTests: XCTestCase {
+    func testGeneratingAPISurfaceForFixturesPackage() throws {
+        // Run `swift build` for `Fixtures` package
+        buildFixturesPackage()
+
+        let surface = try APISurface(
+            forSPMModuleNamed: "Fixtures",
+            inPath: resolveFixturesPackageFolder().path
+        )
+
+        XCTAssertEqual(surface.print(), expectedFixturesAPISurface)
     }
 
-    /// Returns path to the built products directory.
-    var productsDirectory: URL {
-      #if os(macOS)
-        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-            return bundle.bundleURL.deletingLastPathComponent()
+    /// NOTE: Use this test to debug (CMD+U) API surface for Datadog.xcworkspace
+//    func testGeneratingAPISurfaceForDatadogWorkspace() throws {
+//        let surface = try APISurface(
+//            forWorkspaceNamed: "Datadog.xcworkspace",
+//            scheme: "Datadog",
+//            inPath: resolveSwiftPackageFolder().appendingPathComponent("../..").path
+//        )
+//
+//        print(surface.print())
+//    }
+}
+
+// MARK: - Helpers
+
+/// Returns path to the built products directory.
+private let productsDirectory: URL = {
+    for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+        return bundle.bundleURL.deletingLastPathComponent()
+    }
+    fatalError("couldn't find the products directory")
+}()
+
+/// Runs `swift build` for `Fixtures` package.
+/// This generates necessary `.build/debug.yaml` file required by SourceKitten to parse docs for SPM module.
+private func buildFixturesPackage() {
+    let process = Process()
+    process.currentDirectoryURL = resolveFixturesPackageFolder()
+    process.launchPath = "/bin/bash"
+    process.arguments = ["-c", "swift build"]
+    process.launch()
+    process.waitUntilExit()
+}
+
+private func resolveFixturesPackageFolder() -> URL {
+    resolveSwiftPackageFolder().appendingPathComponent("Fixtures")
+}
+
+/// Resolves the url to the folder containing `Package.swift`
+private func resolveSwiftPackageFolder() -> URL {
+    var currentFolder = URL(fileURLWithPath: #file).deletingLastPathComponent()
+
+    while currentFolder.pathComponents.count > 0 {
+        if FileManager.default.fileExists(atPath: currentFolder.appendingPathComponent("Package.swift").path) {
+            return currentFolder
+        } else {
+            currentFolder.deleteLastPathComponent()
         }
-        fatalError("couldn't find the products directory")
-      #else
-        return Bundle.main.bundleURL
-      #endif
     }
 
-    static var allTests = [
-        ("testExample", testExample),
-    ]
+    fatalError("Cannot resolve the URL to folder containing `Package.swif`.")
 }

--- a/tools/api-surface/Tests/api-surfaceTests/api_surfaceTests.swift
+++ b/tools/api-surface/Tests/api-surfaceTests/api_surfaceTests.swift
@@ -46,7 +46,7 @@ final class api_surfaceTests: XCTestCase {
         try process.run()
         process.waitUntilExit()
 
-        let data = pipe.fileHandleForReading.readDataToEndOfFile() 
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         return String(data: data, encoding: .utf8) ?? ""
     }
 }

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -83,6 +83,8 @@ custom_rules:
 included:
   - Sources
   - instrumented-tests/http-server-mock/Sources
+  - tools/api-surface/Sources
+  - tools/api-surface/Fixtures/Sources
   - dependency-manager-tests/carthage/CTProject
   - dependency-manager-tests/cocoapods/CPProject
   - dependency-manager-tests/spm/SPMProject

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -76,7 +76,8 @@ custom_rules:
 
 included:
   - Tests
-  - instrumented-tests/http-server-mock/Test
+  - instrumented-tests/http-server-mock/Tests
+  - tools/api-surface/Tests
   - dependency-manager-tests/carthage/CTProjectTests
   - dependency-manager-tests/carthage/CTProjectUITests
   - dependency-manager-tests/cocoapods/CTProjectTests


### PR DESCRIPTION
### What and why?

📦 This PR adds `api-surface-swift` and `api-surface-objc` files, both listing the `public` interfaces from SDK.

### How?

I created a command-line tool, `api-surface`. It uses [SourceKitten](https://github.com/jpsim/SourceKitten) package to generate documentation for SDK and parses its intermediate output to only list interesting things from publicly available interface.

This tool is used in `Makefile`, so we can re-create api-surfaces using `make api-surface`:
```make
# Makefile

# Generate api-surface files for Datadog and DatadogObjc.
api-surface:
   @cd tools/api-surface/ && swift build --configuration release
   @echo "Generating api-surface-swift"
   ./tools/api-surface/.build/x86_64-apple-macosx/release/api-surface workspace --workspace-name Datadog.xcworkspace --scheme Datadog --path . > api-surface-swift
   @echo "Generating api-surface-objc"
   ./tools/api-surface/.build/x86_64-apple-macosx/release/api-surface workspace --workspace-name Datadog.xcworkspace --scheme DatadogObjc --path . > api-surface-objc
```

### Running `api-surface` on CI

A nice extension to api-surface workflow would be generating surfaces on CI and checking if they are up to date. However, I don't include this in this PR, as `make api-surfaces` needs almost `2 minutes` on my machine on cold run, and `29s` if `swift build` was already cached. We may think of [caching build artifacts between Bitrise CI jobs](https://devcenter.bitrise.io/builds/caching/about-caching-index/) OR shipping `api-surface` as binary to make it faster.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
