### PR TITLE
RUMM-713 Add RUM Views auto instrumentation for navigation controller

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -251,6 +251,11 @@
 		61F3CDAD25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */; };
 		61F8CC092469295500FE2908 /* DatadogConfigurationBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8CC082469295500FE2908 /* DatadogConfigurationBuilderTests.swift */; };
 		61F9CA712512450B000A5E61 /* RUMAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA702512450B000A5E61 /* RUMAutoInstrumentationTests.swift */; };
+		61F9CA792512593A000A5E61 /* RUMNavigationControllerScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61F9CA782512593A000A5E61 /* RUMNavigationControllerScenario.storyboard */; };
+		61F9CA8025125C01000A5E61 /* RUMNCSScreen3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA7F25125C01000A5E61 /* RUMNCSScreen3ViewController.swift */; };
+		61F9CA92251266F7000A5E61 /* RUMNavigationControllerScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA86251266CB000A5E61 /* RUMNavigationControllerScenarioTests.swift */; };
+		61F9CA9F2513978D000A5E61 /* RUMSessionMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA982513977A000A5E61 /* RUMSessionMatcher.swift */; };
+		61F9CABA2513A7F5000A5E61 /* RUMSessionMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA982513977A000A5E61 /* RUMSessionMatcher.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */; };
@@ -581,6 +586,10 @@
 		61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsHandlerTests.swift; sourceTree = "<group>"; };
 		61F8CC082469295500FE2908 /* DatadogConfigurationBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogConfigurationBuilderTests.swift; sourceTree = "<group>"; };
 		61F9CA702512450B000A5E61 /* RUMAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAutoInstrumentationTests.swift; sourceTree = "<group>"; };
+		61F9CA782512593A000A5E61 /* RUMNavigationControllerScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMNavigationControllerScenario.storyboard; sourceTree = "<group>"; };
+		61F9CA7F25125C01000A5E61 /* RUMNCSScreen3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMNCSScreen3ViewController.swift; sourceTree = "<group>"; };
+		61F9CA86251266CB000A5E61 /* RUMNavigationControllerScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMNavigationControllerScenarioTests.swift; sourceTree = "<group>"; };
+		61F9CA982513977A000A5E61 /* RUMSessionMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionMatcher.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilder.swift; sourceTree = "<group>"; };
@@ -1075,6 +1084,7 @@
 				61133C432423990D00786299 /* LogMatcher.swift */,
 				61E45ED02451A8730061DAC7 /* SpanMatcher.swift */,
 				61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */,
+				61F9CA982513977A000A5E61 /* RUMSessionMatcher.swift */,
 			);
 			path = Matchers;
 			sourceTree = "<group>";
@@ -1190,6 +1200,7 @@
 			isa = PBXGroup;
 			children = (
 				61337037250F84FD00236D58 /* ManualInstrumentation */,
+				61F9CA7725125918000A5E61 /* NavigationController */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -1662,6 +1673,7 @@
 			isa = PBXGroup;
 			children = (
 				61C2C20C24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift */,
+				61F9CA86251266CB000A5E61 /* RUMNavigationControllerScenarioTests.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -1692,6 +1704,15 @@
 				61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		61F9CA7725125918000A5E61 /* NavigationController */ = {
+			isa = PBXGroup;
+			children = (
+				61F9CA782512593A000A5E61 /* RUMNavigationControllerScenario.storyboard */,
+				61F9CA7F25125C01000A5E61 /* RUMNCSScreen3ViewController.swift */,
+			);
+			path = NavigationController;
 			sourceTree = "<group>";
 		};
 		61FF281F24B89807000B3D9B /* RUMEvent */ = {
@@ -1997,6 +2018,7 @@
 				61337039250F852E00236D58 /* RUMManualInstrumentationScenario.storyboard in Resources */,
 				61441C0E24616DEC003D8BB8 /* Assets.xcassets in Resources */,
 				61441C0C24616DE9003D8BB8 /* Main.storyboard in Resources */,
+				61F9CA792512593A000A5E61 /* RUMNavigationControllerScenario.storyboard in Resources */,
 				61337035250F84BF00236D58 /* TracingScenario.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2204,6 +2226,7 @@
 				61133C672423990D00786299 /* LogConsoleOutputTests.swift in Sources */,
 				61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */,
 				617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */,
+				61F9CABA2513A7F5000A5E61 /* RUMSessionMatcher.swift in Sources */,
 				61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */,
 				61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */,
 				615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */,
@@ -2308,6 +2331,7 @@
 			files = (
 				618DCFE124C766F500589570 /* SendRUMFixture2ViewController.swift in Sources */,
 				61441C982461A649003D8BB8 /* DebugTracingViewController.swift in Sources */,
+				61F9CA8025125C01000A5E61 /* RUMNCSScreen3ViewController.swift in Sources */,
 				61441C952461A649003D8BB8 /* ConsoleOutputInterceptor.swift in Sources */,
 				614CADCE250FCA0200B93D2D /* TestScenarios.swift in Sources */,
 				61441C972461A649003D8BB8 /* UIViewController+KeyboardControlling.swift in Sources */,
@@ -2336,6 +2360,8 @@
 				61441C4124617013003D8BB8 /* LoggingScenarioTests.swift in Sources */,
 				61441C4B24618052003D8BB8 /* SpanMatcher.swift in Sources */,
 				61F3CD9A2510D8C500C816E5 /* Environment.swift in Sources */,
+				61F9CA9F2513978D000A5E61 /* RUMSessionMatcher.swift in Sources */,
+				61F9CA92251266F7000A5E61 /* RUMNavigationControllerScenarioTests.swift in Sources */,
 				61441C4924618052003D8BB8 /* JSONDataMatcher.swift in Sources */,
 				61F3CD9B2510D95A00C816E5 /* TestScenarios.swift in Sources */,
 				9E307C3224C8846D0039607E /* RUMDataModels.swift in Sources */,
@@ -2739,7 +2765,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG DD_COMPILED_FOR_INTEGRATION_TESTS";
 				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = Example;
 			};
@@ -2758,6 +2784,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_COMPILED_FOR_INTEGRATION_TESTS;
 				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = Example;
 			};
@@ -2776,6 +2803,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_COMPILED_FOR_INTEGRATION_TESTS;
 				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = Example;
 			};

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -244,7 +244,13 @@
 		61F1A623249B811200075390 /* Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A622249B811200075390 /* Encoding.swift */; };
 		61F3CD9A2510D8C500C816E5 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614CADD62510BAC000B93D2D /* Environment.swift */; };
 		61F3CD9B2510D95A00C816E5 /* TestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614CADCD250FCA0200B93D2D /* TestScenarios.swift */; };
+		61F3CDA3251118FB00C816E5 /* UIKitRUMViewsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA2251118FB00C816E5 /* UIKitRUMViewsHandler.swift */; };
+		61F3CDA52511190E00C816E5 /* UIViewControllerSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA42511190E00C816E5 /* UIViewControllerSwizzler.swift */; };
+		61F3CDA72512144600C816E5 /* UIKitRUMViewsPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */; };
+		61F3CDAB25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDAA25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift */; };
+		61F3CDAD25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */; };
 		61F8CC092469295500FE2908 /* DatadogConfigurationBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8CC082469295500FE2908 /* DatadogConfigurationBuilderTests.swift */; };
+		61F9CA712512450B000A5E61 /* RUMAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA702512450B000A5E61 /* RUMAutoInstrumentationTests.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */; };
@@ -568,7 +574,13 @@
 		61F1A6192498A51700075390 /* CoreMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMocks.swift; sourceTree = "<group>"; };
 		61F1A620249A45E400075390 /* DDSpanContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanContextTests.swift; sourceTree = "<group>"; };
 		61F1A622249B811200075390 /* Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encoding.swift; sourceTree = "<group>"; };
+		61F3CDA2251118FB00C816E5 /* UIKitRUMViewsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsHandler.swift; sourceTree = "<group>"; };
+		61F3CDA42511190E00C816E5 /* UIViewControllerSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerSwizzler.swift; sourceTree = "<group>"; };
+		61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsPredicate.swift; sourceTree = "<group>"; };
+		61F3CDAA25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerSwizzlerTests.swift; sourceTree = "<group>"; };
+		61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsHandlerTests.swift; sourceTree = "<group>"; };
 		61F8CC082469295500FE2908 /* DatadogConfigurationBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogConfigurationBuilderTests.swift; sourceTree = "<group>"; };
+		61F9CA702512450B000A5E61 /* RUMAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAutoInstrumentationTests.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilder.swift; sourceTree = "<group>"; };
@@ -1314,6 +1326,7 @@
 			children = (
 				616CCE12250A1868009FED46 /* RUMCommandSubscriber.swift */,
 				616CCE15250A467E009FED46 /* RUMAutoInstrumentation.swift */,
+				61F3CDA1251118DD00C816E5 /* Views */,
 			);
 			path = AutoInstrumentation;
 			sourceTree = "<group>";
@@ -1561,6 +1574,7 @@
 				6156CB9124DDAA13008CB2B2 /* RUMContext */,
 				61FF281F24B89807000B3D9B /* RUMEvent */,
 				61FF282E24BC5E0E000B3D9B /* RUMEventOutputs */,
+				61F3CDA825121F8F00C816E5 /* AutoInstrumentation */,
 				61786F7524FCDDE2009E6BAB /* Debugging */,
 				61411B0E24EC15940012EAB2 /* Utils */,
 			);
@@ -1650,6 +1664,34 @@
 				61C2C20C24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift */,
 			);
 			path = RUM;
+			sourceTree = "<group>";
+		};
+		61F3CDA1251118DD00C816E5 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */,
+				61F3CDA2251118FB00C816E5 /* UIKitRUMViewsHandler.swift */,
+				61F3CDA42511190E00C816E5 /* UIViewControllerSwizzler.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		61F3CDA825121F8F00C816E5 /* AutoInstrumentation */ = {
+			isa = PBXGroup;
+			children = (
+				61F3CDA925121FA100C816E5 /* Views */,
+				61F9CA702512450B000A5E61 /* RUMAutoInstrumentationTests.swift */,
+			);
+			path = AutoInstrumentation;
+			sourceTree = "<group>";
+		};
+		61F3CDA925121FA100C816E5 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				61F3CDAA25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift */,
+				61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		61FF281F24B89807000B3D9B /* RUMEvent */ = {
@@ -2045,6 +2087,7 @@
 				9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */,
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
 				61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */,
+				61F3CDA52511190E00C816E5 /* UIViewControllerSwizzler.swift in Sources */,
 				6156CB9024DDA8BE008CB2B2 /* RUMCurrentContext.swift in Sources */,
 				614B0A4F24EBDC6B00A2A780 /* RUMConnectivityInfoProvider.swift in Sources */,
 				9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */,
@@ -2056,6 +2099,7 @@
 				618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				E1D202EA24C065CF00D1AF3A /* ActiveSpansPool.swift in Sources */,
+				61F3CDA3251118FB00C816E5 /* UIKitRUMViewsHandler.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
 				618DCFD924C7269500589570 /* RUMUUIDGenerator.swift in Sources */,
 				9EFD112C24B32D29003A1A2B /* URLFilter.swift in Sources */,
@@ -2107,6 +2151,7 @@
 				61133BD82423979B00786299 /* HTTPClient.swift in Sources */,
 				61133BDB2423979B00786299 /* DatadogConfiguration.swift in Sources */,
 				614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */,
+				61F3CDA72512144600C816E5 /* UIKitRUMViewsPredicate.swift in Sources */,
 				61133BCE2423979B00786299 /* BatteryStatusProvider.swift in Sources */,
 				61363D9D24D999F70084CD6F /* DDError.swift in Sources */,
 				61133BD52423979B00786299 /* DataUploadConditions.swift in Sources */,
@@ -2146,6 +2191,7 @@
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
 				61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
+				61F3CDAD25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift in Sources */,
 				61D980BC24E293F600E03345 /* RUMIntegrationsTests.swift in Sources */,
 				61363D9F24D99BAA0084CD6F /* DDErrorTests.swift in Sources */,
 				61411B1024EC15AC0012EAB2 /* Casting+RUM.swift in Sources */,
@@ -2217,6 +2263,7 @@
 				61133C642423990D00786299 /* LoggerTests.swift in Sources */,
 				617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */,
 				61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */,
+				61F9CA712512450B000A5E61 /* RUMAutoInstrumentationTests.swift in Sources */,
 				6156CB9324DDAA34008CB2B2 /* RUMCurrentContextTests.swift in Sources */,
 				61E45BE5245196EA00F2C652 /* SpanFileOutputTests.swift in Sources */,
 				61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */,
@@ -2224,6 +2271,7 @@
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
 				614B0A4D24EBD71500A2A780 /* RUMUserInfoProviderTests.swift in Sources */,
 				61133C552423990D00786299 /* BatteryStatusProviderTests.swift in Sources */,
+				61F3CDAB25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift in Sources */,
 				617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */,
 				61133C532423990D00786299 /* MobileDeviceTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -66,6 +66,11 @@
             value = "RUMManualInstrumentationScenario"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_TEST_SCENARIO_IDENTIFIER"
+            value = "RUMNavigationControllerScenario"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/Datadog/Example/Scenarios/RUM/NavigationController/RUMNCSScreen3ViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/NavigationController/RUMNCSScreen3ViewController.swift
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+class RUMNCSScreen3ViewController: UIViewController {
+    @IBAction func didTapPopToTheFirstScreen(_ sender: Any) {
+        navigationController?.popToRootViewController(animated: true)
+    }
+}

--- a/Datadog/Example/Scenarios/RUM/NavigationController/RUMNavigationControllerScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/NavigationController/RUMNavigationControllerScenario.storyboard
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="CXG-Lr-dt2">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Screen 1-->
+        <scene sceneID="i70-2l-dY3">
+            <objects>
+                <viewController id="cne-ho-WYj" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="cyk-Hd-aqi">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hJS-rA-Cju">
+                                <rect key="frame" x="107" y="426" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="6hK-Sd-VYv"/>
+                                    <constraint firstAttribute="height" constant="44" id="lZo-EY-muw"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Push Next Screen">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="yE1-aY-utp" kind="show" id="IxK-EF-yaI"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="qBk-7A-bEv"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="hJS-rA-Cju" firstAttribute="centerY" secondItem="cyk-Hd-aqi" secondAttribute="centerY" id="661-xa-VOJ"/>
+                            <constraint firstItem="hJS-rA-Cju" firstAttribute="centerX" secondItem="cyk-Hd-aqi" secondAttribute="centerX" id="pHA-Q6-lHF"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Screen 1" id="P4A-pe-woL"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen 1"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2fu-A4-xeG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="254" y="1233"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Rud-oH-Ll0">
+            <objects>
+                <navigationController id="CXG-Lr-dt2" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="EVk-Ta-enx">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="cne-ho-WYj" kind="relationship" relationship="rootViewController" id="83i-hW-Of6"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jCy-fQ-5jT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-636" y="1233"/>
+        </scene>
+        <!--Screen 2-->
+        <scene sceneID="CMv-8e-ORh">
+            <objects>
+                <viewController id="yE1-aY-utp" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="VkQ-u2-TXW">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Y6-zB-g5H">
+                                <rect key="frame" x="107" y="426" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="cBF-8Q-2zO"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="gJe-pP-vvZ"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Push Next Screen">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="nQ9-Ge-UXE" kind="show" id="3Ke-BA-g5y"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="rkC-tg-uVc"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="5Y6-zB-g5H" firstAttribute="centerX" secondItem="VkQ-u2-TXW" secondAttribute="centerX" id="iao-kX-KWb"/>
+                            <constraint firstItem="5Y6-zB-g5H" firstAttribute="centerY" secondItem="VkQ-u2-TXW" secondAttribute="centerY" id="oGx-Bv-J1G"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Screen 2" id="fcu-SH-ZkQ"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen 2"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="wab-r6-yIr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1090" y="1233"/>
+        </scene>
+        <!--Screen 3-->
+        <scene sceneID="IYA-Gm-y9m">
+            <objects>
+                <viewController id="nQ9-Ge-UXE" customClass="RUMNCSScreen3ViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="9Ne-ma-h3c">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cJr-jf-nsN">
+                                <rect key="frame" x="107" y="426" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="2xr-Ww-MkF"/>
+                                    <constraint firstAttribute="height" constant="44" id="MQV-hq-na5"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Push Next Screen">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="jAu-2c-5vy" kind="show" id="Nk3-GW-Cbf"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qAj-Gg-tta">
+                                <rect key="frame" x="107" y="490" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="lcU-zx-eyE"/>
+                                    <constraint firstAttribute="height" constant="44" id="shs-U6-REA"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Pop To The First Screen">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="didTapPopToTheFirstScreen:" destination="nQ9-Ge-UXE" eventType="touchUpInside" id="aXU-3E-AoF"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="m24-Im-vDX"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="cJr-jf-nsN" firstAttribute="centerY" secondItem="9Ne-ma-h3c" secondAttribute="centerY" id="Ydb-eQ-Smj"/>
+                            <constraint firstItem="cJr-jf-nsN" firstAttribute="centerX" secondItem="9Ne-ma-h3c" secondAttribute="centerX" id="aPF-bf-ewb"/>
+                            <constraint firstItem="qAj-Gg-tta" firstAttribute="centerX" secondItem="9Ne-ma-h3c" secondAttribute="centerX" id="e6s-L5-mwK"/>
+                            <constraint firstItem="qAj-Gg-tta" firstAttribute="top" secondItem="cJr-jf-nsN" secondAttribute="bottom" constant="20" id="nnu-Wp-YIe"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Screen 3" id="2I8-qx-9iP"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen 3"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="D0G-Vh-GBf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2004" y="1233"/>
+        </scene>
+        <!--Screen 4-->
+        <scene sceneID="64y-Vg-CtC">
+            <objects>
+                <viewController id="jAu-2c-5vy" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="KLe-8D-SAg">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="G74-Ic-rM5"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Screen 4" id="uEt-o1-L9b"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen 4"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jhN-M4-PAG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2861" y="1233"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Datadog/Example/TestScenarios.swift
+++ b/Datadog/Example/TestScenarios.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import Datadog
+import UIKit
 
 // MARK: - TestScenario interface
 
@@ -38,6 +39,8 @@ func createTestScenario(for envIdentifier: String) -> TestScenario {
         return TracingScenario()
     case RUMManualInstrumentationScenario.envIdentifier():
         return RUMManualInstrumentationScenario()
+    case RUMNavigationControllerScenario.envIdentifier():
+        return RUMNavigationControllerScenario()
     default:
         fatalError("Cannot find `TestScenario` for `envIdentifier`: \(envIdentifier)")
     }
@@ -96,4 +99,31 @@ struct TracingScenario: TestScenario {
 /// uses the RUM manual instrumentation API to send RUM events to the server.
 struct RUMManualInstrumentationScenario: TestScenario {
     static let storyboardName = "RUMManualInstrumentationScenario"
+}
+
+/// Scenario which starts a navigation controller and runs through 4 different view controllers by navigating
+/// back and forth.
+struct RUMNavigationControllerScenario: TestScenario {
+    static let storyboardName = "RUMNavigationControllerScenario"
+
+    private class Predicate: UIKitRUMViewsPredicate {
+        func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+            switch viewController.accessibilityLabel {
+            case "Screen 1":
+                return .init(name: "Screen1")
+            case "Screen 2":
+                return .init(name: "Screen2")
+            case "Screen 3":
+                return .init(name: "Screen3")
+            case "Screen 4":
+                return .init(name: "Screen4")
+            default:
+                return nil
+            }
+        }
+    }
+
+    func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder.trackUIKitRUMViews(using: Predicate())
+    }
 }

--- a/Datadog/Example/TestScenarios.swift
+++ b/Datadog/Example/TestScenarios.swift
@@ -110,13 +110,13 @@ struct RUMNavigationControllerScenario: TestScenario {
         func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
             switch viewController.accessibilityLabel {
             case "Screen 1":
-                return .init(name: "Screen1")
+                return .init(path: "Screen1")
             case "Screen 2":
-                return .init(name: "Screen2")
+                return .init(path: "Screen2")
             case "Screen 3":
-                return .init(name: "Screen3")
+                return .init(path: "Screen3")
             case "Screen 4":
-                return .init(name: "Screen4")
+                return .init(path: "Screen4")
             default:
                 return nil
             }

--- a/Sources/Datadog/Core/AutoInstrumentation/MethodSwizzler.swift
+++ b/Sources/Datadog/Core/AutoInstrumentation/MethodSwizzler.swift
@@ -30,13 +30,9 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
         }
     }
 
-    private var implementationCache: [FoundMethod: IMP]
+    private var implementationCache: [FoundMethod: IMP] = [:]
     var swizzledMethods: [FoundMethod] {
         return Array(implementationCache.keys)
-    }
-
-    init() {
-        self.implementationCache = [:]
     }
 
     static func findMethod(with selector: Selector, in klass: AnyClass) throws -> FoundMethod {

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -39,7 +39,7 @@ internal struct FeaturesConfiguration {
 
     struct RUM {
         struct AutoInstrumentation {
-            // TODO: RUMM-713 Add RUM Views insturmentation configuration
+            let uiKitRUMViewsPredicate: UIKitRUMViewsPredicate?
             // TODO: RUMM-717 Add RUM Actions insturmentation configuration
             // TODO: RUMM-718 Add RUM Resources insturmentation configuration
         }
@@ -119,8 +119,13 @@ extension FeaturesConfiguration {
         }
 
         if configuration.rumEnabled {
-            // TODO: RUMM-713 RUMM-717 RUMM-718 Enable RUM.AutoInstrumentation conditionally
-            let autoInstrumentation: RUM.AutoInstrumentation? = nil
+            var autoInstrumentation: RUM.AutoInstrumentation?
+
+            if let rumUIKitViewsPredicate = configuration.rumUIKitViewsPredicate {
+                autoInstrumentation = RUM.AutoInstrumentation(
+                    uiKitRUMViewsPredicate: rumUIKitViewsPredicate
+                )
+            }
 
             if let rumApplicationID = configuration.rumApplicationID {
                 rum = RUM(

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -155,7 +155,10 @@ public class Datadog {
                 commonDependencies: commonDependencies
             )
             if let autoInstrumentationConfiguration = rumConfiguration.autoInstrumentation {
-                rumAutoInstrumentation = RUMAutoInstrumentation(with: autoInstrumentationConfiguration)
+                rumAutoInstrumentation = RUMAutoInstrumentation(
+                    configuration: autoInstrumentationConfiguration,
+                    dateProvider: dateProvider
+                )
             }
         }
 
@@ -164,9 +167,10 @@ public class Datadog {
         RUMFeature.instance = rum
 
         TracingAutoInstrumentation.instance = tracingAutoInstrumentation
-        TracingAutoInstrumentation.instance?.apply()
+        TracingAutoInstrumentation.instance?.enable()
 
         RUMAutoInstrumentation.instance = rumAutoInstrumentation
+        RUMAutoInstrumentation.instance?.enable()
 
         // Only after all features were initialized with no error thrown:
         self.instance = Datadog(

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal protocol UIKitRUMViewsHandlerType: class {
+    func subscribe(commandsSubscriber: RUMCommandSubscriber)
+    func notify_viewWillAppear(viewController: UIViewController, animated: Bool)
+    func notify_viewWillDisappear(viewController: UIViewController, animated: Bool)
+}
+
+internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
+    private let predicate: UIKitRUMViewsPredicate
+    private let dateProvider: DateProvider
+
+    init(predicate: UIKitRUMViewsPredicate, dateProvider: DateProvider) {
+        self.predicate = predicate
+        self.dateProvider = dateProvider
+    }
+
+    // MARK: - UIKitRUMViewsHandlerType
+
+    weak var subscriber: RUMCommandSubscriber?
+
+    func subscribe(commandsSubscriber: RUMCommandSubscriber) {
+        self.subscriber = commandsSubscriber
+    }
+
+    func notify_viewWillAppear(viewController: UIViewController, animated: Bool) {
+        if let rumView = predicate.rumView(for: viewController) {
+            subscriber?.process(
+                command: RUMStartViewCommand(
+                    time: dateProvider.currentDate(),
+                    identity: viewController,
+                    path: rumView.name,
+                    attributes: rumView.attributes
+                )
+            )
+        }
+    }
+
+    func notify_viewWillDisappear(viewController: UIViewController, animated: Bool) {
+        if let rumView = predicate.rumView(for: viewController) {
+            subscriber?.process(
+                command: RUMStopViewCommand(
+                    time: dateProvider.currentDate(),
+                    attributes: rumView.attributes,
+                    identity: viewController
+                )
+            )
+        }
+    }
+}

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -35,7 +35,7 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
                 command: RUMStartViewCommand(
                     time: dateProvider.currentDate(),
                     identity: viewController,
-                    path: rumView.name,
+                    path: rumView.path,
                     attributes: rumView.attributes
                 )
             )

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
@@ -6,19 +6,34 @@
 
 import UIKit
 
-// TODO: RUMM-713 Add public API comment
+/// A description of the RUM View returned from the `UIKitRUMViewsPredicate`.
 public struct RUMViewFromPredicate {
     // TODO: RUMM-726 Rename to `RUMView` when this name is no longer taken by auto-generated model(s).
-    public var name: String
+
+    /// The RUM View path, appearing as `PATH` in RUM Explorer.
+    public var path: String
+
+    /// Additional attributes to associate with the RUM View.
     public var attributes: [AttributeKey: AttributeValue]
 
-    public init(name: String, attributes: [AttributeKey: AttributeValue] = [:]) {
-        self.name = name
+    /// Initializes the RUM View description.
+    /// - Parameters:
+    ///   - path: the RUM View path, appearing as "PATH" in RUM Explorer.
+    ///   - attributes: additional attributes to associate with the RUM View.
+    public init(path: String, attributes: [AttributeKey: AttributeValue] = [:]) {
+        self.path = path
         self.attributes = attributes
     }
 }
 
-// TODO: RUMM-713 Add public API comment
+/// The predicate deciding if a given `UIViewController` marks the beginning or end of the RUM View.
+///
+/// When the app is running, the SDK will ask the implementation of `UIKitRUMViewsPredicate` if any noticed `UIViewController` should be considered
+/// as the RUM View. The predicate implementation should return RUM View parameters if the `UIViewController` should start/end
+/// the RUM View or `nil` otherwise.
 public protocol UIKitRUMViewsPredicate {
+    /// The predicate deciding if the RUM View should be started or ended for given instance of the `UIViewController`.
+    /// - Parameter viewController: an instance of the view controller noticed by the SDK.
+    /// - Returns: RUM View parameters if received view controller should start/end the RUM View, `nil` otherwise.
     func rumView(for viewController: UIViewController) -> RUMViewFromPredicate?
 }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
@@ -10,7 +10,12 @@ import UIKit
 public struct RUMViewFromPredicate {
     // TODO: RUMM-726 Rename to `RUMView` when this name is no longer taken by auto-generated model(s).
     public var name: String
-    public var attributes: [AttributeKey: AttributeValue] = [:]
+    public var attributes: [AttributeKey: AttributeValue]
+
+    public init(name: String, attributes: [AttributeKey: AttributeValue] = [:]) {
+        self.name = name
+        self.attributes = attributes
+    }
 }
 
 // TODO: RUMM-713 Add public API comment

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+// TODO: RUMM-713 Add public API comment
+public struct RUMViewFromPredicate {
+    // TODO: RUMM-726 Rename to `RUMView` when this name is no longer taken by auto-generated model(s).
+    public var name: String
+    public var attributes: [AttributeKey: AttributeValue] = [:]
+}
+
+// TODO: RUMM-713 Add public API comment
+public protocol UIKitRUMViewsPredicate {
+    func rumView(for viewController: UIViewController) -> RUMViewFromPredicate?
+}

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzler.swift
@@ -1,0 +1,74 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal class UIViewControllerSwizzler {
+    let viewWillAppear: ViewWillAppear
+    let viewWillDisappear: ViewWillDisappear
+
+    init(handler: UIKitRUMViewsHandlerType) throws {
+        self.viewWillAppear = try ViewWillAppear(handler: handler)
+        self.viewWillDisappear = try ViewWillDisappear(handler: handler)
+    }
+
+    func swizzle() {
+        viewWillAppear.swizzle()
+        viewWillDisappear.swizzle()
+    }
+
+    // MARK: - Swizzlings
+
+    /// Swizzles the `UIViewController.viewWillAppear()`
+    class ViewWillAppear: MethodSwizzler <
+        @convention(c) (UIViewController, Selector, Bool) -> Void,
+        @convention(block) (UIViewController, Bool) -> Void
+    > {
+        private static let selector = #selector(UIViewController.viewWillAppear)
+        private let method: FoundMethod
+        private let handler: UIKitRUMViewsHandlerType
+
+        init(handler: UIKitRUMViewsHandlerType) throws {
+            self.method = try Self.findMethod(with: Self.selector, in: UIViewController.self)
+            self.handler = handler
+        }
+
+        func swizzle() {
+            typealias Signature = @convention(block) (UIViewController, Bool) -> Void
+            swizzle(method) { previousImplementation -> Signature in
+                return { [weak handler = self.handler] vc, animated  in
+                    handler?.notify_viewWillAppear(viewController: vc, animated: animated)
+                    return previousImplementation(vc, Self.selector, animated)
+                }
+            }
+        }
+    }
+
+    /// Swizzles the `UIViewController.viewWillDisappear()`
+    class ViewWillDisappear: MethodSwizzler <
+        @convention(c) (UIViewController, Selector, Bool) -> Void,
+        @convention(block) (UIViewController, Bool) -> Void
+    > {
+        private static let selector = #selector(UIViewController.viewWillDisappear)
+        private let method: FoundMethod
+        private let handler: UIKitRUMViewsHandlerType
+
+        init(handler: UIKitRUMViewsHandlerType) throws {
+            self.method = try Self.findMethod(with: Self.selector, in: UIViewController.self)
+            self.handler = handler
+        }
+
+        func swizzle() {
+            typealias Signature = @convention(block) (UIViewController, Bool) -> Void
+            swizzle(method) { previousImplementation -> Signature in
+                return { [weak handler = self.handler] vc, animated  in
+                    handler?.notify_viewWillDisappear(viewController: vc, animated: animated)
+                    return previousImplementation(vc, Self.selector, animated)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Datadog/Tracing/AutoInstrumentation/TracingAutoInstrumentation.swift
+++ b/Sources/Datadog/Tracing/AutoInstrumentation/TracingAutoInstrumentation.swift
@@ -35,7 +35,7 @@ internal class TracingAutoInstrumentation {
         }
     }
 
-    func apply() {
+    func enable() {
         swizzler.swizzle(using: interceptor)
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -1,0 +1,80 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import HTTPServerMock
+import XCTest
+
+private extension ExampleApplication {
+    func tapPushNextScreenButton() {
+        buttons["Push Next Screen"].tap()
+    }
+
+    func tapBackButton() {
+        navigationBars["Screen 4"].buttons["Screen 3"].tap()
+    }
+
+    func tapPopToTheFirstScreenButton() {
+        buttons["Pop To The First Screen"].tap()
+    }
+
+    func swipeInteractiveBackGesture() {
+        let coordinate1 = coordinate(withNormalizedOffset: .init(dx: 0, dy: 0.5))
+        let coordinate2 = coordinate(withNormalizedOffset: .init(dx: 0.75, dy: 0.5))
+        coordinate1.press(forDuration: 0.5, thenDragTo: coordinate2)
+    }
+}
+
+class RUMNavigationControllerScenarioTests: IntegrationTests {
+    private struct Constants {
+        /// Time needed for data to be uploaded to mock server.
+        static let dataDeliveryTime: TimeInterval = 30
+    }
+
+    func testRUMNavigationControllerScenario() throws {
+        // Server session recording RUM events send to `HTTPServerMock`.
+        let rumServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenario: RUMNavigationControllerScenario.self,
+            rumEndpointURL: rumServerSession.recordingURL
+        ) // start on "Screen1"
+
+        app.tapPushNextScreenButton() // go to "Screen2"
+        app.tapPushNextScreenButton() // go to "Screen3"
+        app.tapPushNextScreenButton() // go to "Screen4"
+        app.tapBackButton() // go to "Screen3"
+        app.tapPopToTheFirstScreenButton() // go to "Screen1"
+        app.tapPushNextScreenButton() // go to "Screen2"
+        app.swipeInteractiveBackGesture() // swipe back to "Screen1"
+
+        // Get POST requests
+        let recordedRUMRequests = try rumServerSession.pullRecordedPOSTRequests(
+            count: 2,
+            timeout: Constants.dataDeliveryTime
+        )
+
+        // Get RUM Events
+        let rumEventsMatchers = try recordedRUMRequests
+            .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+
+        // Get RUM Sessions
+        let rumSessions = try RUMSessionMatcher.groupMatchersBySessions(rumEventsMatchers)
+        XCTAssertEqual(rumSessions.count, 1, "All events should be tracked within one RUM Session.")
+
+        let session = rumSessions[0]
+        XCTAssertEqual(session.viewVisits.count, 8, "The RUM Session should track 7 RUM Views")
+        XCTAssertEqual(session.viewVisits[0].path, "Screen1")
+        XCTAssertEqual(session.viewVisits[0].actionEvents[0].action.type, .applicationStart)
+        XCTAssertEqual(session.viewVisits[1].path, "Screen2")
+        XCTAssertEqual(session.viewVisits[2].path, "Screen3")
+        XCTAssertEqual(session.viewVisits[3].path, "Screen4")
+        XCTAssertEqual(session.viewVisits[4].path, "Screen3")
+        XCTAssertEqual(session.viewVisits[5].path, "Screen1")
+        XCTAssertEqual(session.viewVisits[6].path, "Screen2")
+        XCTAssertEqual(session.viewVisits[7].path, "Screen1")
+    }
+}

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -34,6 +34,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertNil(configuration.serviceName)
             XCTAssertEqual(configuration.tracedHosts, [])
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 100.0)
+            XCTAssertNil(configuration.rumUIKitViewsPredicate)
         }
     }
 
@@ -49,6 +50,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .set(rumEndpoint: .eu)
                 .set(tracedHosts: ["example.com"])
                 .set(rumSessionsSamplingRate: 42.5)
+                .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock())
         }
 
         let defaultBuilder = Datadog.Configuration
@@ -74,6 +76,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.rumEndpoint.url, "https://rum-http-intake.logs.datadoghq.eu/v1/input/")
             XCTAssertEqual(configuration.tracedHosts, ["example.com"])
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 42.5)
+            XCTAssertNotNil(configuration.rumUIKitViewsPredicate)
         }
     }
 }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -81,6 +81,7 @@ class DatadogTests: XCTestCase {
 
         defer {
             TracingAutoInstrumentation.instance?.swizzler.unswizzle()
+            RUMAutoInstrumentation.instance?.views?.swizzler.unswizzle()
         }
 
         try verify(configuration: defaultBuilder.build()) {
@@ -170,6 +171,17 @@ class DatadogTests: XCTestCase {
         ) {
             XCTAssertFalse(TracingFeature.isEnabled)
             XCTAssertNil(TracingAutoInstrumentation.instance)
+        }
+
+        try verify(configuration: rumBuilder.trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock()).build()) {
+            XCTAssertTrue(RUMFeature.isEnabled)
+            XCTAssertNotNil(RUMAutoInstrumentation.instance?.views)
+        }
+        try verify(
+            configuration: rumBuilder.enableRUM(false).trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock()).build()
+        ) {
+            XCTAssertFalse(RUMFeature.isEnabled)
+            XCTAssertNil(RUMAutoInstrumentation.instance?.views)
         }
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -427,3 +427,39 @@ class RUMContextProviderMock: RUMContextProvider {
 
     var context: RUMContext
 }
+
+// MARK: - Auto Instrumentation Mocks
+
+class RUMCommandSubscriberMock: RUMCommandSubscriber {
+    var receivedCommand: RUMCommand?
+
+    func process(command: RUMCommand) {
+        receivedCommand = command
+    }
+}
+
+class UIKitRUMViewsPredicateMock: UIKitRUMViewsPredicate {
+    var result: RUMViewFromPredicate?
+
+    func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+        return result
+    }
+}
+
+class UIKitRUMViewsHandlerMock: UIKitRUMViewsHandlerType {
+    var onSubscribe: ((RUMCommandSubscriber) -> Void)?
+    var onViewWillAppear: ((UIViewController, Bool) -> Void)?
+    var onViewWillDisappear: ((UIViewController, Bool) -> Void)?
+
+    func subscribe(commandsSubscriber: RUMCommandSubscriber) {
+        onSubscribe?(commandsSubscriber)
+    }
+
+    func notify_viewWillAppear(viewController: UIViewController, animated: Bool) {
+        onViewWillAppear?(viewController, animated)
+    }
+
+    func notify_viewWillDisappear(viewController: UIViewController, animated: Bool) {
+        onViewWillDisappear?(viewController, animated)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentationTests.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMAutoInstrumentationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        XCTAssertNil(RUMFeature.instance)
+        XCTAssertNil(RUMAutoInstrumentation.instance)
+    }
+
+    override func tearDown() {
+        XCTAssertNil(RUMAutoInstrumentation.instance)
+        XCTAssertNil(RUMFeature.instance)
+        super.tearDown()
+    }
+
+    func testGivenRUMAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsViewsHandler() throws {
+        // Given
+        RUMFeature.instance = .mockNoOp()
+        defer { RUMFeature.instance = nil }
+
+        RUMAutoInstrumentation.instance = RUMAutoInstrumentation(
+            configuration: .init(uiKitRUMViewsPredicate: UIKitRUMViewsPredicateMock()),
+            dateProvider: SystemDateProvider()
+        )
+        defer { RUMAutoInstrumentation.instance = nil }
+
+        // When
+        Global.rum = RUMMonitor.initialize()
+        defer { Global.rum = DDNoopRUMMonitor() }
+
+        // Then
+        let viewsHandler = RUMAutoInstrumentation.instance?.views?.handler as? UIKitRUMViewsHandler
+        XCTAssertTrue(viewsHandler?.subscriber === Global.rum)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class UIKitRUMViewsHandlerTests: XCTestCase {
+    private let dateProvider = RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+    private let commandSubscriber = RUMCommandSubscriberMock()
+    private let predicate = UIKitRUMViewsPredicateMock()
+
+    private lazy var handler: UIKitRUMViewsHandler = {
+        let handler = UIKitRUMViewsHandler(predicate: predicate, dateProvider: dateProvider)
+        handler.subscribe(commandsSubscriber: commandSubscriber)
+        return handler
+    }()
+
+    func testGivenAcceptingPredicate_whenViewWillAppear_itSendsRUMStartViewCommand() {
+        // Given
+        predicate.result = .init(name: "Foo", attributes: ["foo": "bar"])
+
+        // When
+        handler.notify_viewWillAppear(viewController: mockView, animated: .mockAny())
+
+        // Then
+        let command = commandSubscriber.receivedCommand as? RUMStartViewCommand
+        XCTAssertTrue(command?.identity === mockView)
+        XCTAssertEqual(command?.path, "Foo")
+        XCTAssertEqual(command?.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
+    }
+
+    func testGivenRejectingPredicate_whenViewWillAppear_itSendsRUMStartViewCommand() {
+        // Given
+        predicate.result = nil
+
+        // When
+        handler.notify_viewWillAppear(viewController: mockView, animated: .mockAny())
+
+        // Then
+        XCTAssertNil(commandSubscriber.receivedCommand)
+    }
+
+    func testGivenAcceptingPredicate_whenViewWillDisappear_itSendsRUMStopViewCommand() {
+        // Given
+        predicate.result = .init(name: "Foo", attributes: ["foo": "bar"])
+
+        // When
+        handler.notify_viewWillDisappear(viewController: mockView, animated: .mockAny())
+
+        // Then
+        let command = commandSubscriber.receivedCommand as? RUMStopViewCommand
+        XCTAssertTrue(command?.identity === mockView)
+        XCTAssertEqual(command?.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
+    }
+
+    func testGivenRejectingPredicate_whenViewWillDisappear_itSendsRUMStopViewCommand() {
+        // Given
+        predicate.result = nil
+
+        // When
+        handler.notify_viewWillDisappear(viewController: mockView, animated: .mockAny())
+
+        // Then
+        XCTAssertNil(commandSubscriber.receivedCommand)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
@@ -20,7 +20,7 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
 
     func testGivenAcceptingPredicate_whenViewWillAppear_itSendsRUMStartViewCommand() {
         // Given
-        predicate.result = .init(name: "Foo", attributes: ["foo": "bar"])
+        predicate.result = .init(path: "Foo", attributes: ["foo": "bar"])
 
         // When
         handler.notify_viewWillAppear(viewController: mockView, animated: .mockAny())
@@ -46,7 +46,7 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
 
     func testGivenAcceptingPredicate_whenViewWillDisappear_itSendsRUMStopViewCommand() {
         // Given
-        predicate.result = .init(name: "Foo", attributes: ["foo": "bar"])
+        predicate.result = .init(path: "Foo", attributes: ["foo": "bar"])
 
         // When
         handler.notify_viewWillDisappear(viewController: mockView, animated: .mockAny())

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzlerTests.swift
@@ -1,0 +1,62 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+extension UIViewControllerSwizzler {
+    func unswizzle() {
+        viewWillAppear.unswizzle()
+        viewWillDisappear.unswizzle()
+    }
+}
+
+class UIViewControllerSwizzlerTests: XCTestCase {
+    private let handler = UIKitRUMViewsHandlerMock()
+    private lazy var swizzler = try! UIViewControllerSwizzler(handler: handler)
+
+    override func setUp() {
+        super.setUp()
+        swizzler.swizzle()
+    }
+
+    override func tearDown() {
+        swizzler.unswizzle()
+        super.tearDown()
+    }
+
+    func testWhenViewWillAppearIsCalled_itNotifiesTheHandler() {
+        let expectation = self.expectation(description: "Notify handler")
+        let viewController = createMockView()
+        let animated = Bool.random()
+
+        handler.onViewWillAppear = { receivedViewController, receivedAnimated in
+            XCTAssertTrue(receivedViewController === viewController)
+            XCTAssertEqual(receivedAnimated, animated)
+            expectation.fulfill()
+        }
+
+        viewController.viewWillAppear(animated)
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testWhenViewWillDisappearIsCalled_itNotifiesTheHandler() {
+        let expectation = self.expectation(description: "Notify handler")
+        let viewController = createMockView()
+        let animated = Bool.random()
+
+        handler.onViewWillDisappear = { receivedViewController, receivedAnimated in
+            XCTAssertTrue(receivedViewController === viewController)
+            XCTAssertEqual(receivedAnimated, animated)
+            expectation.fulfill()
+        }
+
+        viewController.viewWillDisappear(animated)
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+    }
+}

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -34,8 +34,9 @@ internal class RUMEventMatcher {
         return try spansData.map { spanJSONData in try RUMEventMatcher.fromJSONObjectData(spanJSONData) }
     }
 
-    private let jsonMatcher: JSONDataMatcher
-    private let jsonData: Data
+    let jsonData: Data
+    let jsonMatcher: JSONDataMatcher
+
     private let jsonDataDecoder = JSONDecoder()
 
     private init(with jsonData: Data) throws {

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -1,0 +1,160 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+#if !DD_COMPILED_FOR_INTEGRATION_TESTS
+/// This file is compiled both for Unit and Integration tests.
+/// * The Unit Tests target can see `Datadog` by `@testable import Datadog`.
+/// * In Integration Tests target we want to compile `Datadog` in "Release" configuration, so testability is not possible.
+/// This compiler statement gives both targets the visibility of `RUMDataModels.swift` either by import or direct compilation.
+@testable import Datadog
+#endif
+
+/// An error thrown by the `RUMSessionMatcher` if it spots an inconsistency in tracked RUM Session, e.g. when
+/// two RUM View events have the same `view.id` but different path (which is not allowed by the RUM product constraints).
+struct RUMSessionConsistencyException: Error, CustomStringConvertible {
+    let description: String
+}
+
+internal class RUMSessionMatcher {
+    // MARK: - Initialization
+
+    /// Takes the array of `RUMEventMatchers` and groups them by session ID.
+    /// For each distinct session ID, the `RUMSessionMatcher` is created.
+    /// Each `RUMSessionMatcher` groups its RUM Events by kind and `ViewVisit`.
+    class func groupMatchersBySessions(_ matchers: [RUMEventMatcher]) throws -> [RUMSessionMatcher] {
+        let eventMatchersBySessionID: [String: [RUMEventMatcher]] = try Dictionary(grouping: matchers) { eventMatcher in
+            try eventMatcher.jsonMatcher.value(forKeyPath: "session.id") as String
+        }
+
+        return try eventMatchersBySessionID
+            .map { try RUMSessionMatcher(sessionEventMatchers: $0.value) }
+    }
+
+    // MARK: - View Visits
+
+    /// Single RUM View visit tracked in this RUM Session.
+    /// Groups all the `RUMEvents` send during this visit.
+    class ViewVisit {
+        /// The identifier of all `RUM Views` tracked during this visit.
+        let viewID: String
+
+        init(viewID: String) {
+            self.viewID = viewID
+        }
+
+        /// The `path` of the visited RUM View.
+        /// Corresponds to the "PATH GROUP" in RUM Explorer.
+        fileprivate(set) var path: String = ""
+
+        /// `RUMView` events tracked during this visit.
+        fileprivate(set) var viewEvents: [RUMView] = []
+
+        /// `RUMAction` events tracked during this visit.
+        fileprivate(set) var actionEvents: [RUMAction] = []
+
+        /// `RUMResource` events tracked during this visit.
+        fileprivate(set) var resourceEvents: [RUMResource] = []
+
+        /// `RUMError` events tracked during this visit.
+        fileprivate(set) var errorEvents: [RUMError] = []
+    }
+
+    /// An array of view visits tracked during this RUM Session.
+    /// Each `ViewVisit` is determined by unique `view.id` and groups all RUM events linked to that `view.id`.
+    let viewVisits: [ViewVisit]
+
+    private init(sessionEventMatchers: [RUMEventMatcher]) throws {
+        // Sort events so they follow increasing time order
+        let sessionEventOrderedByTime = try sessionEventMatchers.sorted { firstEvent, secondEvent in
+            let firstEventTime: UInt64 = try firstEvent.jsonMatcher.value(forKeyPath: "date")
+            let secondEventTime: UInt64 = try secondEvent.jsonMatcher.value(forKeyPath: "date")
+            return firstEventTime < secondEventTime
+        }
+
+        let eventsMatchersByType: [String: [RUMEventMatcher]] = try Dictionary(grouping: sessionEventOrderedByTime) { eventMatcher in
+            try eventMatcher.jsonMatcher.value(forKeyPath: "type") as String
+        }
+
+        // Get RUM Events by kind:
+
+        let viewEvents: [RUMView] = try (eventsMatchersByType["view"] ?? [])
+            .map { matcher in try matcher.model() }
+
+        let actionEvents: [RUMAction] = try (eventsMatchersByType["action"] ?? [])
+            .map { matcher in try matcher.model() }
+
+        let resourceEvents: [RUMResource] = try (eventsMatchersByType["resource"] ?? [])
+            .map { matcher in try matcher.model() }
+
+        let errorEvents: [RUMError] = try (eventsMatchersByType["error"] ?? [])
+            .map { matcher in try matcher.model() }
+
+        // Group RUMView events into ViewVisits:
+        let uniqueViewIDs = Set(viewEvents.map { $0.view.id })
+        let visits = uniqueViewIDs.map { viewID in ViewVisit(viewID: viewID) }
+
+        var visitsByViewID: [String: ViewVisit] = [:]
+        visits.forEach { visit in visitsByViewID[visit.viewID] = visit }
+
+        // Group RUM Events by View Visits:
+        try viewEvents.forEach { rumEvent in
+            if let visit = visitsByViewID[rumEvent.view.id] {
+                visit.viewEvents.append(rumEvent)
+                if visit.path.isEmpty {
+                    visit.path = rumEvent.view.url
+                } else if visit.path != rumEvent.view.url {
+                    throw RUMSessionConsistencyException(
+                        description: "The RUM View url: \(rumEvent) is different than other RUM View urls for the same `view.id`."
+                    )
+                }
+            } else {
+                throw RUMSessionConsistencyException(
+                    description: "Cannot link RUM Event: \(rumEvent) to `RUMSessionMatcher.ViewVisit` by `view.id`."
+                )
+            }
+        }
+
+        try actionEvents.forEach { rumEvent in
+            if let visit = visitsByViewID[rumEvent.view.id] {
+                visit.actionEvents.append(rumEvent)
+            } else {
+                throw RUMSessionConsistencyException(
+                    description: "Cannot link RUM Event: \(rumEvent) to `RUMSessionMatcher.ViewVisit` by `view.id`."
+                )
+            }
+        }
+
+        try resourceEvents.forEach { rumEvent in
+            if let visit = visitsByViewID[rumEvent.view.id] {
+                visit.resourceEvents.append(rumEvent)
+            } else {
+                throw RUMSessionConsistencyException(
+                    description: "Cannot link RUM Event: \(rumEvent) to `RUMSessionMatcher.ViewVisit` by `view.id`."
+                )
+            }
+        }
+
+        try errorEvents.forEach { rumEvent in
+            if let visit = visitsByViewID[rumEvent.view.id] {
+                visit.errorEvents.append(rumEvent)
+            } else {
+                throw RUMSessionConsistencyException(
+                    description: "Cannot link RUM Event: \(rumEvent) to `RUMSessionMatcher.ViewVisit` by `view.id`."
+                )
+            }
+        }
+
+        // Sort visits by time
+        let visitsEventOrderedByTime = visits.sorted { firstVisit, secondVisit in
+            let firstVisitTime = firstVisit.viewEvents[0].date
+            let secondVisitTime = secondVisit.viewEvents[0].date
+            return firstVisitTime < secondVisitTime
+        }
+
+        self.viewVisits = visitsEventOrderedByTime
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR adds auto instrumentation for monitoring RUM Views in `UINavigationController`.

### How?

Following the RFC, new public APIs were introduced:
```swift
// On Datadog.Configuration.Builder:
public func trackUIKitRUMViews(using predicate: UIKitRUMViewsPredicate) -> Builder

// In UIKitRUMViewsPredicate.swift:
public protocol UIKitRUMViewsPredicate {
   func rumView(for viewController: UIViewController) -> RUMViewFromPredicate?
}
```

The `UIViewControllerSwizzler` was implemented. It swizzles two VC lifecycle methods:
```swift
func viewWillAppear(_:)
func viewWillDisappear(_:)
```
to notify the `UIKitRUMViewsHandler` on VC presentation start / end. The handler uses `UIKitRUMViewsPredicate` to ask the user if given view controller should be accepted as the RUM View. Handler talks to the `RUMMonitor` through `RUMCommandSubscriber` interface and issues suitable `RUMCommands` for views monitoring.

I also added integration test for running the navigation controller scenario. It starts the app and navigates through this hierarchy of view controllers:

<img width="1111" alt="Screenshot 2020-09-18 at 12 40 28" src="https://user-images.githubusercontent.com/2358722/93588758-280f3d80-f9ac-11ea-90bd-7ed3000f374f.png">

by using push / pop / back / back gesture interactions.

As always, RUM Events are send to the Python server mock and are retrieved back by the integration tests runner. Then a set of assertions is made on received JSON data. To make this assertions easier, I introduced another kind of matcher: `RUMSessionMatcher`. It takes the collection of `RUMEventMatchers`, validates their consistency internally (i.e. by checking if all events correspond to the same `session.id`). Then it provides a convenient API to make the assertions:
```swift
// Get RUM Sessions
let rumSessions = try RUMSessionMatcher.groupMatchersBySessions(rumEventsMatchers)
XCTAssertEqual(rumSessions.count, 1, "All events should be tracked within one RUM Session.")

let session = rumSessions[0]
XCTAssertEqual(session.viewVisits.count, 8, "The RUM Session should track 7 RUM Views")
XCTAssertEqual(session.viewVisits[0].path, "Screen1")
XCTAssertEqual(session.viewVisits[1].path, "Screen2")
```
This is a huge improvement to our assertions mechanism. Similar scenario for manual instrumentation test requires >100 lines of assertions code, here it's just a few.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
