### PR TITLE
RUMM-698/699 RUM Debugging UI fixes

### DIFF
--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -28,10 +28,8 @@ private struct RUMDebugInfo {
 
 internal class RUMDebugging {
     private lazy var canvas: UIView = {
-        let window = UIApplication.shared.keyWindow
-        let view = RUMDebugView(frame: window?.bounds ?? .zero)
+        let view = RUMDebugView(frame: .zero)
         view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        window?.addSubview(view)
         return view
     }()
 
@@ -96,6 +94,12 @@ internal class RUMDebugging {
             view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             canvas.addSubview(view)
         }
+        if canvas.superview == nil,
+            let someWindow = UIApplication.shared.keyWindow {
+            canvas.frame.size = someWindow.bounds.size
+            someWindow.addSubview(canvas)
+        }
+        canvas.superview?.bringSubviewToFront(canvas)
     }
 
     @objc


### PR DESCRIPTION
## What and why?

### Bug #1: Enabling debug too early

`Datadog.debugRUM = true` within `AppDelegate.didFinishLaunching...` doesn't work
this call must be made once the app has a window

#### Fix

Now `RUMDebugging` adds itself to the screen lazily
It checks if this is needed at every render pass

### Bug #2: Debug UI blocked with modal VCs

`RUMDebugView` remains at background if a VC is presented modally

#### Fix

`RUMDebugging` calls `bringSubviewToFront(self)` on its superview at every render pass
This call does not have an effect if it is already topmost subview

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference

### Note

I couldn't find a way to write failing tests for these bugs, open to ideas 👂 