### PR TITLE
RUMM-816 SDK is made compile for Catalyst

### DIFF
--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -38,6 +38,7 @@ internal protocol CarrierInfoProviderType {
 extension CarrierInfo.RadioAccessTechnology {
     init(ctRadioAccessTechnologyConstant: String) {
         switch ctRadioAccessTechnologyConstant {
+        #if !targetEnvironment(macCatalyst)
         case CTRadioAccessTechnologyGPRS: self = .GPRS
         case CTRadioAccessTechnologyEdge: self = .Edge
         case CTRadioAccessTechnologyWCDMA: self = .WCDMA
@@ -49,12 +50,16 @@ extension CarrierInfo.RadioAccessTechnology {
         case CTRadioAccessTechnologyCDMAEVDORevB: self = .CDMAEVDORevB
         case CTRadioAccessTechnologyeHRPD: self = .eHRPD
         case CTRadioAccessTechnologyLTE: self = .LTE
+        #endif
         default: self = .unknown
         }
     }
 }
 
 internal class CarrierInfoProvider: CarrierInfoProviderType {
+    #if targetEnvironment(macCatalyst)
+    let current: CarrierInfo? = nil
+    #else
     private let networkInfo: CTTelephonyNetworkInfo
 
     init(networkInfo: CTTelephonyNetworkInfo = CTTelephonyNetworkInfo()) {
@@ -88,4 +93,5 @@ internal class CarrierInfoProvider: CarrierInfoProviderType {
             radioAccessTechnology: .init(ctRadioAccessTechnologyConstant: radioAccessTechnology)
         )
     }
+    #endif
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -47,14 +47,14 @@ public class Datadog {
     ///   - appContext: context passing information about the app.
     ///   - configuration: the SDK configuration obtained using `Datadog.Configuration.builderUsing(clientToken:)`.
     public static func initialize(appContext: AppContext, configuration: Configuration) {
+        // TODO: RUMM-511 remove this warning
+        #if targetEnvironment(macCatalyst)
+        consolePrint("⚠️ Catalyst is not officially supported by Datadog SDK: some features may NOT be functional!")
+        #endif
         do {
             try initializeOrThrow(
                 configuration: try FeaturesConfiguration(configuration: configuration, appContext: appContext)
             )
-            // TODO: RUMM-511 remove this warning
-            #if targetEnvironment(macCatalyst)
-            userLogger.warn("⚠️ Catalyst is not officially supported by Datadog SDK: use at your own risk!")
-            #endif
         } catch {
             consolePrint("\(error)")
         }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -51,6 +51,10 @@ public class Datadog {
             try initializeOrThrow(
                 configuration: try FeaturesConfiguration(configuration: configuration, appContext: appContext)
             )
+            // TODO: RUMM-511 remove this warning
+            #if targetEnvironment(macCatalyst)
+            userLogger.warn("⚠️ Catalyst is not officially supported by Datadog SDK: use at your own risk!")
+            #endif
         } catch {
             consolePrint("\(error)")
         }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -137,16 +137,24 @@ workflows:
             #!/usr/bin/env bash
             set -e
             make test-spm ci=true
+    - xcodebuild:
+        title: Build SPMProject for tests - Catalyst
+        inputs:
+        - scheme: SPMProject
+        - destination: platform=macOS,variant=Mac Catalyst
+        - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/spm/SPMProject.xcodeproj"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPMProject-catalyst-sanity-check.html"
     - xcode-test:
         title: Run SPMProject tests
         inputs:
         - scheme: SPMProject
+        - simulator_device: iPhone 11
         - is_clean_build: 'yes'
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/spm/SPMProject.xcodeproj"
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPMProject-tests.html"
     - script:
-        title: Test Carthage compatibility
+        title: Test Carthage compatibility (Carthage doesn't support Catalyst!)
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -156,6 +164,7 @@ workflows:
         title: Run CTProject tests
         inputs:
         - scheme: CTProject
+        - simulator_device: iPhone 11
         - is_clean_build: 'yes'
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/carthage/CTProject.xcodeproj"
@@ -167,10 +176,18 @@ workflows:
             #!/usr/bin/env bash
             set -e
             make test-cocoapods ci=true
+    - xcodebuild:
+        title: Build CPProject for tests - Catalyst
+        inputs:
+        - scheme: CPProject
+        - destination: platform=macOS,variant=Mac Catalyst
+        - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/cocoapods/CPProject.xcodeproj"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CPProject-catalyst-sanity-check.html"
     - xcode-test:
         title: Run CPProject tests
         inputs:
         - scheme: CPProject
+        - simulator_device: iPhone 11
         - is_clean_build: 'yes'
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/cocoapods/CPProject.xcworkspace"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -154,7 +154,8 @@ workflows:
         - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/spm/SPMProject.xcodeproj"
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPMProject-tests.html"
     - script:
-        title: Test Carthage compatibility (Carthage doesn't support Catalyst!)
+        # Carthage doesn't support Catalyst, so we don't test CTProject for `variant=Mac Catalyst`
+        title: Test Carthage compatibility
         inputs:
         - content: |-
             #!/usr/bin/env bash

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
@@ -534,7 +534,9 @@
 			baseConfigurationReference = 5AD49F84C2EA2EE5CB99586F /* Pods-CPProject.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CPProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -542,6 +544,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -552,7 +557,9 @@
 			baseConfigurationReference = C7DE97263B77DC87F0FC27F0 /* Pods-CPProject.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CPProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -560,6 +567,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -569,7 +579,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CPProjectUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -578,6 +590,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = CPProject;
@@ -588,7 +602,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CPProjectUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -597,6 +613,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = CPProject;
@@ -607,7 +625,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CPProjectTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -616,6 +636,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CPProject.app/CPProject";
@@ -626,7 +648,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CPProjectTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -635,6 +659,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CPProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CPProject.app/CPProject";

--- a/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
+++ b/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
@@ -500,7 +500,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SPMProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -508,6 +510,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.SPMProject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -517,7 +522,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SPMProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -525,6 +532,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.SPMProject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -535,7 +545,10 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SPMProjectTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -544,6 +557,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.SPMProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SPMProject.app/SPMProject";
@@ -555,7 +570,10 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SPMProjectTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -564,6 +582,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.SPMProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SPMProject.app/SPMProject";
@@ -574,7 +594,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SPMProjectUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -583,6 +605,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.SPMProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = SPMProject;
@@ -593,7 +617,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SPMProjectUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -602,6 +628,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.SPMProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = SPMProject;


### PR DESCRIPTION
## ⚠️ Important ⚠️

With this PR the SDK compiles for Catalyst, yet we do not guarantee its correctness at runtime at the moment
Official Catalyst support is in our roadmap and we will announce it once it's done

### What and why?

As #274 points out, our users may need to compile their app target for Mac Catalyst too
Since our SDK doesn't compile for Catalyst, either our users need to duplicate their app target for Catalyst without linking Datadog SDK or add the framework conditionally via linker flags (which may be tricky or impossible with Swift Package Manager though)

### How?

SDK codebase doesn't depend on iOS-only frameworks, except `CoreTelephony`
We used `#if targetEnvironment(macCatalyst)` to disable `CoreTelephony`-dependent code from compiling

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
