### PR TITLE
RUMM-678 UserActions has Name property

### DIFF
--- a/Datadog/Example/Debugging/DebugRUMViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMViewController.swift
@@ -66,7 +66,7 @@ class DebugRUMViewController: UIViewController {
         let viewController = createUIViewControllerSubclassInstance(named: actionViewURL)
         rumMonitor.startView(viewController: viewController)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            rumMonitor.registerUserAction(type: self.actionType)
+            rumMonitor.registerUserAction(type: self.actionType, name: (sender as! UIButton).currentTitle!)
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             rumMonitor.stopView(viewController: viewController)

--- a/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
+++ b/Datadog/Example/IntegrationTestFixtures/SendRUMFixture1ViewController.swift
@@ -37,7 +37,8 @@ internal class SendRUMFixture1ViewController: UIViewController {
 
         rumMonitor.registerUserAction(
             type: .tap,
-            attributes: ["button.label": (sender as! UIButton).currentTitle!]
+            name: (sender as! UIButton).currentTitle!,
+            attributes: ["button.description": String(describing: sender)]
         )
 
         rumMonitor.startResourceLoading(

--- a/Shopist/Shopist/Scenes/CartViewController.swift
+++ b/Shopist/Shopist/Scenes/CartViewController.swift
@@ -87,7 +87,7 @@ final class CartViewController: UITableViewController {
     }
 
     @objc private func pay() {
-        rum?.registerUserAction(type: .tap, attributes: ["info": "button tap -> pay"])
+        rum?.registerUserAction(type: .tap, name: "Pay")
         if let randomError = Self.randomError {
             self.handleError(randomError)
             return

--- a/Shopist/Shopist/Scenes/CategoriesViewController.swift
+++ b/Shopist/Shopist/Scenes/CategoriesViewController.swift
@@ -37,8 +37,8 @@ final class CategoriesViewController: ListViewController {
     }
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        rum?.registerUserAction(type: .tap, attributes: ["info": "cell tap -> products"])
         let selectedCategory = categories[indexPath.row]
+        rum?.registerUserAction(type: .tap, name: selectedCategory.title)
         let detailVC = ProductsViewController(with: selectedCategory)
         show(detailVC, sender: self)
     }

--- a/Shopist/Shopist/Scenes/ProductsViewController.swift
+++ b/Shopist/Shopist/Scenes/ProductsViewController.swift
@@ -49,8 +49,8 @@ final class ProductsViewController: ListViewController {
     }
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        rum?.registerUserAction(type: .tap, attributes: ["info": "cell tap -> product details"])
         let selectedProduct = items[indexPath.row]
+        rum?.registerUserAction(type: .tap, name: selectedProduct.name)
         let detailVC = ProductDetailViewController(product: selectedProduct)
         show(detailVC, sender: self)
     }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -180,6 +180,7 @@ internal struct RUMStartUserActionCommand: RUMUserActionCommand {
     let attributes: [AttributeKey: AttributeValue]
 
     let actionType: RUMUserActionType
+    let name: String
 }
 
 /// Stops continuous User Action.
@@ -188,6 +189,7 @@ internal struct RUMStopUserActionCommand: RUMUserActionCommand {
     let attributes: [AttributeKey: AttributeValue]
 
     let actionType: RUMUserActionType
+    let name: String?
 }
 
 /// Adds discrete (discontinuous) User Action.
@@ -196,4 +198,5 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     let attributes: [AttributeKey: AttributeValue]
 
     let actionType: RUMUserActionType
+    let name: String
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -22,6 +22,8 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
 
     /// The type of this User Action.
     internal let actionType: RUMUserActionType
+    /// The name of this User Action.
+    private(set) var name: String
     /// User Action attributes.
     private(set) var attributes: [AttributeKey: AttributeValue]
 
@@ -44,6 +46,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
     init(
         parent: RUMContextProvider,
         dependencies: RUMScopeDependencies,
+        name: String,
         actionType: RUMUserActionType,
         attributes: [AttributeKey: AttributeValue],
         startTime: Date,
@@ -51,6 +54,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
     ) {
         self.parent = parent
         self.dependencies = dependencies
+        self.name = name
         self.actionType = actionType
         self.attributes = attributes
         self.actionUUID = dependencies.rumUUIDGenerator.generateUnique()
@@ -80,6 +84,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             sendActionEvent(completionTime: command.time)
             return false
         case let command as RUMStopUserActionCommand:
+            name = command.name ?? name
             sendActionEvent(completionTime: command.time, on: command)
             return false
         case is RUMStartResourceCommand:
@@ -121,7 +126,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 type: actionType.toRUMDataFormat,
                 id: actionUUID.toRUMDataFormat,
                 loadingTime: completionTime.timeIntervalSince(actionStartTime).toInt64Nanoseconds,
-                target: nil,
+                target: RUMTarget(name: name),
                 error: .init(count: errorsCount.toInt64),
                 crash: nil,
                 longTask: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -173,6 +173,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         userActionScope = RUMUserActionScope(
             parent: self,
             dependencies: dependencies,
+            name: command.name,
             actionType: command.actionType,
             attributes: command.attributes,
             startTime: command.time,
@@ -184,6 +185,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         userActionScope = RUMUserActionScope(
             parent: self,
             dependencies: dependencies,
+            name: command.name,
             actionType: command.actionType,
             attributes: command.attributes,
             startTime: command.time,

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -271,13 +271,15 @@ public class RUMMonitor {
     /// Such an User Action must be stopped with `stopUserAction(type:)`, and will be stopped automatically if it lasts more than 10 seconds.
     /// - Parameters:
     ///   - type: the User Action type
+    ///   - name: the User Action name
     ///   - attributes: custom attributes to attach to the User Action.
-    public func startUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
+    public func startUserAction(type: RUMUserActionType, name: String, attributes: [AttributeKey: AttributeValue]? = nil) {
         process(
             command: RUMStartUserActionCommand(
                 time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                actionType: type
+                actionType: type,
+                name: name
             )
         )
     }
@@ -286,13 +288,15 @@ public class RUMMonitor {
     /// This is used to stop tracking long running user actions (e.g. "scroll"), started with `startUserAction(type:)`.
     /// - Parameters:
     ///   - type: the User Action type
+    ///   - name: the User Action name. If `nil`, `name` used in `startUserAction` will be effective.
     ///   - attributes: custom attributes to attach to the User Action.
-    public func stopUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
+    public func stopUserAction(type: RUMUserActionType, name: String? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
         process(
             command: RUMStopUserActionCommand(
                 time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                actionType: type
+                actionType: type,
+                name: name
             )
         )
     }
@@ -301,13 +305,15 @@ public class RUMMonitor {
     /// This is used to track discrete User Actions (e.g. "tap").
     /// - Parameters:
     ///   - type: the User Action type
+    ///   - name: the User Action name
     ///   - attributes: custom attributes to attach to the User Action.
-    public func registerUserAction(type: RUMUserActionType, attributes: [AttributeKey: AttributeValue]? = nil) {
+    public func registerUserAction(type: RUMUserActionType, name: String, attributes: [AttributeKey: AttributeValue]? = nil) {
         process(
             command: RUMAddUserActionCommand(
                 time: dateProvider.currentDate(),
                 attributes: attributes ?? [:],
-                actionType: type
+                actionType: type,
+                name: name
             )
         )
     }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -218,10 +218,11 @@ extension RUMStartUserActionCommand {
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
-        actionType: RUMUserActionType = .swipe
+        actionType: RUMUserActionType = .swipe,
+        name: String = .mockAny()
     ) -> RUMStartUserActionCommand {
         return RUMStartUserActionCommand(
-            time: time, attributes: attributes, actionType: actionType
+            time: time, attributes: attributes, actionType: actionType, name: name
         )
     }
 }
@@ -232,10 +233,11 @@ extension RUMStopUserActionCommand {
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
-        actionType: RUMUserActionType = .swipe
+        actionType: RUMUserActionType = .swipe,
+        name: String? = nil
     ) -> RUMStopUserActionCommand {
         return RUMStopUserActionCommand(
-            time: time, attributes: attributes, actionType: actionType
+            time: time, attributes: attributes, actionType: actionType, name: name
         )
     }
 }
@@ -246,10 +248,11 @@ extension RUMAddUserActionCommand {
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
-        actionType: RUMUserActionType = .tap
+        actionType: RUMUserActionType = .tap,
+        name: String = .mockAny()
     ) -> RUMAddUserActionCommand {
         return RUMAddUserActionCommand(
-            time: time, attributes: attributes, actionType: actionType
+            time: time, attributes: attributes, actionType: actionType, name: name
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -24,6 +24,7 @@ class RUMUserActionScopeTests: XCTestCase {
         let scope = RUMUserActionScope(
             parent: parent,
             dependencies: dependencies,
+            name: .mockAny(),
             actionType: .swipe,
             attributes: [:],
             startTime: .mockAny(),
@@ -63,6 +64,7 @@ class RUMUserActionScopeTests: XCTestCase {
         let scope = RUMUserActionScope(
             parent: parent,
             dependencies: dependencies,
+            name: .mockAny(),
             actionType: .swipe,
             attributes: [:],
             startTime: currentTime,
@@ -76,7 +78,8 @@ class RUMUserActionScopeTests: XCTestCase {
                 command: RUMStopUserActionCommand(
                     time: currentTime,
                     attributes: ["foo": "bar"],
-                    actionType: .swipe
+                    actionType: .swipe,
+                    name: nil
                 )
             )
         )
@@ -101,6 +104,7 @@ class RUMUserActionScopeTests: XCTestCase {
         let scope = RUMUserActionScope(
             parent: parent,
             dependencies: dependencies,
+            name: .mockAny(),
             actionType: .swipe,
             attributes: [:],
             startTime: currentTime,
@@ -124,6 +128,7 @@ class RUMUserActionScopeTests: XCTestCase {
         let scope = RUMUserActionScope(
             parent: parent,
             dependencies: dependencies,
+            name: .mockAny(),
             actionType: .scroll,
             attributes: [:],
             startTime: currentTime,
@@ -174,6 +179,7 @@ class RUMUserActionScopeTests: XCTestCase {
         let scope = RUMUserActionScope(
             parent: parent,
             dependencies: dependencies,
+            name: .mockAny(),
             actionType: .scroll,
             attributes: [:],
             startTime: currentTime,
@@ -200,6 +206,34 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertEqual(event.model.action.error?.count, 1)
     }
 
+    func testWhenContinuousUserActionStopsWithName_itChangesItsName() throws {
+        var currentTime = Date()
+        let scope = RUMUserActionScope(
+            parent: parent,
+            dependencies: dependencies,
+            name: .mockAny(),
+            actionType: .scroll,
+            attributes: [:],
+            startTime: currentTime,
+            isContinuous: true
+        )
+
+        currentTime.addTimeInterval(0.5)
+
+        XCTAssertTrue(scope.process(command: RUMCommandMock()))
+
+        currentTime.addTimeInterval(1)
+        let differentName = String.mockRandom()
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopUserActionCommand.mockWith(time: currentTime, actionType: .scroll, name: differentName)
+            )
+        )
+
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).last)
+        XCTAssertEqual(event.model.action.target?.name, differentName)
+    }
+
     // MARK: - Discrete User Action
 
     func testWhenDiscreteUserActionTimesOut_itSendsActionEvent() throws {
@@ -207,6 +241,7 @@ class RUMUserActionScopeTests: XCTestCase {
         let scope = RUMUserActionScope(
             parent: parent,
             dependencies: dependencies,
+            name: .mockAny(),
             actionType: .swipe,
             attributes: [:],
             startTime: currentTime,
@@ -232,6 +267,7 @@ class RUMUserActionScopeTests: XCTestCase {
         let scope = RUMUserActionScope(
             parent: parent,
             dependencies: dependencies,
+            name: .mockAny(),
             actionType: .scroll,
             attributes: [:],
             startTime: currentTime,
@@ -285,6 +321,7 @@ class RUMUserActionScopeTests: XCTestCase {
         let scope = RUMUserActionScope(
             parent: parent,
             dependencies: dependencies,
+            name: .mockAny(),
             actionType: .scroll,
             attributes: [:],
             startTime: currentTime,

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -289,10 +289,12 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         XCTAssertNil(scope.userActionScope)
+        let actionName = String.mockRandom()
         XCTAssertTrue(
-            scope.process(command: RUMStartUserActionCommand.mockWith(actionType: .swipe))
+            scope.process(command: RUMStartUserActionCommand.mockWith(actionType: .swipe, name: actionName))
         )
         XCTAssertNotNil(scope.userActionScope)
+        XCTAssertEqual(scope.userActionScope?.name, actionName)
         XCTAssertTrue(
             scope.process(command: RUMStopUserActionCommand.mockWith(actionType: .swipe))
         )
@@ -301,8 +303,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertFalse(
             scope.process(command: RUMStopViewCommand.mockWith(identity: mockView))
         )
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).last)
-        XCTAssertEqual(event.model.view.action.count, 1, "View should record 1 action")
+        let viewEvent = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).last)
+        XCTAssertEqual(viewEvent.model.view.action.count, 1, "View should record 1 action")
     }
 
     func testItManagesDiscreteUserActionScopeLifecycle() throws {
@@ -321,10 +323,12 @@ class RUMViewScopeTests: XCTestCase {
         currentTime.addTimeInterval(0.5)
 
         XCTAssertNil(scope.userActionScope)
+        let actionName = String.mockRandom()
         XCTAssertTrue(
-            scope.process(command: RUMAddUserActionCommand.mockWith(time: currentTime, actionType: .tap))
+            scope.process(command: RUMAddUserActionCommand.mockWith(time: currentTime, actionType: .tap, name: actionName))
         )
         XCTAssertNotNil(scope.userActionScope)
+        XCTAssertEqual(scope.userActionScope?.name, actionName)
 
         currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration)
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -96,8 +96,9 @@ class RUMMonitorTests: XCTestCase {
 
         let monitor = RUMMonitor.initialize(rumApplicationID: "abc-123")
 
+        let actionName = String.mockRandom()
         monitor.startView(viewController: mockView)
-        monitor.registerUserAction(type: .tap)
+        monitor.registerUserAction(type: .tap, name: actionName)
         monitor.stopView(viewController: mockView)
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
@@ -110,6 +111,7 @@ class RUMMonitorTests: XCTestCase {
         }
         try rumEventMatchers[2].model(ofType: RUMAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .tap)
+            XCTAssertEqual(rumModel.action.target?.name, actionName)
         }
         try rumEventMatchers[3].model(ofType: RUMView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 2)
@@ -124,7 +126,7 @@ class RUMMonitorTests: XCTestCase {
         let monitor = RUMMonitor.initialize(rumApplicationID: "abc-123")
 
         monitor.startView(viewController: mockView)
-        monitor.startUserAction(type: .scroll)
+        monitor.startUserAction(type: .scroll, name: .mockAny())
         monitor.startResourceLoading(resourceName: "/resource/1", url: .mockAny(), httpMethod: .GET)
         monitor.stopResourceLoading(resourceName: "/resource/1", kind: .image, httpStatusCode: 200)
         monitor.startResourceLoading(resourceName: "/resource/2", url: .mockAny(), httpMethod: .GET)
@@ -183,7 +185,7 @@ class RUMMonitorTests: XCTestCase {
         let monitor = RUMMonitor.initialize(rumApplicationID: "abc-123")
 
         monitor.startView(viewController: mockView)
-        monitor.startUserAction(type: .scroll)
+        monitor.startUserAction(type: .scroll, name: .mockAny())
         #sourceLocation(file: "/user/abc/Foo.swift", line: 100)
         monitor.addViewError(message: "View error message", source: .source)
         #sourceLocation()
@@ -236,7 +238,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.startView(viewController: view1)
         let view2 = createMockView(viewControllerClassName: "SecondViewController")
         monitor.startView(viewController: view2)
-        monitor.registerUserAction(type: .tap)
+        monitor.registerUserAction(type: .tap, name: .mockAny())
         monitor.startResourceLoading(resourceName: "/resource/1", url: .mockAny(), httpMethod: .mockAny())
         monitor.stopResourceLoading(resourceName: "/resource/1", kind: .mockAny(), httpStatusCode: .mockAny())
         monitor.stopView(viewController: view1)
@@ -344,7 +346,7 @@ class RUMMonitorTests: XCTestCase {
         let monitor = RUMMonitor.initialize(rumApplicationID: .mockAny())
 
         monitor.startView(viewController: mockView)
-        monitor.startUserAction(type: .scroll)
+        monitor.startUserAction(type: .scroll, name: .mockAny())
         monitor.startResourceLoading(resourceName: "/resource/1", url: .mockWith(pathComponent: "/resource/1"), httpMethod: .mockAny())
         monitor.startResourceLoading(resourceName: "/resource/2", url: .mockWith(pathComponent: "/resource/2"), httpMethod: .mockAny())
         monitor.stopUserAction(type: .scroll)
@@ -388,7 +390,7 @@ class RUMMonitorTests: XCTestCase {
         let monitor = RUMMonitor.initialize(rumApplicationID: .mockAny())
 
         monitor.startView(viewController: mockView)
-        monitor.startUserAction(type: .scroll)
+        monitor.startUserAction(type: .scroll, name: .mockAny())
         monitor.startResourceLoading(resourceName: "/resource/1", url: .mockWith(pathComponent: "/resource/1"), httpMethod: .mockAny())
         monitor.startResourceLoading(resourceName: "/resource/2", url: .mockWith(pathComponent: "/resource/2"), httpMethod: .mockAny())
         monitor.stopUserAction(type: .scroll)
@@ -438,9 +440,9 @@ class RUMMonitorTests: XCTestCase {
             case 5: monitor.stopResourceLoading(resourceName: .mockAny(), kind: .mockAny(), httpStatusCode: .mockAny())
             case 6: monitor.stopResourceLoadingWithError(resourceName: .mockAny(), error: ErrorMock(), source: .network, httpStatusCode: .mockAny())
             case 7: monitor.stopResourceLoadingWithError(resourceName: .mockAny(), errorMessage: .mockAny(), source: .network)
-            case 8: monitor.startUserAction(type: .scroll)
+            case 8: monitor.startUserAction(type: .scroll, name: String.mockRandom())
             case 9: monitor.stopUserAction(type: .scroll)
-            case 10: monitor.registerUserAction(type: .tap)
+            case 10: monitor.registerUserAction(type: .tap, name: String.mockRandom())
             case 11: _ = monitor.contextProvider.context
             default: break
             }


### PR DESCRIPTION
### What and why?

User Actions have Names in RUM Explorer as in the visual below
<img width="320" alt="Screenshot 2020-08-21 at 16 43 56" src="https://user-images.githubusercontent.com/1417500/90930024-1ca31380-e3fa-11ea-9f50-9c6936cec680.png">

### How?

1. Name is added to `RUMMonitor` public interface
2. `UserAction` related commands have `name` property to carry data from `RUMMonitor` to RUM events
3. `UserAction` starts with a name and can end with a different name which overrides the initial name

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
