### PR TITLE
RUMM-738 Shopist: Run is bound to time limit instead of session count

### DIFF
--- a/Shopist/Shopist/API.swift
+++ b/Shopist/Shopist/API.swift
@@ -134,7 +134,7 @@ internal final class API {
         var tracedRequest = request
         headerWriter.tracePropagationHTTPHeaders.forEach { tracedRequest.setValue($1, forHTTPHeaderField: $0) }
 
-        let randomError = isFailable ? fakeError(onceIn: 50) : nil
+        let randomError = isFailable ? fakeError(onceIn: 75) : nil
 
         httpClient.request(tracedRequest).validate().response { result in
             let statusCode = result.response?.statusCode

--- a/Shopist/Shopist/Extensions/UIImageView+Network.swift
+++ b/Shopist/Shopist/Extensions/UIImageView+Network.swift
@@ -20,7 +20,7 @@ internal extension UIImageView {
         _ = Self.setupOnce
         Global.rum.startResourceLoading(resourceName: url.path, url: url, httpMethod: .GET)
         af.setImage(withURL: url) { result in
-            if let someError = (result.error ?? fakeError(onceIn: 20)) {
+            if let someError = (result.error ?? fakeError(onceIn: 40)) {
                 Global.rum.stopResourceLoadingWithError(
                     resourceName: url.path,
                     error: someError,

--- a/Shopist/Shopist/Scenes/CheckoutViewController.swift
+++ b/Shopist/Shopist/Scenes/CheckoutViewController.swift
@@ -20,7 +20,7 @@ private struct CellModel {
 
 internal final class CheckoutViewController: UITableViewController {
     private static var randomError: NSError? {
-        if UInt8.random(in: 1...20) == 1 {
+        if UInt8.random(in: 1...40) == 1 {
             return NSError(
                 domain: "GraphQL",
                 code: 11_235,

--- a/Shopist/ShopistUITests/ShopistUITestHelpers.swift
+++ b/Shopist/ShopistUITests/ShopistUITestHelpers.swift
@@ -52,8 +52,12 @@ class ProductsPage: XCUIApplication {
 }
 
 class ProductDetailsPage: XCUIApplication {
-    func addToCart() {
-        navBar.buttons["addToCart"].safeTap()
+    func addToCart() -> Bool {
+        if navBar.buttons["addToCart"].exists {
+            navBar.buttons["addToCart"].safeTap()
+            return true
+        }
+        return false
     }
 
     func removeFromCart() -> Bool {


### PR DESCRIPTION
### What and why?

Shopist events were not aligned with its build triggers.
1. Runs are triggered once in every 30mins
2. Yet, runs usually take less than 30mins: sometimes takes 15mins sometimes 25mins
That leaves gaps in timeseries of events in RUM Explorer, which is not desired.

### How?

Now we run until the given target duration is reached.
Shopist continues running for 27.5 minutes regardless of session count.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
