### PR TITLE
RUMM-515 RUM data is uploaded to server

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -164,6 +164,9 @@
 		61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */; };
 		61E45BE724519A3700F2C652 /* JSONDataMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */; };
 		61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45ED02451A8730061DAC7 /* SpanMatcher.swift */; };
+		61E5332C24B75C51003D6C4E /* RUMFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5332B24B75C51003D6C4E /* RUMFeature.swift */; };
+		61E5332F24B75DE2003D6C4E /* RUMFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */; };
+		61E5333124B75DFC003D6C4E /* RUMFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */; };
 		61E909ED24A24DD3005EA2DE /* OTSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E624A24DD3005EA2DE /* OTSpan.swift */; };
 		61E909EE24A24DD3005EA2DE /* OTFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E724A24DD3005EA2DE /* OTFormat.swift */; };
 		61E909EF24A24DD3005EA2DE /* OTGlobal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E824A24DD3005EA2DE /* OTGlobal.swift */; };
@@ -194,10 +197,10 @@
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9EB47B92247443FA004F90BE /* URLSessionSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */; };
 		9ED583A32498C222004CFF2A /* TracingAutoInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED583A22498C222004CFF2A /* TracingAutoInstrumentation.swift */; };
-		E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D5AEA624B4D45A007F194B /* Versioning.swift */; };
+		9EFD112C24B32D29003A1A2B /* URLFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFD112B24B32D29003A1A2B /* URLFilter.swift */; };
 		E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */; };
 		E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */; };
-		9EFD112C24B32D29003A1A2B /* URLFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFD112B24B32D29003A1A2B /* URLFilter.swift */; };
+		E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D5AEA624B4D45A007F194B /* Versioning.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -423,6 +426,9 @@
 		61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFileOutputTests.swift; sourceTree = "<group>"; };
 		61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDataMatcher.swift; sourceTree = "<group>"; };
 		61E45ED02451A8730061DAC7 /* SpanMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanMatcher.swift; sourceTree = "<group>"; };
+		61E5332B24B75C51003D6C4E /* RUMFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeature.swift; sourceTree = "<group>"; };
+		61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureTests.swift; sourceTree = "<group>"; };
+		61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureMocks.swift; sourceTree = "<group>"; };
 		61E909E624A24DD3005EA2DE /* OTSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTSpan.swift; sourceTree = "<group>"; };
 		61E909E724A24DD3005EA2DE /* OTFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTFormat.swift; sourceTree = "<group>"; };
 		61E909E824A24DD3005EA2DE /* OTGlobal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTGlobal.swift; sourceTree = "<group>"; };
@@ -458,10 +464,10 @@
 		9ED583A22498C222004CFF2A /* TracingAutoInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingAutoInstrumentation.swift; sourceTree = "<group>"; };
 		9EF49F1624476FBD004F2CA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9EF49F17244770AD004F2CA0 /* DatadogIntegrationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogIntegrationTests.xcconfig; sourceTree = "<group>"; };
-		E1D5AEA624B4D45A007F194B /* Versioning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Versioning.swift; sourceTree = "<group>"; };
+		9EFD112B24B32D29003A1A2B /* URLFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFilter.swift; sourceTree = "<group>"; };
 		E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingBenchmarkTests.swift; sourceTree = "<group>"; };
 		E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingStorageBenchmarkTests.swift; sourceTree = "<group>"; };
-		9EFD112B24B32D29003A1A2B /* URLFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFilter.swift; sourceTree = "<group>"; };
+		E1D5AEA624B4D45A007F194B /* Versioning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Versioning.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -569,6 +575,7 @@
 				61133B9E2423979B00786299 /* Core */,
 				61133BBC2423979B00786299 /* Logging */,
 				61C5A87724509A0C00DA608C /* Tracing */,
+				61E5332A24B75C3B003D6C4E /* RUM */,
 				61216277247D1F2100AC5D67 /* FeaturesIntegration */,
 				61133BB72423979B00786299 /* Utils */,
 				61E909E524A24DD3005EA2DE /* OpenTracing */,
@@ -785,6 +792,7 @@
 				61133C212423990D00786299 /* Core */,
 				61133C392423990D00786299 /* Logging */,
 				61C5A89724509C1100DA608C /* Tracing */,
+				61E5332D24B75DC7003D6C4E /* RUM */,
 				61216278247D20D500AC5D67 /* FeaturesIntegration */,
 				61133C352423990D00786299 /* Utils */,
 			);
@@ -798,6 +806,7 @@
 				61F1A6192498A51700075390 /* CoreMocks.swift */,
 				61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */,
 				61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */,
+				61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */,
 				61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */,
 				61F1A61B2498AD2C00075390 /* SystemFrameworks */,
 			);
@@ -1206,6 +1215,22 @@
 				61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */,
 			);
 			path = SpanOutputs;
+			sourceTree = "<group>";
+		};
+		61E5332A24B75C3B003D6C4E /* RUM */ = {
+			isa = PBXGroup;
+			children = (
+				61E5332B24B75C51003D6C4E /* RUMFeature.swift */,
+			);
+			path = RUM;
+			sourceTree = "<group>";
+		};
+		61E5332D24B75DC7003D6C4E /* RUM */ = {
+			isa = PBXGroup;
+			children = (
+				61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */,
+			);
+			path = RUM;
 			sourceTree = "<group>";
 		};
 		61E909E524A24DD3005EA2DE /* OpenTracing */ = {
@@ -1648,6 +1673,7 @@
 				9EB47B92247443FA004F90BE /* URLSessionSwizzler.swift in Sources */,
 				61133BE92423979B00786299 /* LogOutput.swift in Sources */,
 				61C5A88524509A0C00DA608C /* DDNoOps.swift in Sources */,
+				61E5332C24B75C51003D6C4E /* RUMFeature.swift in Sources */,
 				61C5A88624509A0C00DA608C /* TracingUUIDGenerator.swift in Sources */,
 				61133BD92423979B00786299 /* DataUploadDelay.swift in Sources */,
 				61C5A88C24509A0C00DA608C /* HTTPHeadersWriter.swift in Sources */,
@@ -1707,6 +1733,7 @@
 				61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */,
 				9E544A5124753DDE00E83072 /* MethodSwizzlerTests.swift in Sources */,
 				61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */,
+				61E5333124B75DFC003D6C4E /* RUMFeatureMocks.swift in Sources */,
 				61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */,
 				61133C6C2423990D00786299 /* SwiftExtensions.swift in Sources */,
 				61133C492423990D00786299 /* DDLoggerBuilderTests.swift in Sources */,
@@ -1718,6 +1745,7 @@
 				61133C482423990D00786299 /* DDDatadogTests.swift in Sources */,
 				61133C522423990D00786299 /* FoundationMocks.swift in Sources */,
 				61133C5B2423990D00786299 /* DirectoryTests.swift in Sources */,
+				61E5332F24B75DE2003D6C4E /* RUMFeatureTests.swift in Sources */,
 				61133C562423990D00786299 /* CarrierInfoProviderTests.swift in Sources */,
 				61C5A89E24509C1100DA608C /* WarningsTests.swift in Sources */,
 				9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */,

--- a/Sources/Datadog/Core/Upload/DataUploader.swift
+++ b/Sources/Datadog/Core/Upload/DataUploader.swift
@@ -28,6 +28,12 @@ internal class UploadURLProvider {
             return QueryItemProvider { queryItem }
         }
 
+        /// Creates `ddtags=tag1,tag2,...` query item.
+        static func ddtags(tags: [String]) -> QueryItemProvider {
+            let queryItem = URLQueryItem(name: "ddtags", value: tags.joined(separator: ","))
+            return QueryItemProvider { queryItem }
+        }
+
         private init(value: @escaping () -> URLQueryItem) {
             self.value = value
         }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -117,13 +117,6 @@ public class Datadog {
                 performance: performance,
                 mobileDevice: mobileDevice,
                 httpClient: httpClient,
-                logsUploadURLProvider: UploadURLProvider(
-                    urlWithClientToken: validConfiguration.logsUploadURLWithClientToken,
-                    queryItemProviders: [
-                        .ddsource(),
-                        .batchTime(using: dateProvider)
-                    ]
-                ),
                 dateProvider: dateProvider,
                 userInfoProvider: userInfoProvider,
                 networkConnectionInfoProvider: networkConnectionInfoProvider,
@@ -139,12 +132,6 @@ public class Datadog {
                 loggingFeatureAdapter: logging.flatMap { LoggingForTracingAdapter(loggingFeature: $0) },
                 mobileDevice: mobileDevice,
                 httpClient: httpClient,
-                tracesUploadURLProvider: UploadURLProvider(
-                    urlWithClientToken: validConfiguration.tracesUploadURLWithClientToken,
-                    queryItemProviders: [
-                        .batchTime(using: dateProvider)
-                    ]
-                ),
                 dateProvider: dateProvider,
                 tracingUUIDGenerator: DefaultTracingUUIDGenerator(),
                 userInfoProvider: userInfoProvider,
@@ -160,13 +147,6 @@ public class Datadog {
                 performance: performance,
                 mobileDevice: mobileDevice,
                 httpClient: httpClient,
-                rumUploadURLProvider: UploadURLProvider(
-                    urlWithClientToken: validConfiguration.rumUploadURLWithClientToken,
-                    queryItemProviders: [
-                        .ddsource(),
-                        .batchTime(using: dateProvider) // TODO: RUMM-515 Build correct query and add tests
-                    ]
-                ),
                 dateProvider: dateProvider,
                 userInfoProvider: userInfoProvider,
                 networkConnectionInfoProvider: networkConnectionInfoProvider,

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -73,7 +73,7 @@ internal final class LoggingFeature {
             performance: PerformancePreset,
             mobileDevice: MobileDevice,
             httpClient: HTTPClient,
-            logsUploadURLProvider: UploadURLProvider,
+            dateProvider: DateProvider,
             networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
             uploadQueue: DispatchQueue
         ) {
@@ -93,7 +93,13 @@ internal final class LoggingFeature {
             )
 
             let dataUploader = DataUploader(
-                urlProvider: logsUploadURLProvider,
+                urlProvider: UploadURLProvider(
+                    urlWithClientToken: configuration.logsUploadURLWithClientToken,
+                    queryItemProviders: [
+                        .ddsource(),
+                        .batchTime(using: dateProvider)
+                    ]
+                ),
                 httpClient: httpClient,
                 httpHeaders: httpHeaders
             )
@@ -117,7 +123,6 @@ internal final class LoggingFeature {
         performance: PerformancePreset,
         mobileDevice: MobileDevice,
         httpClient: HTTPClient,
-        logsUploadURLProvider: UploadURLProvider,
         dateProvider: DateProvider,
         userInfoProvider: UserInfoProvider,
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
@@ -154,7 +159,7 @@ internal final class LoggingFeature {
             performance: performance,
             mobileDevice: mobileDevice,
             httpClient: httpClient,
-            logsUploadURLProvider: logsUploadURLProvider,
+            dateProvider: dateProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             uploadQueue: uploadQueue
         )

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -1,0 +1,162 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Obtains a subdirectory in `/Library/Caches` for writting RUM events.
+internal func obtainRUMFeatureDirectory() throws -> Directory {
+    return try Directory(withSubdirectoryPath: "com.datadoghq.rum/v1")
+}
+
+/// Creates and owns componetns enabling RUM feature.
+/// Bundles dependencies for other RUM-related components created later at runtime  (i.e. `RUMMonitor`).
+internal final class RUMFeature {
+    /// Single, shared instance of `RUMFeature`.
+    internal static var instance: RUMFeature?
+
+    // MARK: - Configuration
+
+    let configuration: Datadog.ValidConfiguration
+
+    // MARK: - Dependencies
+
+    let dateProvider: DateProvider
+    let userInfoProvider: UserInfoProvider
+    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
+    let carrierInfoProvider: CarrierInfoProviderType
+
+    // MARK: - Components
+
+    /// RUM files storage.
+    let storage: Storage
+    /// RUM upload worker.
+    let upload: Upload
+
+    /// Encapsulates  storage stack setup for `RUMFeature`.
+    class Storage {
+        /// Writes RUM events to files.
+        let writer: FileWriter
+        /// Reads RUM events from files.
+        let reader: FileReader
+
+        /// NOTE: any change to logs data format requires updating the RUM directory url to be unique
+        static let dataFormat = DataFormat(prefix: "", suffix: "", separator: "\n")
+
+        init(
+            directory: Directory,
+            performance: PerformancePreset,
+            dateProvider: DateProvider,
+            readWriteQueue: DispatchQueue
+        ) {
+            let orchestrator = FilesOrchestrator(
+                directory: directory,
+                performance: performance,
+                dateProvider: dateProvider
+            )
+
+            self.writer = FileWriter(dataFormat: Storage.dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
+            self.reader = FileReader(dataFormat: Storage.dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
+        }
+    }
+
+    /// Encapsulates upload stack setup for `RUMFeature`.
+    class Upload {
+        /// Uploads RUM events to server.
+        let uploader: DataUploadWorker
+
+        init(
+            storage: Storage,
+            configuration: Datadog.ValidConfiguration,
+            performance: PerformancePreset,
+            mobileDevice: MobileDevice,
+            httpClient: HTTPClient,
+            rumUploadURLProvider: UploadURLProvider,
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
+            uploadQueue: DispatchQueue
+        ) {
+            let httpHeaders = HTTPHeaders(
+                headers: [
+                    .contentTypeHeader(contentType: .textPlainUTF8),
+                    .userAgentHeader(
+                        appName: configuration.applicationName,
+                        appVersion: configuration.applicationVersion,
+                        device: mobileDevice
+                    )
+                ]
+            )
+            let uploadConditions = DataUploadConditions(
+                batteryStatus: BatteryStatusProvider(mobileDevice: mobileDevice),
+                networkConnectionInfo: networkConnectionInfoProvider
+            )
+
+            let dataUploader = DataUploader(
+                urlProvider: rumUploadURLProvider,
+                httpClient: httpClient,
+                httpHeaders: httpHeaders
+            )
+
+            self.uploader = DataUploadWorker(
+                queue: uploadQueue,
+                fileReader: storage.reader,
+                dataUploader: dataUploader,
+                uploadConditions: uploadConditions,
+                delay: DataUploadDelay(performance: performance),
+                featureName: "RUM"
+            )
+        }
+    }
+
+    // MARK: - Initialization
+
+    init(
+        directory: Directory,
+        configuration: Datadog.ValidConfiguration,
+        performance: PerformancePreset,
+        mobileDevice: MobileDevice,
+        httpClient: HTTPClient,
+        rumUploadURLProvider: UploadURLProvider,
+        dateProvider: DateProvider,
+        userInfoProvider: UserInfoProvider,
+        networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
+        carrierInfoProvider: CarrierInfoProviderType
+    ) {
+        // Configuration
+        self.configuration = configuration
+
+        // Bundle dependencies
+        self.dateProvider = dateProvider
+        self.userInfoProvider = userInfoProvider
+        self.networkConnectionInfoProvider = networkConnectionInfoProvider
+        self.carrierInfoProvider = carrierInfoProvider
+
+        // Initialize components
+        let readWriteQueue = DispatchQueue(
+            label: "com.datadoghq.ios-sdk-rum-read-write",
+            target: .global(qos: .utility)
+        )
+        self.storage = Storage(
+            directory: directory,
+            performance: performance,
+            dateProvider: dateProvider,
+            readWriteQueue: readWriteQueue
+        )
+
+        let uploadQueue = DispatchQueue(
+            label: "com.datadoghq.ios-sdk-rum-upload",
+            target: .global(qos: .utility)
+        )
+        self.upload = Upload(
+            storage: self.storage,
+            configuration: configuration,
+            performance: performance,
+            mobileDevice: mobileDevice,
+            httpClient: httpClient,
+            rumUploadURLProvider: rumUploadURLProvider,
+            networkConnectionInfoProvider: networkConnectionInfoProvider,
+            uploadQueue: uploadQueue
+        )
+    }
+}

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -73,7 +73,7 @@ internal final class RUMFeature {
             performance: PerformancePreset,
             mobileDevice: MobileDevice,
             httpClient: HTTPClient,
-            rumUploadURLProvider: UploadURLProvider,
+            dateProvider: DateProvider,
             networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
             uploadQueue: DispatchQueue
         ) {
@@ -93,7 +93,21 @@ internal final class RUMFeature {
             )
 
             let dataUploader = DataUploader(
-                urlProvider: rumUploadURLProvider,
+                urlProvider: UploadURLProvider(
+                    urlWithClientToken: configuration.rumUploadURLWithClientToken,
+                    queryItemProviders: [
+                        .ddsource(),
+                        .batchTime(using: dateProvider),
+                        .ddtags(
+                            tags: [
+                                "service:\(configuration.serviceName)",
+                                "version:\(configuration.applicationVersion)",
+                                "sdk_version:\(sdkVersion)",
+                                "env:\(configuration.environment)"
+                            ]
+                        )
+                    ]
+                ),
                 httpClient: httpClient,
                 httpHeaders: httpHeaders
             )
@@ -117,7 +131,6 @@ internal final class RUMFeature {
         performance: PerformancePreset,
         mobileDevice: MobileDevice,
         httpClient: HTTPClient,
-        rumUploadURLProvider: UploadURLProvider,
         dateProvider: DateProvider,
         userInfoProvider: UserInfoProvider,
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
@@ -154,7 +167,7 @@ internal final class RUMFeature {
             performance: performance,
             mobileDevice: mobileDevice,
             httpClient: httpClient,
-            rumUploadURLProvider: rumUploadURLProvider,
+            dateProvider: dateProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             uploadQueue: uploadQueue
         )

--- a/Sources/Datadog/Tracing/TracingAutoInstrumentation.swift
+++ b/Sources/Datadog/Tracing/TracingAutoInstrumentation.swift
@@ -23,7 +23,8 @@ internal class TracingAutoInstrumentation {
             includedHosts: configuration.tracedHosts,
             excludedURLs: [
                 configuration.logsEndpoint.url,
-                configuration.tracesEndpoint.url
+                configuration.tracesEndpoint.url,
+                configuration.rumEndpoint.url
             ]
         )
         self.init(urlFilter: urlFilter)

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -80,7 +80,7 @@ internal final class TracingFeature {
             performance: PerformancePreset,
             mobileDevice: MobileDevice,
             httpClient: HTTPClient,
-            tracesUploadURLProvider: UploadURLProvider,
+            dateProvider: DateProvider,
             networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
             uploadQueue: DispatchQueue
         ) {
@@ -100,7 +100,12 @@ internal final class TracingFeature {
             )
 
             let dataUploader = DataUploader(
-                urlProvider: tracesUploadURLProvider,
+                urlProvider: UploadURLProvider(
+                    urlWithClientToken: configuration.tracesUploadURLWithClientToken,
+                    queryItemProviders: [
+                        .batchTime(using: dateProvider)
+                    ]
+                ),
                 httpClient: httpClient,
                 httpHeaders: httpHeaders
             )
@@ -125,7 +130,6 @@ internal final class TracingFeature {
         loggingFeatureAdapter: LoggingForTracingAdapter?,
         mobileDevice: MobileDevice,
         httpClient: HTTPClient,
-        tracesUploadURLProvider: UploadURLProvider,
         dateProvider: DateProvider,
         tracingUUIDGenerator: TracingUUIDGenerator,
         userInfoProvider: UserInfoProvider,
@@ -167,7 +171,7 @@ internal final class TracingFeature {
             performance: performance,
             mobileDevice: mobileDevice,
             httpClient: httpClient,
-            tracesUploadURLProvider: tracesUploadURLProvider,
+            dateProvider: dateProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             uploadQueue: uploadQueue
         )

--- a/Tests/DatadogIntegrationTests/IntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/IntegrationTests.swift
@@ -16,7 +16,7 @@ class IntegrationTests: XCTestCase {
     private(set) var server: ServerMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUpWithError() throws {
-        try super.setUp()
+        try super.setUpWithError()
         server = try connectToServer()
     }
 

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -116,6 +116,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNotNil(LoggingFeature.instance)
             XCTAssertNotNil(TracingFeature.instance)
+            XCTAssertNotNil(RUMFeature.instance)
             XCTAssertNil(TracingAutoInstrumentation.instance)
             // verify integrations:
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
@@ -124,6 +125,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNil(LoggingFeature.instance)
             XCTAssertNotNil(TracingFeature.instance)
+            XCTAssertNotNil(RUMFeature.instance)
             XCTAssertNil(TracingAutoInstrumentation.instance)
             // verify integrations:
             XCTAssertNil(TracingFeature.instance?.loggingFeatureAdapter)
@@ -132,12 +134,16 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNotNil(LoggingFeature.instance)
             XCTAssertNil(TracingFeature.instance)
+            XCTAssertNotNil(RUMFeature.instance)
+            // verify integrations:
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }
-        try verify(configuration: configurationBuilder.enableLogging(false).enableTracing(false).build()) {
+        try verify(configuration: configurationBuilder.enableRUM(false).build()) {
             // verify features:
-            XCTAssertNil(LoggingFeature.instance)
-            XCTAssertNil(TracingFeature.instance)
+            XCTAssertNotNil(LoggingFeature.instance)
+            XCTAssertNotNil(TracingFeature.instance)
+            XCTAssertNil(RUMFeature.instance)
+            // verify integrations:
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }
 

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -22,22 +22,6 @@ class LoggingFeatureTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Initialization
-
-    func testInitialization() throws {
-        let appContext: AppContext = .mockAny()
-        Datadog.initialize(
-            appContext: appContext,
-            configuration: Datadog.Configuration
-                .builderUsing(clientToken: "abc", environment: "tests")
-                .build()
-        )
-
-        XCTAssertNotNil(LoggingFeature.instance)
-
-        try Datadog.deinitializeOrThrow()
-    }
-
     // MARK: - HTTP Headers
 
     func testItUsesExpectedHTTPHeaders() throws {

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -18,8 +18,10 @@ extension Datadog.Configuration {
         environment: String = .mockAny(),
         loggingEnabled: Bool = false,
         tracingEnabled: Bool = false,
+        rumEnabled: Bool = false,
         logsEndpoint: LogsEndpoint = .us,
         tracesEndpoint: TracesEndpoint = .us,
+        rumEndpoint: RUMEndpoint = .us,
         serviceName: String? = .mockAny()
     ) -> Datadog.Configuration {
         return Datadog.Configuration(
@@ -27,8 +29,10 @@ extension Datadog.Configuration {
             environment: environment,
             loggingEnabled: loggingEnabled,
             tracingEnabled: tracingEnabled,
+            rumEnabled: rumEnabled,
             logsEndpoint: logsEndpoint,
             tracesEndpoint: tracesEndpoint,
+            rumEndpoint: rumEndpoint,
             serviceName: serviceName
         )
     }
@@ -46,7 +50,8 @@ extension Datadog.ValidConfiguration {
         serviceName: String = .mockAny(),
         environment: String = .mockAny(),
         logsUploadURLWithClientToken: URL = .mockAny(),
-        tracesUploadURLWithClientToken: URL = .mockAny()
+        tracesUploadURLWithClientToken: URL = .mockAny(),
+        rumUploadURLWithClientToken: URL = .mockAny()
     ) -> Datadog.ValidConfiguration {
         return Datadog.ValidConfiguration(
             applicationName: applicationName,
@@ -55,7 +60,8 @@ extension Datadog.ValidConfiguration {
             serviceName: serviceName,
             environment: environment,
             logsUploadURLWithClientToken: logsUploadURLWithClientToken,
-            tracesUploadURLWithClientToken: tracesUploadURLWithClientToken
+            tracesUploadURLWithClientToken: tracesUploadURLWithClientToken,
+            rumUploadURLWithClientToken: rumUploadURLWithClientToken
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -15,7 +15,6 @@ extension LoggingFeature {
             performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp),
             mobileDevice: .mockAny(),
             httpClient: .mockAny(),
-            logsUploadURLProvider: .mockAny(),
             dateProvider: SystemDateProvider(),
             userInfoProvider: .mockAny(),
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
@@ -42,7 +41,6 @@ extension LoggingFeature {
                 return BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false)
             }
         ),
-        logsUploadURLProvider: UploadURLProvider = .mockAny(),
         dateProvider: DateProvider = SystemDateProvider(),
         userInfoProvider: UserInfoProvider = .mockAny(),
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockWith(
@@ -63,7 +61,6 @@ extension LoggingFeature {
             performance: performance,
             mobileDevice: mobileDevice,
             httpClient: HTTPClient(session: server.urlSession),
-            logsUploadURLProvider: logsUploadURLProvider,
             dateProvider: dateProvider,
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+@testable import Datadog
+
+extension RUMFeature {
+    /// Mocks feature instance which performs uploads to given `ServerMock` with performance optimized for fast delivery in unit tests.
+    static func mockWorkingFeatureWith(
+        server: ServerMock,
+        directory: Directory,
+        configuration: Datadog.ValidConfiguration = .mockAny(),
+        performance: PerformancePreset = .combining(
+            storagePerformance: .writeEachObjectToNewFileAndReadAllFiles,
+            uploadPerformance: .veryQuick
+        ),
+        mobileDevice: MobileDevice = .mockWith(
+            currentBatteryStatus: {
+                // Mock full battery, so it doesn't rely on battery condition for the upload
+                return BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false)
+            }
+        ),
+        rumUploadURLProvider: UploadURLProvider = .mockAny(),
+        dateProvider: DateProvider = SystemDateProvider(),
+        userInfoProvider: UserInfoProvider = .mockAny(),
+        networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockWith(
+            networkConnectionInfo: .mockWith(
+                reachability: .yes, // so it always meets the upload condition
+                availableInterfaces: [.wifi],
+                supportsIPv4: true,
+                supportsIPv6: true,
+                isExpensive: true,
+                isConstrained: false // so it always meets the upload condition
+            )
+        ),
+        carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
+    ) -> RUMFeature {
+        return RUMFeature(
+            directory: directory,
+            configuration: configuration,
+            performance: performance,
+            mobileDevice: mobileDevice,
+            httpClient: HTTPClient(session: server.urlSession),
+            rumUploadURLProvider: rumUploadURLProvider,
+            dateProvider: dateProvider,
+            userInfoProvider: userInfoProvider,
+            networkConnectionInfoProvider: networkConnectionInfoProvider,
+            carrierInfoProvider: carrierInfoProvider
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -22,7 +22,6 @@ extension RUMFeature {
                 return BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false)
             }
         ),
-        rumUploadURLProvider: UploadURLProvider = .mockAny(),
         dateProvider: DateProvider = SystemDateProvider(),
         userInfoProvider: UserInfoProvider = .mockAny(),
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockWith(
@@ -43,7 +42,6 @@ extension RUMFeature {
             performance: performance,
             mobileDevice: mobileDevice,
             httpClient: HTTPClient(session: server.urlSession),
-            rumUploadURLProvider: rumUploadURLProvider,
             dateProvider: dateProvider,
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -16,7 +16,6 @@ extension TracingFeature {
             loggingFeatureAdapter: nil,
             mobileDevice: .mockAny(),
             httpClient: .mockAny(),
-            tracesUploadURLProvider: .mockAny(),
             dateProvider: SystemDateProvider(),
             tracingUUIDGenerator: DefaultTracingUUIDGenerator(),
             userInfoProvider: .mockAny(),
@@ -45,7 +44,6 @@ extension TracingFeature {
                 return BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false)
             }
         ),
-        tracesUploadURLProvider: UploadURLProvider = .mockAny(),
         dateProvider: DateProvider = SystemDateProvider(),
         tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator(),
         userInfoProvider: UserInfoProvider = .mockAny(),
@@ -68,7 +66,6 @@ extension TracingFeature {
             loggingFeatureAdapter: loggingFeature.flatMap { LoggingForTracingAdapter(loggingFeature: $0) },
             mobileDevice: mobileDevice,
             httpClient: HTTPClient(session: server.urlSession),
-            tracesUploadURLProvider: tracesUploadURLProvider,
             dateProvider: dateProvider,
             tracingUUIDGenerator: tracingUUIDGenerator,
             userInfoProvider: userInfoProvider,

--- a/Tests/DatadogTests/Datadog/Tracing/TracingAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingAutoInstrumentationTests.swift
@@ -22,7 +22,14 @@ class TracingAutoInstrumentationTests: XCTestCase {
         let autoInstrumentation = TracingAutoInstrumentation(with: config)
 
         let urlFilter = try XCTUnwrap(autoInstrumentation?.urlFilter as? URLFilter)
-        let expectedURLFilter = URLFilter(includedHosts: [String.mockAny()], excludedURLs: [config.logsEndpoint.url, config.tracesEndpoint.url])
+        let expectedURLFilter = URLFilter(
+            includedHosts: [String.mockAny()],
+            excludedURLs: [
+                config.logsEndpoint.url,
+                config.tracesEndpoint.url,
+                config.rumEndpoint.url
+            ]
+        )
 
         XCTAssertEqual(urlFilter, expectedURLFilter)
     }

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -22,9 +22,9 @@ class TracingFeatureTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - HTTP Headers
+    // MARK: - HTTP Message
 
-    func testItUsesExpectedHTTPHeaders() throws {
+    func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWorkingFeatureWith(
             server: server,
@@ -33,7 +33,8 @@ class TracingFeatureTests: XCTestCase {
                 applicationName: "FoobarApp",
                 applicationVersion: "2.1.0"
             ),
-            mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1")
+            mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1"),
+            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
         )
         defer { TracingFeature.instance = nil }
 
@@ -42,12 +43,14 @@ class TracingFeatureTests: XCTestCase {
         let span = tracer.startSpan(operationName: "operation 1")
         span.finish()
 
-        let httpHeaders = server.waitAndReturnRequests(count: 1)[0].allHTTPHeaderFields
-        XCTAssertEqual(httpHeaders?["User-Agent"], "FoobarApp/2.1.0 CFNetwork (iPhone; iOS/13.3.1)")
-        XCTAssertEqual(httpHeaders?["Content-Type"], "text/plain;charset=UTF-8")
+        let request = server.waitAndReturnRequests(count: 1)[0]
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.query, "batch_time=1576404000000")
+        XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], "FoobarApp/2.1.0 CFNetwork (iPhone; iOS/13.3.1)")
+        XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "text/plain;charset=UTF-8")
     }
 
-    // MARK: - Payload Format
+    // MARK: - HTTP Payload
 
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))


### PR DESCRIPTION
### What and why?

📦 This PR configures `RUMFeature` so it can upload data to RUM Intake

### How?

I added `RUMFeature` with `Storage` and `Upload` stacks and configured them to use the expected RUM HTTP message format.

RUM uses `text/plain;charset=UTF-8` content type with RUM events encoded as newline-separated JSONs:
```http
POST <rum-intake-url>/<access-token>?ddsource=ios&batch_time=<timestamp in milliseconds>&ddtags=service:<service-name>,version:<app-version>,sdk_version:<sdk-version>,env:<environment-name>
Content-Type: text/plain;charset=UTF-8

rumEventJSON1
rumEventJSON2
rumEventJSON3
```

Except unit tests, to additionally test if all works fine, I've send a fake data to RUM Explorer (I will add this debug utility in a next PR, so we can use it when iterating further on RUM feature):

<img width="718" alt="Screenshot 2020-07-10 at 09 28 03" src="https://user-images.githubusercontent.com/2358722/87129022-f33a8800-c290-11ea-9c96-5e57dea7ba67.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
