### PR TITLE
RUMM-740 Fix: UI Test software keyboard issue

### DIFF
--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -40,6 +40,13 @@ private extension ExampleApplication {
     }
 
     func enterTextUsingKeyboard(_ text: String) {
+        // NOTE: RUMM-740 iOS 13 Swipe typing feature presents its onboarding
+        // That blocks the keyboard with a Continue button
+        // it must be tapped first to get the real keyboard
+        let swipeTypingContinueButton = buttons["Continue"]
+        if swipeTypingContinueButton.exists {
+            swipeTypingContinueButton.tap()
+        }
         text.forEach { letter in
             keys[String(letter)].tap()
         }
@@ -88,8 +95,7 @@ class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapCollectionViewItem(atIndex: 14)
         app.tapShowVariousUIControls()
         app.tapTextField()
-        // TODO: RUMM-740 Enable it back once we fix the Software Keyboard work on CI
-        //app.enterTextUsingKeyboard("foo")
+        app.enterTextUsingKeyboard("foo")
         app.dismissKeyboard()
         app.tapStepperPlusButton()
         app.moveSlider(to: 0.25)


### PR DESCRIPTION
### What and why?

iOS 13 Swipe Typing feature blocks software keyboard with onboarding
We must tap Continue button in order to get the real keyboard

![software-keyboard-detail](https://user-images.githubusercontent.com/1417500/94696661-93a3c400-0337-11eb-9c2d-127384257da4.png)

### How?

Now UI Test tries to tap on `Continue` button if exists before typing given letters
(For demonstration video check out jira ticket 🎥 )

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
