### PR TITLE
RUMM-611 Hotfix App Store submission issues for `DatadogObjc`

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -82,7 +82,6 @@
 		61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C462423990D00786299 /* TestsDirectory.swift */; };
 		61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C472423990D00786299 /* DatadogExtensions.swift */; };
 		61133C702423993200786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
-		61133C712423993200786299 /* Datadog.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612983CC2449E62E00D4424B /* LoggingFeature.swift */; };
 		61345613244756E300E7DA6B /* PerformancePresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61345612244756E300E7DA6B /* PerformancePresetTests.swift */; };
 		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
@@ -142,20 +141,6 @@
 			remoteInfo = Datadog;
 		};
 /* End PBXContainerItemProxy section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		61133C742423993200786299 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				61133C712423993200786299 /* Datadog.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		61133B82242393DE00786299 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -838,7 +823,6 @@
 				61133BEC242397DA00786299 /* Sources */,
 				61133BED242397DA00786299 /* Frameworks */,
 				61133BEE242397DA00786299 /* Resources */,
-				61133C742423993200786299 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
### What and why?

🐛 This PR is addressing #177 where App Store Connect validation issues are reported when uploading the app that links `DatadogObjc` with Carthage:

<img width="721" alt="Screenshot 2020-07-15 at 11 11 03" src="https://user-images.githubusercontent.com/2358722/87529059-b60a3780-c68e-11ea-840d-8b819d89a1c1.png">


### How?

The reason of duplicated framework and colliding `com.datadoghq.Datadog` bundle identifier was a mistaken configuration of `DatadogObjc` "Frameworks and Libraries", where `Datadog.framework` was embedded and signed.

I changed it to **not embed** the `Datadog.framework` (as Carthage users do embed it through Carthage script):

<img width="561" alt="Screenshot 2020-07-15 at 11 22 42" src="https://user-images.githubusercontent.com/2358722/87529326-22853680-c68f-11ea-871e-ee8c40b42e61.png">

I made sure that Objective-C app linking this branch with Carthage passes the ASC validation:

<img width="721" alt="Screenshot 2020-07-15 at 11 22 10" src="https://user-images.githubusercontent.com/2358722/87529426-46487c80-c68f-11ea-84bb-6a5c207f3b56.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
