### PR TITLE
RUMM-656 Shopist: Manual RUM events

### DIFF
--- a/Shopist/Shopist.xcodeproj/project.pbxproj
+++ b/Shopist/Shopist.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		9E5F903824DAF838004A0673 /* Cart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5F903724DAF838004A0673 /* Cart.swift */; };
 		9E5F903F24DAF85E004A0673 /* TableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5F903E24DAF85E004A0673 /* TableViewCells.swift */; };
-		9E6ABAD3244F43BD003AE249 /* ExampleAppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6ABACC244F43BC003AE249 /* ExampleAppConfig.swift */; };
+		9E6ABAD3244F43BD003AE249 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6ABACC244F43BC003AE249 /* AppConfig.swift */; };
 		9E6ABAD7244F43BD003AE249 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6ABAD1244F43BD003AE249 /* AppDelegate.swift */; };
 		9E6ABAD8244F43BD003AE249 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6ABAD2244F43BD003AE249 /* SceneDelegate.swift */; };
 		9E6ABAE1244F4450003AE249 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E6ABADF244F43E2003AE249 /* Assets.xcassets */; };
@@ -107,7 +107,7 @@
 /* Begin PBXFileReference section */
 		9E5F903724DAF838004A0673 /* Cart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cart.swift; sourceTree = "<group>"; };
 		9E5F903E24DAF85E004A0673 /* TableViewCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewCells.swift; sourceTree = "<group>"; };
-		9E6ABACC244F43BC003AE249 /* ExampleAppConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleAppConfig.swift; sourceTree = "<group>"; };
+		9E6ABACC244F43BC003AE249 /* AppConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		9E6ABAD1244F43BD003AE249 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9E6ABAD2244F43BD003AE249 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		9E6ABAD9244F43D4003AE249 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -235,7 +235,7 @@
 				9E92D45224D4651F005980A9 /* Shopist.xcconfig */,
 				9EE1E1C324D81AB700A7A613 /* Shopist.local.xcconfig */,
 				9E6ABAD1244F43BD003AE249 /* AppDelegate.swift */,
-				9E6ABACC244F43BC003AE249 /* ExampleAppConfig.swift */,
+				9E6ABACC244F43BC003AE249 /* AppConfig.swift */,
 				9E6ABAD2244F43BD003AE249 /* SceneDelegate.swift */,
 				9E84A04C24D31EB9007A91A2 /* Scenes */,
 				9E92D45024D463A5005980A9 /* Views */,
@@ -428,7 +428,7 @@
 				9E84A05224D32199007A91A2 /* CollectionViewCells.swift in Sources */,
 				9E6ABAD7244F43BD003AE249 /* AppDelegate.swift in Sources */,
 				9E5F903824DAF838004A0673 /* Cart.swift in Sources */,
-				9E6ABAD3244F43BD003AE249 /* ExampleAppConfig.swift in Sources */,
+				9E6ABAD3244F43BD003AE249 /* AppConfig.swift in Sources */,
 				9E5F903F24DAF85E004A0673 /* TableViewCells.swift in Sources */,
 				9E84A04E24D31EE9007A91A2 /* UIView+Autolayout.swift in Sources */,
 				9E92D44F24D4635C005980A9 /* ListViewController.swift in Sources */,

--- a/Shopist/Shopist/AppConfig.swift
+++ b/Shopist/Shopist/AppConfig.swift
@@ -6,11 +6,13 @@
 
 import Foundation
 
-struct ExampleAppConfig {
+struct AppConfig {
     /// Client token read from `Datadog.xcconfig`.
     let clientToken: String
     /// Service name used for logs and traces.
     let serviceName: String
+    /// RUM application identifier
+    let rumAppID: String
 
     init(serviceName: String) {
         guard let clientToken = Bundle.main.infoDictionary?["DatadogClientToken"] as? String, !clientToken.isEmpty else {
@@ -21,8 +23,17 @@ struct ExampleAppConfig {
             You might need to run `Product > Clean Build Folder` before retrying.
             """)
         }
+        guard let rumAppID = Bundle.main.infoDictionary?["RUMAppID"] as? String, !rumAppID.isEmpty else {
+            fatalError("""
+            ✋⛔️ Cannot read `RUM_APP_ID` from `Info.plist` dictionary.
+            Please update `Shopist.xcconfig` in the repository root with your own
+            RUM application identifier obtained on datadoghq.com.
+            You might need to run `Product > Clean Build Folder` before retrying.
+            """)
+        }
 
         self.clientToken = clientToken
         self.serviceName = serviceName
+        self.rumAppID = rumAppID
     }
 }

--- a/Shopist/Shopist/AppDelegate.swift
+++ b/Shopist/Shopist/AppDelegate.swift
@@ -9,7 +9,8 @@ import Datadog
 
 fileprivate(set) var logger: Logger!
 
-let appConfig = ExampleAppConfig(serviceName: "ios-sdk-shopist-app")
+let appConfig = AppConfig(serviceName: "ios-sdk-shopist-app")
+var rum: RUMMonitor?
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -53,6 +54,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Send some logs 🚀
         logger.info("application did finish launching")
+
+        rum = RUMMonitor.initialize(rumApplicationID: appConfig.rumAppID)
 
         return true
     }

--- a/Shopist/Shopist/Info.plist
+++ b/Shopist/Shopist/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>RUMAppID</key>
+	<string>$(RUM_APPLICATION_ID)</string>
 	<key>ShopistBaseURL</key>
 	<string>$(SHOPIST_BASE_URL)</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Shopist/Shopist/Scenes/CartViewController.swift
+++ b/Shopist/Shopist/Scenes/CartViewController.swift
@@ -61,7 +61,13 @@ final class CartViewController: UITableViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        rum?.startView(viewController: self)
         setupModels(from: cart)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        rum?.stopView(viewController: self)
     }
 
     func setupModels(from cart: Cart) {
@@ -81,6 +87,7 @@ final class CartViewController: UITableViewController {
     }
 
     @objc private func pay() {
+        rum?.registerUserAction(type: .tap, attributes: ["info": "button tap -> pay"])
         if let randomError = Self.randomError {
             self.handleError(randomError)
             return

--- a/Shopist/Shopist/Scenes/CategoriesViewController.swift
+++ b/Shopist/Shopist/Scenes/CategoriesViewController.swift
@@ -37,6 +37,7 @@ final class CategoriesViewController: ListViewController {
     }
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        rum?.registerUserAction(type: .tap, attributes: ["info": "cell tap -> products"])
         let selectedCategory = categories[indexPath.row]
         let detailVC = ProductsViewController(with: selectedCategory)
         show(detailVC, sender: self)

--- a/Shopist/Shopist/Scenes/ListViewController.swift
+++ b/Shopist/Shopist/Scenes/ListViewController.swift
@@ -25,7 +25,13 @@ class ListViewController: UICollectionViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        rum?.startView(viewController: self)
         fetch(with: api)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        rum?.stopView(viewController: self)
     }
 
     func fetch(with api: API) {

--- a/Shopist/Shopist/Scenes/ProductDetailViewController.swift
+++ b/Shopist/Shopist/Scenes/ProductDetailViewController.swift
@@ -30,6 +30,16 @@ class ProductDetailViewController: UIViewController {
         setupBarButtons()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        rum?.startView(viewController: self)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        rum?.stopView(viewController: self)
+    }
+
     private func setupBarButtons() {
         let cartActionButton: UIBarButtonItem
         if cart.products.contains(product) {

--- a/Shopist/Shopist/Scenes/ProductsViewController.swift
+++ b/Shopist/Shopist/Scenes/ProductsViewController.swift
@@ -49,6 +49,7 @@ final class ProductsViewController: ListViewController {
     }
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        rum?.registerUserAction(type: .tap, attributes: ["info": "cell tap -> product details"])
         let selectedProduct = items[indexPath.row]
         let detailVC = ProductDetailViewController(product: selectedProduct)
         show(detailVC, sender: self)

--- a/xcconfigs/Shopist.xcconfig
+++ b/xcconfigs/Shopist.xcconfig
@@ -1,4 +1,7 @@
 #include "Datadog.xcconfig"
 
+// TODO: RUMM-664 temporary value, otherwise test cases fail in CI
+RUM_APPLICATION_ID=12345 // use your own RUM Application ID obtained on datadoghq.com
+DATADOG_CLIENT_TOKEN= // use your own Client Token, generated for RUM_APPLICATION_ID
 SHOPIST_BASE_URL=some.url
 #include? "Shopist.local.xcconfig" // overrides SHOPIST_BASE_URL


### PR DESCRIPTION
### What and why?

Until auto-instrumentation for RUM arrives, we add manual instrumentation calls to a few places in Shopist app

### How?

1. View tracking:
  * `Categories`, `Products`, `ProductDetails` and `Cart` view controllers are tracked
2. Resources
  * `GET` requests made from `Categories` and `Products` are tracked
3. User Actions
  * Cell taps in `Categories` and `Products`, pay action in `Cart` are tracked

## Known Issues

During this task, we noticed that discrete user actions are not tracked properly due to their timeout requirement.
This PR should be merged after a fix 🔜 

I'll add visuals from RUM Explorer after the fix too

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
