### PR TITLE
RUMM-657 Add Active Span attributes to Logs

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */; };
 		61133B8C242393DE00786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61133B93242393DE00786299 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		61133BCA2423979B00786299 /* EncodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* EncodableValue.swift */; };
@@ -321,6 +322,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingWithActiveSpanIntegration.swift; sourceTree = "<group>"; };
 		61133B82242393DE00786299 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61133B85242393DE00786299 /* Datadog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Datadog.h; sourceTree = "<group>"; };
 		61133B86242393DE00786299 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1073,6 +1075,7 @@
 				61D980B924E28D0100E03345 /* RUMIntegrations.swift */,
 				61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */,
 				6156CB9724DEFD44008CB2B2 /* LoggingWithRUMIntegration.swift */,
+				6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */,
 				6156CB9B24E18224008CB2B2 /* TracingWithRUMIntegration.swift */,
 			);
 			path = FeaturesIntegration;
@@ -1921,6 +1924,7 @@
 				61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */,
 				61E909EF24A24DD3005EA2DE /* Global.swift in Sources */,
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,
+				6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */,
 				61133BDC2423979B00786299 /* Logger.swift in Sources */,
 				61133BD02423979B00786299 /* DateProvider.swift in Sources */,
 				6156CB8E24DDA1B5008CB2B2 /* RUMContextProvider.swift in Sources */,

--- a/Sources/Datadog/FeaturesIntegration/LoggingWithActiveSpanIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingWithActiveSpanIntegration.swift
@@ -17,7 +17,7 @@ internal struct LoggingWithActiveSpanIntegration {
     /// Returns `nil` and prints warning if global `Tracer` is not registered.
     var activeSpanAttributes: [String: Encodable]? {
         guard let tracer = Global.sharedTracer as? Tracer else {
-            userLogger.warn("No `Tracer` is registered, so Tracing integration with Logging will not work.")
+            userLogger.warn("Tracing feature is enabled, but no `Tracer` is registered. The Tracing integration with Logging will not work.")
             return nil
         }
 

--- a/Sources/Datadog/FeaturesIntegration/LoggingWithActiveSpanIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingWithActiveSpanIntegration.swift
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Provides the current active span attributes for produced `Logs`.
+internal struct LoggingWithActiveSpanIntegration {
+    struct Attributes {
+        static let traceID = "dd.trace_id"
+        static let spanID = "dd.span_id"
+    }
+
+    /// Produces `Log` attributes describing the current active span.
+    /// Returns `nil` and prints warning if global `Tracer` is not registered.
+    var activeSpanAttributes: [String: Encodable]? {
+        guard let tracer = Global.sharedTracer as? Tracer else {
+            userLogger.warn("No `Tracer` is registered, so Tracing integration with Logging will not work.")
+            return nil
+        }
+
+        if let activeSpanContext = tracer.activeSpan?.context as? DDSpanContext {
+            return [
+                Attributes.traceID: "\(activeSpanContext.traceID.rawValue)",
+                Attributes.spanID: "\(activeSpanContext.spanID.rawValue)"
+            ]
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
@@ -14,7 +14,7 @@ internal struct LoggingWithRUMContextIntegration {
     /// Returns `nil` and prints warning if global `RUMMonitor` is not registered.
     var currentRUMContextAttributes: [String: Encodable]? {
         guard let attributes = rumContextIntegration.currentRUMContextAttributes else {
-            userLogger.warn("No `RUMMonitor` is registered, so RUM integration with Logging will not work.")
+            userLogger.warn("RUM feature is enabled, but no `RUMMonitor` is registered. The RUM integration with Logging will not work.")
             return nil
         }
 

--- a/Sources/Datadog/FeaturesIntegration/TracingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/TracingWithRUMIntegration.swift
@@ -14,7 +14,7 @@ internal struct TracingWithRUMContextIntegration {
     /// Returns `nil` and prints warning if global `RUMMonitor` is not registered.
     var currentRUMContextTags: [String: Encodable]? {
         guard let attributes = rumContextIntegration.currentRUMContextAttributes else {
-            userLogger.warn("No `RUMMonitor` is registered, so RUM integration with Tracing will not work.")
+            userLogger.warn("RUM feature is enabled, but no `RUMMonitor` is registered. The RUM integration with Tracing will not work.")
             return nil
         }
 

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -43,9 +43,9 @@ public class Logger {
     private var loggerTags: Set<String> = []
     /// Queue ensuring thread-safety of the `Logger`. It synchronizes tags and attributes mutation.
     private let queue: DispatchQueue
-    /// Integration with RUM Context. `nil` if disabled for this Logger.
+    /// Integration with RUM Context. `nil` if disabled for this Logger or if the RUM feature disabled.
     internal let rumContextIntegration: LoggingWithRUMContextIntegration?
-    /// Integration with Tracing. `nil` if disabled for this Logger.
+    /// Integration with Tracing. `nil` if disabled for this Logger or if the Tracing feature disabled.
     internal let activeSpanIntegration: LoggingWithActiveSpanIntegration?
 
     init(
@@ -366,8 +366,8 @@ public class Logger {
                 logOutput: resolveLogsOutput(for: loggingFeature),
                 dateProvider: loggingFeature.dateProvider,
                 identifier: resolveLoggerName(for: loggingFeature),
-                rumContextIntegration: bundleWithRUM ? LoggingWithRUMContextIntegration() : nil,
-                activeSpanIntegration: bundleWithTrace ? LoggingWithActiveSpanIntegration() : nil
+                rumContextIntegration: (RUMFeature.isEnabled && bundleWithRUM) ? LoggingWithRUMContextIntegration() : nil,
+                activeSpanIntegration: (TracingFeature.isEnabled && bundleWithTrace) ? LoggingWithActiveSpanIntegration() : nil
             )
         }
 

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -45,12 +45,15 @@ public class Logger {
     private let queue: DispatchQueue
     /// Integration with RUM Context. `nil` if disabled for this Logger.
     internal let rumContextIntegration: LoggingWithRUMContextIntegration?
+    /// Integration with Tracing. `nil` if disabled for this Logger.
+    internal let activeSpanIntegration: LoggingWithActiveSpanIntegration?
 
     init(
         logOutput: LogOutput,
         dateProvider: DateProvider,
         identifier: String,
-        rumContextIntegration: LoggingWithRUMContextIntegration?
+        rumContextIntegration: LoggingWithRUMContextIntegration?,
+        activeSpanIntegration: LoggingWithActiveSpanIntegration?
     ) {
         self.logOutput = logOutput
         self.dateProvider = dateProvider
@@ -59,6 +62,7 @@ public class Logger {
             target: .global(qos: .userInteractive)
         )
         self.rumContextIntegration = rumContextIntegration
+        self.activeSpanIntegration = activeSpanIntegration
     }
 
     // MARK: - Logging
@@ -206,11 +210,20 @@ public class Logger {
 
     private func log(level: LogLevel, message: String, messageAttributes: [String: Encodable]?) {
         let date = dateProvider.currentDate()
-        let combinedAttributes = queue.sync {
+        let combinedUserAttributes = queue.sync {
             return self.loggerAttributes.merging(messageAttributes ?? [:]) { _, messageAttributeValue in
                 return messageAttributeValue // use message attribute when the same key appears also in logger attributes
             }
         }
+
+        var combinedInternalAttributes: [String: Encodable] = [:]
+        if let rumContextAttributes = rumContextIntegration?.currentRUMContextAttributes {
+            combinedInternalAttributes.merge(rumContextAttributes) { $1 }
+        }
+        if let activeSpanAttributes = activeSpanIntegration?.activeSpanAttributes {
+            combinedInternalAttributes.merge(activeSpanAttributes) { $1 }
+        }
+
         let tags = queue.sync {
             return self.loggerTags
         }
@@ -220,8 +233,8 @@ public class Logger {
             message: message,
             date: date,
             attributes: LogAttributes(
-                userAttributes: combinedAttributes,
-                internalAttributes: rumContextIntegration?.currentRUMContextAttributes
+                userAttributes: combinedUserAttributes,
+                internalAttributes: combinedInternalAttributes
             ),
             tags: tags
         )
@@ -245,8 +258,9 @@ public class Logger {
     public class Builder {
         internal var serviceName: String?
         internal var loggerName: String?
-        internal var sendNetworkInfo: Bool = false
-        internal var bundleWithRUM: Bool = true
+        internal var sendNetworkInfo = false
+        internal var bundleWithRUM = true
+        internal var bundleWithTrace = true
         internal var useFileOutput = true
         internal var useConsoleLogFormat: ConsoleLogFormat?
 
@@ -279,6 +293,15 @@ public class Logger {
         /// - Parameter enabled: `true` by default
         public func bundleWithRUM(_ enabled: Bool) -> Builder {
             bundleWithRUM = enabled
+            return self
+        }
+
+        /// Enables the logs integration with active span API from Tracing.
+        /// If enabled all the logs will be bundled with the `Global.sharedTracer.activeSpan` trace and
+        /// it will be possible to see all the logs sent during that specific trace.
+        /// - Parameter enabled: `true` by default
+        public func bundleWithTrace(_ enabled: Bool) -> Builder {
+            bundleWithTrace = enabled
             return self
         }
 
@@ -324,7 +347,8 @@ public class Logger {
                     logOutput: NoOpLogOutput(),
                     dateProvider: SystemDateProvider(),
                     identifier: "no-op",
-                    rumContextIntegration: nil
+                    rumContextIntegration: nil,
+                    activeSpanIntegration: nil
                 )
             }
         }
@@ -342,7 +366,8 @@ public class Logger {
                 logOutput: resolveLogsOutput(for: loggingFeature),
                 dateProvider: loggingFeature.dateProvider,
                 identifier: resolveLoggerName(for: loggingFeature),
-                rumContextIntegration: bundleWithRUM ? LoggingWithRUMContextIntegration() : nil
+                rumContextIntegration: bundleWithRUM ? LoggingWithRUMContextIntegration() : nil,
+                activeSpanIntegration: bundleWithTrace ? LoggingWithActiveSpanIntegration() : nil
             )
         }
 

--- a/Sources/Datadog/Logging/Log/LogSanitizer.swift
+++ b/Sources/Datadog/Logging/Log/LogSanitizer.swift
@@ -19,6 +19,8 @@ internal struct LogSanitizer {
             RUMContextIntegration.Attributes.applicationID,
             RUMContextIntegration.Attributes.sessionID,
             RUMContextIntegration.Attributes.viewID,
+            LoggingWithActiveSpanIntegration.Attributes.traceID,
+            LoggingWithActiveSpanIntegration.Attributes.spanID,
         ]
         /// Maximum number of nested levels in attribute name. E.g. `person.address.street` has 3 levels.
         /// If attribute name exceeds this number, extra levels are escaped by using `_` character (`one.two.(...).nine.ten_eleven_twelve`).

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -17,6 +17,9 @@ internal final class LoggingFeature {
     /// Single, shared instance of `LoggingFeature`.
     internal static var instance: LoggingFeature?
 
+    /// Tells if the feature was enabled by the user in the SDK configuration.
+    static var isEnabled: Bool { instance != nil }
+
     // MARK: - Configuration
 
     let configuration: FeaturesConfiguration.Logging

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -17,6 +17,9 @@ internal final class RUMFeature {
     /// Single, shared instance of `RUMFeature`.
     internal static var instance: RUMFeature?
 
+    /// Tells if the feature was enabled by the user in the SDK configuration.
+    static var isEnabled: Bool { instance != nil }
+
     // MARK: - Configuration
 
     let configuration: FeaturesConfiguration.RUM

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -46,7 +46,7 @@ public class Tracer: OTTracer {
     internal let logOutput: LoggingForTracingAdapter.AdaptedLogOutput?
     /// Queue ensuring thread-safety of the `Tracer` and `DDSpan` operations.
     internal let queue: DispatchQueue
-    /// Integration with RUM Context. `nil` if disabled for this Tracer.
+    /// Integration with RUM Context. `nil` if disabled for this Tracer or if the RUM feature disabled.
     internal let rumContextIntegration: TracingWithRUMContextIntegration?
 
     private let dateProvider: DateProvider
@@ -107,7 +107,7 @@ public class Tracer: OTTracer {
             dateProvider: tracingFeature.dateProvider,
             tracingUUIDGenerator: tracingFeature.tracingUUIDGenerator,
             globalTags: tracerConfiguration.globalTags,
-            rumContextIntegration: tracerConfiguration.bundleWithRUM ? TracingWithRUMContextIntegration() : nil
+            rumContextIntegration: (RUMFeature.isEnabled && tracerConfiguration.bundleWithRUM) ? TracingWithRUMContextIntegration() : nil
         )
     }
 

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -17,6 +17,9 @@ internal final class TracingFeature {
     /// Single, shared instance of `TracingFeatureFeature`.
     internal static var instance: TracingFeature?
 
+    /// Tells if the feature was enabled by the user in the SDK configuration.
+    static var isEnabled: Bool { instance != nil }
+
     // MARK: - Configuration
 
     let configuration: FeaturesConfiguration.Tracing

--- a/Sources/Datadog/Utils/InternalLoggers.swift
+++ b/Sources/Datadog/Utils/InternalLoggers.swift
@@ -62,7 +62,8 @@ internal func createSDKDeveloperLogger(
         logOutput: consoleOutput,
         dateProvider: dateProvider,
         identifier: "sdk-developer",
-        rumContextIntegration: nil
+        rumContextIntegration: nil,
+        activeSpanIntegration: nil
     )
 }
 
@@ -71,7 +72,8 @@ internal func createNoOpSDKUserLogger() -> Logger {
         logOutput: NoOpLogOutput(),
         dateProvider: SystemDateProvider(),
         identifier: "no-op",
-        rumContextIntegration: nil
+        rumContextIntegration: nil,
+        activeSpanIntegration: nil
     )
 }
 
@@ -102,6 +104,7 @@ internal func createSDKUserLogger(
         },
         dateProvider: dateProvider,
         identifier: "sdk-user",
-        rumContextIntegration: nil
+        rumContextIntegration: nil,
+        activeSpanIntegration: nil
     )
 }

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -54,7 +54,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
         let defaultBuilder = Datadog.Configuration
             .builderUsing(clientToken: "abc-123", environment: "tests")
         let defaultRUMBuilder = Datadog.Configuration
-        .builderUsing(rumApplicationID: "rum-app-id", clientToken: "abc-123", environment: "tests")
+            .builderUsing(rumApplicationID: "rum-app-id", clientToken: "abc-123", environment: "tests")
 
         let configuration = customized(defaultBuilder).build()
         let rumConfiguration = customized(defaultRUMBuilder).build()

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -85,9 +85,9 @@ class DatadogTests: XCTestCase {
 
         try verify(configuration: defaultBuilder.build()) {
             // verify features:
-            XCTAssertNotNil(LoggingFeature.instance)
-            XCTAssertNotNil(TracingFeature.instance)
-            XCTAssertNil(RUMFeature.instance, "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertTrue(LoggingFeature.isEnabled)
+            XCTAssertTrue(TracingFeature.isEnabled)
+            XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(TracingAutoInstrumentation.instance)
             // verify integrations:
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
@@ -95,9 +95,9 @@ class DatadogTests: XCTestCase {
         }
         try verify(configuration: rumBuilder.build()) {
             // verify features:
-            XCTAssertNotNil(LoggingFeature.instance)
-            XCTAssertNotNil(TracingFeature.instance)
-            XCTAssertNotNil(RUMFeature.instance, "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertTrue(LoggingFeature.isEnabled)
+            XCTAssertTrue(TracingFeature.isEnabled)
+            XCTAssertTrue(RUMFeature.isEnabled, "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNil(TracingAutoInstrumentation.instance)
             // verify integrations:
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
@@ -106,9 +106,9 @@ class DatadogTests: XCTestCase {
 
         try verify(configuration: defaultBuilder.enableLogging(false).build()) {
             // verify features:
-            XCTAssertNil(LoggingFeature.instance)
-            XCTAssertNotNil(TracingFeature.instance)
-            XCTAssertNil(RUMFeature.instance, "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertFalse(LoggingFeature.isEnabled)
+            XCTAssertTrue(TracingFeature.isEnabled)
+            XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(TracingAutoInstrumentation.instance)
             // verify integrations:
             XCTAssertNil(TracingFeature.instance?.loggingFeatureAdapter)
@@ -116,9 +116,9 @@ class DatadogTests: XCTestCase {
         }
         try verify(configuration: rumBuilder.enableLogging(false).build()) {
             // verify features:
-            XCTAssertNil(LoggingFeature.instance)
-            XCTAssertNotNil(TracingFeature.instance)
-            XCTAssertNotNil(RUMFeature.instance, "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertFalse(LoggingFeature.isEnabled)
+            XCTAssertTrue(TracingFeature.isEnabled)
+            XCTAssertTrue(RUMFeature.isEnabled, "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNil(TracingAutoInstrumentation.instance)
             // verify integrations:
             XCTAssertNil(TracingFeature.instance?.loggingFeatureAdapter)
@@ -127,48 +127,48 @@ class DatadogTests: XCTestCase {
 
         try verify(configuration: defaultBuilder.enableTracing(false).build()) {
             // verify features:
-            XCTAssertNotNil(LoggingFeature.instance)
-            XCTAssertNil(TracingFeature.instance)
-            XCTAssertNil(RUMFeature.instance, "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertTrue(LoggingFeature.isEnabled)
+            XCTAssertFalse(TracingFeature.isEnabled)
+            XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature should be disabled by default")
             // verify integrations:
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }
         try verify(configuration: rumBuilder.enableTracing(false).build()) {
             // verify features:
-            XCTAssertNotNil(LoggingFeature.instance)
-            XCTAssertNil(TracingFeature.instance)
-            XCTAssertNotNil(RUMFeature.instance, "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertTrue(LoggingFeature.isEnabled)
+            XCTAssertFalse(TracingFeature.isEnabled)
+            XCTAssertTrue(RUMFeature.isEnabled, "When using `rumBuilder` RUM feature should be enabled by default")
             // verify integrations:
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }
 
         try verify(configuration: defaultBuilder.enableRUM(true).build()) {
             // verify features:
-            XCTAssertNotNil(LoggingFeature.instance)
-            XCTAssertNotNil(TracingFeature.instance)
-            XCTAssertNil(RUMFeature.instance, "When using `defaultBuilder` RUM feature cannot be enabled")
+            XCTAssertTrue(LoggingFeature.isEnabled)
+            XCTAssertTrue(TracingFeature.isEnabled)
+            XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature cannot be enabled")
             // verify integrations:
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }
         try verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
-            XCTAssertNotNil(LoggingFeature.instance)
-            XCTAssertNotNil(TracingFeature.instance)
-            XCTAssertNil(RUMFeature.instance)
+            XCTAssertTrue(LoggingFeature.isEnabled)
+            XCTAssertTrue(TracingFeature.isEnabled)
+            XCTAssertFalse(RUMFeature.isEnabled)
             // verify integrations:
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }
 
         try verify(configuration: defaultBuilder.set(tracedHosts: ["example.com"]).build()) {
-            XCTAssertNotNil(TracingFeature.instance)
+            XCTAssertTrue(TracingFeature.isEnabled)
             XCTAssertNotNil(TracingAutoInstrumentation.instance)
         }
         try verify(
             configuration: defaultBuilder.enableTracing(false).set(tracedHosts: ["example.com"]).build()
         ) {
-            XCTAssertNil(TracingFeature.instance)
+            XCTAssertFalse(TracingFeature.isEnabled)
             XCTAssertNil(TracingAutoInstrumentation.instance)
         }
     }

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -60,29 +60,41 @@ class LoggerBuilderTests: XCTestCase {
         RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
-        let logger = Logger.builder.build()
+        let logger1 = Logger.builder.build()
+        XCTAssertNotNil(logger1.rumContextIntegration)
 
-        XCTAssertNotNil(logger.rumContextIntegration)
+        let logger2 = Logger.builder.bundleWithRUM(false).build()
+        XCTAssertNil(logger2.rumContextIntegration)
     }
 
     func testDefaultLoggerWithTracingEnabled() throws {
         TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance = nil }
 
-        let logger = Logger.builder.build()
+        let logger1 = Logger.builder.build()
+        XCTAssertNotNil(logger1.activeSpanIntegration)
 
-        XCTAssertNotNil(logger.activeSpanIntegration)
+        let logger2 = Logger.builder.bundleWithTrace(false).build()
+        XCTAssertNil(logger2.activeSpanIntegration)
     }
 
     func testCustomizedLogger() throws {
+        RUMFeature.instance = .mockNoOp()
+        defer { RUMFeature.instance = nil }
+
+        TracingFeature.instance = .mockNoOp()
+        defer { TracingFeature.instance = nil }
+
         let logger = Logger.builder
             .set(serviceName: "custom-service-name")
             .set(loggerName: "custom-logger-name")
             .sendNetworkInfo(true)
             .bundleWithRUM(false)
+            .bundleWithTrace(false)
             .build()
 
         XCTAssertNil(logger.rumContextIntegration)
+        XCTAssertNil(logger.activeSpanIntegration)
 
         guard let logBuilder = (logger.logOutput as? LogFileOutput)?.logBuilder else {
             XCTFail()

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -38,7 +38,8 @@ class LoggerBuilderTests: XCTestCase {
     func testDefaultLogger() throws {
         let logger = Logger.builder.build()
 
-        XCTAssertNotNil(logger.rumContextIntegration)
+        XCTAssertNil(logger.rumContextIntegration)
+        XCTAssertNil(logger.activeSpanIntegration)
 
         guard let logBuilder = (logger.logOutput as? LogFileOutput)?.logBuilder else {
             XCTFail()
@@ -53,6 +54,24 @@ class LoggerBuilderTests: XCTestCase {
         XCTAssertTrue(logBuilder.userInfoProvider === feature.userInfoProvider)
         XCTAssertNil(logBuilder.networkConnectionInfoProvider)
         XCTAssertNil(logBuilder.carrierInfoProvider)
+    }
+
+    func testDefaultLoggerWithRUMEnabled() throws {
+        RUMFeature.instance = .mockNoOp()
+        defer { RUMFeature.instance = nil }
+
+        let logger = Logger.builder.build()
+
+        XCTAssertNotNil(logger.rumContextIntegration)
+    }
+
+    func testDefaultLoggerWithTracingEnabled() throws {
+        TracingFeature.instance = .mockNoOp()
+        defer { TracingFeature.instance = nil }
+
+        let logger = Logger.builder.build()
+
+        XCTAssertNotNil(logger.activeSpanIntegration)
     }
 
     func testCustomizedLogger() throws {

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -506,7 +506,7 @@ class LoggerTests: XCTestCase {
         XCTAssertEqual(output.recordedLog?.level, .warn)
         try XCTAssertTrue(
             XCTUnwrap(output.recordedLog?.message)
-                .contains("No `RUMMonitor` is registered, so RUM integration with Logging will not work.")
+                .contains("RUM feature is enabled, but no `RUMMonitor` is registered. The RUM integration with Logging will not work.")
         )
 
         let logMatcher = try LoggingFeature.waitAndReturnLogMatchers(count: 1)[0]
@@ -611,7 +611,7 @@ class LoggerTests: XCTestCase {
         XCTAssertEqual(output.recordedLog?.level, .warn)
         try XCTAssertTrue(
             XCTUnwrap(output.recordedLog?.message)
-                .contains("No `Tracer` is registered, so Tracing integration with Logging will not work.")
+                .contains("Tracing feature is enabled, but no `Tracer` is registered. The Tracing integration with Logging will not work.")
         )
 
         let logMatcher = try LoggingFeature.waitAndReturnLogMatchers(count: 1)[0]

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -553,6 +553,72 @@ class LoggerTests: XCTestCase {
         }
     }
 
+    // MARK: - Integration With Active Span
+
+    func testGivenBundlingWithTraceEnabledAndTracerRegistered_whenSendingLog_itContainsActiveSpanAttributes() throws {
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        defer { LoggingFeature.instance = nil }
+
+        TracingFeature.instance = .mockNoOp()
+        defer { TracingFeature.instance = nil }
+
+        // given
+        let logger = Logger.builder.build()
+        Global.sharedTracer = Tracer.initialize(configuration: .init())
+        defer { Global.sharedTracer = DDNoopGlobals.tracer }
+
+        // when
+        let span = Global.sharedTracer.startSpan(operationName: "span").setActive()
+        logger.info("info message 1")
+        span.finish()
+        logger.info("info message 2")
+
+        // then
+        let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 2)
+        logMatchers[0].assertValue(
+            forKeyPath: LoggingWithActiveSpanIntegration.Attributes.traceID,
+            equals: "\(span.context.dd.traceID.rawValue)"
+        )
+        logMatchers[0].assertValue(
+            forKeyPath: LoggingWithActiveSpanIntegration.Attributes.spanID,
+            equals: "\(span.context.dd.spanID.rawValue)"
+        )
+        logMatchers[1].assertNoValue(forKey: LoggingWithActiveSpanIntegration.Attributes.traceID)
+        logMatchers[1].assertNoValue(forKey: LoggingWithActiveSpanIntegration.Attributes.spanID)
+    }
+
+    func testGivenBundlingWithTraceEnabledButTracerNotRegistered_whenSendingLog_itPrintsWarning() throws {
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        defer { LoggingFeature.instance = nil }
+
+        TracingFeature.instance = .mockNoOp()
+        defer { TracingFeature.instance = nil }
+
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
+
+        let output = LogOutputMock()
+        userLogger = .mockWith(logOutput: output)
+
+        // given
+        let logger = Logger.builder.build()
+        XCTAssertTrue(Global.sharedTracer is DDNoopTracer)
+
+        // when
+        logger.info("info message")
+
+        // then
+        XCTAssertEqual(output.recordedLog?.level, .warn)
+        try XCTAssertTrue(
+            XCTUnwrap(output.recordedLog?.message)
+                .contains("No `Tracer` is registered, so Tracing integration with Logging will not work.")
+        )
+
+        let logMatcher = try LoggingFeature.waitAndReturnLogMatchers(count: 1)[0]
+        logMatcher.assertNoValue(forKeyPath: LoggingWithActiveSpanIntegration.Attributes.traceID)
+        logMatcher.assertNoValue(forKeyPath: LoggingWithActiveSpanIntegration.Attributes.spanID)
+    }
+
     // MARK: - Thread safety
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -110,13 +110,15 @@ extension Logger {
         logOutput: LogOutput = LogOutputMock(),
         dateProvider: DateProvider = SystemDateProvider(),
         identifier: String = .mockAny(),
-        rumContextIntegration: LoggingWithRUMContextIntegration? = nil
+        rumContextIntegration: LoggingWithRUMContextIntegration? = nil,
+        activeSpanIntegration: LoggingWithActiveSpanIntegration? = nil
     ) -> Logger {
         return Logger(
             logOutput: logOutput,
             dateProvider: dateProvider,
             identifier: identifier,
-            rumContextIntegration: rumContextIntegration
+            rumContextIntegration: rumContextIntegration,
+            activeSpanIntegration: activeSpanIntegration
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -156,7 +156,7 @@ extension LogAttributes: Equatable {
 
     static func mockWith(
         userAttributes: [String: Encodable] = [:],
-        internalAttributes: [String: Encodable]? = nil
+        internalAttributes: [String: Encodable]? = [:]
     ) -> LogAttributes {
         return LogAttributes(
             userAttributes: userAttributes,
@@ -182,7 +182,7 @@ class LogOutputMock: LogOutput {
         var level: LogLevel
         var message: String
         var date: Date
-        var attributes = LogAttributes(userAttributes: [:], internalAttributes: nil)
+        var attributes = LogAttributes(userAttributes: [:], internalAttributes: [:])
         var tags: Set<String> = []
     }
 

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -40,7 +40,7 @@ class TracerConfigurationTests: XCTestCase {
             configuration: .init()
         ).dd
 
-        XCTAssertNotNil(tracer.rumContextIntegration)
+        XCTAssertNil(tracer.rumContextIntegration)
 
         guard let spanBuilder = (tracer.spanOutput as? SpanFileOutput)?.spanBuilder else {
             XCTFail()
@@ -67,6 +67,15 @@ class TracerConfigurationTests: XCTestCase {
         XCTAssertTrue(tracingLogBuilder.userInfoProvider === feature.userInfoProvider)
         XCTAssertNil(tracingLogBuilder.networkConnectionInfoProvider)
         XCTAssertNil(tracingLogBuilder.carrierInfoProvider)
+    }
+
+    func testDefaultTracerWithRUMEnabled() {
+        RUMFeature.instance = .mockNoOp()
+        defer { RUMFeature.instance = nil }
+
+        let tracer = Tracer.initialize(configuration: .init()).dd
+
+        XCTAssertNotNil(tracer.rumContextIntegration)
     }
 
     func testCustomizedTracer() {

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -73,9 +73,11 @@ class TracerConfigurationTests: XCTestCase {
         RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance = nil }
 
-        let tracer = Tracer.initialize(configuration: .init()).dd
+        let tracer1 = Tracer.initialize(configuration: .init()).dd
+        XCTAssertNotNil(tracer1.rumContextIntegration)
 
-        XCTAssertNotNil(tracer.rumContextIntegration)
+        let tracer2 = Tracer.initialize(configuration: .init(bundleWithRUM: false)).dd
+        XCTAssertNil(tracer2.rumContextIntegration)
     }
 
     func testCustomizedTracer() {

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -674,7 +674,7 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(output.recordedLog?.level, .warn)
         try XCTAssertTrue(
             XCTUnwrap(output.recordedLog?.message)
-                .contains("No `RUMMonitor` is registered, so RUM integration with Tracing will not work.")
+                .contains("RUM feature is enabled, but no `RUMMonitor` is registered. The RUM integration with Tracing will not work.")
         )
 
         let spanMatcher = try TracingFeature.waitAndReturnSpanMatchers(count: 1)[0]


### PR DESCRIPTION
### What and why?

📦 This PR adds Logging with Tracing integration. When there is an active span registered, its attributes are added to the produced `Log`.

This enables two-way integration between Logging and APM:
```swift
let span = Global.sharedTracer.startSpan("logs containing span").setActive()
logger.warn("warn message")
logger.error("error message")
logger.critical("critical message")
span.finish()
```

#### User can see traces which contain given log:

<img width="722" alt="Screenshot 2020-09-09 at 15 20 21" src="https://user-images.githubusercontent.com/2358722/92604138-720f6980-f2b0-11ea-9344-2efa7a1f3d23.png">

#### User can see logs send during the trace:

<img width="657" alt="Screenshot 2020-09-09 at 15 20 46" src="https://user-images.githubusercontent.com/2358722/92604146-75a2f080-f2b0-11ea-9928-6675c53d7b9e.png">


### How?

New public API was added to `Logger.Builder`:
```swift
/// Enables the logs integration with active span API from Tracing.
/// If enabled all the logs will be bundled with the `Global.sharedTracer.activeSpan` trace and
/// it will be possible to see all the logs sent during that specific trace.
/// - Parameter enabled: `true` by default
public func bundleWithTrace(_ enabled: Bool) -> Builder
```

it's a counterpart of Android's [`setBundleWithTraceEnabled()`](https://github.com/DataDog/dd-sdk-android/blob/6eb7afdd3f84aa138eec3e50024f8af558176dfd/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt#L257)

The `LoggingWithActiveSpanIntegration` was added in the same form as other features integration.

This new integration unrevealed the bug we had in printing warning messages on SDK misconfiguration:
* when RUM feature is disabled, the warnings from Logging With RUM integration should not be printed,
* when RUM feature is disabled, the warnings from Tracing With RUM integration should not be printed.

This is now fixed.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
