### PR TITLE
RUMM-535 Fix tests flakiness and performance

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		61494CB124C839460082C633 /* RUMResourceScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB024C839460082C633 /* RUMResourceScope.swift */; };
 		61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB424C864680082C633 /* RUMResourceScopeTests.swift */; };
 		61494CBA24CB126F0082C633 /* RUMUserActionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB924CB126F0082C633 /* RUMUserActionScope.swift */; };
+		614D812C24E3EA15004C9C5D /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614D812B24E3EA15004C9C5D /* Feature.swift */; };
 		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		6152C83E24BE1C91006A1679 /* HTTPServerMock in Frameworks */ = {isa = PBXBuildFile; productRef = 6152C83D24BE1C91006A1679 /* HTTPServerMock */; };
 		6152C84024BE1CC8006A1679 /* DataUploaderBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6152C83F24BE1CC8006A1679 /* DataUploaderBenchmarkTests.swift */; };
@@ -420,6 +421,7 @@
 		61494CB024C839460082C633 /* RUMResourceScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceScope.swift; sourceTree = "<group>"; };
 		61494CB424C864680082C633 /* RUMResourceScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceScopeTests.swift; sourceTree = "<group>"; };
 		61494CB924CB126F0082C633 /* RUMUserActionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScope.swift; sourceTree = "<group>"; };
+		614D812B24E3EA15004C9C5D /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		614E9EB2244719FA007EE3E1 /* BundleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleType.swift; sourceTree = "<group>"; };
 		6152C83F24BE1CC8006A1679 /* DataUploaderBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUploaderBenchmarkTests.swift; sourceTree = "<group>"; };
 		6152C84124BE1F47006A1679 /* DatadogBenchmarkTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogBenchmarkTests.xcconfig; sourceTree = "<group>"; };
@@ -678,6 +680,7 @@
 		61133B9E2423979B00786299 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				614D812B24E3EA15004C9C5D /* Feature.swift */,
 				614E9EB2244719FA007EE3E1 /* BundleType.swift */,
 				61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */,
 				9E5D2D4A249137E900763FE4 /* AutoInstrumentation */,
@@ -1891,6 +1894,7 @@
 				9EFD112C24B32D29003A1A2B /* URLFilter.swift in Sources */,
 				61C5A88924509A0C00DA608C /* DDSpanContext.swift in Sources */,
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
+				614D812C24E3EA15004C9C5D /* Feature.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
 				618DCFD724C7265300589570 /* RUMUUID.swift in Sources */,
 				9E544A4F24753C6E00E83072 /* MethodSwizzler.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		61C5A8A624509FAA00DA608C /* SpanEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A424509FAA00DA608C /* SpanEncoder.swift */; };
 		61C5A8A724509FAA00DA608C /* SpanBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A524509FAA00DA608C /* SpanBuilder.swift */; };
 		61D447E224917F8F00649287 /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D447E124917F8F00649287 /* DateFormatting.swift */; };
+		61D6FF7924E42A2900D0E375 /* DataUploadWorkerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D6FF7824E42A2900D0E375 /* DataUploadWorkerMock.swift */; };
 		61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980B924E28D0100E03345 /* RUMIntegrations.swift */; };
 		61D980BC24E293F600E03345 /* RUMIntegrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */; };
 		61E45BCF2450A6EC00F2C652 /* TracingUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */; };
@@ -497,6 +498,7 @@
 		61C5A8A424509FAA00DA608C /* SpanEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanEncoder.swift; sourceTree = "<group>"; };
 		61C5A8A524509FAA00DA608C /* SpanBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanBuilder.swift; sourceTree = "<group>"; };
 		61D447E124917F8F00649287 /* DateFormatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
+		61D6FF7824E42A2900D0E375 /* DataUploadWorkerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUploadWorkerMock.swift; sourceTree = "<group>"; };
 		61D980B924E28D0100E03345 /* RUMIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrations.swift; sourceTree = "<group>"; };
 		61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrationsTests.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDTests.swift; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 			isa = PBXGroup;
 			children = (
 				61C3646F243B5C8300C4D4E6 /* ServerMock.swift */,
+				61D6FF7824E42A2900D0E375 /* DataUploadWorkerMock.swift */,
 				61F1A6192498A51700075390 /* CoreMocks.swift */,
 				61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */,
 				61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */,
@@ -1999,6 +2002,7 @@
 				61133C602423990D00786299 /* HTTPHeadersTests.swift in Sources */,
 				61133C572423990D00786299 /* FileReaderTests.swift in Sources */,
 				61133C5F2423990D00786299 /* DataUploaderTests.swift in Sources */,
+				61D6FF7924E42A2900D0E375 /* DataUploadWorkerMock.swift in Sources */,
 				61133C612423990D00786299 /* HTTPClientTests.swift in Sources */,
 				61133C6A2423990D00786299 /* DatadogTests.swift in Sources */,
 				61133C5E2423990D00786299 /* LogsUploadDelayTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		61C5A8A724509FAA00DA608C /* SpanBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A524509FAA00DA608C /* SpanBuilder.swift */; };
 		61D447E224917F8F00649287 /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D447E124917F8F00649287 /* DateFormatting.swift */; };
 		61D6FF7924E42A2900D0E375 /* DataUploadWorkerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D6FF7824E42A2900D0E375 /* DataUploadWorkerMock.swift */; };
+		61D6FF7E24E53D3B00D0E375 /* BenchmarkMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D6FF7D24E53D3B00D0E375 /* BenchmarkMocks.swift */; };
 		61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980B924E28D0100E03345 /* RUMIntegrations.swift */; };
 		61D980BC24E293F600E03345 /* RUMIntegrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */; };
 		61E45BCF2450A6EC00F2C652 /* TracingUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */; };
@@ -499,6 +500,7 @@
 		61C5A8A524509FAA00DA608C /* SpanBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanBuilder.swift; sourceTree = "<group>"; };
 		61D447E124917F8F00649287 /* DateFormatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
 		61D6FF7824E42A2900D0E375 /* DataUploadWorkerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUploadWorkerMock.swift; sourceTree = "<group>"; };
+		61D6FF7D24E53D3B00D0E375 /* BenchmarkMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkMocks.swift; sourceTree = "<group>"; };
 		61D980B924E28D0100E03345 /* RUMIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrations.swift; sourceTree = "<group>"; };
 		61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrationsTests.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDTests.swift; sourceTree = "<group>"; };
@@ -1138,6 +1140,7 @@
 		61441C772461A204003D8BB8 /* DatadogBenchmarkTests */ = {
 			isa = PBXGroup;
 			children = (
+				61D6FF7D24E53D3B00D0E375 /* BenchmarkMocks.swift */,
 				6152C83F24BE1CC8006A1679 /* DataUploaderBenchmarkTests.swift */,
 				61441C782461A204003D8BB8 /* LoggingBenchmarkTests.swift */,
 				61441C792461A204003D8BB8 /* LoggingStorageBenchmarkTests.swift */,
@@ -2126,6 +2129,7 @@
 				E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */,
 				E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */,
 				61441C7C2461A244003D8BB8 /* TestsDirectory.swift in Sources */,
+				61D6FF7E24E53D3B00D0E375 /* BenchmarkMocks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -1,0 +1,97 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Container with dependencies common to all features (Logging, Tracing and RUM).
+internal struct FeaturesCommonDependencies {
+    let configuration: Datadog.ValidConfiguration
+    let performance: PerformancePreset
+    let httpClient: HTTPClient
+    let mobileDevice: MobileDevice
+    let dateProvider: DateProvider
+    let userInfoProvider: UserInfoProvider
+    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
+    let carrierInfoProvider: CarrierInfoProviderType
+}
+
+internal struct FeatureStorage {
+    /// Writes spans to files.
+    let writer: FileWriterType
+    /// Reads spans from files.
+    let reader: FileReaderType
+
+    init(
+        featureName: String,
+        dataFormat: DataFormat,
+        directory: Directory,
+        commonDependencies: FeaturesCommonDependencies
+    ) {
+        let readWriteQueue = DispatchQueue(
+            label: "com.datadoghq.ios-sdk-\(featureName)-read-write",
+            target: .global(qos: .utility)
+        )
+        let orchestrator = FilesOrchestrator(
+            directory: directory,
+            performance: commonDependencies.performance,
+            dateProvider: commonDependencies.dateProvider
+        )
+
+        self.init(
+            writer: FileWriter(dataFormat: dataFormat, orchestrator: orchestrator, queue: readWriteQueue),
+            reader: FileReader(dataFormat: dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
+        )
+    }
+
+    init(writer: FileWriterType, reader: FileReaderType) {
+        self.writer = writer
+        self.reader = reader
+    }
+}
+
+internal struct FeatureUpload {
+    /// Uploads spans to server.
+    let uploader: DataUploadWorkerType
+
+    init(
+        featureName: String,
+        storage: FeatureStorage,
+        uploadHTTPHeaders: HTTPHeaders,
+        uploadURLProvider: UploadURLProvider,
+        commonDependencies: FeaturesCommonDependencies
+    ) {
+        let uploadQueue = DispatchQueue(
+            label: "com.datadoghq.ios-sdk-\(featureName)-upload",
+            target: .global(qos: .utility)
+        )
+
+        let uploadConditions = DataUploadConditions(
+            batteryStatus: BatteryStatusProvider(mobileDevice: commonDependencies.mobileDevice),
+            networkConnectionInfo: commonDependencies.networkConnectionInfoProvider
+        )
+
+        let dataUploader = DataUploader(
+            urlProvider: uploadURLProvider,
+            httpClient: commonDependencies.httpClient,
+            httpHeaders: uploadHTTPHeaders
+        )
+
+        self.init(
+            uploader: DataUploadWorker(
+                queue: uploadQueue,
+                fileReader: storage.reader,
+                dataUploader: dataUploader,
+                uploadConditions: uploadConditions,
+                delay: DataUploadDelay(performance: commonDependencies.performance),
+                featureName: featureName
+            )
+        )
+    }
+
+    init(uploader: DataUploadWorkerType) {
+        self.uploader = uploader
+    }
+}

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -19,9 +19,9 @@ internal struct FeaturesCommonDependencies {
 }
 
 internal struct FeatureStorage {
-    /// Writes spans to files.
+    /// Writes data to files.
     let writer: FileWriterType
-    /// Reads spans from files.
+    /// Reads data from files.
     let reader: FileReaderType
 
     init(
@@ -53,7 +53,7 @@ internal struct FeatureStorage {
 }
 
 internal struct FeatureUpload {
-    /// Uploads spans to server.
+    /// Uploads data to server.
     let uploader: DataUploadWorkerType
 
     init(

--- a/Sources/Datadog/Core/Persistence/FileReader.swift
+++ b/Sources/Datadog/Core/Persistence/FileReader.swift
@@ -13,7 +13,13 @@ internal struct Batch {
     fileprivate let file: ReadableFile
 }
 
-internal final class FileReader {
+/// Abstracts the `FileReader`, so we can have no-op reader in tests.
+internal protocol FileReaderType {
+    func readNextBatch() -> Batch?
+    func markBatchAsRead(_ batch: Batch)
+}
+
+internal final class FileReader: FileReaderType {
     /// Data reading format.
     private let dataFormat: DataFormat
     /// Orchestrator producing reference to readable file.

--- a/Sources/Datadog/Core/Persistence/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/FileWriter.swift
@@ -6,7 +6,12 @@
 
 import Foundation
 
-internal final class FileWriter {
+/// Abstracts the `FileWriter`, so we can have no-op writer in tests.
+internal protocol FileWriterType {
+    func write<T: Encodable>(value: T)
+}
+
+internal final class FileWriter: FileWriterType {
     /// Data writting format.
     private let dataFormat: DataFormat
     /// Orchestrator producing reference to writable file.

--- a/Sources/Datadog/Core/Persistence/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/FileWriter.swift
@@ -19,7 +19,7 @@ internal final class FileWriter: FileWriterType {
     /// JSON encoder used to encode data.
     private let jsonEncoder: JSONEncoder
     /// Queue used to synchronize files access (read / write) and perform decoding on background thread.
-    private let queue: DispatchQueue
+    internal let queue: DispatchQueue
 
     init(dataFormat: DataFormat, orchestrator: FilesOrchestrator, queue: DispatchQueue) {
         self.dataFormat = dataFormat

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -6,11 +6,14 @@
 
 import Foundation
 
-internal class DataUploadWorker {
+/// Abstracts the `DataUploadWorker`, so we can have no-op uploader in tests.
+internal protocol DataUploadWorkerType {}
+
+internal class DataUploadWorker: DataUploadWorkerType {
     /// Queue to execute uploads.
     private let queue: DispatchQueue
     /// File reader providing data to upload.
-    private let fileReader: FileReader
+    private let fileReader: FileReaderType
     /// Data uploader sending data to server.
     private let dataUploader: DataUploader
     /// Variable system conditions determining if upload should be performed.
@@ -28,7 +31,7 @@ internal class DataUploadWorker {
 
     init(
         queue: DispatchQueue,
-        fileReader: FileReader,
+        fileReader: FileReaderType,
         dataUploader: DataUploader,
         uploadConditions: DataUploadConditions,
         delay: DataUploadDelay,

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -103,54 +103,41 @@ public class Datadog {
 
         // Then, initialize features:
 
-        let httpClient = HTTPClient()
-        let mobileDevice = MobileDevice.current
-
         var logging: LoggingFeature?
         var tracing: TracingFeature?
         var rum: RUMFeature?
 
+        let commonDependencies = FeaturesCommonDependencies(
+            configuration: validConfiguration,
+            performance: performance,
+            httpClient: HTTPClient(),
+            mobileDevice: MobileDevice.current,
+            dateProvider: dateProvider,
+            userInfoProvider: userInfoProvider,
+            networkConnectionInfoProvider: networkConnectionInfoProvider,
+            carrierInfoProvider: carrierInfoProvider
+        )
+
         if configuration.loggingEnabled {
             logging = LoggingFeature(
                 directory: try obtainLoggingFeatureDirectory(),
-                configuration: validConfiguration,
-                performance: performance,
-                mobileDevice: mobileDevice,
-                httpClient: httpClient,
-                dateProvider: dateProvider,
-                userInfoProvider: userInfoProvider,
-                networkConnectionInfoProvider: networkConnectionInfoProvider,
-                carrierInfoProvider: carrierInfoProvider
+                commonDependencies: commonDependencies
             )
         }
 
         if configuration.tracingEnabled {
             tracing = TracingFeature(
                 directory: try obtainTracingFeatureDirectory(),
-                configuration: validConfiguration,
-                performance: performance,
+                commonDependencies: commonDependencies,
                 loggingFeatureAdapter: logging.flatMap { LoggingForTracingAdapter(loggingFeature: $0) },
-                mobileDevice: mobileDevice,
-                httpClient: httpClient,
-                dateProvider: dateProvider,
-                tracingUUIDGenerator: DefaultTracingUUIDGenerator(),
-                userInfoProvider: userInfoProvider,
-                networkConnectionInfoProvider: networkConnectionInfoProvider,
-                carrierInfoProvider: carrierInfoProvider
+                tracingUUIDGenerator: DefaultTracingUUIDGenerator()
             )
         }
 
         if configuration.rumEnabled {
             rum = RUMFeature(
                 directory: try obtainRUMFeatureDirectory(),
-                configuration: validConfiguration,
-                performance: performance,
-                mobileDevice: mobileDevice,
-                httpClient: httpClient,
-                dateProvider: dateProvider,
-                userInfoProvider: userInfoProvider,
-                networkConnectionInfoProvider: networkConnectionInfoProvider,
-                carrierInfoProvider: carrierInfoProvider
+                commonDependencies: commonDependencies
             )
         }
 

--- a/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
@@ -9,7 +9,7 @@ import Foundation
 /// `LogOutput` which saves logs to file.
 internal struct LogFileOutput: LogOutput {
     let logBuilder: LogBuilder
-    let fileWriter: FileWriter
+    let fileWriter: FileWriterType
     /// Integration with RUM Errors.
     let rumErrorsIntegration: LoggingWithRUMErrorsIntegration?
 

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -41,17 +41,17 @@ internal final class LoggingFeature {
 
     // MARK: - Initialization
 
-    convenience init(
-        directory: Directory,
-        commonDependencies: FeaturesCommonDependencies
-    ) {
-        let storage = FeatureStorage(
+    static func createStorage(directory: Directory, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
+        return FeatureStorage(
             featureName: LoggingFeature.featureName,
             dataFormat: LoggingFeature.dataFormat,
             directory: directory,
             commonDependencies: commonDependencies
         )
-        let upload = FeatureUpload(
+    }
+
+    static func createUpload(storage: FeatureStorage, directory: Directory, commonDependencies: FeaturesCommonDependencies) -> FeatureUpload {
+        return FeatureUpload(
             featureName: LoggingFeature.featureName,
             storage: storage,
             uploadHTTPHeaders: HTTPHeaders(
@@ -73,6 +73,14 @@ internal final class LoggingFeature {
             ),
             commonDependencies: commonDependencies
         )
+    }
+
+    convenience init(
+        directory: Directory,
+        commonDependencies: FeaturesCommonDependencies
+    ) {
+        let storage = LoggingFeature.createStorage(directory: directory, commonDependencies: commonDependencies)
+        let upload = LoggingFeature.createUpload(storage: storage, directory: directory, commonDependencies: commonDependencies)
         self.init(
             storage: storage,
             upload: upload,

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -30,138 +30,72 @@ internal final class LoggingFeature {
 
     // MARK: - Components
 
+    static let featureName = "logging"
+    /// NOTE: any change to data format requires updating the directory url to be unique
+    static let dataFormat = DataFormat(prefix: "[", suffix: "]", separator: ",")
+
     /// Log files storage.
-    let storage: Storage
+    let storage: FeatureStorage
     /// Logs upload worker.
-    let upload: Upload
-
-    /// Encapsulates  storage stack setup for `LoggingFeature`.
-    class Storage {
-        /// Writes logs to files.
-        let writer: FileWriter
-        /// Reads logs from files.
-        let reader: FileReader
-
-        /// NOTE: any change to logs data format requires updating the logs directory url to be unique
-        static let dataFormat = DataFormat(prefix: "[", suffix: "]", separator: ",")
-
-        init(
-            directory: Directory,
-            performance: PerformancePreset,
-            dateProvider: DateProvider,
-            readWriteQueue: DispatchQueue
-        ) {
-            let orchestrator = FilesOrchestrator(
-                directory: directory,
-                performance: performance,
-                dateProvider: dateProvider
-            )
-
-            self.writer = FileWriter(dataFormat: Storage.dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
-            self.reader = FileReader(dataFormat: Storage.dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
-        }
-    }
-
-    /// Encapsulates upload stack setup for `LoggingFeature`.
-    class Upload {
-        /// Uploads logs to server.
-        let uploader: DataUploadWorker
-
-        init(
-            storage: Storage,
-            configuration: Datadog.ValidConfiguration,
-            performance: PerformancePreset,
-            mobileDevice: MobileDevice,
-            httpClient: HTTPClient,
-            dateProvider: DateProvider,
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
-            uploadQueue: DispatchQueue
-        ) {
-            let httpHeaders = HTTPHeaders(
-                headers: [
-                    .contentTypeHeader(contentType: .applicationJSON),
-                    .userAgentHeader(
-                        appName: configuration.applicationName,
-                        appVersion: configuration.applicationVersion,
-                        device: mobileDevice
-                    )
-                ]
-            )
-            let uploadConditions = DataUploadConditions(
-                batteryStatus: BatteryStatusProvider(mobileDevice: mobileDevice),
-                networkConnectionInfo: networkConnectionInfoProvider
-            )
-
-            let dataUploader = DataUploader(
-                urlProvider: UploadURLProvider(
-                    urlWithClientToken: configuration.logsUploadURLWithClientToken,
-                    queryItemProviders: [
-                        .ddsource(),
-                        .batchTime(using: dateProvider)
-                    ]
-                ),
-                httpClient: httpClient,
-                httpHeaders: httpHeaders
-            )
-
-            self.uploader = DataUploadWorker(
-                queue: uploadQueue,
-                fileReader: storage.reader,
-                dataUploader: dataUploader,
-                uploadConditions: uploadConditions,
-                delay: DataUploadDelay(performance: performance),
-                featureName: "logging"
-            )
-        }
-    }
+    let upload: FeatureUpload
 
     // MARK: - Initialization
 
-    init(
+    convenience init(
         directory: Directory,
-        configuration: Datadog.ValidConfiguration,
-        performance: PerformancePreset,
-        mobileDevice: MobileDevice,
-        httpClient: HTTPClient,
-        dateProvider: DateProvider,
-        userInfoProvider: UserInfoProvider,
-        networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
-        carrierInfoProvider: CarrierInfoProviderType
+        commonDependencies: FeaturesCommonDependencies
+    ) {
+        let storage = FeatureStorage(
+            featureName: LoggingFeature.featureName,
+            dataFormat: LoggingFeature.dataFormat,
+            directory: directory,
+            commonDependencies: commonDependencies
+        )
+        let upload = FeatureUpload(
+            featureName: LoggingFeature.featureName,
+            storage: storage,
+            uploadHTTPHeaders: HTTPHeaders(
+                headers: [
+                    .contentTypeHeader(contentType: .applicationJSON),
+                    .userAgentHeader(
+                        appName: commonDependencies.configuration.applicationName,
+                        appVersion: commonDependencies.configuration.applicationVersion,
+                        device: commonDependencies.mobileDevice
+                    )
+                ]
+            ),
+            uploadURLProvider: UploadURLProvider(
+                urlWithClientToken: commonDependencies.configuration.logsUploadURLWithClientToken,
+                queryItemProviders: [
+                    .ddsource(),
+                    .batchTime(using: commonDependencies.dateProvider)
+                ]
+            ),
+            commonDependencies: commonDependencies
+        )
+        self.init(
+            storage: storage,
+            upload: upload,
+            commonDependencies: commonDependencies
+        )
+    }
+
+    init(
+        storage: FeatureStorage,
+        upload: FeatureUpload,
+        commonDependencies: FeaturesCommonDependencies
     ) {
         // Configuration
-        self.configuration = configuration
+        self.configuration = commonDependencies.configuration
 
         // Bundle dependencies
-        self.dateProvider = dateProvider
-        self.userInfoProvider = userInfoProvider
-        self.networkConnectionInfoProvider = networkConnectionInfoProvider
-        self.carrierInfoProvider = carrierInfoProvider
+        self.dateProvider = commonDependencies.dateProvider
+        self.userInfoProvider = commonDependencies.userInfoProvider
+        self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
+        self.carrierInfoProvider = commonDependencies.carrierInfoProvider
 
-        // Initialize components
-        let readWriteQueue = DispatchQueue(
-            label: "com.datadoghq.ios-sdk-logs-read-write",
-            target: .global(qos: .utility)
-        )
-        self.storage = Storage(
-            directory: directory,
-            performance: performance,
-            dateProvider: dateProvider,
-            readWriteQueue: readWriteQueue
-        )
-
-        let uploadQueue = DispatchQueue(
-            label: "com.datadoghq.ios-sdk-logs-upload",
-            target: .global(qos: .utility)
-        )
-        self.upload = Upload(
-            storage: self.storage,
-            configuration: configuration,
-            performance: performance,
-            mobileDevice: mobileDevice,
-            httpClient: httpClient,
-            dateProvider: dateProvider,
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            uploadQueue: uploadQueue
-        )
+        // Initialize stacks
+        self.storage = storage
+        self.upload = upload
     }
 }

--- a/Sources/Datadog/RUM/RUMEventOutputs/RUMEventFileOutput.swift
+++ b/Sources/Datadog/RUM/RUMEventOutputs/RUMEventFileOutput.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 internal struct RUMEventFileOutput: RUMEventOutput {
-    let fileWriter: FileWriter
+    let fileWriter: FileWriterType
 
     func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {
         fileWriter.write(value: rumEvent)

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -41,17 +41,17 @@ internal final class RUMFeature {
 
     // MARK: - Initialization
 
-    convenience init(
-        directory: Directory,
-        commonDependencies: FeaturesCommonDependencies
-    ) {
-        let storage = FeatureStorage(
+    static func createStorage(directory: Directory, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
+        return FeatureStorage(
             featureName: RUMFeature.featureName,
             dataFormat: RUMFeature.dataFormat,
             directory: directory,
             commonDependencies: commonDependencies
         )
-        let upload = FeatureUpload(
+    }
+
+    static func createUpload(storage: FeatureStorage, directory: Directory, commonDependencies: FeaturesCommonDependencies) -> FeatureUpload {
+        return FeatureUpload(
             featureName: RUMFeature.featureName,
             storage: storage,
             uploadHTTPHeaders: HTTPHeaders(
@@ -81,6 +81,14 @@ internal final class RUMFeature {
             ),
             commonDependencies: commonDependencies
         )
+    }
+
+    convenience init(
+        directory: Directory,
+        commonDependencies: FeaturesCommonDependencies
+    ) {
+        let storage = RUMFeature.createStorage(directory: directory, commonDependencies: commonDependencies)
+        let upload = RUMFeature.createUpload(storage: storage, directory: directory, commonDependencies: commonDependencies)
         self.init(
             storage: storage,
             upload: upload,

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -30,146 +30,80 @@ internal final class RUMFeature {
 
     // MARK: - Components
 
+    static let featureName = "rum"
+    /// NOTE: any change to data format requires updating the directory url to be unique
+    static let dataFormat = DataFormat(prefix: "", suffix: "", separator: "\n")
+
     /// RUM files storage.
-    let storage: Storage
+    let storage: FeatureStorage
     /// RUM upload worker.
-    let upload: Upload
-
-    /// Encapsulates  storage stack setup for `RUMFeature`.
-    class Storage {
-        /// Writes RUM events to files.
-        let writer: FileWriter
-        /// Reads RUM events from files.
-        let reader: FileReader
-
-        /// NOTE: any change to logs data format requires updating the RUM directory url to be unique
-        static let dataFormat = DataFormat(prefix: "", suffix: "", separator: "\n")
-
-        init(
-            directory: Directory,
-            performance: PerformancePreset,
-            dateProvider: DateProvider,
-            readWriteQueue: DispatchQueue
-        ) {
-            let orchestrator = FilesOrchestrator(
-                directory: directory,
-                performance: performance,
-                dateProvider: dateProvider
-            )
-
-            self.writer = FileWriter(dataFormat: Storage.dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
-            self.reader = FileReader(dataFormat: Storage.dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
-        }
-    }
-
-    /// Encapsulates upload stack setup for `RUMFeature`.
-    class Upload {
-        /// Uploads RUM events to server.
-        let uploader: DataUploadWorker
-
-        init(
-            storage: Storage,
-            configuration: Datadog.ValidConfiguration,
-            performance: PerformancePreset,
-            mobileDevice: MobileDevice,
-            httpClient: HTTPClient,
-            dateProvider: DateProvider,
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
-            uploadQueue: DispatchQueue
-        ) {
-            let httpHeaders = HTTPHeaders(
-                headers: [
-                    .contentTypeHeader(contentType: .textPlainUTF8),
-                    .userAgentHeader(
-                        appName: configuration.applicationName,
-                        appVersion: configuration.applicationVersion,
-                        device: mobileDevice
-                    )
-                ]
-            )
-            let uploadConditions = DataUploadConditions(
-                batteryStatus: BatteryStatusProvider(mobileDevice: mobileDevice),
-                networkConnectionInfo: networkConnectionInfoProvider
-            )
-
-            let dataUploader = DataUploader(
-                urlProvider: UploadURLProvider(
-                    urlWithClientToken: configuration.rumUploadURLWithClientToken,
-                    queryItemProviders: [
-                        .ddsource(),
-                        .batchTime(using: dateProvider),
-                        .ddtags(
-                            tags: [
-                                "service:\(configuration.serviceName)",
-                                "version:\(configuration.applicationVersion)",
-                                "sdk_version:\(sdkVersion)",
-                                "env:\(configuration.environment)"
-                            ]
-                        )
-                    ]
-                ),
-                httpClient: httpClient,
-                httpHeaders: httpHeaders
-            )
-
-            self.uploader = DataUploadWorker(
-                queue: uploadQueue,
-                fileReader: storage.reader,
-                dataUploader: dataUploader,
-                uploadConditions: uploadConditions,
-                delay: DataUploadDelay(performance: performance),
-                featureName: "RUM"
-            )
-        }
-    }
+    let upload: FeatureUpload
 
     // MARK: - Initialization
 
-    init(
+    convenience init(
         directory: Directory,
-        configuration: Datadog.ValidConfiguration,
-        performance: PerformancePreset,
-        mobileDevice: MobileDevice,
-        httpClient: HTTPClient,
-        dateProvider: DateProvider,
-        userInfoProvider: UserInfoProvider,
-        networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
-        carrierInfoProvider: CarrierInfoProviderType
+        commonDependencies: FeaturesCommonDependencies
+    ) {
+        let storage = FeatureStorage(
+            featureName: RUMFeature.featureName,
+            dataFormat: RUMFeature.dataFormat,
+            directory: directory,
+            commonDependencies: commonDependencies
+        )
+        let upload = FeatureUpload(
+            featureName: RUMFeature.featureName,
+            storage: storage,
+            uploadHTTPHeaders: HTTPHeaders(
+                headers: [
+                    .contentTypeHeader(contentType: .textPlainUTF8),
+                    .userAgentHeader(
+                        appName: commonDependencies.configuration.applicationName,
+                        appVersion: commonDependencies.configuration.applicationVersion,
+                        device: commonDependencies.mobileDevice
+                    )
+                ]
+            ),
+            uploadURLProvider: UploadURLProvider(
+                urlWithClientToken: commonDependencies.configuration.rumUploadURLWithClientToken,
+                queryItemProviders: [
+                    .ddsource(),
+                    .batchTime(using: commonDependencies.dateProvider),
+                    .ddtags(
+                        tags: [
+                            "service:\(commonDependencies.configuration.serviceName)",
+                            "version:\(commonDependencies.configuration.applicationVersion)",
+                            "sdk_version:\(sdkVersion)",
+                            "env:\(commonDependencies.configuration.environment)"
+                        ]
+                    )
+                ]
+            ),
+            commonDependencies: commonDependencies
+        )
+        self.init(
+            storage: storage,
+            upload: upload,
+            commonDependencies: commonDependencies
+        )
+    }
+
+    init(
+        storage: FeatureStorage,
+        upload: FeatureUpload,
+        commonDependencies: FeaturesCommonDependencies
     ) {
         // Configuration
-        self.configuration = configuration
+        self.configuration = commonDependencies.configuration
 
         // Bundle dependencies
-        self.dateProvider = dateProvider
-        self.userInfoProvider = userInfoProvider
-        self.networkConnectionInfoProvider = networkConnectionInfoProvider
-        self.carrierInfoProvider = carrierInfoProvider
+        self.dateProvider = commonDependencies.dateProvider
+        self.userInfoProvider = commonDependencies.userInfoProvider
+        self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
+        self.carrierInfoProvider = commonDependencies.carrierInfoProvider
 
-        // Initialize components
-        let readWriteQueue = DispatchQueue(
-            label: "com.datadoghq.ios-sdk-rum-read-write",
-            target: .global(qos: .utility)
-        )
-        self.storage = Storage(
-            directory: directory,
-            performance: performance,
-            dateProvider: dateProvider,
-            readWriteQueue: readWriteQueue
-        )
-
-        let uploadQueue = DispatchQueue(
-            label: "com.datadoghq.ios-sdk-rum-upload",
-            target: .global(qos: .utility)
-        )
-        self.upload = Upload(
-            storage: self.storage,
-            configuration: configuration,
-            performance: performance,
-            mobileDevice: mobileDevice,
-            httpClient: httpClient,
-            dateProvider: dateProvider,
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            uploadQueue: uploadQueue
-        )
+        // Initialize stacks
+        self.storage = storage
+        self.upload = upload
     }
 }

--- a/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
+++ b/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
@@ -9,7 +9,7 @@ import Foundation
 /// `SpanOutput` which saves spans to file.
 internal struct SpanFileOutput: SpanOutput {
     let spanBuilder: SpanBuilder
-    let fileWriter: FileWriter
+    let fileWriter: FileWriterType
     /// Integration with RUM Errors.
     let rumErrorsIntegration = TracingWithRUMErrorsIntegration()
 

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -48,20 +48,18 @@ internal final class TracingFeature {
 
     // MARK: - Initialization
 
-    convenience init(
-        directory: Directory,
-        commonDependencies: FeaturesCommonDependencies,
-        loggingFeatureAdapter: LoggingForTracingAdapter?,
-        tracingUUIDGenerator: TracingUUIDGenerator
-    ) {
-        let storage = FeatureStorage(
+    static func createStorage(directory: Directory, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
+        return FeatureStorage(
             featureName: TracingFeature.featureName,
             dataFormat: TracingFeature.dataFormat,
             directory: directory,
             commonDependencies: commonDependencies
         )
-        let upload = FeatureUpload(
-            featureName: LoggingFeature.featureName,
+    }
+
+    static func createUpload(storage: FeatureStorage, directory: Directory, commonDependencies: FeaturesCommonDependencies) -> FeatureUpload {
+        return FeatureUpload(
+            featureName: TracingFeature.featureName,
             storage: storage,
             uploadHTTPHeaders: HTTPHeaders(
                 headers: [
@@ -81,6 +79,16 @@ internal final class TracingFeature {
             ),
             commonDependencies: commonDependencies
         )
+    }
+
+    convenience init(
+        directory: Directory,
+        commonDependencies: FeaturesCommonDependencies,
+        loggingFeatureAdapter: LoggingForTracingAdapter?,
+        tracingUUIDGenerator: TracingUUIDGenerator
+    ) {
+        let storage = TracingFeature.createStorage(directory: directory, commonDependencies: commonDependencies)
+        let upload = TracingFeature.createUpload(storage: storage, directory: directory, commonDependencies: commonDependencies)
         self.init(
             storage: storage,
             upload: upload,

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -37,143 +37,81 @@ internal final class TracingFeature {
 
     // MARK: - Components
 
+    static let featureName = "tracing"
+    /// NOTE: any change to data format requires updating the directory url to be unique
+    static let dataFormat = DataFormat(prefix: "", suffix: "", separator: "\n")
+
     /// Span files storage.
-    let storage: Storage
+    let storage: FeatureStorage
     /// Spans upload worker.
-    let upload: Upload
-
-    /// Encapsulates  storage stack setup for `TracingFeature`.
-    class Storage {
-        /// Writes spans to files.
-        let writer: FileWriter
-        /// Reads spans from files.
-        let reader: FileReader
-
-        /// NOTE: any change to tracing data format requires updating the tracing directory url to be unique
-        static let dataFormat = DataFormat(prefix: "", suffix: "", separator: "\n")
-
-        init(
-            directory: Directory,
-            performance: PerformancePreset,
-            dateProvider: DateProvider,
-            readWriteQueue: DispatchQueue
-        ) {
-            let orchestrator = FilesOrchestrator(
-                directory: directory,
-                performance: performance,
-                dateProvider: dateProvider
-            )
-
-            self.writer = FileWriter(dataFormat: Storage.dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
-            self.reader = FileReader(dataFormat: Storage.dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
-        }
-    }
-
-    /// Encapsulates upload stack setup for `TracingFeature`.
-    class Upload {
-        /// Uploads spans to server.
-        let uploader: DataUploadWorker
-
-        init(
-            storage: Storage,
-            configuration: Datadog.ValidConfiguration,
-            performance: PerformancePreset,
-            mobileDevice: MobileDevice,
-            httpClient: HTTPClient,
-            dateProvider: DateProvider,
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
-            uploadQueue: DispatchQueue
-        ) {
-            let httpHeaders = HTTPHeaders(
-                headers: [
-                    .contentTypeHeader(contentType: .textPlainUTF8),
-                    .userAgentHeader(
-                        appName: configuration.applicationName,
-                        appVersion: configuration.applicationVersion,
-                        device: mobileDevice
-                    )
-                ]
-            )
-            let uploadConditions = DataUploadConditions(
-                batteryStatus: BatteryStatusProvider(mobileDevice: mobileDevice),
-                networkConnectionInfo: networkConnectionInfoProvider
-            )
-
-            let dataUploader = DataUploader(
-                urlProvider: UploadURLProvider(
-                    urlWithClientToken: configuration.tracesUploadURLWithClientToken,
-                    queryItemProviders: [
-                        .batchTime(using: dateProvider)
-                    ]
-                ),
-                httpClient: httpClient,
-                httpHeaders: httpHeaders
-            )
-
-            self.uploader = DataUploadWorker(
-                queue: uploadQueue,
-                fileReader: storage.reader,
-                dataUploader: dataUploader,
-                uploadConditions: uploadConditions,
-                delay: DataUploadDelay(performance: performance),
-                featureName: "tracing"
-            )
-        }
-    }
+    let upload: FeatureUpload
 
     // MARK: - Initialization
 
-    init(
+    convenience init(
         directory: Directory,
-        configuration: Datadog.ValidConfiguration,
-        performance: PerformancePreset,
+        commonDependencies: FeaturesCommonDependencies,
         loggingFeatureAdapter: LoggingForTracingAdapter?,
-        mobileDevice: MobileDevice,
-        httpClient: HTTPClient,
-        dateProvider: DateProvider,
-        tracingUUIDGenerator: TracingUUIDGenerator,
-        userInfoProvider: UserInfoProvider,
-        networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
-        carrierInfoProvider: CarrierInfoProviderType
+        tracingUUIDGenerator: TracingUUIDGenerator
+    ) {
+        let storage = FeatureStorage(
+            featureName: TracingFeature.featureName,
+            dataFormat: TracingFeature.dataFormat,
+            directory: directory,
+            commonDependencies: commonDependencies
+        )
+        let upload = FeatureUpload(
+            featureName: LoggingFeature.featureName,
+            storage: storage,
+            uploadHTTPHeaders: HTTPHeaders(
+                headers: [
+                    .contentTypeHeader(contentType: .textPlainUTF8),
+                    .userAgentHeader(
+                        appName: commonDependencies.configuration.applicationName,
+                        appVersion: commonDependencies.configuration.applicationVersion,
+                        device: commonDependencies.mobileDevice
+                    )
+                ]
+            ),
+            uploadURLProvider: UploadURLProvider(
+                urlWithClientToken: commonDependencies.configuration.tracesUploadURLWithClientToken,
+                queryItemProviders: [
+                    .batchTime(using: commonDependencies.dateProvider)
+                ]
+            ),
+            commonDependencies: commonDependencies
+        )
+        self.init(
+            storage: storage,
+            upload: upload,
+            commonDependencies: commonDependencies,
+            loggingFeatureAdapter: loggingFeatureAdapter,
+            tracingUUIDGenerator: tracingUUIDGenerator
+        )
+    }
+
+    init(
+        storage: FeatureStorage,
+        upload: FeatureUpload,
+        commonDependencies: FeaturesCommonDependencies,
+        loggingFeatureAdapter: LoggingForTracingAdapter?,
+        tracingUUIDGenerator: TracingUUIDGenerator
     ) {
         // Configuration
-        self.configuration = configuration
+        self.configuration = commonDependencies.configuration
 
         // Integration with other features
         self.loggingFeatureAdapter = loggingFeatureAdapter
 
         // Bundle dependencies
-        self.dateProvider = dateProvider
+        self.dateProvider = commonDependencies.dateProvider
         self.tracingUUIDGenerator = tracingUUIDGenerator
-        self.userInfoProvider = userInfoProvider
-        self.networkConnectionInfoProvider = networkConnectionInfoProvider
-        self.carrierInfoProvider = carrierInfoProvider
+        self.userInfoProvider = commonDependencies.userInfoProvider
+        self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
+        self.carrierInfoProvider = commonDependencies.carrierInfoProvider
 
-        // Initialize components
-        let readWriteQueue = DispatchQueue(
-            label: "com.datadoghq.ios-sdk-spans-read-write",
-            target: .global(qos: .utility)
-        )
-        self.storage = Storage(
-            directory: directory,
-            performance: performance,
-            dateProvider: dateProvider,
-            readWriteQueue: readWriteQueue
-        )
-
-        let uploadQueue = DispatchQueue(
-            label: "com.datadoghq.ios-sdk-spans-upload",
-            target: .global(qos: .utility)
-        )
-        self.upload = Upload(
-            storage: self.storage,
-            configuration: configuration,
-            performance: performance,
-            mobileDevice: mobileDevice,
-            httpClient: httpClient,
-            dateProvider: dateProvider,
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            uploadQueue: uploadQueue
-        )
+        // Initialize stacks
+        self.storage = storage
+        self.upload = upload
     }
 }

--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+@testable import Datadog
+
+extension FeaturesCommonDependencies {
+    static func mockAny() -> FeaturesCommonDependencies {
+        let anyURL = URL(string: "https://foo.com")!
+        return FeaturesCommonDependencies(
+            configuration: .init(
+                applicationName: "",
+                applicationVersion: "",
+                applicationBundleIdentifier: "",
+                serviceName: "",
+                environment: "",
+                logsUploadURLWithClientToken: anyURL,
+                tracesUploadURLWithClientToken: anyURL,
+                rumUploadURLWithClientToken: anyURL
+            ),
+            performance: .default,
+            httpClient: HTTPClient(),
+            mobileDevice: .current,
+            dateProvider: SystemDateProvider(),
+            userInfoProvider: UserInfoProvider(),
+            networkConnectionInfoProvider: NetworkConnectionInfoProvider(),
+            carrierInfoProvider: CarrierInfoProvider()
+        )
+    }
+}

--- a/Tests/DatadogBenchmarkTests/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/LoggingStorageBenchmarkTests.swift
@@ -17,18 +17,12 @@ class LoggingStorageBenchmarkTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        self.queue = DispatchQueue(label: "com.datadoghq.benchmark-logs-io", target: .global(qos: .utility))
         self.directory = try Directory(withSubdirectoryPath: "logging-benchmark")
 
-        let storage = LoggingFeature.Storage(
-            directory: directory,
-            performance: .default,
-            dateProvider: SystemDateProvider(),
-            readWriteQueue: queue
-        )
-
-        self.writer = storage.writer
-        self.reader = storage.reader
+        let storage = LoggingFeature.createStorage(directory: directory, commonDependencies: .mockAny())
+        self.writer = storage.writer as? FileWriter
+        self.reader = storage.reader as? FileReader
+        self.queue = self.writer.queue
 
         XCTAssertTrue(try directory.files().count == 0)
     }

--- a/Tests/DatadogBenchmarkTests/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/TracingStorageBenchmarkTests.swift
@@ -17,18 +17,12 @@ class TracingStorageBenchmarkTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        self.queue = DispatchQueue(label: "com.datadoghq.benchmark-traces-io", target: .global(qos: .utility))
         self.directory = try Directory(withSubdirectoryPath: "tracing-benchmark")
 
-        let storage = TracingFeature.Storage(
-            directory: directory,
-            performance: .default,
-            dateProvider: SystemDateProvider(),
-            readWriteQueue: queue
-        )
-
-        self.writer = storage.writer
-        self.reader = storage.reader
+        let storage = TracingFeature.createStorage(directory: directory, commonDependencies: .mockAny())
+        self.writer = storage.writer as? FileWriter
+        self.reader = storage.reader as? FileReader
+        self.queue = self.writer.queue
 
         XCTAssertTrue(try directory.files().count == 0)
     }

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -41,7 +41,7 @@ class DataUploadWorkerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: server.urlSession),
+            httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
 

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -55,7 +55,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: server.urlSession),
+            httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -68,7 +68,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 300)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: server.urlSession),
+            httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -81,7 +81,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 400)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: server.urlSession),
+            httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -94,7 +94,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 500)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: server.urlSession),
+            httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -107,7 +107,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .failure(error: ErrorMock("network error")))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: server.urlSession),
+            httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -120,7 +120,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: -1)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: server.urlSession),
+            httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())

--- a/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
@@ -11,7 +11,7 @@ class HTTPClientTests: XCTestCase {
     func testWhenRequestIsDelivered_itReturnsHTTPResponse() {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let expectation = self.expectation(description: "receive response")
-        let client = HTTPClient(session: server.urlSession)
+        let client = HTTPClient(session: .serverMockURLSession)
 
         client.send(request: .mockAny()) { result in
             switch result {
@@ -30,7 +30,7 @@ class HTTPClientTests: XCTestCase {
     func testWhenRequestIsNotDelivered_itReturnsHTTPRequestDeliveryError() {
         let server = ServerMock(delivery: .failure(error: ErrorMock("no internet connection")))
         let expectation = self.expectation(description: "receive response")
-        let client = HTTPClient(session: server.urlSession)
+        let client = HTTPClient(session: .serverMockURLSession)
 
         client.send(request: .mockAny()) { result in
             switch result {

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -53,9 +53,9 @@ class RUMErrorsIntegrationTests: XCTestCase {
     }
 
     func testGivenRUMMonitorRegistered_whenAddingErrorMessage_itSendsRUMErrorForCurrentView() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        let uploadWorker = DataUploadWorkerMock()
+        RUMFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory
         )
         defer { RUMFeature.instance = nil }
@@ -68,7 +68,7 @@ class RUMErrorsIntegrationTests: XCTestCase {
         integration.addError(with: "error message")
 
         // then
-        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 3) // [RUMView, RUMAction, RUMError] events sent
+        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 3) // [RUMView, RUMAction, RUMError] events sent
         let rumErrorMatcher = rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) }
         try XCTUnwrap(rumErrorMatcher).model(ofType: RUMError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "error message")

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -11,7 +11,7 @@ class RUMIntegrationsTests: XCTestCase {
     private let integration = RUMContextIntegration()
 
     func testWhenRUMMonitorIsRegistered_itProvidesRUMContextAttributes() throws {
-        RUMFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
         // when
@@ -28,7 +28,7 @@ class RUMIntegrationsTests: XCTestCase {
     }
 
     func testWhenRUMMonitorIsNotRegistered_itReturnsNil() throws {
-        RUMFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
         // when

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -53,11 +53,7 @@ class RUMErrorsIntegrationTests: XCTestCase {
     }
 
     func testGivenRUMMonitorRegistered_whenAddingErrorMessage_itSendsRUMErrorForCurrentView() throws {
-        let uploadWorker = DataUploadWorkerMock()
-        RUMFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
-            directory: temporaryDirectory
-        )
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         defer { RUMFeature.instance = nil }
 
         // given
@@ -68,7 +64,7 @@ class RUMErrorsIntegrationTests: XCTestCase {
         integration.addError(with: "error message")
 
         // then
-        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 3) // [RUMView, RUMAction, RUMError] events sent
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3) // [RUMView, RUMAction, RUMError] events sent
         let rumErrorMatcher = rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) }
         try XCTUnwrap(rumErrorMatcher).model(ofType: RUMError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "error message")

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -10,33 +10,27 @@ import XCTest
 class LoggerBuilderTests: XCTestCase {
     private let networkConnectionInfoProvider: NetworkConnectionInfoProviderMock = .mockAny()
     private let carrierInfoProvider: CarrierInfoProviderMock = .mockAny()
-    private var mockServer: ServerMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUp() {
         super.setUp()
-        temporaryDirectory.create()
-
-        mockServer = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        LoggingFeature.instance = .mockWorkingFeatureWith(
-            server: mockServer,
+        LoggingFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: DataUploadWorkerMock(),
             directory: temporaryDirectory,
-            configuration: .mockWith(
-                applicationVersion: "1.2.3",
-                applicationBundleIdentifier: "com.datadog.unit-tests",
-                serviceName: "service-name",
-                environment: "tests"
-            ),
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            carrierInfoProvider: carrierInfoProvider
+            dependencies: .mockForWorkingFeature(
+                configuration: .mockWith(
+                    applicationVersion: "1.2.3",
+                    applicationBundleIdentifier: "com.datadog.unit-tests",
+                    serviceName: "service-name",
+                    environment: "tests"
+                ),
+                networkConnectionInfoProvider: networkConnectionInfoProvider,
+                carrierInfoProvider: carrierInfoProvider
+            )
         )
     }
 
     override func tearDown() {
-        mockServer.waitAndAssertNoRequestsSent()
         LoggingFeature.instance = nil
-        mockServer = nil
-
-        temporaryDirectory.delete()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -15,7 +15,7 @@ class LoggerBuilderTests: XCTestCase {
         super.setUp()
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(
                     applicationVersion: "1.2.3",
                     applicationBundleIdentifier: "com.datadog.unit-tests",

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -13,8 +13,7 @@ class LoggerBuilderTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        LoggingFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: DataUploadWorkerMock(),
+        LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 configuration: .mockWith(

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -28,7 +28,7 @@ class LoggerTests: XCTestCase {
     func testSendingLogWithDefaultLogger() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(
                     applicationVersion: "1.0.0",
                     applicationBundleIdentifier: "com.datadoghq.ios-sdk",
@@ -93,7 +93,7 @@ class LoggerTests: XCTestCase {
     func testSendingLogsWithDifferentDates() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC(), advancingBySeconds: 1)
             )
         )
@@ -143,7 +143,7 @@ class LoggerTests: XCTestCase {
 
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 userInfoProvider: Datadog.instance!.userInfoProvider
             )
         )
@@ -174,7 +174,7 @@ class LoggerTests: XCTestCase {
         let carrierInfoProvider = CarrierInfoProviderMock(carrierInfo: nil)
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 carrierInfoProvider: carrierInfoProvider
             )
         )
@@ -215,7 +215,7 @@ class LoggerTests: XCTestCase {
         let networkConnectionInfoProvider = NetworkConnectionInfoProviderMock.mockAny()
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 networkConnectionInfoProvider: networkConnectionInfoProvider
             )
         )
@@ -367,7 +367,7 @@ class LoggerTests: XCTestCase {
     func testSendingTags() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(environment: "tests")
             )
         )
@@ -408,7 +408,7 @@ class LoggerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 mobileDevice: .mockWith(
                     currentBatteryStatus: { () -> MobileDevice.BatteryStatus in
                         .mockWith(state: .charging, level: 0.05, isLowPowerModeEnabled: true)
@@ -428,7 +428,7 @@ class LoggerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
                     networkConnectionInfo: .mockWith(reachability: .no)
                 )
@@ -447,7 +447,7 @@ class LoggerTests: XCTestCase {
     func testGivenBundlingWithRUMEnabledAndRUMMonitorRegistered_whenSendingLog_itContainsCurrentRUMContext() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(environment: "tests")
             )
         )
@@ -482,7 +482,7 @@ class LoggerTests: XCTestCase {
     func testGivenBundlingWithRUMEnabledButRUMMonitorNotRegistered_whenSendingLog_itPrintsWarning() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(environment: "tests")
             )
         )

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -469,7 +469,7 @@ class LoggerTests: XCTestCase {
         )
         defer { LoggingFeature.instance = nil }
 
-        RUMFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
         // given
@@ -504,7 +504,7 @@ class LoggerTests: XCTestCase {
         )
         defer { LoggingFeature.instance = nil }
 
-        RUMFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
         let previousUserLogger = userLogger
@@ -535,7 +535,7 @@ class LoggerTests: XCTestCase {
 
     func testWhenSendingErrorOrCriticalLogs_itCreatesRUMErrorForCurrentView() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        LoggingFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        LoggingFeature.instance = .mockNoOp()
         defer { LoggingFeature.instance = nil }
 
         RUMFeature.instance = .mockWorkingFeatureWith(
@@ -578,7 +578,7 @@ class LoggerTests: XCTestCase {
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        LoggingFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        LoggingFeature.instance = .mockNoOp()
         defer { LoggingFeature.instance = nil }
 
         let logger = Logger.builder

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
@@ -24,7 +24,7 @@ class LogFileOutputTests: XCTestCase {
         let output = LogFileOutput(
             logBuilder: .mockAny(),
             fileWriter: FileWriter(
-                dataFormat: LoggingFeature.Storage.dataFormat,
+                dataFormat: LoggingFeature.dataFormat,
                 orchestrator: FilesOrchestrator(
                     directory: temporaryDirectory,
                     performance: PerformancePreset.combining(

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -28,7 +28,7 @@ class LoggingFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(
                     applicationName: "FoobarApp",
                     applicationVersion: "2.1.0"
@@ -55,7 +55,7 @@ class LoggingFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 performance: .combining(
                     storagePerformance: StoragePerformanceMock(
                         maxFileSize: .max,

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -26,7 +26,7 @@ class LoggingFeatureTests: XCTestCase {
 
     func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        LoggingFeature.instance = .mockFullFeature(
+        LoggingFeature.instance = .mockWith(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 configuration: .mockWith(
@@ -53,7 +53,7 @@ class LoggingFeatureTests: XCTestCase {
 
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        LoggingFeature.instance = .mockFullFeature(
+        LoggingFeature.instance = .mockWith(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 performance: .combining(

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -26,15 +26,16 @@ class LoggingFeatureTests: XCTestCase {
 
     func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        LoggingFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        LoggingFeature.instance = .mockFullFeature(
             directory: temporaryDirectory,
-            configuration: .mockWith(
-                applicationName: "FoobarApp",
-                applicationVersion: "2.1.0"
-            ),
-            mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1"),
-            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+            dependencies: .mockForWorkingFeature(
+                configuration: .mockWith(
+                    applicationName: "FoobarApp",
+                    applicationVersion: "2.1.0"
+                ),
+                mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1"),
+                dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+            )
         )
         defer { LoggingFeature.instance = nil }
 
@@ -52,25 +53,26 @@ class LoggingFeatureTests: XCTestCase {
 
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        LoggingFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        LoggingFeature.instance = .mockFullFeature(
             directory: temporaryDirectory,
-            performance: .combining(
-                storagePerformance: StoragePerformanceMock(
-                    maxFileSize: .max,
-                    maxDirectorySize: .max,
-                    maxFileAgeForWrite: .distantFuture, // write all spans to single file,
-                    minFileAgeForRead: StoragePerformanceMock.readAllFiles.minFileAgeForRead,
-                    maxFileAgeForRead: StoragePerformanceMock.readAllFiles.maxFileAgeForRead,
-                    maxObjectsInFile: 3, // write 3 spans to payload,
-                    maxObjectSize: .max
-                ),
-                uploadPerformance: UploadPerformanceMock(
-                    initialUploadDelay: 0.5, // wait enough until spans are written,
-                    defaultUploadDelay: 1,
-                    minUploadDelay: 1,
-                    maxUploadDelay: 1,
-                    uploadDelayDecreaseFactor: 1
+            dependencies: .mockForWorkingFeature(
+                performance: .combining(
+                    storagePerformance: StoragePerformanceMock(
+                        maxFileSize: .max,
+                        maxDirectorySize: .max,
+                        maxFileAgeForWrite: .distantFuture, // write all spans to single file,
+                        minFileAgeForRead: StoragePerformanceMock.readAllFiles.minFileAgeForRead,
+                        maxFileAgeForRead: StoragePerformanceMock.readAllFiles.maxFileAgeForRead,
+                        maxObjectsInFile: 3, // write 3 spans to payload,
+                        maxObjectSize: .max
+                    ),
+                    uploadPerformance: UploadPerformanceMock(
+                        initialUploadDelay: 0.5, // wait enough until spans are written,
+                        defaultUploadDelay: 1,
+                        minUploadDelay: 1,
+                        maxUploadDelay: 1,
+                        uploadDelayDecreaseFactor: 1
+                    )
                 )
             )
         )

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -186,6 +186,45 @@ extension FeaturesCommonDependencies {
             carrierInfoProvider: CarrierInfoProviderMock(carrierInfo: .mockAny())
         )
     }
+
+    /// Mocks dependencies for feature with both Storage and Upload working with performance optimized for unit tests.
+    static func mockForWorkingFeature(
+        configuration: Datadog.ValidConfiguration = .mockAny(),
+        performance: PerformancePreset = .combining(
+            storagePerformance: .writeEachObjectToNewFileAndReadAllFiles,
+            uploadPerformance: .veryQuick
+        ),
+        mobileDevice: MobileDevice = .mockWith(
+            currentBatteryStatus: {
+                // Mock full battery, so it doesn't rely on battery condition for the upload
+                return BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false)
+            }
+        ),
+        dateProvider: DateProvider = SystemDateProvider(),
+        userInfoProvider: UserInfoProvider = .mockAny(),
+        networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockWith(
+            networkConnectionInfo: .mockWith(
+                reachability: .yes, // so it always meets the upload condition
+                availableInterfaces: [.wifi],
+                supportsIPv4: true,
+                supportsIPv6: true,
+                isExpensive: true,
+                isConstrained: false // so it always meets the upload condition
+            )
+        ),
+        carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
+    ) -> FeaturesCommonDependencies {
+        return FeaturesCommonDependencies(
+            configuration: configuration,
+            performance: performance,
+            httpClient: HTTPClient(session: .serverMockURLSession),
+            mobileDevice: mobileDevice,
+            dateProvider: dateProvider,
+            userInfoProvider: userInfoProvider,
+            networkConnectionInfoProvider: networkConnectionInfoProvider,
+            carrierInfoProvider: carrierInfoProvider
+        )
+    }
 }
 
 class NoOpFileWriter: FileWriterType {

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -175,20 +175,12 @@ extension PerformancePreset {
 
 extension FeaturesCommonDependencies {
     static func mockAny() -> FeaturesCommonDependencies {
-        return FeaturesCommonDependencies(
-            configuration: .mockAny(),
-            performance: .default,
-            httpClient: .mockAny(),
-            mobileDevice: .mockAny(),
-            dateProvider: SystemDateProvider(),
-            userInfoProvider: .mockAny(),
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock(networkConnectionInfo: .mockAny()),
-            carrierInfoProvider: CarrierInfoProviderMock(carrierInfo: .mockAny())
-        )
+        return .mockWith()
     }
 
-    /// Mocks dependencies for feature with both Storage and Upload working with performance optimized for unit tests.
-    static func mockForWorkingFeature(
+    /// Mocks features common dependencies.
+    /// Default values describe the environment setup where data can be uploaded to the server (device is online and battery is full).
+    static func mockWith(
         configuration: Datadog.ValidConfiguration = .mockAny(),
         performance: PerformancePreset = .combining(
             storagePerformance: .writeEachObjectToNewFileAndReadAllFiles,

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -173,6 +173,32 @@ extension PerformancePreset {
 
 // MARK: - Features Common Mocks
 
+extension FeaturesCommonDependencies {
+    static func mockAny() -> FeaturesCommonDependencies {
+        return FeaturesCommonDependencies(
+            configuration: .mockAny(),
+            performance: .default,
+            httpClient: .mockAny(),
+            mobileDevice: .mockAny(),
+            dateProvider: SystemDateProvider(),
+            userInfoProvider: .mockAny(),
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock(networkConnectionInfo: .mockAny()),
+            carrierInfoProvider: CarrierInfoProviderMock(carrierInfo: .mockAny())
+        )
+    }
+}
+
+class NoOpFileWriter: FileWriterType {
+    func write<T>(value: T) where T: Encodable {}
+}
+
+class NoOpFileReader: FileReaderType {
+    func readNextBatch() -> Batch? { return nil }
+    func markBatchAsRead(_ batch: Batch) {}
+}
+
+class NoOpDataUploadWorker: DataUploadWorkerType {}
+
 extension DataFormat {
     static func mockAny() -> DataFormat {
         return mockWith()

--- a/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
@@ -113,6 +113,17 @@ class DataUploadWorkerMock: DataUploadWorkerType {
     }
 }
 
+// MARK: - Logging feature helpers
+
+extension DataUploadWorkerMock {
+    func waitAndReturnLogMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
+        return try waitAndReturnBatchedData(count: count, file: file, line: line)
+        .flatMap { batchData in
+            try LogMatcher.fromArrayOfJSONObjectsData(batchData, file: file, line: line)
+        }
+    }
+}
+
 // MARK: - Tracing feature helpers
 
 extension DataUploadWorkerMock {

--- a/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
@@ -134,3 +134,14 @@ extension DataUploadWorkerMock {
         }
     }
 }
+
+// MARK: - RUM feature helpers
+
+extension DataUploadWorkerMock {
+    func waitAndReturnRUMEventMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [RUMEventMatcher] {
+        return try waitAndReturnBatchedData(count: count, file: file, line: line)
+        .flatMap { batchData in
+            try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(batchData)
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
@@ -112,8 +112,9 @@ class DataUploadWorkerMock: DataUploadWorkerType {
     /// Returns recommended timeout for receiving given number of batches.
     private func recommendedTimeoutFor(numberOfBatches: UInt) -> TimeInterval {
         // One batch timeout is arbitrary. It stands for the time interval from receiving the data
-        // to writting it to the file.
-        let arbitraryTimeoutForOneBatch = 0.1
+        // to writting it to the file. Needs to be relatively big as the CI is very slow. Higher value
+        // doesn't impact the execution time of tests.
+        let arbitraryTimeoutForOneBatch = 2.0
         return Double(numberOfBatches) * arbitraryTimeoutForOneBatch
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
@@ -1,0 +1,125 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import XCTest
+@testable import Datadog
+
+private class FileWriterObserver: FileWriterType {
+    let observedWriter: FileWriter
+    let writeCallback: (() -> Void)
+
+    init(_ observedWriter: FileWriter, writeCallback: @escaping (() -> Void)) {
+        self.observedWriter = observedWriter
+        self.writeCallback = writeCallback
+    }
+
+    func write<T>(value: T) where T: Encodable {
+        observedWriter.write(value: value)
+        observedWriter.queue.async { [weak self] in
+            self?.writeCallback()
+        }
+    }
+}
+
+class DataUploadWorkerMock: DataUploadWorkerType {
+    private let queue = DispatchQueue(label: "com.datadoghq.DataUploadWorkerMock-\(UUID().uuidString)")
+
+    private var fileReader: FileReader?
+    private var batches: [Batch] = []
+
+    // MARK: - Observing FeatureStorage
+
+    func observe(featureStorage: FeatureStorage) -> FeatureStorage {
+        let fileWriter = featureStorage.writer as! FileWriter
+        let observedFileWriter = FileWriterObserver(fileWriter) { [weak self] in
+            self?.readNextBatch()
+        }
+        fileReader = featureStorage.reader as? FileReader
+        return FeatureStorage(writer: observedFileWriter, reader: featureStorage.reader)
+    }
+
+    private func readNextBatch() {
+        queue.async {
+            if let nextBatch = self.fileReader?.readNextBatch() {
+                self.record(nextBatch: nextBatch)
+                self.fileReader?.markBatchAsRead(nextBatch)
+            }
+        }
+    }
+
+    private func record(nextBatch: Batch) {
+        queue.async {
+            self.batches.append(nextBatch)
+            self.waitAndReturnDataExpectation?.fulfill()
+        }
+    }
+
+    // MARK: - Receiving Recorded Data
+
+    private var waitAndReturnDataExpectation: XCTestExpectation?
+
+    func waitAndReturnBatchedData(count: UInt, timeout: TimeInterval? = nil, file: StaticString = #file, line: UInt = #line) -> [Data] {
+        precondition(waitAndReturnDataExpectation == nil, "The `DataUploadWorkerMock` is already waiting on `waitAndReturnProcessedCommands`.")
+
+        let expectation = XCTestExpectation(description: "Receive \(count) data batches.")
+        if count > 0 {
+            expectation.expectedFulfillmentCount = Int(count)
+        } else {
+            expectation.isInverted = true
+        }
+
+        queue.sync {
+            self.waitAndReturnDataExpectation = expectation
+            self.batches.forEach { _ in expectation.fulfill() } // fulfill already recorded
+        }
+
+        let timeout = timeout ?? recommendedTimeoutFor(numberOfBatches: max(count, 1))
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+
+        switch result {
+        case .completed:
+            break
+        case .incorrectOrder, .interrupted:
+            fatalError("Can't happen.")
+        case .timedOut:
+            XCTFail("Exceeded timeout of \(timeout)s with receiving \(batches.count) out of \(count) expected batches.", file: file, line: line)
+            // Return array of dummy batches, so the crash will happen leter in the test code, properly
+            // printing the above error.
+            return Array(repeating: .mockAny(), count: Int(count))
+        case .invertedFulfillment:
+            XCTFail("\(batches.count) batches were read, but not expected.", file: file, line: line)
+            // Return array of dummy requests, so the crash will happen leter in the test code, properly
+            // printing the above error.
+            return queue.sync { batches.map { $0.data } }
+        @unknown default:
+            fatalError()
+        }
+
+        return queue.sync { batches.map { $0.data } }
+    }
+
+    // MARK: - Utils
+
+    /// Returns recommended timeout for receiving given number of batches.
+    private func recommendedTimeoutFor(numberOfBatches: UInt) -> TimeInterval {
+        // One batch timeout is arbitrary. It stands for the time interval from receiving the data
+        // to writting it to the file.
+        let arbitraryTimeoutForOneBatch = 0.1
+        return Double(numberOfBatches) * arbitraryTimeoutForOneBatch
+    }
+}
+
+// MARK: - Tracing feature helpers
+
+extension DataUploadWorkerMock {
+    func waitAndReturnSpanMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [SpanMatcher] {
+        return try waitAndReturnBatchedData(count: count, file: file, line: line)
+        .flatMap { batchData in
+            try SpanMatcher.fromNewlineSeparatedJSONObjectsData(batchData)
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -10,19 +10,9 @@ extension LoggingFeature {
     /// Mocks feature instance which performs no writes and no uploads.
     static func mockNoOp(temporaryDirectory: Directory) -> LoggingFeature {
         return LoggingFeature(
-            directory: temporaryDirectory,
-            configuration: .mockAny(),
-            performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp),
-            mobileDevice: .mockAny(),
-            httpClient: .mockAny(),
-            dateProvider: SystemDateProvider(),
-            userInfoProvider: .mockAny(),
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
-                networkConnectionInfo: .mockWith(
-                    reachability: .no // so it doesn't meet the upload condition
-                )
-            ),
-            carrierInfoProvider: CarrierInfoProviderMock.mockAny()
+            storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader()),
+            upload: .init(uploader: NoOpDataUploadWorker()),
+            commonDependencies: .mockAny()
         )
     }
 
@@ -55,16 +45,19 @@ extension LoggingFeature {
         ),
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
     ) -> LoggingFeature {
-        return LoggingFeature(
-            directory: directory,
+        let commonDependencies = FeaturesCommonDependencies(
             configuration: configuration,
             performance: performance,
-            mobileDevice: mobileDevice,
             httpClient: HTTPClient(session: server.urlSession),
+            mobileDevice: mobileDevice,
             dateProvider: dateProvider,
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider
+        )
+        return LoggingFeature(
+            directory: directory,
+            commonDependencies: commonDependencies
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -7,7 +7,7 @@
 @testable import Datadog
 
 extension LoggingFeature {
-    /// Mocks feature instance which performs no writes and no uploads.
+    /// Mocks the feature instance which performs no writes and no uploads.
     static func mockNoOp() -> LoggingFeature {
         return LoggingFeature(
             storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader()),
@@ -16,19 +16,20 @@ extension LoggingFeature {
         )
     }
 
+    /// Mocks the feature instance which performs uploads to `URLSession`.
+    /// Use `ServerMock` to inspect and assert recorded `URLRequests`.
     static func mockWith(
         directory: Directory,
-        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature()
+        dependencies: FeaturesCommonDependencies = .mockWith()
     ) -> LoggingFeature {
-        return LoggingFeature(
-            directory: directory,
-            commonDependencies: dependencies
-        )
+        return LoggingFeature(directory: directory, commonDependencies: dependencies)
     }
 
+    /// Mocks the feature instance which performs uploads to mocked `DataUploadWorker`.
+    /// Use `LogFeature.waitAndReturnLogMatchers()` to inspect and assert recorded `Logs`.
     static func mockByRecordingLogMatchers(
         directory: Directory,
-        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature()
+        dependencies: FeaturesCommonDependencies = .mockWith()
     ) -> LoggingFeature {
         // Get the full feature mock:
         let fullFeature: LoggingFeature = .mockWith(directory: directory, dependencies: dependencies)

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -8,7 +8,7 @@
 
 extension LoggingFeature {
     /// Mocks feature instance which performs no writes and no uploads.
-    static func mockNoOp(temporaryDirectory: Directory) -> LoggingFeature {
+    static func mockNoOp() -> LoggingFeature {
         return LoggingFeature(
             storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader()),
             upload: .init(uploader: NoOpDataUploadWorker()),

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -16,48 +16,33 @@ extension LoggingFeature {
         )
     }
 
-    /// Mocks feature instance which performs uploads to given `ServerMock` with performance optimized for fast delivery in unit tests.
-    static func mockWorkingFeatureWith(
-        server: ServerMock,
+    static func mockFullFeature(
         directory: Directory,
-        configuration: Datadog.ValidConfiguration = .mockAny(),
-        performance: PerformancePreset = .combining(
-            storagePerformance: .writeEachObjectToNewFileAndReadAllFiles,
-            uploadPerformance: .veryQuick
-        ),
-        mobileDevice: MobileDevice = .mockWith(
-            currentBatteryStatus: {
-                // Mock full battery, so it doesn't rely on battery condition for the upload
-                return BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false)
-            }
-        ),
-        dateProvider: DateProvider = SystemDateProvider(),
-        userInfoProvider: UserInfoProvider = .mockAny(),
-        networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockWith(
-            networkConnectionInfo: .mockWith(
-                reachability: .yes, // so it always meets the upload condition
-                availableInterfaces: [.wifi],
-                supportsIPv4: true,
-                supportsIPv6: true,
-                isExpensive: true,
-                isConstrained: false // so it always meets the upload condition
-            )
-        ),
-        carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
+        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature()
     ) -> LoggingFeature {
-        let commonDependencies = FeaturesCommonDependencies(
-            configuration: configuration,
-            performance: performance,
-            httpClient: HTTPClient(session: server.urlSession),
-            mobileDevice: mobileDevice,
-            dateProvider: dateProvider,
-            userInfoProvider: userInfoProvider,
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            carrierInfoProvider: carrierInfoProvider
-        )
         return LoggingFeature(
             directory: directory,
-            commonDependencies: commonDependencies
+            commonDependencies: dependencies
+        )
+    }
+
+    static func mockPartialFeature(
+        dataUploadWorkerMock: DataUploadWorkerMock,
+        directory: Directory,
+        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature(),
+        loggingFeature: LoggingFeature? = nil,
+        tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator()
+    ) -> LoggingFeature {
+        let fullFeature: LoggingFeature = .mockFullFeature(
+            directory: directory,
+            dependencies: dependencies
+        )
+        let observedStorage = dataUploadWorkerMock.observe(featureStorage: fullFeature.storage)
+        let upload = FeatureUpload(uploader: dataUploadWorkerMock)
+        return LoggingFeature(
+            storage: observedStorage,
+            upload: upload,
+            commonDependencies: dependencies
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -17,19 +17,20 @@ extension RUMFeature {
         )
     }
 
+    /// Mocks the feature instance which performs uploads to `URLSession`.
+    /// Use `ServerMock` to inspect and assert recorded `URLRequests`.
     static func mockWith(
         directory: Directory,
-        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature()
+        dependencies: FeaturesCommonDependencies = .mockWith()
     ) -> RUMFeature {
-        return RUMFeature(
-            directory: directory,
-            commonDependencies: dependencies
-        )
+        return RUMFeature(directory: directory, commonDependencies: dependencies)
     }
 
+    /// Mocks the feature instance which performs uploads to mocked `DataUploadWorker`.
+    /// Use `RUMFeature.waitAndReturnRUMEventMatchers()` to inspect and assert recorded `RUMEvents`.
     static func mockByRecordingRUMEventMatchers(
         directory: Directory,
-        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature()
+        dependencies: FeaturesCommonDependencies = .mockWith()
     ) -> RUMFeature {
         // Get the full feature mock:
         let fullFeature: RUMFeature = .mockWith(directory: directory, dependencies: dependencies)

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -17,48 +17,31 @@ extension RUMFeature {
         )
     }
 
-    /// Mocks feature instance which performs uploads to given `ServerMock` with performance optimized for fast delivery in unit tests.
-    static func mockWorkingFeatureWith(
-        server: ServerMock,
+    static func mockFullFeature(
         directory: Directory,
-        configuration: Datadog.ValidConfiguration = .mockAny(),
-        performance: PerformancePreset = .combining(
-            storagePerformance: .writeEachObjectToNewFileAndReadAllFiles,
-            uploadPerformance: .veryQuick
-        ),
-        mobileDevice: MobileDevice = .mockWith(
-            currentBatteryStatus: {
-                // Mock full battery, so it doesn't rely on battery condition for the upload
-                return BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false)
-            }
-        ),
-        dateProvider: DateProvider = SystemDateProvider(),
-        userInfoProvider: UserInfoProvider = .mockAny(),
-        networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockWith(
-            networkConnectionInfo: .mockWith(
-                reachability: .yes, // so it always meets the upload condition
-                availableInterfaces: [.wifi],
-                supportsIPv4: true,
-                supportsIPv6: true,
-                isExpensive: true,
-                isConstrained: false // so it always meets the upload condition
-            )
-        ),
-        carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
+        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature()
     ) -> RUMFeature {
-        let commonDependencies = FeaturesCommonDependencies(
-            configuration: configuration,
-            performance: performance,
-            httpClient: HTTPClient(session: server.urlSession),
-            mobileDevice: mobileDevice,
-            dateProvider: dateProvider,
-            userInfoProvider: userInfoProvider,
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            carrierInfoProvider: carrierInfoProvider
-        )
         return RUMFeature(
             directory: directory,
-            commonDependencies: commonDependencies
+            commonDependencies: dependencies
+        )
+    }
+
+    static func mockPartialFeature(
+        dataUploadWorkerMock: DataUploadWorkerMock,
+        directory: Directory,
+        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature()
+    ) -> RUMFeature {
+        let fullFeature: RUMFeature = .mockFullFeature(
+            directory: directory,
+            dependencies: dependencies
+        )
+        let observedStorage = dataUploadWorkerMock.observe(featureStorage: fullFeature.storage)
+        let upload = FeatureUpload(uploader: dataUploadWorkerMock)
+        return RUMFeature(
+            storage: observedStorage,
+            upload: upload,
+            commonDependencies: dependencies
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -9,7 +9,7 @@ import XCTest
 
 extension RUMFeature {
     /// Mocks feature instance which performs no writes and no uploads.
-    static func mockNoOp(temporaryDirectory: Directory) -> RUMFeature {
+    static func mockNoOp() -> RUMFeature {
         return RUMFeature(
             storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader()),
             upload: .init(uploader: NoOpDataUploadWorker()),

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -11,19 +11,9 @@ extension RUMFeature {
     /// Mocks feature instance which performs no writes and no uploads.
     static func mockNoOp(temporaryDirectory: Directory) -> RUMFeature {
         return RUMFeature(
-            directory: temporaryDirectory,
-            configuration: .mockAny(),
-            performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp),
-            mobileDevice: .mockAny(),
-            httpClient: .mockAny(),
-            dateProvider: SystemDateProvider(),
-            userInfoProvider: .mockAny(),
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
-                networkConnectionInfo: .mockWith(
-                    reachability: .no // so it doesn't meet the upload condition
-                )
-            ),
-            carrierInfoProvider: CarrierInfoProviderMock.mockAny()
+            storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader()),
+            upload: .init(uploader: NoOpDataUploadWorker()),
+            commonDependencies: .mockAny()
         )
     }
 
@@ -56,16 +46,19 @@ extension RUMFeature {
         ),
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
     ) -> RUMFeature {
-        return RUMFeature(
-            directory: directory,
+        let commonDependencies = FeaturesCommonDependencies(
             configuration: configuration,
             performance: performance,
-            mobileDevice: mobileDevice,
             httpClient: HTTPClient(session: server.urlSession),
+            mobileDevice: mobileDevice,
             dateProvider: dateProvider,
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider
+        )
+        return RUMFeature(
+            directory: directory,
+            commonDependencies: commonDependencies
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -58,7 +58,7 @@ private class ServerMockProtocol: URLProtocol {
     }
 }
 
-/// All unit tests use this shared `URLSession`.
+/// All unit tests should use this shared `URLSession` through `URLSession.serverMockURLSession`.
 private let sharedURLSession: URLSession = {
     let configuration = URLSessionConfiguration.ephemeral
     configuration.protocolClasses = [ServerMockProtocol.self]

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -209,8 +209,8 @@ extension ServerMock {
             file: file,
             line: line
         )
-            .map { request in try request.httpBody.unwrapOrThrow() }
-            .flatMap { requestBody in try LogMatcher.fromArrayOfJSONObjectsData(requestBody, file: file, line: line) }
+        .map { request in try request.httpBody.unwrapOrThrow() }
+        .flatMap { requestBody in try LogMatcher.fromArrayOfJSONObjectsData(requestBody, file: file, line: line) }
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -72,8 +72,6 @@ extension URLSession {
 class ServerMock {
     static weak var activeInstance: ServerMock?
 
-    /// `URLSession` to be used for all networking that should be mocked by this `ServerMock`.
-    let urlSession: URLSession = sharedURLSession
     private let queue = DispatchQueue(label: "com.datadoghq.ServerMock-\(UUID().uuidString)")
 
     fileprivate let mockedResponse: HTTPURLResponse?

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -189,59 +189,10 @@ class ServerMock {
     // MARK: - Utils
 
     /// Returns recommended timeout for delivering given number of requests if test-tuned values are used for `PerformancePreset`.
-    func recommendedTimeoutFor(numberOfRequestsMade: UInt) -> TimeInterval {
+    private func recommendedTimeoutFor(numberOfRequestsMade: UInt) -> TimeInterval {
         let uploadPerformanceForTests = UploadPerformanceMock.veryQuick
         // Set the timeout to 40 times more than expected.
         // In `RUMM-311` we observed 0.66% of flakiness for 150 test runs on CI with arbitrary value of `20`.
         return uploadPerformanceForTests.defaultUploadDelay * Double(numberOfRequestsMade) * 40
-    }
-}
-
-// MARK: - Logging feature helpers
-
-extension ServerMock {
-    func waitAndReturnLogMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
-        try waitAndReturnRequests(
-            count: count,
-            timeout: recommendedTimeoutFor(numberOfRequestsMade: count),
-            file: file,
-            line: line
-        )
-        .map { request in try request.httpBody.unwrapOrThrow() }
-        .flatMap { requestBody in try LogMatcher.fromArrayOfJSONObjectsData(requestBody, file: file, line: line) }
-    }
-}
-
-// MARK: - Tracing feature helpers
-
-extension ServerMock {
-    func waitAndReturnSpanMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [SpanMatcher] {
-        return try waitAndReturnRequests(
-            count: count,
-            timeout: recommendedTimeoutFor(numberOfRequestsMade: count),
-            file: file,
-            line: line
-        )
-        .map { request in try request.httpBody.unwrapOrThrow() }
-        .flatMap { requestBody in
-            try SpanMatcher.fromNewlineSeparatedJSONObjectsData(requestBody)
-        }
-    }
-}
-
-// MARK: - RUM feature helpers
-
-extension ServerMock {
-    func waitAndReturnRUMEventMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [RUMEventMatcher] {
-        return try waitAndReturnRequests(
-            count: count,
-            timeout: recommendedTimeoutFor(numberOfRequestsMade: count),
-            file: file,
-            line: line
-        )
-        .map { request in try request.httpBody.unwrapOrThrow() }
-        .flatMap { requestBody in
-            try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(requestBody)
-        }
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -65,6 +65,10 @@ private let sharedURLSession: URLSession = {
     return URLSession(configuration: configuration)
 }()
 
+extension URLSession {
+    static var serverMockURLSession: URLSession { sharedURLSession }
+}
+
 class ServerMock {
     static weak var activeInstance: ServerMock?
 
@@ -186,7 +190,7 @@ class ServerMock {
 
     // MARK: - Utils
 
-    /// Returns recommended timeout for delivering given number of requests if `.mockUnitTestsPerformancePreset()` is used for upload.
+    /// Returns recommended timeout for delivering given number of requests if test-tuned values are used for `PerformancePreset`.
     func recommendedTimeoutFor(numberOfRequestsMade: UInt) -> TimeInterval {
         let uploadPerformanceForTests = UploadPerformanceMock.veryQuick
         // Set the timeout to 40 times more than expected.
@@ -195,7 +199,7 @@ class ServerMock {
     }
 }
 
-// MARK: - Feature helpers
+// MARK: - Logging feature helpers
 
 extension ServerMock {
     func waitAndReturnLogMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -8,7 +8,7 @@
 
 extension TracingFeature {
     /// Mocks feature instance which performs no writes and no uploads.
-    static func mockNoOp(temporaryDirectory: Directory) -> TracingFeature {
+    static func mockNoOp() -> TracingFeature {
         return TracingFeature(
             storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader()),
             upload: .init(uploader: NoOpDataUploadWorker()),

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -18,9 +18,11 @@ extension TracingFeature {
         )
     }
 
+    /// Mocks the feature instance which performs uploads to `URLSession`.
+    /// Use `ServerMock` to inspect and assert recorded `URLRequests`.
     static func mockWith(
         directory: Directory,
-        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature(),
+        dependencies: FeaturesCommonDependencies = .mockWith(),
         loggingFeature: LoggingFeature? = nil,
         tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator()
     ) -> TracingFeature {
@@ -32,9 +34,11 @@ extension TracingFeature {
         )
     }
 
+    /// Mocks the feature instance which performs uploads to mocked `DataUploadWorker`.
+    /// Use `TracingFeature.waitAndReturnSpanMatchers()` to inspect and assert recorded `Spans`.
     static func mockByRecordingSpanMatchers(
         directory: Directory,
-        dependencies: FeaturesCommonDependencies = .mockForWorkingFeature(),
+        dependencies: FeaturesCommonDependencies = .mockWith(),
         loggingFeature: LoggingFeature? = nil,
         tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator()
     ) -> TracingFeature {

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -28,7 +28,7 @@ class RUMEventFileOutputTests: XCTestCase {
         )
         let output = RUMEventFileOutput(
             fileWriter: FileWriter(
-                dataFormat: RUMFeature.Storage.dataFormat,
+                dataFormat: RUMFeature.dataFormat,
                 orchestrator: FilesOrchestrator(
                     directory: temporaryDirectory,
                     performance: PerformancePreset.combining(

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -26,7 +26,7 @@ class RUMFeatureTests: XCTestCase {
 
     func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockFullFeature(
+        RUMFeature.instance = .mockWith(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 configuration: .mockWith(
@@ -62,7 +62,7 @@ class RUMFeatureTests: XCTestCase {
 
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockFullFeature(
+        RUMFeature.instance = .mockWith(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 performance: .combining(

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -26,17 +26,18 @@ class RUMFeatureTests: XCTestCase {
 
     func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        RUMFeature.instance = .mockFullFeature(
             directory: temporaryDirectory,
-            configuration: .mockWith(
-                applicationName: "FoobarApp",
-                applicationVersion: "2.1.0",
-                serviceName: "service-name",
-                environment: "environment-name"
-            ),
-            mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1"),
-            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+            dependencies: .mockForWorkingFeature(
+                configuration: .mockWith(
+                    applicationName: "FoobarApp",
+                    applicationVersion: "2.1.0",
+                    serviceName: "service-name",
+                    environment: "environment-name"
+                ),
+                mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1"),
+                dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+            )
         )
         defer { RUMFeature.instance = nil }
 
@@ -61,25 +62,26 @@ class RUMFeatureTests: XCTestCase {
 
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        RUMFeature.instance = .mockFullFeature(
             directory: temporaryDirectory,
-            performance: .combining(
-                storagePerformance: StoragePerformanceMock(
-                    maxFileSize: .max,
-                    maxDirectorySize: .max,
-                    maxFileAgeForWrite: .distantFuture, // write all spans to single file,
-                    minFileAgeForRead: StoragePerformanceMock.readAllFiles.minFileAgeForRead,
-                    maxFileAgeForRead: StoragePerformanceMock.readAllFiles.maxFileAgeForRead,
-                    maxObjectsInFile: 3, // write 3 spans to payload,
-                    maxObjectSize: .max
-                ),
-                uploadPerformance: UploadPerformanceMock(
-                    initialUploadDelay: 0.5, // wait enough until spans are written,
-                    defaultUploadDelay: 1,
-                    minUploadDelay: 1,
-                    maxUploadDelay: 1,
-                    uploadDelayDecreaseFactor: 1
+            dependencies: .mockForWorkingFeature(
+                performance: .combining(
+                    storagePerformance: StoragePerformanceMock(
+                        maxFileSize: .max,
+                        maxDirectorySize: .max,
+                        maxFileAgeForWrite: .distantFuture, // write all spans to single file,
+                        minFileAgeForRead: StoragePerformanceMock.readAllFiles.minFileAgeForRead,
+                        maxFileAgeForRead: StoragePerformanceMock.readAllFiles.maxFileAgeForRead,
+                        maxObjectsInFile: 3, // write 3 spans to payload,
+                        maxObjectSize: .max
+                    ),
+                    uploadPerformance: UploadPerformanceMock(
+                        initialUploadDelay: 0.5, // wait enough until spans are written,
+                        defaultUploadDelay: 1,
+                        minUploadDelay: 1,
+                        maxUploadDelay: 1,
+                        uploadDelayDecreaseFactor: 1
+                    )
                 )
             )
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -28,7 +28,7 @@ class RUMFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         RUMFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(
                     applicationName: "FoobarApp",
                     applicationVersion: "2.1.0",
@@ -64,7 +64,7 @@ class RUMFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         RUMFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 performance: .combining(
                     storagePerformance: StoragePerformanceMock(
                         maxFileSize: .max,

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -15,7 +15,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
         super.setUp()
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(
                     applicationVersion: "1.2.3",
                     serviceName: "service-name",

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -13,8 +13,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        RUMFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: DataUploadWorkerMock(),
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 configuration: .mockWith(

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -10,32 +10,26 @@ import XCTest
 class RUMMonitorConfigurationTests: XCTestCase {
     private let networkConnectionInfoProvider: NetworkConnectionInfoProviderMock = .mockAny()
     private let carrierInfoProvider: CarrierInfoProviderMock = .mockAny()
-    private var mockServer: ServerMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUp() {
         super.setUp()
-        temporaryDirectory.create()
-
-        mockServer = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: mockServer,
+        RUMFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: DataUploadWorkerMock(),
             directory: temporaryDirectory,
-            configuration: .mockWith(
-                applicationVersion: "1.2.3",
-                serviceName: "service-name",
-                environment: "tests"
-            ),
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            carrierInfoProvider: carrierInfoProvider
+            dependencies: .mockForWorkingFeature(
+                configuration: .mockWith(
+                    applicationVersion: "1.2.3",
+                    serviceName: "service-name",
+                    environment: "tests"
+                ),
+                networkConnectionInfoProvider: networkConnectionInfoProvider,
+                carrierInfoProvider: carrierInfoProvider
+            )
         )
     }
 
     override func tearDown() {
-        mockServer.waitAndAssertNoRequestsSent()
         RUMFeature.instance = nil
-        mockServer = nil
-
-        temporaryDirectory.delete()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -226,7 +226,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize(rumApplicationID: .mockAny())
@@ -260,7 +260,7 @@ class RUMMonitorTests: XCTestCase {
     // TODO: RUMM-614 Change this test when final initialization API is provided
     func testWhenMonitorIsInitialized_itIsRegisteredAsGlobalMonitor() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
         XCTAssertNil(RUMMonitor.shared)

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -29,7 +29,7 @@ class RUMMonitorTests: XCTestCase {
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 dateProvider: dateProvider
             )
         )
@@ -88,7 +88,7 @@ class RUMMonitorTests: XCTestCase {
     func testStartingView_thenTappingButton() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
@@ -170,7 +170,7 @@ class RUMMonitorTests: XCTestCase {
     func testStartingView_thenIssuingAnError_whileScrolling() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0.01)
             )
         )

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -26,12 +26,14 @@ class RUMMonitorTests: XCTestCase {
     // MARK: - Sending RUM events
 
     func testStartingView() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        let uploadWorker = DataUploadWorkerMock()
+        RUMFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory,
-            dateProvider: dateProvider
+            dependencies: .mockForWorkingFeature(
+                dateProvider: dateProvider
+            )
         )
         defer { RUMFeature.instance = nil }
 
@@ -41,7 +43,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.stopView(viewController: mockView)
         monitor.startView(viewController: mockView)
 
-        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 4)
+        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 4)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
@@ -58,9 +60,9 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingResource() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        let uploadWorker = DataUploadWorkerMock()
+        RUMFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory
         )
         defer { RUMFeature.instance = nil }
@@ -71,7 +73,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.startResourceLoading(resourceName: "/resource/1", url: .mockAny(), httpMethod: .mockAny())
         monitor.stopResourceLoading(resourceName: "/resource/1", kind: .image, httpStatusCode: 200)
 
-        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 4)
+        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 4)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
@@ -90,11 +92,13 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenTappingButton() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        let uploadWorker = DataUploadWorkerMock()
+        RUMFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory,
-            dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
+            dependencies: .mockForWorkingFeature(
+                dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
+            )
         )
         defer { RUMFeature.instance = nil }
 
@@ -104,7 +108,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.registerUserAction(type: .tap)
         monitor.stopView(viewController: mockView)
 
-        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 4)
+        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 4)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
@@ -122,9 +126,9 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingResources_whileScrolling() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        let uploadWorker = DataUploadWorkerMock()
+        RUMFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory
         )
         defer { RUMFeature.instance = nil }
@@ -139,7 +143,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.stopResourceLoading(resourceName: "/resource/2", kind: .image, httpStatusCode: 202)
         monitor.stopUserAction(type: .scroll)
 
-        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 8)
+        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 8)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
@@ -176,11 +180,13 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenIssuingAnError_whileScrolling() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        let uploadWorker = DataUploadWorkerMock()
+        RUMFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory,
-            dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0.01)
+            dependencies: .mockForWorkingFeature(
+                dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0.01)
+            )
         )
         defer { RUMFeature.instance = nil }
 
@@ -193,7 +199,7 @@ class RUMMonitorTests: XCTestCase {
         #sourceLocation()
         monitor.stopUserAction(type: .scroll)
 
-        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 6)
+        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 6)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
@@ -225,7 +231,6 @@ class RUMMonitorTests: XCTestCase {
     // MARK: - Thread safety
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
@@ -251,15 +256,12 @@ class RUMMonitorTests: XCTestCase {
             default: break
             }
         }
-
-        server.waitAndAssertNoRequestsSent()
     }
 
     // MARK: - Initialization
 
     // TODO: RUMM-614 Change this test when final initialization API is provided
     func testWhenMonitorIsInitialized_itIsRegisteredAsGlobalMonitor() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
@@ -272,7 +274,5 @@ class RUMMonitorTests: XCTestCase {
         }
 
         XCTAssertNil(RUMMonitor.shared)
-
-        server.waitAndAssertNoRequestsSent()
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -27,9 +27,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView() throws {
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
-        let uploadWorker = DataUploadWorkerMock()
-        RUMFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 dateProvider: dateProvider
@@ -43,7 +41,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.stopView(viewController: mockView)
         monitor.startView(viewController: mockView)
 
-        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 4)
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
@@ -60,11 +58,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingResource() throws {
-        let uploadWorker = DataUploadWorkerMock()
-        RUMFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
-            directory: temporaryDirectory
-        )
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize(rumApplicationID: "abc-123")
@@ -73,7 +67,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.startResourceLoading(resourceName: "/resource/1", url: .mockAny(), httpMethod: .mockAny())
         monitor.stopResourceLoading(resourceName: "/resource/1", kind: .image, httpStatusCode: 200)
 
-        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 4)
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
@@ -92,9 +86,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenTappingButton() throws {
-        let uploadWorker = DataUploadWorkerMock()
-        RUMFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
@@ -108,7 +100,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.registerUserAction(type: .tap)
         monitor.stopView(viewController: mockView)
 
-        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 4)
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
@@ -126,11 +118,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingResources_whileScrolling() throws {
-        let uploadWorker = DataUploadWorkerMock()
-        RUMFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
-            directory: temporaryDirectory
-        )
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize(rumApplicationID: "abc-123")
@@ -143,7 +131,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.stopResourceLoading(resourceName: "/resource/2", kind: .image, httpStatusCode: 202)
         monitor.stopUserAction(type: .scroll)
 
-        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 8)
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 8)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
@@ -180,9 +168,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenIssuingAnError_whileScrolling() throws {
-        let uploadWorker = DataUploadWorkerMock()
-        RUMFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0.01)
@@ -199,7 +185,7 @@ class RUMMonitorTests: XCTestCase {
         #sourceLocation()
         monitor.stopUserAction(type: .scroll)
 
-        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 6)
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 6)
         try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -10,30 +10,28 @@ import XCTest
 class TracerConfigurationTests: XCTestCase {
     private let networkConnectionInfoProvider: NetworkConnectionInfoProviderMock = .mockAny()
     private let carrierInfoProvider: CarrierInfoProviderMock = .mockAny()
-    private var mockServer: ServerMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUp() {
         super.setUp()
 
-        mockServer = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        TracingFeature.instance = .mockWorkingFeatureWith(
-            server: mockServer,
+        TracingFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: DataUploadWorkerMock(),
             directory: temporaryDirectory,
-            configuration: .mockWith(
-                applicationVersion: "1.2.3",
-                serviceName: "service-name",
-                environment: "tests"
+            dependencies: .mockForWorkingFeature(
+                configuration: .mockWith(
+                    applicationVersion: "1.2.3",
+                    serviceName: "service-name",
+                    environment: "tests"
+                ),
+                networkConnectionInfoProvider: networkConnectionInfoProvider,
+                carrierInfoProvider: carrierInfoProvider
             ),
-            loggingFeature: .mockNoOp(),
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            carrierInfoProvider: carrierInfoProvider
+            loggingFeature: .mockNoOp()
         )
     }
 
     override func tearDown() {
-        mockServer.waitAndAssertNoRequestsSent()
         TracingFeature.instance = nil
-        mockServer = nil
 
         super.tearDown()
     }

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -13,7 +13,6 @@ class TracerConfigurationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-
         TracingFeature.instance = .mockPartialFeature(
             dataUploadWorkerMock: DataUploadWorkerMock(),
             directory: temporaryDirectory,
@@ -32,7 +31,6 @@ class TracerConfigurationTests: XCTestCase {
 
     override func tearDown() {
         TracingFeature.instance = nil
-
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -14,7 +14,6 @@ class TracerConfigurationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        temporaryDirectory.create()
 
         mockServer = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWorkingFeatureWith(
@@ -25,7 +24,7 @@ class TracerConfigurationTests: XCTestCase {
                 serviceName: "service-name",
                 environment: "tests"
             ),
-            loggingFeature: .mockNoOp(temporaryDirectory: temporaryDirectory),
+            loggingFeature: .mockNoOp(),
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider
         )
@@ -36,7 +35,6 @@ class TracerConfigurationTests: XCTestCase {
         TracingFeature.instance = nil
         mockServer = nil
 
-        temporaryDirectory.delete()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -13,8 +13,7 @@ class TracerConfigurationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        TracingFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: DataUploadWorkerMock(),
+        TracingFeature.instance = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 configuration: .mockWith(

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -15,7 +15,7 @@ class TracerConfigurationTests: XCTestCase {
         super.setUp()
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(
                     applicationVersion: "1.2.3",
                     serviceName: "service-name",

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -601,12 +601,12 @@ class TracerTests: XCTestCase {
     }
 
     func testWhenSendingSpanError_itCreatesRUMErrorForCurrentView() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance = nil }
 
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        let uploadWorker = DataUploadWorkerMock()
+        RUMFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory
         )
         defer { RUMFeature.instance = nil }
@@ -622,7 +622,7 @@ class TracerTests: XCTestCase {
 
         // then
         // [RUMView, RUMAction, RUMError] events sent:
-        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 3)
+        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 3)
         let rumErrorMatcher = rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) }
         try XCTUnwrap(rumErrorMatcher).model(ofType: RUMError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, #"Span "operation name" reported an error"#)
@@ -632,12 +632,12 @@ class TracerTests: XCTestCase {
     }
 
     func testWhenLoggingSpanError_itCreatesRUMErrorForCurrentView() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance = nil }
 
-        RUMFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        let uploadWorker = DataUploadWorkerMock()
+        RUMFeature.instance = .mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory
         )
         defer { RUMFeature.instance = nil }
@@ -662,7 +662,7 @@ class TracerTests: XCTestCase {
 
         // then
         // [RUMView, RUMAction, RUMError] events sent:
-        let rumEventMatchers = try server.waitAndReturnRUMEventMatchers(count: 3)
+        let rumEventMatchers = try uploadWorker.waitAndReturnRUMEventMatchers(count: 3)
         let rumErrorMatcher = try XCTUnwrap(rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) })
         try rumErrorMatcher.model(ofType: RUMError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, #"Span "operation name" reported an error"#)

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -28,7 +28,7 @@ class TracerTests: XCTestCase {
     func testSendingSpanWithDefaultTracer() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(
                     applicationVersion: "1.0.0",
                     applicationBundleIdentifier: "com.datadoghq.ios-sdk",
@@ -227,7 +227,7 @@ class TracerTests: XCTestCase {
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 userInfoProvider: Datadog.instance!.userInfoProvider
             )
         )
@@ -270,7 +270,7 @@ class TracerTests: XCTestCase {
         let carrierInfoProvider = CarrierInfoProviderMock(carrierInfo: nil)
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 carrierInfoProvider: carrierInfoProvider
             )
         )
@@ -315,7 +315,7 @@ class TracerTests: XCTestCase {
         let networkConnectionInfoProvider = NetworkConnectionInfoProviderMock.mockAny()
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 networkConnectionInfoProvider: networkConnectionInfoProvider
             )
         )
@@ -375,7 +375,7 @@ class TracerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 mobileDevice: .mockWith(
                     currentBatteryStatus: { () -> MobileDevice.BatteryStatus in
                         .mockWith(state: .charging, level: 0.05, isLowPowerModeEnabled: true)
@@ -396,7 +396,7 @@ class TracerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
                     networkConnectionInfo: .mockWith(reachability: .no)
                 )
@@ -486,7 +486,7 @@ class TracerTests: XCTestCase {
     func testSendingSpanLogs() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
@@ -494,7 +494,7 @@ class TracerTests: XCTestCase {
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             ),
             loggingFeature: LoggingFeature.instance!

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -554,7 +554,7 @@ class TracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        RUMFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
         // given
@@ -581,7 +581,7 @@ class TracerTests: XCTestCase {
         )
         defer { TracingFeature.instance = nil }
 
-        RUMFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
         let previousUserLogger = userLogger
@@ -613,7 +613,7 @@ class TracerTests: XCTestCase {
 
     func testWhenSendingSpanError_itCreatesRUMErrorForCurrentView() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        TracingFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance = nil }
 
         RUMFeature.instance = .mockWorkingFeatureWith(
@@ -644,7 +644,7 @@ class TracerTests: XCTestCase {
 
     func testWhenLoggingSpanError_itCreatesRUMErrorForCurrentView() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        TracingFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance = nil }
 
         RUMFeature.instance = .mockWorkingFeatureWith(
@@ -716,7 +716,7 @@ class TracerTests: XCTestCase {
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        TracingFeature.instance = .mockNoOp(temporaryDirectory: temporaryDirectory)
+        TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance = nil }
 
         let tracer = Tracer.initialize(configuration: .init())

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -497,8 +497,9 @@ class TracerTests: XCTestCase {
     // MARK: - Integration With Logging Feature
 
     func testSendingSpanLogs() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        let loggingFeature = LoggingFeature.mockFullFeature(
+        let uploadWorker = DataUploadWorkerMock()
+        let loggingFeature = LoggingFeature.mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
@@ -520,7 +521,7 @@ class TracerTests: XCTestCase {
         span.log(fields: [OTLogFields.message: "hello", "custom.field": "value"])
         span.log(fields: [OTLogFields.event: "error", OTLogFields.errorKind: "Swift error", OTLogFields.message: "Ops!"])
 
-        let logMatchers = try server.waitAndReturnLogMatchers(count: 2)
+        let logMatchers = try uploadWorker.waitAndReturnLogMatchers(count: 2)
 
         let regularLogMatcher = logMatchers[0]
         let errorLogMatcher = logMatchers[1]

--- a/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
@@ -23,7 +23,7 @@ class SpanFileOutputTests: XCTestCase {
         let output = SpanFileOutput(
             spanBuilder: .mockAny(),
             fileWriter: FileWriter(
-                dataFormat: TracingFeature.Storage.dataFormat,
+                dataFormat: TracingFeature.dataFormat,
                 orchestrator: FilesOrchestrator(
                     directory: temporaryDirectory,
                     performance: PerformancePreset.default,

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -26,15 +26,16 @@ class TracingFeatureTests: XCTestCase {
 
     func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        TracingFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        TracingFeature.instance = .mockFullFeature(
             directory: temporaryDirectory,
-            configuration: .mockWith(
-                applicationName: "FoobarApp",
-                applicationVersion: "2.1.0"
-            ),
-            mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1"),
-            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+            dependencies: .mockForWorkingFeature(
+                configuration: .mockWith(
+                    applicationName: "FoobarApp",
+                    applicationVersion: "2.1.0"
+                ),
+                mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1"),
+                dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+            )
         )
         defer { TracingFeature.instance = nil }
 
@@ -54,25 +55,26 @@ class TracingFeatureTests: XCTestCase {
 
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        TracingFeature.instance = .mockWorkingFeatureWith(
-            server: server,
+        TracingFeature.instance = .mockFullFeature(
             directory: temporaryDirectory,
-            performance: .combining(
-                storagePerformance: StoragePerformanceMock(
-                    maxFileSize: .max,
-                    maxDirectorySize: .max,
-                    maxFileAgeForWrite: .distantFuture, // write all spans to single file,
-                    minFileAgeForRead: StoragePerformanceMock.readAllFiles.minFileAgeForRead,
-                    maxFileAgeForRead: StoragePerformanceMock.readAllFiles.maxFileAgeForRead,
-                    maxObjectsInFile: 3, // write 3 spans to payload,
-                    maxObjectSize: .max
-                ),
-                uploadPerformance: UploadPerformanceMock(
-                    initialUploadDelay: 0.5, // wait enough until spans are written,
-                    defaultUploadDelay: 1,
-                    minUploadDelay: 1,
-                    maxUploadDelay: 1,
-                    uploadDelayDecreaseFactor: 1
+            dependencies: .mockForWorkingFeature(
+                performance: .combining(
+                    storagePerformance: StoragePerformanceMock(
+                        maxFileSize: .max,
+                        maxDirectorySize: .max,
+                        maxFileAgeForWrite: .distantFuture, // write all spans to single file,
+                        minFileAgeForRead: StoragePerformanceMock.readAllFiles.minFileAgeForRead,
+                        maxFileAgeForRead: StoragePerformanceMock.readAllFiles.maxFileAgeForRead,
+                        maxObjectsInFile: 3, // write 3 spans to payload,
+                        maxObjectSize: .max
+                    ),
+                    uploadPerformance: UploadPerformanceMock(
+                        initialUploadDelay: 0.5, // wait enough until spans are written,
+                        defaultUploadDelay: 1,
+                        minUploadDelay: 1,
+                        maxUploadDelay: 1,
+                        uploadDelayDecreaseFactor: 1
+                    )
                 )
             )
         )

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -26,7 +26,7 @@ class TracingFeatureTests: XCTestCase {
 
     func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        TracingFeature.instance = .mockFullFeature(
+        TracingFeature.instance = .mockWith(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 configuration: .mockWith(
@@ -55,7 +55,7 @@ class TracingFeatureTests: XCTestCase {
 
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        TracingFeature.instance = .mockFullFeature(
+        TracingFeature.instance = .mockWith(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 performance: .combining(

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -28,7 +28,7 @@ class TracingFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(
                     applicationName: "FoobarApp",
                     applicationVersion: "2.1.0"
@@ -57,7 +57,7 @@ class TracingFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWith(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 performance: .combining(
                     storagePerformance: StoragePerformanceMock(
                         maxFileSize: .max,

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -24,11 +24,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSendingLogsWithDifferentLevels() throws {
-        let uploadWorker = DataUploadWorkerMock()
-        LoggingFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
-            directory: temporaryDirectory
-        )
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defer { LoggingFeature.instance = nil }
 
         let objcLogger = DDLogger.builder().build()
@@ -40,7 +36,7 @@ class DDLoggerTests: XCTestCase {
         objcLogger.error("message")
         objcLogger.critical("message")
 
-        let logMatchers = try uploadWorker.waitAndReturnLogMatchers(count: 6)
+        let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 6)
         logMatchers[0].assertStatus(equals: "debug")
         logMatchers[1].assertStatus(equals: "info")
         logMatchers[2].assertStatus(equals: "notice")
@@ -50,11 +46,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSendingMessageAttributes() throws {
-        let uploadWorker = DataUploadWorkerMock()
-        LoggingFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
-            directory: temporaryDirectory
-        )
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defer { LoggingFeature.instance = nil }
 
         let objcLogger = DDLogger.builder().build()
@@ -66,7 +58,7 @@ class DDLoggerTests: XCTestCase {
         objcLogger.error("message", attributes: ["foo": "bar"])
         objcLogger.critical("message", attributes: ["foo": "bar"])
 
-        let logMatchers = try uploadWorker.waitAndReturnLogMatchers(count: 6)
+        let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 6)
         logMatchers[0].assertStatus(equals: "debug")
         logMatchers[1].assertStatus(equals: "info")
         logMatchers[2].assertStatus(equals: "notice")
@@ -79,11 +71,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSendingLoggerAttributes() throws {
-        let uploadWorker = DataUploadWorkerMock()
-        LoggingFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
-            directory: temporaryDirectory
-        )
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defer { LoggingFeature.instance = nil }
 
         let objcLogger = DDLogger.builder().build()
@@ -107,7 +95,7 @@ class DDLoggerTests: XCTestCase {
         )
         objcLogger.info("message")
 
-        let logMatcher = try uploadWorker.waitAndReturnLogMatchers(count: 1)[0]
+        let logMatcher = try LoggingFeature.waitAndReturnLogMatchers(count: 1)[0]
         logMatcher.assertValue(forKey: "nsstring", equals: "hello")
         logMatcher.assertValue(forKey: "nsbool", equals: true)
         logMatcher.assertValue(forKey: "nsint", equals: 10)
@@ -120,9 +108,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSettingTagsAndAttributes() throws {
-        let uploadWorker = DataUploadWorkerMock()
-        LoggingFeature.instance = .mockPartialFeature(
-            dataUploadWorkerMock: uploadWorker,
+        LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 configuration: .mockWith(environment: "test")
@@ -146,7 +132,7 @@ class DDLoggerTests: XCTestCase {
 
         objcLogger.info(.mockAny())
 
-        let logMatcher = try uploadWorker.waitAndReturnLogMatchers(count: 1)[0]
+        let logMatcher = try LoggingFeature.waitAndReturnLogMatchers(count: 1)[0]
         logMatcher.assertValue(forKeyPath: "foo", equals: "bar")
         logMatcher.assertNoValue(forKey: "bizz")
         logMatcher.assertTags(equal: ["foo:bar", "foobar", "env:test"])

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -110,7 +110,7 @@ class DDLoggerTests: XCTestCase {
     func testSettingTagsAndAttributes() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 configuration: .mockWith(environment: "test")
             )
         )

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -116,10 +116,11 @@ class DDTracerTests: XCTestCase {
 
     func testSendingSpanLogs() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        let loggingFeature = LoggingFeature.mockWorkingFeatureWith(
-            server: server,
+        let loggingFeature = LoggingFeature.mockFullFeature(
             directory: temporaryDirectory,
-            performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+            dependencies: .mockForWorkingFeature(
+                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+            )
         )
         TracingFeature.instance = .mockPartialFeature(
             dataUploadWorkerMock: DataUploadWorkerMock(),

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -116,7 +116,7 @@ class DDTracerTests: XCTestCase {
     func testSendingSpanLogs() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
@@ -124,7 +124,7 @@ class DDTracerTests: XCTestCase {
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
-            dependencies: .mockForWorkingFeature(
+            dependencies: .mockWith(
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             ),
             loggingFeature: LoggingFeature.instance!

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -115,8 +115,9 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogs() throws {
-        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        let loggingFeature = LoggingFeature.mockFullFeature(
+        let uploadWorker = DataUploadWorkerMock()
+        let loggingFeature = LoggingFeature.mockPartialFeature(
+            dataUploadWorkerMock: uploadWorker,
             directory: temporaryDirectory,
             dependencies: .mockForWorkingFeature(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
@@ -139,7 +140,7 @@ class DDTracerTests: XCTestCase {
         objcSpan.log(["bizz": NSNumber(10.5)])
         objcSpan.log(["buzz": NSURL(string: "https://example.com/image.png")!], timestamp: nil)
 
-        let logMatchers = try server.waitAndReturnLogMatchers(count: 3)
+        let logMatchers = try uploadWorker.waitAndReturnLogMatchers(count: 3)
 
         logMatchers[0].assertValue(forKey: "foo", equals: "bar")
         logMatchers[1].assertValue(forKey: "bizz", equals: 10.5)


### PR DESCRIPTION
### What and why?

🏎️  This PR removes recent tests flakiness and speeds up the unit tests execution by 60% (`43s` → `17s` on my local 🚀). 

### How?

I changed the assertions model for all 3 features (Logging, Tracing and RUM). 

#### Before
Before, all the tests for data collection components (`Logger`, `Tracer` and `RUMMonitor`) were using the full cycle of data processing and upload, i.e.:
```swift
logger.info("message")
// 1  → async call to FileWriter
// 2     → FileWriter writes the Log data to the file system
// 3     → ... (nothing happens until DataUploadWorker triggers the upload)
// 4     → DataUploadWorker triggers the upload
// 5        → FileReader reads the Log data
// 6           → DataUploadWorker uploads the Log data with the URLSession
// 7              → ServerMock gets notified through URLProtocol
// 8                 → ServerMock captures the URLRequest body and passes it to the LogMatcher (for decoding)
let logMatcher = try server.waitAndReturnLogMatchers(count: 1)[0]
```

Even though we were using a very small interval in `DataUploadWorker` (3), this whole model had 2 major drawbacks:
* slow performance - a lot of asynchronous work and waiting in every test,
* flakiness - `DataUploadWorker` was scheduling next uploads even after capturing necessary data (stale callbacks resulting with flakiness).

#### After

The new assertion model eliminates the `URLSession` entirely from most of the tests. It uses mocked `DataUploadWorker` which observes the `FileWriter` and gets notified on every write. In this model, the "upload interval" concept doesn't exist at all and we retrieve data faster:
```swift
logger.info("message")
// 1  → async call to FileWriter
// 2     → FileWriter writes the Log data to the file system
// 3     → DataUploadWorkerMock gets notified on the write
// 4        → FileReader reads the Log data
// 5           → DataUploadWorkerMock captures the Log data body and passes it to the LogMatcher (for decoding)
let logMatcher = try server.waitAndReturnLogMatchers(count: 1)[0]
```

#### New API For Mocking Features

To make it work, new API for features mocking was introduced. Most of the changes in this PR do:
```diff
- let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
- LoggingFeature.instance = .mockWorkingFeatureWith(server: server, directory: temporaryDirectory)
+ LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)

- let logMatcher = try server.waitAndReturnLogMatchers(count: 1)[0]
+ let logMatcher = try LoggingFeature.waitAndReturnLogMatchers(count: 1)[0]
```

#### When To Use New Mocking API?

The `.mockByRecording###Matchers` should be used in all tests which need to assert `Logs`, `Spans` or `RUMEvents`. Furthermore, the `ServerMock` is not removed, as we need it for many other tests asserting the real network transport, i.e. in `LoggingFeatureTests` we still use it to assert HTTP headers used by the `LoggingFeature`.

The `ServerMock` shouldn't be used together with mocking the `DataUploadWorker` (in fact, this will not work as no `URLRequest` is made). Instead it should be used as below:

```swift
let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
LoggingFeature.instance = .mockWith(...)

// ...
logger.info("message")

let request = server.waitAndReturnRequests(count: 1)[0].httpBody!
```

#### Changes To The Features Initialization Code

To make the `DataUploadWorker` mocking easy, I had to improve the abstraction over features `Storage` and `Upload`. As they are exactly the same for all features, 3 new components were introduced:
```swift
/// Container with dependencies common to all features (Logging, Tracing and RUM).
internal struct FeaturesCommonDependencies {
   // ... `dateProvider`, `httpClient`, etc.
}

internal struct FeatureStorage {
    let writer: FileWriterType
    let reader: FileReaderType
}

internal struct FeatureUpload {
    let uploader: DataUploadWorkerType
}
```

This can be pushed even more, and we may have `Feature` base class or something else to reuse more code between features. I don't do it right now, to not spend more time on this.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
