### PR TITLE
RUMM-596 Enrich RUM Event with internal and custom attributes

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -170,6 +170,8 @@
 		61E5333424B7A545003D6C4E /* RUMViewEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333324B7A545003D6C4E /* RUMViewEvent.swift */; };
 		61E5333624B84B43003D6C4E /* RUMMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333524B84B43003D6C4E /* RUMMonitor.swift */; };
 		61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */; };
+		61E5333A24B87829003D6C4E /* RUMDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333924B87828003D6C4E /* RUMDataModel.swift */; };
+		61E5333D24B8791A003D6C4E /* RUMEventEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333C24B8791A003D6C4E /* RUMEventEncoder.swift */; };
 		61E909ED24A24DD3005EA2DE /* OTSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E624A24DD3005EA2DE /* OTSpan.swift */; };
 		61E909EE24A24DD3005EA2DE /* OTFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E724A24DD3005EA2DE /* OTFormat.swift */; };
 		61E909EF24A24DD3005EA2DE /* OTGlobal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909E824A24DD3005EA2DE /* OTGlobal.swift */; };
@@ -187,6 +189,13 @@
 		61F8CC092469295500FE2908 /* DatadogConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8CC082469295500FE2908 /* DatadogConfigurationTests.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
+		61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */; };
+		61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */; };
+		61FF282424B8A1C3000B3D9B /* RUMEventFileOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282324B8A1C3000B3D9B /* RUMEventFileOutput.swift */; };
+		61FF282624B8A248000B3D9B /* RUMEventOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282524B8A248000B3D9B /* RUMEventOutput.swift */; };
+		61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */; };
+		61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */; };
+		61FF283024BC5E2D000B3D9B /* RUMEventFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */; };
 		9E330A8E24ADE1250031408E /* NSURLSessionBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E330A8D24ADE1250031408E /* NSURLSessionBridge.m */; };
 		9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */; };
 		9E493E1C249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E493E1B249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift */; };
@@ -435,6 +444,8 @@
 		61E5333324B7A545003D6C4E /* RUMViewEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewEvent.swift; sourceTree = "<group>"; };
 		61E5333524B84B43003D6C4E /* RUMMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitor.swift; sourceTree = "<group>"; };
 		61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRUMViewController.swift; sourceTree = "<group>"; };
+		61E5333924B87828003D6C4E /* RUMDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModel.swift; sourceTree = "<group>"; };
+		61E5333C24B8791A003D6C4E /* RUMEventEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventEncoder.swift; sourceTree = "<group>"; };
 		61E909E624A24DD3005EA2DE /* OTSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTSpan.swift; sourceTree = "<group>"; };
 		61E909E724A24DD3005EA2DE /* OTFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTFormat.swift; sourceTree = "<group>"; };
 		61E909E824A24DD3005EA2DE /* OTGlobal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTGlobal.swift; sourceTree = "<group>"; };
@@ -452,6 +463,12 @@
 		61F8CC082469295500FE2908 /* DatadogConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogConfigurationTests.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
+		61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilder.swift; sourceTree = "<group>"; };
+		61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilderTests.swift; sourceTree = "<group>"; };
+		61FF282324B8A1C3000B3D9B /* RUMEventFileOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutput.swift; sourceTree = "<group>"; };
+		61FF282524B8A248000B3D9B /* RUMEventOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventOutput.swift; sourceTree = "<group>"; };
+		61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventMatcher.swift; sourceTree = "<group>"; };
+		61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutputTests.swift; sourceTree = "<group>"; };
 		9E330A8B24ADE1250031408E /* DatadogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DatadogTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		9E330A8C24ADE1250031408E /* NSURLSessionBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionBridge.h; sourceTree = "<group>"; };
 		9E330A8D24ADE1250031408E /* NSURLSessionBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionBridge.m; sourceTree = "<group>"; };
@@ -923,6 +940,7 @@
 				61E45BE624519A3700F2C652 /* JSONDataMatcher.swift */,
 				61133C432423990D00786299 /* LogMatcher.swift */,
 				61E45ED02451A8730061DAC7 /* SpanMatcher.swift */,
+				61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */,
 			);
 			path = Matchers;
 			sourceTree = "<group>";
@@ -1230,6 +1248,8 @@
 			children = (
 				61E5332B24B75C51003D6C4E /* RUMFeature.swift */,
 				61E5333224B7A504003D6C4E /* DataModels */,
+				61E5333B24B87908003D6C4E /* RUMEvent */,
+				61FF282224B8A1AE000B3D9B /* RUMEventOutputs */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -1238,6 +1258,8 @@
 			isa = PBXGroup;
 			children = (
 				61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */,
+				61FF281F24B89807000B3D9B /* RUMEvent */,
+				61FF282E24BC5E0E000B3D9B /* RUMEventOutputs */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -1245,9 +1267,19 @@
 		61E5333224B7A504003D6C4E /* DataModels */ = {
 			isa = PBXGroup;
 			children = (
+				61E5333924B87828003D6C4E /* RUMDataModel.swift */,
 				61E5333324B7A545003D6C4E /* RUMViewEvent.swift */,
 			);
 			path = DataModels;
+			sourceTree = "<group>";
+		};
+		61E5333B24B87908003D6C4E /* RUMEvent */ = {
+			isa = PBXGroup;
+			children = (
+				61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */,
+				61E5333C24B8791A003D6C4E /* RUMEventEncoder.swift */,
+			);
+			path = RUMEvent;
 			sourceTree = "<group>";
 		};
 		61E909E524A24DD3005EA2DE /* OpenTracing */ = {
@@ -1288,6 +1320,31 @@
 				61133C1B2423990D00786299 /* CoreTelephonyMocks.swift */,
 			);
 			path = SystemFrameworks;
+			sourceTree = "<group>";
+		};
+		61FF281F24B89807000B3D9B /* RUMEvent */ = {
+			isa = PBXGroup;
+			children = (
+				61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */,
+			);
+			path = RUMEvent;
+			sourceTree = "<group>";
+		};
+		61FF282224B8A1AE000B3D9B /* RUMEventOutputs */ = {
+			isa = PBXGroup;
+			children = (
+				61FF282524B8A248000B3D9B /* RUMEventOutput.swift */,
+				61FF282324B8A1C3000B3D9B /* RUMEventFileOutput.swift */,
+			);
+			path = RUMEventOutputs;
+			sourceTree = "<group>";
+		};
+		61FF282E24BC5E0E000B3D9B /* RUMEventOutputs */ = {
+			isa = PBXGroup;
+			children = (
+				61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */,
+			);
+			path = RUMEventOutputs;
 			sourceTree = "<group>";
 		};
 		9E47010324471027000073A4 /* include */ = {
@@ -1649,6 +1706,7 @@
 				9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */,
 				9ED583A32498C222004CFF2A /* TracingAutoInstrumentation.swift in Sources */,
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
+				61FF282624B8A248000B3D9B /* RUMEventOutput.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
 				9EFD112C24B32D29003A1A2B /* URLFilter.swift in Sources */,
@@ -1679,9 +1737,11 @@
 				61133BD72423979B00786299 /* DataUploadWorker.swift in Sources */,
 				61133BD12423979B00786299 /* FilesOrchestrator.swift in Sources */,
 				61133BCD2423979B00786299 /* NetworkConnectionInfoProvider.swift in Sources */,
+				61FF282424B8A1C3000B3D9B /* RUMEventFileOutput.swift in Sources */,
 				61C5A88B24509A0C00DA608C /* SpanOutput.swift in Sources */,
 				61133BE42423979B00786299 /* LogEncoder.swift in Sources */,
 				61C5A88424509A0C00DA608C /* DDSpan.swift in Sources */,
+				61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */,
 				E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */,
 				61133BD82423979B00786299 /* HTTPClient.swift in Sources */,
 				61133BDB2423979B00786299 /* DatadogConfiguration.swift in Sources */,
@@ -1693,8 +1753,10 @@
 				61133BE92423979B00786299 /* LogOutput.swift in Sources */,
 				61C5A88524509A0C00DA608C /* DDNoOps.swift in Sources */,
 				61E5332C24B75C51003D6C4E /* RUMFeature.swift in Sources */,
+				61E5333D24B8791A003D6C4E /* RUMEventEncoder.swift in Sources */,
 				61C5A88624509A0C00DA608C /* TracingUUIDGenerator.swift in Sources */,
 				61133BD92423979B00786299 /* DataUploadDelay.swift in Sources */,
+				61E5333A24B87829003D6C4E /* RUMDataModel.swift in Sources */,
 				61C5A88C24509A0C00DA608C /* HTTPHeadersWriter.swift in Sources */,
 				61BB2B1B244A185D009F3F56 /* PerformancePreset.swift in Sources */,
 				61133BD22423979B00786299 /* Directory.swift in Sources */,
@@ -1707,6 +1769,7 @@
 			files = (
 				61C5A8A024509C1100DA608C /* Casting.swift in Sources */,
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
+				61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				9E330A8E24ADE1250031408E /* NSURLSessionBridge.m in Sources */,
 				9E493E1C249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift in Sources */,
 				61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */,
@@ -1717,6 +1780,7 @@
 				61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
 				61133C622423990D00786299 /* InternalLoggersTests.swift in Sources */,
+				61FF283024BC5E2D000B3D9B /* RUMEventFileOutputTests.swift in Sources */,
 				61133C582423990D00786299 /* FileWriterTests.swift in Sources */,
 				9E544A4D24752A8900E83072 /* URLSessionSwizzlerTests.swift in Sources */,
 				61E917D3246546BF00E6C631 /* TracerConfigurationTests.swift in Sources */,
@@ -1778,6 +1842,7 @@
 				61133C552423990D00786299 /* BatteryStatusProviderTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */,
 				61133C532423990D00786299 /* MobileDeviceTests.swift in Sources */,
+				61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */,
 				61345613244756E300E7DA6B /* PerformancePresetTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1827,6 +1892,7 @@
 			files = (
 				61441C4024617013003D8BB8 /* IntegrationTests.swift in Sources */,
 				61B9ED212462089600C0DCFF /* TracingIntegrationTests.swift in Sources */,
+				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,
 				61441C4124617013003D8BB8 /* LoggingIntegrationTests.swift in Sources */,
 				61441C4B24618052003D8BB8 /* SpanMatcher.swift in Sources */,

--- a/Sources/Datadog/RUM/DataModels/RUMDataModel.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModel.swift
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// A common interface for all auto-generated RUM Events following the
+/// [rum-events-format](https://github.com/DataDog/rum-events-format) spec.
+internal protocol RUMDataModel: Codable {}

--- a/Sources/Datadog/RUM/DataModels/RUMViewEvent.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMViewEvent.swift
@@ -7,7 +7,9 @@
 import Foundation
 
 // TODO: RUMM-517 Replace with auto-generated RUM data model
-internal struct RUMViewEvent: Encodable {
+internal struct RUMViewEvent: Codable, RUMDataModel {
+    typealias DataModelCodingKeys = CodingKeys
+
     enum CodingKeys: String, CodingKey {
         case date
         case application
@@ -24,16 +26,16 @@ internal struct RUMViewEvent: Encodable {
     let view: View
     let dd: DD
 
-    struct Application: Encodable {
+    struct Application: Codable {
         let id: String
     }
 
-    struct Session: Encodable {
+    struct Session: Codable {
         let id: String
         let type: String
     }
 
-    struct View: Encodable {
+    struct View: Codable {
         enum CodingKeys: String, CodingKey {
             case id
             case url
@@ -50,18 +52,18 @@ internal struct RUMViewEvent: Encodable {
         let error: Error
         let resource: Resource
 
-        struct Action: Encodable {
+        struct Action: Codable {
             let count: UInt
         }
-        struct Error: Encodable {
+        struct Error: Codable {
             let count: UInt
         }
-        struct Resource: Encodable {
+        struct Resource: Codable {
             let count: UInt
         }
     }
 
-    struct DD: Encodable {
+    struct DD: Codable {
         enum CodingKeys: String, CodingKey {
             case documentVersion = "document_version"
             case formatVersion  = "format_version"

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct RUMEventBuilder {
+    /// Shared user info provider.
+    let userInfoProvider: UserInfoProvider
+    /// Shared network connection info provider (or `nil` if disabled for given `RUMMonitor`).
+    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType?
+    /// Shared mobile carrier info provider (or `nil` if disabled for given `RUMMonitor`).
+    let carrierInfoProvider: CarrierInfoProviderType?
+
+    func createRUMEvent<DM: RUMDataModel>(with model: DM, attributes: [String: Encodable]?) -> RUMEvent<DM> {
+        return RUMEvent(
+            model: model,
+            userInfo: userInfoProvider.value,
+            networkConnectionInfo: networkConnectionInfoProvider?.current,
+            mobileCarrierInfo: carrierInfoProvider?.current,
+            attributes: attributes
+        )
+    }
+}

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -1,0 +1,93 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// `Encodable` representation of RUM event.
+internal struct RUMEvent<DM: RUMDataModel>: Encodable {
+    /// The actual RUM event model created by `RUMMonitor`
+    let model: DM
+
+    let userInfo: UserInfo
+    let networkConnectionInfo: NetworkConnectionInfo?
+    let mobileCarrierInfo: CarrierInfo?
+
+    /// Custom attributes set by user
+    let attributes: [String: Encodable]?
+
+    func encode(to encoder: Encoder) throws {
+        try RUMEventEncoder().encode(self, to: encoder)
+    }
+}
+
+/// Encodes `RUMEvent` to given encoder.
+internal struct RUMEventEncoder {
+    /// Coding keys for permanent `RUMEvent` attributes.
+    enum StaticCodingKeys: String, CodingKey {
+        // MARK: - User info
+
+        case userId = "usr.id"
+        case userName = "usr.name"
+        case userEmail = "usr.email"
+
+        // MARK: - Network connection info
+
+        case networkReachability = "network.client.reachability"
+        case networkAvailableInterfaces = "network.client.available_interfaces"
+        case networkConnectionSupportsIPv4 = "network.client.supports_ipv4"
+        case networkConnectionSupportsIPv6 = "network.client.supports_ipv6"
+        case networkConnectionIsExpensive = "network.client.is_expensive"
+        case networkConnectionIsConstrained = "network.client.is_constrained"
+
+        // MARK: - Mobile carrier info
+
+        case mobileNetworkCarrierName = "network.client.sim_carrier.name"
+        case mobileNetworkCarrierISOCountryCode = "network.client.sim_carrier.iso_country"
+        case mobileNetworkCarrierRadioTechnology = "network.client.sim_carrier.technology"
+        case mobileNetworkCarrierAllowsVoIP = "network.client.sim_carrier.allows_voip"
+    }
+
+    /// Coding keys for dynamic `RUMEvent` attributes specified by user.
+    private struct DynamicCodingKey: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { return nil }
+        init(_ string: String) { self.stringValue = string }
+}
+
+    func encode<DM: RUMDataModel>(_ event: RUMEvent<DM>, to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: StaticCodingKeys.self)
+
+        // Encode user info
+        try event.userInfo.id.ifNotNil { try container.encode($0, forKey: .userId) }
+        try event.userInfo.name.ifNotNil { try container.encode($0, forKey: .userName) }
+        try event.userInfo.email.ifNotNil { try container.encode($0, forKey: .userEmail) }
+
+        // Encode network info
+        try container.encodeIfPresent(event.networkConnectionInfo?.reachability, forKey: .networkReachability)
+        try container.encodeIfPresent(event.networkConnectionInfo?.availableInterfaces, forKey: .networkAvailableInterfaces)
+        try container.encodeIfPresent(event.networkConnectionInfo?.supportsIPv4, forKey: .networkConnectionSupportsIPv4)
+        try container.encodeIfPresent(event.networkConnectionInfo?.supportsIPv6, forKey: .networkConnectionSupportsIPv6)
+        try container.encodeIfPresent(event.networkConnectionInfo?.isExpensive, forKey: .networkConnectionIsExpensive)
+        try container.encodeIfPresent(event.networkConnectionInfo?.isConstrained, forKey: .networkConnectionIsConstrained)
+
+        // Encode mobile carrier info
+        try container.encodeIfPresent(event.mobileCarrierInfo?.carrierName, forKey: .mobileNetworkCarrierName)
+        try container.encodeIfPresent(event.mobileCarrierInfo?.carrierISOCountryCode, forKey: .mobileNetworkCarrierISOCountryCode)
+        try container.encodeIfPresent(event.mobileCarrierInfo?.radioAccessTechnology, forKey: .mobileNetworkCarrierRadioTechnology)
+        try container.encodeIfPresent(event.mobileCarrierInfo?.carrierAllowsVOIP, forKey: .mobileNetworkCarrierAllowsVoIP)
+
+        // Encode attributes
+        var attributesContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+        try event.attributes?.forEach { attributeName, attributeValue in
+            try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey(attributeName))
+        }
+
+        // Encode `RUMDataModel`
+        try event.model.encode(to: encoder)
+    }
+}

--- a/Sources/Datadog/RUM/RUMEventOutputs/RUMEventFileOutput.swift
+++ b/Sources/Datadog/RUM/RUMEventOutputs/RUMEventFileOutput.swift
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct RUMEventFileOutput: RUMEventOutput {
+   let fileWriter: FileWriter
+
+   func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {
+       fileWriter.write(value: rumEvent)
+   }
+}

--- a/Sources/Datadog/RUM/RUMEventOutputs/RUMEventOutput.swift
+++ b/Sources/Datadog/RUM/RUMEventOutputs/RUMEventOutput.swift
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal protocol RUMEventOutput {
+    func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>)
+}

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -15,6 +15,10 @@ public class RUMMonitor {
 
     /// TODO: RUMM-585 Replace with real RUMMonitor public API
     public func sendFakeViewEvent(viewURL: String) {
+        guard let rumFeature = RUMFeature.instance else {
+            fatalError("RUMFeature must be initialized.")
+        }
+
         let dataModel = RUMViewEvent(
             date: Date(timeIntervalSinceNow: -1).timeIntervalSince1970.toMilliseconds,
             application: .init(id: rumApplicationID),
@@ -30,13 +34,14 @@ public class RUMMonitor {
             dd: .init(documentVersion: 1)
         )
 
-        RUMFeature.instance?.storage.writer.write(value: dataModel)
+        let builder = RUMEventBuilder(
+            userInfoProvider: rumFeature.userInfoProvider,
+            networkConnectionInfoProvider: rumFeature.networkConnectionInfoProvider,
+            carrierInfoProvider: rumFeature.carrierInfoProvider
+        )
 
-//        let event = RUMEvent(
-//            model: dataModel,
-//            userInfo: Datadog.instance!.userInfoProvider.value // swiftlint:disable:this force_unwrapping
-//        )
-//
-//        RUMFeature.instance?.storage.writer.write(value: event)
+        let event = builder.createRUMEvent(with: dataModel, attributes: nil)
+
+        rumFeature.storage.writer.write(value: event)
     }
 }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -15,7 +15,7 @@ public class RUMMonitor {
 
     /// TODO: RUMM-585 Replace with real RUMMonitor public API
     public func sendFakeViewEvent(viewURL: String) {
-        let event = RUMViewEvent(
+        let dataModel = RUMViewEvent(
             date: Date(timeIntervalSinceNow: -1).timeIntervalSince1970.toMilliseconds,
             application: .init(id: rumApplicationID),
             session: .init(id: UUID().uuidString.lowercased(), type: "user"),
@@ -30,6 +30,13 @@ public class RUMMonitor {
             dd: .init(documentVersion: 1)
         )
 
-        RUMFeature.instance?.storage.writer.write(value: event)
+        RUMFeature.instance?.storage.writer.write(value: dataModel)
+
+//        let event = RUMEvent(
+//            model: dataModel,
+//            userInfo: Datadog.instance!.userInfoProvider.value // swiftlint:disable:this force_unwrapping
+//        )
+//
+//        RUMFeature.instance?.storage.writer.write(value: event)
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -49,3 +49,29 @@ extension RUMFeature {
         )
     }
 }
+
+// MARK: - RUM Event Mocks
+
+struct RUMDataModelMock: RUMDataModel, Equatable {
+    let attribute: String
+}
+
+// MARK: - Component Mocks
+
+extension RUMEventBuilder {
+    static func mockAny() -> RUMEventBuilder {
+        return mockWith()
+    }
+
+    static func mockWith(
+        userInfoProvider: UserInfoProvider = .mockAny(),
+        networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockAny(),
+        carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
+    ) -> RUMEventBuilder {
+        return RUMEventBuilder(
+            userInfoProvider: userInfoProvider,
+            networkConnectionInfoProvider: networkConnectionInfoProvider,
+            carrierInfoProvider: carrierInfoProvider
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMEventBuilderTests: XCTestCase {
+    func testItBuildsRUMEvent() {
+        let builder = RUMEventBuilder(
+            userInfoProvider: .mockWith(
+                userInfo: UserInfo(id: "id", name: "name", email: "foo@bar.com")
+            ),
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
+                networkConnectionInfo: .mockWith(
+                    reachability: .yes,
+                    availableInterfaces: [.wifi, .cellular]
+                )
+            ),
+            carrierInfoProvider: CarrierInfoProviderMock.mockWith(
+                carrierInfo: .mockWith(carrierName: "AT&T")
+            )
+        )
+
+        let event = builder.createRUMEvent(
+            with: RUMDataModelMock(attribute: "foo"),
+            attributes: ["foo": "bar", "fizz": "buzz"]
+        )
+
+        XCTAssertEqual(event.model.attribute, "foo")
+        XCTAssertEqual(event.userInfo.id, "id")
+        XCTAssertEqual(event.userInfo.name, "name")
+        XCTAssertEqual(event.userInfo.email, "foo@bar.com")
+        XCTAssertEqual(event.mobileCarrierInfo?.carrierName, "AT&T")
+        XCTAssertEqual(event.networkConnectionInfo?.reachability, .yes)
+        XCTAssertEqual(event.networkConnectionInfo?.availableInterfaces, [.wifi, .cellular])
+        XCTAssertEqual((event.attributes as? [String: String])?["foo"], "bar")
+        XCTAssertEqual((event.attributes as? [String: String])?["fizz"], "buzz")
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -1,0 +1,84 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMEventFileOutputTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        temporaryDirectory.create()
+    }
+
+    override func tearDown() {
+        temporaryDirectory.delete()
+        super.tearDown()
+    }
+
+    func testItWritesRUMEventToFileAsJSON() throws {
+        let fileCreationDateProvider = RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC())
+        let queue = DispatchQueue(label: "com.datadohq.testItWritesRUMEventToFileAsJSON")
+        let builder = RUMEventBuilder(
+            userInfoProvider: .mockWith(userInfo: UserInfo(id: "abc-123", name: "bar", email: "foo@bar.com")),
+            networkConnectionInfoProvider: nil,
+            carrierInfoProvider: nil
+        )
+        let output = RUMEventFileOutput(
+            fileWriter: FileWriter(
+                dataFormat: RUMFeature.Storage.dataFormat,
+                orchestrator: FilesOrchestrator(
+                    directory: temporaryDirectory,
+                    performance: PerformancePreset.combining(
+                        storagePerformance: .writeEachObjectToNewFileAndReadAllFiles,
+                        uploadPerformance: .noOp
+                    ),
+                    dateProvider: fileCreationDateProvider
+                ),
+                queue: queue
+            )
+        )
+
+        let dataModel1 = RUMDataModelMock(attribute: "foo")
+        let dataModel2 = RUMDataModelMock(attribute: "bar")
+        let event1 = builder.createRUMEvent(with: dataModel1, attributes: ["custom.attribute": "value"])
+        let event2 = builder.createRUMEvent(with: dataModel2, attributes: nil)
+
+        output.write(rumEvent: event1)
+        queue.sync {} // wait on writter queue
+
+        fileCreationDateProvider.advance(bySeconds: 1)
+
+        output.write(rumEvent: event2)
+        queue.sync {} // wait on writter queue
+
+        let event1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())
+        let event1Data = try temporaryDirectory.file(named: event1FileName).read()
+        let event1Matcher = try RUMEventMatcher.fromJSONObjectData(event1Data)
+        XCTAssertEqual(try event1Matcher.model(), dataModel1)
+
+        let event2FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
+        let event2Data = try temporaryDirectory.file(named: event2FileName).read()
+        let event2Matcher = try RUMEventMatcher.fromJSONObjectData(event2Data)
+        XCTAssertEqual(try event2Matcher.model(), dataModel2)
+
+        // TODO: RUMM-585 Move assertion of full-json to `RUMMonitorTests`
+        // same as we do for `LoggerTests` and `TracerTests`
+        try event1Matcher.assertItFullyMatches(
+            jsonString: """
+            {
+                "attribute": "foo",
+                "custom.attribute": "value",
+                "usr.email": "foo@bar.com",
+                "usr.id": "abc-123",
+                "usr.name": "bar"
+            }
+            """
+        )
+
+        // TODO: RUMM-585 We also need to test (in `RUMMonitorTests`) that custom user attributes
+        // do not overwrite values given by `RUMDataModel`.
+    }
+}

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -6,8 +6,8 @@
 
 import XCTest
 
-/// Provides set of assertions for single `Log` JSON object or collection of `[Log]`.
-/// Note: this file is individually referenced by integration tests project, so no dependency on other source files should be introduced.
+/// Provides set of assertions for single `Log` JSON object and collection of `[Log]`.
+/// Note: this file is individually referenced by integration tests target, so no dependency on other source files should be introduced.
 internal class LogMatcher: JSONDataMatcher {
     /// Log JSON keys.
     struct JSONKey {

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -12,8 +12,25 @@ import Foundation
 internal class RUMEventMatcher {
     // MARK: - Initialization
 
+    /// Returns "RUM event" matcher for data representing JSON string:
     class func fromJSONObjectData(_ data: Data) throws -> RUMEventMatcher {
         return try RUMEventMatcher(with: data)
+    }
+
+    /// Returns array containing RUM event A, RUM event B RUM event Span C matchers for data representing string:
+    ///
+    ///     ```
+    ///     { /* RUM event A json */ }
+    ///     { /* RUM event B json */ }
+    ///     { /* RUM event C json */ }
+    ///     ```
+    ///
+    /// **See Also** `RUMEventMatcher.fromJSONObjectData(_:)`
+    ///
+    class func fromNewlineSeparatedJSONObjectsData(_ data: Data) throws -> [RUMEventMatcher] {
+        let separator = "\n".data(using: .utf8)![0]
+        let spansData = data.split(separator: separator).map { Data($0) }
+        return try spansData.map { spanJSONData in try RUMEventMatcher.fromJSONObjectData(spanJSONData) }
     }
 
     private let jsonMatcher: JSONDataMatcher

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Provides set of assertions for single `RUMEvent<DM: RUMDataModel>` JSON object and collection of `[RUMEvent<DM: RUMDataModel>]`.
+/// Note: this file is individually referenced by integration tests target, so no dependency on other source files should be introduced except `RUMDataModel` implementations
+/// for partial matching concrete RUM events conforming to [rum-events-format](https://github.com/DataDog/rum-events-format).
+internal class RUMEventMatcher {
+    // MARK: - Initialization
+
+    class func fromJSONObjectData(_ data: Data) throws -> RUMEventMatcher {
+        return try RUMEventMatcher(with: data)
+    }
+
+    private let jsonMatcher: JSONDataMatcher
+    private let jsonData: Data
+    private let jsonDataDecoder = JSONDecoder()
+
+    private init(with jsonData: Data) throws {
+        self.jsonMatcher = JSONDataMatcher(from: try jsonData.toJSONObject())
+        self.jsonData = jsonData
+    }
+
+    // MARK: - Full match
+
+    func assertItFullyMatches(jsonString: String, file: StaticString = #file, line: UInt = #line) throws {
+        try jsonMatcher.assertItFullyMatches(jsonString: jsonString, file: file, line: line)
+    }
+
+    // MARK: - Partial matches
+
+    func model<DM: Decodable>() throws -> DM {
+        return try jsonDataDecoder.decode(DM.self, from: jsonData)
+    }
+
+    func userID()               throws -> String { try jsonMatcher.value(forKeyPath: "usr.id") }
+    func userName()             throws -> String { try jsonMatcher.value(forKeyPath: "usr.name") }
+    func userEmail()            throws -> String { try jsonMatcher.value(forKeyPath: "usr.email") }
+
+    func networkReachability()            throws -> String { try jsonMatcher.value(forKeyPath: "meta.network.client.reachability") }
+    func networkAvailableInterfaces()     throws -> [String] { try jsonMatcher.value(forKeyPath: "meta.network.client.available_interfaces") }
+    func networkConnectionSupportsIPv4()  throws -> Bool { try jsonMatcher.value(forKeyPath: "meta.network.client.supports_ipv4") }
+    func networkConnectionSupportsIPv6()  throws -> Bool { try jsonMatcher.value(forKeyPath: "meta.network.client.supports_ipv6") }
+    func networkConnectionIsExpensive()   throws -> Bool { try jsonMatcher.value(forKeyPath: "meta.network.client.is_expensive") }
+    func networkConnectionIsConstrained() throws -> Bool { try jsonMatcher.value(forKeyPath: "meta.network.client.is_constrained") }
+
+    func mobileNetworkCarrierName()            throws -> String { try jsonMatcher.value(forKeyPath: "meta.network.client.sim_carrier.name") }
+    func mobileNetworkCarrierISOCountryCode()  throws -> String { try jsonMatcher.value(forKeyPath: "meta.network.client.sim_carrier.iso_country") }
+    func mobileNetworkCarrierRadioTechnology() throws -> String { try jsonMatcher.value(forKeyPath: "meta.network.client.sim_carrier.technology") }
+    func mobileNetworkCarrierAllowsVoIP()      throws -> Bool { try jsonMatcher.value(forKeyPath: "meta.network.client.sim_carrier.allows_voip") }
+}

--- a/Tests/DatadogTests/Matchers/SpanMatcher.swift
+++ b/Tests/DatadogTests/Matchers/SpanMatcher.swift
@@ -24,8 +24,8 @@ extension Int: AllowedSpanMetricValue {}
 // Only string values are allowed for `span.meta.*`.
 extension String: AllowedSpanMetaValue {}
 
-/// Provides set of assertions for single `Span` JSON object or collection of `[Span]`.
-/// Note: this file is individually referenced by integration tests project, so no dependency on other source files should be introduced.
+/// Provides set of assertions for single `Span` JSON object and collection of `[Span]`.
+/// Note: this file is individually referenced by integration tests target, so no dependency on other source files should be introduced.
 internal class SpanMatcher {
     // MARK: - Initialization
 


### PR DESCRIPTION
### What and why?

📦 This PR adds more information to events send to RUM Explorer:
* network information,
* mobile carrier information,
* user info,
* custom attributes.

### How?

Following the RFC, this part is structured as a data stream:
* `RUMDataModel` is created in `RUMMonitor`,
* `RUMEventBuilder` transforms `RUMDataModel` into `RUMEvent<DM: RUMDataModel>` and bundles all the extra information in it,
* `RUMEvent<DM>` is passed to `RUMEventFileOutput` which writes it to the file.

All the extra attributes are encoded at the root level of RUM event JSON:
```swift
{
    /* `RUMDataModel` attributes */
    "attribute": "foo",

    /* Extra info attributes added by `RUMEventBuilder` */
    "custom.attribute": "value",
    "usr.email": "foo@bar.com",
    "usr.id": "abc-123",
    "usr.name": "bar"
}
```

Unit tests in `RUMEventFileOutput` provide necessary assertion for JSON format. I also made sure that things are properly displayed once delivered to the RUM Explorer:

<img width="560" alt="Screenshot 2020-07-13 at 12 25 11" src="https://user-images.githubusercontent.com/2358722/87295961-52550280-c506-11ea-8957-5c08d3faf22e.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
