### PR TITLE
RUMM-714 Add RUM Views auto instrumentation for tab bar

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		61345613244756E300E7DA6B /* PerformancePresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61345612244756E300E7DA6B /* PerformancePresetTests.swift */; };
 		61363D9D24D999F70084CD6F /* DDError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61363D9C24D999F70084CD6F /* DDError.swift */; };
 		61363D9F24D99BAA0084CD6F /* DDErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */; };
+		613B77382521E80800155458 /* RUMTabBarControllerScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */; };
 		61410141251A454500E3C2D9 /* TracingCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61410140251A454500E3C2D9 /* TracingCommonAsserts.swift */; };
 		6141014F251A57AF00E3C2D9 /* UIApplicationSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */; };
 		6141015B251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */; };
@@ -454,6 +455,7 @@
 		61345612244756E300E7DA6B /* PerformancePresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePresetTests.swift; sourceTree = "<group>"; };
 		61363D9C24D999F70084CD6F /* DDError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDError.swift; sourceTree = "<group>"; };
 		61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDErrorTests.swift; sourceTree = "<group>"; };
+		613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTabBarControllerScenarioTests.swift; sourceTree = "<group>"; };
 		61410140251A454500E3C2D9 /* TracingCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingCommonAsserts.swift; sourceTree = "<group>"; };
 		6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationSwizzler.swift; sourceTree = "<group>"; };
 		6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandler.swift; sourceTree = "<group>"; };
@@ -1786,6 +1788,7 @@
 				615AAC28251E322D00C89EE9 /* RUMCommonAsserts.swift */,
 				61C2C20C24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift */,
 				61F9CA86251266CB000A5E61 /* RUMNavigationControllerScenarioTests.swift */,
+				613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */,
 				615AAC06251E217B00C89EE9 /* RUMTapActionScenarioTests.swift */,
 			);
 			path = RUM;
@@ -2487,6 +2490,7 @@
 				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,
 				61441C4124617013003D8BB8 /* LoggingScenarioTests.swift in Sources */,
+				613B77382521E80800155458 /* RUMTabBarControllerScenarioTests.swift in Sources */,
 				61441C4B24618052003D8BB8 /* SpanMatcher.swift in Sources */,
 				6167ACFD251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift in Sources */,
 				61F3CD9A2510D8C500C816E5 /* Environment.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		615A4A8D24A356A000233986 /* OTSpanContext+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8C24A356A000233986 /* OTSpanContext+objc.swift */; };
 		615AAC07251E217B00C89EE9 /* RUMTapActionScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615AAC06251E217B00C89EE9 /* RUMTapActionScenarioTests.swift */; };
 		615AAC29251E322D00C89EE9 /* RUMCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615AAC28251E322D00C89EE9 /* RUMCommonAsserts.swift */; };
+		615AAC36251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 615AAC35251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard */; };
 		615C3155251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3154251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift */; };
 		615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */; };
 		6167ACC0251A0B420012B4D0 /* TracingNSURLSessionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6167ACBF251A0B420012B4D0 /* TracingNSURLSessionViewController.m */; };
@@ -508,6 +509,7 @@
 		615A4A8C24A356A000233986 /* OTSpanContext+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTSpanContext+objc.swift"; sourceTree = "<group>"; };
 		615AAC06251E217B00C89EE9 /* RUMTapActionScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTapActionScenarioTests.swift; sourceTree = "<group>"; };
 		615AAC28251E322D00C89EE9 /* RUMCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommonAsserts.swift; sourceTree = "<group>"; };
+		615AAC35251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMTabBarAutoInstrumentationScenario.storyboard; sourceTree = "<group>"; };
 		615C3154251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASVariousUIControllsViewController.swift; sourceTree = "<group>"; };
 		615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandlerTests.swift; sourceTree = "<group>"; };
 		6167ACBD251A0B410012B4D0 /* Example-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Example-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1238,6 +1240,7 @@
 			children = (
 				61337037250F84FD00236D58 /* ManualInstrumentation */,
 				61F9CA7725125918000A5E61 /* NavigationControllerAutoInstrumentation */,
+				615AAC34251E34EF00C89EE9 /* TabBarAutoInstrumentation */,
 				6193DCA2251B5669009B8011 /* TapActionAutoInstrumentation */,
 			);
 			path = RUM;
@@ -1387,6 +1390,14 @@
 				6156CB9224DDAA34008CB2B2 /* RUMCurrentContextTests.swift */,
 			);
 			path = RUMContext;
+			sourceTree = "<group>";
+		};
+		615AAC34251E34EF00C89EE9 /* TabBarAutoInstrumentation */ = {
+			isa = PBXGroup;
+			children = (
+				615AAC35251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard */,
+			);
+			path = TabBarAutoInstrumentation;
 			sourceTree = "<group>";
 		};
 		6167ACF5251A203D0012B4D0 /* ManualInstrumentation */ = {
@@ -2124,6 +2135,7 @@
 				6167ACC7251A0BCE0012B4D0 /* TracingNSURLSessionScenario.storyboard in Resources */,
 				61441C0E24616DEC003D8BB8 /* Assets.xcassets in Resources */,
 				61441C0C24616DE9003D8BB8 /* Main.storyboard in Resources */,
+				615AAC36251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard in Resources */,
 				6167AD19251A27B80012B4D0 /* TracingURLSessionScenario.storyboard in Resources */,
 				61F9CA792512593A000A5E61 /* RUMNavigationControllerScenario.storyboard in Resources */,
 				61337035250F84BF00236D58 /* TracingManualInstrumentationScenario.storyboard in Resources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -86,6 +86,11 @@
             value = "RUMTapActionScenario"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_TEST_SCENARIO_IDENTIFIER"
+            value = "RUMTabBarAutoInstrumentationScenario"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/Datadog/Example/Scenarios/RUM/TabBarAutoInstrumentation/RUMTabBarAutoInstrumentationScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/TabBarAutoInstrumentation/RUMTabBarAutoInstrumentationScenario.storyboard
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="6OB-ZZ-hfI">
+    <device id="retina6_1" orientation="portrait" appearance="dark"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Tab Bar Controller-->
+        <scene sceneID="ahS-Og-0Nr">
+            <objects>
+                <tabBarController id="6OB-ZZ-hfI" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="ag9-30-izB"/>
+                    <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Cg5-qX-QnR">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="49"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="tintColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="selectedImageTintColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                    </tabBar>
+                    <connections>
+                        <segue destination="DZ8-dL-yVR" kind="relationship" relationship="viewControllers" id="0ZL-di-w4D"/>
+                        <segue destination="BUY-f2-0ws" kind="relationship" relationship="viewControllers" id="zOX-5C-v75"/>
+                        <segue destination="DjT-Ju-QuB" kind="relationship" relationship="viewControllers" id="S09-Hf-ccc"/>
+                    </connections>
+                </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6Tt-w3-oRg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1217" y="-90"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="Xb1-Qa-i3b">
+            <objects>
+                <viewController id="Gpl-M0-Tjg" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="tgV-9w-uqw">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MvW-46-lUZ">
+                                <rect key="frame" x="107" y="426" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="5vc-91-k0v"/>
+                                    <constraint firstAttribute="height" constant="44" id="oGM-fe-WjT"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Screen A">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="nQp-ke-A2K"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="MvW-46-lUZ" firstAttribute="centerY" secondItem="tgV-9w-uqw" secondAttribute="centerY" id="1jq-Io-xEr"/>
+                            <constraint firstItem="MvW-46-lUZ" firstAttribute="centerX" secondItem="tgV-9w-uqw" secondAttribute="centerX" id="XZm-WG-Hpf"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="5cW-qm-lRO"/>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen A"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MYU-sG-srH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="768.11594202898561" y="641.51785714285711"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="Jir-MW-ocH">
+            <objects>
+                <viewController id="eqs-Yg-pvx" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="P3x-6I-Fak">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4w4-Kg-eEc">
+                                <rect key="frame" x="107" y="426" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="vDb-qf-1hx"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="ycw-AD-YBa"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Screen B1">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="Gnq-Iq-og4" kind="show" id="8qt-1v-iCL"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Z3E-ah-vds"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="4w4-Kg-eEc" firstAttribute="centerX" secondItem="P3x-6I-Fak" secondAttribute="centerX" id="fVJ-kz-S3U"/>
+                            <constraint firstItem="4w4-Kg-eEc" firstAttribute="centerY" secondItem="P3x-6I-Fak" secondAttribute="centerY" id="pYa-c6-Ucy"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="w7e-cJ-0Pf"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen B1"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jnp-bC-HjU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="768.11594202898561" y="-90.401785714285708"/>
+        </scene>
+        <!--Screen C1-->
+        <scene sceneID="Toc-Na-Xnt">
+            <objects>
+                <viewController id="jbM-DY-Qfy" userLabel="Screen C1" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="zbw-aK-lVW">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qnH-ft-IaO">
+                                <rect key="frame" x="107" y="426" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="KYz-cj-zF5"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Wx8-e4-byZ"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Screen C1">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <segue destination="2fW-Z6-DAF" kind="show" id="Gfj-pM-2UM"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="9lb-xV-c9l"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="qnH-ft-IaO" firstAttribute="centerX" secondItem="zbw-aK-lVW" secondAttribute="centerX" id="64S-Wt-UHw"/>
+                            <constraint firstItem="qnH-ft-IaO" firstAttribute="centerY" secondItem="zbw-aK-lVW" secondAttribute="centerY" id="doD-Lf-Ymn"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="q7D-nB-jDb"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen C1"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6MJ-aG-gvz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="768.11594202898561" y="-800.22321428571422"/>
+        </scene>
+        <!--Screen C2-->
+        <scene sceneID="fqV-XB-fHq">
+            <objects>
+                <viewController id="2fW-Z6-DAF" userLabel="Screen C2" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="PMg-DE-flH">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bCn-hO-zTK">
+                                <rect key="frame" x="107" y="426" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="ow6-ig-Enn"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="zrD-Z7-mJY"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Screen C2">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Zrh-m9-6Z9"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="bCn-hO-zTK" firstAttribute="centerY" secondItem="PMg-DE-flH" secondAttribute="centerY" id="0R6-kd-08A"/>
+                            <constraint firstItem="bCn-hO-zTK" firstAttribute="centerX" secondItem="PMg-DE-flH" secondAttribute="centerX" id="7Ff-ym-8dm"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Screen B" id="90A-PO-e5S"/>
+                    <navigationItem key="navigationItem" id="m3T-IJ-2pC"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen C2"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="r91-T4-7bC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1655.072463768116" y="-800.22321428571422"/>
+        </scene>
+        <!--Tab C-->
+        <scene sceneID="xDp-XO-XIr">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DjT-Ju-QuB" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Tab C" id="IDA-5W-y7X">
+                        <imageReference key="image" image="c.circle" catalog="system" symbolScale="medium"/>
+                    </tabBarItem>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="NM4-Yq-zKI">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="jbM-DY-Qfy" kind="relationship" relationship="rootViewController" id="2aq-XN-nqQ"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="m4s-ri-S5k" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-142.02898550724638" y="-800.22321428571422"/>
+        </scene>
+        <!--Tab B-->
+        <scene sceneID="CXZ-sr-HhC">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="BUY-f2-0ws" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Tab B" id="eGX-ON-tqO">
+                        <imageReference key="image" image="b.circle" catalog="system" symbolScale="medium"/>
+                    </tabBarItem>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="v4P-UG-AdT">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="eqs-Yg-pvx" kind="relationship" relationship="rootViewController" id="mhP-wR-n7O"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ah2-w3-iBC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-142.02898550724638" y="-90.401785714285708"/>
+        </scene>
+        <!--Tab A-->
+        <scene sceneID="aTV-9H-uqM">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DZ8-dL-yVR" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Tab A" id="4q8-Vc-UjF">
+                        <imageReference key="image" image="a.circle" catalog="system" symbolScale="medium"/>
+                    </tabBarItem>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="5YA-al-jgy">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="Gpl-M0-Tjg" kind="relationship" relationship="rootViewController" id="KuJ-gi-pT1"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="NL2-SE-RMZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-142.02898550724638" y="641.51785714285711"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="BeD-2s-vMX">
+            <objects>
+                <viewController hidesBottomBarWhenPushed="YES" id="Gnq-Iq-og4" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="KUm-CS-7Kd">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TmX-0k-6ko">
+                                <rect key="frame" x="107" y="426" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="TjD-gU-WpO"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="tbz-Q2-LgB"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Screen B2">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="DIi-Ev-atP"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="TmX-0k-6ko" firstAttribute="centerY" secondItem="KUm-CS-7Kd" secondAttribute="centerY" id="8cO-4l-bNB"/>
+                            <constraint firstItem="TmX-0k-6ko" firstAttribute="centerX" secondItem="KUm-CS-7Kd" secondAttribute="centerX" id="kRh-Qv-nM4"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="Uws-P7-zTT"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen B2"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="FwL-5f-eAE" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1655" y="-90"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="a.circle" catalog="system" width="128" height="121"/>
+        <image name="b.circle" catalog="system" width="128" height="121"/>
+        <image name="c.circle" catalog="system" width="128" height="121"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Datadog/Example/Scenarios/RUM/TabBarAutoInstrumentation/RUMTabBarAutoInstrumentationScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/TabBarAutoInstrumentation/RUMTabBarAutoInstrumentationScenario.storyboard
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
-        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -220,9 +219,7 @@
         <scene sceneID="xDp-XO-XIr">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DjT-Ju-QuB" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Tab C" id="IDA-5W-y7X">
-                        <imageReference key="image" image="c.circle" catalog="system" symbolScale="medium"/>
-                    </tabBarItem>
+                    <tabBarItem key="tabBarItem" title="Tab C" id="IDA-5W-y7X"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="NM4-Yq-zKI">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
@@ -241,9 +238,7 @@
         <scene sceneID="CXZ-sr-HhC">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="BUY-f2-0ws" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Tab B" id="eGX-ON-tqO">
-                        <imageReference key="image" image="b.circle" catalog="system" symbolScale="medium"/>
-                    </tabBarItem>
+                    <tabBarItem key="tabBarItem" title="Tab B" id="eGX-ON-tqO"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="v4P-UG-AdT">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
@@ -262,9 +257,7 @@
         <scene sceneID="aTV-9H-uqM">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="DZ8-dL-yVR" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Tab A" id="4q8-Vc-UjF">
-                        <imageReference key="image" image="a.circle" catalog="system" symbolScale="medium"/>
-                    </tabBarItem>
+                    <tabBarItem key="tabBarItem" title="Tab A" id="4q8-Vc-UjF"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="5YA-al-jgy">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
@@ -325,9 +318,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="a.circle" catalog="system" width="128" height="121"/>
-        <image name="b.circle" catalog="system" width="128" height="121"/>
-        <image name="c.circle" catalog="system" width="128" height="121"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
@@ -1,0 +1,73 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+
+import HTTPServerMock
+import XCTest
+
+private extension ExampleApplication {
+    func tapTapBarButton(named tabName: String) {
+        tabBars.buttons[tabName].tap()
+    }
+
+    func tapButton(named buttonName: String) {
+        staticTexts[buttonName].tap()
+    }
+
+    func tapBackButton() {
+        navigationBars["UIView"].buttons.firstMatch.tap()
+    }
+}
+
+class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
+    func testRUMTabBarScenario() throws {
+        // Server session recording RUM events send to `HTTPServerMock`.
+        let rumServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenario: RUMTabBarAutoInstrumentationScenario.self,
+            rumEndpointURL: rumServerSession.recordingURL
+        ) // start on "Screen A"
+
+        app.tapTapBarButton(named: "Tab B") // go to "Screen B1"
+        app.tapButton(named: "Screen B1") // go to "Screen B2"
+        app.tapBackButton() // go to "Screen B1"
+        app.tapTapBarButton(named: "Tab C") // go to "Screen C1"
+        app.tapButton(named: "Screen C1") // go to "Screen C2"
+        app.tapTapBarButton(named: "Tab A") // go to "Screen A"
+        app.tapTapBarButton(named: "Tab C") // go to "Screen C2"
+        app.tapTapBarButton(named: "Tab C") // go to "Screen C1"
+
+        // Get POST requests
+        let recordedRUMRequests = try rumServerSession
+            .pullRecordedPOSTRequests(count: 1, timeout: dataDeliveryTimeout)
+
+        // Get RUM Events
+        let rumEventsMatchers = try recordedRUMRequests
+            .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+
+        // Assert common things
+        assertHTTPHeadersAndPath(in: recordedRUMRequests)
+
+        // Get RUM Sessions
+        let rumSessions = try RUMSessionMatcher.groupMatchersBySessions(rumEventsMatchers)
+        XCTAssertEqual(rumSessions.count, 1, "All events should be tracked within one RUM Session.")
+
+        let session = rumSessions[0]
+        XCTAssertEqual(session.viewVisits.count, 9, "The RUM Session should track 9 RUM Views")
+        XCTAssertEqual(session.viewVisits[0].path, "Screen A")
+        XCTAssertEqual(session.viewVisits[0].actionEvents[0].action.type, .applicationStart)
+        XCTAssertEqual(session.viewVisits[1].path, "Screen B1")
+        XCTAssertEqual(session.viewVisits[2].path, "Screen B2")
+        XCTAssertEqual(session.viewVisits[3].path, "Screen B1")
+        XCTAssertEqual(session.viewVisits[4].path, "Screen C1")
+        XCTAssertEqual(session.viewVisits[5].path, "Screen C2")
+        XCTAssertEqual(session.viewVisits[6].path, "Screen A")
+        XCTAssertEqual(session.viewVisits[7].path, "Screen C2")
+        XCTAssertEqual(session.viewVisits[8].path, "Screen C1")
+    }
+}

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -88,7 +88,7 @@ class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapCollectionViewItem(atIndex: 14)
         app.tapShowVariousUIControls()
         app.tapTextField()
-        // TODO: RUMM-740 Enable it back once we fix make the Software Keyboard work on CI
+        // TODO: RUMM-740 Enable it back once we fix the Software Keyboard work on CI
         //app.enterTextUsingKeyboard("foo")
         app.dismissKeyboard()
         app.tapStepperPlusButton()
@@ -96,11 +96,16 @@ class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapSegmentedControlSegment(label: "B")
         app.tapNavigationBarButton(named: "Search")
         app.tapNavigationBarButton(named: "Share")
+
+        // Wait with next action, so the last RUM Event fits another HTTP request. This is to
+        // make it execute the same locally and on CI, where different number of requests is sometimes send.
+        Thread.sleep(forTimeInterval: 2) // TODO: RUMM-742 Make the HTTP Server Mock not depend on the requests count
+
         app.tapNavigationBarButton(named: "Back")
 
         // Get POST requests
         let recordedRUMRequests = try rumServerSession
-            .pullRecordedPOSTRequests(count: 2, timeout: dataDeliveryTimeout)
+            .pullRecordedPOSTRequests(count: 3, timeout: dataDeliveryTimeout)
 
         // Get RUM Events
         let rumEventsMatchers = try recordedRUMRequests


### PR DESCRIPTION
### What and why?

📦 This PR adds RUM Views auto instrumentation for tab bar.

### How?

The `UIViewController` callbacks instrumented in #252 were sufficient to cover interactions with `UITabBarController`, so this PR only adds the test scenario and integration test.

The integration test navigates through hierarchy of `UITabBarController` and 3 `UINavigationControllers`, which is a common configuration for tab bar based applications:

<img width="1165" alt="Screenshot 2020-09-28 at 13 10 58" src="https://user-images.githubusercontent.com/2358722/94425693-a332d980-018c-11eb-8a4b-2dba6f33bfae.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
