### PR TITLE
RUMM-717 Add integration test for RUM Actions instrumentation

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -152,6 +152,8 @@
 		615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8824A34FD700233986 /* DDTracerTests.swift */; };
 		615A4A8B24A3568900233986 /* OTSpan+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8A24A3568900233986 /* OTSpan+objc.swift */; };
 		615A4A8D24A356A000233986 /* OTSpanContext+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8C24A356A000233986 /* OTSpanContext+objc.swift */; };
+		615AAC07251E217B00C89EE9 /* RUMTapActionScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615AAC06251E217B00C89EE9 /* RUMTapActionScenarioTests.swift */; };
+		615AAC29251E322D00C89EE9 /* RUMCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615AAC28251E322D00C89EE9 /* RUMCommonAsserts.swift */; };
 		615C3155251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3154251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift */; };
 		615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */; };
 		6167ACC0251A0B420012B4D0 /* TracingNSURLSessionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6167ACBF251A0B420012B4D0 /* TracingNSURLSessionViewController.m */; };
@@ -504,6 +506,8 @@
 		615A4A8824A34FD700233986 /* DDTracerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerTests.swift; sourceTree = "<group>"; };
 		615A4A8A24A3568900233986 /* OTSpan+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTSpan+objc.swift"; sourceTree = "<group>"; };
 		615A4A8C24A356A000233986 /* OTSpanContext+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTSpanContext+objc.swift"; sourceTree = "<group>"; };
+		615AAC06251E217B00C89EE9 /* RUMTapActionScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTapActionScenarioTests.swift; sourceTree = "<group>"; };
+		615AAC28251E322D00C89EE9 /* RUMCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommonAsserts.swift; sourceTree = "<group>"; };
 		615C3154251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASVariousUIControllsViewController.swift; sourceTree = "<group>"; };
 		615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandlerTests.swift; sourceTree = "<group>"; };
 		6167ACBD251A0B410012B4D0 /* Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Example-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1768,8 +1772,10 @@
 		61F3CD9F2511070300C816E5 /* RUM */ = {
 			isa = PBXGroup;
 			children = (
+				615AAC28251E322D00C89EE9 /* RUMCommonAsserts.swift */,
 				61C2C20C24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift */,
 				61F9CA86251266CB000A5E61 /* RUMNavigationControllerScenarioTests.swift */,
+				615AAC06251E217B00C89EE9 /* RUMTapActionScenarioTests.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -2476,7 +2482,9 @@
 				61F9CA92251266F7000A5E61 /* RUMNavigationControllerScenarioTests.swift in Sources */,
 				61410141251A454500E3C2D9 /* TracingCommonAsserts.swift in Sources */,
 				61441C4924618052003D8BB8 /* JSONDataMatcher.swift in Sources */,
+				615AAC29251E322D00C89EE9 /* RUMCommonAsserts.swift in Sources */,
 				61F3CD9B2510D95A00C816E5 /* TestScenarios.swift in Sources */,
+				615AAC07251E217B00C89EE9 /* RUMTapActionScenarioTests.swift in Sources */,
 				9E307C3224C8846D0039607E /* RUMDataModels.swift in Sources */,
 				61441C4A24618052003D8BB8 /* LogMatcher.swift in Sources */,
 			);

--- a/Datadog/Example/Scenarios/RUM/TapActionAutoInstrumentation/RUMTapActionScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/TapActionAutoInstrumentation/RUMTapActionScenario.storyboard
@@ -171,20 +171,20 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CustomCell" id="fbV-GW-cCQ" userLabel="CustomCell" customClass="RUMTASTableViewCustomCell" customModule="Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="71.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="71.5" width="414" height="43"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fbV-GW-cCQ" id="LEs-az-FnY">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🐶" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mz0-uY-hI9">
-                                            <rect key="frame" x="20" y="11" width="23" height="21.5"/>
+                                            <rect key="frame" x="20" y="11" width="23" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mbu-WB-KIz">
-                                            <rect key="frame" x="53" y="11" width="39" height="21.5"/>
+                                            <rect key="frame" x="53" y="11" width="39" height="21"/>
                                             <fontDescription key="fontDescription" type="system" weight="light" pointSize="16"/>
                                             <nil key="highlightedColor"/>
                                         </label>

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
@@ -1,0 +1,7 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
@@ -4,4 +4,45 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-import Foundation
+import XCTest
+import HTTPServerMock
+
+/// A set of common assertions for all RUM tests.
+protocol RUMCommonAsserts {
+    /// Asserts that RUM requests are sent using expected path and HTTP headers.
+    func assertHTTPHeadersAndPath(in requests: [ServerSession.POSTRequestDetails], file: StaticString, line: UInt)
+}
+
+extension RUMCommonAsserts {
+    func assertHTTPHeadersAndPath(
+        in requests: [ServerSession.POSTRequestDetails],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        requests.forEach { request in
+            // Example path here: `/36882784-420B-494F-910D-CBAC5897A309/ui-tests-client-token?ddsource=ios&batch_time=1576404000000&ddtags=service:ui-tests-service-name,version:1.0,sdk_version:1.3.0-beta3,env:integration`
+            let pathRegexp = #"^(.*)(\/ui-tests-client-token\?ddsource=ios&batch_time=)([0-9]+)(&ddtags=service:ui-tests-service-name,version:1.0,sdk_version:)([0-9].[0-9].[0-9]([-a-z0-9])*)(,env:integration)$"#
+            XCTAssertNotNil(
+                request.path.range(of: pathRegexp, options: .regularExpression, range: nil, locale: nil),
+                """
+                Request path doesn't match the expected regexp.
+                ✉️ path: \(request.path)
+                🧪 expected regexp:  \(pathRegexp)
+                """,
+                file: file,
+                line: line
+            )
+            let expectedHeader = "Content-Type: text/plain;charset=UTF-8"
+            XCTAssertTrue(
+                request.httpHeaders.contains(expectedHeader),
+                """
+                Request doesn't contain expected header.
+                ✉️ request headers: \(request.httpHeaders.joined(separator: "\n"))
+                🧪 expected header:  \(expectedHeader)
+                """,
+                file: file,
+                line: line
+            )
+        }
+    }
+}

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -27,7 +27,7 @@ private extension ExampleApplication {
     }
 }
 
-class RUMNavigationControllerScenarioTests: IntegrationTests {
+class RUMNavigationControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
     func testRUMNavigationControllerScenario() throws {
         // Server session recording RUM events send to `HTTPServerMock`.
         let rumServerSession = server.obtainUniqueRecordingSession()
@@ -53,6 +53,9 @@ class RUMNavigationControllerScenarioTests: IntegrationTests {
         // Get RUM Events
         let rumEventsMatchers = try recordedRUMRequests
             .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+
+        // Assert common things
+        assertHTTPHeadersAndPath(in: recordedRUMRequests)
 
         // Get RUM Sessions
         let rumSessions = try RUMSessionMatcher.groupMatchersBySessions(rumEventsMatchers)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -59,7 +59,7 @@ class RUMNavigationControllerScenarioTests: IntegrationTests {
         XCTAssertEqual(rumSessions.count, 1, "All events should be tracked within one RUM Session.")
 
         let session = rumSessions[0]
-        XCTAssertEqual(session.viewVisits.count, 8, "The RUM Session should track 7 RUM Views")
+        XCTAssertEqual(session.viewVisits.count, 8, "The RUM Session should track 8 RUM Views")
         XCTAssertEqual(session.viewVisits[0].path, "Screen1")
         XCTAssertEqual(session.viewVisits[0].actionEvents[0].action.type, .applicationStart)
         XCTAssertEqual(session.viewVisits[1].path, "Screen2")

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -70,7 +70,7 @@ private extension ExampleApplication {
     }
 }
 
-class RUMTapActionScenarioTests: IntegrationTests {
+class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
     func testRUMTapActionScenario() throws {
         // Server session recording RUM events send to `HTTPServerMock`.
         let rumServerSession = server.obtainUniqueRecordingSession()
@@ -104,6 +104,9 @@ class RUMTapActionScenarioTests: IntegrationTests {
         // Get RUM Events
         let rumEventsMatchers = try recordedRUMRequests
             .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+
+        // Assert common things
+        assertHTTPHeadersAndPath(in: recordedRUMRequests)
 
         // Get RUM Sessions
         let rumSessions = try RUMSessionMatcher.groupMatchersBySessions(rumEventsMatchers)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -88,7 +88,8 @@ class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapCollectionViewItem(atIndex: 14)
         app.tapShowVariousUIControls()
         app.tapTextField()
-        app.enterTextUsingKeyboard("foo")
+        // TODO: RUMM-740 Enable it back once we fix make the Software Keyboard work on CI
+        //app.enterTextUsingKeyboard("foo")
         app.dismissKeyboard()
         app.tapStepperPlusButton()
         app.moveSlider(to: 0.25)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -1,0 +1,156 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import HTTPServerMock
+import XCTest
+
+private extension ExampleApplication {
+    func tapNoOpButton() {
+        buttons["No-op Button"].tap()
+    }
+
+    func tapShowUITableView() {
+        buttons["Show UITableView"].tap()
+    }
+
+    func tapTableViewItem(atIndex index: Int) {
+        tables.staticTexts["Item \(index)"].tap()
+    }
+
+    func tapShowUICollectionView() {
+        buttons["Show UICollectionView"].tap()
+    }
+
+    func tapCollectionViewItem(atIndex index: Int) {
+        collectionViews.staticTexts["Item \(index)"].tap()
+    }
+
+    func tapShowVariousUIControls() {
+        buttons["Show various UIControls"].tap()
+    }
+
+    func tapTextField() {
+        tables.cells
+            .containing(.staticText, identifier: "UITextField")
+            .children(matching: .textField).element
+            .tap()
+    }
+
+    func enterTextUsingKeyboard(_ text: String) {
+        text.forEach { letter in
+            keys[String(letter)].tap()
+        }
+    }
+
+    func dismissKeyboard() {
+        // tap in the middle of the screen
+        coordinate(withNormalizedOffset: .init(dx: 0.5, dy: 0.5))
+            .tap()
+    }
+
+    func tapStepperPlusButton() {
+        tables.buttons["Increment"].tap()
+    }
+
+    func moveSlider(to position: CGFloat) {
+        tables.sliders["50%"].adjust(toNormalizedSliderPosition: position)
+    }
+
+    func tapSegmentedControlSegment(label: String) {
+        tables.buttons[label].tap()
+    }
+
+    func tapNavigationBarButton(named barButtonIdentifier: String) {
+        navigationBars["Example.RUMTASVariousUIControllsView"]
+            .buttons[barButtonIdentifier]
+            .tap()
+    }
+}
+
+class RUMTapActionScenarioTests: IntegrationTests {
+    func testRUMTapActionScenario() throws {
+        // Server session recording RUM events send to `HTTPServerMock`.
+        let rumServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenario: RUMTapActionScenario.self,
+            rumEndpointURL: rumServerSession.recordingURL
+        )
+
+        app.tapNoOpButton()
+        app.tapShowUITableView()
+        app.tapTableViewItem(atIndex: 4)
+        app.tapShowUICollectionView()
+        app.tapCollectionViewItem(atIndex: 14)
+        app.tapShowVariousUIControls()
+        app.tapTextField()
+        app.enterTextUsingKeyboard("foo")
+        app.dismissKeyboard()
+        app.tapStepperPlusButton()
+        app.moveSlider(to: 0.25)
+        app.tapSegmentedControlSegment(label: "B")
+        app.tapNavigationBarButton(named: "Search")
+        app.tapNavigationBarButton(named: "Share")
+        app.tapNavigationBarButton(named: "Back")
+
+        // Get POST requests
+        let recordedRUMRequests = try rumServerSession
+            .pullRecordedPOSTRequests(count: 2, timeout: dataDeliveryTimeout)
+
+        // Get RUM Events
+        let rumEventsMatchers = try recordedRUMRequests
+            .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+
+        // Get RUM Sessions
+        let rumSessions = try RUMSessionMatcher.groupMatchersBySessions(rumEventsMatchers)
+        XCTAssertEqual(rumSessions.count, 1, "All events should be tracked within one RUM Session.")
+
+        let session = rumSessions[0]
+        XCTAssertEqual(session.viewVisits.count, 7, "The RUM Session should track 8 RUM Views")
+
+        XCTAssertEqual(session.viewVisits[0].path, "MenuViewController")
+        XCTAssertEqual(session.viewVisits[0].actionEvents.count, 3)
+        XCTAssertEqual(session.viewVisits[0].actionEvents[0].action.type, .applicationStart)
+        XCTAssertEqual(session.viewVisits[0].actionEvents[1].action.target?.name, "UIButton")
+        XCTAssertEqual(session.viewVisits[0].actionEvents[2].action.target?.name, "UIButton(Show UITableView)")
+
+        XCTAssertEqual(session.viewVisits[1].path, "TableViewController")
+        XCTAssertEqual(session.viewVisits[1].actionEvents.count, 1)
+        XCTAssertEqual(
+            session.viewVisits[1].actionEvents[0].action.target?.name,
+            "UITableViewCell(Item 4)"
+        )
+
+        XCTAssertEqual(session.viewVisits[2].path, "MenuViewController")
+        XCTAssertEqual(session.viewVisits[2].actionEvents.count, 1)
+        XCTAssertEqual(session.viewVisits[2].actionEvents[0].action.target?.name, "UIButton(Show UICollectionView)")
+
+        XCTAssertEqual(session.viewVisits[3].path, "CollectionViewController")
+        XCTAssertEqual(session.viewVisits[3].actionEvents.count, 1)
+        XCTAssertEqual(
+            session.viewVisits[3].actionEvents[0].action.target?.name,
+            "Example.RUMTASCollectionViewCell(Item 14)"
+        )
+
+        XCTAssertEqual(session.viewVisits[4].path, "MenuViewController")
+        XCTAssertEqual(session.viewVisits[4].actionEvents.count, 1)
+        XCTAssertEqual(session.viewVisits[4].actionEvents[0].action.target?.name, "UIButton(Show various UIControls)")
+
+        XCTAssertEqual(session.viewVisits[5].path, "UIControlsViewController")
+        XCTAssertEqual(session.viewVisits[5].actionEvents.count, 7)
+        XCTAssertEqual(session.viewVisits[5].actionEvents[0].action.target?.name, "UITextField")
+        XCTAssertEqual(session.viewVisits[5].actionEvents[1].action.target?.name, "UIStepper")
+        XCTAssertEqual(session.viewVisits[5].actionEvents[2].action.target?.name, "UISlider")
+        XCTAssertEqual(session.viewVisits[5].actionEvents[3].action.target?.name, "UISegmentedControl")
+        XCTAssertEqual(session.viewVisits[5].actionEvents[4].action.target?.name, "_UIButtonBarButton(Search)")
+        XCTAssertEqual(session.viewVisits[5].actionEvents[5].action.target?.name, "_UIButtonBarButton(Share)")
+        XCTAssertEqual(session.viewVisits[5].actionEvents[6].action.target?.name, "_UIButtonBarButton") // back button
+
+        XCTAssertEqual(session.viewVisits[6].path, "MenuViewController")
+        XCTAssertEqual(session.viewVisits[6].actionEvents.count, 0)
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR adds integration test for RUM Actions auto instrumentation.

### How?

Test runner goes through the test scenario UI introduced in #254. RUM requests are send to the Python server, then retrieved and inspected with `RUMSessionMatcher`.

I also decoupled the common assertions for HTTP message format (path and headers), so it's now applied to all RUM integration tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
