### PR TITLE
RUMM-801 Fix unit tests compilation for Xcode 11.5

### DIFF
--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -173,9 +173,9 @@ struct MockDelay: Delay {
     enum Command {
         case increase, decrease
     }
-    let callback: (Command) -> Void
     // NOTE: RUMM-737 private only doesn't compile due to "private initializer is inaccessible", probably a bug in Swift
     private(set) var didReceiveCommand = false
+    let callback: (Command) -> Void
 
     let current: TimeInterval = 0
 


### PR DESCRIPTION
### What and why?

⚙️ This PR fixes the tests compilation issue in Xcode 11.5.

### How?

This seems to be a compiler bug fixed in Xcode 11.6

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
