### PR TITLE
RUMM-521 Add integration test fixtures for User Action

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		61570005246AADFA00E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
 		61570006246AAE5E00E96950 /* DatadogObjc.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61570007246AAED100E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
+		615A20D524D0562000D857A2 /* RUMErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB624C99F7C0082C633 /* RUMErrorEvent.swift */; };
 		615A4A8324A3431600233986 /* Tracer+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8224A3431600233986 /* Tracer+objc.swift */; };
 		615A4A8524A3445700233986 /* TracerConfiguration+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8424A3445700233986 /* TracerConfiguration+objc.swift */; };
 		615A4A8724A3452800233986 /* DDTracerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8624A3452800233986 /* DDTracerConfigurationTests.swift */; };
@@ -2055,6 +2056,7 @@
 			files = (
 				61441C4024617013003D8BB8 /* IntegrationTests.swift in Sources */,
 				61C2C20E24C196E800C0321C /* RUMActionEvent.swift in Sources */,
+				615A20D524D0562000D857A2 /* RUMErrorEvent.swift in Sources */,
 				61C2C20F24C196EB00C0321C /* RUMViewEvent.swift in Sources */,
 				61B9ED212462089600C0DCFF /* TracingIntegrationTests.swift in Sources */,
 				61494CB824C9D8810082C633 /* RUMResourceEvent.swift in Sources */,

--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -1140,12 +1140,34 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RXN-TV-L2P">
+                                <rect key="frame" x="107" y="466.5" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="0pi-Zc-4qA"/>
+                                    <constraint firstAttribute="height" constant="44" id="nZF-2g-e7f"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Download Resource">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="didTapDownloadResourceButton:" destination="aYv-rh-9k5" eventType="touchUpInside" id="1Jy-p6-hJJ"/>
+                                </connections>
+                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ruj-73-qLY">
-                                <rect key="frame" x="107" y="468.5" width="200" height="44"/>
+                                <rect key="frame" x="107" y="518.5" width="200" height="44"/>
                                 <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="Bmg-kT-Yxc"/>
-                                    <constraint firstAttribute="width" constant="200" id="sSM-Io-P5M"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="sSM-Io-P5M"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <state key="normal" title="Push Next Screen">
@@ -1165,8 +1187,10 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="ruj-73-qLY" firstAttribute="top" secondItem="TAP-cq-oB8" secondAttribute="bottom" constant="10" id="AJN-dM-oKe"/>
                             <constraint firstItem="TAP-cq-oB8" firstAttribute="centerY" secondItem="hqR-vc-dhH" secondAttribute="centerY" id="CWP-u7-YDL"/>
+                            <constraint firstItem="ruj-73-qLY" firstAttribute="top" secondItem="RXN-TV-L2P" secondAttribute="bottom" constant="8" id="HbZ-zt-scQ"/>
+                            <constraint firstItem="RXN-TV-L2P" firstAttribute="top" secondItem="TAP-cq-oB8" secondAttribute="bottom" constant="8" id="Hfx-A2-jgX"/>
+                            <constraint firstItem="RXN-TV-L2P" firstAttribute="centerX" secondItem="hqR-vc-dhH" secondAttribute="centerX" id="J8n-CE-UAu"/>
                             <constraint firstItem="ruj-73-qLY" firstAttribute="centerX" secondItem="hqR-vc-dhH" secondAttribute="centerX" id="xyn-52-QCf"/>
                             <constraint firstItem="TAP-cq-oB8" firstAttribute="centerX" secondItem="hqR-vc-dhH" secondAttribute="centerX" id="z26-0p-djn"/>
                         </constraints>
@@ -1200,7 +1224,7 @@
                                 <rect key="frame" x="107" y="468.5" width="200" height="44"/>
                                 <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="200" id="Lfu-z1-wSC"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Lfu-z1-wSC"/>
                                     <constraint firstAttribute="height" constant="44" id="zuJ-2f-nG1"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>

--- a/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
@@ -19,16 +19,31 @@ internal class SendRUMFixture1ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        rumMonitor.startView(viewController: self)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        rumMonitor.stopView(viewController: self)
+    }
+
+    @IBAction func didTapDownloadResourceButton(_ sender: Any) {
         let simulatedResourceName = "/resource/1"
         let simulatedResourceURL = URL(string: "https://foo.com/resource/1")!
+        let simulatedResourceLoadingTime: TimeInterval = 0.1
 
-        rumMonitor.startView(viewController: self)
+        rumMonitor.registerUserAction(
+            type: .tap,
+            attributes: ["button.label": (sender as! UIButton).currentTitle!]
+        )
+
         rumMonitor.startResourceLoading(
             resourceName: simulatedResourceName,
             request: URLRequest(url: simulatedResourceURL)
         )
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + simulatedResourceLoadingTime) {
             rumMonitor.stopResourceLoading(
                 resourceName: simulatedResourceName,
                 response: HTTPURLResponse(
@@ -42,11 +57,5 @@ internal class SendRUMFixture1ViewController: UIViewController {
             // Reveal the "Push Next Screen" button so UITest can continue
             self.pushNextScreenButton.isHidden = false
         }
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        rumMonitor.stopView(viewController: self)
     }
 }

--- a/Tests/DatadogIntegrationTests/RUMIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/RUMIntegrationTests.swift
@@ -25,6 +25,7 @@ class RUMIntegrationTests: IntegrationTests {
             mockSourceEndpointURL: server.obtainUniqueRecordingSession().recordingURL    // mock any 
         )
         let fixture1Screen = app.tapSendRUMEventsForUITests()
+        fixture1Screen.tapDownloadResourceButton()
         let fixture2Screen = fixture1Screen.tapPushNextScreen()
         fixture2Screen.tapPushNextScreen()
 
@@ -48,6 +49,7 @@ class RUMIntegrationTests: IntegrationTests {
         let rumEventsMatchers = try recordedRUMRequests
             .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
 
+        rumEventsMatchers.inspect()
         // Assert Fixture 1 VC ⬇️
 
         // ----> `application_start` Action due to initial startView()
@@ -76,32 +78,38 @@ class RUMIntegrationTests: IntegrationTests {
         XCTAssertEqual(view1UpdateB.view.action.count, 1)
         XCTAssertEqual(view1UpdateB.view.resource.count, 1)
 
+        // --------> Action event after tapping "Download Resource" (postponed until Resource finished loading)
+        let downloadResourceTap: RUMActionEvent = try rumEventsMatchers[4].model()
+        XCTAssertEqual(downloadResourceTap.view.id, view1UpdateA.view.id)
+        XCTAssertEqual(downloadResourceTap.action.type, "tap")
+        XCTAssertEqual(downloadResourceTap.action.resource?.count, 1)
+
         // ----> View update on stopView()
-        let view1UpdateC: RUMViewEvent = try rumEventsMatchers[4].model()
+        let view1UpdateC: RUMViewEvent = try rumEventsMatchers[5].model()
         XCTAssertEqual(view1UpdateC.view.id, view1UpdateA.view.id)
         XCTAssertEqual(view1UpdateC.dd.documentVersion, 3)
-        XCTAssertEqual(view1UpdateC.view.action.count, 1)
+        XCTAssertEqual(view1UpdateC.view.action.count, 2)
         XCTAssertEqual(view1UpdateC.view.resource.count, 1)
 
         // Assert Fixture 2 VC ⬇️
 
         // ----> View update on startView()
-        let view2UpdateA: RUMViewEvent = try rumEventsMatchers[5].model()
+        let view2UpdateA: RUMViewEvent = try rumEventsMatchers[6].model()
         XCTAssertEqual(view2UpdateA.dd.documentVersion, 1)
         XCTAssertEqual(view2UpdateA.view.action.count, 0)
 
         // ----> View update on stopView()
-        let view2UpdateB: RUMViewEvent = try rumEventsMatchers[6].model()
+        let view2UpdateB: RUMViewEvent = try rumEventsMatchers[7].model()
         XCTAssertEqual(view2UpdateB.dd.documentVersion, 2)
         XCTAssertEqual(view2UpdateB.view.action.count, 0)
 
         // Assert Fixture 3 VC ⬇️
 
         // ----> View update on startView()
-        let view3UpdateA: RUMViewEvent = try rumEventsMatchers[7].model()
+        let view3UpdateA: RUMViewEvent = try rumEventsMatchers[8].model()
         XCTAssertEqual(view3UpdateA.dd.documentVersion, 1)
         XCTAssertEqual(view3UpdateA.view.action.count, 0)
 
-        XCTAssertEqual(rumEventsMatchers.count, 8)
+        XCTAssertEqual(rumEventsMatchers.count, 9)
     }
 }

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -40,8 +40,12 @@ class ExampleApplication: XCUIApplication {
 }
 
 class RUMFixture1Screen: XCUIApplication {
+    func tapDownloadResourceButton() {
+        buttons["Download Resource"].tap()
+    }
+
     func tapPushNextScreen() -> RUMFixture2Screen {
-        buttons["Push Next Screen"].waitForExistence(timeout: 2)
+        _ = buttons["Push Next Screen"].waitForExistence(timeout: 2)
         buttons["Push Next Screen"].tap()
         return RUMFixture2Screen()
     }
@@ -50,5 +54,38 @@ class RUMFixture1Screen: XCUIApplication {
 class RUMFixture2Screen: XCUIApplication {
     func tapPushNextScreen() {
         buttons["Push Next Screen"].tap()
+    }
+}
+
+extension Array where Element == RUMEventMatcher {
+    /// Prints a list of generic `RUMEventMatchers` that should be used to assert elements from this array.
+    /// Handy for debugging `[RUMEventMatcher]` with `po rumEventsMatchers`.
+    ///
+    /// Example output:
+    ///
+    ///     [0] - RUMEventMatcher<RUMActionEvent>
+    ///     [1] - RUMEventMatcher<RUMViewEvent>
+    ///     [2] - RUMEventMatcher<RUMResourceEvent>
+    ///     [3] - RUMEventMatcher<RUMViewEvent>
+    ///     [4] - RUMEventMatcher<RUMActionEvent>
+    ///
+    func inspect() {
+        enumerated().forEach { index, matcher in
+            print("[\(index)] - \(getTypeOf(matcher: matcher))")
+        }
+    }
+
+    private func getTypeOf(matcher: RUMEventMatcher) -> String {
+        let allPossibleMatchers: [String: (RUMEventMatcher) -> Bool] = [
+            "RUMEventMatcher<RUMViewEvent>": { matcher in matcher.model(isTypeOf: RUMViewEvent.self) },
+            "RUMEventMatcher<RUMActionEvent>": { matcher in matcher.model(isTypeOf: RUMActionEvent.self) },
+            "RUMEventMatcher<RUMResourceEvent>": { matcher in matcher.model(isTypeOf: RUMResourceEvent.self) },
+            "RUMEventMatcher<RUMErrorEvent>": { matcher in matcher.model(isTypeOf: RUMErrorEvent.self) }
+        ]
+
+        let bestMatcherEntry = allPossibleMatchers
+            .first { _, matcherPredicate in matcherPredicate(matcher) }
+
+        return bestMatcherEntry?.key ?? "unkonwn / unimplemented"
     }
 }


### PR DESCRIPTION
### What and why?

🧪 This PR adds User Action scenario to RUM Integration tests fixtures.

### How?

When RUM Fixture 1 screen is opened, it shows only one button:

<img width="358" alt="Screenshot 2020-07-28 at 15 32 18" src="https://user-images.githubusercontent.com/2358722/88672309-9986ea00-d0e7-11ea-8adb-d1daea9a7720.png">

Tapping that button registers the "tap" User Action and simulates Resource loading which shows next button on completion:

<img width="357" alt="Screenshot 2020-07-28 at 15 32 27" src="https://user-images.githubusercontent.com/2358722/88672376-ac012380-d0e7-11ea-922e-c93260f2e497.png">

Then the UITest runner proceeds to the next screen.

I added an assertion for the new RUM Event sent (`RUMActionEvent`).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
