### PR TITLE
RUMM-737 Fix: Tests flakiness

### DIFF
--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -174,12 +174,22 @@ struct MockDelay: Delay {
         case increase, decrease
     }
     let callback: (Command) -> Void
+    // NOTE: RUMM-737 private only doesn't compile due to "private initializer is inaccessible", probably a bug in Swift
+    private(set) var didReceiveCommand = false
 
     var current: TimeInterval { 0.0 }
-    func decrease() {
+    mutating func decrease() {
+        if didReceiveCommand {
+            return
+        }
+        didReceiveCommand = true
         callback(.decrease)
     }
-    func increase() {
+    mutating func increase() {
+        if didReceiveCommand {
+            return
+        }
+        didReceiveCommand = true
         callback(.increase)
     }
 }


### PR DESCRIPTION
### What and why?

`DataUploadWorkerTests` became more flaky after adding tests for interval logic

### How?

#### Hypothesis
`DataUploadWorkerTests` uses `MockDelay` to test interval logic
In fact, tests assert on the first interval logic command only
However, `MockDelay` was executing assertions on every command
That probably caused wrong assertions on wrong commands in which case there were multiple commands sent

#### Fix
Now `MockDelay` ignores the commands after the first one ✅ 
Hopefully that will improve the situation.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
