### PR TITLE
RUMM-636 Resources loading can exceed the View lifespan

### DIFF
--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -365,8 +365,16 @@ func createMockView() -> UIViewController {
 
 /// Creates an instance of `UIViewController` subclass with a given name.
 func createMockView(viewControllerClassName: String) -> UIViewController {
-    let theClass: AnyClass = objc_allocateClassPair(UIViewController.classForCoder(), viewControllerClassName, 0)!
-    objc_registerClassPair(theClass)
+    var theClass: AnyClass! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    if let existingClass = objc_lookUpClass(viewControllerClassName) {
+        theClass = existingClass
+    } else {
+        let newClass: AnyClass = objc_allocateClassPair(UIViewController.classForCoder(), viewControllerClassName, 0)!
+        objc_registerClassPair(newClass)
+        theClass = newClass
+    }
+
     let viewController = theClass.alloc() as! UIViewController
     mockWindow.rootViewController = viewController
     mockWindow.makeKeyAndVisible()

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -97,6 +97,10 @@ extension URL {
     static func mockAny() -> URL {
         return URL(string: "https://www.datadoghq.com")!
     }
+
+    static func mockWith(pathComponent: String) -> URL {
+        return URL(string: "https://www.foo.com/")!.appendingPathComponent(pathComponent)
+    }
 }
 
 extension String {

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -122,7 +122,7 @@ extension Array where Element == RUMEventMatcher {
         where predicate: ((DM) -> Bool)? = nil
     ) throws -> Element {
         let last = filterRUMEvents(ofType: type, where: predicate).last
-        return try XCTUnwrap(last, file: file, line: line)
+        return try XCTUnwrap(last, "Cannot find RUMEventMatcher matching the predicate", file: file, line: line)
     }
 }
 


### PR DESCRIPTION
### What and why?

📦 This PR makes the View wait for all its pending Resources until it gets finished.

### How?

The `RUMViewScope` is marked `didReceiveStopCommand` on `stopView()`, but it remains in memory until its Resources count goes down to `0`.

Also, the corresponding behaviour test was added to `RUMMonitorTests`:
* `testStartingLoadingResourcesFromTheFirstView_thenStartingAnotherViewWhichAlsoLoadsResources`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
