### PR TITLE
RUMM-659 GovCloud endpoints added

### DIFF
--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -22,6 +22,9 @@ extension Datadog {
             /// Europe based servers.
             /// Sends logs to [app.datadoghq.eu](https://app.datadoghq.eu/).
             case eu
+            /// Gov servers.
+            /// Sends logs to [app.ddog-gov.com](https://app.ddog-gov.com/).
+            case gov
             /// User-defined server.
             case custom(url: String)
 
@@ -29,6 +32,7 @@ extension Datadog {
                 switch self {
                 case .us: return "https://mobile-http-intake.logs.datadoghq.com/v1/input/"
                 case .eu: return "https://mobile-http-intake.logs.datadoghq.eu/v1/input/"
+                case .gov: return "https://mobile-http-intake.logs.ddog-gov.com/v1/input/"
                 case let .custom(url: url): return url
                 }
             }
@@ -42,6 +46,9 @@ extension Datadog {
             /// Europe based servers.
             /// Sends traces to [app.datadoghq.eu](https://app.datadoghq.eu/).
             case eu
+            /// Gov servers.
+            /// Sends traces to [app.ddog-gov.com](https://app.ddog-gov.com/).
+            case gov
             /// User-defined server.
             case custom(url: String)
 
@@ -49,6 +56,7 @@ extension Datadog {
                 switch self {
                 case .us: return "https://public-trace-http-intake.logs.datadoghq.com/v1/input/"
                 case .eu: return "https://public-trace-http-intake.logs.datadoghq.eu/v1/input/"
+                case .gov: return "https://public-trace-http-intake.logs.ddog-gov.com/v1/input/"
                 case let .custom(url: url): return url
                 }
             }
@@ -62,6 +70,9 @@ extension Datadog {
             /// Europe based servers.
             /// Sends RUM events to [app.datadoghq.eu](https://app.datadoghq.eu/).
             case eu
+            /// Gov servers.
+            /// Sends RUM events to [app.ddog-gov.com](https://app.ddog-gov.com/).
+            case gov
             /// User-defined server.
             case custom(url: String)
 
@@ -69,6 +80,7 @@ extension Datadog {
                 switch self {
                 case .us: return "https://rum-http-intake.logs.datadoghq.com/v1/input/"
                 case .eu: return "https://rum-http-intake.logs.datadoghq.eu/v1/input/"
+                case .gov: return "https://rum-http-intake.logs.ddog-gov.com/v1/input/"
                 case let .custom(url: url): return url
                 }
             }

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -19,6 +19,7 @@ public class DDLogsEndpoint: NSObject {
 
     public static func eu() -> DDLogsEndpoint { .init(sdkEndpoint: .eu) }
     public static func us() -> DDLogsEndpoint { .init(sdkEndpoint: .us) }
+    public static func gov() -> DDLogsEndpoint { .init(sdkEndpoint: .gov) }
     public static func custom(url: String) -> DDLogsEndpoint { .init(sdkEndpoint: .custom(url: url)) }
 }
 
@@ -34,6 +35,7 @@ public class DDTracesEndpoint: NSObject {
 
     public static func eu() -> DDTracesEndpoint { .init(sdkEndpoint: .eu) }
     public static func us() -> DDTracesEndpoint { .init(sdkEndpoint: .us) }
+    public static func gov() -> DDTracesEndpoint { .init(sdkEndpoint: .gov) }
     public static func custom(url: String) -> DDTracesEndpoint { .init(sdkEndpoint: .custom(url: url)) }
 }
 

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -129,6 +129,10 @@ class FeaturesConfigurationTests: XCTestCase {
             URL(string: "https://mobile-http-intake.logs.datadoghq.eu/v1/input/abc")!
         )
         XCTAssertEqual(
+            try createConfiguration(clientToken: "abc", logsEndpoint: .gov).logging?.uploadURLWithClientToken,
+            URL(string: "https://mobile-http-intake.logs.ddog-gov.com/v1/input/abc")!
+        )
+        XCTAssertEqual(
             try createConfiguration(clientToken: "abc", logsEndpoint: .custom(url: "http://example.com/api")).logging?.uploadURLWithClientToken,
             URL(string: "http://example.com/api/abc")!
         )
@@ -147,6 +151,10 @@ class FeaturesConfigurationTests: XCTestCase {
         XCTAssertEqual(
             try createConfiguration(clientToken: "abc", tracesEndpoint: .eu).tracing?.uploadURLWithClientToken,
             URL(string: "https://public-trace-http-intake.logs.datadoghq.eu/v1/input/abc")!
+        )
+        XCTAssertEqual(
+            try createConfiguration(clientToken: "abc", tracesEndpoint: .gov).tracing?.uploadURLWithClientToken,
+            URL(string: "https://public-trace-http-intake.logs.ddog-gov.com/v1/input/abc")!
         )
         XCTAssertEqual(
             try createConfiguration(clientToken: "abc", tracesEndpoint: .custom(url: "http://example.com/api")).tracing?.uploadURLWithClientToken,
@@ -183,6 +191,10 @@ class FeaturesConfigurationTests: XCTestCase {
         XCTAssertEqual(
             try createConfiguration(clientToken: "abc", rumEndpoint: .eu).rum?.uploadURLWithClientToken,
             URL(string: "https://rum-http-intake.logs.datadoghq.eu/v1/input/abc")!
+        )
+        XCTAssertEqual(
+            try createConfiguration(clientToken: "abc", rumEndpoint: .gov).rum?.uploadURLWithClientToken,
+            URL(string: "https://rum-http-intake.logs.ddog-gov.com/v1/input/abc")!
         )
         XCTAssertEqual(
             try createConfiguration(clientToken: "abc", rumEndpoint: .custom(url: "http://example.com/api")).rum?.uploadURLWithClientToken,

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -11,8 +11,7 @@ import XCTest
 extension Datadog.Configuration.LogsEndpoint: Equatable {
     public static func == (_ lhs: Datadog.Configuration.LogsEndpoint, _ rhs: Datadog.Configuration.LogsEndpoint) -> Bool {
         switch (lhs, rhs) {
-        case (.us, .us): return true
-        case (.eu, .eu): return true
+        case (.us, .us), (.eu, .eu), (.gov, .gov): return true
         case let (.custom(lhsURL), .custom(rhsURL)): return lhsURL == rhsURL
         default: return false
         }
@@ -22,8 +21,7 @@ extension Datadog.Configuration.LogsEndpoint: Equatable {
 extension Datadog.Configuration.TracesEndpoint: Equatable {
     public static func == (_ lhs: Datadog.Configuration.TracesEndpoint, _ rhs: Datadog.Configuration.TracesEndpoint) -> Bool {
         switch (lhs, rhs) {
-        case (.us, .us): return true
-        case (.eu, .eu): return true
+        case (.us, .us), (.eu, .eu), (.gov, .gov): return true
         case let (.custom(lhsURL), .custom(rhsURL)): return lhsURL == rhsURL
         default: return false
         }
@@ -63,6 +61,12 @@ class DDConfigurationTests: XCTestCase {
         let swiftConfigurationUS = objcBuilder.build().sdkConfiguration
         XCTAssertEqual(swiftConfigurationUS.logsEndpoint, .us)
         XCTAssertEqual(swiftConfigurationUS.tracesEndpoint, .us)
+
+        objcBuilder.set(logsEndpoint: .gov())
+        objcBuilder.set(tracesEndpoint: .gov())
+        let swiftConfigurationGov = objcBuilder.build().sdkConfiguration
+        XCTAssertEqual(swiftConfigurationGov.logsEndpoint, .gov)
+        XCTAssertEqual(swiftConfigurationGov.tracesEndpoint, .gov)
 
         objcBuilder.set(logsEndpoint: .custom(url: "https://api.example.com/v1/logs"))
         objcBuilder.set(tracesEndpoint: .custom(url: "https://api.example.com/v1/logs"))


### PR DESCRIPTION
### What and why?

Datadog adds a new service: GovCloud
It is quite different than our US and EU datacenters

### How?

SDK adds GovCloud endpoints to Logs, Traces and RUM features

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
