### PR TITLE
RUMM-521 Add User Actions monitoring

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB424C864680082C633 /* RUMResourceScopeTests.swift */; };
 		61494CB724C99F7C0082C633 /* RUMErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB624C99F7C0082C633 /* RUMErrorEvent.swift */; };
 		61494CB824C9D8810082C633 /* RUMResourceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB224C844570082C633 /* RUMResourceEvent.swift */; };
+		61494CBA24CB126F0082C633 /* RUMUserActionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB924CB126F0082C633 /* RUMUserActionScope.swift */; };
 		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		61570005246AADFA00E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
 		61570006246AAE5E00E96950 /* DatadogObjc.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -132,6 +133,7 @@
 		617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */; };
 		617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */; };
 		617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */; };
+		617CD0DD24CEDDD300B0B557 /* RUMUserActionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */; };
 		617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617CEB382456BC3A00AD4669 /* TracingUUID.swift */; };
 		618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618C365E248E85B400520CDE /* DateFormattingTests.swift */; };
 		618DCFD724C7265300589570 /* RUMUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFD624C7265300589570 /* RUMUUID.swift */; };
@@ -422,6 +424,7 @@
 		61494CB224C844570082C633 /* RUMResourceEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceEvent.swift; sourceTree = "<group>"; };
 		61494CB424C864680082C633 /* RUMResourceScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceScopeTests.swift; sourceTree = "<group>"; };
 		61494CB624C99F7C0082C633 /* RUMErrorEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMErrorEvent.swift; sourceTree = "<group>"; };
+		61494CB924CB126F0082C633 /* RUMUserActionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScope.swift; sourceTree = "<group>"; };
 		614E9EB2244719FA007EE3E1 /* BundleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleType.swift; sourceTree = "<group>"; };
 		615519252461BCE7002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519262461BCE7002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
@@ -434,6 +437,7 @@
 		617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorTests.swift; sourceTree = "<group>"; };
 		617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMApplicationScopeTests.swift; sourceTree = "<group>"; };
 		617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorConfigurationTests.swift; sourceTree = "<group>"; };
+		617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScopeTests.swift; sourceTree = "<group>"; };
 		617CEB382456BC3A00AD4669 /* TracingUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUID.swift; sourceTree = "<group>"; };
 		618C365E248E85B400520CDE /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
 		618DCFD624C7265300589570 /* RUMUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUUID.swift; sourceTree = "<group>"; };
@@ -1180,6 +1184,7 @@
 				61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */,
 				6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */,
 				61494CB424C864680082C633 /* RUMResourceScopeTests.swift */,
+				617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */,
 			);
 			path = Scopes;
 			sourceTree = "<group>";
@@ -1267,6 +1272,7 @@
 				61C2C20624C098FC00C0321C /* RUMSessionScope.swift */,
 				61C2C21124C5951400C0321C /* RUMViewScope.swift */,
 				61494CB024C839460082C633 /* RUMResourceScope.swift */,
+				61494CB924CB126F0082C633 /* RUMUserActionScope.swift */,
 			);
 			path = Scopes;
 			sourceTree = "<group>";
@@ -1864,6 +1870,7 @@
 				61C5A89024509AA700DA608C /* TracingFeature.swift in Sources */,
 				61E5333624B84B43003D6C4E /* RUMMonitor.swift in Sources */,
 				61133BD62423979B00786299 /* DataUploader.swift in Sources */,
+				61494CBA24CB126F0082C633 /* RUMUserActionScope.swift in Sources */,
 				61C5A88724509A0C00DA608C /* Casting.swift in Sources */,
 				61C3E63724BF191F008053F2 /* RUMScope.swift in Sources */,
 				61133BE52423979B00786299 /* LogBuilder.swift in Sources */,
@@ -1911,6 +1918,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				617CD0DD24CEDDD300B0B557 /* RUMUserActionScopeTests.swift in Sources */,
 				61C5A8A024509C1100DA608C /* Casting.swift in Sources */,
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
 				61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,

--- a/Sources/Datadog/RUM/DataModels/RUMActionEvent.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMActionEvent.swift
@@ -46,11 +46,30 @@ internal struct RUMActionEvent: Codable, RUMDataModel {
     }
 
     struct Action: Codable {
+        enum CodingKeys: String, CodingKey {
+            case id
+            case type
+            case loadingTime = "loading_time"
+            case resource
+            case error
+        }
+
         /// Open discussion: should this be non-optional?
         let id: String?
         /// Allowed values:
         /// `"custom", "click", "tap", "scroll", "swipe", "application_start"`
         let type: String
+        let loadingTime: UInt64?
+
+        let resource: Resource?
+        let error: Error?
+
+        struct Resource: Codable {
+            let count: UInt
+        }
+        struct Error: Codable {
+            let count: UInt
+        }
     }
 
     struct DD: Codable {

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -93,26 +93,31 @@ internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
 
 // MARK: - RUM User Action related commands
 
-internal struct RUMStartUserActionCommand: RUMCommand {
-    let time: Date
-    let attributes: [AttributeKey: AttributeValue]
-
+internal protocol RUMUserActionCommand: RUMCommand {
     /// The action identifying the RUM User Action.
-    let action: RUMUserAction
+    var actionType: RUMUserActionType { get }
 }
 
-internal struct RUMStopUserActionCommand: RUMCommand {
+/// Starts continuous User Action.
+internal struct RUMStartUserActionCommand: RUMUserActionCommand {
     let time: Date
     let attributes: [AttributeKey: AttributeValue]
 
-    /// The action identifying the RUM User Action.
-    let action: RUMUserAction
+    let actionType: RUMUserActionType
 }
 
-internal struct RUMAddUserActionCommand: RUMCommand {
+/// Stops continuous User Action.
+internal struct RUMStopUserActionCommand: RUMUserActionCommand {
     let time: Date
     let attributes: [AttributeKey: AttributeValue]
 
-    /// The action identifying the RUM User Action.
-    let action: RUMUserAction
+    let actionType: RUMUserActionType
+}
+
+/// Adds discrete (discontinuous) User Action.
+internal struct RUMAddUserActionCommand: RUMUserActionCommand {
+    let time: Date
+    let attributes: [AttributeKey: AttributeValue]
+
+    let actionType: RUMUserActionType
 }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMMonitorInternal.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMMonitorInternal.swift
@@ -6,13 +6,6 @@
 
 import Foundation
 
-internal enum RUMUserActionType {
-    case tap
-    case scroll
-    case swipe
-    case custom
-}
-
 /// TODO: RUMM-585 - what else parameters do we need in each method?
 internal protocol RUMMonitorInternal {
     func start(view id: AnyObject, attributes: [AttributeKey: AttributeValue]?)

--- a/Sources/Datadog/RUM/RUMMonitor/RUMMonitorInternal.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMMonitorInternal.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal enum RUMUserAction {
+internal enum RUMUserActionType {
     case tap
     case scroll
     case swipe
@@ -23,7 +23,7 @@ internal protocol RUMMonitorInternal {
     func stop(resource resourceName: String, type: String, httpStatusCode: Int?, size: UInt64?, attributes: [AttributeKey: AttributeValue]?)
     func stop(resource resourceName: String, withError errorMessage: String, errorSource: String, httpStatusCode: Int?, attributes: [AttributeKey: AttributeValue]?)
 
-    func start(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
-    func stop(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
-    func add(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?)
+    func start(userAction: RUMUserActionType, attributes: [AttributeKey: AttributeValue]?)
+    func stop(userAction: RUMUserActionType, attributes: [AttributeKey: AttributeValue]?)
+    func add(userAction: RUMUserActionType, attributes: [AttributeKey: AttributeValue]?)
 }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
@@ -34,9 +34,9 @@ extension RUMScope {
     ///
     /// Returns the `childScopes` array by removing scopes which requested to be closed.
     func manage<S: RUMScope>(childScopes: [S], byPropagatingCommand command: RUMCommand) -> [S] {
-        return childScopes.compactMap { childScope in
+        return childScopes.filter { childScope in
             let shouldBeKept = childScope.process(command: command)
-            return shouldBeKept ? childScope : nil
+            return shouldBeKept
         }
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
@@ -19,16 +19,22 @@ internal protocol RUMScope: class {
 extension RUMScope {
     /// Propagates given `command` to the child scope and manages its lifecycle by
     /// removing it if it gets closed.
-    func manage<S: RUMScope>(childScope: inout S?, byPropagatingCommand command: RUMCommand) {
+    ///
+    /// Returns the `childScope` requested to be kept open, `nil` if it requests to close.
+    func manage<S: RUMScope>(childScope: S?, byPropagatingCommand command: RUMCommand) -> S? {
         if childScope?.process(command: command) == false {
-            childScope = nil
+            return nil
+        } else {
+            return childScope
         }
     }
 
     /// Propagates given `command` through array of child scopes and manages their lifecycle by
     /// removing child scopes that get closed.
-    func manage<S: RUMScope>(childScopes: inout [S], byPropagatingCommand command: RUMCommand) {
-        childScopes = childScopes.compactMap { childScope in
+    ///
+    /// Returns the `childScopes` array by removing scopes which requested to be closed.
+    func manage<S: RUMScope>(childScopes: [S], byPropagatingCommand command: RUMCommand) -> [S] {
+        return childScopes.compactMap { childScope in
             let shouldBeKept = childScope.process(command: command)
             return shouldBeKept ? childScope : nil
         }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -44,7 +44,7 @@ internal class RUMApplicationScope: RUMScope {
 
     func process(command: RUMCommand) -> Bool {
         if let currentSession = sessionScope {
-            manage(childScope: &sessionScope, byPropagatingCommand: command)
+            sessionScope = manage(childScope: sessionScope, byPropagatingCommand: command)
 
             if sessionScope == nil { // if session expired
                 refresh(expiredSession: currentSession, on: command)

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -14,7 +14,7 @@ internal class RUMResourceScope: RUMScope {
     private let dependencies: RUMScopeDependencies
 
     /// The name used to identify this Resource.
-    private(set) var resourceName: String
+    internal let resourceName: String
     /// Resource attributes.
     private(set) var attributes: [AttributeKey: AttributeValue]
 
@@ -69,7 +69,7 @@ internal class RUMResourceScope: RUMScope {
         attributes.merge(rumCommandAttributes: command.attributes)
 
         let eventData = RUMResourceEvent(
-            date: command.time.timeIntervalSince1970.toMilliseconds,
+            date: resourceLoadingStartTime.timeIntervalSince1970.toMilliseconds,
             application: .init(id: context.rumApplicationID),
             session: .init(id: context.sessionID.toString, type: "user"),
             view: .init(

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -97,7 +97,7 @@ internal class RUMSessionScope: RUMScope {
         }
 
         // Propagate command
-        manage(childScopes: &viewScopes, byPropagatingCommand: command)
+        viewScopes = manage(childScopes: viewScopes, byPropagatingCommand: command)
 
         return true
     }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -40,7 +40,7 @@ internal class RUMUserActionScope: RUMScope {
     /// Number of Errors occured during this User Action's lifespan.
     private var errorsCount: UInt = 0
     /// Number of Resources that started but not yet ended during this User Action's lifespan.
-    private var activeResourcesCount: UInt = 0
+    private var activeResourcesCount: Int = 0
 
     init(
         parent: RUMScope,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -1,0 +1,180 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal class RUMUserActionScope: RUMScope {
+    struct Constants {
+        /// If no activity is observed within this period in a discrete (discontinous) User Action, it is condiered ended.
+        /// The activity may be i.e. due to Resource started loading.
+        static let discreteActionTimeoutDuration: TimeInterval = 0.1 // 100 milliseconds
+        /// Maximum duration of a continuous User Action. If it gets exceeded, a new session is started.
+        static let continuousActionMaxDuration: TimeInterval = 10 // 10 seconds
+    }
+
+    // MARK: - Initialization
+
+    // TODO: RUMM-597: Consider using `parent: RUMContextProvider`
+    private unowned let parent: RUMScope
+    private let dependencies: RUMScopeDependencies
+
+    /// The type of this User Action.
+    internal let actionType: RUMUserActionType
+    /// User Action attributes.
+    private(set) var attributes: [AttributeKey: AttributeValue]
+
+    /// This User Action's UUID.
+    internal let actionUUID: RUMUUID
+    /// The start time of this User Action.
+    private var actionStartTime: Date
+    /// Tells if this action is continuous over time, like "scroll" (or discrete, like "tap").
+    internal let isContinuous: Bool
+    /// Time of the last RUM activity noticed by this User Action (i.e. Resource loading).
+    private var lastActivityTime: Date
+
+    /// Number of Resources started during this User Action's lifespan.
+    private var resourcesCount: UInt = 0
+    /// Number of Errors occured during this User Action's lifespan.
+    private var errorsCount: UInt = 0
+    /// Number of Resources that started but not yet ended during this User Action's lifespan.
+    private var activeResourcesCount: UInt = 0
+
+    init(
+        parent: RUMScope,
+        dependencies: RUMScopeDependencies,
+        actionType: RUMUserActionType,
+        attributes: [AttributeKey: AttributeValue],
+        startTime: Date,
+        isContinuous: Bool
+    ) {
+        self.parent = parent
+        self.dependencies = dependencies
+        self.actionType = actionType
+        self.attributes = attributes
+        self.actionUUID = dependencies.rumUUIDGenerator.generateUnique()
+        self.actionStartTime = startTime
+        self.isContinuous = isContinuous
+        self.lastActivityTime = startTime
+    }
+
+    // MARK: - RUMScope
+
+    var context: RUMContext {
+        return parent.context
+    }
+
+    func process(command: RUMCommand) -> Bool {
+        if isContinuous { // e.g. "scroll"
+            if expired(currentTime: command.time) {
+                sendActionEvent(completionTime: command.time)
+                return false
+            }
+        } else { // e.g. "tap"
+            if timedOut(currentTime: command.time) && allResourcesCompletedLoading() {
+                sendActionEvent(completionTime: lastActivityTime)
+                return false
+            }
+        }
+
+        lastActivityTime = command.time
+
+        switch command {
+        case let command as RUMStopUserActionCommand:
+            willStopUserAction(on: command)
+            return false
+
+        case let command as RUMResourceCommand:
+            if command is  RUMStartResourceCommand {
+                startTrackingResource()
+            } else if command is RUMStopResourceCommand {
+                stopTrackingResource()
+            } else if command is RUMStopResourceWithErrorCommand {
+                trackResourceError()
+            }
+
+        default:
+            break
+        }
+        return true
+    }
+
+    // MARK: - RUMCommands Processing
+
+    private func willStopUserAction(on command: RUMStopUserActionCommand) {
+        sendActionEvent(completionTime: command.time, on: command)
+    }
+
+    private func startTrackingResource() {
+        resourcesCount += 1
+        activeResourcesCount += 1
+    }
+
+    private func stopTrackingResource() {
+        activeResourcesCount -= 1
+    }
+
+    private func trackResourceError() {
+        activeResourcesCount -= 1
+        errorsCount += 1
+    }
+
+    // MARK: - Sending RUM Events
+
+    private func sendActionEvent(completionTime: Date, on command: RUMCommand? = nil) {
+        if let commandAttributes = command?.attributes {
+            attributes.merge(rumCommandAttributes: commandAttributes)
+        }
+
+        let eventData = RUMActionEvent(
+            date: actionStartTime.timeIntervalSince1970.toMilliseconds,
+            application: .init(id: context.rumApplicationID),
+            session: .init(id: context.sessionID.toString, type: "user"),
+            view: .init(
+                id: context.activeViewID.orNull.toString,
+                url: context.activeViewURI ?? ""
+            ),
+            action: .init(
+                id: actionUUID.toString,
+                type: rawActionType(for: actionType),
+                loadingTime: completionTime.timeIntervalSince(actionStartTime).toNanoseconds,
+                resource: .init(count: resourcesCount),
+                error: .init(count: errorsCount)
+            ),
+            dd: .init()
+        )
+
+        let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes)
+        dependencies.eventOutput.write(rumEvent: event)
+    }
+
+    // TODO: RUMM-517 Map `RUMUserActionType` to enum cases from generated models
+    private func rawActionType(for actionType: RUMUserActionType) -> String {
+        switch actionType {
+        case .tap: return "tap"
+        case .scroll: return "scroll"
+        case .swipe: return "swipe"
+        case .custom: return "custom"
+        }
+    }
+
+    // MARK: - Private
+
+    private func timedOut(currentTime: Date) -> Bool {
+        let timeElapsedSinceLastActivity = currentTime.timeIntervalSince(lastActivityTime)
+        let timedOut = timeElapsedSinceLastActivity >= Constants.discreteActionTimeoutDuration
+        return timedOut
+    }
+
+    private func expired(currentTime: Date) -> Bool {
+        let actionDuration = currentTime.timeIntervalSince(actionStartTime)
+        let expired = actionDuration >= Constants.continuousActionMaxDuration
+        return expired
+    }
+
+    private func allResourcesCompletedLoading() -> Bool {
+        return activeResourcesCount <= 0
+    }
+}

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -12,6 +12,8 @@ internal class RUMViewScope: RUMScope {
 
     /// Active Resource scopes, keyed by the Resource name.
     private(set) var resourceScopes: [String: RUMResourceScope] = [:]
+    /// Active User Action scope. There can be only one active user action at a time.
+    private(set) var userActionScope: RUMUserActionScope?
 
     // MARK: - Initialization
 
@@ -24,7 +26,7 @@ internal class RUMViewScope: RUMScope {
     /// View attributes.
     private(set) var attributes: [AttributeKey: AttributeValue]
 
-    /// This View UUID.
+    /// This View's UUID.
     let viewUUID: RUMUUID
     /// The URI of this View, used as the `view.url` in RUM Explorer.
     let viewURI: String
@@ -60,28 +62,64 @@ internal class RUMViewScope: RUMScope {
         var context = parent.context
         context.activeViewID = viewUUID
         context.activeViewURI = viewURI
+        context.activeUserActionID = userActionScope?.actionUUID
         return context
     }
 
     func process(command: RUMCommand) -> Bool {
         // Apply side effects
         switch command {
+        // View commands
         case let command as RUMStartViewCommand where command.identity === identity:
             startView(on: command)
         case let command as RUMStopViewCommand where command.identity === identity:
-            stopView(on: command)
+            willStopView(on: command)
             return false
+
+        // Resource commands
         case let command as RUMStartResourceCommand:
             startResource(on: command)
-        case let command as RUMResourceCommand where command is RUMStopResourceCommand || command is RUMStopResourceWithErrorCommand:
-            stopResource(on: command)
+
+        // User Action commands
+        case let command as RUMStartUserActionCommand:
+            startContinuousUserAction(on: command)
+        case let command as RUMAddUserActionCommand:
+            addDiscreteUserAction(on: command)
+
         default:
             break
         }
 
-        // Propagate command
+        // Track active scopes
+        let beforeResourcesCount = resourceScopes.count
+        let beforeHadUserAction = userActionScope != nil
+
+        // Propagate to Resource scopes
         if let resourceCommand = command as? RUMResourceCommand {
-            manage(childScope: &resourceScopes[resourceCommand.resourceName], byPropagatingCommand: resourceCommand)
+            resourceScopes[resourceCommand.resourceName] = manage(
+                childScope: resourceScopes[resourceCommand.resourceName],
+                byPropagatingCommand: resourceCommand
+            )
+        }
+
+        // Propagate to User Action scope
+        userActionScope = manage(childScope: userActionScope, byPropagatingCommand: command)
+
+        let afterResourcesCount = resourceScopes.count
+        let afterHasUserAction = userActionScope != nil
+
+        // Consider closed scopes
+        let didTrackResource = afterResourcesCount < beforeResourcesCount
+        let didTrackUserAction = beforeHadUserAction && !afterHasUserAction
+
+        if didTrackResource {
+            resourcesCount += 1
+            sendViewUpdateEvent(on: command)
+        }
+
+        if didTrackUserAction {
+            actionsCount += 1
+            sendViewUpdateEvent(on: command)
         }
 
         return true
@@ -97,7 +135,7 @@ internal class RUMViewScope: RUMScope {
         sendViewUpdateEvent(on: command)
     }
 
-    private func stopView(on command: RUMStopViewCommand) {
+    private func willStopView(on command: RUMStopViewCommand) {
         sendViewUpdateEvent(on: command)
     }
 
@@ -113,9 +151,26 @@ internal class RUMViewScope: RUMScope {
         )
     }
 
-    private func stopResource(on command: RUMResourceCommand) {
-        resourcesCount += 1
-        sendViewUpdateEvent(on: command)
+    private func startContinuousUserAction(on command: RUMStartUserActionCommand) {
+        userActionScope = RUMUserActionScope(
+            parent: self,
+            dependencies: dependencies,
+            actionType: command.actionType,
+            attributes: command.attributes,
+            startTime: command.time,
+            isContinuous: true
+        )
+    }
+
+    private func addDiscreteUserAction(on command: RUMAddUserActionCommand) {
+        userActionScope = RUMUserActionScope(
+            parent: self,
+            dependencies: dependencies,
+            actionType: command.actionType,
+            attributes: command.attributes,
+            startTime: command.time,
+            isContinuous: false
+        )
     }
 
     // MARK: - Sending RUM Events
@@ -131,7 +186,10 @@ internal class RUMViewScope: RUMScope {
             ),
             action: .init(
                 id: dependencies.rumUUIDGenerator.generateUnique().toString,
-                type: "application_start"
+                type: "application_start",
+                loadingTime: nil,
+                resource: nil,
+                error: nil
             ),
             dd: .init()
         )

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -115,7 +115,6 @@ public class RUMMonitor: RUMMonitorInternal {
     /// Such an User Action must be stopped with `stopUserAction(type:)`, and will be stopped automatically if it lasts more than 10 seconds.
     /// - Parameters:
     ///   - type: the User Action type
-    ///   - name: // TODO: RUMM-521 support UA's `target`
     ///   - attributes: custom attributes to attach to the User Action.
     public func startUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
         start(userAction: type, attributes: attributes)
@@ -125,7 +124,6 @@ public class RUMMonitor: RUMMonitorInternal {
     /// This is used to stop tracking long running user actions (e.g. "scroll"), started with `startUserAction(type:)`.
     /// - Parameters:
     ///   - type: the User Action type
-    ///   - name: // TODO: RUMM-521 support UA's `target`
     ///   - attributes: custom attributes to attach to the User Action.
     public func stopUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
         stop(userAction: type, attributes: attributes)
@@ -135,7 +133,6 @@ public class RUMMonitor: RUMMonitorInternal {
     /// This is used to track discrete User Actions (e.g. "tap").
     /// - Parameters:
     ///   - type: the User Action type
-    ///   - name: // TODO: RUMM-521 support UA's `target`
     ///   - attributes: custom attributes to attach to the User Action.
     public func registerUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
         add(userAction: type, attributes: attributes)

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -7,6 +7,13 @@
 import UIKit
 import Foundation
 
+public enum RUMUserActionType {
+    case tap
+    case scroll
+    case swipe
+    case custom
+}
+
 public class RUMMonitor: RUMMonitorInternal {
     /// The root scope of RUM monitoring.
     internal let applicationScope: RUMScope
@@ -110,7 +117,7 @@ public class RUMMonitor: RUMMonitorInternal {
     ///   - type: the User Action type
     ///   - name: // TODO: RUMM-521 support UA's `target`
     ///   - attributes: custom attributes to attach to the User Action.
-    func startUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
+    public func startUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
         start(userAction: type, attributes: attributes)
     }
 
@@ -120,7 +127,7 @@ public class RUMMonitor: RUMMonitorInternal {
     ///   - type: the User Action type
     ///   - name: // TODO: RUMM-521 support UA's `target`
     ///   - attributes: custom attributes to attach to the User Action.
-    func stopUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
+    public func stopUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
         stop(userAction: type, attributes: attributes)
     }
 
@@ -130,7 +137,7 @@ public class RUMMonitor: RUMMonitorInternal {
     ///   - type: the User Action type
     ///   - name: // TODO: RUMM-521 support UA's `target`
     ///   - attributes: custom attributes to attach to the User Action.
-    func registerUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
+    public func registerUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
         add(userAction: type, attributes: attributes)
     }
 
@@ -249,41 +256,5 @@ public class RUMMonitor: RUMMonitorInternal {
 
     private func resourceSize(from response: HTTPURLResponse) -> UInt64? {
         return nil // TODO: RUMM-633 Add Resource type and size
-    }
-
-    // MARK: - TODO: RUMM-585 Temporary APIs to remove
-
-    public func sendFakeActionEvent(viewURL: String, actionType: String) {
-        guard let rumFeature = RUMFeature.instance else {
-            fatalError("RUMFeature must be initialized.")
-        }
-
-        let dataModel = RUMActionEvent(
-            date: Date().timeIntervalSince1970.toMilliseconds,
-            application: .init(id: applicationScope.context.rumApplicationID),
-            session: .init(id: UUID().uuidString.lowercased(), type: "user"),
-            view: .init(
-                id: UUID().uuidString.lowercased(),
-                url: viewURL
-            ),
-            action: .init(
-                id: UUID().uuidString.lowercased(),
-                type: actionType,
-                loadingTime: nil,
-                resource: nil,
-                error: nil
-            ),
-            dd: .init()
-        )
-
-        let builder = RUMEventBuilder(
-            userInfoProvider: rumFeature.userInfoProvider,
-            networkConnectionInfoProvider: rumFeature.networkConnectionInfoProvider,
-            carrierInfoProvider: rumFeature.carrierInfoProvider
-        )
-
-        let event = builder.createRUMEvent(with: dataModel, attributes: [:])
-
-        rumFeature.storage.writer.write(value: event)
     }
 }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -174,32 +174,32 @@ public class RUMMonitor: RUMMonitorInternal {
         )
     }
 
-    func start(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?) {
+    func start(userAction: RUMUserActionType, attributes: [AttributeKey: AttributeValue]?) {
         process(
             command: RUMStartUserActionCommand(
                 time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                action: userAction
+                actionType: userAction
             )
         )
     }
 
-    func stop(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?) {
+    func stop(userAction: RUMUserActionType, attributes: [AttributeKey: AttributeValue]?) {
         process(
             command: RUMStopUserActionCommand(
                 time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                action: userAction
+                actionType: userAction
             )
         )
     }
 
-    func add(userAction: RUMUserAction, attributes: [AttributeKey: AttributeValue]?) {
+    func add(userAction: RUMUserActionType, attributes: [AttributeKey: AttributeValue]?) {
         process(
             command: RUMAddUserActionCommand(
                 time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                action: userAction
+                actionType: userAction
             )
         )
     }
@@ -237,7 +237,10 @@ public class RUMMonitor: RUMMonitorInternal {
             ),
             action: .init(
                 id: UUID().uuidString.lowercased(),
-                type: actionType
+                type: actionType,
+                loadingTime: nil,
+                resource: nil,
+                error: nil
             ),
             dd: .init()
         )

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -103,6 +103,37 @@ public class RUMMonitor: RUMMonitorInternal {
         )
     }
 
+    /// Notifies that the User Action has started.
+    /// This is used to track long running user actions (e.g. "scroll").
+    /// Such an User Action must be stopped with `stopUserAction(type:)`, and will be stopped automatically if it lasts more than 10 seconds.
+    /// - Parameters:
+    ///   - type: the User Action type
+    ///   - name: // TODO: RUMM-521 support UA's `target`
+    ///   - attributes: custom attributes to attach to the User Action.
+    func startUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
+        start(userAction: type, attributes: attributes)
+    }
+
+    /// Notifies that the User Action has stopped.
+    /// This is used to stop tracking long running user actions (e.g. "scroll"), started with `startUserAction(type:)`.
+    /// - Parameters:
+    ///   - type: the User Action type
+    ///   - name: // TODO: RUMM-521 support UA's `target`
+    ///   - attributes: custom attributes to attach to the User Action.
+    func stopUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
+        stop(userAction: type, attributes: attributes)
+    }
+
+    /// Registers the occurence of an User Action.
+    /// This is used to track discrete User Actions (e.g. "tap").
+    /// - Parameters:
+    ///   - type: the User Action type
+    ///   - name: // TODO: RUMM-521 support UA's `target`
+    ///   - attributes: custom attributes to attach to the User Action.
+    func registerUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
+        add(userAction: type, attributes: attributes)
+    }
+
     // MARK: - RUMMonitorInternal
 
     func start(view id: AnyObject, attributes: [AttributeKey: AttributeValue]?) {

--- a/Tests/DatadogIntegrationTests/RUMIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/RUMIntegrationTests.swift
@@ -48,8 +48,6 @@ class RUMIntegrationTests: IntegrationTests {
         let rumEventsMatchers = try recordedRUMRequests
             .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
 
-        print(rumEventsMatchers.count)
-
         // Assert Fixture 1 VC ⬇️
 
         // ----> `application_start` Action due to initial startView()
@@ -62,21 +60,21 @@ class RUMIntegrationTests: IntegrationTests {
         XCTAssertEqual(view1UpdateA.view.action.count, 1)
         XCTAssertEqual(view1UpdateA.view.resource.count, 0)
 
-        // --------> View update on stopResourceLoading()
-        let view1UpdateB: RUMViewEvent = try rumEventsMatchers[2].model()
-        XCTAssertEqual(view1UpdateB.view.id, view1UpdateA.view.id)
-        XCTAssertEqual(view1UpdateB.dd.documentVersion, 2)
-        XCTAssertEqual(view1UpdateB.view.action.count, 1)
-        XCTAssertEqual(view1UpdateB.view.resource.count, 1)
-
         // --------> Resource event on stopResourceLoading()
-        let resourceLoaded: RUMResourceEvent = try rumEventsMatchers[3].model()
+        let resourceLoaded: RUMResourceEvent = try rumEventsMatchers[2].model()
         XCTAssertEqual(resourceLoaded.view.id, view1UpdateA.view.id)
         XCTAssertEqual(resourceLoaded.resource.url, "https://foo.com/resource/1")
         XCTAssertEqual(resourceLoaded.resource.statusCode, 200)
         XCTAssertEqual(resourceLoaded.resource.type, "other")
         XCTAssertGreaterThan(resourceLoaded.resource.duration, 100_000_000 - 1) // ~0.1s
         XCTAssertLessThan(resourceLoaded.resource.duration, 100_000_000 * 3) // less than 0.3s
+
+        // ----> View update after stopResourceLoading()
+        let view1UpdateB: RUMViewEvent = try rumEventsMatchers[3].model()
+        XCTAssertEqual(view1UpdateB.view.id, view1UpdateA.view.id)
+        XCTAssertEqual(view1UpdateB.dd.documentVersion, 2)
+        XCTAssertEqual(view1UpdateB.view.action.count, 1)
+        XCTAssertEqual(view1UpdateB.view.resource.count, 1)
 
         // ----> View update on stopView()
         let view1UpdateC: RUMViewEvent = try rumEventsMatchers[4].model()
@@ -103,5 +101,7 @@ class RUMIntegrationTests: IntegrationTests {
         let view3UpdateA: RUMViewEvent = try rumEventsMatchers[7].model()
         XCTAssertEqual(view3UpdateA.dd.documentVersion, 1)
         XCTAssertEqual(view3UpdateA.view.action.count, 0)
+
+        XCTAssertEqual(rumEventsMatchers.count, 8)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMScopeTests.swift
@@ -23,33 +23,15 @@ class RUMScopeTests: XCTestCase {
     func testWhenPropagatingCommand_itRemovesCompletedScope() {
         // Direct reference
         var scope: CompletableScope? = CompletableScope(isCompleted: true)
-        RUMScopeMock().manage(childScope: &scope, byPropagatingCommand: RUMCommandMock())
+        scope = RUMScopeMock().manage(childScope: scope, byPropagatingCommand: RUMCommandMock())
         XCTAssertNil(scope)
-
-        // Dictionary item reference
-        var dictionaryOfScopes: [String: CompletableScope] = [
-            "a": CompletableScope(isCompleted: true),
-            "b": CompletableScope(isCompleted: false)
-        ]
-        RUMScopeMock().manage(childScope: &dictionaryOfScopes["a"], byPropagatingCommand: RUMCommandMock())
-        XCTAssertNil(dictionaryOfScopes["a"])
-        XCTAssertNotNil(dictionaryOfScopes["b"])
     }
 
     func testWhenPropagatingCommand_itKeepsNonCompletedScope() {
         // Direct reference
         var scope: CompletableScope? = CompletableScope(isCompleted: false)
-        RUMScopeMock().manage(childScope: &scope, byPropagatingCommand: RUMCommandMock())
+        scope = RUMScopeMock().manage(childScope: scope, byPropagatingCommand: RUMCommandMock())
         XCTAssertNotNil(scope)
-
-        // Dictionary item reference
-        var dictionaryOfScopes: [String: CompletableScope] = [
-            "a": CompletableScope(isCompleted: true),
-            "b": CompletableScope(isCompleted: false)
-        ]
-        RUMScopeMock().manage(childScope: &dictionaryOfScopes["b"], byPropagatingCommand: RUMCommandMock())
-        XCTAssertNotNil(dictionaryOfScopes["a"])
-        XCTAssertNotNil(dictionaryOfScopes["b"])
     }
 
     func testWhenPropagatingCommand_itRemovesCompletedScopes() {
@@ -60,7 +42,7 @@ class RUMScopeTests: XCTestCase {
             CompletableScope(isCompleted: false)
         ]
 
-        RUMScopeMock().manage(childScopes: &scopes, byPropagatingCommand: RUMCommandMock())
+        scopes = RUMScopeMock().manage(childScopes: scopes, byPropagatingCommand: RUMCommandMock())
 
         XCTAssertEqual(scopes.count, 2)
         XCTAssertEqual(scopes.filter { !$0.isCompleted }.count, 2)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -40,7 +40,7 @@ class RUMApplicationScopeTests: XCTestCase {
         // Push time forward by the max session duration:
         currentTime.addTimeInterval(RUMSessionScope.Constants.sessionMaxDuration)
 
-        _ = scope.process(command: RUMAddUserActionCommand(time: currentTime, attributes: [:], action: .tap))
+        _ = scope.process(command: RUMAddUserActionCommand(time: currentTime, attributes: [:], actionType: .tap))
         let secondSessionUUID = try XCTUnwrap(scope.sessionScope?.context.sessionID)
         let secondSessionViewScopes = try XCTUnwrap(scope.sessionScope?.viewScopes)
 
@@ -53,7 +53,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny())
 
         XCTAssertTrue(scope.process(command: RUMStopViewCommand(time: .mockAny(), attributes: [:], identity: mockView)))
-        XCTAssertTrue(scope.process(command: RUMAddUserActionCommand(time: .mockAny(), attributes: [:], action: .tap)))
+        XCTAssertTrue(scope.process(command: RUMAddUserActionCommand(time: .mockAny(), attributes: [:], actionType: .tap)))
         XCTAssertTrue(
             scope.process(
                 command: RUMStopResourceCommand(

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -21,11 +21,8 @@ class RUMResourceScopeTests: XCTestCase {
     )
 
     func testDefaultContext() {
-        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
-        let sessionScope: RUMSessionScope = .mockWith(parent: applicationScope)
-        let viewScope: RUMViewScope = .mockWith(parent: sessionScope)
         let scope = RUMResourceScope(
-            parent: viewScope,
+            parent: parent,
             dependencies: .mockAny(),
             resourceName: .mockAny(),
             attributes: [:],
@@ -34,11 +31,11 @@ class RUMResourceScopeTests: XCTestCase {
             httpMethod: .mockAny()
         )
 
-        XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
-        XCTAssertEqual(scope.context.sessionID, sessionScope.context.sessionID)
-        XCTAssertEqual(scope.context.activeViewID, viewScope.viewUUID)
-        XCTAssertEqual(scope.context.activeViewURI, viewScope.viewURI)
-        XCTAssertNil(scope.context.activeUserActionID)
+        XCTAssertEqual(scope.context.rumApplicationID, parent.context.rumApplicationID)
+        XCTAssertEqual(scope.context.sessionID, parent.context.sessionID)
+        XCTAssertEqual(scope.context.activeViewID, try XCTUnwrap(parent.context.activeViewID))
+        XCTAssertEqual(scope.context.activeViewURI, try XCTUnwrap(parent.context.activeViewURI))
+        XCTAssertEqual(scope.context.activeUserActionID, try XCTUnwrap(parent.context.activeUserActionID))
     }
 
     func testWhenResourceLoadingEnds_itSendsResourceEvent() throws {
@@ -69,10 +66,9 @@ class RUMResourceScopeTests: XCTestCase {
         )
 
         let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMResourceEvent>.self).first)
-        XCTAssertEqual(event.model.date, currentTime.timeIntervalSince1970.toMilliseconds)
+        XCTAssertEqual(event.model.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toMilliseconds)
         XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.model.session.id, scope.context.sessionID.toString)
-        XCTAssertEqual(event.model.session.type, "user")
         XCTAssertEqual(event.model.session.type, "user")
         XCTAssertEqual(event.model.view.id, parent.context.activeViewID?.toString)
         XCTAssertEqual(event.model.view.url, "FooViewController")
@@ -119,7 +115,6 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.date, currentTime.timeIntervalSince1970.toMilliseconds)
         XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.model.session.id, scope.context.sessionID.toString)
-        XCTAssertEqual(event.model.session.type, "user")
         XCTAssertEqual(event.model.session.type, "user")
         XCTAssertEqual(event.model.view.id, parent.context.activeViewID?.toString)
         XCTAssertEqual(event.model.view.url, "FooViewController")

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -1,0 +1,235 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMUserActionScopeTests: XCTestCase {
+    private let output = RUMEventOutputMock()
+    private lazy var dependencies: RUMScopeDependencies = .mockWith(eventOutput: output)
+    private let parent = RUMScopeMock(
+        context: .mockWith(
+            rumApplicationID: "rum-123",
+            sessionID: .mockRandom(),
+            activeViewID: .mockRandom(),
+            activeViewURI: "FooViewController",
+            activeUserActionID: .mockRandom()
+        )
+    )
+
+    func testDefaultContext() {
+        let scope = RUMUserActionScope(
+            parent: parent,
+            dependencies: dependencies,
+            actionType: .swipe,
+            attributes: [:],
+            startTime: .mockAny(),
+            isContinuous: .mockAny()
+        )
+
+        XCTAssertEqual(scope.context.rumApplicationID, parent.context.rumApplicationID)
+        XCTAssertEqual(scope.context.sessionID, parent.context.sessionID)
+        XCTAssertEqual(scope.context.activeViewID, try XCTUnwrap(parent.context.activeViewID))
+        XCTAssertEqual(scope.context.activeViewURI, try XCTUnwrap(parent.context.activeViewURI))
+        XCTAssertEqual(scope.context.activeUserActionID, try XCTUnwrap(parent.context.activeUserActionID))
+    }
+
+    // MARK: - Continuous User Action
+
+    func testWhenContinuousUserActionEnds_itSendsActionEvent() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMUserActionScope(
+            parent: parent,
+            dependencies: dependencies,
+            actionType: .swipe,
+            attributes: [:],
+            startTime: currentTime,
+            isContinuous: true
+        )
+
+        currentTime.addTimeInterval(1)
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopUserActionCommand(
+                    time: currentTime,
+                    attributes: ["foo": "bar"],
+                    actionType: .swipe
+                )
+            )
+        )
+
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMActionEvent>.self).first)
+        XCTAssertEqual(event.model.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toMilliseconds)
+        XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
+        XCTAssertEqual(event.model.session.id, scope.context.sessionID.toString)
+        XCTAssertEqual(event.model.session.type, "user")
+        XCTAssertEqual(event.model.view.id, parent.context.activeViewID?.toString)
+        XCTAssertEqual(event.model.view.url, "FooViewController")
+        XCTAssertEqual(event.model.action.id, scope.actionUUID.toString)
+        XCTAssertEqual(event.model.action.type, "swipe")
+        XCTAssertEqual(event.model.action.loadingTime, 1_000_000_000)
+        XCTAssertEqual(event.model.action.resource?.count, 0)
+        XCTAssertEqual(event.model.action.error?.count, 0)
+        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
+        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
+        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
+    }
+
+    func testWhenContinuousUserActionExpires_itSendsActionEvent() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMUserActionScope(
+            parent: parent,
+            dependencies: dependencies,
+            actionType: .swipe,
+            attributes: [:],
+            startTime: currentTime,
+            isContinuous: true
+        )
+
+        let expirationInterval = RUMUserActionScope.Constants.continuousActionMaxDuration
+
+        currentTime = .mockDecember15th2019At10AMUTC(addingTimeInterval: expirationInterval * 0.5)
+        XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)), "Continuous User Action should not expire after \(expirationInterval * 0.5)s")
+
+        currentTime = .mockDecember15th2019At10AMUTC(addingTimeInterval: expirationInterval)
+        XCTAssertFalse(scope.process(command: RUMCommandMock(time: currentTime)), "Continuous User Action should expire after \(expirationInterval)s")
+
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMActionEvent>.self).first)
+        XCTAssertEqual(event.model.action.loadingTime, 10_000_000_000)
+    }
+
+    func testWhileContinuousUserActionIsActive_itTracksCompletedResources() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMUserActionScope(
+            parent: parent,
+            dependencies: dependencies,
+            actionType: .scroll,
+            attributes: [:],
+            startTime: currentTime,
+            isContinuous: true
+        )
+
+        currentTime.addTimeInterval(0.5)
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartResourceCommand(resourceName: "/resource/1", time: currentTime, attributes: [:], url: .mockAny(), httpMethod: .mockAny())
+            )
+        )
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartResourceCommand(resourceName: "/resource/2", time: currentTime, attributes: [:], url: .mockAny(), httpMethod: .mockAny())
+            )
+        )
+
+        currentTime.addTimeInterval(0.5)
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStopResourceCommand(resourceName: "/resource/1", time: currentTime, attributes: [:], type: .mockAny(), httpStatusCode: 200, size: 0)
+            )
+        )
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(resourceName: "/resource/2", time: currentTime, attributes: [:], errorMessage: .mockAny(), errorSource: .mockAny(), httpStatusCode: 400)
+            )
+        )
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopUserActionCommand(time: currentTime, attributes: [:], actionType: .scroll)
+            )
+        )
+
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMActionEvent>.self).last)
+        XCTAssertEqual(event.model.action.resource?.count, 2)
+        XCTAssertEqual(event.model.action.error?.count, 1)
+    }
+
+    // MARK: - Discrete User Action
+
+    func testWhenDiscreteUserActionTimesOut_itSendsActionEvent() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMUserActionScope(
+            parent: parent,
+            dependencies: dependencies,
+            actionType: .swipe,
+            attributes: [:],
+            startTime: currentTime,
+            isContinuous: false
+        )
+
+        let timeOutInterval = RUMUserActionScope.Constants.discreteActionTimeoutDuration
+
+        currentTime = .mockDecember15th2019At10AMUTC(addingTimeInterval: timeOutInterval * 0.5)
+        XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)), "Discrete User Action should not time out after \(timeOutInterval * 0.5)s")
+
+        currentTime.addTimeInterval(timeOutInterval)
+        XCTAssertFalse(scope.process(command: RUMCommandMock(time: currentTime)), "Discrete User Action should time out after \(timeOutInterval)s")
+
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMActionEvent>.self).first)
+        let nanosecondsInSecond: Double = 1_000_000_000
+        let actionLoadingTimeInSeconds = Double(try XCTUnwrap(event.model.action.loadingTime)) / nanosecondsInSecond
+        XCTAssertEqual(actionLoadingTimeInSeconds, RUMUserActionScope.Constants.discreteActionTimeoutDuration, accuracy: 0.1)
+    }
+
+    func testWhileDiscreteUserActionIsActive_itDoesNotComplete_untilAllTrackedResourcesAreCompleted() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMUserActionScope(
+            parent: parent,
+            dependencies: dependencies,
+            actionType: .scroll,
+            attributes: [:],
+            startTime: currentTime,
+            isContinuous: false
+        )
+
+        currentTime.addTimeInterval(0.05)
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartResourceCommand(resourceName: "/resource/1", time: currentTime, attributes: [:], url: .mockAny(), httpMethod: .mockAny())
+            )
+        )
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartResourceCommand(resourceName: "/resource/2", time: currentTime, attributes: [:], url: .mockAny(), httpMethod: .mockAny())
+            )
+        )
+
+        currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration)
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStopResourceCommand(resourceName: "/resource/1", time: currentTime, attributes: [:], type: .mockAny(), httpStatusCode: 200, size: 0)
+            ),
+            "Discrete User Action should not yet complete as it still has 1 pending Resource"
+        )
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(resourceName: "/resource/2", time: currentTime, attributes: [:], errorMessage: .mockAny(), errorSource: .mockAny(), httpStatusCode: 400)
+            ),
+            "Discrete User Action should not yet complete as it haven't reached the time out duration"
+        )
+
+        currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration)
+
+        XCTAssertFalse(
+            scope.process(command: RUMCommandMock(time: currentTime)),
+            "Discrete User Action should complete as it has no more pending Resources and it reached the timeout duration"
+        )
+
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMActionEvent>.self).last)
+        XCTAssertEqual(event.model.action.resource?.count, 2)
+        XCTAssertEqual(event.model.action.error?.count, 1)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -285,10 +285,6 @@ class RUMViewScopeTests: XCTestCase {
 
         currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration)
 
-        XCTAssertTrue(
-            scope.process(command: RUMCommandMock(time: currentTime))
-        )
-
         XCTAssertFalse(
             scope.process(command: RUMStopViewCommand(time: currentTime, attributes: [:], identity: view))
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -34,6 +34,28 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertNil(scope.context.activeUserActionID)
     }
 
+    func testContextWhenViewHasAnActiveUserAction() {
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
+        let sessionScope: RUMSessionScope = .mockWith(parent: applicationScope)
+        let scope = RUMViewScope(
+            parent: sessionScope,
+            dependencies: .mockAny(),
+            identity: view,
+            attributes: [:],
+            startTime: .mockAny()
+        )
+
+        _ = scope.process(
+            command: RUMStartUserActionCommand(time: Date(), attributes: [:], actionType: .swipe)
+        )
+
+        XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
+        XCTAssertEqual(scope.context.sessionID, sessionScope.context.sessionID)
+        XCTAssertEqual(scope.context.activeViewID, scope.viewUUID)
+        XCTAssertEqual(scope.context.activeViewURI, scope.viewURI)
+        XCTAssertEqual(scope.context.activeUserActionID, try XCTUnwrap(scope.userActionScope?.actionUUID))
+    }
+
     func testWhenInitialViewIsStarted_itSendsApplicationStartAction() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
@@ -180,31 +202,97 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
 
+    // MARK: - Resources Tracking
+
     func testItManagesResourceScopesLifecycle() throws {
         let scope = RUMViewScope(parent: parent, dependencies: dependencies, identity: view, attributes: [:], startTime: Date())
-        _ = scope.process(command: RUMStartViewCommand(time: Date(), attributes: [:], identity: view))
+        XCTAssertTrue(
+            scope.process(command: RUMStartViewCommand(time: Date(), attributes: [:], identity: view))
+        )
 
         XCTAssertEqual(scope.resourceScopes.count, 0)
-        _ = scope.process(
-            command: RUMStartResourceCommand(resourceName: "/resource/1", time: Date(), attributes: [:], url: .mockAny(), httpMethod: .mockAny())
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartResourceCommand(resourceName: "/resource/1", time: Date(), attributes: [:], url: .mockAny(), httpMethod: .mockAny())
+            )
         )
         XCTAssertEqual(scope.resourceScopes.count, 1)
-        _ = scope.process(
-            command: RUMStartResourceCommand(resourceName: "/resource/2", time: Date(), attributes: [:], url: .mockAny(), httpMethod: .mockAny())
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStartResourceCommand(resourceName: "/resource/2", time: Date(), attributes: [:], url: .mockAny(), httpMethod: .mockAny())
+            )
         )
         XCTAssertEqual(scope.resourceScopes.count, 2)
-        _ = scope.process(
-            command: RUMStopResourceCommand(resourceName: "/resource/1", time: Date(), attributes: [:], type: .mockAny(), httpStatusCode: 200, size: 0)
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStopResourceCommand(resourceName: "/resource/1", time: Date(), attributes: [:], type: .mockAny(), httpStatusCode: 200, size: 0)
+            )
         )
         XCTAssertEqual(scope.resourceScopes.count, 1)
-        _ = scope.process(
-            command: RUMStopResourceWithErrorCommand(resourceName: "/resource/2", time: Date(), attributes: [:], errorMessage: .mockAny(), errorSource: .mockAny(), httpStatusCode: 400)
+        XCTAssertTrue(
+            scope.process(
+                command: RUMStopResourceWithErrorCommand(resourceName: "/resource/2", time: Date(), attributes: [:], errorMessage: .mockAny(), errorSource: .mockAny(), httpStatusCode: 400)
+            )
         )
         XCTAssertEqual(scope.resourceScopes.count, 0)
 
-        _ = scope.process(command: RUMStopViewCommand(time: Date(), attributes: [:], identity: view))
-
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).dropFirst(2).first)
+        XCTAssertFalse(
+            scope.process(command: RUMStopViewCommand(time: Date(), attributes: [:], identity: view))
+        )
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)
         XCTAssertEqual(event.model.view.resource.count, 2, "View should record 2 resources")
+    }
+
+    // MARK: - User Action Tracking
+
+    func testItManagesContinuousUserActionScopeLifecycle() throws {
+        let scope = RUMViewScope(parent: parent, dependencies: dependencies, identity: view, attributes: [:], startTime: Date())
+        XCTAssertTrue(
+            scope.process(command: RUMStartViewCommand(time: Date(), attributes: [:], identity: view))
+        )
+
+        XCTAssertNil(scope.userActionScope)
+        XCTAssertTrue(
+            scope.process(command: RUMStartUserActionCommand(time: Date(), attributes: [:], actionType: .swipe))
+        )
+        XCTAssertNotNil(scope.userActionScope)
+        XCTAssertTrue(
+            scope.process(command: RUMStopUserActionCommand(time: Date(), attributes: [:], actionType: .swipe))
+        )
+        XCTAssertNil(scope.userActionScope)
+
+        XCTAssertFalse(
+            scope.process(command: RUMStopViewCommand(time: Date(), attributes: [:], identity: view))
+        )
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)
+        XCTAssertEqual(event.model.view.action.count, 1, "View should record 1 action")
+    }
+
+    func testItManagesDiscreteUserActionScopeLifecycle() throws {
+        var currentTime = Date()
+        let scope = RUMViewScope(parent: parent, dependencies: dependencies, identity: view, attributes: [:], startTime: currentTime)
+        XCTAssertTrue(
+            scope.process(command: RUMStartViewCommand(time: currentTime, attributes: [:], identity: view))
+        )
+
+        currentTime.addTimeInterval(0.5)
+
+        XCTAssertNil(scope.userActionScope)
+        XCTAssertTrue(
+            scope.process(command: RUMAddUserActionCommand(time: currentTime, attributes: [:], actionType: .tap))
+        )
+        XCTAssertNotNil(scope.userActionScope)
+
+        currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration)
+
+        XCTAssertTrue(
+            scope.process(command: RUMCommandMock(time: currentTime))
+        )
+
+        XCTAssertFalse(
+            scope.process(command: RUMStopViewCommand(time: currentTime, attributes: [:], identity: view))
+        )
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)
+        XCTAssertEqual(event.model.view.action.count, 1, "View should record 1 action")
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -146,14 +146,14 @@ class RUMMonitorTests: XCTestCase {
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize(rumApplicationID: .mockAny())
-        let mockView = UIViewController()
+        let view = mockView
 
         DispatchQueue.concurrentPerform(iterations: 900) { iteration in
             let modulo = iteration % 9
 
             switch modulo {
-            case 0: monitor.start(view: mockView, attributes: nil)
-            case 1: monitor.stop(view: mockView, attributes: nil)
+            case 0: monitor.start(view: view, attributes: nil)
+            case 1: monitor.stop(view: view, attributes: nil)
             case 2: monitor.addViewError(message: .mockAny(), error: ErrorMock(), attributes: nil)
             case 3: monitor.start(resource: .mockAny(), url: .mockAny(), httpMethod: .mockAny(), attributes: nil)
             case 4: monitor.stop(resource: .mockAny(), type: .mockAny(), httpStatusCode: 200, size: 0, attributes: nil)

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -120,7 +120,7 @@ class RUMMonitorTests: XCTestCase {
         }
     }
 
-    func testStartingView_thenTappingButton_thenLoadingResources() throws {
+    func testStartingView_thenLoadingResources_whileScrolling() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         RUMFeature.instance = .mockWorkingFeatureWith(
             server: server,

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -85,6 +85,19 @@ internal class RUMEventMatcher {
     }
 }
 
+extension RUMEventMatcher: CustomStringConvertible {
+    /// Returns prety JSON representation of this matcher. Handy for debugging with `po matcher`.
+    var description: String {
+        do {
+            let jsonObject = try jsonData.toJSONObject()
+            let prettyPrintedJSONData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
+            return prettyPrintedJSONData.utf8String
+        } catch {
+            return "Cannot build pretty JSON: \(error)"
+        }
+    }
+}
+
 func XCTAssertValidRumUUID(_ string: String?, file: StaticString = #file, line: UInt = #line) {
     guard let string = string else {
         XCTFail("`nil` is not valid RUM UUID", file: file, line: line)

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -91,7 +91,7 @@ extension RUMEventMatcher: CustomStringConvertible {
         do {
             let jsonObject = try jsonData.toJSONObject()
             let prettyPrintedJSONData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
-            return prettyPrintedJSONData.utf8String
+            return String(data: prettyPrintedJSONData, encoding: .utf8) ?? "Failed to build String from utf8 data"
         } catch {
             return "Cannot build pretty JSON: \(error)"
         }


### PR DESCRIPTION
### What and why?

🚚 This PR adds User Actions monitoring.

<img width="1207" alt="Screenshot 2020-07-28 at 13 08 52" src="https://user-images.githubusercontent.com/2358722/88659234-047af580-d0d5-11ea-9103-ec561f5eb764.png">

To keep this PR relatively small, additional User Action details were detached to `RUMM-642 Add more User Action information`.

### How?

Public APIs added to `RUMMonitor`:
```swift
/// Notifies that the User Action has started.
/// This is used to track long running user actions (e.g. "scroll").
/// Such an User Action must be stopped with `stopUserAction(type:)`, and will be stopped automatically if it lasts more than 10 seconds.
/// - Parameters:
///   - type: the User Action type
///   - attributes: custom attributes to attach to the User Action.
public func startUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
    start(userAction: type, attributes: attributes)
}

/// Notifies that the User Action has stopped.
/// This is used to stop tracking long running user actions (e.g. "scroll"), started with `startUserAction(type:)`.
/// - Parameters:
///   - type: the User Action type
///   - attributes: custom attributes to attach to the User Action.
public func stopUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
    stop(userAction: type, attributes: attributes)
}

/// Registers the occurence of an User Action.
/// This is used to track discrete User Actions (e.g. "tap").
/// - Parameters:
///   - type: the User Action type
///   - attributes: custom attributes to attach to the User Action.
public func registerUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
    add(userAction: type, attributes: attributes)
}
```

There are two types of User Action and it is up to the user to decide how he/she wants to track a given interaction:
* continuous (like "scroll"),
* discrete (like "tap").

**Continuous UAs** last from their `RUMStartUserActionCommand` to `RUMStopUserActionCommand` commands. If they exceed `10s` expiration interval, they are completed automatically. 

**Discrete UAs** are registered on `RUMAddUserActionCommand` and get closed automatically after `0.1s` of no interaction (no other `RUMCommand` passed to `RUMMonitor`).

If any Resource is started and stopped within the UA's lifespan, it is counted on `action.resource.count` and displayed in the RUM Explorer. Discrete UAs do not get closed until all its monitored Resources are done.

### Coming in next PR

This also requires adding the User Action fixture in integration tests - this comes in #196, to keep this one small.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
