### PR TITLE
RUM-621 Fix `make ship` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ bump:
 
 ship:
 		pod spec lint DatadogSDK.podspec
-		pod spec lint DatadogSDKObjc.podspec
 		pod trunk push DatadogSDK.podspec
+		pod repo update
+		pod spec lint DatadogSDKObjc.podspec
 		pod trunk push DatadogSDKObjc.podspec


### PR DESCRIPTION
### What and why?

📦 This PR fixes the `make ship` command.

### How?

The Swift `.pospec` must be pushed to pod Specs repo before validating Objc `.podspec`.

### Review checklist

~- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)~
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
