### PR TITLE
RUMM-671 DatadogObjC target is fixed for SPM

### DIFF
--- a/Sources/DatadogObjc/OpenTracing/OTGlobal+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTGlobal+objc.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
 import Datadog
 
 @objcMembers

--- a/Sources/DatadogObjc/OpenTracing/OTNoop.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTNoop.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
+
 internal let noopTracer: OTTracer = DDNoopTracer()
 internal let noopSpan: OTSpan = DDNoopSpan()
 internal let noopSpanContext: OTSpanContext = DDNoopSpanContext()

--- a/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
+
 @objc
 /// Corresponds to: https://github.com/opentracing/opentracing-objc/blob/master/Pod/Classes/OTSpan.h
 public protocol OTSpan {

--- a/Sources/DatadogObjc/OpenTracing/OTSpanContext+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTSpanContext+objc.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
+
 @objc
 /// Corresponds to: https://github.com/opentracing/opentracing-objc/blob/master/Pod/Classes/OTSpanContext.h
 public protocol OTSpanContext {

--- a/Sources/DatadogObjc/OpenTracing/OTTracer+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTTracer+objc.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
 public let OTFormatHTTPHeaders = "OTFormatHTTPHeaders"
 
 @objc

--- a/Sources/DatadogObjc/Tracer+objc.swift
+++ b/Sources/DatadogObjc/Tracer+objc.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
 import class Datadog.Tracer
 import protocol Datadog.OTTracer
 import struct Datadog.OTReference

--- a/Sources/DatadogObjc/TracerConfiguration+objc.swift
+++ b/Sources/DatadogObjc/TracerConfiguration+objc.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
 import Datadog
 
 @objcMembers

--- a/Sources/DatadogObjc/Tracing/DDSpan+objc.swift
+++ b/Sources/DatadogObjc/Tracing/DDSpan+objc.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
 import protocol Datadog.OTSpan
 
 internal class DDSpanObjc: NSObject, DatadogObjc.OTSpan {

--- a/Sources/DatadogObjc/Tracing/DDSpanContext+objc.swift
+++ b/Sources/DatadogObjc/Tracing/DDSpanContext+objc.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
 import protocol Datadog.OTSpanContext
 
 internal class DDSpanContextObjc: NSObject, OTSpanContext {

--- a/Sources/DatadogObjc/Tracing/Propagation/HTTPHeadersWriter+objc.swift
+++ b/Sources/DatadogObjc/Tracing/Propagation/HTTPHeadersWriter+objc.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
 import class Datadog.HTTPHeadersWriter
 
 @objcMembers

--- a/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
+++ b/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
@@ -14,8 +14,8 @@
 		61C363E624374D6000C4D4E6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61C363E424374D6000C4D4E6 /* LaunchScreen.storyboard */; };
 		61C363F124374D6100C4D4E6 /* SPMProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363F024374D6100C4D4E6 /* SPMProjectTests.swift */; };
 		61C363FC24374D6100C4D4E6 /* SPMProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363FB24374D6100C4D4E6 /* SPMProjectUITests.swift */; };
-		61C3640B24374DF200C4D4E6 /* Datadog in Frameworks */ = {isa = PBXBuildFile; productRef = 61C3640A24374DF200C4D4E6 /* Datadog */; };
-		9E1F996A244DDABE00BD10FC /* Datadog in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 61C3640A24374DF200C4D4E6 /* Datadog */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		9EC32C6224E596C20063BCCE /* DatadogObjc in Frameworks */ = {isa = PBXBuildFile; productRef = 9EC32C6124E596C20063BCCE /* DatadogObjc */; };
+		9EC32C6324E596C20063BCCE /* DatadogObjc in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 9EC32C6124E596C20063BCCE /* DatadogObjc */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,7 +42,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9E1F996A244DDABE00BD10FC /* Datadog in Embed Frameworks */,
+				9EC32C6324E596C20063BCCE /* DatadogObjc in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -72,7 +72,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				61C3640B24374DF200C4D4E6 /* Datadog in Frameworks */,
+				9EC32C6224E596C20063BCCE /* DatadogObjc in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,6 +101,7 @@
 				61C363EF24374D6100C4D4E6 /* SPMProjectTests */,
 				61C363FA24374D6100C4D4E6 /* SPMProjectUITests */,
 				61C363D724374D5F00C4D4E6 /* Products */,
+				9EC32C6024E596C20063BCCE /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -155,6 +156,13 @@
 			path = ../../xcconfigs;
 			sourceTree = "<group>";
 		};
+		9EC32C6024E596C20063BCCE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -174,7 +182,7 @@
 			);
 			name = SPMProject;
 			packageProductDependencies = (
-				61C3640A24374DF200C4D4E6 /* Datadog */,
+				9EC32C6124E596C20063BCCE /* DatadogObjc */,
 			);
 			productName = SPMProject;
 			productReference = 61C363D624374D5F00C4D4E6 /* SPMProject.app */;
@@ -653,10 +661,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		61C3640A24374DF200C4D4E6 /* Datadog */ = {
+		9EC32C6124E596C20063BCCE /* DatadogObjc */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 61C3640924374DF200C4D4E6 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
-			productName = Datadog;
+			productName = DatadogObjc;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/dependency-manager-tests/spm/SPMProject/ViewController.swift
+++ b/dependency-manager-tests/spm/SPMProject/ViewController.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 import Datadog
+import DatadogObjc
 
 internal class ViewController: UIViewController {
     private var logger: Logger! // swiftlint:disable:this implicitly_unwrapped_optional


### PR DESCRIPTION
### What and why?

`DatadogObjC` wasn't compiling with _@objc attribute used without importing module 'Foundation'_ errors
This only happens in Swift Package Manager; other dependency managers work fine
For more info: https://github.com/DataDog/dd-sdk-ios/issues/218

### How?

I added `import Foundation` lines to source files.
I also made dep-manager-test/spm import `DatadogObjC` instead of `Datadog`, this should test both targets at once.
Note: I'm still investigating how come Xcode manages to build the project without those imports 🤔 

Release info

This PR is branched off from 1.3.0 tag and to be merged into master
We will ship this change as a hotfix once it is merged

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
