### PR TITLE
RUMM-486 Fix `test-all-platforms` trigger

### DIFF
--- a/.github/workflows/all-platform-tests.yml
+++ b/.github/workflows/all-platform-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Look for a keyword triggering Bitrise build
+      - name: Look for a keyword triggering the build on Bitrise
         id: check-keyword-trigger
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -27,13 +27,15 @@ jobs:
         env:
           BITRISE_APP_SLUG: ${{ secrets.BITRISE_APP_SLUG }}
           BITRISE_TOKEN: ${{ secrets.BITRISE_TOKEN }}
-          CURRENT_BRANCH: ${{ github.ref }}
           CURRENT_PR_SOURCE_BRANCH: ${{ github.head_ref }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         shell: bash
         run: |
           if [[ -z "${CURRENT_PR_SOURCE_BRANCH}" ]]; then
-            # when running due to a push to existing Pull Request
-            CURRENT_BRANCH="${GITHUB_REF#refs/heads/}"
+            # when running on Pull Request comment (get the branch name from comment's body)
+            SANITIZED_COMMENT=${COMMENT_BODY//[^a-zA-Z0-9@ -\/]/} # sanitize the user input
+            BRANCH_NAME_REGEXP='[a-z]*\/[a-zA-Z0-9-]*'
+            CURRENT_BRANCH=$(echo "${SANITIZED_COMMENT}" | grep -oe '@test-all-platforms '$BRANCH_NAME_REGEXP | grep -oe $BRANCH_NAME_REGEXP)
           else
             # when running due to opening a Pull Request
             CURRENT_BRANCH="${CURRENT_PR_SOURCE_BRANCH}"

--- a/.github/workflows/all-platform-tests.yml
+++ b/.github/workflows/all-platform-tests.yml
@@ -34,7 +34,7 @@ jobs:
           if [[ -z "${CURRENT_PR_SOURCE_BRANCH}" ]]; then
             # when running on Pull Request comment (get the branch name from comment's body)
             SANITIZED_COMMENT=${COMMENT_BODY//[^a-zA-Z0-9@ -\/]/} # sanitize the user input
-            BRANCH_NAME_REGEXP='[a-z]*\/[a-zA-Z0-9-]*'
+            BRANCH_NAME_REGEXP='[a-zA-Z0-9-]*\/[a-zA-Z0-9-]*'
             CURRENT_BRANCH=$(echo "${SANITIZED_COMMENT}" | grep -oe '@test-all-platforms '$BRANCH_NAME_REGEXP | grep -oe $BRANCH_NAME_REGEXP)
           else
             # when running due to opening a Pull Request


### PR DESCRIPTION
### What and why?

📦 This PR fixes the `test-all-platforms.yml` CI job to pick the right git branch when triggered from a PR comment.

### How?

The GH workflow was configured to either:
* run if `@test-all-platforms` is mentioned in PR description,
* run if `@test-all-platforms` is mentioned in PR comment.

The first scenario used to work fine and is not changed 👌. The second scenario was buggy: because of how GH `issue_comment` trigger works, the workflow was always triggered on the `master` branch, resulting with CI picking the `master` for its job.

I changed the behaviour of `Trigger Bitrise build` step to get the branch name from PR comment. **From now, the expected syntax for running `test-all-platforms.yml` CI job from PR comment is**:
```
@test-all-platforms <branch-name>
```
e.g.:
```
"@test-all-platforms ncreated/RUMM-486-fix-all-platform-tests"
```

I added regexp to get the branch name from comment, so this is also allowed and should work:
```
"Please 🙏 @test-all-platforms ncreated/RUMM-486-fix-all-platform-tests thank you!"
```

### Testing

I tested the script locally as much as possible, but again, we can only verify if it works, after this is merged to `master` 🤞.

### Review checklist

~~- [] Feature or bugfix MUST have appropriate tests (unit, integration)~~
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
