### PR TITLE
RUMM-677 Fix bug with User Action not being send

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -111,9 +111,13 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         // User Action commands
         case let command as RUMStartUserActionCommand where isActiveView:
-            startContinuousUserAction(on: command)
+            if userActionScope == nil {
+                startContinuousUserAction(on: command)
+            }
         case let command as RUMAddUserActionCommand where isActiveView:
-            addDiscreteUserAction(on: command)
+            if userActionScope == nil {
+                addDiscreteUserAction(on: command)
+            }
 
         // Error command
         case let command as RUMAddCurrentViewErrorCommand where isActiveView:

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -78,6 +78,16 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         // Tells if the View did change and an update event should be send.
         var needsViewUpdate = false
 
+        // Propagate to User Action scope
+        let beforeHadUserAction = userActionScope != nil
+        userActionScope = manage(childScope: userActionScope, byPropagatingCommand: command)
+        let afterHasUserAction = userActionScope != nil
+
+        if beforeHadUserAction && !afterHasUserAction { // if User Action was tracked
+            actionsCount += 1
+            needsViewUpdate = true
+        }
+
         // Apply side effects
         switch command {
         // View commands
@@ -131,16 +141,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             } else {
                 resourcesCount += 1
             }
-            needsViewUpdate = true
-        }
-
-        // Propagate to User Action scope
-        let beforeHadUserAction = userActionScope != nil
-        userActionScope = manage(childScope: userActionScope, byPropagatingCommand: command)
-        let afterHasUserAction = userActionScope != nil
-
-        if beforeHadUserAction && !afterHasUserAction { // if User Action was tracked
-            actionsCount += 1
             needsViewUpdate = true
         }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -295,6 +295,12 @@ class RUMViewScopeTests: XCTestCase {
         )
         XCTAssertNotNil(scope.userActionScope)
         XCTAssertEqual(scope.userActionScope?.name, actionName)
+
+        XCTAssertTrue(
+            scope.process(command: RUMStartUserActionCommand.mockWith(actionType: .swipe, name: .mockRandom()))
+        )
+        XCTAssertEqual(scope.userActionScope?.name, actionName, "View should ignore the next UA if one is pending.")
+
         XCTAssertTrue(
             scope.process(command: RUMStopUserActionCommand.mockWith(actionType: .swipe))
         )
@@ -329,6 +335,11 @@ class RUMViewScopeTests: XCTestCase {
         )
         XCTAssertNotNil(scope.userActionScope)
         XCTAssertEqual(scope.userActionScope?.name, actionName)
+
+        XCTAssertTrue(
+            scope.process(command: RUMAddUserActionCommand.mockWith(time: currentTime, actionType: .tap, name: .mockRandom()))
+        )
+        XCTAssertEqual(scope.userActionScope?.name, actionName, "View should ignore the next UA if one is pending.")
 
         currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration)
 


### PR DESCRIPTION
### What and why?

🐞 This PR fixes the bug with discrete User Action event not being send when the UA expires and the next propagated command is `RUMStartUserActionCommand` or `RUMAddUserActionCommand`.

### How?

To reproduce the bug:
```swift
monitor.startView(viewController: mockView)
// wait 1s
monitor.registerUserAction(type: .tap, name: "1st action")
// wait 1s
monitor.registerUserAction(type: .swipe, name: "2nd action")
```

I added unit test to reproduce the bug and fixed it by enforcing the command processing in UA scope before it gets replaced with the next instance.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
