### PR TITLE
RUMM-535 Resources and User Actions are linked with the active View

### DIFF
--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -363,6 +363,16 @@ func createMockView() -> UIViewController {
     return viewController
 }
 
+/// Creates an instance of `UIViewController` subclass with a given name.
+func createMockView(viewControllerClassName: String) -> UIViewController {
+    let theClass: AnyClass = objc_allocateClassPair(UIViewController.classForCoder(), viewControllerClassName, 0)!
+    objc_registerClassPair(theClass)
+    let viewController = theClass.alloc() as! UIViewController
+    mockWindow.rootViewController = viewController
+    mockWindow.makeKeyAndVisible()
+    return viewController
+}
+
 /// Holds the `mockView` object so it can be weakily referenced by `RUMViewScope` mocks.
 let mockView: UIViewController = createMockView()
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -140,9 +140,12 @@ class RUMMonitorTests: XCTestCase {
             XCTAssertEqual(rumModel.view.resource.count, 0)
             XCTAssertEqual(rumModel.view.error.count, 0)
         }
+        var userActionID: String?
         try rumEventMatchers[2].model(ofType: RUMResource.self) { rumModel in
+            userActionID = rumModel.action?.id
             XCTAssertEqual(rumModel.resource.statusCode, 200)
         }
+        XCTAssertNotNil(userActionID, "Resource should be associated with the User Action that issued its loading")
         try rumEventMatchers[3].model(ofType: RUMView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.resource.count, 1)
@@ -159,6 +162,7 @@ class RUMMonitorTests: XCTestCase {
         try rumEventMatchers[6].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.resource?.count, 2)
             XCTAssertEqual(rumModel.action.error?.count, 0)
+            XCTAssertEqual(rumModel.action.id, userActionID)
         }
         try rumEventMatchers[7].model(ofType: RUMView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 2)
@@ -212,6 +216,58 @@ class RUMMonitorTests: XCTestCase {
             XCTAssertEqual(rumModel.view.resource.count, 0)
             XCTAssertEqual(rumModel.view.error.count, 1)
         }
+    }
+
+    func testStartingAnotherViewBeforeFirstIsStopped_thenLoadingResourcesAfterTapingButton() throws {
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(
+            directory: temporaryDirectory,
+            dependencies: .mockWith(
+                dateProvider: RelativeDateProvider(
+                    startingFrom: Date(),
+                    advancingBySeconds: RUMUserActionScope.Constants.discreteActionTimeoutDuration
+                )
+            )
+        )
+        defer { RUMFeature.instance = nil }
+
+        let monitor = RUMMonitor.initialize(rumApplicationID: "abc-123")
+
+        let view1 = createMockView(viewControllerClassName: "FirstViewController")
+        monitor.startView(viewController: view1)
+        let view2 = createMockView(viewControllerClassName: "SecondViewController")
+        monitor.startView(viewController: view2)
+        monitor.registerUserAction(type: .tap)
+        monitor.startResourceLoading(resourceName: "/resource/1", url: .mockAny(), httpMethod: .mockAny())
+        monitor.stopResourceLoading(resourceName: "/resource/1", kind: .mockAny(), httpStatusCode: .mockAny())
+        monitor.stopView(viewController: view1)
+        monitor.stopView(viewController: view2)
+
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 9)
+        try rumEventMatchers
+            .lastRUMEvent(ofType: RUMView.self) { rumModel in rumModel.view.url == "FirstViewController" }
+            .model(ofType: RUMView.self) { rumModel in
+                XCTAssertEqual(rumModel.view.url, "FirstViewController")
+                XCTAssertEqual(rumModel.view.action.count, 1, "First View should track only the 'applicationStart' Action")
+                XCTAssertEqual(rumModel.view.resource.count, 0)
+            }
+        try rumEventMatchers
+            .lastRUMEvent(ofType: RUMView.self) { rumModel in rumModel.view.url == "SecondViewController" }
+            .model(ofType: RUMView.self) { rumModel in
+                XCTAssertEqual(rumModel.view.url, "SecondViewController")
+                XCTAssertEqual(rumModel.view.action.count, 1, "Second View should track the 'tap' Action")
+                XCTAssertEqual(rumModel.view.resource.count, 1, "Second View should track the Resource")
+            }
+        try rumEventMatchers
+            .lastRUMEvent(ofType: RUMAction.self)
+            .model(ofType: RUMAction.self) { rumModel in
+                XCTAssertEqual(rumModel.view.url, "SecondViewController", "Action should be associated with the second View")
+                XCTAssertEqual(rumModel.action.type, .tap)
+            }
+        try rumEventMatchers
+            .lastRUMEvent(ofType: RUMResource.self)
+            .model(ofType: RUMResource.self) { rumModel in
+                XCTAssertEqual(rumModel.view.url, "SecondViewController", "Resource should be associated with the second View")
+            }
     }
 
     // MARK: - Thread safety

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -109,6 +109,23 @@ extension RUMEventMatcher: CustomStringConvertible {
     }
 }
 
+extension Array where Element == RUMEventMatcher {
+    func filterRUMEvents<DM: Decodable>(ofType type: DM.Type, where predicate: ((DM) -> Bool)? = nil) -> [Element] {
+        return filter { matcher in matcher.model(isTypeOf: type) }
+            .filter { matcher in predicate?(try! matcher.model()) ?? true }
+    }
+
+    func lastRUMEvent<DM: Decodable>(
+        ofType type: DM.Type,
+        file: StaticString = #file,
+        line: UInt = #line,
+        where predicate: ((DM) -> Bool)? = nil
+    ) throws -> Element {
+        let last = filterRUMEvents(ofType: type, where: predicate).last
+        return try XCTUnwrap(last, file: file, line: line)
+    }
+}
+
 func XCTAssertValidRumUUID(_ string: String?, file: StaticString = #file, line: UInt = #line) {
     let schemaReference = "given by https://github.com/DataDog/rum-events-format/blob/master/schemas/_common-schema.json"
     guard let string = string else {


### PR DESCRIPTION
### What and why?

📦 This PR makes the Resources and User Actions being associated with the active View.

### How?

This corresponds to the case where multiple Views are started at a time, for example:
```swift
monitor.startView(viewController: master)
monitor.startView(viewController: details)
monitor.startResourceLoading(resourceName: "/resource/1")
```

In such case, prior to this PR, the `/resource/1` would appear in both, "master" and "details" Views in RUM Explorer. This PR updates this behaviour, and the Resource will be linked only to the "details" View.

This also solves the range of errors with manual (and further: auto) instrumentation, where `startView()` and `stopView()` are called from different `UIViewController` lifecycle callbacks, i.e. when calling "start" from `viewDidLoad()` and "stop" from `viewDidDisappear()`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
