### PR TITLE
RUMM-605 - POC: UIViewControllers auto instrumentation

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -212,6 +212,9 @@
 		9EFD112C24B32D29003A1A2B /* URLFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFD112B24B32D29003A1A2B /* URLFilter.swift */; };
 		E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */; };
 		E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */; };
+		E168630A24BD96AB003C8ADC /* UIViewControllerSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E168630924BD96AB003C8ADC /* UIViewControllerSwizzler.swift */; };
+		E168630E24BDCDD5003C8ADC /* UIViewControllerAutoInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E168630D24BDCDD4003C8ADC /* UIViewControllerAutoInstrumentation.swift */; };
+		E168631024BDEC27003C8ADC /* UIViewControllerUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E168630F24BDEC27003C8ADC /* UIViewControllerUtils.swift */; };
 		E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D5AEA624B4D45A007F194B /* Versioning.swift */; };
 /* End PBXBuildFile section */
 
@@ -490,6 +493,9 @@
 		9EFD112B24B32D29003A1A2B /* URLFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFilter.swift; sourceTree = "<group>"; };
 		E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingBenchmarkTests.swift; sourceTree = "<group>"; };
 		E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingStorageBenchmarkTests.swift; sourceTree = "<group>"; };
+		E168630924BD96AB003C8ADC /* UIViewControllerSwizzler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewControllerSwizzler.swift; sourceTree = "<group>"; };
+		E168630D24BDCDD4003C8ADC /* UIViewControllerAutoInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerAutoInstrumentation.swift; sourceTree = "<group>"; };
+		E168630F24BDEC27003C8ADC /* UIViewControllerUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerUtils.swift; sourceTree = "<group>"; };
 		E1D5AEA624B4D45A007F194B /* Versioning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Versioning.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -629,6 +635,7 @@
 				61D447E124917F8F00649287 /* DateFormatting.swift */,
 				61133BA02423979B00786299 /* EncodableValue.swift */,
 				9E58E8E024615C75008E5063 /* JSONEncoder.swift */,
+				E168630F24BDEC27003C8ADC /* UIViewControllerUtils.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1156,6 +1163,7 @@
 				61C5A87824509A0C00DA608C /* DDSpan.swift */,
 				61C5A87E24509A0C00DA608C /* DDSpanContext.swift */,
 				9ED583A22498C222004CFF2A /* TracingAutoInstrumentation.swift */,
+				E168630D24BDCDD4003C8ADC /* UIViewControllerAutoInstrumentation.swift */,
 				61C5A8A324509FAA00DA608C /* Span */,
 				61C5A87F24509A0C00DA608C /* SpanOutputs */,
 				61C5A88224509A0C00DA608C /* Propagation */,
@@ -1360,6 +1368,7 @@
 			children = (
 				9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */,
 				9EB47B91247443FA004F90BE /* URLSessionSwizzler.swift */,
+				E168630924BD96AB003C8ADC /* UIViewControllerSwizzler.swift */,
 			);
 			path = AutoInstrumentation;
 			sourceTree = "<group>";
@@ -1721,14 +1730,17 @@
 				61E909EE24A24DD3005EA2DE /* OTFormat.swift in Sources */,
 				61133BE32423979B00786299 /* UserInfo.swift in Sources */,
 				61133BE02423979B00786299 /* Datadog.swift in Sources */,
+				E168631024BDEC27003C8ADC /* UIViewControllerUtils.swift in Sources */,
 				61133BCB2423979B00786299 /* CarrierInfoProvider.swift in Sources */,
 				61C5A89024509AA700DA608C /* TracingFeature.swift in Sources */,
 				61E5333624B84B43003D6C4E /* RUMMonitor.swift in Sources */,
 				61133BD62423979B00786299 /* DataUploader.swift in Sources */,
 				61C5A88724509A0C00DA608C /* Casting.swift in Sources */,
+				E168630E24BDCDD5003C8ADC /* UIViewControllerAutoInstrumentation.swift in Sources */,
 				61133BE52423979B00786299 /* LogBuilder.swift in Sources */,
 				61133BD42423979B00786299 /* FileReader.swift in Sources */,
 				61C5A88A24509A0C00DA608C /* SpanFileOutput.swift in Sources */,
+				E168630A24BD96AB003C8ADC /* UIViewControllerSwizzler.swift in Sources */,
 				61133BD32423979B00786299 /* File.swift in Sources */,
 				61D447E224917F8F00649287 /* DateFormatting.swift in Sources */,
 				61133BE72423979B00786299 /* LogUtilityOutputs.swift in Sources */,

--- a/Sources/Datadog/Core/AutoInstrumentation/UIViewControllerSwizzler.swift
+++ b/Sources/Datadog/Core/AutoInstrumentation/UIViewControllerSwizzler.swift
@@ -1,0 +1,79 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import UIKit
+
+public protocol Instrumentable {
+    func getInstrumentedName() -> String
+}
+
+public extension Instrumentable where Self: UIViewController {
+    func getInstrumentedName() -> String {
+        return UIViewControllerUtils.getInstrumentedName(for: self)
+    }
+}
+
+internal class UIViewControllerSwizzler {
+    let viewDidAppear: ViewDidAppear
+
+    init(instrumentationMode: Datadog.Configuration.ViewControllerInstrumentationMode) throws {
+        self.viewDidAppear = try ViewDidAppear(instrumentationMode: instrumentationMode)
+    }
+
+    func swizzle() {
+        self.viewDidAppear.swizzle()
+    }
+}
+
+internal class ViewDidAppear: MethodSwizzler <
+    @convention(c) (UIViewController, Selector, Bool) -> Void,
+    @convention(block) (UIViewController, Bool) -> Void
+> {
+    private static let selector = #selector(UIViewController.viewDidAppear)
+    private let method: FoundMethod
+    private let instrumentationMode: Datadog.Configuration.ViewControllerInstrumentationMode
+
+    init(instrumentationMode: Datadog.Configuration.ViewControllerInstrumentationMode) throws {
+        method = try Self.findMethod(with: Self.selector, in: UIViewController.self)
+        self.instrumentationMode = instrumentationMode
+    }
+
+    func swizzle() {
+        typealias BlockIMP = @convention(block) (UIViewController, Bool) -> Void
+        swizzle(method) {  currentTypedImp -> BlockIMP in
+            return { impSelf, impAnimated  in
+                impSelf.registerViewAppeared(instrumentationMode: self.instrumentationMode)
+                return currentTypedImp(impSelf, Self.selector, impAnimated)
+            }
+        }
+    }
+}
+
+private extension UIViewController {
+    func registerViewAppeared(instrumentationMode: Datadog.Configuration.ViewControllerInstrumentationMode) {
+        guard let rootViewController = UIViewControllerUtils.getRootViewController(for: self.view) else {
+            return
+        }
+
+        var viewControllerName: String
+        switch instrumentationMode {
+        case .userdefined:
+            if let instrumentedViewController = rootViewController as? Instrumentable {
+                viewControllerName = instrumentedViewController.getInstrumentedName()
+            } else {
+                return
+            }
+        case .automatic:
+            viewControllerName = UIViewControllerUtils.getInstrumentedName(for: rootViewController)
+        case .off:
+            return
+        }
+
+        //Create real RUM Event
+        print("Showed ViewController: \(viewControllerName)")
+    }
+}

--- a/Sources/Datadog/Core/Utils/UIViewControllerUtils.swift
+++ b/Sources/Datadog/Core/Utils/UIViewControllerUtils.swift
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import UIKit
+
+internal struct UIViewControllerUtils {
+    static func getRootViewController(for view: UIView) -> UIViewController? {
+        guard let rootViewController = view.window?.rootViewController else {
+            return nil
+        }
+        return UIViewControllerUtils.topViewController(for: rootViewController)
+    }
+
+    static func topViewController(for rootViewController: UIViewController) -> UIViewController? {
+        if let nextRootViewController = UIViewControllerUtils.nextRootViewController(for: rootViewController ) {
+            return UIViewControllerUtils.topViewController(for: nextRootViewController)
+        }
+        return rootViewController
+    }
+
+    static func nextRootViewController(for viewController: UIViewController) -> UIViewController? {
+        if let presentedViewController = viewController.presentedViewController {
+            return presentedViewController
+        }
+
+        if let navigationController = viewController as? UINavigationController {
+            return navigationController.viewControllers.last
+        }
+
+        if let tabBarController = viewController as? UITabBarController {
+            return tabBarController.selectedViewController
+        }
+
+        if let children = viewController.children.first {
+            return children
+        }
+        return nil
+    }
+
+    static func getInstrumentedName( for viewController: UIViewController) -> String {
+        var name = (type(of: viewController).description())
+
+        if let title = viewController.title {
+            name += ", title: \(title)"
+        } else if let parent = viewController.parent {
+            if let navigationController = parent as? UINavigationController,
+                let navigationTitle = navigationController.navigationBar.topItem?.title {
+                name += ", title: \(navigationTitle)"
+            } else if let tabBarController = parent as? UITabBarController,
+                let tabTitle = tabBarController.tabBarItem.title {
+                name += ", title: \(tabTitle)"
+            }
+        }
+        return name
+    }
+}

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -161,6 +161,9 @@ public class Datadog {
         TracingAutoInstrumentation.instance = TracingAutoInstrumentation(with: configuration)
         TracingAutoInstrumentation.instance?.apply()
 
+        UIViewControllerAutoInstrumentation.instance = UIViewControllerAutoInstrumentation(with: configuration)
+        UIViewControllerAutoInstrumentation.instance?.apply()
+
         // Only after all features were initialized with no error thrown:
         self.instance = Datadog(
             userInfoProvider: userInfoProvider

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -74,6 +74,15 @@ extension Datadog {
             }
         }
 
+        public enum ViewControllerInstrumentationMode {
+            /// No View Controller instrumentation
+            case off
+            /// Automatic viewcontroller instrumentation, all view controllers are logged, name is automatically set
+            case automatic
+            /// Only view controller implementing Instrumentable protocol will be logged, name can be defined by user
+            case userdefined
+        }
+
         internal let clientToken: String
         internal let environment: String
         internal var loggingEnabled: Bool
@@ -84,6 +93,7 @@ extension Datadog {
         internal var rumEndpoint: RUMEndpoint
         internal let serviceName: String?
         internal var tracedHosts = Set<String>()
+        internal var vcInstrumentationMode: ViewControllerInstrumentationMode
 
         /// Creates configuration builder and sets client token.
         /// - Parameter clientToken: client token obtained on Datadog website.
@@ -112,6 +122,7 @@ extension Datadog {
             internal var rumEndpoint: RUMEndpoint = .us
             internal var serviceName: String? = nil
             internal var tracedHosts = Set<String>()
+            internal var vcInstrumentationMode: ViewControllerInstrumentationMode = .off
 
             internal init(clientToken: String, environment: String) {
                 self.clientToken = clientToken
@@ -223,7 +234,8 @@ extension Datadog {
                     tracesEndpoint: tracesEndpoint,
                     rumEndpoint: rumEndpoint,
                     serviceName: serviceName,
-                    tracedHosts: tracedHosts
+                    tracedHosts: tracedHosts,
+                    vcInstrumentationMode: vcInstrumentationMode
                 )
             }
         }

--- a/Sources/Datadog/Tracing/UIViewControllerAutoInstrumentation.swift
+++ b/Sources/Datadog/Tracing/UIViewControllerAutoInstrumentation.swift
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal class UIViewControllerAutoInstrumentation {
+    static var instance: UIViewControllerAutoInstrumentation?
+
+    let swizzler: UIViewControllerSwizzler
+
+    convenience init?(with configuration: Datadog.Configuration) {
+        if !configuration.rumEnabled || configuration.vcInstrumentationMode == .off {
+            return nil
+        }
+        self.init(instrumentationMode: configuration.vcInstrumentationMode)
+    }
+
+    init?(instrumentationMode: Datadog.Configuration.ViewControllerInstrumentationMode) {
+        do {
+            self.swizzler = try UIViewControllerSwizzler(instrumentationMode: instrumentationMode)
+        } catch {
+            userLogger.warn("🔥 UIViewControllers won't be instrumented automatically: \(error)")
+            developerLogger?.warn("🔥 UIViewController won't be instrumented automatically: \(error)")
+            return nil
+        }
+    }
+
+    func apply() {
+        swizzler.swizzle()
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -22,7 +22,8 @@ extension Datadog.Configuration {
         logsEndpoint: LogsEndpoint = .us,
         tracesEndpoint: TracesEndpoint = .us,
         rumEndpoint: RUMEndpoint = .us,
-        serviceName: String? = .mockAny()
+        serviceName: String? = .mockAny(),
+        vcInstrumentationMode: ViewControllerInstrumentationMode = .off
     ) -> Datadog.Configuration {
         return Datadog.Configuration(
             clientToken: clientToken,
@@ -33,7 +34,8 @@ extension Datadog.Configuration {
             logsEndpoint: logsEndpoint,
             tracesEndpoint: tracesEndpoint,
             rumEndpoint: rumEndpoint,
-            serviceName: serviceName
+            serviceName: serviceName,
+            vcInstrumentationMode: vcInstrumentationMode
         )
     }
 }


### PR DESCRIPTION
### What and why?
POC: UIViewControllers auto instrumentation

### How?

Create a `UIViewControllerAutoInstrumentation` class that can be configured to monitor `UIViewController.viewDidLoad()` it uses UIViewControllerSwizzler swizzle `viesDidLoadMethod` and log viewControllers loads depending on Configuration.
By default instrumentation is off, it can be configured in two ways:
	- `.automatic` mode, to instrument all UIViewController's ( it tries to guess  viewcontroller's name)
	-`.userdefined` mode, it only instruments those UIViewController implementing `Instrumentable` protocol, and user can set a name implementing `getInstrumentedName()` or let system guess

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
