### PR TITLE
RUM-515 Add "Debug RUM" screen in Example app

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		61E5332F24B75DE2003D6C4E /* RUMFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */; };
 		61E5333124B75DFC003D6C4E /* RUMFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */; };
 		61E5333424B7A545003D6C4E /* RUMViewEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333324B7A545003D6C4E /* RUMViewEvent.swift */; };
+		61E5333624B84B43003D6C4E /* RUMMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333524B84B43003D6C4E /* RUMMonitor.swift */; };
+		61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */; };
 		61E909ED24A24DD3005EA2DE /* OTSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E624A24DD3005EA2DE /* OTSpan.swift */; };
 		61E909EE24A24DD3005EA2DE /* OTFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E724A24DD3005EA2DE /* OTFormat.swift */; };
 		61E909EF24A24DD3005EA2DE /* OTGlobal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E824A24DD3005EA2DE /* OTGlobal.swift */; };
@@ -431,6 +433,8 @@
 		61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureTests.swift; sourceTree = "<group>"; };
 		61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureMocks.swift; sourceTree = "<group>"; };
 		61E5333324B7A545003D6C4E /* RUMViewEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewEvent.swift; sourceTree = "<group>"; };
+		61E5333524B84B43003D6C4E /* RUMMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitor.swift; sourceTree = "<group>"; };
+		61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRUMViewController.swift; sourceTree = "<group>"; };
 		61E909E624A24DD3005EA2DE /* OTSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTSpan.swift; sourceTree = "<group>"; };
 		61E909E724A24DD3005EA2DE /* OTFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTFormat.swift; sourceTree = "<group>"; };
 		61E909E824A24DD3005EA2DE /* OTGlobal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTGlobal.swift; sourceTree = "<group>"; };
@@ -569,10 +573,11 @@
 			children = (
 				9E9EB37624468CE90002C80B /* Datadog.modulemap */,
 				61133BBB2423979B00786299 /* Datadog.swift */,
+				61133BB52423979B00786299 /* DatadogConfiguration.swift */,
 				61133BB62423979B00786299 /* Logger.swift */,
 				61C5A88D24509A1F00DA608C /* Tracer.swift */,
 				61E917D02465423600E6C631 /* TracerConfiguration.swift */,
-				61133BB52423979B00786299 /* DatadogConfiguration.swift */,
+				61E5333524B84B43003D6C4E /* RUMMonitor.swift */,
 				E1D5AEA624B4D45A007F194B /* Versioning.swift */,
 				61133B9E2423979B00786299 /* Core */,
 				61133BBC2423979B00786299 /* Logging */,
@@ -1058,6 +1063,7 @@
 			children = (
 				61441C942461A649003D8BB8 /* DebugLoggingViewController.swift */,
 				61441C932461A649003D8BB8 /* DebugTracingViewController.swift */,
+				61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */,
 			);
 			path = Debugging;
 			sourceTree = "<group>";
@@ -1659,6 +1665,7 @@
 				61133BE02423979B00786299 /* Datadog.swift in Sources */,
 				61133BCB2423979B00786299 /* CarrierInfoProvider.swift in Sources */,
 				61C5A89024509AA700DA608C /* TracingFeature.swift in Sources */,
+				61E5333624B84B43003D6C4E /* RUMMonitor.swift in Sources */,
 				61133BD62423979B00786299 /* DataUploader.swift in Sources */,
 				61C5A88724509A0C00DA608C /* Casting.swift in Sources */,
 				61133BE52423979B00786299 /* LogBuilder.swift in Sources */,
@@ -1806,6 +1813,7 @@
 				61441C972461A649003D8BB8 /* UIViewController+KeyboardControlling.swift in Sources */,
 				61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */,
 				61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */,
+				61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */,
 				61441C9D2461A796003D8BB8 /* AppConfig.swift in Sources */,
 				61441C0524616DE9003D8BB8 /* AppDelegate.swift in Sources */,
 				61441C992461A649003D8BB8 /* DebugLoggingViewController.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		61E5332C24B75C51003D6C4E /* RUMFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5332B24B75C51003D6C4E /* RUMFeature.swift */; };
 		61E5332F24B75DE2003D6C4E /* RUMFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */; };
 		61E5333124B75DFC003D6C4E /* RUMFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */; };
+		61E5333424B7A545003D6C4E /* RUMViewEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333324B7A545003D6C4E /* RUMViewEvent.swift */; };
 		61E909ED24A24DD3005EA2DE /* OTSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E624A24DD3005EA2DE /* OTSpan.swift */; };
 		61E909EE24A24DD3005EA2DE /* OTFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E724A24DD3005EA2DE /* OTFormat.swift */; };
 		61E909EF24A24DD3005EA2DE /* OTGlobal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E824A24DD3005EA2DE /* OTGlobal.swift */; };
@@ -429,6 +430,7 @@
 		61E5332B24B75C51003D6C4E /* RUMFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeature.swift; sourceTree = "<group>"; };
 		61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureTests.swift; sourceTree = "<group>"; };
 		61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMFeatureMocks.swift; sourceTree = "<group>"; };
+		61E5333324B7A545003D6C4E /* RUMViewEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewEvent.swift; sourceTree = "<group>"; };
 		61E909E624A24DD3005EA2DE /* OTSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTSpan.swift; sourceTree = "<group>"; };
 		61E909E724A24DD3005EA2DE /* OTFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTFormat.swift; sourceTree = "<group>"; };
 		61E909E824A24DD3005EA2DE /* OTGlobal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTGlobal.swift; sourceTree = "<group>"; };
@@ -1221,6 +1223,7 @@
 			isa = PBXGroup;
 			children = (
 				61E5332B24B75C51003D6C4E /* RUMFeature.swift */,
+				61E5333224B7A504003D6C4E /* DataModels */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -1231,6 +1234,14 @@
 				61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */,
 			);
 			path = RUM;
+			sourceTree = "<group>";
+		};
+		61E5333224B7A504003D6C4E /* DataModels */ = {
+			isa = PBXGroup;
+			children = (
+				61E5333324B7A545003D6C4E /* RUMViewEvent.swift */,
+			);
+			path = DataModels;
 			sourceTree = "<group>";
 		};
 		61E909E524A24DD3005EA2DE /* OpenTracing */ = {
@@ -1640,6 +1651,7 @@
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
 				9E544A4F24753C6E00E83072 /* MethodSwizzler.swift in Sources */,
 				61133BEA2423979B00786299 /* LogConsoleOutput.swift in Sources */,
+				61E5333424B7A545003D6C4E /* RUMViewEvent.swift in Sources */,
 				61C5A8A624509FAA00DA608C /* SpanEncoder.swift in Sources */,
 				61C5A88E24509A1F00DA608C /* Tracer.swift in Sources */,
 				61E909EE24A24DD3005EA2DE /* OTFormat.swift in Sources */,

--- a/Datadog/Example/AppDelegate.swift
+++ b/Datadog/Example/AppDelegate.swift
@@ -38,7 +38,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Create logger instance
         logger = Logger.builder
-            .set(serviceName: appConfig.serviceName)
             .set(loggerName: "logger-name")
             .sendNetworkInfo(true)
             .printLogsToConsole(true, usingFormat: .shortWith(prefix: "[iOS App] "))
@@ -47,7 +46,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Register global tracer
         Global.sharedTracer = Tracer.initialize(
             configuration: Tracer.Configuration(
-                serviceName: appConfig.serviceName,
                 sendNetworkInfo: true
             )
         )

--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="wle-IX-rUl">
-                            <rect key="frame" x="0.0" y="286" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="329.5" width="414" height="0.0"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         </view>
@@ -64,12 +64,32 @@
                                             <segue destination="FaI-gu-eql" kind="show" id="ePB-Ph-XzE"/>
                                         </connections>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="yCu-pq-IYL" style="IBUITableViewCellStyleDefault" id="3G8-Wa-fSQ">
+                                        <rect key="frame" x="0.0" y="115" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3G8-Wa-fSQ" id="7IJ-XI-RAR">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="RUM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="yCu-pq-IYL">
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="CBf-fg-exz" kind="show" id="5Im-MK-mpd"/>
+                                        </connections>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="UITest scenarios:" id="6Zm-Kj-Vxy">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="cup-8g-amw" style="IBUITableViewCellStyleDefault" id="0R8-Cw-D1v">
-                                        <rect key="frame" x="0.0" y="171" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="214.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0R8-Cw-D1v" id="qW4-7f-cXH">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -89,7 +109,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Mfa-d4-bXd" style="IBUITableViewCellStyleDefault" id="TY6-N9-9Dp">
-                                        <rect key="frame" x="0.0" y="214.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="258" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TY6-N9-9Dp" id="1CW-VC-avL">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -354,7 +374,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-99" y="-410"/>
+            <point key="canvasLocation" x="-1319" y="-273"/>
         </scene>
         <!--Debug Tracing View Controller-->
         <scene sceneID="qsy-Bu-n9m">
@@ -660,7 +680,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LiQ-0O-emZ" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="264" y="252"/>
+            <point key="canvasLocation" x="-310" y="-273"/>
         </scene>
         <!--Send Logs Fixture View Controller-->
         <scene sceneID="pAJ-JA-qyP">
@@ -719,6 +739,172 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6qc-vU-hqo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-309" y="1611"/>
+        </scene>
+        <!--DebugRUM View Controller-->
+        <scene sceneID="JCG-Nr-eCn">
+            <objects>
+                <viewController id="CBf-fg-exz" customClass="DebugRUMViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="S49-nI-DRG">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Il3-pF-p3a">
+                                <rect key="frame" x="15" y="103" width="384" height="744"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tn8-3S-fPF">
+                                        <rect key="frame" x="0.0" y="0.0" width="384" height="20"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="SERVICE:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eka-Ej-HZy">
+                                                <rect key="frame" x="0.0" y="0.0" width="53.5" height="20"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t9m-tT-F8j">
+                                                <rect key="frame" x="53.5" y="0.0" width="10" height="20"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="10" id="Wwl-46-fmK"/>
+                                                </constraints>
+                                            </view>
+                                            <textField opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="ios-sdk-example-app" borderStyle="roundedRect" placeholder="Enter service name..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vzP-ny-3dq">
+                                                <rect key="frame" x="63.5" y="0.0" width="320.5" height="20"/>
+                                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="20" id="QZg-gK-U52"/>
+                                        </constraints>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fM2-qe-QkK" userLabel="Vertical gap 15">
+                                        <rect key="frame" x="0.0" y="20" width="384" height="15"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="15" id="wcN-Gv-yCO"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View Event" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zjv-y9-VvL">
+                                        <rect key="frame" x="0.0" y="35" width="384" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DmQ-rb-UiO" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="55.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="0En-Yf-gGB"/>
+                                        </constraints>
+                                    </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="abs-xz-lgo">
+                                        <rect key="frame" x="0.0" y="65.5" width="384" height="30"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="79A-KI-slP">
+                                                <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lU8-Dq-owV">
+                                                        <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="view.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QS9-fr-2yR">
+                                                                <rect key="frame" x="0.0" y="0.0" width="43" height="30"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                                <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="U9s-H3-pzA">
+                                                                <rect key="frame" x="48" y="0.0" width="281" height="30"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                            </textField>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="30" id="HUf-w1-2g3"/>
+                                                        </constraints>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ixr-vj-rNH">
+                                                <rect key="frame" x="334" y="0.0" width="50" height="30"/>
+                                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="Wbf-l6-3G4"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="Send">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="7"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="didTapSendViewEvent:" destination="CBf-fg-exz" eventType="touchUpInside" id="TSV-7j-gK0"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W1b-Ap-trU" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="95.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="Zk1-nz-tiQ"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1CX-Pk-Oad" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="105.5" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="J1D-8z-qtE"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONSOLE OUTPUT:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="heX-eV-XM4">
+                                        <rect key="frame" x="0.0" y="115.5" width="384" height="14.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cUF-XZ-rO4" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="130" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="Kmx-dC-T5D"/>
+                                        </constraints>
+                                    </view>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xE1-F9-dzh">
+                                        <rect key="frame" x="0.0" y="140" width="384" height="604"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    </textView>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="Il3-pF-p3a" firstAttribute="top" secondItem="bZp-wc-KwC" secondAttribute="top" constant="15" id="5X6-Dm-xjN"/>
+                            <constraint firstItem="bZp-wc-KwC" firstAttribute="trailing" secondItem="Il3-pF-p3a" secondAttribute="trailing" constant="15" id="V2B-EN-ONG"/>
+                            <constraint firstItem="Il3-pF-p3a" firstAttribute="leading" secondItem="bZp-wc-KwC" secondAttribute="leading" constant="15" id="VLL-yL-8P0"/>
+                            <constraint firstItem="bZp-wc-KwC" firstAttribute="bottom" secondItem="Il3-pF-p3a" secondAttribute="bottom" constant="15" id="vsV-h4-zjs"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="bZp-wc-KwC"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="uWQ-hu-SiG"/>
+                    <connections>
+                        <outlet property="consoleTextView" destination="xE1-F9-dzh" id="EZv-yU-A1l"/>
+                        <outlet property="rumServiceNameTextField" destination="vzP-ny-3dq" id="erc-CQ-v5k"/>
+                        <outlet property="sendViewEventButton" destination="Ixr-vj-rNH" id="UxV-V9-WZL"/>
+                        <outlet property="viewURLTextField" destination="U9s-H3-pzA" id="lLu-p7-x7L"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="z20-g6-vwL" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="675" y="-273"/>
         </scene>
     </scenes>
 </document>

--- a/Datadog/Example/Debugging/DebugRUMViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMViewController.swift
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+import Datadog
+
+class DebugRUMViewController: UIViewController {
+    @IBOutlet weak var rumServiceNameTextField: UITextField!
+    @IBOutlet weak var consoleTextView: UITextView!
+
+    private let rumMonitor = RUMMonitor(rumApplicationID: appConfig.rumApplicationID)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        rumServiceNameTextField.text = appConfig.serviceName
+        hideKeyboardWhenTapOutside()
+        startDisplayingDebugInfo(in: consoleTextView)
+
+        viewURLTextField.placeholder = viewURL
+    }
+
+    // MARK: - View Event
+
+    @IBOutlet weak var viewURLTextField: UITextField!
+    @IBOutlet weak var sendViewEventButton: UIButton!
+
+    private var viewURL: String {
+        viewURLTextField.text!.isEmpty ? "/hello/rum" : viewURLTextField.text!
+    }
+
+    @IBAction func didTapSendViewEvent(_ sender: Any) {
+        rumMonitor.sendFakeViewEvent(viewURL: viewURL)
+        sendViewEventButton.disableFor(seconds: 0.5)
+    }
+}

--- a/Datadog/TargetSupport/Example/Info.plist
+++ b/Datadog/TargetSupport/Example/Info.plist
@@ -22,6 +22,8 @@
 	<string>$(DATADOG_CLIENT_TOKEN)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>RUMApplicationID</key>
+	<string>$(RUM_APPLICATION_ID)</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Sources/Datadog/RUM/DataModels/RUMViewEvent.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMViewEvent.swift
@@ -1,0 +1,73 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+// TODO: RUMM-517 Replace with auto-generated RUM data model
+internal struct RUMViewEvent: Encodable {
+    enum CodingKeys: String, CodingKey {
+        case date
+        case application
+        case session
+        case type
+        case view
+        case dd  = "_dd"
+    }
+
+    let date: UInt64
+    let application: Application
+    let session: Session
+    let type = "view"
+    let view: View
+    let dd: DD
+
+    struct Application: Encodable {
+        let id: String
+    }
+
+    struct Session: Encodable {
+        let id: String
+        let type: String
+    }
+
+    struct View: Encodable {
+        enum CodingKeys: String, CodingKey {
+            case id
+            case url
+            case timeSpent = "time_spent"
+            case action
+            case error
+            case resource
+        }
+
+        let id: String
+        let url: String
+        let timeSpent: UInt64
+        let action: Action
+        let error: Error
+        let resource: Resource
+
+        struct Action: Encodable {
+            let count: UInt
+        }
+        struct Error: Encodable {
+            let count: UInt
+        }
+        struct Resource: Encodable {
+            let count: UInt
+        }
+    }
+
+    struct DD: Encodable {
+        enum CodingKeys: String, CodingKey {
+            case documentVersion = "document_version"
+            case formatVersion  = "format_version"
+        }
+
+        let documentVersion: UInt
+        let formatVersion = 2
+    }
+}

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+public class RUMMonitor {
+    private let rumApplicationID: String
+
+    public init(rumApplicationID: String) {
+        self.rumApplicationID = rumApplicationID
+    }
+
+    /// TODO: RUMM-585 Replace with real RUMMonitor public API
+    public func sendFakeViewEvent(viewURL: String) {
+        let event = RUMViewEvent(
+            date: Date(timeIntervalSinceNow: -1).timeIntervalSince1970.toMilliseconds,
+            application: .init(id: rumApplicationID),
+            session: .init(id: UUID().uuidString.lowercased(), type: "user"),
+            view: .init(
+                id: UUID().uuidString.lowercased(),
+                url: viewURL,
+                timeSpent: TimeInterval(0.5).toNanoseconds,
+                action: .init(count: 0),
+                error: .init(count: 0),
+                resource: .init(count: 0)
+            ),
+            dd: .init(documentVersion: 1)
+        )
+
+        RUMFeature.instance?.storage.writer.write(value: event)
+    }
+}

--- a/xcconfigs/Datadog.xcconfig
+++ b/xcconfigs/Datadog.xcconfig
@@ -1,4 +1,5 @@
-DATADOG_CLIENT_TOKEN=// use your own Client Token obtained on datadoghq.com
+RUM_APPLICATION_ID=// use your own RUMM Application ID obtained on datadoghq.com
+DATADOG_CLIENT_TOKEN=// use your own Client Token, generated for RUM_APPLICATION_ID
 DEVELOPMENT_TEAM[sdk=iphoneos*]=// use your own Development Team
 
 // Overwrite with secrets

--- a/xcconfigs/Datadog.xcconfig
+++ b/xcconfigs/Datadog.xcconfig
@@ -1,4 +1,4 @@
-RUM_APPLICATION_ID=// use your own RUMM Application ID obtained on datadoghq.com
+RUM_APPLICATION_ID=// use your own RUM Application ID obtained on datadoghq.com
 DATADOG_CLIENT_TOKEN=// use your own Client Token, generated for RUM_APPLICATION_ID
 DEVELOPMENT_TEAM[sdk=iphoneos*]=// use your own Development Team
 


### PR DESCRIPTION
### What and why?

🚚 This PR adds "Debug RUM" screen in Example app. It can be used to send events to RUM Explorer:

<img width="496" alt="Screenshot 2020-07-10 at 11 45 30" src="https://user-images.githubusercontent.com/2358722/87141205-08b8ad80-c2a3-11ea-8175-dec364bd062f.png">


### How?

As RUM data upload was done in #174, in this PR I just pass the `RUMViewEvent` encodable model to RUM's `fileWriter`, so it gets uploaded by the RUM's upload worker.

To not block RUM development by _"`RUM-517` RUM data models are auto generated"_, we can keep crafting `RUMDataModels` manually (as I did for `RUMViewEvent`). After `RUM-517` is done, we will just replace them.

#### `Datadog.xcconfig`

For RUM, we have to update the `.xcconfig` file. Now, next to `DATADOG_CLIENT_TOKEN` it also takes `RUM_APPLICATION_ID`:
```
RUM_APPLICATION_ID=// use your own RUM Application ID obtained on datadoghq.com
DATADOG_CLIENT_TOKEN=// use your own Client Token, generated for RUM_APPLICATION_ID
```

RUM application needs a separate `DATADOG_CLIENT_TOKEN`, but this token works also for Logging and Tracing. Both, application ID and token can be found in `UX Monitoring > RUM Applications > ios-sdk-example-app > Edit Application`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
