### PR TITLE
RUMM-520 Add Resources monitoring

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -114,6 +114,11 @@
 		61441C992461A649003D8BB8 /* DebugLoggingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C942461A649003D8BB8 /* DebugLoggingViewController.swift */; };
 		61441C9D2461A796003D8BB8 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C9C2461A796003D8BB8 /* AppConfig.swift */; };
 		614872772485067300E3EBDB /* SpanTagsReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614872762485067300E3EBDB /* SpanTagsReducer.swift */; };
+		61494CB124C839460082C633 /* RUMResourceScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB024C839460082C633 /* RUMResourceScope.swift */; };
+		61494CB324C844570082C633 /* RUMResourceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB224C844570082C633 /* RUMResourceEvent.swift */; };
+		61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB424C864680082C633 /* RUMResourceScopeTests.swift */; };
+		61494CB724C99F7C0082C633 /* RUMErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB624C99F7C0082C633 /* RUMErrorEvent.swift */; };
+		61494CB824C9D8810082C633 /* RUMResourceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB224C844570082C633 /* RUMResourceEvent.swift */; };
 		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		61570005246AADFA00E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
 		61570006246AAE5E00E96950 /* DatadogObjc.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -413,6 +418,10 @@
 		61441C942461A649003D8BB8 /* DebugLoggingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugLoggingViewController.swift; sourceTree = "<group>"; };
 		61441C9C2461A796003D8BB8 /* AppConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		614872762485067300E3EBDB /* SpanTagsReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanTagsReducer.swift; sourceTree = "<group>"; };
+		61494CB024C839460082C633 /* RUMResourceScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceScope.swift; sourceTree = "<group>"; };
+		61494CB224C844570082C633 /* RUMResourceEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceEvent.swift; sourceTree = "<group>"; };
+		61494CB424C864680082C633 /* RUMResourceScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceScopeTests.swift; sourceTree = "<group>"; };
+		61494CB624C99F7C0082C633 /* RUMErrorEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMErrorEvent.swift; sourceTree = "<group>"; };
 		614E9EB2244719FA007EE3E1 /* BundleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleType.swift; sourceTree = "<group>"; };
 		615519252461BCE7002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519262461BCE7002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
@@ -1170,6 +1179,7 @@
 				617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */,
 				61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */,
 				6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */,
+				61494CB424C864680082C633 /* RUMResourceScopeTests.swift */,
 			);
 			path = Scopes;
 			sourceTree = "<group>";
@@ -1256,6 +1266,7 @@
 				61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */,
 				61C2C20624C098FC00C0321C /* RUMSessionScope.swift */,
 				61C2C21124C5951400C0321C /* RUMViewScope.swift */,
+				61494CB024C839460082C633 /* RUMResourceScope.swift */,
 			);
 			path = Scopes;
 			sourceTree = "<group>";
@@ -1386,6 +1397,8 @@
 				61E5333324B7A545003D6C4E /* RUMViewEvent.swift */,
 				61C2C20424C0862700C0321C /* RUMActionEvent.swift */,
 				9E26E6B824C87693000B3270 /* RUMDataModels.swift */,
+				61494CB224C844570082C633 /* RUMResourceEvent.swift */,
+				61494CB624C99F7C0082C633 /* RUMErrorEvent.swift */,
 			);
 			path = DataModels;
 			sourceTree = "<group>";
@@ -1809,6 +1822,7 @@
 				61E909F124A24DD3005EA2DE /* OTReference.swift in Sources */,
 				61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */,
 				61E909EF24A24DD3005EA2DE /* OTGlobal.swift in Sources */,
+				61494CB724C99F7C0082C633 /* RUMErrorEvent.swift in Sources */,
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,
 				61133BDC2423979B00786299 /* Logger.swift in Sources */,
 				61133BD02423979B00786299 /* DateProvider.swift in Sources */,
@@ -1824,6 +1838,7 @@
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
 				9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */,
 				9ED583A32498C222004CFF2A /* TracingAutoInstrumentation.swift in Sources */,
+				61494CB124C839460082C633 /* RUMResourceScope.swift in Sources */,
 				61C2C20724C098FC00C0321C /* RUMSessionScope.swift in Sources */,
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
 				61FF282624B8A248000B3D9B /* RUMEventOutput.swift in Sources */,
@@ -1869,6 +1884,7 @@
 				61133BE42423979B00786299 /* LogEncoder.swift in Sources */,
 				61C5A88424509A0C00DA608C /* DDSpan.swift in Sources */,
 				61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */,
+				61494CB324C844570082C633 /* RUMResourceEvent.swift in Sources */,
 				E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */,
 				61133BD82423979B00786299 /* HTTPClient.swift in Sources */,
 				61133BDB2423979B00786299 /* DatadogConfiguration.swift in Sources */,
@@ -1971,6 +1987,7 @@
 				61133C642423990D00786299 /* LoggerTests.swift in Sources */,
 				617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */,
 				61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */,
+				61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */,
 				61133C4E2423990D00786299 /* UIKitMocks.swift in Sources */,
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
 				61133C552423990D00786299 /* BatteryStatusProviderTests.swift in Sources */,
@@ -2032,6 +2049,7 @@
 				61C2C20E24C196E800C0321C /* RUMActionEvent.swift in Sources */,
 				61C2C20F24C196EB00C0321C /* RUMViewEvent.swift in Sources */,
 				61B9ED212462089600C0DCFF /* TracingIntegrationTests.swift in Sources */,
+				61494CB824C9D8810082C633 /* RUMResourceEvent.swift in Sources */,
 				61C2C20D24C1831700C0321C /* RUMIntegrationTests.swift in Sources */,
 				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,

--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -967,35 +967,129 @@
                                             </stackView>
                                         </subviews>
                                     </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="gmK-cB-MeK" userLabel="Resource Event">
+                                        <rect key="frame" x="0.0" y="201" width="384" height="105.5"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lmP-RX-JRw" userLabel="Vertical gap 15">
+                                                <rect key="frame" x="0.0" y="0.0" width="384" height="15"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="15" id="xLd-uF-LMm"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Resource Event" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CN8-y2-J5a">
+                                                <rect key="frame" x="0.0" y="15" width="384" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AJK-Wb-frZ" userLabel="Vertical gap 10">
+                                                <rect key="frame" x="0.0" y="35.5" width="384" height="10"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="10" id="tyX-cw-Sbz"/>
+                                                </constraints>
+                                            </view>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="YxY-We-gJ0">
+                                                <rect key="frame" x="0.0" y="45.5" width="384" height="60"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="OjT-bZ-PeB">
+                                                        <rect key="frame" x="0.0" y="0.0" width="329" height="60"/>
+                                                        <subviews>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="816-Ge-4Rb" userLabel="view.url">
+                                                                <rect key="frame" x="0.0" y="0.0" width="329" height="30"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="view.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j2C-yW-r83">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="43" height="30"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Rlu-N1-eFy">
+                                                                        <rect key="frame" x="48" y="0.0" width="281" height="30"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="30" id="rIL-sm-DqY"/>
+                                                                </constraints>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="O5v-e2-dpA" userLabel="action.type">
+                                                                <rect key="frame" x="0.0" y="30" width="329" height="30"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="resource.url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mhk-NZ-U8q">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="68" height="30"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                                        <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="lWm-uh-OR0">
+                                                                        <rect key="frame" x="73" y="0.0" width="256" height="30"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="continue" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="30" id="D6m-U3-3hR"/>
+                                                                </constraints>
+                                                            </stackView>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zMn-pC-Jmx">
+                                                        <rect key="frame" x="334" y="0.0" width="50" height="60"/>
+                                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="9P0-Fa-4Uh"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <state key="normal" title="Send">
+                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                <integer key="value" value="7"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="didTapSendResourceEvent:" destination="CBf-fg-exz" eventType="touchUpInside" id="eYv-6M-8c5"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W1b-Ap-trU" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="201" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="306.5" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="Zk1-nz-tiQ"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1CX-Pk-Oad" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="211" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="316.5" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="J1D-8z-qtE"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONSOLE OUTPUT:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="heX-eV-XM4">
-                                        <rect key="frame" x="0.0" y="221" width="384" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="326.5" width="384" height="14.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                         <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cUF-XZ-rO4" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="235.5" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="341" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="Kmx-dC-T5D"/>
                                         </constraints>
                                     </view>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xE1-F9-dzh">
-                                        <rect key="frame" x="0.0" y="245.5" width="384" height="498.5"/>
+                                        <rect key="frame" x="0.0" y="351" width="384" height="393"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
@@ -1018,8 +1112,11 @@
                         <outlet property="actionTypeTextField" destination="AzU-sp-7lm" id="CBf-7Z-Hdo"/>
                         <outlet property="actionViewURLTextField" destination="vhd-M4-bzl" id="enq-vJ-ATt"/>
                         <outlet property="consoleTextView" destination="xE1-F9-dzh" id="EZv-yU-A1l"/>
+                        <outlet property="resourceURLTextField" destination="lWm-uh-OR0" id="o40-qc-gad"/>
+                        <outlet property="resourceViewURLTextField" destination="Rlu-N1-eFy" id="uNw-Yv-Ms6"/>
                         <outlet property="rumServiceNameTextField" destination="vzP-ny-3dq" id="erc-CQ-v5k"/>
                         <outlet property="sendActionEventButton" destination="g0R-5h-ruu" id="qo2-I4-hPd"/>
+                        <outlet property="sendResourceEventButton" destination="zMn-pC-Jmx" id="Ibf-bo-vMz"/>
                         <outlet property="sendViewEventButton" destination="Ixr-vj-rNH" id="UxV-V9-WZL"/>
                         <outlet property="viewURLTextField" destination="U9s-H3-pzA" id="lLu-p7-x7L"/>
                     </connections>
@@ -1076,6 +1173,9 @@
                         <viewLayoutGuide key="safeArea" id="nQt-QF-hgQ"/>
                     </view>
                     <navigationItem key="navigationItem" id="3Wo-iA-H76"/>
+                    <connections>
+                        <outlet property="pushNextScreenButton" destination="ruj-73-qLY" id="c7N-Ar-CIq"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ugy-cJ-IEs" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
@@ -19,17 +19,20 @@ internal class SendRUMFixture1ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        let simulatedResourceName = "/resource/1"
+        let simulatedResourceURL = URL(string: "https://foo.com/resource/1")!
+
         rumMonitor.startView(viewController: self)
         rumMonitor.startResourceLoading(
-            resourceName: "/resource/1",
-            request: URLRequest(url: URL(string: "https://foo.com/resource/1")!)
+            resourceName: simulatedResourceName,
+            request: URLRequest(url: simulatedResourceURL)
         )
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             rumMonitor.stopResourceLoading(
-                resourceName: "/resource/1",
+                resourceName: simulatedResourceName,
                 response: HTTPURLResponse(
-                    url: URL(string: "https://foo.com/resource/1")!,
+                    url: simulatedResourceURL,
                     mimeType: "image/jpeg",
                     expectedContentLength: -1,
                     textEncodingName: nil

--- a/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
@@ -7,15 +7,43 @@
 import UIKit
 
 internal class SendRUMFixture1ViewController: UIViewController {
+    @IBOutlet weak var pushNextScreenButton: UIButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Hide the "Push Next Screen" button until simulated resource is loaded
+        pushNextScreenButton.isHidden = true
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        rumMonitor.start(viewController: self)
+        rumMonitor.startView(viewController: self)
+        rumMonitor.startResourceLoading(
+            resourceName: "/resource/1",
+            request: URLRequest(url: URL(string: "https://foo.com/resource/1")!)
+        )
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            rumMonitor.stopResourceLoading(
+                resourceName: "/resource/1",
+                response: HTTPURLResponse(
+                    url: URL(string: "https://foo.com/resource/1")!,
+                    mimeType: "image/jpeg",
+                    expectedContentLength: -1,
+                    textEncodingName: nil
+                )
+            )
+
+            // Reveal the "Push Next Screen" button so UITest can continue
+            self.pushNextScreenButton.isHidden = false
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        rumMonitor.stop(viewController: self)
+        rumMonitor.stopView(viewController: self)
     }
 }

--- a/Datadog/Example/IntegrationTestFixtures/SendRUMFixture2ViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendRUMFixture2ViewController.swift
@@ -10,12 +10,12 @@ internal class SendRUMFixture2ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        rumMonitor.start(viewController: self)
+        rumMonitor.startView(viewController: self)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        rumMonitor.stop(viewController: self)
+        rumMonitor.stopView(viewController: self)
     }
 }

--- a/Datadog/Example/IntegrationTestFixtures/SendRUMFixture3ViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendRUMFixture3ViewController.swift
@@ -10,6 +10,12 @@ internal class SendRUMFixture3ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        rumMonitor.start(viewController: self)
+        rumMonitor.startView(viewController: self)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        rumMonitor.stopView(viewController: self)
     }
 }

--- a/Sources/Datadog/RUM/DataModels/RUMErrorEvent.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMErrorEvent.swift
@@ -17,6 +17,17 @@ internal struct RUMErrorEvent: Codable, RUMDataModel {
     let action: Action?
     let dd: DD
 
+    enum CodingKeys: String, CodingKey {
+        case date
+        case application
+        case session
+        case type
+        case view
+        case error
+        case action
+        case dd = "_dd"
+    }
+
     struct Application: Codable {
         let id: String
     }

--- a/Sources/Datadog/RUM/DataModels/RUMErrorEvent.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMErrorEvent.swift
@@ -1,0 +1,68 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+// TODO: RUMM-517 Replace with auto-generated RUM data model
+internal struct RUMErrorEvent: Codable, RUMDataModel {
+    let date: UInt64
+    let application: Application
+    let session: Session
+    let type = "error"
+    let view: View
+    let error: Error
+    let action: Action?
+    let dd: DD
+
+    struct Application: Codable {
+        let id: String
+    }
+
+    struct Session: Codable {
+        let id: String
+        let type: String
+    }
+
+    struct View: Codable {
+        enum CodingKeys: String, CodingKey {
+            case id
+            case url
+        }
+
+        let id: String
+        let url: String
+    }
+
+    struct Error: Codable {
+        let message: String
+        let source: String
+        let resource: Resource?
+
+        struct Resource: Codable {
+            enum CodingKeys: String, CodingKey {
+                case method
+                case statusCode = "status_coded"
+                case url
+            }
+
+            let method: String
+            let statusCode: Int
+            let url: String
+        }
+    }
+
+    struct Action: Codable {
+        let id: String
+    }
+
+    struct DD: Codable {
+        enum CodingKeys: String, CodingKey {
+            case formatVersion  = "format_version"
+        }
+
+        let formatVersion = 2
+    }
+}

--- a/Sources/Datadog/RUM/DataModels/RUMResourceEvent.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMResourceEvent.swift
@@ -1,0 +1,79 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+// TODO: RUMM-517 Replace with auto-generated RUM data model
+internal struct RUMResourceEvent: Codable, RUMDataModel {
+    enum CodingKeys: String, CodingKey {
+        case date
+        case application
+        case session
+        case type
+        case view
+        case resource
+        case action
+        case dd  = "_dd"
+    }
+
+    let date: UInt64
+    let application: Application
+    let session: Session
+    let type = "resource"
+    let view: View
+    let resource: Resource
+    let action: Action?
+    let dd: DD
+
+    struct Application: Codable {
+        let id: String
+    }
+
+    struct Session: Codable {
+        let id: String
+        let type: String
+    }
+
+    struct View: Codable {
+        enum CodingKeys: String, CodingKey {
+            case id
+            case url
+        }
+
+        let id: String
+        let url: String
+    }
+
+    struct Resource: Codable {
+        enum CodingKeys: String, CodingKey {
+            case type
+            case url
+            case method
+            case statusCode = "status_code"
+            case duration
+            case size
+        }
+
+        let type: String
+        let url: String
+        let method: String?
+        let statusCode: Int?
+        let duration: UInt64
+        let size: UInt64?
+    }
+
+    struct Action: Codable {
+        let id: String
+    }
+
+    struct DD: Codable {
+        enum CodingKeys: String, CodingKey {
+            case formatVersion  = "format_version"
+        }
+
+        let formatVersion = 2
+    }
+}

--- a/Sources/Datadog/RUM/RUMEventOutputs/RUMEventFileOutput.swift
+++ b/Sources/Datadog/RUM/RUMEventOutputs/RUMEventFileOutput.swift
@@ -7,9 +7,9 @@
 import Foundation
 
 internal struct RUMEventFileOutput: RUMEventOutput {
-   let fileWriter: FileWriter
+    let fileWriter: FileWriter
 
-   func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {
-       fileWriter.write(value: rumEvent)
-   }
+    func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {
+        fileWriter.write(value: rumEvent)
+    }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -49,30 +49,46 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
 
 // MARK: - RUM Resource related commands
 
-internal struct RUMStartResourceCommand: RUMCommand {
-    let time: Date
-    let attributes: [AttributeKey: AttributeValue]
-
+internal protocol RUMResourceCommand: RUMCommand {
     /// The name identifying the RUM Resource.
-    let name: String
+    var resourceName: String { get }
 }
 
-internal struct RUMStopResourceCommand: RUMCommand {
+internal struct RUMStartResourceCommand: RUMResourceCommand {
+    let resourceName: String
     let time: Date
     let attributes: [AttributeKey: AttributeValue]
 
-    /// The name identifying the RUM Resource.
-    let name: String
+    /// Resource url
+    let url: String
+    /// HTTP method used to load the Resource
+    let httpMethod: String
 }
 
-internal struct RUMStopResourceWithErrorCommand: RUMCommand {
+internal struct RUMStopResourceCommand: RUMResourceCommand {
+    let resourceName: String
     let time: Date
     let attributes: [AttributeKey: AttributeValue]
 
-    /// The name identifying the RUM Resource.
-    let name: String
-    /// The error object.
-    let error: Error
+    /// A type of the Resource (image, font, ...)
+    let type: String
+    /// HTTP status code of loading the Ressource
+    let httpStatusCode: Int?
+    /// The size of loaded Resource
+    let size: UInt64?
+}
+
+internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
+    let resourceName: String
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    /// The error message.
+    let errorMessage: String
+    /// The origin of the error (network, webview, ...)
+    let errorSource: String
+    /// HTTP status code of the Ressource error.
+    let httpStatusCode: Int?
 }
 
 // MARK: - RUM User Action related commands

--- a/Sources/Datadog/RUM/RUMMonitor/RUMMonitorInternal.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMMonitorInternal.swift
@@ -19,9 +19,9 @@ internal protocol RUMMonitorInternal {
     func stop(view id: AnyObject, attributes: [AttributeKey: AttributeValue]?)
     func addViewError(message: String, error: Error?, attributes: [AttributeKey: AttributeValue]?)
 
-    func start(resource resourceName: String, attributes: [AttributeKey: AttributeValue]?)
-    func stop(resource resourceName: String, attributes: [AttributeKey: AttributeValue]?)
-    func stop(resource resourceName: String, withError error: Error, attributes: [AttributeKey: AttributeValue]?)
+    func start(resource resourceName: String, url: String, httpMethod: String, attributes: [AttributeKey: AttributeValue]?)
+    func stop(resource resourceName: String, type: String, httpStatusCode: Int?, size: UInt64?, attributes: [AttributeKey: AttributeValue]?)
+    func stop(resource resourceName: String, withError errorMessage: String, errorSource: String, httpStatusCode: Int?, attributes: [AttributeKey: AttributeValue]?)
 
     func start(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
     func stop(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)

--- a/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
@@ -19,7 +19,7 @@ internal protocol RUMScope: class {
 extension RUMScope {
     /// Propagates given `command` to the child scope and manages its lifecycle by
     /// removing it if it gets closed.
-    func manage(childScope: inout RUMScope?, byPropagatingCommand command: RUMCommand) {
+    func manage<S: RUMScope>(childScope: inout S?, byPropagatingCommand command: RUMCommand) {
         if childScope?.process(command: command) == false {
             childScope = nil
         }
@@ -27,7 +27,7 @@ extension RUMScope {
 
     /// Propagates given `command` through array of child scopes and manages their lifecycle by
     /// removing child scopes that get closed.
-    func manage(childScopes: inout [RUMScope], byPropagatingCommand command: RUMCommand) {
+    func manage<S: RUMScope>(childScopes: inout [S], byPropagatingCommand command: RUMCommand) {
         childScopes = childScopes.compactMap { childScope in
             let shouldBeKept = childScope.process(command: command)
             return shouldBeKept ? childScope : nil

--- a/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
@@ -19,15 +19,15 @@ internal protocol RUMScope: class {
 extension RUMScope {
     /// Propagates given `command` to the child scope and manages its lifecycle by
     /// removing it if it gets closed.
-    func propagate(command: RUMCommand, to chilScope: inout RUMScope?) {
-        if chilScope?.process(command: command) == false {
-            chilScope = nil
+    func manage(childScope: inout RUMScope?, byPropagatingCommand command: RUMCommand) {
+        if childScope?.process(command: command) == false {
+            childScope = nil
         }
     }
 
     /// Propagates given `command` through array of child scopes and manages their lifecycle by
     /// removing child scopes that get closed.
-    func propagate(command: RUMCommand, to childScopes: inout [RUMScope]) {
+    func manage(childScopes: inout [RUMScope], byPropagatingCommand command: RUMCommand) {
         childScopes = childScopes.compactMap { childScope in
             let shouldBeKept = childScope.process(command: command)
             return shouldBeKept ? childScope : nil

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -18,7 +18,7 @@ internal class RUMApplicationScope: RUMScope {
 
     /// Session scope. It gets created with the first `.startView` event.
     /// Might be re-created later according to session duration constraints.
-    private(set) var sessionScope: RUMScope?
+    private(set) var sessionScope: RUMSessionScope?
 
     // MARK: - Initialization
 
@@ -43,7 +43,7 @@ internal class RUMApplicationScope: RUMScope {
     let context: RUMContext
 
     func process(command: RUMCommand) -> Bool {
-        if let currentSession = sessionScope as? RUMSessionScope {
+        if let currentSession = sessionScope {
             manage(childScope: &sessionScope, byPropagatingCommand: command)
 
             if sessionScope == nil { // if session expired

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -44,7 +44,7 @@ internal class RUMApplicationScope: RUMScope {
 
     func process(command: RUMCommand) -> Bool {
         if let currentSession = sessionScope as? RUMSessionScope {
-            propagate(command: command, to: &sessionScope)
+            manage(childScope: &sessionScope, byPropagatingCommand: command)
 
             if sessionScope == nil { // if session expired
                 refresh(expiredSession: currentSession, on: command)

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -9,6 +9,7 @@ import Foundation
 internal class RUMResourceScope: RUMScope {
     // MARK: - Initialization
 
+    // TODO: RUMM-597: Consider using `parent: RUMContextProvider`
     private unowned let parent: RUMScope
     private let dependencies: RUMScopeDependencies
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -52,25 +52,15 @@ internal class RUMResourceScope: RUMScope {
     func process(command: RUMCommand) -> Bool {
         switch command {
         case let command as RUMStopResourceCommand where command.resourceName == resourceName:
-            stopResource(on: command)
+            sendResourceEvent(on: command)
             return false
         case let command as RUMStopResourceWithErrorCommand where command.resourceName == resourceName:
-            stopResource(on: command)
+            sendErrorEvent(on: command)
             return false
         default:
             break
         }
         return true
-    }
-
-    // MARK: - RUMCommands Processing
-
-    private func stopResource(on command: RUMStopResourceCommand) {
-        sendResourceEvent(on: command)
-    }
-
-    private func stopResource(on command: RUMStopResourceWithErrorCommand) {
-        sendErrorEvent(on: command)
     }
 
     // MARK: - Sending RUM Events

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -1,0 +1,135 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal class RUMResourceScope: RUMScope {
+    // MARK: - Initialization
+
+    private unowned let parent: RUMScope
+    private let dependencies: RUMScopeDependencies
+
+    /// The name used to identify this Resource.
+    private(set) var resourceName: String
+    /// Resource attributes.
+    private(set) var attributes: [AttributeKey: AttributeValue]
+
+    /// The Resource url.
+    private var resourceURL: String
+    /// The start time of this Resource loading.
+    private var resourceLoadingStartTime: Date
+    /// The HTTP method used to load this Resource.
+    private var resourceHTTPMethod: String
+
+    init(
+        parent: RUMScope,
+        dependencies: RUMScopeDependencies,
+        resourceName: String,
+        attributes: [AttributeKey: AttributeValue],
+        startTime: Date,
+        url: String,
+        httpMethod: String
+    ) {
+        self.parent = parent
+        self.dependencies = dependencies
+        self.resourceName = resourceName
+        self.attributes = attributes
+        self.resourceURL = url
+        self.resourceLoadingStartTime = startTime
+        self.resourceHTTPMethod = httpMethod
+    }
+
+    // MARK: - RUMScope
+
+    var context: RUMContext {
+        return parent.context
+    }
+
+    func process(command: RUMCommand) -> Bool {
+        switch command {
+        case let command as RUMStopResourceCommand where command.resourceName == resourceName:
+            stopResource(on: command)
+            return false
+        case let command as RUMStopResourceWithErrorCommand where command.resourceName == resourceName:
+            stopResource(on: command)
+            return false
+        default:
+            break
+        }
+        return true
+    }
+
+    // MARK: - RUMCommands Processing
+
+    private func stopResource(on command: RUMStopResourceCommand) {
+        sendResourceEvent(on: command)
+    }
+
+    private func stopResource(on command: RUMStopResourceWithErrorCommand) {
+        sendErrorEvent(on: command)
+    }
+
+    // MARK: - Sending RUM Events
+
+    private func sendResourceEvent(on command: RUMStopResourceCommand) {
+        attributes.merge(rumCommandAttributes: command.attributes)
+
+        let eventData = RUMResourceEvent(
+            date: command.time.timeIntervalSince1970.toMilliseconds,
+            application: .init(id: context.rumApplicationID),
+            session: .init(id: context.sessionID.toString, type: "user"),
+            view: .init(
+                id: context.activeViewID.orNull.toString,
+                url: context.activeViewURI ?? ""
+            ),
+            resource: .init(
+                type: command.type,
+                url: resourceURL,
+                method: resourceHTTPMethod,
+                statusCode: command.httpStatusCode,
+                duration: command.time.timeIntervalSince(resourceLoadingStartTime).toNanoseconds,
+                size: command.size
+            ),
+            action: context.activeUserActionID.flatMap { rumUUID in
+                .init(id: rumUUID.toString)
+            },
+            dd: .init()
+        )
+
+        let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes)
+        dependencies.eventOutput.write(rumEvent: event)
+    }
+
+    private func sendErrorEvent(on command: RUMStopResourceWithErrorCommand) {
+        attributes.merge(rumCommandAttributes: command.attributes)
+
+        let eventData = RUMErrorEvent(
+            date: command.time.timeIntervalSince1970.toMilliseconds,
+            application: .init(id: context.rumApplicationID),
+            session: .init(id: context.sessionID.toString, type: "user"),
+            view: .init(
+                id: context.activeViewID.orNull.toString,
+                url: context.activeViewURI ?? ""
+            ),
+            error: .init(
+                message: command.errorMessage,
+                source: command.errorSource,
+                resource: .init(
+                    method: resourceHTTPMethod,
+                    statusCode: command.httpStatusCode ?? 0,
+                    url: resourceURL
+                )
+            ),
+            action: context.activeUserActionID.flatMap { rumUUID in
+                .init(id: rumUUID.toString)
+            },
+            dd: .init()
+        )
+
+        let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes)
+        dependencies.eventOutput.write(rumEvent: event)
+    }
+}

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -92,7 +92,7 @@ internal class RUMSessionScope: RUMScope {
         }
 
         // Propagate command
-        propagate(command: command, to: &viewScopes)
+        manage(childScopes: &viewScopes, byPropagatingCommand: command)
 
         return true
     }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -17,7 +17,7 @@ internal class RUMSessionScope: RUMScope {
     // MARK: - Child Scopes
 
     /// Active View scopes. Scopes are added / removed when the View starts / stops displaying.
-    private(set) var viewScopes: [RUMScope] = []
+    private(set) var viewScopes: [RUMViewScope] = []
 
     // MARK: - Initialization
 
@@ -57,7 +57,7 @@ internal class RUMSessionScope: RUMScope {
 
         // Transfer active Views by creating new `RUMViewScopes` for their identity objects:
         self.viewScopes = expiredSession.viewScopes.compactMap { expiredView in
-            guard let expiredView = expiredView as? RUMViewScope, let expiredViewIdentity = expiredView.identity else {
+            guard let expiredViewIdentity = expiredView.identity else {
                 return nil // if the underlying `UIVIewController` no longer exists, skip transferring its scope
             }
             return RUMViewScope(

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -57,7 +57,7 @@ internal class RUMSessionScope: RUMScope {
         // Transfer active Views by creating new `RUMViewScopes` for their identity objects:
         self.viewScopes = expiredSession.viewScopes.compactMap { expiredView in
             guard let expiredView = expiredView as? RUMViewScope, let expiredViewIdentity = expiredView.identity else {
-                return nil // if the underlying `UIVIewController` no longer exists, skip transferring this scope
+                return nil // if the underlying `UIVIewController` no longer exists, skip transferring its scope
             }
             return RUMViewScope(
                 parent: self,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -21,6 +21,7 @@ internal class RUMSessionScope: RUMScope {
 
     // MARK: - Initialization
 
+    // TODO: RUMM-597: Consider using `parent: RUMContextProvider`
     unowned let parent: RUMScope
     private let dependencies: RUMScopeDependencies
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import class UIKit.UIViewController
 
 internal class RUMSessionScope: RUMScope {
     struct Constants {
@@ -59,6 +60,9 @@ internal class RUMSessionScope: RUMScope {
         self.viewScopes = expiredSession.viewScopes.compactMap { expiredView in
             guard let expiredViewIdentity = expiredView.identity else {
                 return nil // if the underlying `UIVIewController` no longer exists, skip transferring its scope
+            }
+            guard (expiredViewIdentity as? UIViewController)?.view?.window != nil else {
+                return nil // TODO: RUMM-634 Produce a RUM error when the VC is leaked
             }
             return RUMViewScope(
                 parent: self,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -80,7 +80,7 @@ internal class RUMViewScope: RUMScope {
 
         // Propagate command
         if let resourceCommand = command as? RUMResourceCommand {
-            propagate(command: resourceCommand, to: &resourceScopes[resourceCommand.resourceName])
+            manage(childScope: &resourceScopes[resourceCommand.resourceName], byPropagatingCommand: resourceCommand)
         }
 
         return true

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -15,6 +15,7 @@ internal class RUMViewScope: RUMScope {
 
     // MARK: - Initialization
 
+    // TODO: RUMM-597: Consider using `parent: RUMContextProvider`
     private unowned let parent: RUMScope
     private let dependencies: RUMScopeDependencies
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -93,10 +93,8 @@ internal class RUMViewScope: RUMScope {
         if command.isInitialView {
             actionsCount += 1
             sendApplicationStartAction()
-            sendViewUpdateEvent(on: command)
-        } else {
-            sendViewUpdateEvent(on: command)
         }
+        sendViewUpdateEvent(on: command)
     }
 
     private func stopView(on command: RUMStopViewCommand) {

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -8,12 +8,17 @@ import Foundation
 import UIKit
 
 internal class RUMViewScope: RUMScope {
+    // MARK: - Child Scopes
+
+    /// Active Resource scopes, keyed by the Resource name.
+    private(set) var resourceScopes: [String: RUMScope] = [:]
+
     // MARK: - Initialization
 
     private unowned let parent: RUMScope
     private let dependencies: RUMScopeDependencies
 
-    /// Weak reference to the `UIViewController` which issued this scope.
+    /// Weak reference to corresponding `UIViewController`, used to identify this View.
     private(set) weak var identity: AnyObject?
     /// View attributes.
     private(set) var attributes: [AttributeKey: AttributeValue]
@@ -25,8 +30,10 @@ internal class RUMViewScope: RUMScope {
     /// The start time of this View.
     private var viewStartTime: Date
 
-    /// Number of actions happened on this View.
+    /// Number of Actions happened on this View.
     private var actionsCount: UInt = 0
+    /// Number of Resources tracked by this View.
+    private var resourcesCount: UInt = 0
     /// Current version of this View to use for RUM `documentVersion`.
     private var version: UInt = 0
 
@@ -56,14 +63,24 @@ internal class RUMViewScope: RUMScope {
     }
 
     func process(command: RUMCommand) -> Bool {
+        // Apply side effects
         switch command {
         case let command as RUMStartViewCommand where command.identity === identity:
             startView(on: command)
         case let command as RUMStopViewCommand where command.identity === identity:
             stopView(on: command)
             return false
+        case let command as RUMStartResourceCommand:
+            startResource(on: command)
+        case let command as RUMResourceCommand where command is RUMStopResourceCommand || command is RUMStopResourceWithErrorCommand:
+            stopResource(on: command)
         default:
             break
+        }
+
+        // Propagate command
+        if let resourceCommand = command as? RUMResourceCommand {
+            propagate(command: resourceCommand, to: &resourceScopes[resourceCommand.resourceName])
         }
 
         return true
@@ -73,6 +90,7 @@ internal class RUMViewScope: RUMScope {
 
     private func startView(on command: RUMStartViewCommand) {
         if command.isInitialView {
+            actionsCount += 1
             sendApplicationStartAction()
             sendViewUpdateEvent(on: command)
         } else {
@@ -84,11 +102,26 @@ internal class RUMViewScope: RUMScope {
         sendViewUpdateEvent(on: command)
     }
 
+    private func startResource(on command: RUMStartResourceCommand) {
+        resourceScopes[command.resourceName] = RUMResourceScope(
+            parent: self,
+            dependencies: dependencies,
+            resourceName: command.resourceName,
+            attributes: command.attributes,
+            startTime: command.time,
+            url: command.url,
+            httpMethod: command.httpMethod
+        )
+    }
+
+    private func stopResource(on command: RUMResourceCommand) {
+        resourcesCount += 1
+        sendViewUpdateEvent(on: command)
+    }
+
     // MARK: - Sending RUM Events
 
     private func sendApplicationStartAction() {
-        actionsCount += 1
-
         let eventData = RUMActionEvent(
             date: viewStartTime.timeIntervalSince1970.toMilliseconds,
             application: .init(id: context.rumApplicationID),
@@ -113,7 +146,7 @@ internal class RUMViewScope: RUMScope {
         attributes.merge(rumCommandAttributes: command.attributes)
 
         let eventData = RUMViewEvent(
-            date: command.time.timeIntervalSince1970.toMilliseconds,
+            date: viewStartTime.timeIntervalSince1970.toMilliseconds,
             application: .init(id: context.rumApplicationID),
             session: .init(id: context.sessionID.toString, type: "user"),
             view: .init(
@@ -122,7 +155,7 @@ internal class RUMViewScope: RUMScope {
                 timeSpent: command.time.timeIntervalSince(viewStartTime).toNanoseconds,
                 action: .init(count: actionsCount),
                 error: .init(count: 0),
-                resource: .init(count: 0)
+                resource: .init(count: resourcesCount)
             ),
             dd: .init(documentVersion: version)
         )

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -11,7 +11,7 @@ internal class RUMViewScope: RUMScope {
     // MARK: - Child Scopes
 
     /// Active Resource scopes, keyed by the Resource name.
-    private(set) var resourceScopes: [String: RUMScope] = [:]
+    private(set) var resourceScopes: [String: RUMResourceScope] = [:]
 
     // MARK: - Initialization
 

--- a/Sources/Datadog/RUM/UUIDs/RUMUUID.swift
+++ b/Sources/Datadog/RUM/UUIDs/RUMUUID.swift
@@ -17,3 +17,7 @@ internal struct RUMUUID: Equatable {
         return rawValue.uuidString.lowercased()
     }
 }
+
+extension Optional where Wrapped == RUMUUID {
+    var orNull: RUMUUID { self ?? RUMUUID.nullUUID }
+}

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -41,6 +41,7 @@ class ExampleApplication: XCUIApplication {
 
 class RUMFixture1Screen: XCUIApplication {
     func tapPushNextScreen() -> RUMFixture2Screen {
+        buttons["Push Next Screen"].waitForExistence(timeout: 2)
         buttons["Push Next Screen"].tap()
         return RUMFixture2Screen()
     }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -197,14 +197,17 @@ class RelativeDateProvider: DateProvider {
     internal let timeInterval: TimeInterval
     private let queue = DispatchQueue(label: "queue-RelativeDateProvider-\(UUID().uuidString)")
 
-    init(using date: Date = Date()) {
+    private init(date: Date, timeInterval: TimeInterval) {
         self.date = date
-        self.timeInterval = 0
+        self.timeInterval = timeInterval
     }
 
-    init(startingFrom referenceDate: Date = Date(), advancingBySeconds timeInterval: TimeInterval = 0) {
-        self.date = referenceDate
-        self.timeInterval = timeInterval
+    convenience init(using date: Date = Date()) {
+        self.init(date: date, timeInterval: 0)
+    }
+
+    convenience init(startingFrom referenceDate: Date = Date(), advancingBySeconds timeInterval: TimeInterval = 0) {
+        self.init(date: referenceDate, timeInterval: timeInterval)
     }
 
     /// Returns current date and advances next date by `timeInterval`.

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -205,8 +205,15 @@ extension RUMSessionScope {
     }
 }
 
+private let mockWindow = UIWindow(frame: .zero)
+
 /// Holds the `mockView` object so it can be weakily referenced by `RUMViewScope` mocks.
-let mockView = UIViewController()
+let mockView: UIViewController = {
+    let viewController = UIViewController()
+    mockWindow.rootViewController = viewController
+    mockWindow.makeKeyAndVisible()
+    return viewController
+}()
 
 extension RUMViewScope {
     static func mockAny() -> RUMViewScope {

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -70,7 +70,7 @@ extension RUMFeature {
     }
 }
 
-// MARK: - RUM Event Mocks
+// MARK: - RUMDataModel Mocks
 
 struct RUMDataModelMock: RUMDataModel, Equatable {
     let attribute: String
@@ -115,6 +115,36 @@ class RUMEventOutputMock: RUMEventOutput {
 struct RUMCommandMock: RUMCommand {
     var time: Date = .mockAny()
     var attributes: [AttributeKey: AttributeValue] = [:]
+}
+
+// MARK: - RUMContext Mocks
+
+extension RUMUUID {
+    static func mockRandom() -> RUMUUID {
+        return RUMUUID(rawValue: UUID())
+    }
+}
+
+extension RUMContext {
+    static func mockAny() -> RUMContext {
+        return mockWith()
+    }
+
+    static func mockWith(
+        rumApplicationID: String = .mockAny(),
+        sessionID: RUMUUID = .mockRandom(),
+        activeViewID: RUMUUID? = nil,
+        activeViewURI: String? = nil,
+        activeUserActionID: RUMUUID? = nil
+    ) -> RUMContext {
+        return RUMContext(
+            rumApplicationID: rumApplicationID,
+            sessionID: sessionID,
+            activeViewID: activeViewID,
+            activeViewURI: activeViewURI,
+            activeUserActionID: activeUserActionID
+        )
+    }
 }
 
 // MARK: - RUMScope Mocks
@@ -175,11 +205,40 @@ extension RUMSessionScope {
     }
 }
 
+/// Holds the `mockView` object so it can be weakily referenced by `RUMViewScope` mocks.
+let mockView = UIViewController()
+
+extension RUMViewScope {
+    static func mockAny() -> RUMViewScope {
+        return mockWith()
+    }
+
+    static func mockWith(
+        parent: RUMSessionScope = .mockAny(),
+        dependencies: RUMScopeDependencies = .mockAny(),
+        identity: AnyObject = mockView,
+        attributes: [AttributeKey: AttributeValue] = [:],
+        startTime: Date = .mockAny()
+    ) -> RUMViewScope {
+        return RUMViewScope(
+            parent: parent,
+            dependencies: dependencies,
+            identity: identity,
+            attributes: attributes,
+            startTime: startTime
+        )
+    }
+}
+
 /// `RUMScope` recording processed commands.
 class RUMScopeMock: RUMScope {
     private let queue = DispatchQueue(label: "com.datadoghq.RUMScopeMock")
     private var expectation: XCTestExpectation?
     private var commands: [RUMCommand] = []
+
+    init(context: RUMContext = .mockAny()) {
+        self.context = context
+    }
 
     func waitAndReturnProcessedCommands(
         count: UInt,
@@ -208,13 +267,7 @@ class RUMScopeMock: RUMScope {
 
     // MARK: - RUMScope
 
-    let context = RUMContext(
-        rumApplicationID: .mockAny(),
-        sessionID: .nullUUID,
-        activeViewID: nil,
-        activeViewURI: nil,
-        activeUserActionID: nil
-    )
+    let context: RUMContext
 
     func process(command: RUMCommand) -> Bool {
         queue.async {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMScopeTests.swift
@@ -19,15 +19,35 @@ class RUMScopeTests: XCTestCase {
     }
 
     func testWhenPropagatingCommand_itRemovesCompletedScope() {
+        // Direct reference
         var scope: RUMScope? = CompletedScope()
         RUMScopeMock().propagate(command: RUMCommandMock(), to: &scope)
         XCTAssertNil(scope)
+
+        // Dictionary item reference
+        var dictionaryOfScopes: [String: RUMScope] = [
+            "a": CompletedScope(),
+            "b": NonCompletedScope(),
+        ]
+        RUMScopeMock().propagate(command: RUMCommandMock(), to: &dictionaryOfScopes["a"])
+        XCTAssertNil(dictionaryOfScopes["a"])
+        XCTAssertNotNil(dictionaryOfScopes["b"])
     }
 
     func testWhenPropagatingCommand_itKeepsNonCompletedScope() {
+        // Direct reference
         var scope: RUMScope? = NonCompletedScope()
         RUMScopeMock().propagate(command: RUMCommandMock(), to: &scope)
         XCTAssertNotNil(scope)
+
+        // Dictionary item reference
+        var dictionaryOfScopes: [String: RUMScope] = [
+            "a": CompletedScope(),
+            "b": NonCompletedScope(),
+        ]
+        RUMScopeMock().propagate(command: RUMCommandMock(), to: &dictionaryOfScopes["b"])
+        XCTAssertNotNil(dictionaryOfScopes["a"])
+        XCTAssertNotNil(dictionaryOfScopes["b"])
     }
 
     func testWhenPropagatingCommand_itRemovesCompletedScopes() {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMScopeTests.swift
@@ -21,7 +21,7 @@ class RUMScopeTests: XCTestCase {
     func testWhenPropagatingCommand_itRemovesCompletedScope() {
         // Direct reference
         var scope: RUMScope? = CompletedScope()
-        RUMScopeMock().propagate(command: RUMCommandMock(), to: &scope)
+        RUMScopeMock().manage(childScope: &scope, byPropagatingCommand: RUMCommandMock())
         XCTAssertNil(scope)
 
         // Dictionary item reference
@@ -29,7 +29,7 @@ class RUMScopeTests: XCTestCase {
             "a": CompletedScope(),
             "b": NonCompletedScope(),
         ]
-        RUMScopeMock().propagate(command: RUMCommandMock(), to: &dictionaryOfScopes["a"])
+        RUMScopeMock().manage(childScope: &dictionaryOfScopes["a"], byPropagatingCommand: RUMCommandMock())
         XCTAssertNil(dictionaryOfScopes["a"])
         XCTAssertNotNil(dictionaryOfScopes["b"])
     }
@@ -37,7 +37,7 @@ class RUMScopeTests: XCTestCase {
     func testWhenPropagatingCommand_itKeepsNonCompletedScope() {
         // Direct reference
         var scope: RUMScope? = NonCompletedScope()
-        RUMScopeMock().propagate(command: RUMCommandMock(), to: &scope)
+        RUMScopeMock().manage(childScope: &scope, byPropagatingCommand: RUMCommandMock())
         XCTAssertNotNil(scope)
 
         // Dictionary item reference
@@ -45,7 +45,7 @@ class RUMScopeTests: XCTestCase {
             "a": CompletedScope(),
             "b": NonCompletedScope(),
         ]
-        RUMScopeMock().propagate(command: RUMCommandMock(), to: &dictionaryOfScopes["b"])
+        RUMScopeMock().manage(childScope: &dictionaryOfScopes["b"], byPropagatingCommand: RUMCommandMock())
         XCTAssertNotNil(dictionaryOfScopes["a"])
         XCTAssertNotNil(dictionaryOfScopes["b"])
     }
@@ -58,7 +58,7 @@ class RUMScopeTests: XCTestCase {
             NonCompletedScope()
         ]
 
-        RUMScopeMock().propagate(command: RUMCommandMock(), to: &scopes)
+        RUMScopeMock().manage(childScopes: &scopes, byPropagatingCommand: RUMCommandMock())
 
         XCTAssertEqual(scopes.count, 2)
         XCTAssertEqual(scopes.filter { $0 is NonCompletedScope }.count, 2)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -37,18 +37,18 @@ class RUMApplicationScopeTests: XCTestCase {
 
         _ = scope.process(command: RUMStartViewCommand(time: currentTime, attributes: [:], identity: view))
         let firstSessionUUID = try XCTUnwrap(scope.sessionScope?.context.sessionID)
-        let firstsSessionViewScopes = try XCTUnwrap((scope.sessionScope as? RUMSessionScope)?.viewScopes)
+        let firstsSessionViewScopes = try XCTUnwrap(scope.sessionScope?.viewScopes)
 
         // Push time forward by the max session duration:
         currentTime.addTimeInterval(RUMSessionScope.Constants.sessionMaxDuration)
 
         _ = scope.process(command: RUMAddUserActionCommand(time: currentTime, attributes: [:], action: .tap))
         let secondSessionUUID = try XCTUnwrap(scope.sessionScope?.context.sessionID)
-        let secondSessionViewScopes = try XCTUnwrap((scope.sessionScope as? RUMSessionScope)?.viewScopes)
+        let secondSessionViewScopes = try XCTUnwrap(scope.sessionScope?.viewScopes)
 
         XCTAssertNotEqual(firstSessionUUID, secondSessionUUID)
         XCTAssertEqual(firstsSessionViewScopes.count, secondSessionViewScopes.count)
-        XCTAssertTrue((secondSessionViewScopes.first as? RUMViewScope)?.identity === view)
+        XCTAssertTrue(secondSessionViewScopes.first?.identity === view)
     }
 
     func testUntilSessionIsStarted_itIgnoresOtherCommands() {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -8,8 +8,6 @@ import XCTest
 @testable import Datadog
 
 class RUMApplicationScopeTests: XCTestCase {
-    private let view = UIViewController()
-
     func testRootContext() {
         let scope = RUMApplicationScope(
             rumApplicationID: "abc-123",
@@ -27,7 +25,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny())
 
         XCTAssertNil(scope.sessionScope)
-        XCTAssertTrue(scope.process(command: RUMStartViewCommand(time: .mockAny(), attributes: [:], identity: view)))
+        XCTAssertTrue(scope.process(command: RUMStartViewCommand(time: .mockAny(), attributes: [:], identity: mockView)))
         XCTAssertNotNil(scope.sessionScope)
     }
 
@@ -35,7 +33,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny())
         var currentTime = Date()
 
-        _ = scope.process(command: RUMStartViewCommand(time: currentTime, attributes: [:], identity: view))
+        _ = scope.process(command: RUMStartViewCommand(time: currentTime, attributes: [:], identity: mockView))
         let firstSessionUUID = try XCTUnwrap(scope.sessionScope?.context.sessionID)
         let firstsSessionViewScopes = try XCTUnwrap(scope.sessionScope?.viewScopes)
 
@@ -48,13 +46,13 @@ class RUMApplicationScopeTests: XCTestCase {
 
         XCTAssertNotEqual(firstSessionUUID, secondSessionUUID)
         XCTAssertEqual(firstsSessionViewScopes.count, secondSessionViewScopes.count)
-        XCTAssertTrue(secondSessionViewScopes.first?.identity === view)
+        XCTAssertTrue(secondSessionViewScopes.first?.identity === mockView)
     }
 
     func testUntilSessionIsStarted_itIgnoresOtherCommands() {
         let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny())
 
-        XCTAssertTrue(scope.process(command: RUMStopViewCommand(time: .mockAny(), attributes: [:], identity: view)))
+        XCTAssertTrue(scope.process(command: RUMStopViewCommand(time: .mockAny(), attributes: [:], identity: mockView)))
         XCTAssertTrue(scope.process(command: RUMAddUserActionCommand(time: .mockAny(), attributes: [:], action: .tap)))
         XCTAssertTrue(
             scope.process(

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -56,7 +56,13 @@ class RUMApplicationScopeTests: XCTestCase {
 
         XCTAssertTrue(scope.process(command: RUMStopViewCommand(time: .mockAny(), attributes: [:], identity: view)))
         XCTAssertTrue(scope.process(command: RUMAddUserActionCommand(time: .mockAny(), attributes: [:], action: .tap)))
-        XCTAssertTrue(scope.process(command: RUMStartResourceCommand(time: .mockAny(), attributes: [:], name: .mockAny())))
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStopResourceCommand(
+                    resourceName: .mockAny(), time: .mockAny(), attributes: [:], type: .mockAny(), httpStatusCode: 200, size: 0
+                )
+            )
+        )
         XCTAssertNil(scope.sessionScope)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -1,0 +1,137 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMResourceScopeTests: XCTestCase {
+    private let output = RUMEventOutputMock()
+    private lazy var dependencies: RUMScopeDependencies = .mockWith(eventOutput: output)
+    private let parent = RUMScopeMock(
+        context: .mockWith(
+            rumApplicationID: "rum-123",
+            sessionID: .mockRandom(),
+            activeViewID: .mockRandom(),
+            activeViewURI: "FooViewController",
+            activeUserActionID: .mockRandom()
+        )
+    )
+
+    func testDefaultContext() {
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
+        let sessionScope: RUMSessionScope = .mockWith(parent: applicationScope)
+        let viewScope: RUMViewScope = .mockWith(parent: sessionScope)
+        let scope = RUMResourceScope(
+            parent: viewScope,
+            dependencies: .mockAny(),
+            resourceName: .mockAny(),
+            attributes: [:],
+            startTime: .mockAny(),
+            url: .mockAny(),
+            httpMethod: .mockAny()
+        )
+
+        XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
+        XCTAssertEqual(scope.context.sessionID, sessionScope.context.sessionID)
+        XCTAssertEqual(scope.context.activeViewID, viewScope.viewUUID)
+        XCTAssertEqual(scope.context.activeViewURI, viewScope.viewURI)
+        XCTAssertNil(scope.context.activeUserActionID)
+    }
+
+    func testWhenResourceLoadingEnds_itSendsResourceEvent() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMResourceScope(
+            parent: parent,
+            dependencies: dependencies,
+            resourceName: "/resource/1",
+            attributes: [:],
+            startTime: currentTime,
+            url: "https://foo.com/resource/1",
+            httpMethod: "POST"
+        )
+
+        currentTime.addTimeInterval(2)
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceCommand(
+                    resourceName: "/resource/1",
+                    time: currentTime,
+                    attributes: ["foo": "bar"],
+                    type: "image",
+                    httpStatusCode: 200,
+                    size: 1_024
+                )
+            )
+        )
+
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMResourceEvent>.self).first)
+        XCTAssertEqual(event.model.date, currentTime.timeIntervalSince1970.toMilliseconds)
+        XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
+        XCTAssertEqual(event.model.session.id, scope.context.sessionID.toString)
+        XCTAssertEqual(event.model.session.type, "user")
+        XCTAssertEqual(event.model.session.type, "user")
+        XCTAssertEqual(event.model.view.id, parent.context.activeViewID?.toString)
+        XCTAssertEqual(event.model.view.url, "FooViewController")
+        XCTAssertEqual(event.model.resource.type, "image")
+        XCTAssertEqual(event.model.resource.url, "https://foo.com/resource/1")
+        XCTAssertEqual(event.model.resource.statusCode, 200)
+        XCTAssertEqual(event.model.resource.duration, 2_000_000_000)
+        XCTAssertEqual(event.model.resource.size, 1_024)
+        XCTAssertEqual(try XCTUnwrap(event.model.action?.id), parent.context.activeUserActionID?.toString)
+        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
+        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
+        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
+    }
+
+    func testWhenResourceLoadingEndsWithError_itSendsErrorEvent() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMResourceScope(
+            parent: parent,
+            dependencies: dependencies,
+            resourceName: "/resource/1",
+            attributes: [:],
+            startTime: currentTime,
+            url: "https://foo.com/resource/1",
+            httpMethod: "POST"
+        )
+
+        currentTime.addTimeInterval(2)
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(
+                    resourceName: "/resource/1",
+                    time: currentTime,
+                    attributes: ["foo": "bar"],
+                    errorMessage: "error message",
+                    errorSource: "network",
+                    httpStatusCode: 404
+                )
+            )
+        )
+
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).first)
+        XCTAssertEqual(event.model.date, currentTime.timeIntervalSince1970.toMilliseconds)
+        XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
+        XCTAssertEqual(event.model.session.id, scope.context.sessionID.toString)
+        XCTAssertEqual(event.model.session.type, "user")
+        XCTAssertEqual(event.model.session.type, "user")
+        XCTAssertEqual(event.model.view.id, parent.context.activeViewID?.toString)
+        XCTAssertEqual(event.model.view.url, "FooViewController")
+        XCTAssertEqual(event.model.error.message, "error message")
+        XCTAssertEqual(event.model.error.source, "network")
+        XCTAssertEqual(event.model.error.resource?.method, "POST")
+        XCTAssertEqual(event.model.error.resource?.statusCode, 404)
+        XCTAssertEqual(event.model.error.resource?.url, "https://foo.com/resource/1")
+        XCTAssertEqual(try XCTUnwrap(event.model.action?.id), parent.context.activeUserActionID?.toString)
+        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
+        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
+        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -25,7 +25,39 @@ class RUMMonitorTests: XCTestCase {
 
     // MARK: - Sending RUM events
 
-    func testWhenFirstViewIsStarted_itSendsApplicationStartActionAndViewEvent() throws {
+    func testStartingView() throws {
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
+        RUMFeature.instance = .mockWorkingFeatureWith(
+            server: server,
+            directory: temporaryDirectory,
+            dateProvider: dateProvider
+        )
+        defer { RUMFeature.instance = nil }
+
+        let monitor = RUMMonitor.initialize(rumApplicationID: "abc-123")
+
+        monitor.startView(viewController: mockView)
+        monitor.stopView(viewController: mockView)
+        monitor.startView(viewController: mockView)
+
+        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 4)
+        try rumEventMatchers[0].model(ofType: RUMActionEvent.self) { rumModel in
+            XCTAssertEqual(rumModel.action.type, "application_start")
+        }
+        try rumEventMatchers[1].model(ofType: RUMViewEvent.self) { rumModel in
+            XCTAssertEqual(rumModel.view.action.count, 1)
+        }
+        try rumEventMatchers[2].model(ofType: RUMViewEvent.self) { rumModel in
+            XCTAssertEqual(rumModel.view.action.count, 1)
+            XCTAssertEqual(rumModel.view.timeSpent, 1_000_000_000)
+        }
+        try rumEventMatchers[3].model(ofType: RUMViewEvent.self) { rumModel in
+            XCTAssertEqual(rumModel.view.action.count, 0)
+        }
+    }
+
+    func testStartingView_thenLoadingResource() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         RUMFeature.instance = .mockWorkingFeatureWith(
             server: server,
@@ -35,14 +67,25 @@ class RUMMonitorTests: XCTestCase {
 
         let monitor = RUMMonitor.initialize(rumApplicationID: "abc-123")
 
-        monitor.start(view: UIViewController(), attributes: ["foo": "bar"])
+        monitor.startView(viewController: mockView)
+        monitor.startResourceLoading(resourceName: "/resource/1", request: .mockAny())
+        monitor.stopResourceLoading(resourceName: "/resource/1", response: .mockResponseWith(statusCode: 200))
 
-        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 2)
-        let applicationStartAction: RUMActionEvent = try rumEventMatchers[0].model()
-        let viewEvent: RUMViewEvent = try rumEventMatchers[1].model()
-
-        XCTAssertEqual(applicationStartAction.action.type, "application_start")
-        XCTAssertEqual(viewEvent.view.action.count, 1)
+        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 4)
+        try rumEventMatchers[0].model(ofType: RUMActionEvent.self) { rumModel in
+            XCTAssertEqual(rumModel.action.type, "application_start")
+        }
+        try rumEventMatchers[1].model(ofType: RUMViewEvent.self) { rumModel in
+            XCTAssertEqual(rumModel.view.action.count, 1)
+            XCTAssertEqual(rumModel.view.resource.count, 0)
+        }
+        try rumEventMatchers[2].model(ofType: RUMViewEvent.self) { rumModel in
+            XCTAssertEqual(rumModel.view.action.count, 1)
+            XCTAssertEqual(rumModel.view.resource.count, 1)
+        }
+        try rumEventMatchers[3].model(ofType: RUMResourceEvent.self) { rumModel in
+            XCTAssertEqual(rumModel.resource.statusCode, 200)
+        }
     }
 
     // MARK: - Thread safety
@@ -62,9 +105,9 @@ class RUMMonitorTests: XCTestCase {
             case 0: monitor.start(view: mockView, attributes: nil)
             case 1: monitor.stop(view: mockView, attributes: nil)
             case 2: monitor.addViewError(message: .mockAny(), error: ErrorMock(), attributes: nil)
-            case 3: monitor.start(resource: .mockAny(), attributes: nil)
-            case 4: monitor.stop(resource: .mockAny(), attributes: nil)
-            case 5: monitor.stop(resource: .mockAny(), withError: ErrorMock(), attributes: nil)
+            case 3: monitor.start(resource: .mockAny(), url: .mockAny(), httpMethod: .mockAny(), attributes: nil)
+            case 4: monitor.stop(resource: .mockAny(), type: .mockAny(), httpStatusCode: 200, size: 0, attributes: nil)
+            case 5: monitor.stop(resource: .mockAny(), withError: .mockAny(), errorSource: .mockAny(), httpStatusCode: 400, attributes: nil)
             case 6: monitor.start(userAction: .scroll, attributes: nil)
             case 7: monitor.stop(userAction: .scroll, attributes: nil)
             case 8: monitor.add(userAction: .tap, attributes: nil)
@@ -83,21 +126,20 @@ class RUMMonitorTests: XCTestCase {
         let monitor = RUMMonitor(applicationScope: scope, dateProvider: dateProvider)
 
         let mockView = UIViewController()
-        let mockAttributes = ["foo": "bar"]
         let mockError = ErrorMock()
 
         // TODO: RUMM-585 Replace these internal API calls with public APIs
-        monitor.start(view: mockView, attributes: mockAttributes)
-        monitor.stop(view: mockView, attributes: mockAttributes)
-        monitor.addViewError(message: "error", error: mockError, attributes: mockAttributes)
+        monitor.start(view: mockView, attributes: nil)
+        monitor.stop(view: mockView, attributes: nil)
+        monitor.addViewError(message: .mockAny(), error: mockError, attributes: nil)
 
-        monitor.start(resource: "/resource/1", attributes: mockAttributes)
-        monitor.stop(resource: "/resource/1", attributes: mockAttributes)
-        monitor.stop(resource: "/resource/1", withError: ErrorMock(), attributes: mockAttributes)
+        monitor.start(resource: .mockAny(), url: .mockAny(), httpMethod: .mockAny(), attributes: nil)
+        monitor.stop(resource: .mockAny(), type: .mockAny(), httpStatusCode: 200, size: 0, attributes: nil)
+        monitor.stop(resource: .mockAny(), withError: .mockAny(), errorSource: .mockAny(), httpStatusCode: 400, attributes: nil)
 
-        monitor.start(userAction: .scroll, attributes: mockAttributes)
-        monitor.stop(userAction: .scroll, attributes: mockAttributes)
-        monitor.add(userAction: .tap, attributes: mockAttributes)
+        monitor.start(userAction: .scroll, attributes: nil)
+        monitor.stop(userAction: .scroll, attributes: nil)
+        monitor.add(userAction: .tap, attributes: nil)
 
         let commands = scope.waitAndReturnProcessedCommands(count: 9, timeout: 0.5)
 

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -55,6 +55,11 @@ internal class RUMEventMatcher {
         return try jsonDataDecoder.decode(DM.self, from: jsonData)
     }
 
+    func model<DM: Decodable>(ofType type: DM.Type, matches matcher: (DM) -> Void) throws {
+        let model = try jsonDataDecoder.decode(DM.self, from: jsonData)
+        matcher(model)
+    }
+
     func model<DM: Decodable>(isTypeOf type: DM.Type) -> Bool {
         return (try? model() as DM) != nil
     }


### PR DESCRIPTION
### What and why?

📦 This PR adds RUM Resources monitoring.

<img width="1296" alt="Screenshot 2020-07-23 at 17 15 29" src="https://user-images.githubusercontent.com/2358722/88304691-e1cd9300-cd08-11ea-92b1-dc5fb2db35ce.png">

To keep this PR relatively small, Resource timing details were detached to `RUMM-633 Add Resource type and size`.

### How?

Public APIs added to `RUMMonitor`:
```swift
/// Notifies that the Resource starts being loaded.
/// - Parameters:
///   - resourceName: the name representing this Resource - must be unique among all Resources currently being loaded.
///   - request: the `URLRequest` issued for this Resource
///   - attributes: custom attributes to attach to the Resource.
public func startResourceLoading(resourceName: String, request: URLRequest, attributes: [AttributeKey: AttributeValue]? = nil)

/// Notifies that the Resource stops being loaded.
/// - Parameters:
///   - resourceName: the name representing this Resource - must match the one used in `startResourceLoading(...)`.
///   - response: the `HTTPURLResponse` issued for this Resource
///   - size: size of loaded Resource (in bytes). If not specified, it will be inferred from the `Content-Length` HTTP header if available.
///   - attributes: custom attributes to attach to the Resource.
public func stopResourceLoading(resourceName: String, response: HTTPURLResponse, size: UInt64? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
```

The `RUMResourceScope` is implemented. It tracks the resource from `RUMStartResourceCommand` to `RUMStopResourceCommand` (or `RUMStopResourceWithErrorCommand`). The `RUMResourceEvent` (following `rum-events-format`) is send only after the resource loading is completed (stopped).

`RUMViewScope` tracks number of loaded resources (on `resourceCount` property) and sends `RUMViewEvents` with RUM View updates.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
