### PR TITLE
RUMM-682 Resources are associated with actions at init

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -6,10 +6,10 @@
 
 import Foundation
 
-internal class RUMResourceScope: RUMScope, RUMContextProvider {
+internal class RUMResourceScope: RUMScope {
     // MARK: - Initialization
 
-    private unowned let parent: RUMContextProvider
+    let context: RUMContext
     private let dependencies: RUMScopeDependencies
 
     /// The name used to identify this Resource.
@@ -25,7 +25,7 @@ internal class RUMResourceScope: RUMScope, RUMContextProvider {
     private var resourceHTTPMethod: RUMHTTPMethod
 
     init(
-        parent: RUMContextProvider,
+        context: RUMContext,
         dependencies: RUMScopeDependencies,
         resourceName: String,
         attributes: [AttributeKey: AttributeValue],
@@ -33,19 +33,13 @@ internal class RUMResourceScope: RUMScope, RUMContextProvider {
         url: String,
         httpMethod: RUMHTTPMethod
     ) {
-        self.parent = parent
+        self.context = context
         self.dependencies = dependencies
         self.resourceName = resourceName
         self.attributes = attributes
         self.resourceURL = url
         self.resourceLoadingStartTime = startTime
         self.resourceHTTPMethod = httpMethod
-    }
-
-    // MARK: - RUMContextProvider
-
-    var context: RUMContext {
-        return parent.context
     }
 
     // MARK: - RUMScope

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -163,7 +163,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
     private func startResource(on command: RUMStartResourceCommand) {
         resourceScopes[command.resourceName] = RUMResourceScope(
-            parent: self,
+            context: context,
             dependencies: dependencies,
             resourceName: command.resourceName,
             attributes: command.attributes,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -417,5 +417,5 @@ class RUMContextProviderMock: RUMContextProvider {
         self.context = context
     }
 
-    let context: RUMContext
+    var context: RUMContext
 }


### PR DESCRIPTION
### What and why?

Expected behavior is resource being associated with the action which caused/triggered the resource
Resource scope was getting active user action from the current context at `sendEvent` phase
This resulted in unexpected behavior

### How?

Now resource scope keeps the active user action info at its `init`
If active user action changes during the lifetime of the resource, it doesn't change resource event's action

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
