### PR TITLE
RUMM-590 Add RUM Sessions sampling

### DIFF
--- a/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
@@ -23,6 +23,10 @@ internal struct RUMContextIntegration {
             return nil
         }
 
+        if rumContext.sessionID == .nullUUID { // if Session was sampled or not yet started
+            return [:]
+        }
+
         return [
             Attributes.applicationID: rumContext.rumApplicationID,
             Attributes.sessionID: rumContext.sessionID.rawValue.uuidString.lowercased(),

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -19,6 +19,8 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     /// Session scope. It gets created with the first `.startView` event.
     /// Might be re-created later according to session duration constraints.
     private(set) var sessionScope: RUMSessionScope?
+    /// RUM Sessions sampling rate.
+    private let samplingRate: Float
 
     // MARK: - Initialization
 
@@ -26,9 +28,11 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
     init(
         rumApplicationID: String,
-        dependencies: RUMScopeDependencies
+        dependencies: RUMScopeDependencies,
+        samplingRate: Float
     ) {
         self.dependencies = dependencies
+        self.samplingRate = samplingRate
         self.context = RUMContext(
             rumApplicationID: rumApplicationID,
             sessionID: .nullUUID,
@@ -74,7 +78,14 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     private func startInitialSession(on command: RUMStartViewCommand) {
         var startInitialViewCommand = command
         startInitialViewCommand.isInitialView = true
-        let initialSession = RUMSessionScope(parent: self, dependencies: dependencies, startTime: command.time)
+
+        let initialSession = RUMSessionScope(
+            parent: self,
+            dependencies: dependencies,
+            samplingRate: samplingRate,
+            startTime: command.time
+        )
+
         sessionScope = initialSession
         _ = initialSession.process(command: startInitialViewCommand)
     }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -90,7 +90,8 @@ public class RUMMonitor {
                         fileWriter: rumFeature.storage.writer
                     ),
                     rumUUIDGenerator: DefaultRUMUUIDGenerator()
-                )
+                ),
+                samplingRate: rumFeature.configuration.rumSessionSamplingRate
             ),
             dateProvider: rumFeature.dateProvider
         )

--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -18,7 +18,8 @@ extension FeaturesCommonDependencies {
                 environment: "",
                 logsUploadURLWithClientToken: anyURL,
                 tracesUploadURLWithClientToken: anyURL,
-                rumUploadURLWithClientToken: anyURL
+                rumUploadURLWithClientToken: anyURL,
+                rumSessionSamplingRate: 100.0
             ),
             performance: .default,
             httpClient: HTTPClient(),

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationTests.swift
@@ -21,6 +21,8 @@ class DatadogConfigurationTests: XCTestCase {
         XCTAssertEqual(defaultConfiguration.tracesEndpoint.url, "https://public-trace-http-intake.logs.datadoghq.com/v1/input/")
         XCTAssertEqual(defaultConfiguration.rumEndpoint.url, "https://rum-http-intake.logs.datadoghq.com/v1/input/")
         XCTAssertNil(defaultConfiguration.serviceName)
+        XCTAssertEqual(defaultConfiguration.tracedHosts, [])
+        XCTAssertEqual(defaultConfiguration.rumSessionsSamplingRate, 100.0)
     }
 
     func testCustomConfiguration() {
@@ -29,6 +31,8 @@ class DatadogConfigurationTests: XCTestCase {
             .enableLogging(false)
             .enableTracing(false)
             .enableRUM(false)
+            .set(tracedHosts: ["example.com"])
+            .set(rumSessionsSamplingRate: 42.5)
             .build()
         XCTAssertEqual(configuration.clientToken, "abcd")
         XCTAssertEqual(configuration.environment, "tests")
@@ -36,6 +40,8 @@ class DatadogConfigurationTests: XCTestCase {
         XCTAssertFalse(configuration.tracingEnabled)
         XCTAssertFalse(configuration.rumEnabled)
         XCTAssertEqual(configuration.serviceName, "service-name")
+        XCTAssertEqual(configuration.tracedHosts, ["example.com"])
+        XCTAssertEqual(configuration.rumSessionsSamplingRate, 42.5)
     }
 
     // MARK: - Log endpoints
@@ -173,6 +179,15 @@ class DatadogValidConfigurationTests: XCTestCase {
             appContext: .mockWith(bundleIdentifier: nil)
         )
         XCTAssertEqual(configuration.serviceName, "ios")
+    }
+
+    func testRUMSessionSamplingRate() throws {
+        // it equals `Datadog.Configuration.rumSessionSamplingRate`
+        let configuration = try Configuration(
+            configuration: .mockWith(rumSessionsSamplingRate: 42.5),
+            appContext: .mockAny()
+        )
+        XCTAssertEqual(configuration.rumSessionSamplingRate, 42.5)
     }
 
     // MARK: - Validation

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -22,7 +22,9 @@ extension Datadog.Configuration {
         logsEndpoint: LogsEndpoint = .us,
         tracesEndpoint: TracesEndpoint = .us,
         rumEndpoint: RUMEndpoint = .us,
-        serviceName: String? = .mockAny()
+        serviceName: String? = .mockAny(),
+        tracedHosts: Set<String> = [],
+        rumSessionsSamplingRate: Float = 100.0
     ) -> Datadog.Configuration {
         return Datadog.Configuration(
             clientToken: clientToken,
@@ -33,7 +35,9 @@ extension Datadog.Configuration {
             logsEndpoint: logsEndpoint,
             tracesEndpoint: tracesEndpoint,
             rumEndpoint: rumEndpoint,
-            serviceName: serviceName
+            serviceName: serviceName,
+            tracedHosts: tracedHosts,
+            rumSessionsSamplingRate: rumSessionsSamplingRate
         )
     }
 }
@@ -51,7 +55,8 @@ extension Datadog.ValidConfiguration {
         environment: String = .mockAny(),
         logsUploadURLWithClientToken: URL = .mockAny(),
         tracesUploadURLWithClientToken: URL = .mockAny(),
-        rumUploadURLWithClientToken: URL = .mockAny()
+        rumUploadURLWithClientToken: URL = .mockAny(),
+        rumSessionSamplingRate: Float = 100.0
     ) -> Datadog.ValidConfiguration {
         return Datadog.ValidConfiguration(
             applicationName: applicationName,
@@ -61,7 +66,8 @@ extension Datadog.ValidConfiguration {
             environment: environment,
             logsUploadURLWithClientToken: logsUploadURLWithClientToken,
             tracesUploadURLWithClientToken: tracesUploadURLWithClientToken,
-            rumUploadURLWithClientToken: rumUploadURLWithClientToken
+            rumUploadURLWithClientToken: rumUploadURLWithClientToken,
+            rumSessionSamplingRate: rumSessionSamplingRate
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -327,11 +327,13 @@ extension RUMApplicationScope {
 
     static func mockWith(
         rumApplicationID: String = .mockAny(),
-        dependencies: RUMScopeDependencies = .mockAny()
+        dependencies: RUMScopeDependencies = .mockAny(),
+        samplingRate: Float = 100
     ) -> RUMApplicationScope {
         return RUMApplicationScope(
             rumApplicationID: rumApplicationID,
-            dependencies: dependencies
+            dependencies: dependencies,
+            samplingRate: samplingRate
         )
     }
 }
@@ -344,11 +346,13 @@ extension RUMSessionScope {
     static func mockWith(
         parent: RUMApplicationScope = .mockAny(),
         dependencies: RUMScopeDependencies = .mockAny(),
+        samplingRate: Float = 100,
         startTime: Date = .mockAny()
     ) -> RUMSessionScope {
         return RUMSessionScope(
             parent: parent,
             dependencies: dependencies,
+            samplingRate: samplingRate,
             startTime: startTime
         )
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
@@ -13,7 +13,7 @@ class RUMCurrentContextTests: XCTestCase {
     private let queue = DispatchQueue(label: "\(#file)")
 
     func testContextAfterInitializingTheApplication() {
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny())
+        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: .mockAny())
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         XCTAssertEqual(
@@ -29,7 +29,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextAfterStartingView() throws {
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny())
+        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
@@ -47,7 +47,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextWhilePendingUserAction() throws {
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny())
+        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
@@ -66,7 +66,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextChangeWhenNavigatingBetweenViews() throws {
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny())
+        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         let firstView = createMockView()
@@ -93,7 +93,7 @@ class RUMCurrentContextTests: XCTestCase {
 
     func testContextChangeWhenSessionIsRenewed() throws {
         var currentTime = Date()
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny())
+        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         let view = createMockView()
@@ -124,6 +124,24 @@ class RUMCurrentContextTests: XCTestCase {
                 sessionID: XCTUnwrap(applicationScope.sessionScope?.sessionUUID),
                 activeViewID: XCTUnwrap(applicationScope.sessionScope?.viewScopes.last?.viewUUID),
                 activeViewURI: XCTUnwrap(applicationScope.sessionScope?.viewScopes.last?.viewURI),
+                activeUserActionID: nil
+            )
+        )
+    }
+
+    func testContextWhenSessionIsSampled() throws {
+        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 0)
+        let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
+
+        _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
+
+        XCTAssertEqual(
+            provider.context,
+            RUMContext(
+                rumApplicationID: "rum-123",
+                sessionID: .nullUUID,
+                activeViewID: nil,
+                activeViewURI: nil,
                 activeUserActionID: nil
             )
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -33,7 +33,7 @@ class RUMSessionScopeTests: XCTestCase {
     func testWhenSessionExceedsMaxDuration_itGetsClosed() {
         var currentTime = Date()
         let parent = RUMContextProviderMock()
-        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: currentTime)
+        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 50, startTime: currentTime)
 
         XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)))
 
@@ -46,7 +46,7 @@ class RUMSessionScopeTests: XCTestCase {
     func testWhenSessionIsInactiveForCertainDuration_itGetsClosed() {
         var currentTime = Date()
         let parent = RUMContextProviderMock()
-        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: currentTime)
+        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 50, startTime: currentTime)
 
         XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)))
 
@@ -82,7 +82,10 @@ class RUMSessionScopeTests: XCTestCase {
 
         let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 0, startTime: Date())
         XCTAssertEqual(scope.viewScopes.count, 0)
-        _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
+        XCTAssertTrue(
+            scope.process(command: RUMStartViewCommand.mockWith(identity: mockView)),
+            "Sampled session should be kept until it expires or reaches the timeout."
+        )
         XCTAssertEqual(scope.viewScopes.count, 0)
     }
 }

--- a/Tests/DatadogTests/Datadog/Tracing/TracingAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingAutoInstrumentationTests.swift
@@ -16,18 +16,16 @@ private struct MockURLFilter: URLFiltering {
 
 class TracingAutoInstrumentationTests: XCTestCase {
     func testInitializationWithDatadogConfiguration() throws {
-        var config = Datadog.Configuration.mockAny()
-        config.tracingEnabled = true
-        config.tracedHosts = [String.mockAny()]
-        let autoInstrumentation = TracingAutoInstrumentation(with: config)
+        let configuration: Datadog.Configuration = .mockWith(tracingEnabled: true, tracedHosts: [String.mockAny()])
+        let autoInstrumentation = TracingAutoInstrumentation(with: configuration)
 
         let urlFilter = try XCTUnwrap(autoInstrumentation?.urlFilter as? URLFilter)
         let expectedURLFilter = URLFilter(
             includedHosts: [String.mockAny()],
             excludedURLs: [
-                config.logsEndpoint.url,
-                config.tracesEndpoint.url,
-                config.rumEndpoint.url
+                configuration.logsEndpoint.url,
+                configuration.tracesEndpoint.url,
+                configuration.rumEndpoint.url
             ]
         )
 


### PR DESCRIPTION
### What and why?

📦 This PR adds the option to sample RUM Sessions.

### How?

The public API was added to `Datadog.Configuration` builder:
```swift
/// Sets the sampling rate for RUM Sessions.
///
/// - Parameter rumSessionsSamplingRate: the sampling rate must be a value between `0.0` and `100.0`. A value of `0.0`
/// means no RUM events will be sent, `100.0` means all sessions will be kept (default value is `100.0`).
public func set(rumSessionsSamplingRate: Float)
```

RUM Events from sampled-out session are not send to Datadog. Such session's scope is marked as `shouldBeSampledOut` and it doesn't create any child scopes.

When RUM Session is sampled, `RUMContext` attributes are not added to Logs nor Traces.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
