### PR TITLE
RUMM-715 RUM Views - modal presentation instrumentation - part 1

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C462423990D00786299 /* TestsDirectory.swift */; };
 		61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C472423990D00786299 /* DatadogExtensions.swift */; };
 		61133C702423993200786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
+		61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */; };
+		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
 		611720D52524D9FB00634D9E /* DDURLSessionDelegate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */; };
 		61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */; };
 		6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */; };
@@ -98,6 +100,7 @@
 		61345613244756E300E7DA6B /* PerformancePresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61345612244756E300E7DA6B /* PerformancePresetTests.swift */; };
 		61363D9D24D999F70084CD6F /* DDError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61363D9C24D999F70084CD6F /* DDError.swift */; };
 		61363D9F24D99BAA0084CD6F /* DDErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */; };
+		6137E649252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6137E648252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard */; };
 		613B77382521E80800155458 /* RUMTabBarControllerScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */; };
 		613F23E4252B062F006CD2D7 /* TaskInterceptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23E3252B062F006CD2D7 /* TaskInterceptionTests.swift */; };
 		613F23F1252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23F0252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift */; };
@@ -459,6 +462,8 @@
 		61133C452423990D00786299 /* SwiftExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExtensions.swift; sourceTree = "<group>"; };
 		61133C462423990D00786299 /* TestsDirectory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestsDirectory.swift; sourceTree = "<group>"; };
 		61133C472423990D00786299 /* DatadogExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogExtensions.swift; sourceTree = "<group>"; };
+		61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSViewController.swift; sourceTree = "<group>"; };
+		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
 		611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDURLSessionDelegate+objc.swift"; sourceTree = "<group>"; };
 		61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapter.swift; sourceTree = "<group>"; };
 		61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapterTests.swift; sourceTree = "<group>"; };
@@ -476,6 +481,7 @@
 		61345612244756E300E7DA6B /* PerformancePresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePresetTests.swift; sourceTree = "<group>"; };
 		61363D9C24D999F70084CD6F /* DDError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDError.swift; sourceTree = "<group>"; };
 		61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDErrorTests.swift; sourceTree = "<group>"; };
+		6137E648252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMModalViewsAutoInstrumentationScenario.storyboard; sourceTree = "<group>"; };
 		613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTabBarControllerScenarioTests.swift; sourceTree = "<group>"; };
 		613F23E3252B062F006CD2D7 /* TaskInterceptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInterceptionTests.swift; sourceTree = "<group>"; };
 		613F23F0252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionRUMResourcesHandlerTests.swift; sourceTree = "<group>"; };
@@ -1289,6 +1295,7 @@
 				61337037250F84FD00236D58 /* ManualInstrumentation */,
 				61F9CA7725125918000A5E61 /* NavigationControllerAutoInstrumentation */,
 				615AAC34251E34EF00C89EE9 /* TabBarAutoInstrumentation */,
+				6137E647252DD85400720485 /* ModalViewsAutoInstrumentation */,
 				6193DCA2251B5669009B8011 /* TapActionAutoInstrumentation */,
 			);
 			path = RUM;
@@ -1303,6 +1310,16 @@
 				618DCFE224C766FB00589570 /* SendRUMFixture3ViewController.swift */,
 			);
 			path = ManualInstrumentation;
+			sourceTree = "<group>";
+		};
+		6137E647252DD85400720485 /* ModalViewsAutoInstrumentation */ = {
+			isa = PBXGroup;
+			children = (
+				6137E648252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard */,
+				61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */,
+				61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */,
+			);
+			path = ModalViewsAutoInstrumentation;
 			sourceTree = "<group>";
 		};
 		613F23DC252B05BD006CD2D7 /* URLFiltering */ = {
@@ -2280,6 +2297,7 @@
 				6193DCA4251B5691009B8011 /* RUMTapActionScenario.storyboard in Resources */,
 				6167ACC7251A0BCE0012B4D0 /* NSURLSessionScenario.storyboard in Resources */,
 				61441C0E24616DEC003D8BB8 /* Assets.xcassets in Resources */,
+				6137E649252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard in Resources */,
 				61441C0C24616DE9003D8BB8 /* Main.storyboard in Resources */,
 				615AAC36251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard in Resources */,
 				6167AD19251A27B80012B4D0 /* URLSessionScenario.storyboard in Resources */,
@@ -2619,6 +2637,7 @@
 				61441C982461A649003D8BB8 /* DebugTracingViewController.swift in Sources */,
 				61F9CA8025125C01000A5E61 /* RUMNCSScreen3ViewController.swift in Sources */,
 				6164AE89252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift in Sources */,
+				61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */,
 				61441C952461A649003D8BB8 /* ConsoleOutputInterceptor.swift in Sources */,
 				614CADCE250FCA0200B93D2D /* TestScenarios.swift in Sources */,
 				61441C972461A649003D8BB8 /* UIViewController+KeyboardControlling.swift in Sources */,
@@ -2634,6 +2653,7 @@
 				6164AF0E252C9016000D78C4 /* ObjcSendThirdPartyRequestsViewController.m in Sources */,
 				61441C0524616DE9003D8BB8 /* ExampleAppDelegate.swift in Sources */,
 				6193DCCE251B6201009B8011 /* RUMTASScreen1ViewController.swift in Sources */,
+				61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */,
 				61441C992461A649003D8BB8 /* DebugLoggingViewController.swift in Sources */,
 				6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */,
 				618DCFE324C766FB00589570 /* SendRUMFixture3ViewController.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		61133C702423993200786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */; };
 		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
+		61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */; };
 		611720D52524D9FB00634D9E /* DDURLSessionDelegate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */; };
 		61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */; };
 		6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */; };
@@ -464,6 +465,7 @@
 		61133C472423990D00786299 /* DatadogExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogExtensions.swift; sourceTree = "<group>"; };
 		61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSViewController.swift; sourceTree = "<group>"; };
 		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
+		61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMModalViewsScenarioTests.swift; sourceTree = "<group>"; };
 		611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDURLSessionDelegate+objc.swift"; sourceTree = "<group>"; };
 		61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapter.swift; sourceTree = "<group>"; };
 		61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapterTests.swift; sourceTree = "<group>"; };
@@ -1951,6 +1953,7 @@
 				61F9CA86251266CB000A5E61 /* RUMNavigationControllerScenarioTests.swift */,
 				613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */,
 				615AAC06251E217B00C89EE9 /* RUMTapActionScenarioTests.swift */,
+				61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */,
 				6164AF2D252C9C51000D78C4 /* RUMResourcesScenarioTests.swift */,
 			);
 			path = RUM;
@@ -2667,6 +2670,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61441C4024617013003D8BB8 /* IntegrationTests.swift in Sources */,
+				61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */,
 				61B9ED212462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift in Sources */,
 				61C2C20D24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift in Sources */,
 				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -93,6 +93,11 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_TEST_SCENARIO_IDENTIFIER"
+            value = "RUMModalViewsAutoInstrumentationScenario"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_TEST_SCENARIO_IDENTIFIER"
             value = "RUMResourcesScenario"
             isEnabled = "NO">
          </EnvironmentVariable>

--- a/Datadog/Example/Scenarios/RUM/ModalViewsAutoInstrumentation/RUMMVSModalViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/ModalViewsAutoInstrumentation/RUMMVSModalViewController.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+/// The VC presented modally.
+class RUMMVSModalViewController: UIViewController {
+    @IBAction func didTapDismissUsingSelf(_ sender: Any) {
+        if Bool.random() {
+            dismiss(animated: true) { /* empty completion block */ }
+        } else {
+            dismiss(animated: true)
+        }
+    }
+
+    @IBAction func didTapDismissUsingParent(_ sender: Any) {
+        let presentingNavigationController = (presentingViewController as! UINavigationController)
+        let presentingViewController = (presentingNavigationController.viewControllers[0] as! RUMMVSViewController)
+        presentingViewController.dismissPresentedViewController()
+    }
+}

--- a/Datadog/Example/Scenarios/RUM/ModalViewsAutoInstrumentation/RUMMVSViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/ModalViewsAutoInstrumentation/RUMMVSViewController.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+/// The VC which presents another VC modally.
+class RUMMVSViewController: UIViewController {
+    @IBAction func didTapPresentModallyFromCode(_ sender: Any) {
+        let modalViewController = storyboard!.instantiateViewController(withIdentifier: "ModalVC")
+
+        if Bool.random() {
+            present(modalViewController, animated: true) { /* empty completion block */ }
+        } else {
+            present(modalViewController, animated: true)
+        }
+    }
+
+    /// This method gets called from presented view controller.
+    func dismissPresentedViewController() {
+        if Bool.random() {
+            dismiss(animated: true) { /* empty completion block */ }
+        } else {
+            dismiss(animated: true)
+        }
+    }
+}

--- a/Datadog/Example/Scenarios/RUM/ModalViewsAutoInstrumentation/RUMModalViewsAutoInstrumentationScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/ModalViewsAutoInstrumentation/RUMModalViewsAutoInstrumentationScenario.storyboard
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="yYn-cJ-9uk">
+    <device id="retina6_1" orientation="portrait" appearance="dark"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Navigation Controller-->
+        <scene sceneID="42Y-YJ-XC9">
+            <objects>
+                <navigationController id="yYn-cJ-9uk" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="n5j-rh-GT3">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="XRh-Qd-KvE" kind="relationship" relationship="rootViewController" id="doi-DH-TJA"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xnH-K8-Hgo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-201" y="569"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="3LJ-yU-L0k">
+            <objects>
+                <viewController hidesBottomBarWhenPushed="YES" id="XRh-Qd-KvE" customClass="RUMMVSViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="1hq-Ia-ebN">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PXa-aF-cTn">
+                                <rect key="frame" x="8" y="96" width="398" height="96"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LYP-xe-cXi">
+                                        <rect key="frame" x="0.0" y="0.0" width="398" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="AgU-OF-4eN"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Sfb-Qf-VBn"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Present modally using segue">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="7X1-5F-bV7" kind="presentation" id="tt3-9E-4sn"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nVV-wE-8aD">
+                                        <rect key="frame" x="0.0" y="52" width="398" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="5Ne-6r-buf"/>
+                                            <constraint firstAttribute="height" constant="44" id="k1n-6v-bcD"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Present modally from code">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="didTapPresentModallyFromCode:" destination="XRh-Qd-KvE" eventType="touchUpInside" id="1NQ-wi-P8u"/>
+                                            <action selector="didTapPresentModallyFromCode:" destination="EcB-yF-k5k" eventType="touchUpInside" id="1X6-sb-Idl"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="hHi-2P-qsF"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="hHi-2P-qsF" firstAttribute="trailing" secondItem="PXa-aF-cTn" secondAttribute="trailing" constant="8" id="0YL-OF-Rvq"/>
+                            <constraint firstItem="PXa-aF-cTn" firstAttribute="top" secondItem="hHi-2P-qsF" secondAttribute="top" constant="8" id="6nz-xV-OjE"/>
+                            <constraint firstItem="PXa-aF-cTn" firstAttribute="leading" secondItem="hHi-2P-qsF" secondAttribute="leading" constant="8" id="XZb-50-B5N"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="VKG-U3-He7"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen1"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="tmI-bf-Hla" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <exit id="EcB-yF-k5k" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="646" y="569"/>
+        </scene>
+        <!--Modal View Controller-->
+        <scene sceneID="PKt-Yc-fOQ">
+            <objects>
+                <viewController storyboardIdentifier="ModalVC" hidesBottomBarWhenPushed="YES" id="7X1-5F-bV7" customClass="RUMMVSModalViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Pf4-r4-ZjT">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="baS-0f-sHa">
+                                <rect key="frame" x="8" y="8" width="398" height="96"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="108-MZ-dJP">
+                                        <rect key="frame" x="0.0" y="0.0" width="398" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="QrA-vt-Q4o"/>
+                                            <constraint firstAttribute="height" constant="44" id="Ufi-aF-S9M"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Dismiss by self.dismiss()">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="didTapDismissUsingSelf:" destination="7X1-5F-bV7" eventType="touchUpInside" id="02U-lJ-R9A"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pf1-mM-ywB">
+                                        <rect key="frame" x="0.0" y="52" width="398" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="YeA-Uz-3TV"/>
+                                            <constraint firstAttribute="height" constant="44" id="kvT-8j-L1Z"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Dismiss by parent.dismiss()">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="didTapDismissUsingParent:" destination="7X1-5F-bV7" eventType="touchUpInside" id="Ju8-Tc-vuL"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="4AW-jT-NHH"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="baS-0f-sHa" firstAttribute="top" secondItem="4AW-jT-NHH" secondAttribute="top" constant="8" id="JIV-Q7-HRI"/>
+                            <constraint firstItem="4AW-jT-NHH" firstAttribute="trailing" secondItem="baS-0f-sHa" secondAttribute="trailing" constant="8" id="Yqt-EL-lIR"/>
+                            <constraint firstItem="baS-0f-sHa" firstAttribute="leading" secondItem="4AW-jT-NHH" secondAttribute="leading" constant="8" id="rLb-kS-UE3"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="nGy-Yh-Ivr"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen2"/>
+                    </userDefinedRuntimeAttributes>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Yhs-EO-mhP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1649" y="569"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Datadog/Example/TestScenarios.swift
+++ b/Datadog/Example/TestScenarios.swift
@@ -49,6 +49,8 @@ func createTestScenario(for envIdentifier: String) -> TestScenario {
         return RUMTabBarAutoInstrumentationScenario()
     case RUMTapActionScenario.envIdentifier():
         return RUMTapActionScenario()
+    case RUMModalViewsAutoInstrumentationScenario.envIdentifier():
+        return RUMModalViewsAutoInstrumentationScenario()
     case RUMResourcesScenario.envIdentifier():
         return RUMResourcesScenario()
     default:
@@ -203,6 +205,29 @@ struct RUMNavigationControllerScenario: TestScenario {
 /// its view controllers. Tracks view controllers as RUM Views.
 struct RUMTabBarAutoInstrumentationScenario: TestScenario {
     static var storyboardName: String = "RUMTabBarAutoInstrumentationScenario"
+
+    private class Predicate: UIKitRUMViewsPredicate {
+        func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+            if let viewName = viewController.accessibilityLabel {
+                return .init(path: viewName)
+            } else {
+                return nil
+            }
+        }
+    }
+
+    func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder
+            .trackUIKitRUMViews(using: Predicate())
+            .enableLogging(false)
+            .enableTracing(false)
+    }
+}
+
+/// Scenario based on `UINavigationController` hierarchy, which presents different VCs modally.
+/// Tracks view controllers as RUM Views.
+struct RUMModalViewsAutoInstrumentationScenario: TestScenario {
+    static var storyboardName: String = "RUMModalViewsAutoInstrumentationScenario"
 
     private class Predicate: UIKitRUMViewsPredicate {
         func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import HTTPServerMock
+import XCTest
+
+private extension ExampleApplication {
+    func tapButton(titled buttonTitle: String) {
+        buttons[buttonTitle].tap()
+    }
+
+    func swipeToPullModalDown() {
+        let coordinate1 = coordinate(withNormalizedOffset: .init(dx: 0.5, dy: 0.25))
+        let coordinate2 = coordinate(withNormalizedOffset: .init(dx: 0.5, dy: 0.75))
+        coordinate1.press(forDuration: 0.3, thenDragTo: coordinate2)
+    }
+
+    func swipeToPullModalDownButThenCancel() {
+        let coordinate1 = coordinate(withNormalizedOffset: .init(dx: 0.5, dy: 0.25))
+        let coordinate2 = coordinate(withNormalizedOffset: .init(dx: 0.5, dy: 0.35))
+        coordinate1.press(forDuration: 0.3, thenDragTo: coordinate2)
+    }
+}
+
+class RUMModalViewsScenarioTests: IntegrationTests {
+    func testRUMModalViewsScenario() throws {
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenario: RUMModalViewsAutoInstrumentationScenario.self,
+            serverConfiguration: HTTPServerMockConfiguration()
+        ) // start on "Screen1"
+
+        app.tapButton(titled: "Present modally using segue") // go to modal "Screen2"
+        app.tapButton(titled: "Dismiss by self.dismiss()") // dismiss to "Screen1"
+        app.tapButton(titled: "Present modally from code") // go to modal "Screen2"
+        app.tapButton(titled: "Dismiss by parent.dismiss()") // dismiss to "Screen1"
+        app.tapButton(titled: "Present modally using segue") // go to modal "Screen2"
+        app.swipeToPullModalDown() // interactive dismiss to "Screen1"
+        app.tapButton(titled: "Present modally from code") // go to modal "Screen2"
+        app.swipeToPullModalDownButThenCancel() // interactive and cancelled dismiss, stay on "Screen2"
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This is the initial PR for modal view controllers auto instrumentation with RUM Views. It adds the test scenario fixture for developing, debugging and testing (with integration test) this feature.

### How?

I added a simple storyboard composed of 2 VCs. The first one presents the second modally. The integration test (yet with no assertions) runs 6 behaviours:
* presenting modal VC using storyboard segue,
* presenting modal VC using `present(_:animated:)`,
* dismissing modal VC using `self.dismiss(animated:)`,
* dismissing modal VC using `presentingViewController.dismiss(animated:)`,
* dismissing modal VC using interactive "pull down" gesture,
* cancelling modal VC dismissal by cancelling the interactive "pull down" gesture.

![Oct-07-2020 16-22-43](https://user-images.githubusercontent.com/2358722/95347061-c6f8cc80-08bc-11eb-84eb-71fea82a324b.gif)

In the next PRs I'll be adding necessary implementation for instrumenting this flow with RUM Views.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
