### PR TITLE
RUMM-739 Fix: URLProtocol alters error in iOS 14

### DIFF
--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -117,7 +117,8 @@ class DataUploaderTests: XCTestCase {
     }
 
     func testWhenDataIsNotSentDueToNetworkError_itReturnsDataUploadStatus_networkError() {
-        let server = ServerMock(delivery: .failure(error: ErrorMock("network error")))
+        let mockError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "network error"])
+        let server = ServerMock(delivery: .failure(error: mockError))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
             httpClient: HTTPClient(session: .serverMockURLSession),

--- a/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
@@ -28,7 +28,8 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testWhenRequestIsNotDelivered_itReturnsHTTPRequestDeliveryError() {
-        let server = ServerMock(delivery: .failure(error: ErrorMock("no internet connection")))
+        let mockError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "no internet connection"])
+        let server = ServerMock(delivery: .failure(error: mockError))
         let expectation = self.expectation(description: "receive response")
         let client = HTTPClient(session: .serverMockURLSession)
 
@@ -37,7 +38,7 @@ class HTTPClientTests: XCTestCase {
             case .success:
                 break
             case .failure(let error):
-                XCTAssertEqual((error as? ErrorMock)?.description, "no internet connection")
+                XCTAssertEqual((error as NSError).localizedDescription, "no internet connection")
                 expectation.fulfill()
             }
         }

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -76,11 +76,11 @@ class ServerMock {
 
     fileprivate let mockedResponse: HTTPURLResponse?
     fileprivate let mockedData: Data?
-    fileprivate let mockedError: Error?
+    fileprivate let mockedError: NSError?
 
     enum Delivery {
         case success(response: HTTPURLResponse, data: Data = .mockAny())
-        case failure(error: Error)
+        case failure(error: NSError)
     }
 
     init(delivery: Delivery) {


### PR DESCRIPTION
### What and why?

`URLProtocol` doesn't give what you set anymore
It envelopes what you give in an `NSURLError` instance
That breaks one of our test cases ❌ 

### How?

Now we give `NSError` to `URLProtocol`, that way we can preserve `localizedDescription` and assert on it

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
