### PR TITLE
RUMM-520 Abstract `RUMMCommand` as protocol, not enum

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -6,60 +6,97 @@
 
 import Foundation
 
-/// Commands processed by the tree of `RUMScopes`.
-internal enum RUMCommand {
-    // MARK: - Commands Published by `RUMMonitor`
-
-    case startView(id: AnyObject, attributes: [AttributeKey: AttributeValue], time: Date)
-    case stopView(id: AnyObject, attributes: [AttributeKey: AttributeValue], time: Date)
-    case addCurrentViewError(message: String, error: Error?, attributes: [AttributeKey: AttributeValue], time: Date)
-
-    case startResource(resourceName: String, attributes: [AttributeKey: AttributeValue], time: Date)
-    case stopResource(resourceName: String, attributes: [AttributeKey: AttributeValue], time: Date)
-    case stopResourceWithError(resourceName: String, error: Error, attributes: [AttributeKey: AttributeValue], time: Date)
-
-    case startUserAction(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue], time: Date)
-    case stopUserAction(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue], time: Date)
-    case addUserAction(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue], time: Date)
-
-    // MARK: - Commands Published by `RUMScopes`
-
-    /// Replaces `.startView` command for the first View started in the application.
-    case startInitialView(id: AnyObject, attributes: [AttributeKey: AttributeValue], time: Date)
-
-    // MARK: - Properties
-
-    /// Time of the command issue.
-    var time: Date {
-        switch self {
-        case .startView(_, _, let time),
-             .stopView(_, _, let time),
-             .addCurrentViewError(_, _, _, let time),
-             .startResource(_, _, let time),
-             .stopResource(_, _, let time),
-             .stopResourceWithError(_, _, _, let time),
-             .startUserAction(_, _, let time),
-             .stopUserAction(_, _, let time),
-             .addUserAction(_, _, let time),
-             .startInitialView(_, _, let time):
-            return time
-        }
-    }
-
+/// Command processed through the tree of `RUMScopes`.
+internal protocol RUMCommand {
+    /// The time of command issue.
+    var time: Date { get }
     /// Attributes associated with the command.
-    var attributes: [AttributeKey: AttributeValue] {
-        switch self {
-        case .startView(_, let attributes, _),
-             .stopView(_, let attributes, _),
-             .addCurrentViewError(_, _, let attributes, _),
-             .startResource(_, let attributes, _),
-             .stopResource(_, let attributes, _),
-             .stopResourceWithError(_, _, let attributes, _),
-             .startUserAction(_, let attributes, _),
-             .stopUserAction(_, let attributes, _),
-             .addUserAction(_, let attributes, _),
-             .startInitialView(_, let attributes, _):
-            return attributes
-        }
-    }
+    var attributes: [AttributeKey: AttributeValue] { get }
+}
+
+// MARK: - RUM View related commands
+
+internal struct RUMStartViewCommand: RUMCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The object (typically `UIViewController`) identifying the RUM View.
+    let identity: AnyObject
+
+    /// Used to indicate if this command starts the very first View in the app.
+    /// * default `false` means _it's not yet known_,
+    /// * it can be set to `true` by the `RUMApplicationScope` which tracks this state.
+    var isInitialView = false
+}
+
+internal struct RUMStopViewCommand: RUMCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The object (typically `UIViewController`) identifying the RUM View.
+    let identity: AnyObject
+}
+
+internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The error message.
+    let message: String
+    /// The error object.
+    let error: Error?
+}
+
+// MARK: - RUM Resource related commands
+
+internal struct RUMStartResourceCommand: RUMCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The name identifying the RUM Resource.
+    let name: String
+}
+
+internal struct RUMStopResourceCommand: RUMCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The name identifying the RUM Resource.
+    let name: String
+}
+
+internal struct RUMStopResourceWithErrorCommand: RUMCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The name identifying the RUM Resource.
+    let name: String
+    /// The error object.
+    let error: Error
+}
+
+// MARK: - RUM User Action related commands
+
+internal struct RUMStartUserActionCommand: RUMCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The action identifying the RUM User Action.
+    let action: RUMUserAction
+}
+
+internal struct RUMStopUserActionCommand: RUMCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The action identifying the RUM User Action.
+    let action: RUMUserAction
+}
+
+internal struct RUMAddUserActionCommand: RUMCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The action identifying the RUM User Action.
+    let action: RUMUserAction
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -51,8 +51,8 @@ internal class RUMApplicationScope: RUMScope {
             }
         } else {
             switch command {
-            case .startView(let id, let attributes, _):
-                startInitialSessionWithView(id: id, attributes: attributes, on: command)
+            case let command as RUMStartViewCommand:
+                startInitialSession(on: command)
             default:
                 break
             }
@@ -69,9 +69,11 @@ internal class RUMApplicationScope: RUMScope {
         _ = refreshedSession.process(command: command)
     }
 
-    private func startInitialSessionWithView(id: AnyObject, attributes: [AttributeKey: AttributeValue], on command: RUMCommand) {
+    private func startInitialSession(on command: RUMStartViewCommand) {
+        var startInitialViewCommand = command
+        startInitialViewCommand.isInitialView = true
         let initialSession = RUMSessionScope(parent: self, dependencies: dependencies, startTime: command.time)
         sessionScope = initialSession
-        _ = initialSession.process(command: .startInitialView(id: id, attributes: attributes, time: command.time))
+        _ = initialSession.process(command: startInitialViewCommand)
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -85,11 +85,8 @@ internal class RUMSessionScope: RUMScope {
 
         // Apply side effects
         switch command {
-        case .startInitialView(let id, let attributes, let time),
-             .startView(let id, let attributes, let time):
-            viewScopes.append(
-                RUMViewScope(parent: self, dependencies: dependencies, identity: id, attributes: attributes, startTime: time)
-            )
+        case let command as RUMStartViewCommand:
+            startView(on: command)
         default:
             break
         }
@@ -98,6 +95,20 @@ internal class RUMSessionScope: RUMScope {
         propagate(command: command, to: &viewScopes)
 
         return true
+    }
+
+    // MARK: - RUMCommands Processing
+
+    private func startView(on command: RUMStartViewCommand) {
+        viewScopes.append(
+            RUMViewScope(
+                parent: self,
+                dependencies: dependencies,
+                identity: command.identity,
+                attributes: command.attributes,
+                startTime: command.time
+            )
+        )
     }
 
     // MARK: - Private

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -57,11 +57,9 @@ internal class RUMViewScope: RUMScope {
 
     func process(command: RUMCommand) -> Bool {
         switch command {
-        case .startInitialView(let id, _, _) where id === identity:
-            startAsInitialView(on: command)
-        case .startView(let id, _, _) where id === identity:
+        case let command as RUMStartViewCommand where command.identity === identity:
             startView(on: command)
-        case .stopView(let id, _, _) where id === identity:
+        case let command as RUMStopViewCommand where command.identity === identity:
             stopView(on: command)
             return false
         default:
@@ -73,16 +71,16 @@ internal class RUMViewScope: RUMScope {
 
     // MARK: - RUMCommands Processing
 
-    private func startAsInitialView(on command: RUMCommand) {
-        sendApplicationStartAction()
-        sendViewUpdateEvent(on: command)
+    private func startView(on command: RUMStartViewCommand) {
+        if command.isInitialView {
+            sendApplicationStartAction()
+            sendViewUpdateEvent(on: command)
+        } else {
+            sendViewUpdateEvent(on: command)
+        }
     }
 
-    private func startView(on command: RUMCommand) {
-        sendViewUpdateEvent(on: command)
-    }
-
-    private func stopView(on command: RUMCommand) {
+    private func stopView(on command: RUMStopViewCommand) {
         sendViewUpdateEvent(on: command)
     }
 

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -77,92 +77,92 @@ public class RUMMonitor: RUMMonitorInternal {
 
     func start(view id: AnyObject, attributes: [AttributeKey: AttributeValue]?) {
         process(
-            command: .startView(
-                id: id,
+            command: RUMStartViewCommand(
+                time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                time: dateProvider.currentDate()
+                identity: id
             )
         )
     }
 
     func stop(view id: AnyObject, attributes: [AttributeKey: AttributeValue]?) {
         process(
-            command: .stopView(
-                id: id,
+            command: RUMStopViewCommand(
+                time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                time: dateProvider.currentDate()
+                identity: id
             )
         )
     }
 
     func addViewError(message: String, error: Error?, attributes: [AttributeKey: AttributeValue]?) {
         process(
-            command: .addCurrentViewError(
-                message: message,
-                error: error,
+            command: RUMAddCurrentViewErrorCommand(
+                time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                time: dateProvider.currentDate()
+                message: message,
+                error: error
             )
         )
     }
 
     func start(resource resourceName: String, attributes: [AttributeKey: AttributeValue]?) {
         process(
-            command: .startResource(
-                resourceName: resourceName,
+            command: RUMStartResourceCommand(
+                time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                time: dateProvider.currentDate()
+                name: resourceName
             )
         )
     }
 
     func stop(resource resourceName: String, attributes: [AttributeKey: AttributeValue]?) {
         process(
-            command: .stopResource(
-                resourceName: resourceName,
+            command: RUMStopResourceCommand(
+                time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                time: dateProvider.currentDate()
+                name: resourceName
             )
         )
     }
 
     func stop(resource resourceName: String, withError error: Error, attributes: [AttributeKey: AttributeValue]?) {
         process(
-            command: .stopResourceWithError(
-                resourceName: resourceName,
-                error: error,
+            command: RUMStopResourceWithErrorCommand(
+                time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                time: dateProvider.currentDate()
+                name: resourceName,
+                error: error
             )
         )
     }
 
     func start(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?) {
         process(
-            command: .startUserAction(
-                userAction: userAction,
+            command: RUMStartUserActionCommand(
+                time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                time: dateProvider.currentDate()
+                action: userAction
             )
         )
     }
 
     func stop(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?) {
         process(
-            command: .stopUserAction(
-                userAction: userAction,
+            command: RUMStopUserActionCommand(
+                time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                time: dateProvider.currentDate()
+                action: userAction
             )
         )
     }
 
     func add(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?) {
         process(
-            command: .addUserAction(
-                userAction: userAction,
+            command: RUMAddUserActionCommand(
+                time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                time: dateProvider.currentDate()
+                action: userAction
             )
         )
     }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -112,14 +112,9 @@ class RUMEventOutputMock: RUMEventOutput {
 
 // MARK: - RUMCommand Mocks
 
-extension RUMCommand {
-    static func mockAny() -> RUMCommand {
-        return mockWith(time: .mockAny())
-    }
-
-    static func mockWith(time: Date) -> RUMCommand {
-        return .addUserAction(userAction: .tap, attributes: [:], time: time)
-    }
+struct RUMCommandMock: RUMCommand {
+    var time: Date = .mockAny()
+    var attributes: [AttributeKey: AttributeValue] = [:]
 }
 
 // MARK: - RUMScope Mocks
@@ -227,13 +222,5 @@ class RUMScopeMock: RUMScope {
             self.expectation?.fulfill()
         }
         return true
-    }
-}
-
-// MARK: - Utilities
-
-extension RUMCommand: Equatable {
-    public static func == (_ lhs: RUMCommand, _ rhs: RUMCommand) -> Bool {
-        return String(describing: lhs) == String(describing: rhs)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMScopeTests.swift
@@ -20,13 +20,13 @@ class RUMScopeTests: XCTestCase {
 
     func testWhenPropagatingCommand_itRemovesCompletedScope() {
         var scope: RUMScope? = CompletedScope()
-        RUMScopeMock().propagate(command: .mockAny(), to: &scope)
+        RUMScopeMock().propagate(command: RUMCommandMock(), to: &scope)
         XCTAssertNil(scope)
     }
 
     func testWhenPropagatingCommand_itKeepsNonCompletedScope() {
         var scope: RUMScope? = NonCompletedScope()
-        RUMScopeMock().propagate(command: .mockAny(), to: &scope)
+        RUMScopeMock().propagate(command: RUMCommandMock(), to: &scope)
         XCTAssertNotNil(scope)
     }
 
@@ -38,7 +38,7 @@ class RUMScopeTests: XCTestCase {
             NonCompletedScope()
         ]
 
-        RUMScopeMock().propagate(command: .mockAny(), to: &scopes)
+        RUMScopeMock().propagate(command: RUMCommandMock(), to: &scopes)
 
         XCTAssertEqual(scopes.count, 2)
         XCTAssertEqual(scopes.filter { $0 is NonCompletedScope }.count, 2)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -24,12 +24,12 @@ class RUMSessionScopeTests: XCTestCase {
         let parent = RUMScopeMock()
         let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), startTime: currentTime)
 
-        XCTAssertTrue(scope.process(command: .mockWith(time: currentTime)))
+        XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)))
 
         // Push time forward by the max session duration:
         currentTime.addTimeInterval(RUMSessionScope.Constants.sessionMaxDuration)
 
-        XCTAssertFalse(scope.process(command: .mockWith(time: currentTime)))
+        XCTAssertFalse(scope.process(command: RUMCommandMock(time: currentTime)))
     }
 
     func testWhenSessionIsInactiveForCertainDuration_itGetsClosed() {
@@ -37,17 +37,17 @@ class RUMSessionScopeTests: XCTestCase {
         let parent = RUMScopeMock()
         let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), startTime: currentTime)
 
-        XCTAssertTrue(scope.process(command: .mockWith(time: currentTime)))
+        XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)))
 
         // Push time forward by less than the session timeout duration:
         currentTime.addTimeInterval(0.5 * RUMSessionScope.Constants.sessionTimeoutDuration)
 
-        XCTAssertTrue(scope.process(command: .mockWith(time: currentTime)))
+        XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)))
 
         // Push time forward by the session timeout duration:
         currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration)
 
-        XCTAssertFalse(scope.process(command: .mockWith(time: currentTime)))
+        XCTAssertFalse(scope.process(command: RUMCommandMock(time: currentTime)))
     }
 
     func testItManagesViewScopeLifecycle() {
@@ -56,14 +56,14 @@ class RUMSessionScopeTests: XCTestCase {
 
         let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), startTime: Date())
         XCTAssertEqual(scope.viewScopes.count, 0)
-        _ = scope.process(command: .startInitialView(id: view, attributes: [:], time: Date()))
+        _ = scope.process(command: RUMStartViewCommand(time: Date(), attributes: [:], identity: view))
         XCTAssertEqual(scope.viewScopes.count, 1)
-        _ = scope.process(command: .stopView(id: view, attributes: [:], time: Date()))
+        _ = scope.process(command: RUMStopViewCommand(time: Date(), attributes: [:], identity: view))
         XCTAssertEqual(scope.viewScopes.count, 0)
 
-        _ = scope.process(command: .startView(id: view, attributes: [:], time: Date()))
+        _ = scope.process(command: RUMStartViewCommand(time: Date(), attributes: [:], identity: view))
         XCTAssertEqual(scope.viewScopes.count, 1)
-        _ = scope.process(command: .stopView(id: view, attributes: [:], time: Date()))
+        _ = scope.process(command: RUMStopViewCommand(time: Date(), attributes: [:], identity: view))
         XCTAssertEqual(scope.viewScopes.count, 0)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -44,7 +44,11 @@ class RUMViewScopeTests: XCTestCase {
             startTime: currentTime
         )
 
-        XCTAssertTrue(scope.process(command: .startInitialView(id: view, attributes: ["foo": "bar"], time: currentTime)))
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand(time: currentTime, attributes: ["foo": "bar"], identity: view, isInitialView: true)
+            )
+        )
 
         let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMActionEvent>.self).first)
         XCTAssertEqual(event.model.date, currentTime.timeIntervalSince1970.toMilliseconds)
@@ -71,7 +75,11 @@ class RUMViewScopeTests: XCTestCase {
             startTime: currentTime
         )
 
-        XCTAssertTrue(scope.process(command: .startInitialView(id: view, attributes: ["foo": "bar"], time: currentTime)))
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand(time: currentTime, attributes: ["foo": "bar"], identity: view, isInitialView: true)
+            )
+        )
 
         let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).first)
         XCTAssertEqual(event.model.date, currentTime.timeIntervalSince1970.toMilliseconds)
@@ -101,7 +109,11 @@ class RUMViewScopeTests: XCTestCase {
             startTime: currentTime
         )
 
-        XCTAssertTrue(scope.process(command: .startView(id: view, attributes: ["foo": "bar 2"], time: currentTime)))
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartViewCommand(time: currentTime, attributes: ["foo": "bar 2"], identity: view)
+            )
+        )
 
         let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).first)
         XCTAssertEqual(event.model.date, currentTime.timeIntervalSince1970.toMilliseconds)
@@ -131,9 +143,14 @@ class RUMViewScopeTests: XCTestCase {
             startTime: currentTime
         )
 
-        XCTAssertTrue(scope.process(command: .startView(id: view, attributes: [:], time: currentTime)))
+        XCTAssertTrue(
+            scope.process(command: RUMStartViewCommand(time: currentTime, attributes: [:], identity: view))
+        )
         currentTime.addTimeInterval(2)
-        XCTAssertFalse(scope.process(command: .stopView(id: view, attributes: [:], time: currentTime)), "The scope should end.")
+        XCTAssertFalse(
+            scope.process(command: RUMStopViewCommand(time: currentTime, attributes: [:], identity: view)),
+            "The scope should end."
+        )
 
         let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).dropFirst().first)
         XCTAssertEqual(event.model.date, currentTime.timeIntervalSince1970.toMilliseconds)

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -99,21 +99,16 @@ class RUMMonitorTests: XCTestCase {
         monitor.stop(userAction: .scroll, attributes: mockAttributes)
         monitor.add(userAction: .tap, attributes: mockAttributes)
 
-        let recordedCommands = scope.waitAndReturnProcessedCommands(count: 9, timeout: 0.5)
+        let commands = scope.waitAndReturnProcessedCommands(count: 9, timeout: 0.5)
 
-        XCTAssertEqual(
-            recordedCommands,
-            [
-                .startView(id: mockView, attributes: mockAttributes, time: .mockDecember15th2019At10AMUTC()),
-                .stopView(id: mockView, attributes: mockAttributes, time: .mockDecember15th2019At10AMUTC()),
-                .addCurrentViewError(message: "error", error: mockError, attributes: mockAttributes, time: .mockDecember15th2019At10AMUTC()),
-                .startResource(resourceName: "/resource/1", attributes: mockAttributes, time: .mockDecember15th2019At10AMUTC()),
-                .stopResource(resourceName: "/resource/1", attributes: mockAttributes, time: .mockDecember15th2019At10AMUTC()),
-                .stopResourceWithError(resourceName: "/resource/1", error: mockError, attributes: mockAttributes, time: .mockDecember15th2019At10AMUTC()),
-                .startUserAction(userAction: .scroll, attributes: mockAttributes, time: .mockDecember15th2019At10AMUTC()),
-                .stopUserAction(userAction: .scroll, attributes: mockAttributes, time: .mockDecember15th2019At10AMUTC()),
-                .addUserAction(userAction: .tap, attributes: mockAttributes, time: .mockDecember15th2019At10AMUTC()),
-            ]
-        )
+        XCTAssertTrue(commands[0] is RUMStartViewCommand)
+        XCTAssertTrue(commands[1] is RUMStopViewCommand)
+        XCTAssertTrue(commands[2] is RUMAddCurrentViewErrorCommand)
+        XCTAssertTrue(commands[3] is RUMStartResourceCommand)
+        XCTAssertTrue(commands[4] is RUMStopResourceCommand)
+        XCTAssertTrue(commands[5] is RUMStopResourceWithErrorCommand)
+        XCTAssertTrue(commands[6] is RUMStartUserActionCommand)
+        XCTAssertTrue(commands[7] is RUMStopUserActionCommand)
+        XCTAssertTrue(commands[8] is RUMAddUserActionCommand)
     }
 }


### PR DESCRIPTION
### What and why?

⚙️ This is purely a refactoring PR. It changes the `RUMCommand` to be `protocol`, not `enum`.

Modelling commands as `enum` resulted with their associated values being widely repeated in the codebase, so adding a new value become very tedious:
```swift
// In definition:
enum RUMCommand {
   // ...
   case startResource(name: String, time: Date, url: String, resourceCode: Int, ...)
   // ...
}

// During propagation:
switch command {
   // ...
   case .startResource(let name, let time, let url, let resourceCode, ...):
      startResourceScope(name: name, time: time, url: url, resourceCode: resourceCode, ...)
   // ...
}

// In handler definition
private func startResourceScope(name: String, time: Date, url: String, resourceCode: Int, ...) {
   // ...
}
```

By using the `RUMCommand` protocol, now there is only one place to list command fields:
```swift
struct RUMStartResourceCommand: RUMCommand {
   let name: String
   let time: Date
   // ...
}
``` 

### How?

I added the `RUMCommand` interface and a bunch of concrete commands.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
