### PR TITLE
RUMM-672 Add improvements noticed in RUM dogfooding

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */; };
 		61AD4E3824531500006E34EA /* DataFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3724531500006E34EA /* DataFormat.swift */; };
 		61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3924534075006E34EA /* TracingFeatureTests.swift */; };
+		61B22E5A24F3E6B700DC26D2 /* RUMDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */; };
 		61B558CF2469561C001460D3 /* LoggerBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */; };
 		61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */; };
 		61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */; };
@@ -473,6 +474,7 @@
 		61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingFeatureMocks.swift; sourceTree = "<group>"; };
 		61AD4E3724531500006E34EA /* DataFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataFormat.swift; sourceTree = "<group>"; };
 		61AD4E3924534075006E34EA /* TracingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingFeatureTests.swift; sourceTree = "<group>"; };
+		61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebugging.swift; sourceTree = "<group>"; };
 		61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerBuilderTests.swift; sourceTree = "<group>"; };
 		61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDGeneratorTests.swift; sourceTree = "<group>"; };
 		61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendLogsFixtureViewController.swift; sourceTree = "<group>"; };
@@ -1303,6 +1305,14 @@
 			path = UUIDs;
 			sourceTree = "<group>";
 		};
+		61B22E5824F3E6A700DC26D2 /* Debugging */ = {
+			isa = PBXGroup;
+			children = (
+				61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */,
+			);
+			path = Debugging;
+			sourceTree = "<group>";
+		};
 		61B9ED142461DFEE00C0DCFF /* IntegrationTestFixtures */ = {
 			isa = PBXGroup;
 			children = (
@@ -1452,6 +1462,7 @@
 				61E5333B24B87908003D6C4E /* RUMEvent */,
 				61FF282224B8A1AE000B3D9B /* RUMEventOutputs */,
 				618DCFD524C7264100589570 /* UUIDs */,
+				61B22E5824F3E6A700DC26D2 /* Debugging */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -1960,6 +1971,7 @@
 				61133BD12423979B00786299 /* FilesOrchestrator.swift in Sources */,
 				61133BCD2423979B00786299 /* NetworkConnectionInfoProvider.swift in Sources */,
 				61FF282424B8A1C3000B3D9B /* RUMEventFileOutput.swift in Sources */,
+				61B22E5A24F3E6B700DC26D2 /* RUMDebugging.swift in Sources */,
 				61C5A88B24509A0C00DA608C /* SpanOutput.swift in Sources */,
 				61133BE42423979B00786299 /* LogEncoder.swift in Sources */,
 				61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8824A34FD700233986 /* DDTracerTests.swift */; };
 		615A4A8B24A3568900233986 /* OTSpan+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8A24A3568900233986 /* OTSpan+objc.swift */; };
 		615A4A8D24A356A000233986 /* OTSpanContext+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8C24A356A000233986 /* OTSpanContext+objc.swift */; };
+		61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */; };
 		617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */; };
 		617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */; };
 		617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */; };
@@ -456,6 +457,7 @@
 		615A4A8824A34FD700233986 /* DDTracerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerTests.swift; sourceTree = "<group>"; };
 		615A4A8A24A3568900233986 /* OTSpan+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTSpan+objc.swift"; sourceTree = "<group>"; };
 		615A4A8C24A356A000233986 /* OTSpanContext+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTSpanContext+objc.swift"; sourceTree = "<group>"; };
+		61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebuggingTests.swift; sourceTree = "<group>"; };
 		617B953C24BF4D8F00E6F443 /* RUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorTests.swift; sourceTree = "<group>"; };
 		617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMApplicationScopeTests.swift; sourceTree = "<group>"; };
 		617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorConfigurationTests.swift; sourceTree = "<group>"; };
@@ -1238,6 +1240,14 @@
 			path = RUMContext;
 			sourceTree = "<group>";
 		};
+		61786F7524FCDDE2009E6BAB /* Debugging */ = {
+			isa = PBXGroup;
+			children = (
+				61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */,
+			);
+			path = Debugging;
+			sourceTree = "<group>";
+		};
 		617B953B24BF4D7300E6F443 /* RUMMonitor */ = {
 			isa = PBXGroup;
 			children = (
@@ -1476,6 +1486,7 @@
 				6156CB9124DDAA13008CB2B2 /* RUMContext */,
 				61FF281F24B89807000B3D9B /* RUMEvent */,
 				61FF282E24BC5E0E000B3D9B /* RUMEventOutputs */,
+				61786F7524FCDDE2009E6BAB /* Debugging */,
 				61411B0E24EC15940012EAB2 /* Utils */,
 			);
 			path = RUM;
@@ -2089,6 +2100,7 @@
 				61F1A623249B811200075390 /* Encoding.swift in Sources */,
 				61133C642423990D00786299 /* LoggerTests.swift in Sources */,
 				617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */,
+				61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */,
 				6156CB9324DDAA34008CB2B2 /* RUMCurrentContextTests.swift in Sources */,
 				61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */,
 				61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */,

--- a/Datadog/Example/AppDelegate.swift
+++ b/Datadog/Example/AppDelegate.swift
@@ -57,6 +57,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Set highest verbosity level to see internal actions made in SDK
         Datadog.verbosityLevel = .debug
 
+        // Enable RUM Views debug utility.
+        Datadog.debugRUM = true
+
         // Add attributes
         logger.addAttribute(forKey: "device-model", value: UIDevice.current.model)
 

--- a/Sources/Datadog/DDRUMMonitor.swift
+++ b/Sources/Datadog/DDRUMMonitor.swift
@@ -16,8 +16,9 @@ public class DDRUMMonitor {
     /// Notifies that the View starts being presented to the user.
     /// - Parameters:
     ///   - viewController: the instance of `UIViewController` representing this View.
+    ///   - path: the View path used for RUM Explorer. If not provided, the `UIViewController` class name will be used.
     ///   - attributes: custom attributes to attach to the View.
-    public func startView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]? = nil) {
+    public func startView(viewController: UIViewController, path: String? = nil, attributes: [AttributeKey: AttributeValue]? = nil) {
     }
 
     /// Notifies that the View stops being presented to the user.

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -61,6 +61,16 @@ public class Datadog {
     /// Default is `nil`.
     public static var verbosityLevel: LogLevel? = nil
 
+    /// Utility setting to inspect the active RUM View. It only makes effect on the iOS Simulator.
+    /// If set, a debugging outline will be diesplayed on top of the application, describing the name of the active RUM View.
+    /// May be used to debug issues with RUM instrumentation in your app.
+    /// Default is `false`.
+    public static var debugRUM: Bool = false {
+        didSet {
+            (Global.rum as? RUMMonitor)?.enableRUMDebugging(debugRUM)
+        }
+    }
+
     public static func setUserInfo(
         id: String? = nil,
         name: String? = nil,

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -62,7 +62,7 @@ public class Datadog {
     public static var verbosityLevel: LogLevel? = nil
 
     /// Utility setting to inspect the active RUM View. It only makes effect on the iOS Simulator.
-    /// If set, a debugging outline will be diesplayed on top of the application, describing the name of the active RUM View.
+    /// If set, a debugging outline will be displayed on top of the application, describing the name of the active RUM View.
     /// May be used to debug issues with RUM instrumentation in your app.
     /// Default is `false`.
     public static var debugRUM: Bool = false {

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -61,7 +61,7 @@ public class Datadog {
     /// Default is `nil`.
     public static var verbosityLevel: LogLevel? = nil
 
-    /// Utility setting to inspect the active RUM View. It only makes effect on the iOS Simulator.
+    /// Utility setting to inspect the active RUM View.
     /// If set, a debugging outline will be displayed on top of the application, describing the name of the active RUM View.
     /// May be used to debug issues with RUM instrumentation in your app.
     /// Default is `false`.

--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -109,7 +109,7 @@ internal class RUMDebuggingInSimulator: RUMDebugging {
     }
 }
 
-private class RUMViewOutline: RUMDebugView {
+internal class RUMViewOutline: RUMDebugView {
     private struct Constants {
         static let activeViewColor =  #colorLiteral(red: 0.3882352941, green: 0.1725490196, blue: 0.6509803922, alpha: 1)
         static let inactiveViewColor =  #colorLiteral(red: 0.6000000238, green: 0.6000000238, blue: 0.6000000238, alpha: 1)
@@ -128,7 +128,7 @@ private class RUMViewOutline: RUMDebugView {
     private let label: UILabel
     private let stackOffset: CGFloat
 
-    init(viewInfo: RUMDebugInfo.View, stack: (index: Int, total: Int)) {
+    fileprivate init(viewInfo: RUMDebugInfo.View, stack: (index: Int, total: Int)) {
         self.label = UILabel(frame: .zero)
         self.stackOffset = CGFloat(stack.index) * Constants.labelHeight
 
@@ -170,7 +170,7 @@ private class RUMViewOutline: RUMDebugView {
     }
 }
 
-private class RUMDebugView: UIView {
+internal class RUMDebugView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.backgroundColor = .clear

--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -110,17 +110,17 @@ internal class RUMDebuggingInSimulator: RUMDebugging {
 }
 
 private class RUMViewOutline: RUMDebugView {
-    struct Constants {
-        static let activeViewColor =  #colorLiteral(red: 0.4686954021, green: 0.2687242031, blue: 0.7103499174, alpha: 1)
+    private struct Constants {
+        static let activeViewColor =  #colorLiteral(red: 0.3882352941, green: 0.1725490196, blue: 0.6509803922, alpha: 1)
         static let inactiveViewColor =  #colorLiteral(red: 0.6000000238, green: 0.6000000238, blue: 0.6000000238, alpha: 1)
-        static let lineWidth: CGFloat = 16
+        static let labelHeight: CGFloat = 16
 
         static let viewNameTextAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.monospacedDigitSystemFont(ofSize: Constants.lineWidth * 0.8, weight: .semibold),
+            .font: UIFont.monospacedDigitSystemFont(ofSize: Constants.labelHeight * 0.8, weight: .semibold),
             .foregroundColor: UIColor.white,
         ]
         static let viewDetailsTextAttributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.monospacedDigitSystemFont(ofSize: Constants.lineWidth * 0.5, weight: .regular),
+            .font: UIFont.monospacedDigitSystemFont(ofSize: Constants.labelHeight * 0.5, weight: .regular),
             .foregroundColor: UIColor.white,
         ]
     }
@@ -130,7 +130,7 @@ private class RUMViewOutline: RUMDebugView {
 
     init(viewInfo: RUMDebugInfo.View, stack: (index: Int, total: Int)) {
         self.label = UILabel(frame: .zero)
-        self.stackOffset = CGFloat(stack.index) * Constants.lineWidth
+        self.stackOffset = CGFloat(stack.index) * Constants.labelHeight
 
         let viewName = viewInfo.uri
         let separator = " # "
@@ -163,9 +163,9 @@ private class RUMViewOutline: RUMDebugView {
         let safeAreaBounds = bounds.inset(by: safeAreaInsets)
         label.frame = .init(
             x: bounds.minX,
-            y: safeAreaBounds.maxY - stackOffset - Constants.lineWidth,
+            y: safeAreaBounds.maxY - stackOffset - Constants.labelHeight,
             width: bounds.width,
-            height: Constants.lineWidth
+            height: Constants.labelHeight
         )
     }
 }

--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -1,0 +1,162 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+internal protocol RUMDebugging {
+    func debug(applicationScope: RUMApplicationScope)
+}
+
+#if targetEnvironment(simulator)
+import UIKit
+import Foundation
+
+internal struct RUMDebugInfo {
+    struct View {
+        let uri: String
+        let isActive: Bool
+
+        init(scope: RUMViewScope) {
+            self.uri = scope.viewURI
+            self.isActive = scope.isActiveView
+        }
+    }
+
+    let views: [View]
+
+    init(applicationScope: RUMApplicationScope) {
+        self.views = (applicationScope.sessionScope?.viewScopes ?? [])
+            .map { View(scope: $0) }
+    }
+}
+
+internal class RUMDebuggingInSimulator: RUMDebugging {
+    private lazy var canvas: UIView = {
+        let window = UIApplication.shared.keyWindow
+        let view = RUMDebugView(frame: window?.bounds ?? .zero)
+        window?.addSubview(view)
+        return view
+    }()
+
+    deinit {
+        let canvas = self.canvas
+        DispatchQueue.main.async {
+            canvas.removeFromSuperview()
+        }
+    }
+
+    func debug(applicationScope: RUMApplicationScope) {
+        // `RUMDebugInfo` must be created on the caller thread.
+        let debugInfo = RUMDebugInfo(applicationScope: applicationScope)
+
+        DispatchQueue.main.async {
+            // `RUMDebugInfo` rendering must be called on the main thread.
+            self.renderOnMainThread(rumDebugInfo: debugInfo)
+        }
+    }
+
+    private func renderOnMainThread(rumDebugInfo: RUMDebugInfo) {
+        canvas.subviews.forEach {
+            $0.removeFromSuperview()
+        }
+
+        let viewOutlines = rumDebugInfo.views.map { RUMViewOutline(viewInfo: $0) }
+
+        var nextOutlineFrame = canvas.bounds.inset(by: canvas.safeAreaInsets)
+        var nextOutlineAlpha = CGFloat(0.75)
+
+        viewOutlines.forEach { viewOutline in
+            viewOutline.frame = nextOutlineFrame
+            viewOutline.alpha = nextOutlineAlpha
+
+            nextOutlineFrame = nextOutlineFrame.insetBy(
+                dx: RUMViewOutline.Constants.lineWidth,
+                dy: RUMViewOutline.Constants.lineWidth
+            )
+            nextOutlineAlpha *= nextOutlineAlpha
+        }
+
+        viewOutlines.forEach {
+            canvas.addSubview($0)
+            $0.setNeedsDisplay()
+        }
+    }
+}
+
+private class RUMViewOutline: RUMDebugView {
+    struct Constants {
+        static let activeViewColor =  #colorLiteral(red: 0.4686954021, green: 0.2687242031, blue: 0.7103499174, alpha: 1)
+        static let inactiveViewColor =  #colorLiteral(red: 0.501960814, green: 0.501960814, blue: 0.501960814, alpha: 1)
+        static let lineWidth: CGFloat = 15
+
+        static let viewNameTextAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.monospacedDigitSystemFont(ofSize: Constants.lineWidth * 0.8, weight: .semibold),
+            .foregroundColor: UIColor.white,
+        ]
+        static let viewDetailsTextAttributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.monospacedDigitSystemFont(ofSize: Constants.lineWidth * 0.5, weight: .regular),
+            .foregroundColor: UIColor.white,
+        ]
+    }
+
+    private let color: UIColor
+    private let label: UILabel
+
+    init(viewInfo: RUMDebugInfo.View) {
+        self.color = viewInfo.isActive ? Constants.activeViewColor : Constants.inactiveViewColor
+        self.label = UILabel(frame: .zero)
+
+        let viewName = viewInfo.uri
+        let separator = " # "
+        let viewDetails = (viewInfo.isActive ? "ACTIVE" : "INACTIVE")
+        let labelText = "\(viewName)\(separator)\(viewDetails)"
+        let labelAttributedText = NSMutableAttributedString(string: labelText)
+
+        labelAttributedText.setAttributes(
+            Constants.viewNameTextAttributes,
+            range: NSRange(location: 0, length: viewName.count)
+        )
+
+        labelAttributedText.setAttributes(
+            Constants.viewDetailsTextAttributes,
+            range: NSRange(location: viewName.count, length: separator.count + viewDetails.count)
+        )
+
+        label.attributedText = labelAttributedText
+        label.textAlignment = .left
+        super.init(frame: .zero)
+        addSubview(label)
+    }
+
+    override func draw(_ rect: CGRect) {
+        let innerRect = rect.insetBy(dx: Constants.lineWidth * 0.5, dy: Constants.lineWidth * 0.5)
+        let path = UIBezierPath(rect: innerRect)
+        color.set()
+        path.lineWidth = Constants.lineWidth
+        path.stroke()
+    }
+
+    override func layoutSubviews() {
+        label.frame = .init(
+            x: bounds.minX + Constants.lineWidth,
+            y: bounds.maxY - Constants.lineWidth,
+            width: bounds.width - 2 * Constants.lineWidth,
+            height: Constants.lineWidth
+        )
+    }
+}
+
+private class RUMDebugView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .clear
+        self.isUserInteractionEnabled = false
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+#endif

--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -4,11 +4,6 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-internal protocol RUMDebugging {
-    func debug(applicationScope: RUMApplicationScope)
-}
-
-#if targetEnvironment(simulator)
 import UIKit
 import Foundation
 
@@ -31,7 +26,7 @@ private struct RUMDebugInfo {
     }
 }
 
-internal class RUMDebuggingInSimulator: RUMDebugging {
+internal class RUMDebugging {
     private lazy var canvas: UIView = {
         let window = UIApplication.shared.keyWindow
         let view = RUMDebugView(frame: window?.bounds ?? .zero)
@@ -48,7 +43,7 @@ internal class RUMDebuggingInSimulator: RUMDebugging {
         NotificationCenter.default
             .addObserver(
                 self,
-                selector: #selector(RUMDebuggingInSimulator.updateLayout),
+                selector: #selector(RUMDebugging.updateLayout),
                 name: UIDevice.orientationDidChangeNotification,
                 object: nil
         )
@@ -182,4 +177,3 @@ internal class RUMDebugView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 }
-#endif

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import UIKit
 
 /// Command processed through the tree of `RUMScopes`.
 internal protocol RUMCommand {
@@ -23,10 +24,28 @@ internal struct RUMStartViewCommand: RUMCommand {
     /// The object (typically `UIViewController`) identifying the RUM View.
     let identity: AnyObject
 
+    /// The path of this View, rendered in RUM Explorer.
+    let path: String
+
     /// Used to indicate if this command starts the very first View in the app.
     /// * default `false` means _it's not yet known_,
     /// * it can be set to `true` by the `RUMApplicationScope` which tracks this state.
     var isInitialView = false
+
+    init(time: Date, identity: AnyObject, path: String?, attributes: [AttributeKey: AttributeValue]) {
+        self.time = time
+        self.attributes = attributes
+        self.identity = identity
+        self.path = path ?? RUMStartViewCommand.viewPath(from: identity)
+    }
+
+    private static func viewPath(from id: AnyObject) -> String {
+        guard let viewController = id as? UIViewController else {
+            return ""
+        }
+
+        return "\(type(of: viewController))"
+    }
 }
 
 internal struct RUMStopViewCommand: RUMCommand {

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -5,7 +5,6 @@
  */
 
 import Foundation
-import UIKit
 
 /// Command processed through the tree of `RUMScopes`.
 internal protocol RUMCommand {
@@ -40,11 +39,7 @@ internal struct RUMStartViewCommand: RUMCommand {
     }
 
     private static func viewPath(from id: AnyObject) -> String {
-        guard let viewController = id as? UIViewController else {
-            return ""
-        }
-
-        return "\(type(of: viewController))"
+        return "\(type(of: id))"
     }
 }
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -72,6 +72,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 parent: self,
                 dependencies: dependencies,
                 identity: expiredViewIdentity,
+                uri: expiredView.viewURI,
                 attributes: expiredView.attributes,
                 startTime: startTime
             )
@@ -120,6 +121,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 parent: self,
                 dependencies: dependencies,
                 identity: command.identity,
+                uri: command.path,
                 attributes: command.attributes,
                 startTime: command.time
             )

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -31,7 +31,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     /// The start time of this View.
     private let viewStartTime: Date
     /// Tells if this View is the active one. `true` for every new started View. `false` if any other View was started before this one is stopped.
-    private var isActiveView: Bool = true
+    private(set) var isActiveView: Bool = true
     /// Tells if this scope has received the "stop" command. Used to delay the actual completion of this scope  until all tracked Resources are finished.
     private var didReceiveStopCommand = false
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -5,7 +5,6 @@
  */
 
 import Foundation
-import UIKit
 
 internal class RUMViewScope: RUMScope, RUMContextProvider {
     // MARK: - Child Scopes
@@ -50,6 +49,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         parent: RUMContextProvider,
         dependencies: RUMScopeDependencies,
         identity: AnyObject,
+        uri: String,
         attributes: [AttributeKey: AttributeValue],
         startTime: Date
     ) {
@@ -58,7 +58,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         self.identity = identity
         self.attributes = attributes
         self.viewUUID = dependencies.rumUUIDGenerator.generateUnique()
-        self.viewURI = RUMViewScope.viewURI(from: identity)
+        self.viewURI = uri
         self.viewStartTime = startTime
     }
 
@@ -292,15 +292,5 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes)
         dependencies.eventOutput.write(rumEvent: event)
-    }
-
-    // MARK: - Private
-
-    private static func viewURI(from id: AnyObject) -> String {
-        guard let viewController = id as? UIViewController else {
-            return ""
-        }
-
-        return "\(type(of: viewController))"
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -30,10 +30,13 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     let viewURI: String
     /// The start time of this View.
     private let viewStartTime: Date
-    /// Tells if this View is the active one. `true` for every new started View. `false` if any other View was started before this one is stopped.
+    /// Tells if this View is the active one.
+    /// `true` for every new started View.
+    /// `false` if the View was stopped or any other View was started.
     private(set) var isActiveView: Bool = true
-    /// Tells if this scope has received the "stop" command. Used to delay the actual completion of this scope  until all tracked Resources are finished.
-    private var didReceiveStopCommand = false
+    /// Tells if this scope has received the "start" command.
+    /// If `didReceiveStartCommand == true` and another "start" command is received for this View this scope is marked as inactive.
+    private var didReceiveStartCommand = false
 
     /// Number of Actions happened on this View.
     private var actionsCount: UInt = 0
@@ -92,10 +95,16 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         switch command {
         // View commands
         case let command as RUMStartViewCommand where command.identity === identity:
+            if didReceiveStartCommand {
+                // This is the case of duplicated "start" command. We know that the Session scope has created another instance of
+                // the `RUMViewScope` for tracking this View, so we mark this one as inactive.
+                isActiveView = false
+            }
             if command.isInitialView {
                 actionsCount += 1
                 sendApplicationStartAction(on: command)
             }
+            didReceiveStartCommand = true
             needsViewUpdate = true
         case let command as RUMStartViewCommand where command.identity !== identity:
             isActiveView = false
@@ -103,7 +112,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         case let command as RUMStopViewCommand where command.identity === identity:
             isActiveView = false
             needsViewUpdate = true
-            didReceiveStopCommand = true
 
         // Resource commands
         case let command as RUMStartResourceCommand where isActiveView:
@@ -154,7 +162,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         }
 
         let hasNoPendingResources = resourceScopes.isEmpty
-        let shouldComplete = didReceiveStopCommand && hasNoPendingResources
+        let shouldComplete = !isActiveView && hasNoPendingResources
 
         return !shouldComplete
     }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -123,12 +123,13 @@ public class RUMMonitor: DDRUMMonitor {
 
     // MARK: - Public DDRUMMonitor conformance
 
-    override public func startView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]?) {
+    override public func startView(viewController: UIViewController, path: String?, attributes: [AttributeKey: AttributeValue]?) {
         process(
             command: RUMStartViewCommand(
                 time: dateProvider.currentDate(),
-                attributes: aggregate(attributes),
-                identity: viewController
+                identity: viewController,
+                path: path,
+                attributes: aggregate(attributes)
             )
         )
     }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -280,12 +280,10 @@ public class RUMMonitor: DDRUMMonitor {
     // MARK: - Internal
 
     func enableRUMDebugging(_ enabled: Bool) {
-        #if targetEnvironment(simulator)
         queue.async {
-            self.debugging = enabled ? RUMDebuggingInSimulator() : nil
+            self.debugging = enabled ? RUMDebugging() : nil
             self.debugging?.debug(applicationScope: self.applicationScope)
         }
-        #endif
     }
 
     // MARK: - Private
@@ -300,9 +298,9 @@ public class RUMMonitor: DDRUMMonitor {
         queue.async {
             _ = self.applicationScope.process(command: command)
 
-            #if targetEnvironment(simulator)
-            self.debugging?.debug(applicationScope: self.applicationScope)
-            #endif
+            if let debugging = self.debugging {
+                debugging.debug(applicationScope: self.applicationScope)
+            }
         }
     }
 }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -59,12 +59,12 @@ public class RUMMonitor: DDRUMMonitor {
     /// Attributes associated with every command.
     private var rumAttributes: [AttributeKey: AttributeValue] = [:]
     /// Queue for processing RUM commands off the main thread and providing current RUM context.
-    private let queue = DispatchQueue(
+    internal let queue = DispatchQueue(
         label: "com.datadoghq.rum-monitor",
         target: .global(qos: .userInteractive)
     )
     /// User-targeted, debugging utility which can be toggled with `Datadog.debugRUM`.
-    private var debugging: RUMDebugging? = nil
+    private(set) var debugging: RUMDebugging? = nil
 
     // MARK: - Initialization
 

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -189,6 +189,10 @@ class DatadogTests: XCTestCase {
 
         try Datadog.deinitializeOrThrow()
     }
+
+    func testDefaultDebugRUM() {
+        XCTAssertFalse(Datadog.debugRUM)
+    }
 }
 
 class AppContextTests: XCTestCase {

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -112,11 +112,17 @@ extension RUMStartViewCommand {
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
         identity: AnyObject = mockView,
+        path: String? = nil,
         isInitialView: Bool = false
     ) -> RUMStartViewCommand {
-        return RUMStartViewCommand(
-            time: time, attributes: attributes, identity: identity, isInitialView: isInitialView
+        var command = RUMStartViewCommand(
+            time: time,
+            identity: identity,
+            path: path,
+            attributes: attributes
         )
+        command.isInitialView = isInitialView
+        return command
     }
 }
 
@@ -396,9 +402,10 @@ extension RUMViewScope {
     }
 
     static func mockWith(
-        parent: RUMSessionScope = .mockAny(),
+        parent: RUMContextProvider = RUMContextProviderMock(),
         dependencies: RUMScopeDependencies = .mockAny(),
         identity: AnyObject = mockView,
+        uri: String = .mockAny(),
         attributes: [AttributeKey: AttributeValue] = [:],
         startTime: Date = .mockAny()
     ) -> RUMViewScope {
@@ -406,6 +413,7 @@ extension RUMViewScope {
             parent: parent,
             dependencies: dependencies,
             identity: identity,
+            uri: uri,
             attributes: attributes,
             startTime: startTime
         )

--- a/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
@@ -4,7 +4,6 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-#if targetEnvironment(simulator)
 import XCTest
 import UIKit
 @testable import Datadog
@@ -23,7 +22,7 @@ class RUMDebuggingTests: XCTestCase {
             command: RUMStartViewCommand.mockWith(identity: mockView, path: "FirstViewController")
         )
 
-        let debugging = RUMDebuggingInSimulator()
+        let debugging = RUMDebugging()
         debugging.debug(applicationScope: applicationScope)
 
         DispatchQueue.main.async { expectation.fulfill() }
@@ -60,7 +59,7 @@ class RUMDebuggingTests: XCTestCase {
             command: RUMStartViewCommand.mockWith(identity: mockView, path: "SecondViewController")
         )
 
-        let debugging = RUMDebuggingInSimulator()
+        let debugging = RUMDebugging()
         debugging.debug(applicationScope: applicationScope)
 
         DispatchQueue.main.async { expectation.fulfill() }
@@ -82,5 +81,3 @@ class RUMDebuggingTests: XCTestCase {
         XCTAssertLessThan(firstViewOutlineLabel.alpha, secondViewOutlineLabel.alpha)
     }
 }
-
-#endif

--- a/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
@@ -1,0 +1,86 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+#if targetEnvironment(simulator)
+import XCTest
+import UIKit
+@testable import Datadog
+
+class RUMDebuggingTests: XCTestCase {
+    func testWhenOneRUMViewIsActive_itDisplaysSingleRUMViewOutline() throws {
+        let expectation = self.expectation(description: "Render RUMDebugging")
+
+        // when
+        let applicationScope = RUMApplicationScope(
+            rumApplicationID: "abc-123",
+            dependencies: .mockAny(),
+            samplingRate: 100
+        )
+        _ = applicationScope.process(
+            command: RUMStartViewCommand.mockWith(identity: mockView, path: "FirstViewController")
+        )
+
+        let debugging = RUMDebuggingInSimulator()
+        debugging.debug(applicationScope: applicationScope)
+
+        DispatchQueue.main.async { expectation.fulfill() }
+        waitForExpectations(timeout: 1, handler: nil)
+
+        // then
+        let canvas = try XCTUnwrap(
+            UIApplication.shared.keyWindow?.subviews.first { $0 is RUMDebugView },
+            "Cannot find `RUMDebugging` canvas."
+        )
+
+        XCTAssertEqual(canvas.subviews.count, 1)
+        let viewOutline = try XCTUnwrap(canvas.subviews.first)
+        let viewOutlineLabel = try XCTUnwrap(viewOutline.subviews.first as? UILabel)
+        XCTAssertEqual(viewOutlineLabel.text, "FirstViewController # ACTIVE")
+    }
+
+    func testWhenOneRUMViewIsInactive_andSecondIsActive_itDisplaysTwoRUMViewOutlines() throws {
+        let expectation = self.expectation(description: "Render RUMDebugging")
+
+        // when
+        let applicationScope = RUMApplicationScope(
+            rumApplicationID: "abc-123",
+            dependencies: .mockAny(),
+            samplingRate: 100
+        )
+        _ = applicationScope.process(
+            command: RUMStartViewCommand.mockWith(identity: mockView, path: "FirstViewController")
+        )
+        _ = applicationScope.process(
+            command: RUMStartResourceCommand.mockAny()
+        )
+        _ = applicationScope.process(
+            command: RUMStartViewCommand.mockWith(identity: mockView, path: "SecondViewController")
+        )
+
+        let debugging = RUMDebuggingInSimulator()
+        debugging.debug(applicationScope: applicationScope)
+
+        DispatchQueue.main.async { expectation.fulfill() }
+        waitForExpectations(timeout: 1, handler: nil)
+
+        // then
+        let canvas = try XCTUnwrap(
+            UIApplication.shared.keyWindow?.subviews.first { $0 is RUMDebugView },
+            "Cannot find `RUMDebugging` canvas."
+        )
+
+        XCTAssertEqual(canvas.subviews.count, 2)
+        let firstViewOutline = try XCTUnwrap(canvas.subviews.first)
+        let firstViewOutlineLabel = try XCTUnwrap(firstViewOutline.subviews.first as? UILabel)
+        XCTAssertEqual(firstViewOutlineLabel.text, "FirstViewController # INACTIVE")
+        let secondViewOutline = try XCTUnwrap(canvas.subviews.dropFirst().first)
+        let secondViewOutlineLabel = try XCTUnwrap(secondViewOutline.subviews.first as? UILabel)
+        XCTAssertEqual(secondViewOutlineLabel.text, "SecondViewController # ACTIVE")
+        XCTAssertLessThan(firstViewOutlineLabel.alpha, secondViewOutlineLabel.alpha)
+    }
+}
+
+#endif

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -39,7 +39,7 @@ class RUMUserActionScopeTests: XCTestCase {
     }
 
     func testGivenActiveUserAction_whenViewIsStopped_itSendsUserActionEvent() throws {
-        let scope = RUMViewScope(
+        let scope = RUMViewScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             identity: mockView,

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -20,6 +20,7 @@ class RUMViewScopeTests: XCTestCase {
             parent: sessionScope,
             dependencies: .mockAny(),
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: .mockAny()
         )
@@ -38,6 +39,7 @@ class RUMViewScopeTests: XCTestCase {
             parent: sessionScope,
             dependencies: .mockAny(),
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: .mockAny()
         )
@@ -57,13 +59,14 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: currentTime
         )
 
         XCTAssertTrue(
             scope.process(
-                command: RUMStartViewCommand(time: currentTime, attributes: ["foo": "bar"], identity: mockView, isInitialView: true)
+                command: RUMStartViewCommand.mockWith(time: currentTime, attributes: ["foo": "bar"], identity: mockView, isInitialView: true)
             )
         )
 
@@ -84,13 +87,14 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: currentTime
         )
 
         XCTAssertTrue(
             scope.process(
-                command: RUMStartViewCommand(time: currentTime, attributes: ["foo": "bar"], identity: mockView, isInitialView: true)
+                command: RUMStartViewCommand.mockWith(time: currentTime, attributes: ["foo": "bar"], identity: mockView, isInitialView: true)
             )
         )
 
@@ -115,13 +119,14 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: ["foo": "bar", "fizz": "buzz"],
             startTime: currentTime
         )
 
         XCTAssertTrue(
             scope.process(
-                command: RUMStartViewCommand(time: currentTime, attributes: ["foo": "bar 2"], identity: mockView)
+                command: RUMStartViewCommand.mockWith(time: currentTime, attributes: ["foo": "bar 2"], identity: mockView)
             )
         )
 
@@ -146,6 +151,7 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: currentTime
         )
@@ -191,6 +197,7 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: Date()
         )
@@ -237,6 +244,7 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: Date()
         )
@@ -280,6 +288,7 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: Date()
         )
@@ -318,6 +327,7 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: currentTime
         )
@@ -357,6 +367,7 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: currentTime
         )
@@ -401,6 +412,7 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
+            uri: "UIViewController",
             attributes: [:],
             startTime: Date()
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -190,6 +190,64 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertTrue(event.attributes.isEmpty)
     }
 
+    func testWhenAnotherViewIsStarted_itEndsTheScope() throws {
+        let view1 = createMockView(viewControllerClassName: "FirstViewController")
+        let view2 = createMockView(viewControllerClassName: "SecondViewController")
+        var currentTime = Date()
+        let scope = RUMViewScope(
+            parent: parent,
+            dependencies: dependencies,
+            identity: view1,
+            uri: "FirstViewController",
+            attributes: [:],
+            startTime: currentTime
+        )
+
+        XCTAssertTrue(
+             scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: view1))
+         )
+
+        currentTime.addTimeInterval(1)
+
+        XCTAssertFalse(
+            scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: view2)),
+            "The scope should end as another View is started."
+        )
+
+        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMView>.self)
+        let event = try XCTUnwrap(viewEvents.dropFirst().first)
+        XCTAssertEqual(event.model.view.url, "FirstViewController")
+        XCTAssertEqual(event.model.view.timeSpent, TimeInterval(1).toInt64Nanoseconds, "The View should last for 1 second")
+    }
+
+    func testWhenTheViewIsStartedAnotherTime_itEndsTheScope() throws {
+        var currentTime = Date()
+        let scope = RUMViewScope(
+            parent: parent,
+            dependencies: dependencies,
+            identity: mockView,
+            uri: "FirstViewController",
+            attributes: [:],
+            startTime: currentTime
+        )
+
+        currentTime.addTimeInterval(1)
+
+        XCTAssertTrue(
+            scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: mockView)),
+            "The scope should be kept as the View was started for the first time."
+        )
+        XCTAssertFalse(
+            scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: mockView)),
+            "The scope should end as the View was started for another time."
+        )
+
+        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMView>.self)
+        let event = try XCTUnwrap(viewEvents.first)
+        XCTAssertEqual(event.model.view.url, "FirstViewController")
+        XCTAssertEqual(event.model.view.timeSpent, TimeInterval(1).toInt64Nanoseconds, "The View should last for 1 second")
+    }
+
     // MARK: - Resources Tracking
 
     func testItManagesResourceScopesLifecycle() throws {

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -612,7 +612,6 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testGivenRUMMonitorInitialized_whenTogglingDatadogDebugRUM_itTogglesRUMDebugging() throws {
-        #if targetEnvironment(simulator)
         // given
         Datadog.initialize(
             appContext: .mockAny(),
@@ -638,7 +637,6 @@ class RUMMonitorTests: XCTestCase {
         }
 
         try Datadog.deinitializeOrThrow()
-        #endif
     }
 
     // MARK: - Private helpers


### PR DESCRIPTION
### What and why?

🐣 This PR fixes 3 first issues noticed when early dogfooding the RUM feature in Datadog mobile app.

While installing the RUM feature in mobile app I noticed 3 main problems:
* It wasn't possible to infer a meaningful name for the RUM Views as our Datadog mobile app heavily uses generic view controllers.
* It wasn't possible to match each `startView()` call with the corresponding `stopView()` for all view controllers because our Datadog mobile app uses `UISearchController` which follows `viewWillAppear()` / `didDisappear()` differently.
* Because of the 2nd, it wasn't easy to debug the current state of the `RUM` feature, mainly active / inactive RUM Views.

### How?

Each problem lead to a separate solution / improvement, respectively:

#### New `path: String?` parameter in `monitor.startView(...)` API

To fix the first issue, new `path: String?` parameter was added to `monitor.startView()` public API:
> - path: the View path used for RUM Explorer. If not provided, the `UIViewController` class name will be used.
```diff
- startView(viewController: UIViewController, attributes: [AttributeKey: AttributeValue]?)
+ startView(viewController: UIViewController, path: String?, attributes: [AttributeKey: AttributeValue]?)
```

#### Starting next View automatically stops the previous one

The second issue was fixed by unifying the iOS SDK behaviour with [the Android one](https://github.com/DataDog/dd-sdk-android/blob/2a9cd519fc2ac63671d64d1d43c1b7803e4540eb/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt#L123-L127). Whenever a new RUM View is started, the previous one gets closed (or becomes inactive until all its Resources complete). Although this is an optimisation done only for `UIKit`, I decided to make it default (instead of introducing `UIKit`-specific component) to match both SDKs behaviours.

With this improvement, some of the app scenarios (like the one with `UISearchController`) can be instrumented by only using the `rum.startView()` API.

#### New `Datadog.debugRUM` utility

To make it easy for the user to inspect the current RUM state, I introduced a new public API:
```swift
/// Utility setting to inspect the active RUM View. It only makes effect on the iOS Simulator.
/// If set, a debugging outline will be diesplayed on top of the application, describing the name of the active RUM View.
/// May be used to debug issues with RUM instrumentation in your app.
/// Default is `false`.
public static var debugRUM: Bool = false
```

It helps the user by rendering the RUM Views information in iOS Simulator. This makes it easy to spot the current or stale RUM Views (i.e. when their Resources are never completed due to wrong instrumentation):

![Simulator Screen Shot - iPhone 11 - 2020-08-28 at 19 38 01](https://user-images.githubusercontent.com/2358722/91710520-ac785880-eb84-11ea-8c18-ba421e5abdbe.png)


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
