### PR TITLE
RUMM-526 Add `RUMMonitor` foundations

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -140,6 +140,12 @@
 		61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */; };
 		61C3638524361E9200C4D4E6 /* Globals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638424361E9200C4D4E6 /* Globals.swift */; };
 		61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3646F243B5C8300C4D4E6 /* ServerMock.swift */; };
+		61C3E63324BF1456008053F2 /* RUMMonitorInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63224BF1456008053F2 /* RUMMonitorInternal.swift */; };
+		61C3E63524BF1794008053F2 /* Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63424BF1794008053F2 /* Attributes.swift */; };
+		61C3E63724BF191F008053F2 /* RUMScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63624BF191F008053F2 /* RUMScope.swift */; };
+		61C3E63924BF19B4008053F2 /* RUMContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63824BF19B4008053F2 /* RUMContext.swift */; };
+		61C3E63B24BF1A4B008053F2 /* RUMCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63A24BF1A4B008053F2 /* RUMCommand.swift */; };
+		61C3E63E24BF1B91008053F2 /* RUMApplicationScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */; };
 		61C5A88424509A0C00DA608C /* DDSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87824509A0C00DA608C /* DDSpan.swift */; };
 		61C5A88524509A0C00DA608C /* DDNoOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87924509A0C00DA608C /* DDNoOps.swift */; };
 		61C5A88624509A0C00DA608C /* TracingUUIDGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87B24509A0C00DA608C /* TracingUUIDGenerator.swift */; };
@@ -413,6 +419,12 @@
 		61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogPrivateMocks.swift; sourceTree = "<group>"; };
 		61C3638424361E9200C4D4E6 /* Globals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Globals.swift; sourceTree = "<group>"; };
 		61C3646F243B5C8300C4D4E6 /* ServerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerMock.swift; sourceTree = "<group>"; };
+		61C3E63224BF1456008053F2 /* RUMMonitorInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorInternal.swift; sourceTree = "<group>"; };
+		61C3E63424BF1794008053F2 /* Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attributes.swift; sourceTree = "<group>"; };
+		61C3E63624BF191F008053F2 /* RUMScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMScope.swift; sourceTree = "<group>"; };
+		61C3E63824BF19B4008053F2 /* RUMContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMContext.swift; sourceTree = "<group>"; };
+		61C3E63A24BF1A4B008053F2 /* RUMCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommand.swift; sourceTree = "<group>"; };
+		61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMApplicationScope.swift; sourceTree = "<group>"; };
 		61C5A8732450989E00DA608C /* OpenTracing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenTracing.framework; path = ../Carthage/Build/iOS/OpenTracing.framework; sourceTree = "<group>"; };
 		61C5A87824509A0C00DA608C /* DDSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDSpan.swift; sourceTree = "<group>"; };
 		61C5A87924509A0C00DA608C /* DDNoOps.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDNoOps.swift; sourceTree = "<group>"; };
@@ -591,6 +603,7 @@
 				9E9EB37624468CE90002C80B /* Datadog.modulemap */,
 				61133BBB2423979B00786299 /* Datadog.swift */,
 				61133BB52423979B00786299 /* DatadogConfiguration.swift */,
+				61C3E63424BF1794008053F2 /* Attributes.swift */,
 				61133BB62423979B00786299 /* Logger.swift */,
 				61C5A88D24509A1F00DA608C /* Tracer.swift */,
 				61E917D02465423600E6C631 /* TracerConfiguration.swift */,
@@ -1148,6 +1161,26 @@
 			path = DatadogPrivate;
 			sourceTree = "<group>";
 		};
+		61C3E63124BF143C008053F2 /* RUMMonitor */ = {
+			isa = PBXGroup;
+			children = (
+				61C3E63224BF1456008053F2 /* RUMMonitorInternal.swift */,
+				61C3E63624BF191F008053F2 /* RUMScope.swift */,
+				61C3E63824BF19B4008053F2 /* RUMContext.swift */,
+				61C3E63A24BF1A4B008053F2 /* RUMCommand.swift */,
+				61C3E63C24BF1B7F008053F2 /* Scopes */,
+			);
+			path = RUMMonitor;
+			sourceTree = "<group>";
+		};
+		61C3E63C24BF1B7F008053F2 /* Scopes */ = {
+			isa = PBXGroup;
+			children = (
+				61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */,
+			);
+			path = Scopes;
+			sourceTree = "<group>";
+		};
 		61C5A87724509A0C00DA608C /* Tracing */ = {
 			isa = PBXGroup;
 			children = (
@@ -1248,6 +1281,7 @@
 			children = (
 				61E5332B24B75C51003D6C4E /* RUMFeature.swift */,
 				61E5333224B7A504003D6C4E /* DataModels */,
+				61C3E63124BF143C008053F2 /* RUMMonitor */,
 				61E5333B24B87908003D6C4E /* RUMEvent */,
 				61FF282224B8A1AE000B3D9B /* RUMEventOutputs */,
 			);
@@ -1696,6 +1730,7 @@
 				61133BDC2423979B00786299 /* Logger.swift in Sources */,
 				61133BD02423979B00786299 /* DateProvider.swift in Sources */,
 				614872772485067300E3EBDB /* SpanTagsReducer.swift in Sources */,
+				61C3E63E24BF1B91008053F2 /* RUMApplicationScope.swift in Sources */,
 				61133BCF2423979B00786299 /* FileWriter.swift in Sources */,
 				61E909F224A24DD3005EA2DE /* OTConstants.swift in Sources */,
 				61133BCC2423979B00786299 /* MobileDevice.swift in Sources */,
@@ -1707,6 +1742,7 @@
 				9ED583A32498C222004CFF2A /* TracingAutoInstrumentation.swift in Sources */,
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
 				61FF282624B8A248000B3D9B /* RUMEventOutput.swift in Sources */,
+				61C3E63324BF1456008053F2 /* RUMMonitorInternal.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
 				9EFD112C24B32D29003A1A2B /* URLFilter.swift in Sources */,
@@ -1726,13 +1762,16 @@
 				61E5333624B84B43003D6C4E /* RUMMonitor.swift in Sources */,
 				61133BD62423979B00786299 /* DataUploader.swift in Sources */,
 				61C5A88724509A0C00DA608C /* Casting.swift in Sources */,
+				61C3E63724BF191F008053F2 /* RUMScope.swift in Sources */,
 				61133BE52423979B00786299 /* LogBuilder.swift in Sources */,
 				61133BD42423979B00786299 /* FileReader.swift in Sources */,
 				61C5A88A24509A0C00DA608C /* SpanFileOutput.swift in Sources */,
+				61C3E63524BF1794008053F2 /* Attributes.swift in Sources */,
 				61133BD32423979B00786299 /* File.swift in Sources */,
 				61D447E224917F8F00649287 /* DateFormatting.swift in Sources */,
 				61133BE72423979B00786299 /* LogUtilityOutputs.swift in Sources */,
 				61133BDA2423979B00786299 /* HTTPHeaders.swift in Sources */,
+				61C3E63924BF19B4008053F2 /* RUMContext.swift in Sources */,
 				61133BE82423979B00786299 /* LogFileOutput.swift in Sources */,
 				61133BD72423979B00786299 /* DataUploadWorker.swift in Sources */,
 				61133BD12423979B00786299 /* FilesOrchestrator.swift in Sources */,
@@ -1750,6 +1789,7 @@
 				61133BD52423979B00786299 /* DataUploadConditions.swift in Sources */,
 				612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */,
 				9EB47B92247443FA004F90BE /* URLSessionSwizzler.swift in Sources */,
+				61C3E63B24BF1A4B008053F2 /* RUMCommand.swift in Sources */,
 				61133BE92423979B00786299 /* LogOutput.swift in Sources */,
 				61C5A88524509A0C00DA608C /* DDNoOps.swift in Sources */,
 				61E5332C24B75C51003D6C4E /* RUMFeature.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -124,6 +124,9 @@
 		615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8824A34FD700233986 /* DDTracerTests.swift */; };
 		615A4A8B24A3568900233986 /* OTSpan+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8A24A3568900233986 /* OTSpan+objc.swift */; };
 		615A4A8D24A356A000233986 /* OTSpanContext+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8C24A356A000233986 /* OTSpanContext+objc.swift */; };
+		617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */; };
+		617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */; };
+		617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */; };
 		617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617CEB382456BC3A00AD4669 /* TracingUUID.swift */; };
 		618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618C365E248E85B400520CDE /* DateFormattingTests.swift */; };
 		61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */; };
@@ -403,6 +406,9 @@
 		615A4A8824A34FD700233986 /* DDTracerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerTests.swift; sourceTree = "<group>"; };
 		615A4A8A24A3568900233986 /* OTSpan+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTSpan+objc.swift"; sourceTree = "<group>"; };
 		615A4A8C24A356A000233986 /* OTSpanContext+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTSpanContext+objc.swift"; sourceTree = "<group>"; };
+		617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorTests.swift; sourceTree = "<group>"; };
+		617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMApplicationScopeTests.swift; sourceTree = "<group>"; };
+		617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorConfigurationTests.swift; sourceTree = "<group>"; };
 		617CEB382456BC3A00AD4669 /* TracingUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUID.swift; sourceTree = "<group>"; };
 		618C365E248E85B400520CDE /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
 		61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingFeatureMocks.swift; sourceTree = "<group>"; };
@@ -826,6 +832,8 @@
 				61C5A89524509BF600DA608C /* TracerTests.swift */,
 				61E917D2246546BF00E6C631 /* TracerConfigurationTests.swift */,
 				61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */,
+				617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */,
+				617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */,
 				61133C212423990D00786299 /* Core */,
 				61133C392423990D00786299 /* Logging */,
 				61C5A89724509C1100DA608C /* Tracing */,
@@ -1117,6 +1125,22 @@
 			path = ../../xcconfigs;
 			sourceTree = "<group>";
 		};
+		617B953B24BF4D7300E6F443 /* RUMMonitor */ = {
+			isa = PBXGroup;
+			children = (
+				617B953E24BF4D9D00E6F443 /* Scopes */,
+			);
+			path = RUMMonitor;
+			sourceTree = "<group>";
+		};
+		617B953E24BF4D9D00E6F443 /* Scopes */ = {
+			isa = PBXGroup;
+			children = (
+				617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */,
+			);
+			path = Scopes;
+			sourceTree = "<group>";
+		};
 		617CEB372456BC2200AD4669 /* UUIDs */ = {
 			isa = PBXGroup;
 			children = (
@@ -1292,6 +1316,7 @@
 			isa = PBXGroup;
 			children = (
 				61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */,
+				617B953B24BF4D7300E6F443 /* RUMMonitor */,
 				61FF281F24B89807000B3D9B /* RUMEvent */,
 				61FF282E24BC5E0E000B3D9B /* RUMEventOutputs */,
 			);
@@ -1827,6 +1852,7 @@
 				61C5A89D24509C1100DA608C /* DDSpanTests.swift in Sources */,
 				61133C672423990D00786299 /* LogConsoleOutputTests.swift in Sources */,
 				61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */,
+				617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */,
 				61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */,
 				61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */,
 				615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */,
@@ -1876,10 +1902,12 @@
 				61F8CC092469295500FE2908 /* DatadogConfigurationTests.swift in Sources */,
 				61F1A623249B811200075390 /* Encoding.swift in Sources */,
 				61133C642423990D00786299 /* LoggerTests.swift in Sources */,
+				617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */,
 				61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */,
 				61133C4E2423990D00786299 /* UIKitMocks.swift in Sources */,
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
 				61133C552423990D00786299 /* BatteryStatusProviderTests.swift in Sources */,
+				617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */,
 				61133C532423990D00786299 /* MobileDeviceTests.swift in Sources */,
 				61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */,

--- a/Datadog/Example/Debugging/DebugRUMViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMViewController.swift
@@ -11,7 +11,7 @@ class DebugRUMViewController: UIViewController {
     @IBOutlet weak var rumServiceNameTextField: UITextField!
     @IBOutlet weak var consoleTextView: UITextView!
 
-    private let rumMonitor = RUMMonitor(rumApplicationID: appConfig.rumApplicationID)
+    private let rumMonitor = RUMMonitor.initialize(rumApplicationID: appConfig.rumApplicationID)
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Sources/Datadog/Attributes.swift
+++ b/Sources/Datadog/Attributes.swift
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// A `String` value naming the attribute.
+///
+/// Dot syntax can be used to nest objects:
+///
+///     logger.addAttribute(forKey: "person.name", value: "Adam")
+///     logger.addAttribute(forKey: "person.age", value: 32)
+///
+///     // When seen in Datadog console:
+///     {
+///         person: {
+///             name: "Adam"
+///             age: 32
+///         }
+///     }
+///
+/// - Important
+/// Values can be nested up to 10 levels deep. Keys using more than 10 levels will be sanitized by SDK.
+///
+public typealias AttributeKey = String
+
+/// Any `Ecodable` value of the attribute (`String`, `Int`, `Bool`, `Date` etc.).
+///
+/// Custom `Encodable` types are supported as well with nested encoding containers:
+///
+///     struct Person: Codable {
+///         let name: String
+///         let age: Int
+///         let address: Address
+///     }
+///
+///     struct Address: Codable {
+///         let city: String
+///         let street: String
+///     }
+///
+///     let address = Address(city: "Paris", street: "Champs Elysees")
+///     let person = Person(name: "Adam", age: 32, address: address)
+///
+///     // When seen in Datadog console:
+///     {
+///         person: {
+///             name: "Adam"
+///             age: 32
+///             address: {
+///                 city: "Paris",
+///                 street: "Champs Elysees"
+///             }
+///         }
+///     }
+///
+/// - Important
+/// Attributes in Datadog console can be nested up to 10 levels deep. If number of nested attribute levels
+/// defined as sum of key levels and value levels exceeds 10, the data may not be delivered.
+///
+public typealias AttributeValue = Encodable

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -17,62 +17,6 @@ public enum LogLevel: Int, Codable {
     case critical
 }
 
-/// A `String` value naming the attribute.
-///
-/// Dot syntax can be used to nest objects:
-///
-///     logger.addAttribute(forKey: "person.name", value: "Adam")
-///     logger.addAttribute(forKey: "person.age", value: 32)
-///
-///     // When seen in Datadog console:
-///     {
-///         person: {
-///             name: "Adam"
-///             age: 32
-///         }
-///     }
-///
-/// - Important
-/// Values can be nested up to 10 levels deep. Keys using more than 10 levels will be sanitized by SDK.
-///
-public typealias AttributeKey = String
-
-/// Any `Ecodable` value of the attribute (`String`, `Int`, `Bool`, `Date` etc.).
-///
-/// Custom `Encodable` types are supported as well with nested encoding containers:
-///
-///     struct Person: Codable {
-///         let name: String
-///         let age: Int
-///         let address: Address
-///     }
-///
-///     struct Address: Codable {
-///         let city: String
-///         let street: String
-///     }
-///
-///     let address = Address(city: "Paris", street: "Champs Elysees")
-///     let person = Person(name: "Adam", age: 32, address: address)
-///
-///     // When seen in Datadog console:
-///     {
-///         person: {
-///             name: "Adam"
-///             age: 32
-///             address: {
-///                 city: "Paris",
-///                 street: "Champs Elysees"
-///             }
-///         }
-///     }
-///
-/// - Important
-/// Attributes in Datadog console can be nested up to 10 levels deep. If number of nested attribute levels
-/// defined as sum of key levels and value levels exceeds 10, the log will not be delivered.
-///
-public typealias AttributeValue = Encodable
-
 /// Because `Logger` is a common name widely used across different projects, the `Datadog.Logger` may conflict when
 /// using `Logger.builder`. In such case, following `DDLogger` typealias can be used to avoid compiler ambiguity.
 ///

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Commands processed by the tree of `RUMScopes`.
+internal enum RUMCommand {
+    case startView(id: AnyObject, attributes: [AttributeKey: AttributeValue]?)
+    case stopView(id: AnyObject, attributes: [AttributeKey: AttributeValue]?)
+    case addCurrentViewError(message: String, error: Error?, attributes: [AttributeKey: AttributeValue]?)
+
+    case startResource(resourceName: String, attributes: [AttributeKey: AttributeValue]?)
+    case stopResource(resourceName: String, attributes: [AttributeKey: AttributeValue]?)
+    case stopResourceWithError(resourceName: String, error: Error, attributes: [AttributeKey: AttributeValue]?)
+
+    case startUserAction(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
+    case stopUserAction(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
+    case addUserAction(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
+}

--- a/Sources/Datadog/RUM/RUMMonitor/RUMContext.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMContext.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct RUMContext {
+    /// An ID of RUM application.
+    let rumApplicationID: String
+    /// An ID of current RUM session. May change over time.
+    var sessionID: UUID
+
+    /// An ID of currently displayed view.
+    var activeViewID: UUID?
+    /// An URI of currently displayed view.
+    var activeViewURI: String?
+    /// An ID of active user action.
+    var activeUserActionID: UUID?
+}

--- a/Sources/Datadog/RUM/RUMMonitor/RUMMonitorInternal.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMMonitorInternal.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal enum RUMUserAction {
+    case tap
+    case scroll
+    case swipe
+    case custom
+}
+
+/// TODO: RUMM-585 - what else parameters do we need in each method?
+internal protocol RUMMonitorInternal {
+    func start(view id: AnyObject, attributes: [AttributeKey: AttributeValue]?)
+    func stop(view id: AnyObject, attributes: [AttributeKey: AttributeValue]?)
+    func addViewError(message: String, error: Error?, attributes: [AttributeKey: AttributeValue]?)
+
+    func start(resource resourceName: String, attributes: [AttributeKey: AttributeValue]?)
+    func stop(resource resourceName: String, attributes: [AttributeKey: AttributeValue]?)
+    func stop(resource resourceName: String, withError error: Error, attributes: [AttributeKey: AttributeValue]?)
+
+    func start(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
+    func stop(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
+    func add(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
+}

--- a/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal protocol RUMScope: class {
+    /// The context of this scope. Should inherit data from parent scope's context.
+    var context: RUMContext { get }
+
+    /// Processes given command and returns `true` when the scope should be closed.
+    func process(command: RUMCommand) -> Bool
+}

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -10,13 +10,16 @@ internal class RUMApplicationScope: RUMScope {
     /// No-op session ID used shortly before the real session is initialized.
     static let nullSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000000") ?? UUID()
 
-    internal init(
+    let eventBuilder: RUMEventBuilder // TODO: RUMM-518 move to `RUMMSessionScope`
+    let eventOutput: RUMEventOutput // TODO: RUMM-518 move to `RUMMSessionScope`
+
+    init(
         rumApplicationID: String,
         eventBuilder: RUMEventBuilder,
         eventOutput: RUMEventOutput
     ) {
-        _ = eventBuilder // TODO: RUMM-518 both builder and output will be passed to child scopes
-        _ = eventOutput
+        self.eventBuilder = eventBuilder
+        self.eventOutput = eventOutput
         self.context = RUMContext(
             rumApplicationID: rumApplicationID,
             sessionID: RUMApplicationScope.nullSessionID,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal class RUMApplicationScope: RUMScope {
+    /// No-op session ID used shortly before the real session is initialized.
+    static let nullSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000000") ?? UUID()
+
+    internal init(
+        rumApplicationID: String,
+        eventBuilder: RUMEventBuilder,
+        eventOutput: RUMEventOutput
+    ) {
+        _ = eventBuilder // TODO: RUMM-518 both builder and output will be passed to child scopes
+        _ = eventOutput
+        self.context = RUMContext(
+            rumApplicationID: rumApplicationID,
+            sessionID: RUMApplicationScope.nullSessionID,
+            activeViewID: nil,
+            activeViewURI: nil,
+            activeUserActionID: nil
+        )
+    }
+
+    // MARK: - RUMScope
+
+    let context: RUMContext
+
+    func process(command: RUMCommand) -> Bool {
+        return false
+    }
+}

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -14,10 +14,10 @@ public class RUMMonitor: RUMMonitorInternal {
 
     // MARK: - Initialization
 
-    // TODO: RUMM-600 `RUMMonitor` initialization API
+    // TODO: RUMM-614 `RUMMonitor` initialization and configuration API
     public static func initialize(rumApplicationID: String) -> RUMMonitor {
         guard let rumFeature = RUMFeature.instance else {
-            // TODO: RUMM-600 `RUMMonitor` initialization API
+            // TODO: RUMM-614 `RUMMonitor` initialization API
             fatalError("RUMFeature not initialized")
         }
 

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -10,7 +10,10 @@ public class RUMMonitor: RUMMonitorInternal {
     /// The root scope of RUM monitoring.
     internal let applicationScope: RUMScope
     /// Queue for processing RUM events off the main thread..
-    internal let queue: DispatchQueue
+    private let queue = DispatchQueue(
+        label: "com.datadoghq.rum-monitor",
+        target: .global(qos: .userInteractive)
+    )
 
     // MARK: - Initialization
 
@@ -36,17 +39,12 @@ public class RUMMonitor: RUMMonitorInternal {
                 eventOutput: RUMEventFileOutput(
                     fileWriter: rumFeature.storage.writer
                 )
-            ),
-            queue: DispatchQueue(
-                label: "com.datadoghq.rum-monitor",
-                target: .global(qos: .userInteractive)
             )
         )
     }
 
-    internal init(applicationScope: RUMScope, queue: DispatchQueue) {
+    internal init(applicationScope: RUMScope) {
         self.applicationScope = applicationScope
-        self.queue = queue
     }
 
     // MARK: - RUMMonitorInternal

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -6,14 +6,97 @@
 
 import Foundation
 
-public class RUMMonitor {
-    private let rumApplicationID: String
+public class RUMMonitor: RUMMonitorInternal {
+    /// The root scope of RUM monitoring.
+    internal let applicationScope: RUMScope
+    /// Queue for processing RUM events off the main thread..
+    internal let queue: DispatchQueue
 
-    public init(rumApplicationID: String) {
-        self.rumApplicationID = rumApplicationID
+    // MARK: - Initialization
+
+    // TODO: RUMM-600 `RUMMonitor` initialization API
+    public static func initialize(rumApplicationID: String) -> RUMMonitor {
+        guard let rumFeature = RUMFeature.instance else {
+            // TODO: RUMM-600 `RUMMonitor` initialization API
+            fatalError("RUMFeature not initialized")
+        }
+
+        return RUMMonitor(rumFeature: rumFeature, rumApplicationID: rumApplicationID)
     }
 
-    /// TODO: RUMM-585 Replace with real RUMMonitor public API
+    internal convenience init(rumFeature: RUMFeature, rumApplicationID: String) {
+        self.init(
+            applicationScope: RUMApplicationScope(
+                rumApplicationID: rumApplicationID,
+                eventBuilder: RUMEventBuilder(
+                    userInfoProvider: rumFeature.userInfoProvider,
+                    networkConnectionInfoProvider: rumFeature.networkConnectionInfoProvider,
+                    carrierInfoProvider: rumFeature.carrierInfoProvider
+                ),
+                eventOutput: RUMEventFileOutput(
+                    fileWriter: rumFeature.storage.writer
+                )
+            ),
+            queue: DispatchQueue(
+                label: "com.datadoghq.rum-monitor",
+                target: .global(qos: .userInteractive)
+            )
+        )
+    }
+
+    internal init(applicationScope: RUMScope, queue: DispatchQueue) {
+        self.applicationScope = applicationScope
+        self.queue = queue
+    }
+
+    // MARK: - RUMMonitorInternal
+
+    func start(view id: AnyObject, attributes: [AttributeKey: AttributeValue]?) {
+        process(command: .startView(id: id, attributes: attributes))
+    }
+
+    func stop(view id: AnyObject, attributes: [AttributeKey: AttributeValue]?) {
+        process(command: .stopView(id: id, attributes: attributes))
+    }
+
+    func addViewError(message: String, error: Error?, attributes: [AttributeKey: AttributeValue]?) {
+        process(command: .addCurrentViewError(message: message, error: error, attributes: attributes))
+    }
+
+    func start(resource resourceName: String, attributes: [AttributeKey: AttributeValue]?) {
+        process(command: .startResource(resourceName: resourceName, attributes: attributes))
+    }
+
+    func stop(resource resourceName: String, attributes: [AttributeKey: AttributeValue]?) {
+        process(command: .stopResource(resourceName: resourceName, attributes: attributes))
+    }
+
+    func stop(resource resourceName: String, withError error: Error, attributes: [AttributeKey: AttributeValue]?) {
+        process(command: .stopResourceWithError(resourceName: resourceName, error: error, attributes: attributes))
+    }
+
+    func start(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?) {
+        process(command: .startUserAction(userAction: userAction, attributes: attributes))
+    }
+
+    func stop(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?) {
+        process(command: .stopUserAction(userAction: userAction, attributes: attributes))
+    }
+
+    func add(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?) {
+        process(command: .addUserAction(userAction: userAction, attributes: attributes))
+    }
+
+    // MARK: - Private
+
+    private func process(command: RUMCommand) {
+        queue.async {
+            _ = self.applicationScope.process(command: command)
+        }
+    }
+
+    // MARK: - TODO: RUMM-585 Temporary APIs to remove
+
     public func sendFakeViewEvent(viewURL: String) {
         guard let rumFeature = RUMFeature.instance else {
             fatalError("RUMFeature must be initialized.")
@@ -21,7 +104,7 @@ public class RUMMonitor {
 
         let dataModel = RUMViewEvent(
             date: Date(timeIntervalSinceNow: -1).timeIntervalSince1970.toMilliseconds,
-            application: .init(id: rumApplicationID),
+            application: .init(id: applicationScope.context.rumApplicationID),
             session: .init(id: UUID().uuidString.lowercased(), type: "user"),
             view: .init(
                 id: UUID().uuidString.lowercased(),

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -7,6 +7,25 @@
 @testable import Datadog
 
 extension RUMFeature {
+    /// Mocks feature instance which performs no writes and no uploads.
+    static func mockNoOp(temporaryDirectory: Directory) -> RUMFeature {
+        return RUMFeature(
+            directory: temporaryDirectory,
+            configuration: .mockAny(),
+            performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp),
+            mobileDevice: .mockAny(),
+            httpClient: .mockAny(),
+            dateProvider: SystemDateProvider(),
+            userInfoProvider: .mockAny(),
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
+                networkConnectionInfo: .mockWith(
+                    reachability: .no // so it doesn't meet the upload condition
+                )
+            ),
+            carrierInfoProvider: CarrierInfoProviderMock.mockAny()
+        )
+    }
+
     /// Mocks feature instance which performs uploads to given `ServerMock` with performance optimized for fast delivery in unit tests.
     static func mockWorkingFeatureWith(
         server: ServerMock,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -75,3 +75,33 @@ extension RUMEventBuilder {
         )
     }
 }
+
+/// `RUMScope` recording processed commands.
+class RUMScopeMock: RUMScope {
+    let context = RUMContext(
+        rumApplicationID: .mockAny(),
+        sessionID: UUID(),
+        activeViewID: nil,
+        activeViewURI: nil,
+        activeUserActionID: nil
+    )
+
+    var recordedCommands: [RUMCommand] = []
+
+    func process(command: RUMCommand) -> Bool {
+        recordedCommands.append(command)
+        return false
+    }
+}
+
+class RUMEventOutputMock: RUMEventOutput {
+    func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {}
+}
+
+// MARK: - Utilities
+
+extension RUMCommand: Equatable {
+    public static func == (_ lhs: RUMCommand, _ rhs: RUMCommand) -> Bool {
+        return String(describing: lhs) == String(describing: rhs)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -138,7 +138,10 @@ class RUMScopeMock: RUMScope {
     )
 
     func process(command: RUMCommand) -> Bool {
-        queue.async { self.commands.append(command) }
+        queue.async {
+            self.commands.append(command)
+            self.expectation?.fulfill()
+        }
         return false
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMApplicationScopeTests: XCTestCase {
+    func testContextPropagation() {
+        let scope = RUMApplicationScope(
+            rumApplicationID: "abc-123",
+            eventBuilder: .mockAny(),
+            eventOutput: RUMEventOutputMock()
+        )
+
+        XCTAssertEqual(scope.context.rumApplicationID, "abc-123")
+        XCTAssertEqual(scope.context.sessionID, RUMApplicationScope.nullSessionID)
+        XCTAssertNil(scope.context.activeViewID)
+        XCTAssertNil(scope.context.activeViewURI)
+        XCTAssertNil(scope.context.activeUserActionID)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMMonitorConfigurationTests: XCTestCase {
+    private let networkConnectionInfoProvider: NetworkConnectionInfoProviderMock = .mockAny()
+    private let carrierInfoProvider: CarrierInfoProviderMock = .mockAny()
+    private var mockServer: ServerMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        temporaryDirectory.create()
+
+        mockServer = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        RUMFeature.instance = .mockWorkingFeatureWith(
+            server: mockServer,
+            directory: temporaryDirectory,
+            configuration: .mockWith(
+                applicationVersion: "1.2.3",
+                serviceName: "service-name",
+                environment: "tests"
+            ),
+            networkConnectionInfoProvider: networkConnectionInfoProvider,
+            carrierInfoProvider: carrierInfoProvider
+        )
+    }
+
+    override func tearDown() {
+        mockServer.waitAndAssertNoRequestsSent()
+        RUMFeature.instance = nil
+        mockServer = nil
+
+        temporaryDirectory.delete()
+        super.tearDown()
+    }
+
+    func testDefaultRUMMonitor() throws {
+        let monitor = RUMMonitor.initialize(rumApplicationID: .mockAny())
+
+        let feature = try XCTUnwrap(RUMFeature.instance)
+        let applicationScope = try XCTUnwrap(monitor.applicationScope as? RUMApplicationScope)
+        let rumEventBuilder = applicationScope.eventBuilder
+
+        XCTAssertTrue(rumEventBuilder.userInfoProvider === feature.userInfoProvider)
+        XCTAssertTrue(rumEventBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
+        XCTAssertTrue(rumEventBuilder.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
+    }
+
+    func testCustomizedRUMMonitor() {
+        // TODO: RUMM-614 Test customized `RUMMonitor`
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import UIKit
+@testable import Datadog
+
+class RUMMonitorTests: XCTestCase {
+    func testWhenCallingPublicAPI_itProcessessExpectedCommandsThrougScopes() {
+        let queue = DispatchQueue(label: #function)
+        let scope = RUMScopeMock()
+
+        let monitor = RUMMonitor(applicationScope: scope, queue: queue)
+
+        let mockView = UIViewController()
+        let mockAttributes = ["foo": "bar"]
+        let mockError = ErrorMock()
+
+        monitor.start(view: mockView, attributes: mockAttributes)
+        monitor.stop(view: mockView, attributes: mockAttributes)
+        monitor.addViewError(message: "error", error: mockError, attributes: mockAttributes)
+
+        monitor.start(resource: "/resource/1", attributes: mockAttributes)
+        monitor.stop(resource: "/resource/1", attributes: mockAttributes)
+        monitor.stop(resource: "/resource/1", withError: ErrorMock(), attributes: mockAttributes)
+
+        monitor.start(userAction: .scroll, attributes: mockAttributes)
+        monitor.stop(userAction: .scroll, attributes: mockAttributes)
+        monitor.add(userAction: .tap, attributes: mockAttributes)
+
+        queue.sync {}
+
+        XCTAssertEqual(
+            scope.recordedCommands,
+            [
+                .startView(id: mockView, attributes: mockAttributes),
+                .stopView(id: mockView, attributes: mockAttributes),
+                .addCurrentViewError(message: "error", error: mockError, attributes: mockAttributes),
+                .startResource(resourceName: "/resource/1", attributes: mockAttributes),
+                .stopResource(resourceName: "/resource/1", attributes: mockAttributes),
+                .stopResourceWithError(resourceName: "/resource/1", error: mockError, attributes: mockAttributes),
+                .startUserAction(userAction: .scroll, attributes: mockAttributes),
+                .stopUserAction(userAction: .scroll, attributes: mockAttributes),
+                .addUserAction(userAction: .tap, attributes: mockAttributes)
+            ]
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -10,10 +10,8 @@ import UIKit
 
 class RUMMonitorTests: XCTestCase {
     func testWhenCallingPublicAPI_itProcessessExpectedCommandsThrougScopes() {
-        let queue = DispatchQueue(label: #function)
         let scope = RUMScopeMock()
-
-        let monitor = RUMMonitor(applicationScope: scope, queue: queue)
+        let monitor = RUMMonitor(applicationScope: scope)
 
         let mockView = UIViewController()
         let mockAttributes = ["foo": "bar"]
@@ -31,10 +29,10 @@ class RUMMonitorTests: XCTestCase {
         monitor.stop(userAction: .scroll, attributes: mockAttributes)
         monitor.add(userAction: .tap, attributes: mockAttributes)
 
-        queue.sync {}
+        let recordedCommands = scope.waitAndReturnProcessedCommands(count: 9, timeout: 0.5)
 
         XCTAssertEqual(
-            scope.recordedCommands,
+            recordedCommands,
             [
                 .startView(id: mockView, attributes: mockAttributes),
                 .stopView(id: mockView, attributes: mockAttributes),


### PR DESCRIPTION
### What and why?

📦 This PR grounds necessary foundation for RUM Data Collection, including:

- `RUMMonitor` class conforming to `RUMInternal`
- `RUMScope` protocol
- `RUMCommand` enum
- `RUMContext` struct
- `RUMApplicationScope`

### How?

The `RUMMonitor` interface follows the RFC with only one difference: it is not possible to identify resources by `Hashable` value as proposed:
```swift
// Compiler error: Protocol 'Hashable' can only be used as a generic constraint
func start(resource id: Hashable, name: String, ..., attributes: [String: Encodable])
```

Instead, I decided to identify resources by `String` ([as we do in `dd-sdk-android`](https://github.com/DataDog/dd-sdk-android/blob/0153e4211d457d2739e6938e0c7598e9f9f7fe79/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt#L77)) which should bring enough flexibility.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
