### PR TITLE
RUMM-610 Hotfix for memory leaks on data upload

### DIFF
--- a/Sources/Datadog/Core/Upload/HTTPClient.swift
+++ b/Sources/Datadog/Core/Upload/HTTPClient.swift
@@ -12,6 +12,10 @@ internal final class HTTPClient {
 
     convenience init() {
         let configuration: URLSessionConfiguration = .ephemeral
+        // NOTE: RUMM-610 Default behaviour of `.ephemeral` session is to cache requests.
+        // To not leak requests memory (including their `.httpBody` which may be significant)
+        // we explicitly opt-out from using cache. This cannot be achieved using `.requestCachePolicy`.
+        configuration.urlCache = nil
         // TODO: RUMM-123 Optimize `URLSessionConfiguration` for good traffic performance
         // and move session configuration constants to `PerformancePreset`.
         self.init(session: URLSession(configuration: configuration))


### PR DESCRIPTION
### What and why?

🐛 This hotfix is addressing  #178 - where constantly growing memory usage is reported due to intensive logging.

With intensive logging comes frequent upload... and what I noticed is that every upload results with a memory leak. Here, allocations graph for 10 uploads (each batch was `~1MB`):
<img width="1171" alt="Screenshot 2020-07-14 at 18 16 31" src="https://user-images.githubusercontent.com/2358722/87474718-d7820980-c623-11ea-9d75-b82efddee85a.png">

### How?

The reason of this leak, was an internal caching applied by the `URLSession` - by default, the session's `configuration.urlCache` is not `nil`, which results with some representation of the `URLRequest` being kept in memory (together with its `.httpBody`):

<img width="1546" alt="Screenshot 2020-07-14 at 18 28 13" src="https://user-images.githubusercontent.com/2358722/87475681-7c511680-c625-11ea-951c-0a324b4a10f6.png">

This started being visible after #65, where the `?batch_time=` query parameter was introduced and cache keys become unique for every new request.

The fix is simple - we need to opt-out from using the `.urlCache` for the `URLSession`. After this, the allocation graph is no longer growing infinitely (same 10 batches, `~1MB` each - no more "Live" blobs):

<img width="1171" alt="Screenshot 2020-07-14 at 18 22 47" src="https://user-images.githubusercontent.com/2358722/87476203-47918f00-c626-11ea-9aac-5f848a7a9bf5.png">



### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
