### PR TITLE
RUMM-710 Prepare `-alpha1` dogfooding release

### DIFF
--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
   s.module_name  = "Datadog"
-  s.version      = "1.3.1"
+  s.version      = "1.4.0-alpha1"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKObjc"
   s.module_name  = "DatadogObjc"
-  s.version      = "1.3.1"
+  s.version      = "1.4.0-alpha1"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/Sources/Datadog/Versioning.swift
+++ b/Sources/Datadog/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let sdkVersion = "1.3.1"
+internal let sdkVersion = "1.4.0-alpha1"

--- a/Tests/DatadogIntegrationTests/RUMIntegrationTests.swift
+++ b/Tests/DatadogIntegrationTests/RUMIntegrationTests.swift
@@ -37,7 +37,7 @@ class RUMIntegrationTests: IntegrationTests {
 
         recordedRUMRequests.forEach { request in
             // Example path here: `/36882784-420B-494F-910D-CBAC5897A309/ui-tests-client-token?ddsource=ios&batch_time=1576404000000&ddtags=service:ui-tests-service-name,version:1.0,sdk_version:1.3.0-beta3,env:integration`
-            let pathRegexp = #"^(.*)(\/ui-tests-client-token\?ddsource=ios&batch_time=)([0-9]+)(&ddtags=service:ui-tests-service-name,version:1.0,sdk_version:)([0-9].[0-9].[0-9](-[a-z0-9])*)(,env:integration)$"#
+            let pathRegexp = #"^(.*)(\/ui-tests-client-token\?ddsource=ios&batch_time=)([0-9]+)(&ddtags=service:ui-tests-service-name,version:1.0,sdk_version:)([0-9].[0-9].[0-9]([-a-z0-9])*)(,env:integration)$"#
             XCTAssertNotNil(
                 request.path.range(of: pathRegexp, options: .regularExpression, range: nil, locale: nil),
                 "RUM request path: \(request.path) should match regexp: \(pathRegexp)"


### PR DESCRIPTION
### What and why?

📦 This PR bumps the SDK version to `1.4.0-alpha1` so it can be updated in the Datadog mobile app.

### How?

`make bump & 1.4.0-alpha1`. No `make ship` as we're not yet releasing.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
