### PR TITLE
RUMM-679 Encode Span error attributes in RUM Error fields

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		61D6FF7E24E53D3B00D0E375 /* BenchmarkMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D6FF7D24E53D3B00D0E375 /* BenchmarkMocks.swift */; };
 		61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980B924E28D0100E03345 /* RUMIntegrations.swift */; };
 		61D980BC24E293F600E03345 /* RUMIntegrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */; };
+		61DE6B1625066973004EFCB3 /* TracingWithRUMErrorsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DE6B1525066973004EFCB3 /* TracingWithRUMErrorsIntegrationTests.swift */; };
 		61E45BCF2450A6EC00F2C652 /* TracingUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */; };
 		61E45BD22450F65B00F2C652 /* SpanBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BD12450F65B00F2C652 /* SpanBuilderTests.swift */; };
 		61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */; };
@@ -523,6 +524,7 @@
 		61D6FF7D24E53D3B00D0E375 /* BenchmarkMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkMocks.swift; sourceTree = "<group>"; };
 		61D980B924E28D0100E03345 /* RUMIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrations.swift; sourceTree = "<group>"; };
 		61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrationsTests.swift; sourceTree = "<group>"; };
+		61DE6B1525066973004EFCB3 /* TracingWithRUMErrorsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingWithRUMErrorsIntegrationTests.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDTests.swift; sourceTree = "<group>"; };
 		61E45BD12450F65B00F2C652 /* SpanBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanBuilderTests.swift; sourceTree = "<group>"; };
 		61E45BE4245196EA00F2C652 /* SpanFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanFileOutputTests.swift; sourceTree = "<group>"; };
@@ -1081,6 +1083,7 @@
 			children = (
 				61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */,
 				61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */,
+				61DE6B1525066973004EFCB3 /* TracingWithRUMErrorsIntegrationTests.swift */,
 			);
 			path = FeaturesIntegration;
 			sourceTree = "<group>";
@@ -2091,6 +2094,7 @@
 				61E5332F24B75DE2003D6C4E /* RUMFeatureTests.swift in Sources */,
 				E1D203FD24C1885C00D1AF3A /* ActiveSpansPoolTests.swift in Sources */,
 				61133C562423990D00786299 /* CarrierInfoProviderTests.swift in Sources */,
+				61DE6B1625066973004EFCB3 /* TracingWithRUMErrorsIntegrationTests.swift in Sources */,
 				618DCFDF24C75FD300589570 /* RUMScopeTests.swift in Sources */,
 				61C5A89E24509C1100DA608C /* WarningsTests.swift in Sources */,
 				9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */,

--- a/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
@@ -27,6 +27,6 @@ internal struct LoggingWithRUMErrorsIntegration {
     private let rumErrorsIntegration = RUMErrorsIntegration()
 
     func addError(for log: Log) {
-        rumErrorsIntegration.addError(with: log.message)
+        rumErrorsIntegration.addError(with: log.message, stack: nil, source: .logger)
     }
 }

--- a/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
@@ -37,8 +37,8 @@ internal struct RUMContextIntegration {
 
 /// Creates RUM Errors with given message.
 internal struct RUMErrorsIntegration {
-    /// Adds RUM Error with given message to current RUM View.
-    func addError(with message: String, attributes: [AttributeKey: AttributeValue]? = nil) {
-        rumMonitor?.addViewError(message: message, source: .logger, attributes: attributes, file: nil, line: nil)
+    /// Adds RUM Error with given message and stack to current RUM View.
+    func addError(with message: String, stack: String?, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue]? = nil) {
+        rumMonitor?.addViewError(message: message, stack: stack, source: source, attributes: attributes)
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -65,20 +65,15 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
     init(
         time: Date,
         message: String,
+        stack: String?,
         source: RUMErrorSource,
-        stack: (file: StaticString, line: UInt)?,
         attributes: [AttributeKey: AttributeValue]
     ) {
         self.time = time
         self.source = source
         self.attributes = attributes
         self.message = message
-
-        if let stack = stack, let fileName = "\(stack.file)".split(separator: "/").last {
-            self.stack = "\(fileName): \(stack.line)"
-        } else {
-            self.stack = nil
-        }
+        self.stack = stack
     }
 
     init(

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -153,16 +153,20 @@ public class RUMMonitor: DDRUMMonitor {
     }
 
     override public func addViewError(message: String, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue]?, file: StaticString?, line: UInt?) {
-        var stack: (file: StaticString, line: UInt)? = nil
-        if let file = file, let line = line {
-            stack = (file: file, line: line)
+        var stack: String? = nil
+        if let file = file, let fileName = "\(file)".split(separator: "/").last, let line = line {
+            stack = "\(fileName):\(line)"
         }
+        addViewError(message: message, stack: stack, source: source, attributes: attributes)
+    }
+
+    internal func addViewError(message: String, stack: String?, source: RUMErrorSource, attributes: [AttributeKey: AttributeValue]?) {
         process(
             command: RUMAddCurrentViewErrorCommand(
                 time: dateProvider.currentDate(),
                 message: message,
-                source: source,
                 stack: stack,
+                source: source,
                 attributes: aggregate(attributes)
             )
         )

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -86,7 +86,7 @@ class RUMErrorsIntegrationTests: XCTestCase {
         defer { Global.rum = DDNoopRUMMonitor() }
 
         // when
-        integration.addError(with: "error message")
+        integration.addError(with: "error message", stack: "Foo.swift:10", source: .logger)
 
         // then
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3) // [RUMView, RUMAction, RUMError] events sent
@@ -94,7 +94,7 @@ class RUMErrorsIntegrationTests: XCTestCase {
         try XCTUnwrap(rumErrorMatcher).model(ofType: RUMError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "error message")
             XCTAssertEqual(rumModel.error.source, .logger)
-            XCTAssertNil(rumModel.error.stack)
+            XCTAssertEqual(rumModel.error.stack, "Foo.swift:10")
         }
     }
 }

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithRUMErrorsIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithRUMErrorsIntegrationTests.swift
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class TracingWithRUMErrorsIntegrationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        temporaryDirectory.create()
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        Global.rum = RUMMonitor.initialize()
+        Global.rum.startView(viewController: mockView)
+    }
+
+    override func tearDown() {
+        temporaryDirectory.delete()
+        RUMFeature.instance = nil
+        Global.rum = DDNoopRUMMonitor()
+        super.tearDown()
+    }
+
+    func testWhenSpanErrorHasMessageAndType() throws {
+        let integration = TracingWithRUMErrorsIntegration()
+        integration.addError(
+            for: .mockWith(
+                operationName: "operation name",
+                tags: [
+                    DDTags.errorMessage: "message",
+                    DDTags.errorType: "type"
+                ]
+            )
+        )
+
+        let rumError = try waitAndReturnRUMErrorSent()
+        XCTAssertEqual(rumError.error.message, #"Span error (operation name): type | message"#)
+        XCTAssertEqual(rumError.error.source, .source)
+        XCTAssertNil(rumError.error.stack)
+    }
+
+    func testWhenSpanErrorHasMessageButNoType() throws {
+        let integration = TracingWithRUMErrorsIntegration()
+        integration.addError(
+            for: .mockWith(operationName: "operation name", tags: [DDTags.errorMessage: "message"])
+        )
+
+        let rumError = try waitAndReturnRUMErrorSent()
+        XCTAssertEqual(rumError.error.message, #"Span error (operation name): message"#)
+        XCTAssertEqual(rumError.error.source, .source)
+        XCTAssertNil(rumError.error.stack)
+    }
+
+    func testWhenSpanErrorHasTypeButNoMessage() throws {
+        let integration = TracingWithRUMErrorsIntegration()
+        integration.addError(
+            for: .mockWith(operationName: "operation name", tags: [DDTags.errorType: "type"])
+        )
+
+        let rumError = try waitAndReturnRUMErrorSent()
+        XCTAssertEqual(rumError.error.message, #"Span error (operation name): type"#)
+        XCTAssertEqual(rumError.error.source, .source)
+        XCTAssertNil(rumError.error.stack)
+    }
+
+    func testWhenSpanErrorHasTypeNoMessageAndNoType() throws {
+        let integration = TracingWithRUMErrorsIntegration()
+        integration.addError(
+            for: .mockWith(operationName: "operation name", tags: [:])
+        )
+
+        let rumError = try waitAndReturnRUMErrorSent()
+        XCTAssertEqual(rumError.error.message, #"Span error (operation name)"#)
+        XCTAssertEqual(rumError.error.source, .source)
+        XCTAssertNil(rumError.error.stack)
+    }
+
+    // MARK: - Helpers
+
+    private func waitAndReturnRUMErrorSent() throws -> RUMError {
+        // [RUMView, RUMAction, RUMError] events sent:
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
+        let rumErrorMatcher = try XCTUnwrap(rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) })
+        return try rumErrorMatcher.model()
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -156,11 +156,11 @@ extension RUMAddCurrentViewErrorCommand {
         time: Date = Date(),
         message: String = .mockAny(),
         source: RUMErrorSource = .source,
-        stack: (file: StaticString, line: UInt)? = (file: "Foo.swift", line: 10),
+        stack: String? = "Foo.swift:10",
         attributes: [AttributeKey: AttributeValue] = [:]
     ) -> RUMAddCurrentViewErrorCommand {
         return RUMAddCurrentViewErrorCommand(
-            time: time, message: message, source: source, stack: stack, attributes: attributes
+            time: time, message: message, stack: stack, source: source, attributes: attributes
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMCommandTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMCommandTests.swift
@@ -8,22 +8,6 @@ import XCTest
 @testable import Datadog
 
 class RUMCommandTests: XCTestCase {
-    func testWhenRUMAddCurrentViewErrorCommand_isBuildWithMessage() {
-        #sourceLocation(file: "/user/abc/Foo.swift", line: 100)
-        var command = RUMAddCurrentViewErrorCommand(time: .mockAny(), message: "foo", source: .source, stack: (file: #file, line: #line), attributes: [:])
-        #sourceLocation()
-
-        XCTAssertEqual(command.message, "foo")
-        XCTAssertEqual(command.stack, "Foo.swift: 100")
-
-        #sourceLocation(file: "", line: 100)
-        command = RUMAddCurrentViewErrorCommand(time: .mockAny(), message: "foo", source: .source, stack: (file: #file, line: #line), attributes: [:])
-        #sourceLocation()
-
-        XCTAssertEqual(command.message, "foo")
-        XCTAssertNil(command.stack)
-    }
-
     func testWhenRUMAddCurrentViewErrorCommand_isBuildWithErrorObject() {
         struct SwiftError: Error, CustomDebugStringConvertible {
             let debugDescription = "error description"

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -211,7 +211,7 @@ class RUMMonitorTests: XCTestCase {
         }
         try rumEventMatchers[2].model(ofType: RUMError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "View error message")
-            XCTAssertEqual(rumModel.error.stack, "Foo.swift: 100")
+            XCTAssertEqual(rumModel.error.stack, "Foo.swift:100")
             XCTAssertEqual(rumModel.error.source, .source)
         }
         try rumEventMatchers[3].model(ofType: RUMView.self) { rumModel in

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -705,8 +705,8 @@ class TracerTests: XCTestCase {
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
         let rumErrorMatcher = rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) }
         try XCTUnwrap(rumErrorMatcher).model(ofType: RUMError.self) { rumModel in
-            XCTAssertEqual(rumModel.error.message, #"Span "operation name" reported an error"#)
-            XCTAssertEqual(rumModel.error.source, .logger)
+            XCTAssertEqual(rumModel.error.message, #"Span error (operation name)"#)
+            XCTAssertEqual(rumModel.error.source, .source)
             XCTAssertNil(rumModel.error.stack)
         }
     }
@@ -742,22 +742,10 @@ class TracerTests: XCTestCase {
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
         let rumErrorMatcher = try XCTUnwrap(rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) })
         try rumErrorMatcher.model(ofType: RUMError.self) { rumModel in
-            XCTAssertEqual(rumModel.error.message, #"Span "operation name" reported an error"#)
-            XCTAssertEqual(rumModel.error.source, .logger)
-            XCTAssertNil(rumModel.error.stack)
+            XCTAssertEqual(rumModel.error.message, #"Span error (operation name): Swift error | span error message"#)
+            XCTAssertEqual(rumModel.error.source, .source)
+            XCTAssertEqual(rumModel.error.stack, "Foo.swift:123")
         }
-        try XCTAssertEqual(
-            rumErrorMatcher.attribute(forKeyPath: TracingWithRUMErrorsIntegration.Attributes.spanErrorMessage),
-            "span error message"
-        )
-        try XCTAssertEqual(
-            rumErrorMatcher.attribute(forKeyPath: TracingWithRUMErrorsIntegration.Attributes.spanErrorType),
-            "Swift error"
-        )
-        try XCTAssertEqual(
-            rumErrorMatcher.attribute(forKeyPath: TracingWithRUMErrorsIntegration.Attributes.spanErrorStack),
-            "Foo.swift:123"
-        )
     }
 
     // MARK: - Injecting span context into carrier


### PR DESCRIPTION
### What and why?

📦 This PR updates the way we encode `Span` error attributes for RUM Errors in "Tracing with RUM" integration. 

This unifies the data of RUM Errors on Android and iOS when user marks the `Span` as error (either directly or through `span.log()` integration). Counterpart of https://github.com/DataDog/dd-sdk-android/pull/351

### How?

Before, the error attributes were encoded at the root level of RUM event JSON using 3 custom fields:
```diff
-        static let spanErrorMessage = "span.error_message"
-        static let spanErrorType = "span.error_type"
-        static let spanErrorStack = "span.error_stack"
```

From now, span's `errorMessage`, `errorType` and `errorStack` are encoded into `RUMError` object directly:
```swift
// RUMViewScope.swift

let eventData = RUMError(
	// ...
    error: .init(
        message: command.message,
        source: command.source.toRUMDataFormat,
        stack: command.stack,
		// ...
    ),
    // ...
)
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
