### PR TITLE
RUMM-630 Encode network and user info attributes using `rum-events-format`

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 		61494CB124C839460082C633 /* RUMResourceScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB024C839460082C633 /* RUMResourceScope.swift */; };
 		61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB424C864680082C633 /* RUMResourceScopeTests.swift */; };
 		61494CBA24CB126F0082C633 /* RUMUserActionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB924CB126F0082C633 /* RUMUserActionScope.swift */; };
+		614B0A4B24EBC43D00A2A780 /* RUMUserInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B0A4A24EBC43D00A2A780 /* RUMUserInfoProvider.swift */; };
+		614B0A4D24EBD71500A2A780 /* RUMUserInfoProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B0A4C24EBD71500A2A780 /* RUMUserInfoProviderTests.swift */; };
 		614D812C24E3EA15004C9C5D /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614D812B24E3EA15004C9C5D /* Feature.swift */; };
 		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		6152C83E24BE1C91006A1679 /* HTTPServerMock in Frameworks */ = {isa = PBXBuildFile; productRef = 6152C83D24BE1C91006A1679 /* HTTPServerMock */; };
@@ -423,6 +425,8 @@
 		61494CB024C839460082C633 /* RUMResourceScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceScope.swift; sourceTree = "<group>"; };
 		61494CB424C864680082C633 /* RUMResourceScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceScopeTests.swift; sourceTree = "<group>"; };
 		61494CB924CB126F0082C633 /* RUMUserActionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScope.swift; sourceTree = "<group>"; };
+		614B0A4A24EBC43D00A2A780 /* RUMUserInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserInfoProvider.swift; sourceTree = "<group>"; };
+		614B0A4C24EBD71500A2A780 /* RUMUserInfoProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserInfoProviderTests.swift; sourceTree = "<group>"; };
 		614D812B24E3EA15004C9C5D /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		614E9EB2244719FA007EE3E1 /* BundleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleType.swift; sourceTree = "<group>"; };
 		6152C83F24BE1CC8006A1679 /* DataUploaderBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUploaderBenchmarkTests.swift; sourceTree = "<group>"; };
@@ -1453,6 +1457,7 @@
 		61E5333B24B87908003D6C4E /* RUMEvent */ = {
 			isa = PBXGroup;
 			children = (
+				614B0A4A24EBC43D00A2A780 /* RUMUserInfoProvider.swift */,
 				61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */,
 				61E5333C24B8791A003D6C4E /* RUMEventEncoder.swift */,
 			);
@@ -1502,6 +1507,7 @@
 		61FF281F24B89807000B3D9B /* RUMEvent */ = {
 			isa = PBXGroup;
 			children = (
+				614B0A4C24EBD71500A2A780 /* RUMUserInfoProviderTests.swift */,
 				61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */,
 			);
 			path = RUMEvent;
@@ -1957,6 +1963,7 @@
 				61133BD92423979B00786299 /* DataUploadDelay.swift in Sources */,
 				61C5A88C24509A0C00DA608C /* HTTPHeadersWriter.swift in Sources */,
 				61BB2B1B244A185D009F3F56 /* PerformancePreset.swift in Sources */,
+				614B0A4B24EBC43D00A2A780 /* RUMUserInfoProvider.swift in Sources */,
 				61133BD22423979B00786299 /* Directory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2051,6 +2058,7 @@
 				61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */,
 				61133C4E2423990D00786299 /* UIKitMocks.swift in Sources */,
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
+				614B0A4D24EBD71500A2A780 /* RUMUserInfoProviderTests.swift in Sources */,
 				61133C552423990D00786299 /* BatteryStatusProviderTests.swift in Sources */,
 				617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -120,6 +120,8 @@
 		61494CBA24CB126F0082C633 /* RUMUserActionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB924CB126F0082C633 /* RUMUserActionScope.swift */; };
 		614B0A4B24EBC43D00A2A780 /* RUMUserInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B0A4A24EBC43D00A2A780 /* RUMUserInfoProvider.swift */; };
 		614B0A4D24EBD71500A2A780 /* RUMUserInfoProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B0A4C24EBD71500A2A780 /* RUMUserInfoProviderTests.swift */; };
+		614B0A4F24EBDC6B00A2A780 /* RUMConnectivityInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B0A4E24EBDC6B00A2A780 /* RUMConnectivityInfoProvider.swift */; };
+		614B0A5124EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614B0A5024EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift */; };
 		614D812C24E3EA15004C9C5D /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614D812B24E3EA15004C9C5D /* Feature.swift */; };
 		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		6152C83E24BE1C91006A1679 /* HTTPServerMock in Frameworks */ = {isa = PBXBuildFile; productRef = 6152C83D24BE1C91006A1679 /* HTTPServerMock */; };
@@ -427,6 +429,8 @@
 		61494CB924CB126F0082C633 /* RUMUserActionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScope.swift; sourceTree = "<group>"; };
 		614B0A4A24EBC43D00A2A780 /* RUMUserInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserInfoProvider.swift; sourceTree = "<group>"; };
 		614B0A4C24EBD71500A2A780 /* RUMUserInfoProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserInfoProviderTests.swift; sourceTree = "<group>"; };
+		614B0A4E24EBDC6B00A2A780 /* RUMConnectivityInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMConnectivityInfoProvider.swift; sourceTree = "<group>"; };
+		614B0A5024EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMConnectivityInfoProviderTests.swift; sourceTree = "<group>"; };
 		614D812B24E3EA15004C9C5D /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
 		614E9EB2244719FA007EE3E1 /* BundleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleType.swift; sourceTree = "<group>"; };
 		6152C83F24BE1CC8006A1679 /* DataUploaderBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUploaderBenchmarkTests.swift; sourceTree = "<group>"; };
@@ -1460,6 +1464,7 @@
 				614B0A4A24EBC43D00A2A780 /* RUMUserInfoProvider.swift */,
 				61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */,
 				61E5333C24B8791A003D6C4E /* RUMEventEncoder.swift */,
+				614B0A4E24EBDC6B00A2A780 /* RUMConnectivityInfoProvider.swift */,
 			);
 			path = RUMEvent;
 			sourceTree = "<group>";
@@ -1509,6 +1514,7 @@
 			children = (
 				614B0A4C24EBD71500A2A780 /* RUMUserInfoProviderTests.swift */,
 				61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */,
+				614B0A5024EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift */,
 			);
 			path = RUMEvent;
 			sourceTree = "<group>";
@@ -1892,6 +1898,7 @@
 				9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */,
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
 				6156CB9024DDA8BE008CB2B2 /* RUMCurrentContext.swift in Sources */,
+				614B0A4F24EBDC6B00A2A780 /* RUMConnectivityInfoProvider.swift in Sources */,
 				9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */,
 				9ED583A32498C222004CFF2A /* TracingAutoInstrumentation.swift in Sources */,
 				61494CB124C839460082C633 /* RUMResourceScope.swift in Sources */,
@@ -2048,6 +2055,7 @@
 				618DCFDF24C75FD300589570 /* RUMScopeTests.swift in Sources */,
 				61C5A89E24509C1100DA608C /* WarningsTests.swift in Sources */,
 				9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */,
+				614B0A5124EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift in Sources */,
 				61133C652423990D00786299 /* LogBuilderTests.swift in Sources */,
 				61F8CC092469295500FE2908 /* DatadogConfigurationTests.swift in Sources */,
 				61F1A623249B811200075390 /* Encoding.swift in Sources */,

--- a/Sources/Datadog/RUM/RUMEvent/RUMConnectivityInfoProvider.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMConnectivityInfoProvider.swift
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Reduces the values from shared `NetworkConnectionInfoProvider` and `CarrierInfoProvider` to `RUMConnectivity` format.
+internal struct RUMConnectivityInfoProvider {
+    /// Shared network connection info provider.
+    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
+    /// Shared mobile carrier info provider.
+    let carrierInfoProvider: CarrierInfoProviderType
+
+    var current: RUMConnectivity? {
+        guard let networkInfo = networkConnectionInfoProvider.current else {
+            return nil
+        }
+        let carrierInfo = carrierInfoProvider.current
+
+        return RUMConnectivity(
+            status: connectivityStatus(for: networkInfo),
+            interfaces: connectivityInterfaces(for: networkInfo),
+            cellular: carrierInfo.flatMap { connectivityCellularInfo(for: $0) }
+        )
+    }
+
+    // MARK: - Private
+
+    private func connectivityStatus(for networkInfo: NetworkConnectionInfo) -> RUMStatus {
+        switch networkInfo.reachability {
+        case .yes:   return .connected
+        case .maybe: return .maybe
+        case .no:    return .notConnected
+        }
+    }
+
+    private func connectivityInterfaces(for networkInfo: NetworkConnectionInfo) -> [RUMInterface] {
+        guard let availableInterfaces = networkInfo.availableInterfaces, !availableInterfaces.isEmpty else {
+            return [.none]
+        }
+
+        return availableInterfaces.map { interface in
+            switch interface {
+            case .cellular:         return .cellular
+            case .wifi:             return .wifi
+            case .wiredEthernet:    return .ethernet
+            case .loopback, .other: return .other
+            }
+        }
+    }
+
+    private func connectivityCellularInfo(for carrierInfo: CarrierInfo) -> RUMCellular {
+        return .init(
+            technology: carrierInfo.radioAccessTechnology.rawValue,
+            carrierName: carrierInfo.carrierName
+        )
+    }
+}

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -7,8 +7,6 @@
 import Foundation
 
 internal struct RUMEventBuilder {
-    /// Shared user info provider.
-    let userInfoProvider: UserInfoProvider
     /// Shared network connection info provider (or `nil` if disabled for given `RUMMonitor`).
     let networkConnectionInfoProvider: NetworkConnectionInfoProviderType?
     /// Shared mobile carrier info provider (or `nil` if disabled for given `RUMMonitor`).
@@ -17,7 +15,6 @@ internal struct RUMEventBuilder {
     func createRUMEvent<DM: RUMDataModel>(with model: DM, attributes: [String: Encodable]) -> RUMEvent<DM> {
         return RUMEvent(
             model: model,
-            userInfo: userInfoProvider.value,
             networkConnectionInfo: networkConnectionInfoProvider?.current,
             mobileCarrierInfo: carrierInfoProvider?.current,
             attributes: attributes

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -7,17 +7,7 @@
 import Foundation
 
 internal struct RUMEventBuilder {
-    /// Shared network connection info provider (or `nil` if disabled for given `RUMMonitor`).
-    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType?
-    /// Shared mobile carrier info provider (or `nil` if disabled for given `RUMMonitor`).
-    let carrierInfoProvider: CarrierInfoProviderType?
-
     func createRUMEvent<DM: RUMDataModel>(with model: DM, attributes: [String: Encodable]) -> RUMEvent<DM> {
-        return RUMEvent(
-            model: model,
-            networkConnectionInfo: networkConnectionInfoProvider?.current,
-            mobileCarrierInfo: carrierInfoProvider?.current,
-            attributes: attributes
-        )
+        return RUMEvent(model: model, attributes: attributes)
     }
 }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -11,9 +11,6 @@ internal struct RUMEvent<DM: RUMDataModel>: Encodable {
     /// The actual RUM event model created by `RUMMonitor`
     let model: DM
 
-    let networkConnectionInfo: NetworkConnectionInfo?
-    let mobileCarrierInfo: CarrierInfo?
-
     /// Custom attributes set by the user
     let attributes: [String: Encodable]
 
@@ -24,25 +21,6 @@ internal struct RUMEvent<DM: RUMDataModel>: Encodable {
 
 /// Encodes `RUMEvent` to given encoder.
 internal struct RUMEventEncoder {
-    /// Coding keys for permanent `RUMEvent` attributes.
-    enum StaticCodingKeys: String, CodingKey {
-        // MARK: - Network connection info
-
-        case networkReachability = "network.client.reachability"
-        case networkAvailableInterfaces = "network.client.available_interfaces"
-        case networkConnectionSupportsIPv4 = "network.client.supports_ipv4"
-        case networkConnectionSupportsIPv6 = "network.client.supports_ipv6"
-        case networkConnectionIsExpensive = "network.client.is_expensive"
-        case networkConnectionIsConstrained = "network.client.is_constrained"
-
-        // MARK: - Mobile carrier info
-
-        case mobileNetworkCarrierName = "network.client.sim_carrier.name"
-        case mobileNetworkCarrierISOCountryCode = "network.client.sim_carrier.iso_country"
-        case mobileNetworkCarrierRadioTechnology = "network.client.sim_carrier.technology"
-        case mobileNetworkCarrierAllowsVoIP = "network.client.sim_carrier.allows_voip"
-    }
-
     /// Coding keys for dynamic `RUMEvent` attributes specified by user.
     private struct DynamicCodingKey: CodingKey {
         var stringValue: String
@@ -53,22 +31,6 @@ internal struct RUMEventEncoder {
 }
 
     func encode<DM: RUMDataModel>(_ event: RUMEvent<DM>, to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StaticCodingKeys.self)
-
-        // Encode network info
-        try container.encodeIfPresent(event.networkConnectionInfo?.reachability, forKey: .networkReachability)
-        try container.encodeIfPresent(event.networkConnectionInfo?.availableInterfaces, forKey: .networkAvailableInterfaces)
-        try container.encodeIfPresent(event.networkConnectionInfo?.supportsIPv4, forKey: .networkConnectionSupportsIPv4)
-        try container.encodeIfPresent(event.networkConnectionInfo?.supportsIPv6, forKey: .networkConnectionSupportsIPv6)
-        try container.encodeIfPresent(event.networkConnectionInfo?.isExpensive, forKey: .networkConnectionIsExpensive)
-        try container.encodeIfPresent(event.networkConnectionInfo?.isConstrained, forKey: .networkConnectionIsConstrained)
-
-        // Encode mobile carrier info
-        try container.encodeIfPresent(event.mobileCarrierInfo?.carrierName, forKey: .mobileNetworkCarrierName)
-        try container.encodeIfPresent(event.mobileCarrierInfo?.carrierISOCountryCode, forKey: .mobileNetworkCarrierISOCountryCode)
-        try container.encodeIfPresent(event.mobileCarrierInfo?.radioAccessTechnology, forKey: .mobileNetworkCarrierRadioTechnology)
-        try container.encodeIfPresent(event.mobileCarrierInfo?.carrierAllowsVOIP, forKey: .mobileNetworkCarrierAllowsVoIP)
-
         // Encode attributes
         var attributesContainer = encoder.container(keyedBy: DynamicCodingKey.self)
         try event.attributes.forEach { attributeName, attributeValue in

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -11,7 +11,6 @@ internal struct RUMEvent<DM: RUMDataModel>: Encodable {
     /// The actual RUM event model created by `RUMMonitor`
     let model: DM
 
-    let userInfo: UserInfo
     let networkConnectionInfo: NetworkConnectionInfo?
     let mobileCarrierInfo: CarrierInfo?
 
@@ -27,12 +26,6 @@ internal struct RUMEvent<DM: RUMDataModel>: Encodable {
 internal struct RUMEventEncoder {
     /// Coding keys for permanent `RUMEvent` attributes.
     enum StaticCodingKeys: String, CodingKey {
-        // MARK: - User info
-
-        case userId = "usr.id"
-        case userName = "usr.name"
-        case userEmail = "usr.email"
-
         // MARK: - Network connection info
 
         case networkReachability = "network.client.reachability"
@@ -61,11 +54,6 @@ internal struct RUMEventEncoder {
 
     func encode<DM: RUMDataModel>(_ event: RUMEvent<DM>, to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: StaticCodingKeys.self)
-
-        // Encode user info
-        try event.userInfo.id.ifNotNil { try container.encode($0, forKey: .userId) }
-        try event.userInfo.name.ifNotNil { try container.encode($0, forKey: .userName) }
-        try event.userInfo.email.ifNotNil { try container.encode($0, forKey: .userEmail) }
 
         // Encode network info
         try container.encodeIfPresent(event.networkConnectionInfo?.reachability, forKey: .networkReachability)

--- a/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Maps the value from shared `UserInfoProvider` to RUM data format.
+/// Maps the value from shared `UserInfoProvider` to `RUMUSR` format.
 internal struct RUMUserInfoProvider {
     /// Shared user info provider.
     let userInfoProvider: UserInfoProvider
@@ -17,7 +17,7 @@ internal struct RUMUserInfoProvider {
         if userInfo.id == nil && userInfo.name == nil && userInfo.email == nil {
             return nil
         } else {
-            return .init(id: userInfo.id, name: userInfo.name, email: userInfo.email)
+            return RUMUSR(id: userInfo.id, name: userInfo.name, email: userInfo.email)
         }
     }
 }

--- a/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Maps the value from shared `UserInfoProvider` to RUM data format.
+internal struct RUMUserInfoProvider {
+    /// Shared user info provider.
+    let userInfoProvider: UserInfoProvider
+
+    var current: RUMUSR? {
+        let userInfo = userInfoProvider.value
+
+        if userInfo.id == nil && userInfo.name == nil && userInfo.email == nil {
+            return nil
+        } else {
+            return .init(id: userInfo.id, name: userInfo.name, email: userInfo.email)
+        }
+    }
+}

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -8,6 +8,7 @@ import Foundation
 
 /// Injection container for common dependencies used by all `RUMScopes`.
 internal struct RUMScopeDependencies {
+    let userInfoProvider: RUMUserInfoProvider
     let eventBuilder: RUMEventBuilder
     let eventOutput: RUMEventOutput
     let rumUUIDGenerator: RUMUUIDGenerator

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -9,6 +9,7 @@ import Foundation
 /// Injection container for common dependencies used by all `RUMScopes`.
 internal struct RUMScopeDependencies {
     let userInfoProvider: RUMUserInfoProvider
+    let connectivityInfoProvider: RUMConnectivityInfoProvider
     let eventBuilder: RUMEventBuilder
     let eventOutput: RUMEventOutput
     let rumUUIDGenerator: RUMUUIDGenerator

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -79,7 +79,7 @@ internal class RUMResourceScope: RUMScope, RUMContextProvider {
                 url: context.activeViewURI ?? ""
             ),
             usr: dependencies.userInfoProvider.current,
-            connectivity: nil,
+            connectivity: dependencies.connectivityInfoProvider.current,
             dd: .init(),
             resource: .init(
                 type: command.kind.toRUMDataFormat,
@@ -117,7 +117,7 @@ internal class RUMResourceScope: RUMScope, RUMContextProvider {
                 url: context.activeViewURI ?? ""
             ),
             usr: dependencies.userInfoProvider.current,
-            connectivity: nil,
+            connectivity: dependencies.connectivityInfoProvider.current,
             dd: .init(),
             error: .init(
                 message: command.errorMessage,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -78,7 +78,7 @@ internal class RUMResourceScope: RUMScope, RUMContextProvider {
                 referrer: nil,
                 url: context.activeViewURI ?? ""
             ),
-            usr: nil,
+            usr: dependencies.userInfoProvider.current,
             connectivity: nil,
             dd: .init(),
             resource: .init(
@@ -116,7 +116,7 @@ internal class RUMResourceScope: RUMScope, RUMContextProvider {
                 referrer: nil,
                 url: context.activeViewURI ?? ""
             ),
-            usr: nil,
+            usr: dependencies.userInfoProvider.current,
             connectivity: nil,
             dd: .init(),
             error: .init(

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -123,7 +123,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 referrer: nil,
                 url: context.activeViewURI ?? ""
             ),
-            usr: nil,
+            usr: dependencies.userInfoProvider.current,
             connectivity: nil,
             dd: .init(),
             action: .init(

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -124,7 +124,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 url: context.activeViewURI ?? ""
             ),
             usr: dependencies.userInfoProvider.current,
-            connectivity: nil,
+            connectivity: dependencies.connectivityInfoProvider.current,
             dd: .init(),
             action: .init(
                 type: actionType.toRUMDataFormat,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -203,7 +203,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 referrer: nil,
                 url: viewURI
             ),
-            usr: nil,
+            usr: dependencies.userInfoProvider.current,
             connectivity: nil,
             dd: .init(),
             action: .init(
@@ -248,7 +248,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 longTask: nil,
                 resource: .init(count: resourcesCount.toInt64)
             ),
-            usr: nil,
+            usr: dependencies.userInfoProvider.current,
             connectivity: nil,
             dd: .init(documentVersion: version.toInt64)
         )
@@ -269,7 +269,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 referrer: nil,
                 url: context.activeViewURI ?? ""
             ),
-            usr: nil,
+            usr: dependencies.userInfoProvider.current,
             connectivity: nil,
             dd: .init(),
             error: .init(

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -204,7 +204,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 url: viewURI
             ),
             usr: dependencies.userInfoProvider.current,
-            connectivity: nil,
+            connectivity: dependencies.connectivityInfoProvider.current,
             dd: .init(),
             action: .init(
                 type: .applicationStart,
@@ -249,7 +249,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 resource: .init(count: resourcesCount.toInt64)
             ),
             usr: dependencies.userInfoProvider.current,
-            connectivity: nil,
+            connectivity: dependencies.connectivityInfoProvider.current,
             dd: .init(documentVersion: version.toInt64)
         )
 
@@ -270,7 +270,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 url: context.activeViewURI ?? ""
             ),
             usr: dependencies.userInfoProvider.current,
-            connectivity: nil,
+            connectivity: dependencies.connectivityInfoProvider.current,
             dd: .init(),
             error: .init(
                 message: command.message,

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -81,8 +81,8 @@ public class RUMMonitor {
             applicationScope: RUMApplicationScope(
                 rumApplicationID: rumApplicationID,
                 dependencies: RUMScopeDependencies(
+                    userInfoProvider: RUMUserInfoProvider(userInfoProvider: rumFeature.userInfoProvider),
                     eventBuilder: RUMEventBuilder(
-                        userInfoProvider: rumFeature.userInfoProvider,
                         networkConnectionInfoProvider: rumFeature.networkConnectionInfoProvider,
                         carrierInfoProvider: rumFeature.carrierInfoProvider
                     ),

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -82,10 +82,11 @@ public class RUMMonitor {
                 rumApplicationID: rumApplicationID,
                 dependencies: RUMScopeDependencies(
                     userInfoProvider: RUMUserInfoProvider(userInfoProvider: rumFeature.userInfoProvider),
-                    eventBuilder: RUMEventBuilder(
+                    connectivityInfoProvider: RUMConnectivityInfoProvider(
                         networkConnectionInfoProvider: rumFeature.networkConnectionInfoProvider,
                         carrierInfoProvider: rumFeature.carrierInfoProvider
                     ),
+                    eventBuilder: RUMEventBuilder(),
                     eventOutput: RUMEventFileOutput(
                         fileWriter: rumFeature.storage.writer
                     ),

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -76,12 +76,10 @@ extension RUMEventBuilder {
     }
 
     static func mockWith(
-        userInfoProvider: UserInfoProvider = .mockAny(),
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockAny(),
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
     ) -> RUMEventBuilder {
         return RUMEventBuilder(
-            userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider
         )
@@ -304,8 +302,8 @@ extension RUMScopeDependencies {
     }
 
     static func mockWith(
+        userInfoProvider: RUMUserInfoProvider = RUMUserInfoProvider(userInfoProvider: .mockAny()),
         eventBuilder: RUMEventBuilder = RUMEventBuilder(
-            userInfoProvider: .mockAny(),
             networkConnectionInfoProvider: nil,
             carrierInfoProvider: nil
         ),
@@ -313,6 +311,7 @@ extension RUMScopeDependencies {
         rumUUIDGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
+            userInfoProvider: userInfoProvider,
             eventBuilder: eventBuilder,
             eventOutput: eventOutput,
             rumUUIDGenerator: rumUUIDGenerator

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -72,17 +72,7 @@ struct RUMDataModelMock: RUMDataModel, Equatable {
 
 extension RUMEventBuilder {
     static func mockAny() -> RUMEventBuilder {
-        return mockWith()
-    }
-
-    static func mockWith(
-        networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockAny(),
-        carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny()
-    ) -> RUMEventBuilder {
-        return RUMEventBuilder(
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            carrierInfoProvider: carrierInfoProvider
-        )
+        return RUMEventBuilder()
     }
 }
 
@@ -303,15 +293,17 @@ extension RUMScopeDependencies {
 
     static func mockWith(
         userInfoProvider: RUMUserInfoProvider = RUMUserInfoProvider(userInfoProvider: .mockAny()),
-        eventBuilder: RUMEventBuilder = RUMEventBuilder(
-            networkConnectionInfoProvider: nil,
-            carrierInfoProvider: nil
+        connectivityInfoProvider: RUMConnectivityInfoProvider = RUMConnectivityInfoProvider(
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock(networkConnectionInfo: nil),
+            carrierInfoProvider: CarrierInfoProviderMock(carrierInfo: nil)
         ),
+        eventBuilder: RUMEventBuilder = RUMEventBuilder(),
         eventOutput: RUMEventOutput = RUMEventOutputMock(),
         rumUUIDGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             userInfoProvider: userInfoProvider,
+            connectivityInfoProvider: connectivityInfoProvider,
             eventBuilder: eventBuilder,
             eventOutput: eventOutput,
             rumUUIDGenerator: rumUUIDGenerator

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMConnectivityInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMConnectivityInfoProviderTests.swift
@@ -1,0 +1,96 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+extension RUMConnectivity: EquatableInTests {}
+
+class RUMConnectivityInfoProviderTests: XCTestCase {
+    private let networkInfoProvider = NetworkConnectionInfoProviderMock(networkConnectionInfo: .mockAny())
+    private let carrierInfoProvider = CarrierInfoProviderMock(carrierInfo: .mockAny())
+    private lazy var rumConnectivityInfoProvider = RUMConnectivityInfoProvider(
+        networkConnectionInfoProvider: networkInfoProvider,
+        carrierInfoProvider: carrierInfoProvider
+    )
+
+    func testWhenBothNetworkAndCarrierInfoAreAvailable() throws {
+        func verifyConnectivity(
+            networkInfo: NetworkConnectionInfo,
+            carrierInfo: CarrierInfo,
+            verification: (RUMConnectivity) -> Void
+        ) throws {
+            networkInfoProvider.set(current: networkInfo)
+            carrierInfoProvider.set(current: carrierInfo)
+            verification(try XCTUnwrap(rumConnectivityInfoProvider.current))
+        }
+
+        try verifyConnectivity(
+            networkInfo: .mockWith(reachability: .yes, availableInterfaces: [.cellular]),
+            carrierInfo: .mockAny()
+        ) { rumConnectivity in
+            XCTAssertEqual(rumConnectivity.status, .connected)
+            XCTAssertEqual(rumConnectivity.interfaces, [.cellular])
+        }
+
+        try verifyConnectivity(
+            networkInfo: .mockAny(),
+            carrierInfo: .mockWith(carrierName: "Carrier Name", radioAccessTechnology: .LTE)
+        ) { rumConnectivity in
+            XCTAssertEqual(rumConnectivity.cellular?.carrierName, "Carrier Name")
+            XCTAssertEqual(rumConnectivity.cellular?.technology, "LTE")
+        }
+
+        try verifyConnectivity(
+            networkInfo: .mockWith(reachability: .maybe),
+            carrierInfo: .mockAny()
+        ) { rumConnectivity in
+            XCTAssertEqual(rumConnectivity.status, .maybe)
+        }
+
+        try verifyConnectivity(
+            networkInfo: .mockWith(reachability: .no),
+            carrierInfo: .mockAny()
+        ) { rumConnectivity in
+            XCTAssertEqual(rumConnectivity.status, .notConnected)
+        }
+
+        try verifyConnectivity(
+            networkInfo: .mockWith(availableInterfaces: [.cellular, .wifi, .wiredEthernet, .loopback, .other]),
+            carrierInfo: .mockAny()
+        ) { rumConnectivity in
+            XCTAssertEqual(rumConnectivity.interfaces, [.cellular, .wifi, .ethernet, .other, .other])
+        }
+
+        try verifyConnectivity(
+            networkInfo: .mockWith(availableInterfaces: []),
+            carrierInfo: .mockAny()
+        ) { rumConnectivity in
+            XCTAssertEqual(rumConnectivity.interfaces, [.none])
+        }
+    }
+
+    func testWhenBothNetworkAndCarrierInfoAreNotAvailable() throws {
+        networkInfoProvider.set(current: nil)
+        carrierInfoProvider.set(current: nil)
+
+        XCTAssertNil(rumConnectivityInfoProvider.current)
+    }
+
+    func testWhenNetworkInfoInfoIsNotAvailable() throws {
+        networkInfoProvider.set(current: nil)
+        carrierInfoProvider.set(current: .mockAny())
+
+        XCTAssertNil(rumConnectivityInfoProvider.current)
+    }
+
+    func testWhenCarrierInfoInfoIsNotAvailable() throws {
+        networkInfoProvider.set(current: .mockAny())
+        carrierInfoProvider.set(current: nil)
+
+        XCTAssertNotNil(rumConnectivityInfoProvider.current)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
@@ -9,27 +9,13 @@ import XCTest
 
 class RUMEventBuilderTests: XCTestCase {
     func testItBuildsRUMEvent() {
-        let builder = RUMEventBuilder(
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
-                networkConnectionInfo: .mockWith(
-                    reachability: .yes,
-                    availableInterfaces: [.wifi, .cellular]
-                )
-            ),
-            carrierInfoProvider: CarrierInfoProviderMock.mockWith(
-                carrierInfo: .mockWith(carrierName: "AT&T")
-            )
-        )
-
+        let builder = RUMEventBuilder()
         let event = builder.createRUMEvent(
             with: RUMDataModelMock(attribute: "foo"),
             attributes: ["foo": "bar", "fizz": "buzz"]
         )
 
         XCTAssertEqual(event.model.attribute, "foo")
-        XCTAssertEqual(event.mobileCarrierInfo?.carrierName, "AT&T")
-        XCTAssertEqual(event.networkConnectionInfo?.reachability, .yes)
-        XCTAssertEqual(event.networkConnectionInfo?.availableInterfaces, [.wifi, .cellular])
         XCTAssertEqual((event.attributes as? [String: String])?["foo"], "bar")
         XCTAssertEqual((event.attributes as? [String: String])?["fizz"], "buzz")
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
@@ -10,9 +10,6 @@ import XCTest
 class RUMEventBuilderTests: XCTestCase {
     func testItBuildsRUMEvent() {
         let builder = RUMEventBuilder(
-            userInfoProvider: .mockWith(
-                userInfo: UserInfo(id: "id", name: "name", email: "foo@bar.com")
-            ),
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
                 networkConnectionInfo: .mockWith(
                     reachability: .yes,
@@ -30,9 +27,6 @@ class RUMEventBuilderTests: XCTestCase {
         )
 
         XCTAssertEqual(event.model.attribute, "foo")
-        XCTAssertEqual(event.userInfo.id, "id")
-        XCTAssertEqual(event.userInfo.name, "name")
-        XCTAssertEqual(event.userInfo.email, "foo@bar.com")
         XCTAssertEqual(event.mobileCarrierInfo?.carrierName, "AT&T")
         XCTAssertEqual(event.networkConnectionInfo?.reachability, .yes)
         XCTAssertEqual(event.networkConnectionInfo?.availableInterfaces, [.wifi, .cellular])

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+extension RUMUSR: EquatableInTests {}
+
+class RUMUserInfoProviderTests: XCTestCase {
+    private let userInfoProvider = UserInfoProvider()
+    private lazy var rumUserInfoProvider = RUMUserInfoProvider(userInfoProvider: userInfoProvider)
+
+    func testWhenUserInfoIsNotAvailable_itReturnsNil() {
+        userInfoProvider.value = .mockEmpty()
+        XCTAssertNil(rumUserInfoProvider.current)
+    }
+
+    func testWhenUserInfoIsAvailable_itReturnsRUMUserInfo() {
+        userInfoProvider.value = UserInfo(id: "abc-123", name: nil, email: nil)
+        XCTAssertEqual(rumUserInfoProvider.current, RUMUSR(id: "abc-123", name: nil, email: nil))
+
+        userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: nil)
+        XCTAssertEqual(rumUserInfoProvider.current, RUMUSR(id: "abc-123", name: "Foo", email: nil))
+
+        userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com")
+        XCTAssertEqual(rumUserInfoProvider.current, RUMUSR(id: "abc-123", name: "Foo", email: "foo@bar.com"))
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -21,10 +21,7 @@ class RUMEventFileOutputTests: XCTestCase {
     func testItWritesRUMEventToFileAsJSON() throws {
         let fileCreationDateProvider = RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC())
         let queue = DispatchQueue(label: "com.datadohq.testItWritesRUMEventToFileAsJSON")
-        let builder = RUMEventBuilder(
-            networkConnectionInfoProvider: nil,
-            carrierInfoProvider: nil
-        )
+        let builder = RUMEventBuilder()
         let output = RUMEventFileOutput(
             fileWriter: FileWriter(
                 dataFormat: RUMFeature.dataFormat,

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -22,7 +22,6 @@ class RUMEventFileOutputTests: XCTestCase {
         let fileCreationDateProvider = RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC())
         let queue = DispatchQueue(label: "com.datadohq.testItWritesRUMEventToFileAsJSON")
         let builder = RUMEventBuilder(
-            userInfoProvider: .mockWith(userInfo: UserInfo(id: "abc-123", name: "bar", email: "foo@bar.com")),
             networkConnectionInfoProvider: nil,
             carrierInfoProvider: nil
         )
@@ -70,15 +69,12 @@ class RUMEventFileOutputTests: XCTestCase {
             jsonString: """
             {
                 "attribute": "foo",
-                "custom.attribute": "value",
-                "usr.email": "foo@bar.com",
-                "usr.id": "abc-123",
-                "usr.name": "bar"
+                "custom.attribute": "value"
             }
             """
         )
 
-        // TODO: RUMM-585 We also need to test (in `RUMMonitorTests`) that custom user attributes
+        // TODO: RUMM-638 We also need to test (in `RUMMonitorTests`) that custom user attributes
         // do not overwrite values given by `RUMDataModel`.
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -79,7 +79,6 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.resource.size, 1_024)
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), parent.context.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
         XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
         XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
@@ -126,7 +125,6 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.error.resource?.url, "https://foo.com/resource/1")
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), parent.context.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
         XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
         XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -79,8 +79,6 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.resource.size, 1_024)
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), parent.context.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
-        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
 
     func testWhenResourceLoadingEndsWithError_itSendsErrorEvent() throws {
@@ -125,7 +123,5 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.error.resource?.url, "https://foo.com/resource/1")
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), parent.context.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
-        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -75,7 +75,6 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertEqual(event.model.action.resource?.count, 0)
         XCTAssertEqual(event.model.action.error?.count, 0)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
         XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
         XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -75,8 +75,6 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertEqual(event.model.action.resource?.count, 0)
         XCTAssertEqual(event.model.action.error?.count, 0)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
-        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
 
     func testWhenContinuousUserActionExpires_itSendsActionEvent() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -77,8 +77,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertValidRumUUID(event.model.action.id)
         XCTAssertEqual(event.model.action.type, .applicationStart)
         XCTAssertTrue(event.attributes.isEmpty, "The `application_start` event must have no attributes.")
-        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
-        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
 
     func testWhenInitialViewIsStarted_itSendsViewUpdateEvent() throws {
@@ -110,8 +108,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
-        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
 
     func testWhenViewIsStarted_itSendsViewUpdateEvent() throws {
@@ -143,8 +139,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar 2", "fizz": "buzz"])
-        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
-        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
 
     func testWhenViewIsStopped_itSendsViewUpdateEvent_andEndsTheScope() throws {
@@ -189,8 +183,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 2)
         XCTAssertTrue(event.attributes.isEmpty)
-        XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
-        XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
 
     // MARK: - Resources Tracking
@@ -385,8 +377,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertNil(error.model.error.resource)
         XCTAssertNil(error.model.action)
         XCTAssertEqual(error.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(error.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
-        XCTAssertEqual(error.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
 
         let viewUpdate = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).last)
         XCTAssertEqual(viewUpdate.model.view.error.count, 1)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -77,7 +77,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertValidRumUUID(event.model.action.id)
         XCTAssertEqual(event.model.action.type, .applicationStart)
         XCTAssertTrue(event.attributes.isEmpty, "The `application_start` event must have no attributes.")
-        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
         XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
         XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
@@ -111,7 +110,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
         XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
         XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
@@ -145,7 +143,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar 2", "fizz": "buzz"])
-        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
         XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
         XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
@@ -192,7 +189,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 2)
         XCTAssertTrue(event.attributes.isEmpty)
-        XCTAssertEqual(event.userInfo, dependencies.eventBuilder.userInfoProvider.value)
         XCTAssertEqual(event.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
         XCTAssertEqual(event.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
     }
@@ -389,7 +385,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertNil(error.model.error.resource)
         XCTAssertNil(error.model.action)
         XCTAssertEqual(error.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(error.userInfo, dependencies.eventBuilder.userInfoProvider.value)
         XCTAssertEqual(error.networkConnectionInfo, dependencies.eventBuilder.networkConnectionInfoProvider?.current)
         XCTAssertEqual(error.mobileCarrierInfo, dependencies.eventBuilder.carrierInfoProvider?.current)
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -36,12 +36,11 @@ class RUMMonitorConfigurationTests: XCTestCase {
         let monitor = RUMMonitor.initialize(rumApplicationID: .mockAny())
 
         let feature = try XCTUnwrap(RUMFeature.instance)
-        let rumEventBuilder = monitor.applicationScope.dependencies.eventBuilder
         let scopeDependencies = monitor.applicationScope.dependencies
 
         XCTAssertTrue(scopeDependencies.userInfoProvider.userInfoProvider === feature.userInfoProvider)
-        XCTAssertTrue(rumEventBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
-        XCTAssertTrue(rumEventBuilder.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
+        XCTAssertTrue(scopeDependencies.connectivityInfoProvider.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
+        XCTAssertTrue(scopeDependencies.connectivityInfoProvider.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
     }
 
     func testCustomizedRUMMonitor() {

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -37,8 +37,9 @@ class RUMMonitorConfigurationTests: XCTestCase {
 
         let feature = try XCTUnwrap(RUMFeature.instance)
         let rumEventBuilder = monitor.applicationScope.dependencies.eventBuilder
+        let scopeDependencies = monitor.applicationScope.dependencies
 
-        XCTAssertTrue(rumEventBuilder.userInfoProvider === feature.userInfoProvider)
+        XCTAssertTrue(scopeDependencies.userInfoProvider.userInfoProvider === feature.userInfoProvider)
         XCTAssertTrue(rumEventBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
         XCTAssertTrue(rumEventBuilder.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
     }

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -124,6 +124,11 @@ extension Array where Element == RUMEventMatcher {
         let last = filterRUMEvents(ofType: type, where: predicate).last
         return try XCTUnwrap(last, "Cannot find RUMEventMatcher matching the predicate", file: file, line: line)
     }
+
+    func forEachRUMEvent<DM: Decodable>(ofType type: DM.Type, body: ((DM) -> Void)) throws {
+        return try filter { matcher in matcher.model(isTypeOf: type) }
+            .forEach { matcher in body(try matcher.model()) }
+    }
 }
 
 func XCTAssertValidRumUUID(_ string: String?, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
### What and why?

📦 This PR changes from encoding user, network and carrier info attributes at the root level of RUM event JSON to using dedicated `event.usr` and `event.connectivity` types.

### How?

The network and carrier info retrieved from `NetworkInfoProvider` and `CarrierInfoProvider` go through `RUMConnectivityInfoProvider` and are mapped to single `RUMConnectivity`.

The user info retrieved from `UserInfoProvider` goes through `RUMUserInfoProvider` and is mapped to `RUMUSR`.

```swift
RUMUserInfoProvider(userInfoProvider:).current → RUMUSR?
RUMConnectivityInfoProvider(networkInfoProvider:carrierInfoProvider:).current → RUMConnectivity?
```

<img width="576" alt="Screenshot 2020-08-18 at 13 41 58" src="https://user-images.githubusercontent.com/2358722/90508883-bba8e080-e158-11ea-9715-f2d51b679025.png">
<img width="574" alt="Screenshot 2020-08-18 at 13 42 24" src="https://user-images.githubusercontent.com/2358722/90508939-d8ddaf00-e158-11ea-82eb-250383684439.png">

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
