### PR TITLE
RUMM-571 Let users add global tags on Tracer

### DIFF
--- a/Sources/Datadog/TracerConfiguration.swift
+++ b/Sources/Datadog/TracerConfiguration.swift
@@ -18,15 +18,20 @@ extension Tracer {
         /// - Parameter enabled: `false` by default
         public var sendNetworkInfo: Bool
 
+        /// Tags that will be added to all new spans created by the tracer
+        public var globalTags: [String: Encodable]?
+
         /// Initializes the Datadog Tracer configuration.
         /// - Parameter serviceName: the service name that will appear in traces (if not provided or `nil`, the SDK default `serviceName` will be used).
         /// - Parameter sendNetworkInfo: adds network connection info to every span and span logs (`false` by default).
         public init(
             serviceName: String? = nil,
-            sendNetworkInfo: Bool = false
+            sendNetworkInfo: Bool = false,
+            globalTags: [String: Encodable]? = nil
         ) {
             self.serviceName = serviceName
             self.sendNetworkInfo = sendNetworkInfo
+            self.globalTags = globalTags
         }
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -170,13 +170,15 @@ extension Tracer {
         spanOutput: SpanOutput = SpanOutputMock(),
         logOutput: LoggingForTracingAdapter.AdaptedLogOutput = .init(loggingOutput: LogOutputMock()),
         dateProvider: DateProvider = SystemDateProvider(),
-        tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator()
+        tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator(),
+        globalTags: [String: Encodable]? = nil
     ) -> Tracer {
         return Tracer(
             spanOutput: spanOutput,
             logOutput: logOutput,
             dateProvider: dateProvider,
-            tracingUUIDGenerator: tracingUUIDGenerator
+            tracingUUIDGenerator: tracingUUIDGenerator,
+            globalTags: globalTags
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -127,12 +127,13 @@ class TracerTests: XCTestCase {
         )
 
         let span = tracer.startSpan(operationName: .mockAny())
+        span.setTag(key:"globaltag2", value: "overwrittenValue" )
         span.finish()
 
         let spanMatcher = try server.waitAndReturnSpanMatchers(count: 1)[0]
         XCTAssertEqual(try spanMatcher.serviceName(), "custom-service-name")
         XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.globaltag1"), "globalValue1")
-        XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.globaltag2"), "globalValue2")
+        XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.globaltag2"), "overwrittenValue")
     }
 
     // MARK: - Sending Customized Spans

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -108,6 +108,33 @@ class TracerTests: XCTestCase {
         }
     }
 
+    func testSendingSpanWithGlobalTags() throws {
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        TracingFeature.instance = .mockWorkingFeatureWith(
+            server: server,
+            directory: temporaryDirectory
+        )
+        defer { TracingFeature.instance = nil }
+
+        let tracer = Tracer.initialize(
+            configuration: .init(
+                serviceName: "custom-service-name",
+                globalTags: [
+                    "globaltag1": "globalValue1",
+                    "globaltag2": "globalValue2"
+                ]
+            )
+        )
+
+        let span = tracer.startSpan(operationName: .mockAny())
+        span.finish()
+
+        let spanMatcher = try server.waitAndReturnSpanMatchers(count: 1)[0]
+        XCTAssertEqual(try spanMatcher.serviceName(), "custom-service-name")
+        XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.globaltag1"), "globalValue1")
+        XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.globaltag2"), "globalValue2")
+    }
+
     // MARK: - Sending Customized Spans
 
     func testSendingCustomizedSpan() throws {


### PR DESCRIPTION
### What and why?

It let users add global tags on Tracer

### How?

The desired tags must be set set in TracerConfiguration before initializing the tracer and will be copied to all created spans

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
