### PR TITLE
RUMM-801 Fix tests flakiness on CI

### DIFF
--- a/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/FileWriterTests.swift
@@ -177,8 +177,8 @@ class FileWriterTests: XCTestCase {
             var foo = "bar"
         }
 
-        // Write 500 of `Foo`s and interrupt writes randomly
-        (0..<500).forEach { _ in
+        // Write 300 of `Foo`s and interrupt writes randomly
+        (0..<300).forEach { _ in
             writer.write(value: Foo())
             randomlyInterruptIO(for: try? temporaryDirectory.files().first)
         }
@@ -193,9 +193,9 @@ class FileWriterTests: XCTestCase {
 
         // Assert that data written is not malformed
         let writtenData = try jsonDecoder.decode([Foo].self, from: "[".utf8Data + fileData + "]".utf8Data)
-        // Assert that some, but not all `Foo`s were skipped
+        // Assert that some (including all) `Foo`s were written
         XCTAssertGreaterThan(writtenData.count, 0)
-        XCTAssertLessThan(writtenData.count, 500)
+        XCTAssertLessThanOrEqual(writtenData.count, 300)
     }
 
     private func waitForWritesCompletion(on queue: DispatchQueue, thenFulfill expectation: XCTestExpectation) {

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -131,7 +131,7 @@ class DataUploadWorkerTests: XCTestCase {
                 featureName: .mockAny()
             )
         ]) {
-            self.wait(for: [expectation], timeout: (mockDelay.current + 0.1) * 1.5)
+            self.wait(for: [expectation], timeout: 1.5)
         }
     }
 
@@ -163,7 +163,7 @@ class DataUploadWorkerTests: XCTestCase {
                 featureName: .mockAny()
             )
         ]) {
-            self.wait(for: [expectation], timeout: (mockDelay.current + 0.1) * 1.5)
+            self.wait(for: [expectation], timeout: 1.5)
         }
     }
     // swiftlint:enable multiline_arguments_brackets
@@ -177,7 +177,8 @@ struct MockDelay: Delay {
     // NOTE: RUMM-737 private only doesn't compile due to "private initializer is inaccessible", probably a bug in Swift
     private(set) var didReceiveCommand = false
 
-    var current: TimeInterval { 0.0 }
+    let current: TimeInterval = 0
+
     mutating func decrease() {
         if didReceiveCommand {
             return

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -54,7 +54,10 @@ private class ServerMockProtocol: URLProtocol {
     }
 
     override func stopLoading() {
-        precondition(ServerMock.activeInstance != nil, "Request was stopped while no `ServerMock` instance is active.")
+        if ServerMock.activeInstance != nil {
+            // This may happen when testing requests which deliver completion on the `URLSessionDelegate`.
+            print("⚠️ Request was stopped while no `ServerMock` instance is active.")
+        }
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -32,24 +32,20 @@ private class ServerMockProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        guard let serverMock = ServerMock.activeInstance else {
-            preconditionFailure("Request was started while no `ServerMock` instance is active.")
-        }
-
-        if let response = serverMock.mockedResponse {
+        if let response = ServerMock.activeInstance?.mockedResponse {
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         }
-        if let data = serverMock.mockedData {
+        if let data = ServerMock.activeInstance?.mockedData {
             client?.urlProtocol(self, didLoad: data)
         }
-        if let error = serverMock.mockedError {
+        if let error = ServerMock.activeInstance?.mockedError {
             client?.urlProtocol(self, didFailWithError: error)
         }
 
         client?.urlProtocolDidFinishLoading(self)
 
         DispatchQueue.main.async {
-            serverMock.record(newRequest: self.request)
+            ServerMock.activeInstance?.record(newRequest: self.request)
         }
     }
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,7 +21,7 @@ workflows:
     description: |-
         Does `make dependencies` to prepare source code in repo for building and testing.
     steps:
-    - script@1.1.6:
+    - script:
         title: Do `make dependencies`.
         inputs:
         - content: |-
@@ -54,7 +54,7 @@ workflows:
         - linting_path: "$BITRISE_SOURCE_DIR"
         - lint_config_file: "$BITRISE_SOURCE_DIR/tools/lint/tests.swiftlint.yml"
         - reporter: emoji
-    - script@1.1.6:
+    - script:
         title: Check license headers
         is_always_run: true
         inputs:
@@ -62,7 +62,7 @@ workflows:
             #!/usr/bin/env bash
             set -e
             ./tools/license/check-license.sh
-    - script@1.1.6:
+    - script:
         title: Verify RUM data models
         is_always_run: true
         inputs:
@@ -77,7 +77,7 @@ workflows:
         Runs benchmarks for SDK on iOS Simulator.
         Runs unit tests for HTTPServerMock package on macOS.
     steps:
-    - xcode-test@2.4.5:
+    - xcode-test:
         title: Run unit tests for Datadog - iOS Simulator
         inputs:
         - scheme: Datadog
@@ -96,7 +96,7 @@ workflows:
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Benchmark-tests.html"
-    - script@1.1.6:
+    - script:
         title: Generate HTTPServerMock.xcodeproj
         inputs:
         - content: |-
@@ -130,7 +130,7 @@ workflows:
         Uses supported dependency managers to fetch, install and link the SDK
         to test projects.
     steps:
-    - script@1.1.6:
+    - script:
         title: Test SPM compatibility
         inputs:
         - content: |-
@@ -145,7 +145,7 @@ workflows:
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/spm/SPMProject.xcodeproj"
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPMProject-tests.html"
-    - script@1.1.6:
+    - script:
         title: Test Carthage compatibility
         inputs:
         - content: |-
@@ -160,7 +160,7 @@ workflows:
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/carthage/CTProject.xcodeproj"
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CTProject-tests.html"
-    - script@1.1.6:
+    - script:
         title: Test Cocoapods compatibility
         inputs:
         - content: |-


### PR DESCRIPTION
### What and why?

⚙️ This PR fixes recent flakiness observed on CI.

### How?

When analysing failed job reports, I observed two main sources of the flakiness:
* too optimistic timeouts,
* failed preconditions in `ServerMock`.

The conclusion made back in #72 was that for some complex tests, CI needs the timeout of 40x more than the test execution in local. I bumped recently failing timeouts to level close to this.

With the introduction of `URLSessionDelegate`, we no longer make blocking `expectation.fulfill()` for all `URLSessionTask` completions (the one received on delegate are not blocking). This makes some of the original assumptions included in `ServerMock` invalid. I changed them to print warning, instead of failing the test.

More in description of each commit.

### Result

I ran unit tests successfully 20 times in a row on CI ✅, vs 40% of flakiness before.

### Further improvements

This PR should improve the workflow for now, but some small flakiness may still be observed. There are two JIRAs created a while a go and both are still valid:
* `RUMM-417` to look closer into `ServerMock`,
* `RUMM-742` to make integration tests not depend on the number of requests sent to the Python server.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
