### PR TITLE
RUMM-518 Add user Session monitoring

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -142,6 +142,11 @@
 		61C2C20524C0862700C0321C /* RUMActionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20424C0862700C0321C /* RUMActionEvent.swift */; };
 		61C2C20724C098FC00C0321C /* RUMSessionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20624C098FC00C0321C /* RUMSessionScope.swift */; };
 		61C2C20924C0C75500C0321C /* RUMSessionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */; };
+		61C2C20B24C1045300C0321C /* SendRUMFixture1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20A24C1045300C0321C /* SendRUMFixture1ViewController.swift */; };
+		61C2C20D24C1831700C0321C /* RUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20C24C1831700C0321C /* RUMIntegrationTests.swift */; };
+		61C2C20E24C196E800C0321C /* RUMActionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20424C0862700C0321C /* RUMActionEvent.swift */; };
+		61C2C20F24C196EB00C0321C /* RUMViewEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333324B7A545003D6C4E /* RUMViewEvent.swift */; };
+		61C2C21024C196EE00C0321C /* RUMDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E5333924B87828003D6C4E /* RUMDataModel.swift */; };
 		61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */; };
 		61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */; };
 		61C3638524361E9200C4D4E6 /* Globals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638424361E9200C4D4E6 /* Globals.swift */; };
@@ -427,6 +432,8 @@
 		61C2C20424C0862700C0321C /* RUMActionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMActionEvent.swift; sourceTree = "<group>"; };
 		61C2C20624C098FC00C0321C /* RUMSessionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionScope.swift; sourceTree = "<group>"; };
 		61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionScopeTests.swift; sourceTree = "<group>"; };
+		61C2C20A24C1045300C0321C /* SendRUMFixture1ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendRUMFixture1ViewController.swift; sourceTree = "<group>"; };
+		61C2C20C24C1831700C0321C /* RUMIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrationTests.swift; sourceTree = "<group>"; };
 		61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcExceptionHandlerTests.swift; sourceTree = "<group>"; };
 		61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogPrivateMocks.swift; sourceTree = "<group>"; };
 		61C3638424361E9200C4D4E6 /* Globals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Globals.swift; sourceTree = "<group>"; };
@@ -1067,6 +1074,7 @@
 				61441C3B24617013003D8BB8 /* IntegrationTests.swift */,
 				61441C3C24617013003D8BB8 /* LoggingIntegrationTests.swift */,
 				61B9ED202462089600C0DCFF /* TracingIntegrationTests.swift */,
+				61C2C20C24C1831700C0321C /* RUMIntegrationTests.swift */,
 				61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */,
 			);
 			name = DatadogIntegrationTests;
@@ -1180,6 +1188,7 @@
 			children = (
 				61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */,
 				61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */,
+				61C2C20A24C1045300C0321C /* SendRUMFixture1ViewController.swift */,
 			);
 			path = IntegrationTestFixtures;
 			sourceTree = "<group>";
@@ -1958,6 +1967,7 @@
 				61441C972461A649003D8BB8 /* UIViewController+KeyboardControlling.swift in Sources */,
 				61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */,
 				61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */,
+				61C2C20B24C1045300C0321C /* SendRUMFixture1ViewController.swift in Sources */,
 				61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */,
 				61441C9D2461A796003D8BB8 /* AppConfig.swift in Sources */,
 				61441C0524616DE9003D8BB8 /* AppDelegate.swift in Sources */,
@@ -1971,10 +1981,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				61441C4024617013003D8BB8 /* IntegrationTests.swift in Sources */,
+				61C2C20E24C196E800C0321C /* RUMActionEvent.swift in Sources */,
+				61C2C20F24C196EB00C0321C /* RUMViewEvent.swift in Sources */,
 				61B9ED212462089600C0DCFF /* TracingIntegrationTests.swift in Sources */,
+				61C2C20D24C1831700C0321C /* RUMIntegrationTests.swift in Sources */,
 				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,
 				61441C4124617013003D8BB8 /* LoggingIntegrationTests.swift in Sources */,
+				61C2C21024C196EE00C0321C /* RUMDataModel.swift in Sources */,
 				61441C4B24618052003D8BB8 /* SpanMatcher.swift in Sources */,
 				61441C4924618052003D8BB8 /* JSONDataMatcher.swift in Sources */,
 				61441C4A24618052003D8BB8 /* LogMatcher.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -140,6 +140,8 @@
 		61B9ED212462089600C0DCFF /* TracingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED202462089600C0DCFF /* TracingIntegrationTests.swift */; };
 		61BB2B1B244A185D009F3F56 /* PerformancePreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */; };
 		61C2C20524C0862700C0321C /* RUMActionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20424C0862700C0321C /* RUMActionEvent.swift */; };
+		61C2C20724C098FC00C0321C /* RUMSessionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20624C098FC00C0321C /* RUMSessionScope.swift */; };
+		61C2C20924C0C75500C0321C /* RUMSessionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */; };
 		61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */; };
 		61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */; };
 		61C3638524361E9200C4D4E6 /* Globals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638424361E9200C4D4E6 /* Globals.swift */; };
@@ -423,6 +425,8 @@
 		61B9ED202462089600C0DCFF /* TracingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingIntegrationTests.swift; sourceTree = "<group>"; };
 		61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePreset.swift; sourceTree = "<group>"; };
 		61C2C20424C0862700C0321C /* RUMActionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMActionEvent.swift; sourceTree = "<group>"; };
+		61C2C20624C098FC00C0321C /* RUMSessionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionScope.swift; sourceTree = "<group>"; };
+		61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionScopeTests.swift; sourceTree = "<group>"; };
 		61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcExceptionHandlerTests.swift; sourceTree = "<group>"; };
 		61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogPrivateMocks.swift; sourceTree = "<group>"; };
 		61C3638424361E9200C4D4E6 /* Globals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Globals.swift; sourceTree = "<group>"; };
@@ -1139,6 +1143,7 @@
 			isa = PBXGroup;
 			children = (
 				617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */,
+				61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */,
 			);
 			path = Scopes;
 			sourceTree = "<group>";
@@ -1203,6 +1208,7 @@
 			isa = PBXGroup;
 			children = (
 				61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */,
+				61C2C20624C098FC00C0321C /* RUMSessionScope.swift */,
 			);
 			path = Scopes;
 			sourceTree = "<group>";
@@ -1768,6 +1774,7 @@
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
 				9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */,
 				9ED583A32498C222004CFF2A /* TracingAutoInstrumentation.swift in Sources */,
+				61C2C20724C098FC00C0321C /* RUMSessionScope.swift in Sources */,
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
 				61FF282624B8A248000B3D9B /* RUMEventOutput.swift in Sources */,
 				61C3E63324BF1456008053F2 /* RUMMonitorInternal.swift in Sources */,
@@ -1840,6 +1847,7 @@
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
 				61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				9E330A8E24ADE1250031408E /* NSURLSessionBridge.m in Sources */,
+				61C2C20924C0C75500C0321C /* RUMSessionScopeTests.swift in Sources */,
 				9E493E1C249B7BAA005F95F5 /* TracingAutoInstrumentationTests.swift in Sources */,
 				61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */,
 				61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */; };
 		61B9ED212462089600C0DCFF /* TracingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED202462089600C0DCFF /* TracingIntegrationTests.swift */; };
 		61BB2B1B244A185D009F3F56 /* PerformancePreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */; };
+		61C2C20524C0862700C0321C /* RUMActionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20424C0862700C0321C /* RUMActionEvent.swift */; };
 		61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */; };
 		61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */; };
 		61C3638524361E9200C4D4E6 /* Globals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3638424361E9200C4D4E6 /* Globals.swift */; };
@@ -421,6 +422,7 @@
 		61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsHelpers.swift; sourceTree = "<group>"; };
 		61B9ED202462089600C0DCFF /* TracingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingIntegrationTests.swift; sourceTree = "<group>"; };
 		61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePreset.swift; sourceTree = "<group>"; };
+		61C2C20424C0862700C0321C /* RUMActionEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMActionEvent.swift; sourceTree = "<group>"; };
 		61C3637F2436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjcExceptionHandlerTests.swift; sourceTree = "<group>"; };
 		61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogPrivateMocks.swift; sourceTree = "<group>"; };
 		61C3638424361E9200C4D4E6 /* Globals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Globals.swift; sourceTree = "<group>"; };
@@ -1328,6 +1330,7 @@
 			children = (
 				61E5333924B87828003D6C4E /* RUMDataModel.swift */,
 				61E5333324B7A545003D6C4E /* RUMViewEvent.swift */,
+				61C2C20424C0862700C0321C /* RUMActionEvent.swift */,
 			);
 			path = DataModels;
 			sourceTree = "<group>";
@@ -1811,6 +1814,7 @@
 				61133BDB2423979B00786299 /* DatadogConfiguration.swift in Sources */,
 				614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */,
 				61133BCE2423979B00786299 /* BatteryStatusProvider.swift in Sources */,
+				61C2C20524C0862700C0321C /* RUMActionEvent.swift in Sources */,
 				61133BD52423979B00786299 /* DataUploadConditions.swift in Sources */,
 				612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */,
 				9EB47B92247443FA004F90BE /* URLSessionSwizzler.swift in Sources */,

--- a/Datadog/Example/AppConfig.swift
+++ b/Datadog/Example/AppConfig.swift
@@ -76,6 +76,7 @@ struct UITestAppConfig: AppConfig {
     init() {
         let mockLogsEndpoint = ProcessInfo.processInfo.environment["DD_MOCK_LOGS_ENDPOINT_URL"]!
         let mockTracesEndpoint = ProcessInfo.processInfo.environment["DD_MOCK_TRACES_ENDPOINT_URL"]!
+        let mockRUMEndpoint = ProcessInfo.processInfo.environment["DD_MOCK_RUM_ENDPOINT_URL"]!
         let sourceEndpoint = ProcessInfo.processInfo.environment["DD_MOCK_SOURCE_ENDPOINT_URL"]!
         let tracedhost = URL(string: sourceEndpoint)!.host!
         self.datadogConfiguration = Datadog.Configuration
@@ -83,6 +84,7 @@ struct UITestAppConfig: AppConfig {
             .set(serviceName: serviceName)
             .set(logsEndpoint: .custom(url: mockLogsEndpoint))
             .set(tracesEndpoint: .custom(url: mockTracesEndpoint))
+            .set(rumEndpoint: .custom(url: mockRUMEndpoint))
             .set(tracedHosts: [tracedhost, "foo.bar"])
             .build()
 

--- a/Datadog/Example/AppDelegate.swift
+++ b/Datadog/Example/AppDelegate.swift
@@ -9,6 +9,7 @@ import Datadog
 
 var logger: Logger!
 var tracer: OTTracer { Global.sharedTracer }
+var rumMonitor: RUMMonitor!
 
 let appConfig: AppConfig = currentAppConfig()
 
@@ -49,6 +50,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 sendNetworkInfo: true
             )
         )
+
+        // Create RUM monitor instance
+        rumMonitor = RUMMonitor.initialize(rumApplicationID: appConfig.rumApplicationID)
 
         // Set highest verbosity level to see internal actions made in SDK
         Datadog.verbosityLevel = .debug

--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="wle-IX-rUl">
-                            <rect key="frame" x="0.0" y="329.5" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="373" width="414" height="0.0"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         </view>
@@ -126,6 +126,26 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="dQd-PO-4F8" kind="show" id="A9W-uP-Mly"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="l3V-Ox-kSa" style="IBUITableViewCellStyleDefault" id="fQz-Mr-2Bo">
+                                        <rect key="frame" x="0.0" y="301.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fQz-Mr-2Bo" id="LHK-QM-RpV">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Send RUM events for UI Tests" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="l3V-Ox-kSa">
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="aYv-rh-9k5" kind="show" id="GFk-KX-86C"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -709,7 +729,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8d2-uk-OiR" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="259" y="915"/>
+            <point key="canvasLocation" x="-1386" y="1233"/>
         </scene>
         <!--Send Traces Fixture View Controller-->
         <scene sceneID="LEY-wo-4ju">
@@ -738,7 +758,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6qc-vU-hqo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-309" y="1611"/>
+            <point key="canvasLocation" x="-542" y="1233"/>
         </scene>
         <!--DebugRUM View Controller-->
         <scene sceneID="JCG-Nr-eCn">
@@ -1007,6 +1027,35 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="z20-g6-vwL" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="675" y="-273"/>
+        </scene>
+        <!--SendRUM Fixture1 View Controller-->
+        <scene sceneID="c26-v4-HIp">
+            <objects>
+                <viewController id="aYv-rh-9k5" customClass="SendRUMFixture1ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="hqR-vc-dhH">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending RUM events... " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TAP-cq-oB8">
+                                <rect key="frame" x="116" y="437.5" width="182.5" height="21"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="TAP-cq-oB8" firstAttribute="centerY" secondItem="hqR-vc-dhH" secondAttribute="centerY" id="CWP-u7-YDL"/>
+                            <constraint firstItem="TAP-cq-oB8" firstAttribute="centerX" secondItem="hqR-vc-dhH" secondAttribute="centerX" id="z26-0p-djn"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="nQt-QF-hgQ"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="3Wo-iA-H76"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ugy-cJ-IEs" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="258" y="1233"/>
         </scene>
     </scenes>
 </document>

--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -778,105 +778,204 @@
                                             <constraint firstAttribute="height" constant="20" id="QZg-gK-U52"/>
                                         </constraints>
                                     </stackView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fM2-qe-QkK" userLabel="Vertical gap 15">
-                                        <rect key="frame" x="0.0" y="20" width="384" height="15"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="15" id="wcN-Gv-yCO"/>
-                                        </constraints>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View Event" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zjv-y9-VvL">
-                                        <rect key="frame" x="0.0" y="35" width="384" height="20.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DmQ-rb-UiO" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="55.5" width="384" height="10"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="10" id="0En-Yf-gGB"/>
-                                        </constraints>
-                                    </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="abs-xz-lgo">
-                                        <rect key="frame" x="0.0" y="65.5" width="384" height="30"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="e81-o8-mqx" userLabel="View Event">
+                                        <rect key="frame" x="0.0" y="20" width="384" height="75.5"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="79A-KI-slP">
-                                                <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fM2-qe-QkK" userLabel="Vertical gap 15">
+                                                <rect key="frame" x="0.0" y="0.0" width="384" height="15"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="15" id="wcN-Gv-yCO"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View Event" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zjv-y9-VvL">
+                                                <rect key="frame" x="0.0" y="15" width="384" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DmQ-rb-UiO" userLabel="Vertical gap 10">
+                                                <rect key="frame" x="0.0" y="35.5" width="384" height="10"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="10" id="0En-Yf-gGB"/>
+                                                </constraints>
+                                            </view>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="abs-xz-lgo">
+                                                <rect key="frame" x="0.0" y="45.5" width="384" height="30"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lU8-Dq-owV">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="79A-KI-slP">
                                                         <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="view.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QS9-fr-2yR">
-                                                                <rect key="frame" x="0.0" y="0.0" width="43" height="30"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="U9s-H3-pzA">
-                                                                <rect key="frame" x="48" y="0.0" width="281" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
-                                                            </textField>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="lU8-Dq-owV">
+                                                                <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="view.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QS9-fr-2yR">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="43" height="30"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="U9s-H3-pzA">
+                                                                        <rect key="frame" x="48" y="0.0" width="281" height="30"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="30" id="HUf-w1-2g3"/>
+                                                                </constraints>
+                                                            </stackView>
                                                         </subviews>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="30" id="HUf-w1-2g3"/>
-                                                        </constraints>
                                                     </stackView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ixr-vj-rNH">
+                                                        <rect key="frame" x="334" y="0.0" width="50" height="30"/>
+                                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="Wbf-l6-3G4"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <state key="normal" title="Send">
+                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                <integer key="value" value="7"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="didTapSendViewEvent:" destination="CBf-fg-exz" eventType="touchUpInside" id="TSV-7j-gK0"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                             </stackView>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ixr-vj-rNH">
-                                                <rect key="frame" x="334" y="0.0" width="50" height="30"/>
-                                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EoW-hq-iwp" userLabel="Action Event">
+                                        <rect key="frame" x="0.0" y="95.5" width="384" height="105.5"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xge-K9-YNh" userLabel="Vertical gap 15">
+                                                <rect key="frame" x="0.0" y="0.0" width="384" height="15"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="Wbf-l6-3G4"/>
+                                                    <constraint firstAttribute="height" constant="15" id="lTB-PH-2wv"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <state key="normal" title="Send">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                </state>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
-                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                        <integer key="value" value="7"/>
-                                                    </userDefinedRuntimeAttribute>
-                                                </userDefinedRuntimeAttributes>
-                                                <connections>
-                                                    <action selector="didTapSendViewEvent:" destination="CBf-fg-exz" eventType="touchUpInside" id="TSV-7j-gK0"/>
-                                                </connections>
-                                            </button>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Action Event" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wRU-yO-WNe">
+                                                <rect key="frame" x="0.0" y="15" width="384" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TDR-6h-k8W" userLabel="Vertical gap 10">
+                                                <rect key="frame" x="0.0" y="35.5" width="384" height="10"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="10" id="Lqf-ua-fgv"/>
+                                                </constraints>
+                                            </view>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="fDD-nV-d90">
+                                                <rect key="frame" x="0.0" y="45.5" width="384" height="60"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="VFn-cp-8QB">
+                                                        <rect key="frame" x="0.0" y="0.0" width="329" height="60"/>
+                                                        <subviews>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Mjy-ml-yml" userLabel="view.url">
+                                                                <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="view.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yFp-ta-kUm">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="43" height="30"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="vhd-M4-bzl">
+                                                                        <rect key="frame" x="48" y="0.0" width="281" height="30"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="30" id="czu-nZ-69D"/>
+                                                                </constraints>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Z5H-d5-PQz" userLabel="action.type">
+                                                                <rect key="frame" x="0.0" y="30" width="329" height="30"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="action.type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AjS-Id-uD9">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="63.5" height="30"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="AzU-sp-7lm">
+                                                                        <rect key="frame" x="68.5" y="0.0" width="260.5" height="30"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="30" id="aO2-LH-Ovb"/>
+                                                                </constraints>
+                                                            </stackView>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g0R-5h-ruu">
+                                                        <rect key="frame" x="334" y="0.0" width="50" height="60"/>
+                                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="mKt-t4-WUj"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <state key="normal" title="Send">
+                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                <integer key="value" value="7"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="didTapSendActionEvent:" destination="CBf-fg-exz" eventType="touchUpInside" id="Piu-FH-aoi"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W1b-Ap-trU" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="95.5" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="201" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="Zk1-nz-tiQ"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1CX-Pk-Oad" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="105.5" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="211" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="J1D-8z-qtE"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONSOLE OUTPUT:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="heX-eV-XM4">
-                                        <rect key="frame" x="0.0" y="115.5" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="221" width="384" height="14.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                         <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cUF-XZ-rO4" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="130" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="235.5" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="Kmx-dC-T5D"/>
                                         </constraints>
                                     </view>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xE1-F9-dzh">
-                                        <rect key="frame" x="0.0" y="140" width="384" height="604"/>
+                                        <rect key="frame" x="0.0" y="245.5" width="384" height="498.5"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
@@ -896,8 +995,11 @@
                     </view>
                     <navigationItem key="navigationItem" id="uWQ-hu-SiG"/>
                     <connections>
+                        <outlet property="actionTypeTextField" destination="AzU-sp-7lm" id="CBf-7Z-Hdo"/>
+                        <outlet property="actionViewURLTextField" destination="vhd-M4-bzl" id="enq-vJ-ATt"/>
                         <outlet property="consoleTextView" destination="xE1-F9-dzh" id="EZv-yU-A1l"/>
                         <outlet property="rumServiceNameTextField" destination="vzP-ny-3dq" id="erc-CQ-v5k"/>
+                        <outlet property="sendActionEventButton" destination="g0R-5h-ruu" id="qo2-I4-hPd"/>
                         <outlet property="sendViewEventButton" destination="Ixr-vj-rNH" id="UxV-V9-WZL"/>
                         <outlet property="viewURLTextField" destination="U9s-H3-pzA" id="lLu-p7-x7L"/>
                     </connections>

--- a/Datadog/Example/Debugging/DebugRUMViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMViewController.swift
@@ -20,6 +20,8 @@ class DebugRUMViewController: UIViewController {
         startDisplayingDebugInfo(in: consoleTextView)
 
         viewURLTextField.placeholder = viewURL
+        actionViewURLTextField.placeholder = actionViewURL
+        actionTypeTextField.placeholder = actionType
     }
 
     // MARK: - View Event
@@ -34,5 +36,33 @@ class DebugRUMViewController: UIViewController {
     @IBAction func didTapSendViewEvent(_ sender: Any) {
         rumMonitor.sendFakeViewEvent(viewURL: viewURL)
         sendViewEventButton.disableFor(seconds: 0.5)
+    }
+
+    // MARK: - Action Event
+
+    @IBOutlet weak var actionViewURLTextField: UITextField!
+    @IBOutlet weak var actionTypeTextField: UITextField!
+    @IBOutlet weak var sendActionEventButton: UIButton!
+
+    private var actionViewURL: String {
+        actionViewURLTextField.text!.isEmpty ? "/hello/rum" : actionViewURLTextField.text!
+    }
+
+    private var actionType: String {
+        let allowedTypes = ["custom", "click", "tap", "scroll", "swipe", "application_start"]
+        let defaultType = "custom"
+        let actionType = actionTypeTextField.text ?? defaultType
+        return allowedTypes.contains(actionType) ? actionType : defaultType // limit to allowed types
+    }
+
+    @IBAction func didTapSendActionEvent(_ sender: Any) {
+        rumMonitor.sendFakeActionEvent(viewURL: actionViewURL, actionType: actionType)
+        sendActionEventButton.disableFor(seconds: 0.5)
+
+        if actionType != actionTypeTextField.text { // if `actionType` was replaced with allowed type
+            if !actionTypeTextField.text!.isEmpty { // when not using placeholder
+                actionTypeTextField.text = actionType
+            }
+        }
     }
 }

--- a/Datadog/Example/Debugging/DebugRUMViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMViewController.swift
@@ -11,8 +11,6 @@ class DebugRUMViewController: UIViewController {
     @IBOutlet weak var rumServiceNameTextField: UITextField!
     @IBOutlet weak var consoleTextView: UITextView!
 
-    private let rumMonitor = RUMMonitor.initialize(rumApplicationID: appConfig.rumApplicationID)
-
     override func viewDidLoad() {
         super.viewDidLoad()
         rumServiceNameTextField.text = appConfig.serviceName

--- a/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal class SendRUMFixture1ViewController: UIViewController {
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // Notify RUM that View was presented - add custom attributes.
+        rumMonitor.start(viewController: self)
+    }
+}

--- a/Sources/Datadog/RUM/DataModels/RUMActionEvent.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMActionEvent.swift
@@ -46,6 +46,8 @@ internal struct RUMActionEvent: Codable, RUMDataModel {
     }
 
     struct Action: Codable {
+        /// Open discussion: should this be non-optional?
+        let id: String?
         /// Allowed values:
         /// `"custom", "click", "tap", "scroll", "swipe", "application_start"`
         let type: String

--- a/Sources/Datadog/RUM/DataModels/RUMActionEvent.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMActionEvent.swift
@@ -7,21 +7,23 @@
 import Foundation
 
 // TODO: RUMM-517 Replace with auto-generated RUM data model
-internal struct RUMViewEvent: Codable, RUMDataModel {
+internal struct RUMActionEvent: Codable, RUMDataModel {
     enum CodingKeys: String, CodingKey {
         case date
         case application
         case session
         case type
         case view
+        case action
         case dd  = "_dd"
     }
 
     let date: UInt64
     let application: Application
     let session: Session
-    let type = "view"
     let view: View
+    let type = "action"
+    let action: Action
     let dd: DD
 
     struct Application: Codable {
@@ -37,37 +39,23 @@ internal struct RUMViewEvent: Codable, RUMDataModel {
         enum CodingKeys: String, CodingKey {
             case id
             case url
-            case timeSpent = "time_spent"
-            case action
-            case error
-            case resource
         }
 
         let id: String
         let url: String
-        let timeSpent: UInt64
-        let action: Action
-        let error: Error
-        let resource: Resource
+    }
 
-        struct Action: Codable {
-            let count: UInt
-        }
-        struct Error: Codable {
-            let count: UInt
-        }
-        struct Resource: Codable {
-            let count: UInt
-        }
+    struct Action: Codable {
+        /// Allowed values:
+        /// `"custom", "click", "tap", "scroll", "swipe", "application_start"`
+        let type: String
     }
 
     struct DD: Codable {
         enum CodingKeys: String, CodingKey {
-            case documentVersion = "document_version"
             case formatVersion  = "format_version"
         }
 
-        let documentVersion: UInt
         let formatVersion = 2
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
@@ -10,6 +10,8 @@ internal protocol RUMScope: class {
     /// The context of this scope. Should inherit data from parent scope's context.
     var context: RUMContext { get }
 
-    /// Processes given command and returns `true` when the scope should be closed.
+    /// Processes given command. Returns:
+    /// * `true` if the scope should be kept open.
+    /// * `false` if the scope should be closed.
     func process(command: RUMCommand) -> Bool
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -49,8 +49,8 @@ internal class RUMApplicationScope: RUMScope {
 
     func process(command: RUMCommand) -> Bool {
         if let currentSession = sessionScope {
-            let shouldRefreshSession = currentSession.process(command: command)
-            if shouldRefreshSession {
+            let keepCurrentSession = currentSession.process(command: command)
+            if !keepCurrentSession {
                 let refreshedSession = RUMSessionScope(parent: self, dependencies: dependencies)
                 sessionScope = refreshedSession
                 _ = refreshedSession.process(command: command)
@@ -66,6 +66,6 @@ internal class RUMApplicationScope: RUMScope {
             }
         }
 
-        return false
+        return true
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -1,0 +1,118 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal class RUMSessionScope: RUMScope {
+    struct Constants {
+        /// If no interaction is registered within this period, a new session is started.
+        static let sessionTimeoutDuration: TimeInterval = 15 * 60 // 15 minutes
+        /// Maximum duration of a session. If it gets exceeded, a new session is started.
+        static let sessionMaxDuration: TimeInterval = 4 * 60 * 60 // 4 hours
+    }
+
+    // MARK: - Initialization
+
+    unowned let parent: RUMScope
+    private let dependencies: RUMScopeDependencies
+
+    /// Current session ID. May change due to inactivity or when exceeding max duration.
+    private var sessionID: UUID?
+    /// The start time of current session.
+    private var sessionStartTime: Date?
+    /// Time of the last processed RUM command.
+    private var lastInteractionTime: Date?
+
+    init(
+        parent: RUMApplicationScope,
+        dependencies: RUMScopeDependencies
+    ) {
+        self.parent = parent
+        self.dependencies = dependencies
+    }
+
+    // MARK: - RUMScope
+
+    var context: RUMContext {
+        var context = parent.context
+        context.sessionID = sessionID ?? parent.context.sessionID
+        return context
+    }
+
+    func process(command: RUMCommand) -> Bool {
+        startNewSessionIfNeeded()
+
+        switch command {
+        case .startView:
+            sendApplicationStartActionOnlyOnce()
+        default:
+            break
+        }
+
+        lastInteractionTime = dependencies.dateProvider.currentDate()
+        return false
+    }
+
+    // MARK: - Sending RUM Events
+
+    /// Tracks if the `application_start` RUM action was already sent.
+    private var didSendApplicationStartAction = false
+
+    private func sendApplicationStartActionOnlyOnce() {
+        guard !didSendApplicationStartAction else {
+            return
+        }
+
+        let eventData = RUMActionEvent(
+            date: Date().timeIntervalSince1970.toMilliseconds,
+            application: .init(id: context.rumApplicationID),
+            session: .init(id: UUID().uuidString.lowercased(), type: "user"),
+            view: .init(
+                // The `application_start` event uses null UUID for its `view.id`
+                id: RUMApplicationScope.Constants.nullUUID.uuidString.lowercased(),
+                // The `application_start` event uses empty string for its `view.url`
+                url: ""
+            ),
+            action: .init(
+                type: "application_start"
+            ),
+            dd: .init()
+        )
+
+        let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: nil)
+        dependencies.eventOutput.write(rumEvent: event)
+
+        didSendApplicationStartAction = true
+    }
+
+    // MARK: - Private
+
+    private func startNewSessionIfNeeded() {
+        let currentTime = dependencies.dateProvider.currentDate()
+
+        guard sessionID != nil,
+              let sessionStartTime = sessionStartTime,
+              let lastInteractionTime = lastInteractionTime
+        else {
+            // No session was created, start the first one:
+            self.sessionID = UUID()
+            self.sessionStartTime = currentTime
+            return
+        }
+
+        let timeElapsedSinceLastInteraction = currentTime.timeIntervalSince(lastInteractionTime)
+        let wasInactiveTooLong = timeElapsedSinceLastInteraction >= Constants.sessionTimeoutDuration
+
+        let sessionDuration = currentTime.timeIntervalSince(sessionStartTime)
+        let isLastingTooLong = sessionDuration >= Constants.sessionMaxDuration
+
+        if wasInactiveTooLong || isLastingTooLong {
+            // start new session
+            self.sessionID = UUID()
+            self.sessionStartTime = currentTime
+        }
+    }
+}

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -77,6 +77,7 @@ internal class RUMSessionScope: RUMScope {
                 url: ""
             ),
             action: .init(
+                id: UUID().uuidString.lowercased(),
                 type: "application_start"
             ),
             dd: .init()

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -47,7 +47,7 @@ internal class RUMSessionScope: RUMScope {
 
     func process(command: RUMCommand) -> Bool {
         if timedOutOrExpired() {
-            return true // end session
+            return false // no longer keep this session
         }
 
         switch command {
@@ -59,7 +59,7 @@ internal class RUMSessionScope: RUMScope {
         }
 
         lastInteractionTime = dependencies.dateProvider.currentDate()
-        return false
+        return true
     }
 
     // MARK: - Sending RUM Events

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -154,6 +154,7 @@ public class RUMMonitor: RUMMonitorInternal {
                 url: viewURL
             ),
             action: .init(
+                id: UUID().uuidString.lowercased(),
                 type: actionType
             ),
             dd: .init()

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -31,13 +31,16 @@ public class RUMMonitor: RUMMonitorInternal {
         self.init(
             applicationScope: RUMApplicationScope(
                 rumApplicationID: rumApplicationID,
-                eventBuilder: RUMEventBuilder(
-                    userInfoProvider: rumFeature.userInfoProvider,
-                    networkConnectionInfoProvider: rumFeature.networkConnectionInfoProvider,
-                    carrierInfoProvider: rumFeature.carrierInfoProvider
-                ),
-                eventOutput: RUMEventFileOutput(
-                    fileWriter: rumFeature.storage.writer
+                dependencies: RUMScopeDependencies(
+                    dateProvider: rumFeature.dateProvider,
+                    eventBuilder: RUMEventBuilder(
+                        userInfoProvider: rumFeature.userInfoProvider,
+                        networkConnectionInfoProvider: rumFeature.networkConnectionInfoProvider,
+                        carrierInfoProvider: rumFeature.carrierInfoProvider
+                    ),
+                    eventOutput: RUMEventFileOutput(
+                        fileWriter: rumFeature.storage.writer
+                    )
                 )
             )
         )

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -125,4 +125,34 @@ public class RUMMonitor: RUMMonitorInternal {
 
         rumFeature.storage.writer.write(value: event)
     }
+
+    public func sendFakeActionEvent(viewURL: String, actionType: String) {
+        guard let rumFeature = RUMFeature.instance else {
+            fatalError("RUMFeature must be initialized.")
+        }
+
+        let dataModel = RUMActionEvent(
+            date: Date().timeIntervalSince1970.toMilliseconds,
+            application: .init(id: applicationScope.context.rumApplicationID),
+            session: .init(id: UUID().uuidString.lowercased(), type: "user"),
+            view: .init(
+                id: UUID().uuidString.lowercased(),
+                url: viewURL
+            ),
+            action: .init(
+                type: actionType
+            ),
+            dd: .init()
+        )
+
+        let builder = RUMEventBuilder(
+            userInfoProvider: rumFeature.userInfoProvider,
+            networkConnectionInfoProvider: rumFeature.networkConnectionInfoProvider,
+            carrierInfoProvider: rumFeature.carrierInfoProvider
+        )
+
+        let event = builder.createRUMEvent(with: dataModel, attributes: nil)
+
+        rumFeature.storage.writer.write(value: event)
+    }
 }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import UIKit
 import Foundation
 
 public class RUMMonitor: RUMMonitorInternal {
@@ -48,6 +49,16 @@ public class RUMMonitor: RUMMonitorInternal {
 
     internal init(applicationScope: RUMScope) {
         self.applicationScope = applicationScope
+    }
+
+    // MARK: - Public API
+
+    /// Notifies that a View is being shown to the user.
+    /// - Parameters:
+    ///   - viewController: the instance of `UIViewController` representing this View.
+    ///   - attributes: custom attributes to attach to the View.
+    public func start(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]? = nil) {
+        start(view: viewController, attributes: attributes)
     }
 
     // MARK: - RUMMonitorInternal

--- a/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/LoggingIntegrationTests.swift
@@ -15,14 +15,19 @@ class LoggingIntegrationTests: IntegrationTests {
     }
 
     func testLaunchTheAppAndSendLogs() throws {
-        let serverSession = server.obtainUniqueRecordingSession()
+        let loggingServerSession = server.obtainUniqueRecordingSession()
 
         let app = ExampleApplication()
-        app.launchWith(mockServerURL: serverSession.recordingURL)
+        app.launchWith(
+            mockLogsEndpointURL: loggingServerSession.recordingURL,
+            mockTracesEndpointURL: server.obtainUniqueRecordingSession().recordingURL,   // mock any
+            mockRUMEndpointURL: server.obtainUniqueRecordingSession().recordingURL,      // mock any
+            mockSourceEndpointURL: server.obtainUniqueRecordingSession().recordingURL    // mock any
+        )
         app.tapSendLogsForUITests()
 
         // Return desired count or timeout
-        let recordedRequests = try serverSession.pullRecordedPOSTRequests(count: 1, timeout: Constants.logsDeliveryTime)
+        let recordedRequests = try loggingServerSession.pullRecordedPOSTRequests(count: 1, timeout: Constants.logsDeliveryTime)
 
         recordedRequests.forEach { request in
             // Example path here: `/36882784-420B-494F-910D-CBAC5897A309/ui-tests-client-token?ddsource=ios&batch_time=1589969230153`

--- a/Tests/DatadogIntegrationTests/RUMIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/RUMIntegrationTests.swift
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import HTTPServerMock
+import XCTest
+
+class RUMIntegrationTests: IntegrationTests {
+    private struct Constants {
+        /// Time needed for data to be uploaded to mock server.
+        static let dataDeliveryTime: TimeInterval = 30
+    }
+
+    func testLaunchTheAppNavigateThroughRUMFixtures() throws {
+        // Server session recording RUM events send to `HTTPServerMock`.
+        let rumServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            mockLogsEndpointURL: server.obtainUniqueRecordingSession().recordingURL,     // mock any
+            mockTracesEndpointURL: server.obtainUniqueRecordingSession().recordingURL,   // mock any
+            mockRUMEndpointURL: rumServerSession.recordingURL,
+            mockSourceEndpointURL: server.obtainUniqueRecordingSession().recordingURL    // mock any 
+        )
+        app.tapSendRUMEventsForUITests()
+
+        // Return desired count or timeout
+        let recordedRUMRequests = try rumServerSession.pullRecordedPOSTRequests(
+            count: 1,
+            timeout: Constants.dataDeliveryTime
+        )
+
+        recordedRUMRequests.forEach { request in
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309/ui-tests-client-token?ddsource=ios&batch_time=1576404000000&ddtags=service:ui-tests-service-name,version:1.0,sdk_version:1.3.0-beta3,env:integration`
+            let pathRegexp = #"^(.*)(\/ui-tests-client-token\?ddsource=ios&batch_time=)([0-9]+)(&ddtags=service:ui-tests-service-name,version:1.0,sdk_version:)([0-9].[0-9].[0-9](-[a-z0-9]*))(,env:integration)$"#
+            XCTAssertNotNil(
+                request.path.range(of: pathRegexp, options: .regularExpression, range: nil, locale: nil),
+                "RUM request path: \(request.path) should match regexp: \(pathRegexp)"
+            )
+            XCTAssertTrue(request.httpHeaders.contains("Content-Type: text/plain;charset=UTF-8"))
+        }
+
+        // Assert RUM events
+        let rumEventsMatchers = try recordedRUMRequests
+            .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+
+        let applicationStartAction: RUMActionEvent = try rumEventsMatchers[0].model()
+        XCTAssertEqual(applicationStartAction.action.type, "application_start")
+    }
+}

--- a/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/TracingIntegrationTests.swift
@@ -28,6 +28,7 @@ class TracingIntegrationTests: IntegrationTests {
         app.launchWith(
             mockLogsEndpointURL: loggingServerSession.recordingURL,
             mockTracesEndpointURL: tracingServerSession.recordingURL,
+            mockRUMEndpointURL: server.obtainUniqueRecordingSession().recordingURL, // mock any
             mockSourceEndpointURL: dataSourceServerSession.recordingURL
         )
         app.tapSendTracesForUITests()

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -8,17 +8,18 @@ import XCTest
 
 /// Convenient interface to navigate through Example app's main screen.
 class ExampleApplication: XCUIApplication {
-    /// Launches the app by mocking all feature endpoints with `mockServerURL`.
-    func launchWith(mockServerURL: URL) {
-        self.launchWith(mockLogsEndpointURL: mockServerURL, mockTracesEndpointURL: mockServerURL, mockSourceEndpointURL: mockServerURL)
-    }
-
-    /// Launches the app by mocking feature endpoints separately.
-    func launchWith(mockLogsEndpointURL: URL, mockTracesEndpointURL: URL, mockSourceEndpointURL: URL) {
+    /// Launches the app by mocking feature endpoints.
+    func launchWith(
+        mockLogsEndpointURL: URL,
+        mockTracesEndpointURL: URL,
+        mockRUMEndpointURL: URL,
+        mockSourceEndpointURL: URL
+    ) {
         launchArguments = ["IS_RUNNING_UI_TESTS"]
         launchEnvironment = [
             "DD_MOCK_LOGS_ENDPOINT_URL": mockLogsEndpointURL.absoluteString,
             "DD_MOCK_TRACES_ENDPOINT_URL": mockTracesEndpointURL.absoluteString,
+            "DD_MOCK_RUM_ENDPOINT_URL": mockRUMEndpointURL.absoluteString,
             "DD_MOCK_SOURCE_ENDPOINT_URL": mockSourceEndpointURL.absoluteString
         ]
         super.launch()
@@ -30,5 +31,9 @@ class ExampleApplication: XCUIApplication {
 
     func tapSendTracesForUITests() {
         tables.staticTexts["Send traces for UI Tests"].tap()
+    }
+
+    func tapSendRUMEventsForUITests() {
+        tables.staticTexts["Send RUM events for UI Tests"].tap()
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -194,7 +194,7 @@ class RUMScopeMock: RUMScope {
             self.commands.append(command)
             self.expectation?.fulfill()
         }
-        return false
+        return true
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -96,6 +96,50 @@ extension RUMEventBuilder {
     }
 }
 
+class RUMEventOutputMock: RUMEventOutput {
+    func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {}
+}
+
+// MARK: - RUMScope Mocks
+
+extension RUMScopeDependencies {
+    static func mockAny() -> RUMScopeDependencies {
+        return mockWith()
+    }
+
+    static func mockWith(
+        dateProvider: DateProvider = SystemDateProvider(),
+        eventBuilder: RUMEventBuilder = RUMEventBuilder(
+            userInfoProvider: .mockAny(),
+            networkConnectionInfoProvider: nil,
+            carrierInfoProvider: nil
+        ),
+        eventOutput: RUMEventOutput = RUMEventOutputMock()
+    ) -> RUMScopeDependencies {
+        return RUMScopeDependencies(
+            dateProvider: dateProvider,
+            eventBuilder: eventBuilder,
+            eventOutput: eventOutput
+        )
+    }
+}
+
+extension RUMApplicationScope {
+    static func mockAny() -> RUMApplicationScope {
+        return mockWith()
+    }
+
+    static func mockWith(
+        rumApplicationID: String = .mockAny(),
+        dependencies: RUMScopeDependencies = .mockAny()
+    ) -> RUMApplicationScope {
+        return RUMApplicationScope(
+            rumApplicationID: rumApplicationID,
+            dependencies: dependencies
+        )
+    }
+}
+
 /// `RUMScope` recording processed commands.
 class RUMScopeMock: RUMScope {
     private let queue = DispatchQueue(label: "com.datadoghq.RUMScopeMock")
@@ -144,10 +188,6 @@ class RUMScopeMock: RUMScope {
         }
         return false
     }
-}
-
-class RUMEventOutputMock: RUMEventOutput {
-    func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {}
 }
 
 // MARK: - Utilities

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -100,6 +100,14 @@ class RUMEventOutputMock: RUMEventOutput {
     func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {}
 }
 
+// MARK: - RUMCommand Mocks
+
+extension RUMCommand {
+    static func mockAny() -> RUMCommand {
+        return .addUserAction(userAction: .tap, attributes: nil)
+    }
+}
+
 // MARK: - RUMScope Mocks
 
 extension RUMScopeDependencies {

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -226,3 +226,20 @@ extension ServerMock {
         }
     }
 }
+
+// MARK: - RUM feature helpers
+
+extension ServerMock {
+    func waitAndReturnRUMEventMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [RUMEventMatcher] {
+        return try waitAndReturnRequests(
+            count: count,
+            timeout: recommendedTimeoutFor(numberOfRequestsMade: count),
+            file: file,
+            line: line
+        )
+        .map { request in try request.httpBody.unwrapOrThrow() }
+        .flatMap { requestBody in
+            try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(requestBody)
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -40,12 +40,10 @@ class RUMFeatureTests: XCTestCase {
         )
         defer { RUMFeature.instance = nil }
 
-        // TODO: RUMM-585 Replace with real data created by `RUMMonitor`
-        struct DummyRUMMEvent: Encodable {
-            let someAttribute = "foo"
-        }
-        let fileWriter = try XCTUnwrap(RUMFeature.instance?.storage.writer)
-        fileWriter.write(value: DummyRUMMEvent())
+        let monitor = RUMMonitor.initialize(rumApplicationID: "rum-123")
+
+        // Starting first view sends `application_start` action event
+        monitor.start(view: UIViewController(), attributes: nil)
 
         let request = server.waitAndReturnRequests(count: 1)[0]
         XCTAssertEqual(request.httpMethod, "POST")

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -25,7 +25,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny())
 
         XCTAssertNil(scope.sessionScope)
-        XCTAssertFalse(scope.process(command: .startView(id: UIViewController(), attributes: nil)))
+        XCTAssertTrue(scope.process(command: .startView(id: UIViewController(), attributes: nil)))
         XCTAssertNotNil(scope.sessionScope)
     }
 
@@ -48,9 +48,9 @@ class RUMApplicationScopeTests: XCTestCase {
     func testUntilSessionIsStarted_itIgnoresOtherCommands() {
         let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny())
 
-        XCTAssertFalse(scope.process(command: .stopView(id: UIViewController(), attributes: nil)))
-        XCTAssertFalse(scope.process(command: .addUserAction(userAction: .tap, attributes: nil)))
-        XCTAssertFalse(scope.process(command: .startResource(resourceName: .mockAny(), attributes: nil)))
+        XCTAssertTrue(scope.process(command: .stopView(id: UIViewController(), attributes: nil)))
+        XCTAssertTrue(scope.process(command: .addUserAction(userAction: .tap, attributes: nil)))
+        XCTAssertTrue(scope.process(command: .startResource(resourceName: .mockAny(), attributes: nil)))
         XCTAssertNil(scope.sessionScope)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -8,15 +8,14 @@ import XCTest
 @testable import Datadog
 
 class RUMApplicationScopeTests: XCTestCase {
-    func testContextPropagation() {
+    func testRootContext() {
         let scope = RUMApplicationScope(
             rumApplicationID: "abc-123",
-            eventBuilder: .mockAny(),
-            eventOutput: RUMEventOutputMock()
+            dependencies: .mockAny()
         )
 
         XCTAssertEqual(scope.context.rumApplicationID, "abc-123")
-        XCTAssertEqual(scope.context.sessionID, RUMApplicationScope.nullSessionID)
+        XCTAssertEqual(scope.context.sessionID, RUMApplicationScope.Constants.nullUUID)
         XCTAssertNil(scope.context.activeViewID)
         XCTAssertNil(scope.context.activeViewURI)
         XCTAssertNil(scope.context.activeUserActionID)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -27,12 +27,12 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(dateProvider: dateProvider)
         )
 
-        XCTAssertFalse(scope.process(command: .mockAny()))
+        XCTAssertTrue(scope.process(command: .mockAny()))
 
         // Push time forward by the max session duration:
         dateProvider.advance(bySeconds: RUMSessionScope.Constants.sessionMaxDuration)
 
-        XCTAssertTrue(scope.process(command: .mockAny()))
+        XCTAssertFalse(scope.process(command: .mockAny()))
     }
 
     func testWhenSessionIsInactiveForCertainDuration_itGetsClosed() {
@@ -43,16 +43,16 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(dateProvider: dateProvider)
         )
 
-        XCTAssertFalse(scope.process(command: .mockAny()))
+        XCTAssertTrue(scope.process(command: .mockAny()))
 
         // Push time forward by less than the session timeout duration:
         dateProvider.advance(bySeconds: 0.5 * RUMSessionScope.Constants.sessionTimeoutDuration)
 
-        XCTAssertFalse(scope.process(command: .mockAny()))
+        XCTAssertTrue(scope.process(command: .mockAny()))
 
         // Push time forward by the session timeout duration:
         dateProvider.advance(bySeconds: RUMSessionScope.Constants.sessionTimeoutDuration)
 
-        XCTAssertTrue(scope.process(command: .mockAny()))
+        XCTAssertFalse(scope.process(command: .mockAny()))
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -1,0 +1,78 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMSessionScopeTests: XCTestCase {
+    func testDefaultContext() {
+        let parent: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
+        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny())
+
+        XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
+        XCTAssertEqual(scope.context.sessionID, RUMApplicationScope.Constants.nullUUID)
+        XCTAssertNil(scope.context.activeViewID)
+        XCTAssertNil(scope.context.activeViewURI)
+        XCTAssertNil(scope.context.activeUserActionID)
+    }
+
+    func testWhenFirstViewIsStarted_itStartsNewSession() {
+        let parent: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
+        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny())
+
+        XCTAssertFalse(scope.process(command: .startView(id: UIViewController(), attributes: nil)))
+
+        XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
+        XCTAssertNotEqual(scope.context.sessionID, RUMApplicationScope.Constants.nullUUID)
+        XCTAssertNil(scope.context.activeViewID)
+        XCTAssertNil(scope.context.activeViewURI)
+        XCTAssertNil(scope.context.activeUserActionID)
+    }
+
+    func testWhenSessionExceedsMaxDuration_itStartsNewSession() {
+        let dateProvider = RelativeDateProvider()
+        let parent: RUMApplicationScope = .mockAny()
+        let scope = RUMSessionScope(
+            parent: parent,
+            dependencies: .mockWith(dateProvider: dateProvider)
+        )
+
+        XCTAssertFalse(scope.process(command: .startView(id: UIViewController(), attributes: nil)))
+        let firstSessionID = scope.context.sessionID
+        XCTAssertFalse(parent.process(command: .stopView(id: UIViewController(), attributes: nil)))
+        XCTAssertFalse(scope.process(command: .startView(id: UIViewController(), attributes: nil)))
+        XCTAssertEqual(scope.context.sessionID, firstSessionID, "It should keep the same session")
+
+        // Push time forward by the max session duration:
+        dateProvider.advance(bySeconds: RUMSessionScope.Constants.sessionMaxDuration)
+
+        XCTAssertFalse(scope.process(command: .stopView(id: UIViewController(), attributes: nil)))
+        XCTAssertNotEqual(scope.context.sessionID, firstSessionID, "It should start new session")
+    }
+
+    func testWhenSessionIsInactiveForCertainDuration_itStartsNewSession() {
+        let dateProvider = RelativeDateProvider()
+        let parent: RUMApplicationScope = .mockAny()
+        let scope = RUMSessionScope(
+            parent: parent,
+            dependencies: .mockWith(dateProvider: dateProvider)
+        )
+
+        XCTAssertFalse(scope.process(command: .startView(id: UIViewController(), attributes: nil)))
+        let firstSessionID = scope.context.sessionID
+
+        // Push time forward by less than the session timeout duration:
+        dateProvider.advance(bySeconds: 0.5 * RUMSessionScope.Constants.sessionTimeoutDuration)
+        XCTAssertFalse(scope.process(command: .addUserAction(userAction: .tap, attributes: nil)))
+        XCTAssertEqual(scope.context.sessionID, firstSessionID, "It should keep the same session")
+
+        // Push time forward by the session timeout duration:
+        dateProvider.advance(bySeconds: RUMSessionScope.Constants.sessionTimeoutDuration)
+
+        XCTAssertFalse(scope.process(command: .stopView(id: UIViewController(), attributes: nil)))
+        XCTAssertNotEqual(scope.context.sessionID, firstSessionID, "It should start new session")
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -44,7 +44,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
 
         let feature = try XCTUnwrap(RUMFeature.instance)
         let applicationScope = try XCTUnwrap(monitor.applicationScope as? RUMApplicationScope)
-        let rumEventBuilder = applicationScope.eventBuilder
+        let rumEventBuilder = applicationScope.dependencies.eventBuilder
 
         XCTAssertTrue(rumEventBuilder.userInfoProvider === feature.userInfoProvider)
         XCTAssertTrue(rumEventBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -9,42 +9,42 @@ import UIKit
 @testable import Datadog
 
 class RUMMonitorTests: XCTestCase {
-    func testWhenCallingPublicAPI_itProcessessExpectedCommandsThrougScopes() {
-        let scope = RUMScopeMock()
-        let monitor = RUMMonitor(applicationScope: scope)
+    override func setUp() {
+        super.setUp()
+        XCTAssertNil(Datadog.instance)
+        XCTAssertNil(RUMFeature.instance)
+        temporaryDirectory.create()
+    }
 
-        let mockView = UIViewController()
-        let mockAttributes = ["foo": "bar"]
-        let mockError = ErrorMock()
+    override func tearDown() {
+        XCTAssertNil(Datadog.instance)
+        XCTAssertNil(RUMFeature.instance)
+        temporaryDirectory.delete()
+        super.tearDown()
+    }
 
-        monitor.start(view: mockView, attributes: mockAttributes)
-        monitor.stop(view: mockView, attributes: mockAttributes)
-        monitor.addViewError(message: "error", error: mockError, attributes: mockAttributes)
+    // MARK: - Sending RUM events
 
-        monitor.start(resource: "/resource/1", attributes: mockAttributes)
-        monitor.stop(resource: "/resource/1", attributes: mockAttributes)
-        monitor.stop(resource: "/resource/1", withError: ErrorMock(), attributes: mockAttributes)
-
-        monitor.start(userAction: .scroll, attributes: mockAttributes)
-        monitor.stop(userAction: .scroll, attributes: mockAttributes)
-        monitor.add(userAction: .tap, attributes: mockAttributes)
-
-        let recordedCommands = scope.waitAndReturnProcessedCommands(count: 9, timeout: 0.5)
-
-        XCTAssertEqual(
-            recordedCommands,
-            [
-                .startView(id: mockView, attributes: mockAttributes),
-                .stopView(id: mockView, attributes: mockAttributes),
-                .addCurrentViewError(message: "error", error: mockError, attributes: mockAttributes),
-                .startResource(resourceName: "/resource/1", attributes: mockAttributes),
-                .stopResource(resourceName: "/resource/1", attributes: mockAttributes),
-                .stopResourceWithError(resourceName: "/resource/1", error: mockError, attributes: mockAttributes),
-                .startUserAction(userAction: .scroll, attributes: mockAttributes),
-                .stopUserAction(userAction: .scroll, attributes: mockAttributes),
-                .addUserAction(userAction: .tap, attributes: mockAttributes)
-            ]
+    func testWhenFirstViewIsStarted_itSendsApplicationStartAction() throws {
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        RUMFeature.instance = .mockWorkingFeatureWith(
+            server: server,
+            directory: temporaryDirectory
         )
+        defer { RUMFeature.instance = nil }
+
+        let monitor = RUMMonitor.initialize(rumApplicationID: "abc-123")
+
+        monitor.start(view: UIViewController(), attributes: nil)
+
+        let rumEventMatcher = try server.waitAndReturnRUMEventMatchers(count: 1)[0]
+
+        let event: RUMActionEvent = try rumEventMatcher.model()
+        XCTAssertEqual(event.application.id, "abc-123")
+        XCTAssertEqual(event.action.type, "application_start")
+        XCTAssertEqual(event.view.id, "00000000-0000-0000-0000-000000000000")
+        XCTAssertEqual(event.view.url, "")
+        XCTAssertNotEqual(event.session.id, "00000000-0000-0000-0000-000000000000")
     }
 
     // MARK: - Thread safety
@@ -75,5 +75,46 @@ class RUMMonitorTests: XCTestCase {
         }
 
         server.waitAndAssertNoRequestsSent()
+    }
+
+    // MARK: - Usage
+
+    func testWhenCallingPublicAPI_itProcessessExpectedCommandsThrougScopes() {
+        let scope = RUMScopeMock()
+        let monitor = RUMMonitor(applicationScope: scope)
+
+        let mockView = UIViewController()
+        let mockAttributes = ["foo": "bar"]
+        let mockError = ErrorMock()
+
+        // TODO: RUMM-585 Replace these internal API calls with public APIs
+        monitor.start(view: mockView, attributes: mockAttributes)
+        monitor.stop(view: mockView, attributes: mockAttributes)
+        monitor.addViewError(message: "error", error: mockError, attributes: mockAttributes)
+
+        monitor.start(resource: "/resource/1", attributes: mockAttributes)
+        monitor.stop(resource: "/resource/1", attributes: mockAttributes)
+        monitor.stop(resource: "/resource/1", withError: ErrorMock(), attributes: mockAttributes)
+
+        monitor.start(userAction: .scroll, attributes: mockAttributes)
+        monitor.stop(userAction: .scroll, attributes: mockAttributes)
+        monitor.add(userAction: .tap, attributes: mockAttributes)
+
+        let recordedCommands = scope.waitAndReturnProcessedCommands(count: 9, timeout: 0.5)
+
+        XCTAssertEqual(
+            recordedCommands,
+            [
+                .startView(id: mockView, attributes: mockAttributes),
+                .stopView(id: mockView, attributes: mockAttributes),
+                .addCurrentViewError(message: "error", error: mockError, attributes: mockAttributes),
+                .startResource(resourceName: "/resource/1", attributes: mockAttributes),
+                .stopResource(resourceName: "/resource/1", attributes: mockAttributes),
+                .stopResourceWithError(resourceName: "/resource/1", error: mockError, attributes: mockAttributes),
+                .startUserAction(userAction: .scroll, attributes: mockAttributes),
+                .stopUserAction(userAction: .scroll, attributes: mockAttributes),
+                .addUserAction(userAction: .tap, attributes: mockAttributes)
+            ]
+        )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -79,7 +79,7 @@ class RUMMonitorTests: XCTestCase {
 
     // MARK: - Usage
 
-    func testWhenCallingPublicAPI_itProcessessExpectedCommandsThrougScopes() {
+    func testWhenCallingPublicAPI_itProcessesExpectedCommandsThrougScopes() {
         let scope = RUMScopeMock()
         let monitor = RUMMonitor(applicationScope: scope)
 

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -69,4 +69,8 @@ internal class RUMEventMatcher {
     func mobileNetworkCarrierISOCountryCode()  throws -> String { try jsonMatcher.value(forKeyPath: "meta.network.client.sim_carrier.iso_country") }
     func mobileNetworkCarrierRadioTechnology() throws -> String { try jsonMatcher.value(forKeyPath: "meta.network.client.sim_carrier.technology") }
     func mobileNetworkCarrierAllowsVoIP()      throws -> Bool { try jsonMatcher.value(forKeyPath: "meta.network.client.sim_carrier.allows_voip") }
+
+    func attribute<T: Equatable>(forKeyPath keyPath: String) throws -> T {
+        return try jsonMatcher.value(forKeyPath: keyPath)
+    }
 }


### PR DESCRIPTION
### What and why?

📦 This PR adds RUM session monitoring.

### How?

The RUM Session monitoring has 3 requirements:
* the initial Session is started with the first View,
* if Session duration exceeds `4h`, a new one is started,
* if no interaction is observed for more than `15min`, a new Session is started.

This logic is implemented in two scopes:
* `RUMSessionScope` tracks the activity time and returns `true` from `process(command:)` on expiration or timeout.
* `RUMApplicationScope` manages creation and re-start of the `RUMSessionScope`.

When the RUM Session is started for the first time, the `application_start` RUM Action is sent. Right now, this is implemented in `RUMSessionScope`, but will be moved to `RUMViewScope` in `RUMM-519`. The test is already added and won't change: `RUMMonitorTests.testWhenFirstViewIsStarted_itSendsApplicationStartAction()`

I also added RUM integration tests fixture. When the Example app is launched and the "Send RUM events for UI Tests" button is tapped, the presented view controller starts a new RUM View. This sends the `application_start ` RUM Action, which is asserted in `RUMIntegrationTests`:

<img width="581" alt="Screenshot 2020-07-17 at 10 34 39" src="https://user-images.githubusercontent.com/2358722/87766248-247b0100-c819-11ea-80c4-d2948fa71146.png">

I also added UI to debug RUM Action events:

<img width="370" alt="Screenshot 2020-07-17 at 10 41 30" src="https://user-images.githubusercontent.com/2358722/87766909-23969f00-c81a-11ea-9d31-6ffff6585882.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
