### PR TITLE
RUMM-709 Upload delay increases in case of network error

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		61133C5B2423990D00786299 /* DirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C2D2423990D00786299 /* DirectoryTests.swift */; };
 		61133C5C2423990D00786299 /* DataUploadWorkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C2F2423990D00786299 /* DataUploadWorkerTests.swift */; };
 		61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C302423990D00786299 /* DataUploadConditionsTests.swift */; };
-		61133C5E2423990D00786299 /* LogsUploadDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C312423990D00786299 /* LogsUploadDelayTests.swift */; };
+		61133C5E2423990D00786299 /* DataUploadDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C312423990D00786299 /* DataUploadDelayTests.swift */; };
 		61133C5F2423990D00786299 /* DataUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C322423990D00786299 /* DataUploaderTests.swift */; };
 		61133C602423990D00786299 /* HTTPHeadersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C332423990D00786299 /* HTTPHeadersTests.swift */; };
 		61133C612423990D00786299 /* HTTPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C342423990D00786299 /* HTTPClientTests.swift */; };
@@ -384,7 +384,7 @@
 		61133C2D2423990D00786299 /* DirectoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectoryTests.swift; sourceTree = "<group>"; };
 		61133C2F2423990D00786299 /* DataUploadWorkerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataUploadWorkerTests.swift; sourceTree = "<group>"; };
 		61133C302423990D00786299 /* DataUploadConditionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataUploadConditionsTests.swift; sourceTree = "<group>"; };
-		61133C312423990D00786299 /* LogsUploadDelayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogsUploadDelayTests.swift; sourceTree = "<group>"; };
+		61133C312423990D00786299 /* DataUploadDelayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataUploadDelayTests.swift; sourceTree = "<group>"; };
 		61133C322423990D00786299 /* DataUploaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataUploaderTests.swift; sourceTree = "<group>"; };
 		61133C332423990D00786299 /* HTTPHeadersTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPHeadersTests.swift; sourceTree = "<group>"; };
 		61133C342423990D00786299 /* HTTPClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClientTests.swift; sourceTree = "<group>"; };
@@ -993,7 +993,7 @@
 			children = (
 				61133C2F2423990D00786299 /* DataUploadWorkerTests.swift */,
 				61133C302423990D00786299 /* DataUploadConditionsTests.swift */,
-				61133C312423990D00786299 /* LogsUploadDelayTests.swift */,
+				61133C312423990D00786299 /* DataUploadDelayTests.swift */,
 				61133C322423990D00786299 /* DataUploaderTests.swift */,
 				61133C332423990D00786299 /* HTTPHeadersTests.swift */,
 				61133C342423990D00786299 /* HTTPClientTests.swift */,
@@ -2068,7 +2068,7 @@
 				61BBD19724ED50040023E65F /* FeaturesConfigurationTests.swift in Sources */,
 				61133C612423990D00786299 /* HTTPClientTests.swift in Sources */,
 				61133C6A2423990D00786299 /* DatadogTests.swift in Sources */,
-				61133C5E2423990D00786299 /* LogsUploadDelayTests.swift in Sources */,
+				61133C5E2423990D00786299 /* DataUploadDelayTests.swift in Sources */,
 				61133C5C2423990D00786299 /* DataUploadWorkerTests.swift in Sources */,
 				61E909F624A32D1C005EA2DE /* GlobalTests.swift in Sources */,
 				9E58E8E324615EDA008E5063 /* JSONEncoderTests.swift in Sources */,

--- a/Sources/Datadog/Core/PerformancePreset.swift
+++ b/Sources/Datadog/Core/PerformancePreset.swift
@@ -45,9 +45,9 @@ internal protocol UploadPerformancePreset {
     var minUploadDelay: TimeInterval { get }
     /// Maximum interval of data upload (in seconds).
     var maxUploadDelay: TimeInterval { get }
-    /// If upload succeeds, current interval is multiplied by this factor.
-    /// Should be less or equal `1.0`.
-    var uploadDelayDecreaseFactor: Double { get }
+    /// If upload succeeds or fails, current interval is changed by this rate. Should be less or equal `1.0`.
+    /// E.g: if rate is `0.1` then `delay` can be increased or decreased by `delay * 0.1`.
+    var uploadDelayChangeRate: Double { get }
 }
 
 internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPerformancePreset {
@@ -67,7 +67,7 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
     let defaultUploadDelay: TimeInterval
     let minUploadDelay: TimeInterval
     let maxUploadDelay: TimeInterval
-    let uploadDelayDecreaseFactor: Double
+    let uploadDelayChangeRate: Double
 
     // MARK: - Predefined presets
 
@@ -91,7 +91,7 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
         defaultUploadDelay: 5,
         minUploadDelay: 1,
         maxUploadDelay: 20,
-        uploadDelayDecreaseFactor: 0.9
+        uploadDelayChangeRate: 0.1
     )
 
     /// Performance preset optimized for instant data delivery.
@@ -111,7 +111,7 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
         defaultUploadDelay: 3,
         minUploadDelay: 1,
         maxUploadDelay: 5,
-        uploadDelayDecreaseFactor: 0.5 // reduce significantly for more uploads in short-lived app extensions
+        uploadDelayChangeRate: 0.5 // reduce significantly for more uploads in short-lived app extensions
     )
 
     static func best(for bundleType: BundleType) -> PerformancePreset {

--- a/Sources/Datadog/Core/Upload/DataUploadDelay.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadDelay.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 internal protocol Delay {
-    func nextUploadDelay() -> TimeInterval
+    var current: TimeInterval { get }
     mutating func decrease()
     mutating func increase()
 }
@@ -29,9 +29,7 @@ internal struct DataUploadDelay: Delay {
         self.delay = performance.initialUploadDelay
     }
 
-    func nextUploadDelay() -> TimeInterval {
-        return delay
-    }
+    var current: TimeInterval { delay }
 
     mutating func decrease() {
         delay = max(minDelay, delay * (1.0 - changeRate))

--- a/Sources/Datadog/Core/Upload/DataUploadDelay.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadDelay.swift
@@ -6,12 +6,18 @@
 
 import Foundation
 
+internal protocol Delay {
+    func nextUploadDelay() -> TimeInterval
+    mutating func decrease()
+    mutating func increase()
+}
+
 /// Mutable interval used for periodic data uploads.
-internal struct DataUploadDelay {
+internal struct DataUploadDelay: Delay {
     private let defaultDelay: TimeInterval
     private let minDelay: TimeInterval
     private let maxDelay: TimeInterval
-    private let decreaseFactor: Double
+    private let changeRate: Double
 
     private var delay: TimeInterval
 
@@ -19,24 +25,19 @@ internal struct DataUploadDelay {
         self.defaultDelay = performance.defaultUploadDelay
         self.minDelay = performance.minUploadDelay
         self.maxDelay = performance.maxUploadDelay
-        self.decreaseFactor = performance.uploadDelayDecreaseFactor
+        self.changeRate = performance.uploadDelayChangeRate
         self.delay = performance.initialUploadDelay
     }
 
-    mutating func nextUploadDelay() -> TimeInterval {
-        defer {
-            if delay == maxDelay {
-                delay = defaultDelay
-            }
-        }
+    func nextUploadDelay() -> TimeInterval {
         return delay
     }
 
     mutating func decrease() {
-        delay = max(minDelay, delay * decreaseFactor)
+        delay = max(minDelay, delay * (1.0 - changeRate))
     }
 
-    mutating func increaseOnce() {
-        delay = maxDelay
+    mutating func increase() {
+        delay = min(delay * (1.0 + changeRate), maxDelay)
     }
 }

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -44,7 +44,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
         self.delay = delay
         self.featureName = featureName
 
-        scheduleNextUpload(after: self.delay.nextUploadDelay())
+        scheduleNextUpload(after: self.delay.current)
     }
 
     private func scheduleNextUpload(after delay: TimeInterval) {
@@ -86,7 +86,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
                 self.delay.increase()
             }
 
-            self.scheduleNextUpload(after: self.delay.nextUploadDelay())
+            self.scheduleNextUpload(after: self.delay.current)
         }
     }
 }

--- a/Sources/Datadog/Core/Upload/DataUploader.swift
+++ b/Sources/Datadog/Core/Upload/DataUploader.swift
@@ -108,6 +108,9 @@ internal enum DataUploadStatus: Equatable, Hashable {
     case success
     /// Corresponds to HTTP 3xx response status codes.
     case redirection
+    /// Corresponds to HTTP 403 response status codes,
+    /// which means client token is invalid
+    case clientTokenError
     /// Corresponds to HTTP 4xx response status codes.
     case clientError
     /// Corresponds to HTTP 5xx response status codes.
@@ -121,6 +124,7 @@ internal enum DataUploadStatus: Equatable, Hashable {
         switch httpResponse.statusCode {
         case 200...299: self = .success
         case 300...399: self = .redirection
+        case 403: self = .clientTokenError
         case 400...499: self = .clientError
         case 500...599: self = .serverError
         default:        self = .unknown

--- a/Sources/Datadog/Core/Upload/HTTPClient.swift
+++ b/Sources/Datadog/Core/Upload/HTTPClient.swift
@@ -37,7 +37,7 @@ internal final class HTTPClient {
 /// The code execution in `URLSessionTransport` should never reach its initialization.
 internal struct URLSessionTransportInconsistencyException: Error {}
 
-/// As `URLSession` returns 3-values-touple for request execution, this function applies consistency constraints and turns
+/// As `URLSession` returns 3-values-tuple for request execution, this function applies consistency constraints and turns
 /// it into only two possible states of `HTTPTransportResult`.
 private func httpClientResult(for urlSessionTaskCompletion: (Data?, URLResponse?, Error?)) -> Result<HTTPURLResponse, Error> {
     let (_, response, error) = urlSessionTaskCompletion

--- a/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
@@ -47,14 +47,14 @@ class PerformancePresetTests: XCTestCase {
                 "Upload delay boundaries must be consistent."
             )
             XCTAssertLessThanOrEqual(
-                preset.uploadDelayDecreaseFactor,
+                preset.uploadDelayChangeRate,
                 1,
-                "Upload delay should not be increased towards infinity."
+                "Upload delay should not change by more than %100 at once."
             )
             XCTAssertGreaterThan(
-                preset.uploadDelayDecreaseFactor,
+                preset.uploadDelayChangeRate,
                 0,
-                "Upload delay must never result with 0."
+                "Upload delay must change at non-zero rate."
             )
         }
     }

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadDelayTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadDelayTests.swift
@@ -13,11 +13,11 @@ class DataUploadDelayTests: XCTestCase {
         defaultUploadDelay: 5,
         minUploadDelay: 1,
         maxUploadDelay: 20,
-        uploadDelayDecreaseFactor: 0.9
+        uploadDelayChangeRate: 0.1
     )
 
     func testWhenNotModified_itReturnsInitialDelay() {
-        var delay = DataUploadDelay(performance: mockPerformance)
+        let delay = DataUploadDelay(performance: mockPerformance)
         XCTAssertEqual(delay.nextUploadDelay(), mockPerformance.initialUploadDelay)
         XCTAssertEqual(delay.nextUploadDelay(), mockPerformance.initialUploadDelay)
     }
@@ -26,13 +26,13 @@ class DataUploadDelayTests: XCTestCase {
         var delay = DataUploadDelay(performance: mockPerformance)
         var previousValue: TimeInterval = delay.nextUploadDelay()
 
-        while previousValue != mockPerformance.minUploadDelay {
+        while previousValue > mockPerformance.minUploadDelay {
             delay.decrease()
 
             let nextValue = delay.nextUploadDelay()
             XCTAssertEqual(
                 nextValue / previousValue,
-                mockPerformance.uploadDelayDecreaseFactor,
+                1.0 - mockPerformance.uploadDelayChangeRate,
                 accuracy: 0.1
             )
             XCTAssertLessThanOrEqual(nextValue, max(previousValue, mockPerformance.minUploadDelay))
@@ -41,13 +41,21 @@ class DataUploadDelayTests: XCTestCase {
         }
     }
 
-    func testWhenIncreasedOnce_itReturnsMaximumDelayOnceThenGoesBackToDefaultDelay() {
+    func testWhenIncreasing_itClampsToMaximumDelay() {
         var delay = DataUploadDelay(performance: mockPerformance)
-        delay.decrease()
-        delay.increaseOnce()
+        var previousValue: TimeInterval = delay.nextUploadDelay()
 
-        XCTAssertEqual(delay.nextUploadDelay(), mockPerformance.maxUploadDelay)
-        XCTAssertEqual(delay.nextUploadDelay(), mockPerformance.defaultUploadDelay)
-        XCTAssertEqual(delay.nextUploadDelay(), mockPerformance.defaultUploadDelay)
+        while previousValue < mockPerformance.maxUploadDelay {
+            delay.increase()
+
+            let nextValue = delay.nextUploadDelay()
+            XCTAssertEqual(
+                nextValue / previousValue,
+                1.0 + mockPerformance.uploadDelayChangeRate,
+                accuracy: 0.1
+            )
+            XCTAssertGreaterThanOrEqual(nextValue, min(previousValue, mockPerformance.maxUploadDelay))
+            previousValue = nextValue
+        }
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadDelayTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadDelayTests.swift
@@ -18,18 +18,18 @@ class DataUploadDelayTests: XCTestCase {
 
     func testWhenNotModified_itReturnsInitialDelay() {
         let delay = DataUploadDelay(performance: mockPerformance)
-        XCTAssertEqual(delay.nextUploadDelay(), mockPerformance.initialUploadDelay)
-        XCTAssertEqual(delay.nextUploadDelay(), mockPerformance.initialUploadDelay)
+        XCTAssertEqual(delay.current, mockPerformance.initialUploadDelay)
+        XCTAssertEqual(delay.current, mockPerformance.initialUploadDelay)
     }
 
     func testWhenDecreasing_itGoesDownToMinimumDelay() {
         var delay = DataUploadDelay(performance: mockPerformance)
-        var previousValue: TimeInterval = delay.nextUploadDelay()
+        var previousValue: TimeInterval = delay.current
 
         while previousValue > mockPerformance.minUploadDelay {
             delay.decrease()
 
-            let nextValue = delay.nextUploadDelay()
+            let nextValue = delay.current
             XCTAssertEqual(
                 nextValue / previousValue,
                 1.0 - mockPerformance.uploadDelayChangeRate,
@@ -43,12 +43,12 @@ class DataUploadDelayTests: XCTestCase {
 
     func testWhenIncreasing_itClampsToMaximumDelay() {
         var delay = DataUploadDelay(performance: mockPerformance)
-        var previousValue: TimeInterval = delay.nextUploadDelay()
+        var previousValue: TimeInterval = delay.current
 
         while previousValue < mockPerformance.maxUploadDelay {
             delay.increase()
 
-            let nextValue = delay.nextUploadDelay()
+            let nextValue = delay.current
             XCTAssertEqual(
                 nextValue / previousValue,
                 1.0 + mockPerformance.uploadDelayChangeRate,

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -73,7 +73,7 @@ class DataUploadWorkerTests: XCTestCase {
     }
 
     // swiftlint:disable multiline_arguments_brackets
-    func test_whenThereIsNoBatch_thenIntervalIncreases() throws {
+    func testWhenThereIsNoBatch_thenIntervalIncreases() throws {
         let expectation = XCTestExpectation(description: "high expectation")
         let mockDelay = MockDelay { command in
             if case .increase = command {
@@ -99,11 +99,11 @@ class DataUploadWorkerTests: XCTestCase {
                 featureName: .mockAny()
             )
         ]) {
-            self.wait(for: [expectation], timeout: (mockDelay.nextUploadDelay() + 0.1) * 2.0)
+            self.wait(for: [expectation], timeout: (mockDelay.current + 0.1) * 1.5)
         }
     }
 
-    func test_whenBatchFails_thenIntervalIncreases() throws {
+    func testWhenBatchFails_thenIntervalIncreases() throws {
         let expectation = XCTestExpectation(description: "high expectation")
         let mockDelay = MockDelay { command in
             if case .increase = command {
@@ -131,11 +131,11 @@ class DataUploadWorkerTests: XCTestCase {
                 featureName: .mockAny()
             )
         ]) {
-            self.wait(for: [expectation], timeout: mockDelay.nextUploadDelay() + 0.1)
+            self.wait(for: [expectation], timeout: (mockDelay.current + 0.1) * 1.5)
         }
     }
 
-    func test_whenBatchSucceeds_thenIntervalDecreases() throws {
+    func testWhenBatchSucceeds_thenIntervalDecreases() throws {
         let expectation = XCTestExpectation(description: "low expectation")
         let mockDelay = MockDelay { command in
             if case .decrease = command {
@@ -163,7 +163,7 @@ class DataUploadWorkerTests: XCTestCase {
                 featureName: .mockAny()
             )
         ]) {
-            self.wait(for: [expectation], timeout: mockDelay.nextUploadDelay() + 0.1)
+            self.wait(for: [expectation], timeout: (mockDelay.current + 0.1) * 1.5)
         }
     }
     // swiftlint:enable multiline_arguments_brackets
@@ -175,9 +175,7 @@ struct MockDelay: Delay {
     }
     let callback: (Command) -> Void
 
-    func nextUploadDelay() -> TimeInterval {
-        return 0.0
-    }
+    var current: TimeInterval { 0.0 }
     func decrease() {
         callback(.decrease)
     }

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -90,6 +90,19 @@ class DataUploaderTests: XCTestCase {
         server.waitFor(requestsCompletion: 1)
     }
 
+    func testWhenDataIsSentWith403Code_itReturnsDataUploadStatus_clientTokenError() {
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 403)))
+        let uploader = DataUploader(
+            urlProvider: .mockAny(),
+            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpHeaders: .mockAny()
+        )
+        let status = uploader.upload(data: .mockAny())
+
+        XCTAssertEqual(status, .clientTokenError)
+        server.waitFor(requestsCompletion: 1)
+    }
+
     func testWhenDataIsSentWith500Code_itReturnsDataUploadStatus_serverError() {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 500)))
         let uploader = DataUploader(

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -73,7 +73,7 @@ class LoggingFeatureTests: XCTestCase {
                         defaultUploadDelay: 1,
                         minUploadDelay: 1,
                         maxUploadDelay: 1,
-                        uploadDelayDecreaseFactor: 1
+                        uploadDelayChangeRate: 0
                     )
                 )
             )

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -192,14 +192,14 @@ struct UploadPerformanceMock: UploadPerformancePreset {
     let defaultUploadDelay: TimeInterval
     let minUploadDelay: TimeInterval
     let maxUploadDelay: TimeInterval
-    let uploadDelayDecreaseFactor: Double
+    let uploadDelayChangeRate: Double
 
     static let noOp = UploadPerformanceMock(
         initialUploadDelay: .distantFuture,
         defaultUploadDelay: .distantFuture,
         minUploadDelay: .distantFuture,
         maxUploadDelay: .distantFuture,
-        uploadDelayDecreaseFactor: 1
+        uploadDelayChangeRate: 0
     )
 
     static let veryQuick = UploadPerformanceMock(
@@ -207,7 +207,7 @@ struct UploadPerformanceMock: UploadPerformancePreset {
         defaultUploadDelay: 0.05,
         minUploadDelay: 0.05,
         maxUploadDelay: 0.05,
-        uploadDelayDecreaseFactor: 1
+        uploadDelayChangeRate: 0
     )
 }
 
@@ -225,7 +225,7 @@ extension PerformancePreset {
             defaultUploadDelay: upload.defaultUploadDelay,
             minUploadDelay: upload.minUploadDelay,
             maxUploadDelay: upload.maxUploadDelay,
-            uploadDelayDecreaseFactor: upload.uploadDelayDecreaseFactor
+            uploadDelayChangeRate: upload.uploadDelayChangeRate
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -82,7 +82,7 @@ class RUMFeatureTests: XCTestCase {
                         defaultUploadDelay: 1,
                         minUploadDelay: 1,
                         maxUploadDelay: 1,
-                        uploadDelayDecreaseFactor: 1
+                        uploadDelayChangeRate: 0
                     )
                 )
             )

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -807,7 +807,7 @@ class TracerTests: XCTestCase {
         )
     }
 
-    func test_whenSpanStateChangesFromDifferentThreads_itChangesSpanState() {
+    func testWhenSpanStateChangesFromDifferentThreads_itChangesSpanState() {
         TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance = nil }
         let tracer = Tracer.initialize(configuration: .init())

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -75,7 +75,7 @@ class TracingFeatureTests: XCTestCase {
                         defaultUploadDelay: 1,
                         minUploadDelay: 1,
                         maxUploadDelay: 1,
-                        uploadDelayDecreaseFactor: 1
+                        uploadDelayChangeRate: 0
                     )
                 )
             )


### PR DESCRIPTION
### What and why?

SDK was decreasing upload interval as long as there is a batch to upload
That caused problems in case of network errors

Example case: the device can't resolve upload URL for some reason, yet SDK keeps trying to upload at short intervals.

### How?

Now if there is a network error or client token error, interval increases (interval used to decrease in that case)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
