### PR TITLE
RUMM-759 Workaround for Carthage&Xcode 12 issue

### DIFF
--- a/dependency-manager-tests/carthage/Makefile
+++ b/dependency-manager-tests/carthage/Makefile
@@ -5,6 +5,9 @@ else
 endif
 
 PWD := $(shell pwd)
+# TODO: RUMM-760 Remove this workaround once Carthage fixes their Xcode 12 issue
+# https://github.com/Carthage/Carthage/issues/3019
+export XCODE_XCCONFIG_FILE := $(PWD)/tmp.xcconfig
 
 test:
 		@echo "⚙️  Configuring CTProject with remote branch: '${GIT_BRANCH}'..."

--- a/dependency-manager-tests/carthage/tmp.xcconfig
+++ b/dependency-manager-tests/carthage/tmp.xcconfig
@@ -1,0 +1,4 @@
+// TODO: RUMM-760 Remove this workaround once Carthage fixes their Xcode 12 issue
+// https://github.com/Carthage/Carthage/issues/3019
+EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64 arm64e armv7 armv7s armv6 armv8
+EXCLUDED_ARCHS=$(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))


### PR DESCRIPTION
### What and why?

Carthage has an known issue with Xcode 12
For more: https://github.com/Carthage/Carthage/issues/3019

### How?

This workaround excludes ARM arches from carthage build
It fixes our build failure as lipo doesn't merge x86 and ARM anymore
Source: https://github.com/Carthage/Carthage/issues/3019#issuecomment-664099506

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
