### PR TITLE
RUMM-700 Environment regex changed

### DIFF
--- a/Shopist/Shopist/AppDelegate.swift
+++ b/Shopist/Shopist/AppDelegate.swift
@@ -52,7 +52,7 @@ internal class AppDelegate: UIResponder, UIApplicationDelegate {
                 .builderUsing(
                     rumApplicationID: appConfig.rumAppID,
                     clientToken: appConfig.clientToken,
-                    environment: "shopist"
+                    environment: "shop.ist"
                 )
                 .set(serviceName: appConfig.serviceName)
                 // Currently, SDK doesn't auto-trace Alamofire requests

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -140,9 +140,12 @@ extension FeaturesConfiguration {
 }
 
 private func ifValid(environment: String) throws -> String {
-    let regex = #"^[a-zA-Z0-9_]+$"#
+    /// 1. cannot be more than 200 chars (including `env:` prefix)
+    /// 2. cannot end with `:`
+    /// 3. can contain letters, numbers and _:./-_ (other chars are converted to _ at backend)
+    let regex = #"^[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]$"#
     if environment.range(of: regex, options: .regularExpression, range: nil, locale: nil) == nil {
-        throw ProgrammerError(description: "`environment` contains illegal characters (only alphanumerics and `_` are allowed)")
+        throw ProgrammerError(description: "`environment`: \(environment) contains illegal characters (only alphanumerics and `_` are allowed)")
     }
     return environment
 }

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -86,18 +86,22 @@ class FeaturesConfigurationTests: XCTestCase {
             XCTAssertThrowsError(try FeaturesConfiguration(configuration: .mockWith(environment: environment), appContext: .mockAny())) { error in
                 XCTAssertEqual(
                     (error as? ProgrammerError)?.description,
-                    "🔥 Datadog SDK usage error: `environment` contains illegal characters (only alphanumerics and `_` are allowed)"
+                    "🔥 Datadog SDK usage error: `environment`: \(environment) contains illegal characters (only alphanumerics and `_` are allowed)"
                 )
             }
         }
 
         try verify(validEnvironmentName: "staging_1")
         try verify(validEnvironmentName: "production")
+        try verify(validEnvironmentName: "production:some")
+        try verify(validEnvironmentName: "pro/d-uct.ion_")
 
         verify(invalidEnvironmentName: "")
         verify(invalidEnvironmentName: "*^@!&#")
         verify(invalidEnvironmentName: "abc def")
         verify(invalidEnvironmentName: "*^@!&#")
+        verify(invalidEnvironmentName: "*^@!&#\nsome_env")
+        verify(invalidEnvironmentName: String(repeating: "a", count: 197))
     }
 
     func testPerformance() throws {


### PR DESCRIPTION
### What and why?

There was a discrepancy between Android's environment validation rule and ours.
For instance, `shop.ist` was invalid for us whereas it was valid for Android and more importantly valid for RUM Explorer.

### How?

Now we use Android's regex, which allows "_./-" as non-alphanumerics.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference