### PR TITLE
RUMM-522 Add RUM with Tracing integration

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -125,7 +125,7 @@
 		6156CB9024DDA8BE008CB2B2 /* RUMCurrentContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156CB8F24DDA8BE008CB2B2 /* RUMCurrentContext.swift */; };
 		6156CB9324DDAA34008CB2B2 /* RUMCurrentContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156CB9224DDAA34008CB2B2 /* RUMCurrentContextTests.swift */; };
 		6156CB9824DEFD44008CB2B2 /* LoggingWithRUMIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156CB9724DEFD44008CB2B2 /* LoggingWithRUMIntegration.swift */; };
-		6156CB9A24E13D90008CB2B2 /* LoggingWithRUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156CB9924E13D90008CB2B2 /* LoggingWithRUMIntegrationTests.swift */; };
+		6156CB9D24E18600008CB2B2 /* TracingWithRUMIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156CB9B24E18224008CB2B2 /* TracingWithRUMIntegration.swift */; };
 		61570005246AADFA00E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
 		61570006246AAE5E00E96950 /* DatadogObjc.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61570007246AAED100E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
@@ -193,6 +193,8 @@
 		61C5A8A624509FAA00DA608C /* SpanEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A424509FAA00DA608C /* SpanEncoder.swift */; };
 		61C5A8A724509FAA00DA608C /* SpanBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A524509FAA00DA608C /* SpanBuilder.swift */; };
 		61D447E224917F8F00649287 /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D447E124917F8F00649287 /* DateFormatting.swift */; };
+		61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980B924E28D0100E03345 /* RUMIntegrations.swift */; };
+		61D980BC24E293F600E03345 /* RUMIntegrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */; };
 		61E45BCF2450A6EC00F2C652 /* TracingUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */; };
 		61E45BD22450F65B00F2C652 /* SpanBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BD12450F65B00F2C652 /* SpanBuilderTests.swift */; };
 		61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */; };
@@ -428,7 +430,7 @@
 		6156CB8F24DDA8BE008CB2B2 /* RUMCurrentContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCurrentContext.swift; sourceTree = "<group>"; };
 		6156CB9224DDAA34008CB2B2 /* RUMCurrentContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCurrentContextTests.swift; sourceTree = "<group>"; };
 		6156CB9724DEFD44008CB2B2 /* LoggingWithRUMIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingWithRUMIntegration.swift; sourceTree = "<group>"; };
-		6156CB9924E13D90008CB2B2 /* LoggingWithRUMIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingWithRUMIntegrationTests.swift; sourceTree = "<group>"; };
+		6156CB9B24E18224008CB2B2 /* TracingWithRUMIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingWithRUMIntegration.swift; sourceTree = "<group>"; };
 		615A4A8224A3431600233986 /* Tracer+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tracer+objc.swift"; sourceTree = "<group>"; };
 		615A4A8424A3445700233986 /* TracerConfiguration+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TracerConfiguration+objc.swift"; sourceTree = "<group>"; };
 		615A4A8624A3452800233986 /* DDTracerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerConfigurationTests.swift; sourceTree = "<group>"; };
@@ -493,6 +495,8 @@
 		61C5A8A424509FAA00DA608C /* SpanEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanEncoder.swift; sourceTree = "<group>"; };
 		61C5A8A524509FAA00DA608C /* SpanBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanBuilder.swift; sourceTree = "<group>"; };
 		61D447E124917F8F00649287 /* DateFormatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
+		61D980B924E28D0100E03345 /* RUMIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrations.swift; sourceTree = "<group>"; };
+		61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrationsTests.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDTests.swift; sourceTree = "<group>"; };
 		61E45BD12450F65B00F2C652 /* SpanBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanBuilderTests.swift; sourceTree = "<group>"; };
 		61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFileOutputTests.swift; sourceTree = "<group>"; };
@@ -1032,8 +1036,10 @@
 		61216277247D1F2100AC5D67 /* FeaturesIntegration */ = {
 			isa = PBXGroup;
 			children = (
+				61D980B924E28D0100E03345 /* RUMIntegrations.swift */,
 				61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */,
 				6156CB9724DEFD44008CB2B2 /* LoggingWithRUMIntegration.swift */,
+				6156CB9B24E18224008CB2B2 /* TracingWithRUMIntegration.swift */,
 			);
 			path = FeaturesIntegration;
 			sourceTree = "<group>";
@@ -1041,8 +1047,8 @@
 		61216278247D20D500AC5D67 /* FeaturesIntegration */ = {
 			isa = PBXGroup;
 			children = (
+				61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */,
 				61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */,
-				6156CB9924E13D90008CB2B2 /* LoggingWithRUMIntegrationTests.swift */,
 			);
 			path = FeaturesIntegration;
 			sourceTree = "<group>";
@@ -1919,6 +1925,7 @@
 				61FF282424B8A1C3000B3D9B /* RUMEventFileOutput.swift in Sources */,
 				61C5A88B24509A0C00DA608C /* SpanOutput.swift in Sources */,
 				61133BE42423979B00786299 /* LogEncoder.swift in Sources */,
+				61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */,
 				61C5A88424509A0C00DA608C /* DDSpan.swift in Sources */,
 				61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */,
 				E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */,
@@ -1935,6 +1942,7 @@
 				61C5A88524509A0C00DA608C /* DDNoOps.swift in Sources */,
 				61E5332C24B75C51003D6C4E /* RUMFeature.swift in Sources */,
 				61E5333D24B8791A003D6C4E /* RUMEventEncoder.swift in Sources */,
+				6156CB9D24E18600008CB2B2 /* TracingWithRUMIntegration.swift in Sources */,
 				61C5A88624509A0C00DA608C /* TracingUUIDGenerator.swift in Sources */,
 				61133BD92423979B00786299 /* DataUploadDelay.swift in Sources */,
 				61C5A88C24509A0C00DA608C /* HTTPHeadersWriter.swift in Sources */,
@@ -1962,6 +1970,7 @@
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
 				61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
+				61D980BC24E293F600E03345 /* RUMIntegrationsTests.swift in Sources */,
 				61363D9F24D99BAA0084CD6F /* DDErrorTests.swift in Sources */,
 				61133C622423990D00786299 /* InternalLoggersTests.swift in Sources */,
 				61FF283024BC5E2D000B3D9B /* RUMEventFileOutputTests.swift in Sources */,
@@ -2018,7 +2027,6 @@
 				61E5332F24B75DE2003D6C4E /* RUMFeatureTests.swift in Sources */,
 				E1D203FD24C1885C00D1AF3A /* ActiveSpansPoolTests.swift in Sources */,
 				61133C562423990D00786299 /* CarrierInfoProviderTests.swift in Sources */,
-				6156CB9A24E13D90008CB2B2 /* LoggingWithRUMIntegrationTests.swift in Sources */,
 				618DCFDF24C75FD300589570 /* RUMScopeTests.swift in Sources */,
 				61C5A89E24509C1100DA608C /* WarningsTests.swift in Sources */,
 				9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */,

--- a/Sources/Datadog/FeaturesIntegration/LoggingForTracingAdapter.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingForTracingAdapter.swift
@@ -28,7 +28,12 @@ internal struct LoggingForTracingAdapter {
                     networkConnectionInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.networkConnectionInfoProvider : nil,
                     carrierInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.carrierInfoProvider : nil
                 ),
-                fileWriter: loggingFeature.storage.writer
+                fileWriter: loggingFeature.storage.writer,
+
+                // The RUM Errors integration is not set for this instance of the `LogFileOutput`, as RUM Errors for
+                // spans are managed through more comprehensive `TracingWithRUMErrorsIntegration`.
+                // Having additional integration here would produce duplicated RUM Errors for span errors set through `span.log()` API.
+                rumErrorsIntegration: nil
             )
         )
     }

--- a/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
@@ -21,3 +21,12 @@ internal struct LoggingWithRUMContextIntegration {
         return attributes
     }
 }
+
+/// Sends given `Log` as RUM Errors.
+internal struct LoggingWithRUMErrorsIntegration {
+    private let rumErrorsIntegration = RUMErrorsIntegration()
+
+    func addError(for log: Log) {
+        rumErrorsIntegration.addError(with: log.message)
+    }
+}

--- a/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
@@ -34,7 +34,7 @@ internal struct RUMContextIntegration {
 /// Creates RUM Errors with given message.
 internal struct RUMErrorsIntegration {
     /// Adds RUM Error with given message to current RUM View.
-    func addError(with message: String) {
-        rumMonitor?.addViewError(message: message, source: .logger, attributes: nil, file: nil, line: nil)
+    func addError(with message: String, attributes: [AttributeKey: AttributeValue]? = nil) {
+        rumMonitor?.addViewError(message: message, source: .logger, attributes: attributes, file: nil, line: nil)
     }
 }

--- a/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Global `RUMMonitor` (if registered).
+private var rumMonitor: RUMMonitor? { RUMMonitor.shared }
+
+/// Integration providing the current RUM context attributes.
+internal struct RUMContextIntegration {
+    struct Attributes {
+        static let applicationID = "application_id"
+        static let sessionID = "session_id"
+        static let viewID = "view.id"
+    }
+
+    /// Returns attributes describing the current RUM context or `nil`if global `RUMMonitor` is not registered.
+    var currentRUMContextAttributes: [String: Encodable]? {
+        guard let rumContext = rumMonitor?.contextProvider.context else {
+            return nil
+        }
+
+        return [
+            Attributes.applicationID: rumContext.rumApplicationID,
+            Attributes.sessionID: rumContext.sessionID.rawValue.uuidString.lowercased(),
+            Attributes.viewID: rumContext.activeViewID?.rawValue.uuidString.lowercased(),
+        ]
+    }
+}
+
+/// Creates RUM Errors with given message.
+internal struct RUMErrorsIntegration {
+    /// Adds RUM Error with given message to current RUM View.
+    func addError(with message: String) {
+        rumMonitor?.addViewError(message: message, source: .logger, attributes: nil, file: nil, line: nil)
+    }
+}

--- a/Sources/Datadog/FeaturesIntegration/TracingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/TracingWithRUMIntegration.swift
@@ -6,15 +6,15 @@
 
 import Foundation
 
-/// Provides the current RUM context attributes for produced `Logs`.
-internal struct LoggingWithRUMContextIntegration {
+/// Provides the current RUM context tags for produced `Spans`.
+internal struct TracingWithRUMContextIntegration {
     private let rumContextIntegration = RUMContextIntegration()
 
-    /// Produces `Log` attributes describing the current RUM context.
+    /// Produces `Span` tags describing the current RUM context.
     /// Returns `nil` and prints warning if global `RUMMonitor` is not registered.
-    var currentRUMContextAttributes: [String: Encodable]? {
+    var currentRUMContextTags: [String: Encodable]? {
         guard let attributes = rumContextIntegration.currentRUMContextAttributes else {
-            userLogger.warn("No `RUMMonitor` is registered, so RUM integration with Logging will not work.")
+            userLogger.warn("No `RUMMonitor` is registered, so RUM integration with Tracing will not work.")
             return nil
         }
 

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -363,7 +363,8 @@ public class Logger {
                     combine: [
                         LogFileOutput(
                             logBuilder: logBuilder,
-                            fileWriter: loggingFeature.storage.writer
+                            fileWriter: loggingFeature.storage.writer,
+                            rumErrorsIntegration: LoggingWithRUMErrorsIntegration()
                         ),
                         LogConsoleOutput(
                             logBuilder: logBuilder,
@@ -375,7 +376,8 @@ public class Logger {
             case (true, nil):
                 return LogFileOutput(
                     logBuilder: logBuilder,
-                    fileWriter: loggingFeature.storage.writer
+                    fileWriter: loggingFeature.storage.writer,
+                    rumErrorsIntegration: LoggingWithRUMErrorsIntegration()
                 )
             case (false, let format?):
                 return LogConsoleOutput(

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -45,15 +45,12 @@ public class Logger {
     private let queue: DispatchQueue
     /// Integration with RUM Context. `nil` if disabled for this Logger.
     internal let rumContextIntegration: LoggingWithRUMContextIntegration?
-    /// Integration with RUM Errors. `nil` if not available for this Logger.
-    internal let rumErrorsIntegration: RUMErrorsIntegration?
 
     init(
         logOutput: LogOutput,
         dateProvider: DateProvider,
         identifier: String,
-        rumContextIntegration: LoggingWithRUMContextIntegration?,
-        rumErrorsIntegration: RUMErrorsIntegration?
+        rumContextIntegration: LoggingWithRUMContextIntegration?
     ) {
         self.logOutput = logOutput
         self.dateProvider = dateProvider
@@ -62,7 +59,6 @@ public class Logger {
             target: .global(qos: .userInteractive)
         )
         self.rumContextIntegration = rumContextIntegration
-        self.rumErrorsIntegration = rumErrorsIntegration
     }
 
     // MARK: - Logging
@@ -229,10 +225,6 @@ public class Logger {
             ),
             tags: tags
         )
-
-        if level.rawValue >= LogLevel.error.rawValue {
-            rumErrorsIntegration?.addError(with: message)
-        }
     }
 
     // MARK: - Logger.Builder
@@ -332,8 +324,7 @@ public class Logger {
                     logOutput: NoOpLogOutput(),
                     dateProvider: SystemDateProvider(),
                     identifier: "no-op",
-                    rumContextIntegration: nil,
-                    rumErrorsIntegration: nil
+                    rumContextIntegration: nil
                 )
             }
         }
@@ -351,8 +342,7 @@ public class Logger {
                 logOutput: resolveLogsOutput(for: loggingFeature),
                 dateProvider: loggingFeature.dateProvider,
                 identifier: resolveLoggerName(for: loggingFeature),
-                rumContextIntegration: bundleWithRUM ? LoggingWithRUMContextIntegration() : nil,
-                rumErrorsIntegration: RUMErrorsIntegration()
+                rumContextIntegration: bundleWithRUM ? LoggingWithRUMContextIntegration() : nil
             )
         }
 

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -46,14 +46,14 @@ public class Logger {
     /// Integration with RUM Context. `nil` if disabled for this Logger.
     internal let rumContextIntegration: LoggingWithRUMContextIntegration?
     /// Integration with RUM Errors. `nil` if not available for this Logger.
-    internal let rumErrorsIntegration: LoggingWithRUMErrorsIntegration?
+    internal let rumErrorsIntegration: RUMErrorsIntegration?
 
     init(
         logOutput: LogOutput,
         dateProvider: DateProvider,
         identifier: String,
         rumContextIntegration: LoggingWithRUMContextIntegration?,
-        rumErrorsIntegration: LoggingWithRUMErrorsIntegration?
+        rumErrorsIntegration: RUMErrorsIntegration?
     ) {
         self.logOutput = logOutput
         self.dateProvider = dateProvider
@@ -352,7 +352,7 @@ public class Logger {
                 dateProvider: loggingFeature.dateProvider,
                 identifier: resolveLoggerName(for: loggingFeature),
                 rumContextIntegration: bundleWithRUM ? LoggingWithRUMContextIntegration() : nil,
-                rumErrorsIntegration: LoggingWithRUMErrorsIntegration()
+                rumErrorsIntegration: RUMErrorsIntegration()
             )
         }
 

--- a/Sources/Datadog/Logging/Log/LogSanitizer.swift
+++ b/Sources/Datadog/Logging/Log/LogSanitizer.swift
@@ -16,9 +16,9 @@ internal struct LogSanitizer {
             OTLogFields.errorKind,
             LoggingForTracingAdapter.TracingAttributes.traceID,
             LoggingForTracingAdapter.TracingAttributes.spanID,
-            LoggingWithRUMContextIntegration.RUMLogAttributes.applicationID,
-            LoggingWithRUMContextIntegration.RUMLogAttributes.sessionID,
-            LoggingWithRUMContextIntegration.RUMLogAttributes.viewID,
+            RUMContextIntegration.Attributes.applicationID,
+            RUMContextIntegration.Attributes.sessionID,
+            RUMContextIntegration.Attributes.viewID,
         ]
         /// Maximum number of nested levels in attribute name. E.g. `person.address.street` has 3 levels.
         /// If attribute name exceeds this number, extra levels are escaped by using `_` character (`one.two.(...).nine.ten_eleven_twelve`).

--- a/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
@@ -11,14 +11,14 @@ internal struct LogFileOutput: LogOutput {
     let logBuilder: LogBuilder
     let fileWriter: FileWriter
     /// Integration with RUM Errors.
-    let rumErrorsIntegration = RUMErrorsIntegration()
+    let rumErrorsIntegration = LoggingWithRUMErrorsIntegration()
 
     func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) {
         let log = logBuilder.createLogWith(level: level, message: message, date: date, attributes: attributes, tags: tags)
         fileWriter.write(value: log)
 
         if level.rawValue >= LogLevel.error.rawValue {
-            rumErrorsIntegration.addError(with: message)
+            rumErrorsIntegration.addError(for: log)
         }
     }
 }

--- a/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
@@ -11,14 +11,14 @@ internal struct LogFileOutput: LogOutput {
     let logBuilder: LogBuilder
     let fileWriter: FileWriter
     /// Integration with RUM Errors.
-    let rumErrorsIntegration = LoggingWithRUMErrorsIntegration()
+    let rumErrorsIntegration: LoggingWithRUMErrorsIntegration?
 
     func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) {
         let log = logBuilder.createLogWith(level: level, message: message, date: date, attributes: attributes, tags: tags)
         fileWriter.write(value: log)
 
         if level.rawValue >= LogLevel.error.rawValue {
-            rumErrorsIntegration.addError(for: log)
+            rumErrorsIntegration?.addError(for: log)
         }
     }
 }

--- a/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
@@ -10,9 +10,15 @@ import Foundation
 internal struct LogFileOutput: LogOutput {
     let logBuilder: LogBuilder
     let fileWriter: FileWriter
+    /// Integration with RUM Errors.
+    let rumErrorsIntegration = RUMErrorsIntegration()
 
     func writeLogWith(level: LogLevel, message: String, date: Date, attributes: LogAttributes, tags: Set<String>) {
         let log = logBuilder.createLogWith(level: level, message: message, date: date, attributes: attributes, tags: tags)
         fileWriter.write(value: log)
+
+        if level.rawValue >= LogLevel.error.rawValue {
+            rumErrorsIntegration.addError(with: message)
+        }
     }
 }

--- a/Sources/Datadog/TracerConfiguration.swift
+++ b/Sources/Datadog/TracerConfiguration.swift
@@ -18,8 +18,14 @@ extension Tracer {
         /// - Parameter enabled: `false` by default
         public var sendNetworkInfo: Bool
 
-        /// Tags that will be added to all new spans created by the tracer.
+        /// Tags that will be added to all spans created by the tracer.
         public var globalTags: [String: Encodable]?
+
+        /// Enables the traces integration with RUM.
+        /// If enabled all the spans will be enriched with the current RUM View information and
+        /// it will be possible to see all the spans produced during a specific View lifespan in the RUM Explorer.
+        /// - Parameter enabled: `true` by default
+        public var bundleWithRUM: Bool
 
         /// Initializes the Datadog Tracer configuration.
         /// - Parameter serviceName: the service name that will appear in traces (if not provided or `nil`, the SDK default `serviceName` will be used).
@@ -27,10 +33,12 @@ extension Tracer {
         public init(
             serviceName: String? = nil,
             sendNetworkInfo: Bool = false,
+            bundleWithRUM: Bool = true,
             globalTags: [String: Encodable]? = nil
         ) {
             self.serviceName = serviceName
             self.sendNetworkInfo = sendNetworkInfo
+            self.bundleWithRUM = bundleWithRUM
             self.globalTags = globalTags
         }
     }

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -24,7 +24,7 @@ internal struct SpanBuilder {
     /// Encodes tag `Span` tag values as JSON string
     private let tagsJSONEncoder: JSONEncoder = .default()
 
-    func createSpan(from ddspan: DDSpan, finishTime: Date) throws -> Span {
+    func createSpan(from ddspan: DDSpan, finishTime: Date) -> Span {
         let tagsReducer = SpanTagsReducer(spanTags: ddspan.tags, logFields: ddspan.logFields)
 
         var jsonStringEncodedTags: [String: JSONStringEncodableValue] = [:]

--- a/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
+++ b/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
@@ -11,7 +11,7 @@ internal struct SpanFileOutput: SpanOutput {
     let spanBuilder: SpanBuilder
     let fileWriter: FileWriter
     /// Integration with RUM Errors.
-    let rumErrorsIntegration = RUMErrorsIntegration()
+    let rumErrorsIntegration = TracingWithRUMErrorsIntegration()
 
     func write(ddspan: DDSpan, finishTime: Date) {
         let span = spanBuilder.createSpan(from: ddspan, finishTime: finishTime)
@@ -19,7 +19,7 @@ internal struct SpanFileOutput: SpanOutput {
         fileWriter.write(value: envelope)
 
         if span.isError {
-            rumErrorsIntegration.addError(with: span.operationName)
+            rumErrorsIntegration.addError(for: ddspan)
         }
     }
 }

--- a/Sources/Datadog/Utils/InternalLoggers.swift
+++ b/Sources/Datadog/Utils/InternalLoggers.swift
@@ -62,8 +62,7 @@ internal func createSDKDeveloperLogger(
         logOutput: consoleOutput,
         dateProvider: dateProvider,
         identifier: "sdk-developer",
-        rumContextIntegration: nil,
-        rumErrorsIntegration: nil
+        rumContextIntegration: nil
     )
 }
 
@@ -72,8 +71,7 @@ internal func createNoOpSDKUserLogger() -> Logger {
         logOutput: NoOpLogOutput(),
         dateProvider: SystemDateProvider(),
         identifier: "no-op",
-        rumContextIntegration: nil,
-        rumErrorsIntegration: nil
+        rumContextIntegration: nil
     )
 }
 
@@ -104,7 +102,6 @@ internal func createSDKUserLogger(
         },
         dateProvider: dateProvider,
         identifier: "sdk-user",
-        rumContextIntegration: nil,
-        rumErrorsIntegration: nil
+        rumContextIntegration: nil
     )
 }

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -44,7 +44,6 @@ class LoggerBuilderTests: XCTestCase {
         let logger = Logger.builder.build()
 
         XCTAssertNotNil(logger.rumContextIntegration)
-        XCTAssertNotNil(logger.rumErrorsIntegration)
 
         guard let logBuilder = (logger.logOutput as? LogFileOutput)?.logBuilder else {
             XCTFail()
@@ -70,7 +69,6 @@ class LoggerBuilderTests: XCTestCase {
             .build()
 
         XCTAssertNil(logger.rumContextIntegration)
-        XCTAssertNotNil(logger.rumErrorsIntegration)
 
         guard let logBuilder = (logger.logOutput as? LogFileOutput)?.logBuilder else {
             XCTFail()

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -474,7 +474,6 @@ class LoggerTests: XCTestCase {
 
         // given
         let logger = Logger.builder.build()
-
         let monitor = RUMMonitor.initialize(rumApplicationID: "rum-123")
         monitor.startView(viewController: mockView)
 
@@ -546,13 +545,11 @@ class LoggerTests: XCTestCase {
         defer { RUMFeature.instance = nil }
 
         // given
+        let logger = Logger.builder.build()
         let monitor = RUMMonitor.initialize(rumApplicationID: "rum-123")
         monitor.startView(viewController: mockView)
 
-        let logger = Logger.builder.build()
-
         // when
-
         logger.debug("debug message")
         logger.info("info message")
         logger.notice("notice message")
@@ -567,9 +564,13 @@ class LoggerTests: XCTestCase {
         let rumErrorMatcher2 = rumEventMatchers.last { $0.model(isTypeOf: RUMError.self) }
         try XCTUnwrap(rumErrorMatcher1).model(ofType: RUMError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "error message")
+            XCTAssertEqual(rumModel.error.source, .logger)
+            XCTAssertNil(rumModel.error.stack)
         }
         try XCTUnwrap(rumErrorMatcher2).model(ofType: RUMError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "critical message")
+            XCTAssertEqual(rumModel.error.source, .logger)
+            XCTAssertNil(rumModel.error.stack)
         }
     }
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -460,7 +460,7 @@ class LoggerTests: XCTestCase {
 
     // MARK: - Integration With RUM Feature
 
-    func testGivenBundlingWithRUMEnabled_whenSendingLog_itContainsCurrentRUMContext() throws {
+    func testGivenBundlingWithRUMEnabledAndRUMMonitorRegistered_whenSendingLog_itContainsCurrentRUMContext() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWorkingFeatureWith(
             server: server,
@@ -473,28 +473,65 @@ class LoggerTests: XCTestCase {
         defer { RUMFeature.instance = nil }
 
         // given
-        let logger = Logger.builder
-            .bundleWithRUM(true)
-            .build()
+        let logger = Logger.builder.build()
 
-        // when
         let monitor = RUMMonitor.initialize(rumApplicationID: "rum-123")
         monitor.startView(viewController: mockView)
-        logger.info("info message 3")
+
+        // when
+        logger.info("info message")
 
         // then
-        let logMatchers = try server.waitAndReturnLogMatchers(count: 1)
-        logMatchers[0].assertValue(
-            forKeyPath: LoggingWithRUMContextIntegration.RUMLogAttributes.applicationID, equals: "rum-123"
+        let logMatcher = try server.waitAndReturnLogMatchers(count: 1)[0]
+        logMatcher.assertValue(
+            forKeyPath: RUMContextIntegration.Attributes.applicationID, equals: "rum-123"
         )
-        logMatchers[0].assertValue(
-            forKeyPath: LoggingWithRUMContextIntegration.RUMLogAttributes.sessionID,
+        logMatcher.assertValue(
+            forKeyPath: RUMContextIntegration.Attributes.sessionID,
             isTypeOf: String.self
         )
-        logMatchers[0].assertValue(
-            forKeyPath: LoggingWithRUMContextIntegration.RUMLogAttributes.viewID,
+        logMatcher.assertValue(
+            forKeyPath: RUMContextIntegration.Attributes.viewID,
             isTypeOf: String.self
         )
+    }
+
+    func testGivenBundlingWithRUMEnabledButRUMMonitorNotRegistered_whenSendingLog_itPrintsWarning() throws {
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        LoggingFeature.instance = .mockWorkingFeatureWith(
+            server: server,
+            directory: temporaryDirectory,
+            configuration: .mockWith(environment: "tests")
+        )
+        defer { LoggingFeature.instance = nil }
+
+        RUMFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        defer { RUMFeature.instance = nil }
+
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
+
+        let output = LogOutputMock()
+        userLogger = .mockWith(logOutput: output)
+
+        // given
+        let logger = Logger.builder.build()
+        XCTAssertNil(RUMMonitor.shared)
+
+        // when
+        logger.info("info message")
+
+        // then
+        XCTAssertEqual(output.recordedLog?.level, .warn)
+        try XCTAssertTrue(
+            XCTUnwrap(output.recordedLog?.message)
+                .contains("No `RUMMonitor` is registered, so RUM integration with Logging will not work.")
+        )
+
+        let logMatcher = try server.waitAndReturnLogMatchers(count: 1)[0]
+        logMatcher.assertNoValue(forKeyPath: RUMContextIntegration.Attributes.applicationID)
+        logMatcher.assertNoValue(forKeyPath: RUMContextIntegration.Attributes.sessionID)
+        logMatcher.assertNoValue(forKeyPath: RUMContextIntegration.Attributes.viewID)
     }
 
     func testWhenSendingErrorOrCriticalLogs_itCreatesRUMErrorForCurrentView() throws {

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
@@ -34,7 +34,8 @@ class LogFileOutputTests: XCTestCase {
                     dateProvider: fileCreationDateProvider
                 ),
                 queue: queue
-            )
+            ),
+            rumErrorsIntegration: nil
         )
 
         output.writeLogWith(level: .info, message: "log message 1", date: .mockAny(), attributes: .mockAny(), tags: [])

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -121,7 +121,7 @@ extension Logger {
         dateProvider: DateProvider = SystemDateProvider(),
         identifier: String = .mockAny(),
         rumContextIntegration: LoggingWithRUMContextIntegration? = nil,
-        rumErrorsIntegration: LoggingWithRUMErrorsIntegration? = nil
+        rumErrorsIntegration: RUMErrorsIntegration? = nil
     ) -> Logger {
         return Logger(
             logOutput: logOutput,

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -120,15 +120,13 @@ extension Logger {
         logOutput: LogOutput = LogOutputMock(),
         dateProvider: DateProvider = SystemDateProvider(),
         identifier: String = .mockAny(),
-        rumContextIntegration: LoggingWithRUMContextIntegration? = nil,
-        rumErrorsIntegration: RUMErrorsIntegration? = nil
+        rumContextIntegration: LoggingWithRUMContextIntegration? = nil
     ) -> Logger {
         return Logger(
             logOutput: logOutput,
             dateProvider: dateProvider,
             identifier: identifier,
-            rumContextIntegration: rumContextIntegration,
-            rumErrorsIntegration: rumErrorsIntegration
+            rumContextIntegration: rumContextIntegration
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -168,14 +168,16 @@ extension Tracer {
         logOutput: LoggingForTracingAdapter.AdaptedLogOutput = .init(loggingOutput: LogOutputMock()),
         dateProvider: DateProvider = SystemDateProvider(),
         tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator(),
-        globalTags: [String: Encodable]? = nil
+        globalTags: [String: Encodable]? = nil,
+        rumContextIntegration: TracingWithRUMContextIntegration? = nil
     ) -> Tracer {
         return Tracer(
             spanOutput: spanOutput,
             logOutput: logOutput,
             dateProvider: dateProvider,
             tracingUUIDGenerator: tracingUUIDGenerator,
-            globalTags: globalTags
+            globalTags: globalTags,
+            rumContextIntegration: rumContextIntegration
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -45,6 +45,8 @@ class TracerConfigurationTests: XCTestCase {
             configuration: .init()
         ).dd
 
+        XCTAssertNotNil(tracer.rumContextIntegration)
+
         guard let spanBuilder = (tracer.spanOutput as? SpanFileOutput)?.spanBuilder else {
             XCTFail()
             return
@@ -76,9 +78,12 @@ class TracerConfigurationTests: XCTestCase {
         let tracer = Tracer.initialize(
             configuration: .init(
                 serviceName: "custom-service-name",
-                sendNetworkInfo: true
+                sendNetworkInfo: true,
+                bundleWithRUM: false
             )
         ).dd
+
+        XCTAssertNil(tracer.rumContextIntegration)
 
         guard let spanBuilder = (tracer.spanOutput as? SpanFileOutput)?.spanBuilder else {
             XCTFail()

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanBuilderTests.swift
@@ -17,7 +17,7 @@ class SpanBuilderTests: XCTestCase {
             startTime: .mockDecember15th2019At10AMUTC(),
             tags: ["foo": "bar", "bizz": 123]
         )
-        let span = try builder.createSpan(from: ddspan, finishTime: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5))
+        let span = builder.createSpan(from: ddspan, finishTime: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5))
 
         XCTAssertEqual(span.traceID, 1)
         XCTAssertEqual(span.spanID, 2)
@@ -37,7 +37,7 @@ class SpanBuilderTests: XCTestCase {
 
         // given
         var ddspan: DDSpan = .mockWith(tags: [OTTags.error: true])
-        var span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+        var span = builder.createSpan(from: ddspan, finishTime: .mockAny())
 
         // then
         XCTAssertTrue(span.isError)
@@ -45,7 +45,7 @@ class SpanBuilderTests: XCTestCase {
 
         // given
         ddspan = .mockWith(tags: [OTTags.error: false])
-        span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+        span = builder.createSpan(from: ddspan, finishTime: .mockAny())
 
         // then
         XCTAssertFalse(span.isError)
@@ -58,7 +58,7 @@ class SpanBuilderTests: XCTestCase {
         // given
         var ddspan: DDSpan = .mockWith(tags: [:])
         ddspan.log(fields: [OTLogFields.errorKind: "Swift error"])
-        var span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+        var span = builder.createSpan(from: ddspan, finishTime: .mockAny())
 
         // then
         XCTAssertTrue(span.isError)
@@ -74,7 +74,7 @@ class SpanBuilderTests: XCTestCase {
                 OTLogFields.stack: "Foo.swift:42",
             ]
         )
-        span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+        span = builder.createSpan(from: ddspan, finishTime: .mockAny())
 
         // then
         XCTAssertTrue(span.isError)
@@ -92,7 +92,7 @@ class SpanBuilderTests: XCTestCase {
         ddspan.log(fields: ["foo": "bar"]) // ignored
         ddspan.log(fields: [OTLogFields.errorKind: "Swift error 1"]) // captured
         ddspan.log(fields: [OTLogFields.errorKind: "Swift error 2"]) // ignored
-        span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+        span = builder.createSpan(from: ddspan, finishTime: .mockAny())
 
         // then
         XCTAssertTrue(span.isError)
@@ -105,7 +105,7 @@ class SpanBuilderTests: XCTestCase {
         // given
         var ddspan: DDSpan = .mockWith(tags: ["error": true])
         ddspan.log(fields: [OTLogFields.event: "error"])
-        var span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+        var span = builder.createSpan(from: ddspan, finishTime: .mockAny())
 
         // then
         XCTAssertTrue(span.isError)
@@ -113,7 +113,7 @@ class SpanBuilderTests: XCTestCase {
         // given
         ddspan = .mockWith(tags: ["error": false])
         ddspan.log(fields: [OTLogFields.event: "error"])
-        span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+        span = builder.createSpan(from: ddspan, finishTime: .mockAny())
 
         // then
         XCTAssertTrue(span.isError)
@@ -124,7 +124,7 @@ class SpanBuilderTests: XCTestCase {
 
         // given
         let ddspan: DDSpan = .mockWith(tags: [DDTags.resource: "custom resource name"])
-        let span = try builder.createSpan(from: ddspan, finishTime: .mockAny())
+        let span = builder.createSpan(from: ddspan, finishTime: .mockAny())
 
         // then
         XCTAssertEqual(span.resource, "custom resource name")


### PR DESCRIPTION
### What and why?

🚚  This PR Adds RUM with Tracing integration, so users can see in RUM Explorer which spans were produced while given View was being displayed:

<img width="785" alt="Screenshot 2020-08-11 at 18 28 45" src="https://user-images.githubusercontent.com/2358722/89923577-172b1980-dc01-11ea-88f7-22d3bedb6923.png">

Also, when `Span` is marked as error, the RUM Error is produced and added to the active RUM View. This can happen in two ways:

1/ Setting `Span` as error:
```swift
let span = tracer.startSpan(operationName: "Span with error log")
span.setTag(key: OTTags.error, value: true)
span.finish()
```
<img width="684" alt="1" src="https://user-images.githubusercontent.com/2358722/89924805-cfa58d00-dc02-11ea-916b-aa114932dcaf.png">

2/ Logging an error from `Span` (through existing Tracing with Logging integration):
```swift
let span = tracer.startSpan(operationName: "Span with error")
span.log(
    fields: [
        OTLogFields.event: "error",
        OTLogFields.errorKind: "Swift error",
        OTLogFields.message: "error message",
        OTLogFields.stack: "Foo.swift:123"
    ]
)
span.finish()
```
<img width="761" alt="2a" src="https://user-images.githubusercontent.com/2358722/89924888-ed72f200-dc02-11ea-87c9-88611f863e32.png">

In the second case, Open Tracing attributes are digested and set as the custom attributes on the RUM Error:

<img width="600" alt="2b" src="https://user-images.githubusercontent.com/2358722/89924939-ff549500-dc02-11ea-8609-98ff3889a660.png">


### How?

Both, "Logging with RUM" and "Tracing with RUM" integrations are similar at glance but different in details, so I decided to decouple it into agnostic and specific components:

* feature-agnostic integrations:
   * `RUMContextIntegration` - provides the current RUM context,
   * `RUMErrorsIntegration` - adds error to the active RUM View,

* feature-specific integrations:
   * `LoggingWithRUMContextIntegration` - adapts the `RUMContextIntegration` for Logging,
   * `LoggingWithRUMErrorsIntegration` - adapts the `RUMErrorsIntegration` for Logging,
   * `TracingWithRUMContextIntegration` - adapts the `RUMContextIntegration` for Tracing,
   * `TracingWithRUMErrorsIntegration` - adapts the `RUMErrorsIntegration` for Tracing.

4 new behaviours were added to the Tracing feature:
* given `bundleWithError: true` and `RUMMonitor` initialized, when sending a `Span`, the `RUMContext` is injected,
* given `bundleWithError: true` and `RUMMonitor` not initialized, when sending a `Span`, a warning is printed,
* when sending `Span` with error, a corresponding RUM Error is created,
* when logging error from a `Span`, a corresponding RUM Error is created.

All 4 are translated into test scenarios in `TracerTests`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
