### PR TITLE
RUMM-670 Fix the active span concept to let create several root spans on the same thread

### DIFF
--- a/Sources/Datadog/OpenTracing/OTSpan.swift
+++ b/Sources/Datadog/OpenTracing/OTSpan.swift
@@ -44,6 +44,7 @@ public protocol OTSpan {
     /// Sets this span as the active span in the current execution context, this span is assigned as the parent of any
     /// created Span in the same execution context without explicit parent.
     /// Will be the active span until it finishes or another span is set as active.
+    @discardableResult
     func setActive() -> OTSpan
 }
 

--- a/Sources/Datadog/OpenTracing/OTSpan.swift
+++ b/Sources/Datadog/OpenTracing/OTSpan.swift
@@ -41,9 +41,21 @@ public protocol OTSpan {
     /// - parameter time: If non-nil, time at which to finish the span; default time is used if nil
     func finish(at time: Date)
 
-    /// Sets this span as the active span in the current execution context, this span is assigned as the parent of any
-    /// created Span in the same execution context without explicit parent.
-    /// Will be the active span until it finishes or another span is set as active.
+    /// Sets this span as the active span in the current execution context.
+    /// The active span becomes the parent of any other span created in the same execution context
+    /// if the parent is not set explicitly. The span remains active until it finishes or another span is set as active.
+    ///
+    /// Example:
+    ///
+    ///     // `span1` becomes active in this thread:
+    ///     let span1 = tracer.startSpan(operationName: "root").setActive()
+    ///
+    ///     // As `span2` has no explicit parent, it becomes the child of the active `span1`:
+    ///     let span2 = tracer.startSpan(operationName: "child of `span1`")
+    ///
+    ///     // As `span3` has the explicit parent (nil) it won't become the child of the active span:
+    ///     let span3 = tracer.startSpan(operationName: "another root", childOf: nil)
+    ///
     @discardableResult
     func setActive() -> OTSpan
 }

--- a/Sources/Datadog/OpenTracing/OTSpan.swift
+++ b/Sources/Datadog/OpenTracing/OTSpan.swift
@@ -40,6 +40,11 @@ public protocol OTSpan {
     ///
     /// - parameter time: If non-nil, time at which to finish the span; default time is used if nil
     func finish(at time: Date)
+
+    /// Sets this span as the active span in the current execution context, this span is assigned as the parent of any
+    /// created Span in the same execution context without explicit parent.
+    /// Will be the active span until it finishes or another span is set as active.
+    func setActive() -> OTSpan
 }
 
 /// Convenience extension

--- a/Sources/Datadog/OpenTracing/OTTracer.swift
+++ b/Sources/Datadog/OpenTracing/OTTracer.swift
@@ -57,7 +57,7 @@ public protocol OTTracer {
 
     /// Returns the active span in the current execution context, this span will be automatically assigned as the parent of any
     /// created Span without explicit parent.
-    /// For a span to be set as the active one in the current context,  it must explicitly call span.setActive()
+    /// For a span to be set as the active one in the current context, it must explicitly call `span.setActive()`.
     /// This method can return different results depending on the context that is executed.
     var activeSpan: OTSpan? { get }
 }

--- a/Sources/Datadog/OpenTracing/OTTracer.swift
+++ b/Sources/Datadog/OpenTracing/OTTracer.swift
@@ -57,6 +57,8 @@ public protocol OTTracer {
 
     /// Returns the active span in the current execution context, this span will be automatically assigned as the parent of any
     /// created Span without explicit parent.
+    /// For a span to be set as the active one in the current context,  it must explicitly call span.setActive()
+    /// This method can return different results depending on the context that is executed.
     var activeSpan: OTSpan? { get }
 }
 

--- a/Sources/Datadog/Tracing/DDNoOps.swift
+++ b/Sources/Datadog/Tracing/DDNoOps.swift
@@ -28,6 +28,7 @@ internal struct DDNoopSpan: OTSpan {
     func baggageItem(withKey key: String) -> String? { nil }
     func setBaggageItem(key: String, value: String) {}
     func setTag(key: String, value: Encodable) {}
+    func setActive() -> OTSpan { self}
 }
 
 internal struct DDNoopSpanContext: OTSpanContext {

--- a/Sources/Datadog/Tracing/DDNoOps.swift
+++ b/Sources/Datadog/Tracing/DDNoOps.swift
@@ -28,7 +28,8 @@ internal struct DDNoopSpan: OTSpan {
     func baggageItem(withKey key: String) -> String? { nil }
     func setBaggageItem(key: String, value: String) {}
     func setTag(key: String, value: Encodable) {}
-    func setActive() -> OTSpan { self}
+    @discardableResult
+    func setActive() -> OTSpan { self }
 }
 
 internal struct DDNoopSpanContext: OTSpanContext {

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -113,6 +113,7 @@ internal class DDSpan: OTSpan {
         ddTracer.write(span: self, finishTime: time)
     }
 
+    @discardableResult
     func setActive() -> OTSpan {
         let dso = UnsafeMutableRawPointer(mutating: #dsohandle)
         let activity = _os_activity_create(dso, "InitDDSpanContext", OS_ACTIVITY_CURRENT, OS_ACTIVITY_FLAG_DEFAULT)

--- a/Sources/DatadogObjc/OpenTracing/OTNoop.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTNoop.swift
@@ -31,6 +31,7 @@ private class DDNoopSpan: OTSpan {
     func getBaggageItem(_ key: String) -> String? { nil }
     func finish() {}
     func finishWithTime(_ finishTime: Date?) {}
+    @discardableResult
     func setActive() -> OTSpan { self }
 }
 

--- a/Sources/DatadogObjc/OpenTracing/OTNoop.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTNoop.swift
@@ -31,6 +31,7 @@ private class DDNoopSpan: OTSpan {
     func getBaggageItem(_ key: String) -> String? { nil }
     func finish() {}
     func finishWithTime(_ finishTime: Date?) {}
+    func setActive() -> OTSpan { self }
 }
 
 private class DDNoopSpanContext: OTSpanContext {

--- a/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
@@ -24,4 +24,6 @@ public protocol OTSpan {
 
     func finish()
     func finishWithTime(_ finishTime: Date?)
+
+    func setActive() -> OTSpan
 }

--- a/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
@@ -25,5 +25,6 @@ public protocol OTSpan {
     func finish()
     func finishWithTime(_ finishTime: Date?)
 
+    @discardableResult
     func setActive() -> OTSpan
 }

--- a/Sources/DatadogObjc/Tracing/DDSpan+objc.swift
+++ b/Sources/DatadogObjc/Tracing/DDSpan+objc.swift
@@ -74,4 +74,9 @@ internal class DDSpanObjc: NSObject, DatadogObjc.OTSpan {
             swiftSpan.finish()
         }
     }
+
+    func setActive() -> DatadogObjc.OTSpan {
+        _ = swiftSpan.setActive()
+        return self
+    }
 }

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -742,7 +742,7 @@ class TracerTests: XCTestCase {
 
         let spanMatchers = try server.waitAndReturnSpanMatchers(count: 2)
         XCTAssertEqual(try spanMatchers[0].parentSpanID(), "0")
-        XCTAssertEqual(try spanMatchers[1].parentSpanID(), "0") // fails, as 2 is child of 1
+        XCTAssertEqual(try spanMatchers[1].parentSpanID(), "0")
     }
 }
 // swiftlint:enable multiline_arguments_brackets

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/ActiveSpansPoolTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/ActiveSpansPoolTests.swift
@@ -13,7 +13,7 @@ class ActiveSpansPoolTests: XCTestCase {
         let previousSpan = tracer.activeSpan
         XCTAssertNil(previousSpan)
 
-        let oneSpan = tracer.startSpan(operationName: .mockAny())
+        let oneSpan = tracer.startSpan(operationName: .mockAny()).setActive()
         XCTAssert(tracer.activeSpan?.dd.ddContext.spanID == oneSpan.dd.ddContext.spanID)
         oneSpan.finish()
         XCTAssertNil(tracer.activeSpan)
@@ -23,7 +23,7 @@ class ActiveSpansPoolTests: XCTestCase {
         let tracer = Tracer.mockAny()
         XCTAssertNil(tracer.activeSpan)
 
-        let oneSpan = tracer.startSpan(operationName: .mockAny())
+        let oneSpan = tracer.startSpan(operationName: .mockAny()).setActive()
         XCTAssert(tracer.activeSpan?.dd.ddContext.spanID == oneSpan.dd.ddContext.spanID)
 
         oneSpan.finish()
@@ -32,10 +32,10 @@ class ActiveSpansPoolTests: XCTestCase {
 
     func testsSpanWithoutParentInheritsActiveSpan() throws {
         let tracer = Tracer.mockAny()
-        let firstSpan = tracer.startSpan(operationName: .mockAny())
+        let firstSpan = tracer.startSpan(operationName: .mockAny()).setActive()
 
         let previousActiveSpan = tracer.activeSpan
-        let secondSpan = tracer.startSpan(operationName: .mockAny())
+        let secondSpan = tracer.startSpan(operationName: .mockAny()).setActive()
 
         XCTAssertEqual(secondSpan.dd.ddContext.parentSpanID, previousActiveSpan?.dd.ddContext.spanID)
         XCTAssertEqual(secondSpan.dd.ddContext.spanID,  tracer.activeSpan?.dd.ddContext.spanID)
@@ -50,7 +50,7 @@ class ActiveSpansPoolTests: XCTestCase {
     func testsSpanWithParentDoesntInheritActiveSpan() throws {
         let tracer = Tracer.mockAny()
         let oneSpan = tracer.startSpan(operationName: .mockAny())
-        let otherSpan = tracer.startSpan(operationName: .mockAny())
+        let otherSpan = tracer.startSpan(operationName: .mockAny()).setActive()
 
         let spanWithParent = tracer.startSpan(operationName: .mockAny(), childOf: oneSpan.context)
 
@@ -63,12 +63,12 @@ class ActiveSpansPoolTests: XCTestCase {
 
     func testActiveSpanIsKeptPerTask() throws {
         let tracer = Tracer.mockAny()
-        let oneSpan = tracer.startSpan(operationName: .mockAny())
+        let oneSpan = tracer.startSpan(operationName: .mockAny()).setActive()
         let expectation1 = self.expectation(description: "firstSpan created")
         let expectation2 = self.expectation(description: "secondSpan created")
 
         DispatchQueue.global(qos: .default).async {
-            let firstSpan = tracer.startSpan(operationName: .mockAny())
+            let firstSpan = tracer.startSpan(operationName: .mockAny()).setActive()
             XCTAssertEqual(tracer.activeSpan?.dd.ddContext.spanID, firstSpan.dd.ddContext.spanID)
             expectation1.fulfill()
         }
@@ -76,7 +76,7 @@ class ActiveSpansPoolTests: XCTestCase {
         DispatchQueue.global(qos: .default).async {
             Thread.sleep(forTimeInterval: 0.5)
             XCTAssertEqual(tracer.activeSpan?.dd.ddContext.spanID, oneSpan.dd.ddContext.spanID)
-            let secondSpan = tracer.startSpan(operationName: .mockAny())
+            let secondSpan = tracer.startSpan(operationName: .mockAny()).setActive()
             XCTAssertEqual(tracer.activeSpan?.dd.ddContext.spanID, secondSpan.dd.ddContext.spanID)
             expectation2.fulfill()
         }

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/ActiveSpansPoolTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/ActiveSpansPoolTests.swift
@@ -33,10 +33,11 @@ class ActiveSpansPoolTests: XCTestCase {
     func testsSpanWithoutParentInheritsActiveSpan() throws {
         let tracer = Tracer.mockAny()
         let firstSpan = tracer.startSpan(operationName: .mockAny()).setActive()
-
+        firstSpan.setActive()
         let previousActiveSpan = tracer.activeSpan
         let secondSpan = tracer.startSpan(operationName: .mockAny()).setActive()
-
+        firstSpan.setActive()
+        secondSpan.setActive()
         XCTAssertEqual(secondSpan.dd.ddContext.parentSpanID, previousActiveSpan?.dd.ddContext.spanID)
         XCTAssertEqual(secondSpan.dd.ddContext.spanID,  tracer.activeSpan?.dd.ddContext.spanID)
         XCTAssertEqual(secondSpan.dd.ddContext.parentSpanID, firstSpan.dd.ddContext.spanID)
@@ -84,5 +85,26 @@ class ActiveSpansPoolTests: XCTestCase {
         XCTAssertEqual(tracer.activeSpan?.dd.ddContext.spanID, oneSpan.dd.ddContext.spanID)
         waitForExpectations(timeout: 5, handler: nil)
         oneSpan.finish()
+    }
+
+    func testsSetActiveSpanCalledMultipleTimes() throws {
+        let tracer = Tracer.mockAny()
+        let firstSpan = tracer.startSpan(operationName: .mockAny()).setActive()
+        firstSpan.setActive()
+
+        let previousActiveSpan = tracer.activeSpan
+
+        let secondSpan = tracer.startSpan(operationName: .mockAny()).setActive()
+        firstSpan.setActive()
+        secondSpan.setActive()
+
+        XCTAssertEqual(secondSpan.dd.ddContext.parentSpanID, previousActiveSpan?.dd.ddContext.spanID)
+        XCTAssertEqual(secondSpan.dd.ddContext.spanID,  tracer.activeSpan?.dd.ddContext.spanID)
+        XCTAssertEqual(secondSpan.dd.ddContext.parentSpanID, firstSpan.dd.ddContext.spanID)
+
+        secondSpan.finish()
+        XCTAssertEqual(tracer.activeSpan?.dd.ddContext.spanID, firstSpan.dd.ddContext.spanID)
+        firstSpan.finish()
+        XCTAssertNil(tracer.activeSpan)
     }
 }

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -216,8 +216,8 @@ class DDTracerTests: XCTestCase {
         let firstSpan = objcTracer.startSpan(.mockAny(), childOf: noopSpanContext)
         XCTAssertNil(firstSpan.dd!.swiftSpan.dd.ddContext.parentSpanID)
 
-        let secondSpan = objcTracer.startSpan(.mockAny(), childOf: noopSpanContext, tags: NSDictionary())
-        XCTAssertEqual(secondSpan.dd!.swiftSpan.dd.ddContext.parentSpanID, firstSpan.dd!.swiftSpan.dd.ddContext.spanID)
+        let secondSpan = objcTracer.startSpan(.mockAny(), childOf: noopSpanContext, tags: NSDictionary()).setActive()
+        XCTAssertNil(secondSpan.dd!.swiftSpan.dd.ddContext.parentSpanID)
 
         let thirdSpan = objcTracer.startSpan(.mockAny(), childOf: noopSpanContext, tags: NSDictionary(), startTime: .mockAny())
         XCTAssertEqual(thirdSpan.dd!.swiftSpan.dd.ddContext.parentSpanID, secondSpan .dd!.swiftSpan.dd.ddContext.spanID)


### PR DESCRIPTION
### What and why?

Fix the active span concept to let create several root spans on the same thread. Previous to this change with this code:

````
let job1Span = tracer.startSpan("async work 1”)
doSomethingAsynchronously(completion: { job1Span.finish() })

let job2Span = tracer.startSpan("async work 2")
doSomethingAsynchronously(completion: { job2Span.finish() })
````

`job2Span` would be assigned as child of` job1Span`

With this change both spans will have the same parent (the `activeSpan` or none if there is no `activeSpan`). 
For job2Span to be child of job1span you must now set it explicitly as its parent:
````
let job1Span = tracer.startSpan("async work 1”)
doSomethingAsynchronously(completion: { job1Span.finish() })

let job2Span = tracer.startSpan("async work 2", childOf: job1Span)
doSomethingAsynchronously(completion: { job2Span.finish() })
````
or you must set `job1Span` as active span before creating `job2Span`:
````
let job1Span = tracer.startSpan("async work 1”)
doSomethingAsynchronously(completion: { job1Span.finish() })
job1Span.setActive()

let job2Span = tracer.startSpan("async work 2")
doSomethingAsynchronously(completion: { job2Span.finish() })
````
### How?

Now, a span is not automatically set as the `activeSpan` when it is created, there is a new method `setActive()` that must be called explicitly in the span for it.
Any span will still use the current `activeSpan` as its parent on creation, except if any other explicit parent is assigned.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
