### PR TITLE
RUMM-669 Xcode 11.3.1 compilation fix

### DIFF
--- a/Sources/Datadog/Core/AutoInstrumentation/MethodSwizzler.swift
+++ b/Sources/Datadog/Core/AutoInstrumentation/MethodSwizzler.swift
@@ -62,8 +62,8 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
     @discardableResult
     func swizzle(
         _ foundMethod: FoundMethod,
-        impProvider: (TypedIMP) -> TypedBlockIMP,
-        onlyIfNonSwizzled: Bool = false
+        onlyIfNonSwizzled: Bool = false,
+        impProvider: (TypedIMP) -> TypedBlockIMP
     ) -> Bool {
         sync {
             if onlyIfNonSwizzled &&

--- a/Sources/Datadog/Core/AutoInstrumentation/URLSessionSwizzler.swift
+++ b/Sources/Datadog/Core/AutoInstrumentation/URLSessionSwizzler.swift
@@ -146,14 +146,13 @@ internal class URLSessionSwizzler {
             typealias BlockIMP = @convention(block) (URLSessionTask) -> Void
             swizzle(
                 foundMethod,
-                impProvider: { currentTypedImp -> BlockIMP in
-                    return { impSelf in
-                        impSelf.consumePayloads { $0(.starting(impSelf.currentRequest)) }
-                        return currentTypedImp(impSelf, Self.selector)
-                    }
-                },
                 onlyIfNonSwizzled: true
-            )
+            ) { currentTypedImp -> BlockIMP in
+                return { impSelf in
+                    impSelf.consumePayloads { $0(.starting(impSelf.currentRequest)) }
+                    return currentTypedImp(impSelf, Self.selector)
+                }
+            }
         }
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/MethodSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/AutoInstrumentation/MethodSwizzlerTests.swift
@@ -107,7 +107,7 @@ class MethodSwizzlerTests: XCTestCase {
         let secondSwizzlingReturnValue = "Second swizzling"
         let newImp: TypedBlockIMPReturnString = { _ in secondSwizzlingReturnValue }
         XCTAssertFalse(
-            swizzler.swizzle(foundMethod, impProvider: { _ in newImp }, onlyIfNonSwizzled: true),
+            swizzler.swizzle(foundMethod, onlyIfNonSwizzled: true) { _ in newImp },
             "Already swizzled method should not be swizzled again"
         )
 
@@ -130,12 +130,11 @@ class MethodSwizzlerTests: XCTestCase {
         XCTAssertFalse(
             swizzler.swizzle(
                 foundMethod,
-                impProvider: { _ -> TypedBlockIMPReturnString in
-                    XCTFail("New IMP should not be created after error")
-                    return newIMPReturnString
-                },
                 onlyIfNonSwizzled: true
-            ),
+            ) { _ -> TypedBlockIMPReturnString in
+                XCTFail("New IMP should not be created after error")
+                return newIMPReturnString
+            },
             "Already swizzled method should not be swizzled again"
         )
     }
@@ -178,13 +177,12 @@ class MethodSwizzlerTests: XCTestCase {
         DispatchQueue.concurrentPerform(iterations: iterations) { _ in
             swizzler.swizzle(
                 foundMethod,
-                impProvider: { originalImp -> TypedBlockIMPReturnString in
-                    return { impSelf -> String in
-                        return originalImp(impSelf, selector).appending(appendString)
-                    }
-                },
                 onlyIfNonSwizzled: true
-            )
+            ) { originalImp -> TypedBlockIMPReturnString in
+                return { impSelf -> String in
+                    return originalImp(impSelf, selector).appending(appendString)
+                }
+            }
             expectation.fulfill()
         }
 


### PR DESCRIPTION
### What and why?

Xcode 11.3.1 doesn't have iOS 13.4 as base SDK
therefore `#available(iOS 13.4)` closures don't compile

For more: https://github.com/DataDog/dd-sdk-ios/issues/214

### How?

We added compiler version macros as workaround
```swift
#if compiler(>=5.2)
  if #available(iOS 13.4, *) { newMethod() }
  else { legacy() }
#else
legacy()
#endif
```

_Note:_ It's not trivial to run our tests in different Xcode versions with our CI provider

<img width="530" alt="Screenshot 2020-08-13 at 14 19 59" src="https://user-images.githubusercontent.com/1417500/90133745-4dd37200-dd70-11ea-8376-8d1d87ca9521.png">

### Release info

This PR is branched off from `1.3.0` tag and to be merged into `master`
We will ship this change as a hotfix once it is merged

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
