### PR TITLE
RUMM-715 RUM Views auto instrumentation - modal presentation

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 		61F1A61A2498A51700075390 /* CoreMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A6192498A51700075390 /* CoreMocks.swift */; };
 		61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A620249A45E400075390 /* DDSpanContextTests.swift */; };
 		61F1A623249B811200075390 /* Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A622249B811200075390 /* Encoding.swift */; };
+		61F3C9712535AE9400E2F8C4 /* UIKitHierarchyInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3C9702535AE9400E2F8C4 /* UIKitHierarchyInspector.swift */; };
 		61F3CD9A2510D8C500C816E5 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614CADD62510BAC000B93D2D /* Environment.swift */; };
 		61F3CD9B2510D95A00C816E5 /* TestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614CADCD250FCA0200B93D2D /* TestScenarios.swift */; };
 		61F3CDA3251118FB00C816E5 /* UIKitRUMViewsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA2251118FB00C816E5 /* UIKitRUMViewsHandler.swift */; };
@@ -676,6 +677,7 @@
 		61F1A6192498A51700075390 /* CoreMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMocks.swift; sourceTree = "<group>"; };
 		61F1A620249A45E400075390 /* DDSpanContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanContextTests.swift; sourceTree = "<group>"; };
 		61F1A622249B811200075390 /* Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encoding.swift; sourceTree = "<group>"; };
+		61F3C9702535AE9400E2F8C4 /* UIKitHierarchyInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitHierarchyInspector.swift; sourceTree = "<group>"; };
 		61F3CDA2251118FB00C816E5 /* UIKitRUMViewsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsHandler.swift; sourceTree = "<group>"; };
 		61F3CDA42511190E00C816E5 /* UIViewControllerSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerSwizzler.swift; sourceTree = "<group>"; };
 		61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsPredicate.swift; sourceTree = "<group>"; };
@@ -1917,6 +1919,14 @@
 			path = SystemFrameworks;
 			sourceTree = "<group>";
 		};
+		61F3C96F2535AC7600E2F8C4 /* UIKitHierarchyInspection */ = {
+			isa = PBXGroup;
+			children = (
+				61F3C9702535AE9400E2F8C4 /* UIKitHierarchyInspector.swift */,
+			);
+			path = UIKitHierarchyInspection;
+			sourceTree = "<group>";
+		};
 		61F3CD9C251106EB00C816E5 /* Scenarios */ = {
 			isa = PBXGroup;
 			children = (
@@ -1962,6 +1972,7 @@
 		61F3CDA1251118DD00C816E5 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				61F3C96F2535AC7600E2F8C4 /* UIKitHierarchyInspection */,
 				61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */,
 				61F3CDA2251118FB00C816E5 /* UIKitRUMViewsHandler.swift */,
 				61F3CDA42511190E00C816E5 /* UIViewControllerSwizzler.swift */,
@@ -2382,6 +2393,7 @@
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,
 				6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */,
 				61133BDC2423979B00786299 /* Logger.swift in Sources */,
+				61F3C9712535AE9400E2F8C4 /* UIKitHierarchyInspector.swift in Sources */,
 				61133BD02423979B00786299 /* DateProvider.swift in Sources */,
 				6156CB8E24DDA1B5008CB2B2 /* RUMContextProvider.swift in Sources */,
 				61C2C21224C5951400C0321C /* RUMViewScope.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
 		61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */; };
 		611720D52524D9FB00634D9E /* DDURLSessionDelegate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */; };
+		611B413D2535FA7F000F8939 /* RUMM742Workaround.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611B413C2535FA7F000F8939 /* RUMM742Workaround.swift */; };
 		61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */; };
 		6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */; };
 		612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612983CC2449E62E00D4424B /* LoggingFeature.swift */; };
@@ -469,6 +470,7 @@
 		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
 		61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMModalViewsScenarioTests.swift; sourceTree = "<group>"; };
 		611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDURLSessionDelegate+objc.swift"; sourceTree = "<group>"; };
+		611B413C2535FA7F000F8939 /* RUMM742Workaround.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMM742Workaround.swift; sourceTree = "<group>"; };
 		61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapter.swift; sourceTree = "<group>"; };
 		61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapterTests.swift; sourceTree = "<group>"; };
 		612983CC2449E62E00D4424B /* LoggingFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeature.swift; sourceTree = "<group>"; };
@@ -1429,6 +1431,7 @@
 				61441C3B24617013003D8BB8 /* IntegrationTests.swift */,
 				61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */,
 				61F3CD9C251106EB00C816E5 /* Scenarios */,
+				611B413C2535FA7F000F8939 /* RUMM742Workaround.swift */,
 			);
 			name = DatadogIntegrationTests;
 			path = ../Tests/DatadogIntegrationTests;
@@ -2707,6 +2710,7 @@
 				61F9CA9F2513978D000A5E61 /* RUMSessionMatcher.swift in Sources */,
 				61F9CA92251266F7000A5E61 /* RUMNavigationControllerScenarioTests.swift in Sources */,
 				61410141251A454500E3C2D9 /* TracingCommonAsserts.swift in Sources */,
+				611B413D2535FA7F000F8939 /* RUMM742Workaround.swift in Sources */,
 				61441C4924618052003D8BB8 /* JSONDataMatcher.swift in Sources */,
 				615AAC29251E322D00C89EE9 /* RUMCommonAsserts.swift in Sources */,
 				61F3CD9B2510D95A00C816E5 /* TestScenarios.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		6167ACFD251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167ACFC251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift */; };
 		6167AD19251A27B80012B4D0 /* URLSessionScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6167AD18251A27B80012B4D0 /* URLSessionScenario.storyboard */; };
 		6167AD20251A27CC0012B4D0 /* SendFirstPartyRequestsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167AD1F251A27CC0012B4D0 /* SendFirstPartyRequestsViewController.swift */; };
+		616A9CD22535D38200DB83CF /* UIKitHierarchyInspectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616A9CD12535D38200DB83CF /* UIKitHierarchyInspectorTests.swift */; };
 		616CCE13250A1868009FED46 /* RUMCommandSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CCE12250A1868009FED46 /* RUMCommandSubscriber.swift */; };
 		616CCE16250A467E009FED46 /* RUMAutoInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CCE15250A467E009FED46 /* RUMAutoInstrumentation.swift */; };
 		61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */; };
@@ -562,6 +563,7 @@
 		6167ACFC251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingURLSessionScenarioTests.swift; sourceTree = "<group>"; };
 		6167AD18251A27B80012B4D0 /* URLSessionScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = URLSessionScenario.storyboard; sourceTree = "<group>"; };
 		6167AD1F251A27CC0012B4D0 /* SendFirstPartyRequestsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendFirstPartyRequestsViewController.swift; sourceTree = "<group>"; };
+		616A9CD12535D38200DB83CF /* UIKitHierarchyInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitHierarchyInspectorTests.swift; sourceTree = "<group>"; };
 		616CCE12250A1868009FED46 /* RUMCommandSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommandSubscriber.swift; sourceTree = "<group>"; };
 		616CCE15250A467E009FED46 /* RUMAutoInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAutoInstrumentation.swift; sourceTree = "<group>"; };
 		61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebuggingTests.swift; sourceTree = "<group>"; };
@@ -1569,6 +1571,14 @@
 			path = URLSessionAutoInstrumentation;
 			sourceTree = "<group>";
 		};
+		616A9CD02535D36A00DB83CF /* UIKitHierarchyInspection */ = {
+			isa = PBXGroup;
+			children = (
+				616A9CD12535D38200DB83CF /* UIKitHierarchyInspectorTests.swift */,
+			);
+			path = UIKitHierarchyInspection;
+			sourceTree = "<group>";
+		};
 		616CCE11250A181C009FED46 /* AutoInstrumentation */ = {
 			isa = PBXGroup;
 			children = (
@@ -1994,6 +2004,7 @@
 		61F3CDA925121FA100C816E5 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				616A9CD02535D36A00DB83CF /* UIKitHierarchyInspection */,
 				61F3CDAA25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift */,
 				61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */,
 			);
@@ -2618,6 +2629,7 @@
 				61133C532423990D00786299 /* MobileDeviceTests.swift in Sources */,
 				61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */,
 				61345613244756E300E7DA6B /* PerformancePresetTests.swift in Sources */,
+				616A9CD22535D38200DB83CF /* UIKitHierarchyInspectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Datadog/Example/Scenarios/RUM/ModalViewsAutoInstrumentation/RUMModalViewsAutoInstrumentationScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/ModalViewsAutoInstrumentation/RUMModalViewsAutoInstrumentationScenario.storyboard
@@ -34,32 +34,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PXa-aF-cTn">
-                                <rect key="frame" x="8" y="96" width="398" height="96"/>
+                                <rect key="frame" x="8" y="96" width="398" height="148"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LYP-xe-cXi">
-                                        <rect key="frame" x="0.0" y="0.0" width="398" height="44"/>
-                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="AgU-OF-4eN"/>
-                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Sfb-Qf-VBn"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <state key="normal" title="Present modally using segue">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                <integer key="value" value="7"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <segue destination="7X1-5F-bV7" kind="presentation" id="tt3-9E-4sn"/>
-                                        </connections>
-                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nVV-wE-8aD">
-                                        <rect key="frame" x="0.0" y="52" width="398" height="44"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="398" height="44"/>
                                         <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="5Ne-6r-buf"/>
@@ -81,6 +59,50 @@
                                             <action selector="didTapPresentModallyFromCode:" destination="EcB-yF-k5k" eventType="touchUpInside" id="1X6-sb-Idl"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LYP-xe-cXi">
+                                        <rect key="frame" x="0.0" y="52" width="398" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="AgU-OF-4eN"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Sfb-Qf-VBn"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Present modally - .fullScreen">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="7X1-5F-bV7" kind="presentation" modalPresentationStyle="fullScreen" id="tt3-9E-4sn"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yf8-KK-id5">
+                                        <rect key="frame" x="0.0" y="104" width="398" height="44"/>
+                                        <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="JaL-50-yKF"/>
+                                            <constraint firstAttribute="height" constant="44" id="XNE-hY-8Vd"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <state key="normal" title="Present modally - .pageSheet">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="7X1-5F-bV7" kind="presentation" modalPresentationStyle="pageSheet" id="sad-nE-IfX"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                             </stackView>
                         </subviews>
@@ -94,7 +116,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="VKG-U3-He7"/>
                     <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen1"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen"/>
                     </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tmI-bf-Hla" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -170,7 +192,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="nGy-Yh-Ivr"/>
                     <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Screen2"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="Modal"/>
                     </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Yhs-EO-mhP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -178,6 +200,9 @@
             <point key="canvasLocation" x="1649" y="569"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="sad-nE-IfX"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/ObjcSendFirstPartyRequestsViewController.m
+++ b/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/ObjcSendFirstPartyRequestsViewController.m
@@ -24,8 +24,8 @@
     assert(self.testScenario != nil);
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
 
     [self callSuccessfullFirstPartyURL];
     [self callSuccessfullFirstPartyURLRequest];

--- a/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/ObjcSendThirdPartyRequestsViewController.m
+++ b/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/ObjcSendThirdPartyRequestsViewController.m
@@ -24,8 +24,8 @@
     assert(self.testScenario != nil);
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
 
     [self callThirdPartyURL];
     [self callThirdPartyURLRequest];

--- a/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/SendFirstPartyRequestsViewController.swift
+++ b/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/SendFirstPartyRequestsViewController.swift
@@ -21,8 +21,8 @@ internal class SendFirstPartyRequestsViewController: UIViewController {
         testScenario = (appConfiguration.testScenario as! URLSessionBaseScenario)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
 
         callSuccessfullFirstPartyURL()
         callSuccessfullFirstPartyURLRequest()

--- a/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/SendThirdPartyRequestsViewController.swift
+++ b/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/SendThirdPartyRequestsViewController.swift
@@ -21,8 +21,8 @@ internal class SendThirdPartyRequestsViewController: UIViewController {
         self.testScenario = (appConfiguration.testScenario as! URLSessionBaseScenario)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
 
         callThirdPartyURL()
         callThirdPartyURLRequest()

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspector.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspector.swift
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+/// Inspects the view controllers hierarchy of the current window and finds
+/// the `UIViewController` which is currently displayed to the user.
+internal protocol UIKitHierarchyInspectorType {
+    func topViewController() -> UIViewController?
+}
+
+internal struct UIKitHierarchyInspector: UIKitHierarchyInspectorType {
+    func topViewController() -> UIViewController? {
+        return nil
+    }
+}

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspector.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspector.swift
@@ -9,11 +9,61 @@ import UIKit
 /// Inspects the view controllers hierarchy of the current window and finds
 /// the `UIViewController` which is currently displayed to the user.
 internal protocol UIKitHierarchyInspectorType {
+    /// The top-most `UIViewController` currently displayed to the user.
     func topViewController() -> UIViewController?
 }
 
 internal struct UIKitHierarchyInspector: UIKitHierarchyInspectorType {
+    private let rootViewControllerProvider: () -> UIViewController?
+
+    init(
+        rootViewControllerProvider: @escaping () -> UIViewController? = {
+            UIApplication.shared.keyWindow?.rootViewController
+        }
+    ) {
+        self.rootViewControllerProvider = rootViewControllerProvider
+    }
+
+    // MARK: - UIKitHierarchyInspectorType
+
     func topViewController() -> UIViewController? {
-        return nil
+        guard let rootVC = rootViewControllerProvider() else {
+            return nil
+        }
+
+        guard let highestPresentedVC = findHighestPresentedViewControllerInHierarchy(of: rootVC) else {
+            return nil
+        }
+
+        return findTopViewControllerInHierarchy(of: highestPresentedVC)
+    }
+
+    // MARK: - Private
+
+    private func findHighestPresentedViewControllerInHierarchy(of viewController: UIViewController) -> UIViewController? {
+        if let presentedVC = viewController.presentedViewController {
+            return findHighestPresentedViewControllerInHierarchy(of: presentedVC)
+        }
+        return viewController
+    }
+
+    private func findTopViewControllerInHierarchy(of viewController: UIViewController) -> UIViewController? {
+        if let tabBarVC = viewController as? UITabBarController {
+            guard let selectedVC = tabBarVC.selectedViewController else {
+                return tabBarVC // when `UITabBarController` displays no view controllers
+            }
+            // When `UITabBarController` has selected VC, continue searching, as the selected VC
+            // may be containing another hierarchy (e.g. `UINavigationController`).
+            return findTopViewControllerInHierarchy(of: selectedVC)
+        } else if let navigationVC = viewController as? UINavigationController {
+            guard let topVC = navigationVC.topViewController else {
+                return navigationVC // when `UINavigationController` displays no view controllers
+            }
+            // When `UINavigationController` has top VC, continue searching, as the top VC
+            // may be containing another hierarchy (e.g. `UITabBarController`).
+            return findTopViewControllerInHierarchy(of: topVC)
+        } else {
+            return viewController
+        }
     }
 }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspector.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspector.swift
@@ -18,7 +18,8 @@ internal struct UIKitHierarchyInspector: UIKitHierarchyInspectorType {
 
     init(
         rootViewControllerProvider: @escaping () -> UIViewController? = {
-            UIApplication.shared.keyWindow?.rootViewController
+            let keyWindow = UIApplication.shared.windows.first { $0.isKeyWindow }
+            return keyWindow?.rootViewController
         }
     ) {
         self.rootViewControllerProvider = rootViewControllerProvider
@@ -27,15 +28,11 @@ internal struct UIKitHierarchyInspector: UIKitHierarchyInspectorType {
     // MARK: - UIKitHierarchyInspectorType
 
     func topViewController() -> UIViewController? {
-        guard let rootVC = rootViewControllerProvider() else {
-            return nil
+        if let rootVC = rootViewControllerProvider(),
+           let highestPresentedVC = findHighestPresentedViewControllerInHierarchy(of: rootVC) {
+            return findTopViewControllerInHierarchy(of: highestPresentedVC)
         }
-
-        guard let highestPresentedVC = findHighestPresentedViewControllerInHierarchy(of: rootVC) else {
-            return nil
-        }
-
-        return findTopViewControllerInHierarchy(of: highestPresentedVC)
+        return nil
     }
 
     // MARK: - Private

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -44,11 +44,8 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
     }
 
     func notify_viewDidDisappear(viewController: UIViewController, animated: Bool) {
-        guard let topViewController = inspector.topViewController() else {
-            return
-        }
-
-        if let rumView = predicate.rumView(for: topViewController) {
+        if let topViewController = inspector.topViewController(),
+           let rumView = predicate.rumView(for: topViewController) {
             startIfNotStarted(rumView: rumView, for: topViewController)
         }
     }
@@ -58,7 +55,7 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
     private weak var lastStartedViewController: UIViewController?
 
     private func startIfNotStarted(rumView: RUMViewFromPredicate, for viewController: UIViewController) {
-        guard viewController !== lastStartedViewController else {
+        if viewController === lastStartedViewController {
             return
         }
 

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -8,17 +8,25 @@ import UIKit
 
 internal protocol UIKitRUMViewsHandlerType: class {
     func subscribe(commandsSubscriber: RUMCommandSubscriber)
-    func notify_viewWillAppear(viewController: UIViewController, animated: Bool)
-    func notify_viewWillDisappear(viewController: UIViewController, animated: Bool)
+    /// Gets called on `super.viewDidAppear()`.
+    func notify_viewDidAppear(viewController: UIViewController, animated: Bool)
+    /// Gets called on `super.viewDidDisappear()`.
+    func notify_viewDidDisappear(viewController: UIViewController, animated: Bool)
 }
 
 internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
     private let predicate: UIKitRUMViewsPredicate
     private let dateProvider: DateProvider
+    private let inspector: UIKitHierarchyInspectorType
 
-    init(predicate: UIKitRUMViewsPredicate, dateProvider: DateProvider) {
+    init(
+        predicate: UIKitRUMViewsPredicate,
+        dateProvider: DateProvider,
+        inspector: UIKitHierarchyInspectorType = UIKitHierarchyInspector()
+    ) {
         self.predicate = predicate
         self.dateProvider = dateProvider
+        self.inspector = inspector
     }
 
     // MARK: - UIKitRUMViewsHandlerType
@@ -29,28 +37,50 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
         self.subscriber = commandsSubscriber
     }
 
-    func notify_viewWillAppear(viewController: UIViewController, animated: Bool) {
+    func notify_viewDidAppear(viewController: UIViewController, animated: Bool) {
         if let rumView = predicate.rumView(for: viewController) {
-            subscriber?.process(
-                command: RUMStartViewCommand(
-                    time: dateProvider.currentDate(),
-                    identity: viewController,
-                    path: rumView.path,
-                    attributes: rumView.attributes
-                )
-            )
+            startIfNotStarted(rumView: rumView, for: viewController)
         }
     }
 
-    func notify_viewWillDisappear(viewController: UIViewController, animated: Bool) {
-        if let rumView = predicate.rumView(for: viewController) {
+    func notify_viewDidDisappear(viewController: UIViewController, animated: Bool) {
+        guard let topViewController = inspector.topViewController() else {
+            return
+        }
+
+        if let rumView = predicate.rumView(for: topViewController) {
+            startIfNotStarted(rumView: rumView, for: topViewController)
+        }
+    }
+
+    // MARK: - Private
+
+    private weak var lastStartedViewController: UIViewController?
+
+    private func startIfNotStarted(rumView: RUMViewFromPredicate, for viewController: UIViewController) {
+        guard viewController !== lastStartedViewController else {
+            return
+        }
+
+        if let lastStartedViewController = lastStartedViewController {
             subscriber?.process(
                 command: RUMStopViewCommand(
                     time: dateProvider.currentDate(),
                     attributes: rumView.attributes,
-                    identity: viewController
+                    identity: lastStartedViewController
                 )
             )
         }
+
+        subscriber?.process(
+            command: RUMStartViewCommand(
+                time: dateProvider.currentDate(),
+                identity: viewController,
+                path: rumView.path,
+                attributes: rumView.attributes
+            )
+        )
+
+        lastStartedViewController = viewController
     }
 }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzler.swift
@@ -7,27 +7,27 @@
 import UIKit
 
 internal class UIViewControllerSwizzler {
-    let viewWillAppear: ViewWillAppear
-    let viewWillDisappear: ViewWillDisappear
+    let viewDidAppear: ViewDidAppear
+    let viewDidDisappear: ViewDidDisappear
 
     init(handler: UIKitRUMViewsHandlerType) throws {
-        self.viewWillAppear = try ViewWillAppear(handler: handler)
-        self.viewWillDisappear = try ViewWillDisappear(handler: handler)
+        self.viewDidAppear = try ViewDidAppear(handler: handler)
+        self.viewDidDisappear = try ViewDidDisappear(handler: handler)
     }
 
     func swizzle() {
-        viewWillAppear.swizzle()
-        viewWillDisappear.swizzle()
+        viewDidAppear.swizzle()
+        viewDidDisappear.swizzle()
     }
 
     // MARK: - Swizzlings
 
-    /// Swizzles the `UIViewController.viewWillAppear()`
-    class ViewWillAppear: MethodSwizzler <
+    /// Swizzles the `UIViewController.viewDidAppear()`
+    class ViewDidAppear: MethodSwizzler <
         @convention(c) (UIViewController, Selector, Bool) -> Void,
         @convention(block) (UIViewController, Bool) -> Void
     > {
-        private static let selector = #selector(UIViewController.viewWillAppear(_:))
+        private static let selector = #selector(UIViewController.viewDidAppear(_:))
         private let method: FoundMethod
         private let handler: UIKitRUMViewsHandlerType
 
@@ -40,19 +40,19 @@ internal class UIViewControllerSwizzler {
             typealias Signature = @convention(block) (UIViewController, Bool) -> Void
             swizzle(method) { previousImplementation -> Signature in
                 return { [weak handler = self.handler] vc, animated  in
-                    handler?.notify_viewWillAppear(viewController: vc, animated: animated)
-                    return previousImplementation(vc, Self.selector, animated)
+                    handler?.notify_viewDidAppear(viewController: vc, animated: animated)
+                    previousImplementation(vc, Self.selector, animated)
                 }
             }
         }
     }
 
-    /// Swizzles the `UIViewController.viewWillDisappear()`
-    class ViewWillDisappear: MethodSwizzler <
+    /// Swizzles the `UIViewController.viewDidDisappear()`
+    class ViewDidDisappear: MethodSwizzler <
         @convention(c) (UIViewController, Selector, Bool) -> Void,
         @convention(block) (UIViewController, Bool) -> Void
     > {
-        private static let selector = #selector(UIViewController.viewWillDisappear(_:))
+        private static let selector = #selector(UIViewController.viewDidDisappear(_:))
         private let method: FoundMethod
         private let handler: UIKitRUMViewsHandlerType
 
@@ -65,8 +65,8 @@ internal class UIViewControllerSwizzler {
             typealias Signature = @convention(block) (UIViewController, Bool) -> Void
             swizzle(method) { previousImplementation -> Signature in
                 return { [weak handler = self.handler] vc, animated  in
-                    handler?.notify_viewWillDisappear(viewController: vc, animated: animated)
-                    return previousImplementation(vc, Self.selector, animated)
+                    handler?.notify_viewDidDisappear(viewController: vc, animated: animated)
+                    previousImplementation(vc, Self.selector, animated)
                 }
             }
         }

--- a/Tests/DatadogIntegrationTests/RUMM742Workaround.swift
+++ b/Tests/DatadogIntegrationTests/RUMM742Workaround.swift
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import HTTPServerMock
+
+/// TODO: RUMM-742 Replace this workaround with a nicer way.
+protocol RUMM742Workaround {
+    /// Pulls requests from the mock server until given `condition` is met.
+    func pullRecordedRUMRequests(
+        from serverSession: ServerSession,
+        until condition: (RUMSessionMatcher) -> Bool
+    ) throws -> [ServerSession.POSTRequestDetails]
+}
+
+extension RUMM742Workaround {
+    func pullRecordedRUMRequests(
+        from serverSession: ServerSession,
+        until condition: (RUMSessionMatcher) -> Bool
+    ) throws -> [ServerSession.POSTRequestDetails] {
+        return try pullRecordedRUMRequests(count: 1, from: serverSession, until: condition)
+    }
+
+    private func pullRecordedRUMRequests(
+        count: Int,
+        from serverSession: ServerSession,
+        until condition: (RUMSessionMatcher) -> Bool
+    ) throws -> [ServerSession.POSTRequestDetails] {
+        let requests = try serverSession.pullRecordedPOSTRequests(count: count, timeout: 30)
+        let matchers = try requests.flatMap { try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData($0.httpBody) }
+        let session = try RUMSessionMatcher.groupMatchersBySessions(matchers).first!
+
+        if condition(session) {
+            return requests
+        } else if count + 1 < 4 { // try 4 requests at max
+            return try pullRecordedRUMRequests(count: count + 1, from: serverSession, until: condition)
+        } else {
+            fatalError("Pulled 4 requests, without matching the `condition()`.")
+        }
+    }
+}

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
@@ -31,15 +31,19 @@ class RUMModalViewsScenarioTests: IntegrationTests {
         app.launchWith(
             testScenario: RUMModalViewsAutoInstrumentationScenario.self,
             serverConfiguration: HTTPServerMockConfiguration()
-        ) // start on "Screen1"
+        ) // start on "Screen"
 
-        app.tapButton(titled: "Present modally using segue") // go to modal "Screen2"
-        app.tapButton(titled: "Dismiss by self.dismiss()") // dismiss to "Screen1"
-        app.tapButton(titled: "Present modally from code") // go to modal "Screen2"
-        app.tapButton(titled: "Dismiss by parent.dismiss()") // dismiss to "Screen1"
-        app.tapButton(titled: "Present modally using segue") // go to modal "Screen2"
-        app.swipeToPullModalDown() // interactive dismiss to "Screen1"
-        app.tapButton(titled: "Present modally from code") // go to modal "Screen2"
-        app.swipeToPullModalDownButThenCancel() // interactive and cancelled dismiss, stay on "Screen2"
+        app.tapButton(titled: "Present modally from code") // go to modal "Modal"
+        app.tapButton(titled: "Dismiss by self.dismiss()") // dismiss to "Screen"
+
+        app.tapButton(titled: "Present modally - .fullScreen") // go to modal "Modal"
+        app.tapButton(titled: "Dismiss by parent.dismiss()") // dismiss to "Screen"
+
+        app.tapButton(titled: "Present modally - .pageSheet") // go to modal "Modal"
+        app.swipeToPullModalDown() // interactive dismiss to "Screen"
+
+        app.tapButton(titled: "Present modally - .pageSheet") // go to modal "Modal"
+        app.swipeToPullModalDownButThenCancel() // interactive and cancelled dismiss, stay on "Modal"
+        app.tapButton(titled: "Dismiss by self.dismiss()") // dismiss to "Screen"
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
@@ -21,7 +21,7 @@ private extension ExampleApplication {
     }
 }
 
-class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
+class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts, RUMM742Workaround {
     func testRUMTabBarScenario() throws {
         // Server session recording RUM events send to `HTTPServerMock`.
         let rumServerSession = server.obtainUniqueRecordingSession()
@@ -44,8 +44,9 @@ class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapTapBarButton(named: "Tab C") // go to "Screen C1"
 
         // Get POST requests
-        let recordedRUMRequests = try rumServerSession
-            .pullRecordedPOSTRequests(count: 1, timeout: dataDeliveryTimeout)
+        let recordedRUMRequests = try pullRecordedRUMRequests(from: rumServerSession) { session in
+            session.viewVisits.count >= 9 // TODO: RUMM-742 Replace this workaround with a nicer way.
+        }
 
         // Get RUM Events
         let rumEventsMatchers = try recordedRUMRequests

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Actions/UIKitRUMUserActionsHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Actions/UIKitRUMUserActionsHandlerTests.swift
@@ -66,7 +66,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
             )
 
             // Then
-            let command = commandSubscriber.receivedCommand as? RUMAddUserActionCommand
+            let command = commandSubscriber.lastReceivedCommand as? RUMAddUserActionCommand
             XCTAssertEqual(command?.name, expectedRUMActionName)
             XCTAssertEqual(command?.actionType, .tap)
             XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
@@ -102,7 +102,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
             )
 
             // Then
-            let command = commandSubscriber.receivedCommand as? RUMAddUserActionCommand
+            let command = commandSubscriber.lastReceivedCommand as? RUMAddUserActionCommand
             XCTAssertEqual(command?.name, expectedRUMActionName)
             XCTAssertEqual(command?.actionType, .tap)
             XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
@@ -124,7 +124,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         )
 
         // Then
-        XCTAssertNil(commandSubscriber.receivedCommand)
+        XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
     func testGivenAnyViewPresentedInKeyboardWindow_whenTouchEnds_itGetsIgnoredForPrivacyReason() {
@@ -140,7 +140,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         )
 
         // Then
-        XCTAssertNil(commandSubscriber.receivedCommand)
+        XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
     func testGivenAnyUIControlNotAttachedToAnyWindow_itGetsIgnoredForPrivacyReason() {
@@ -154,7 +154,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         )
 
         // Then
-        XCTAssertNil(commandSubscriber.receivedCommand)
+        XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
     func testItIgnoresSingleTouchEventWithPhaseOtherThanEnded() {
@@ -176,7 +176,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
             )
 
             // Then
-            XCTAssertNil(commandSubscriber.receivedCommand)
+            XCTAssertNil(commandSubscriber.lastReceivedCommand)
         }
     }
 
@@ -196,7 +196,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         )
 
         // Then
-        XCTAssertNil(commandSubscriber.receivedCommand)
+        XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 
     func testItIgnoresEventsWithNoTouch() {
@@ -207,7 +207,7 @@ class UIKitRUMUserActionsHandlerTests: XCTestCase {
         )
 
         // Then
-        XCTAssertNil(commandSubscriber.receivedCommand)
+        XCTAssertNil(commandSubscriber.lastReceivedCommand)
     }
 }
 

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -34,7 +34,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let resourceStartCommand = try XCTUnwrap(commandSubscriber.receivedCommand as? RUMStartResourceCommand)
+        let resourceStartCommand = try XCTUnwrap(commandSubscriber.lastReceivedCommand as? RUMStartResourceCommand)
         XCTAssertEqual(resourceStartCommand.resourceName, taskInterception.identifier.uuidString)
         XCTAssertEqual(resourceStartCommand.time, .mockDecember15th2019At10AMUTC())
         XCTAssertEqual(resourceStartCommand.attributes.count, 0)

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspectorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspectorTests.swift
@@ -1,0 +1,94 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class UIKitHierarchyInspectorTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    // MARK: - Non-modal presentation
+
+    func testGivenNoRootViewController_itFindsNoTopVC() {
+        // Given
+        let inspector = UIKitHierarchyInspector { nil }
+
+        // Then
+        XCTAssertNil(inspector.topViewController())
+    }
+
+    func testGivenBasicViewControllerAsTheRoot_itFindsTopVC() {
+        // Given
+        let viewController = UIViewController()
+        let inspector = UIKitHierarchyInspector { viewController }
+
+        // Then
+        XCTAssertTrue(inspector.topViewController() === viewController)
+    }
+
+    func testGivenNavigationControllerAsRoot_itFindsTopVC() {
+        // Given
+        let navigationController = UINavigationController()
+        let inspector = UIKitHierarchyInspector { navigationController }
+
+        // Then
+        XCTAssertTrue(inspector.topViewController() === navigationController)
+        navigationController.setViewControllers([UIViewController(), UIViewController()], animated: false)
+        XCTAssertTrue(inspector.topViewController() === navigationController.viewControllers[1])
+    }
+
+    func testGivenTabBarControllerAsTheRoot_itFindsTopVC() {
+        // Given
+        let tabBarController = UITabBarController()
+        let inspector = UIKitHierarchyInspector { tabBarController }
+
+        // Then
+        XCTAssertTrue(inspector.topViewController() === tabBarController)
+        tabBarController.setViewControllers([UIViewController(), UIViewController()], animated: false)
+        XCTAssertTrue(inspector.topViewController() === tabBarController.viewControllers![0])
+    }
+
+    func testGivenTabBarControllerAsTheRoot_whenItEmbedsNavigationControllerOnSecondTab_itFindsTopVC() {
+        // Given
+        let tabBarController = UITabBarController()
+        let inspector = UIKitHierarchyInspector { tabBarController }
+
+        // When
+        let navigationController = UINavigationController()
+        navigationController.setViewControllers([UIViewController(), UIViewController()], animated: false)
+        tabBarController.setViewControllers([UIViewController(), navigationController], animated: false)
+        tabBarController.selectedIndex = 1
+
+        // Then
+        XCTAssertTrue(inspector.topViewController() === navigationController.viewControllers[1])
+    }
+
+    // MARK: - Modal presentation
+
+    func testGivenAnyVCAsTheRoot_whenNavigationControllerIsPresentedModally_itFindsTopVC() {
+        // Given
+        let anyViewController = [UINavigationController(), UITabBarController(), UIViewController()].randomElement()!
+        let inspector = UIKitHierarchyInspector { anyViewController }
+
+        // When
+        let modalNavigationController = UINavigationController()
+        modalNavigationController.setViewControllers([UIViewController(), UIViewController()], animated: false)
+
+        let window = UIWindow(frame: .zero) // we need a window, so `.present()` doesn't throw an exception
+        window.rootViewController = anyViewController
+        window.makeKeyAndVisible()
+        anyViewController.present(modalNavigationController, animated: false)
+
+        // Then
+        XCTAssertTrue(inspector.topViewController() === modalNavigationController.viewControllers[1])
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
@@ -7,65 +7,152 @@
 import XCTest
 @testable import Datadog
 
+private class UIKitHierarchyInspectorMock: UIKitHierarchyInspectorType {
+    var mockTopViewController: UIViewController?
+
+    func topViewController() -> UIViewController? { mockTopViewController }
+}
+
 class UIKitRUMViewsHandlerTests: XCTestCase {
     private let dateProvider = RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
     private let commandSubscriber = RUMCommandSubscriberMock()
     private let predicate = UIKitRUMViewsPredicateMock()
+    private let uiKitHierarchyInspector = UIKitHierarchyInspectorMock()
 
     private lazy var handler: UIKitRUMViewsHandler = {
-        let handler = UIKitRUMViewsHandler(predicate: predicate, dateProvider: dateProvider)
+        let handler = UIKitRUMViewsHandler(
+            predicate: predicate,
+            dateProvider: dateProvider,
+            inspector: uiKitHierarchyInspector
+        )
         handler.subscribe(commandsSubscriber: commandSubscriber)
         return handler
     }()
 
-    func testGivenAcceptingPredicate_whenViewWillAppear_itSendsRUMStartViewCommand() {
+    // MARK: - Handling `viewDidAppear`
+
+    func testGivenAcceptingPredicate_whenViewDidAppear_itStartsRUMView() {
+        let view = createMockViewInWindow()
+
         // Given
         predicate.result = .init(path: "Foo", attributes: ["foo": "bar"])
 
         // When
-        handler.notify_viewWillAppear(viewController: mockView, animated: .mockAny())
+        handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
 
         // Then
-        let command = commandSubscriber.receivedCommand as? RUMStartViewCommand
-        XCTAssertTrue(command?.identity === mockView)
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 1)
+
+        let command = commandSubscriber.receivedCommands[0] as? RUMStartViewCommand
+        XCTAssertTrue(command?.identity === view)
         XCTAssertEqual(command?.path, "Foo")
         XCTAssertEqual(command?.attributes as? [String: String], ["foo": "bar"])
         XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
     }
 
-    func testGivenRejectingPredicate_whenViewWillAppear_itSendsRUMStartViewCommand() {
+    func testGivenAcceptingPredicate_whenViewDidAppear_itStopsPreviousRUMView() {
+        let view1 = createMockViewInWindow()
+        let view2 = createMockViewInWindow()
+
+        // Given
+        predicate.resultByViewController = [
+            view1: .init(path: "First"),
+            view2: .init(path: "Second"),
+        ]
+
+        // When
+        handler.notify_viewDidAppear(viewController: view1, animated: .mockAny())
+        handler.notify_viewDidAppear(viewController: view2, animated: .mockAny())
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 3)
+
+        let startCommand1 = commandSubscriber.receivedCommands[0] as? RUMStartViewCommand
+        let stopCommand = commandSubscriber.receivedCommands[1] as? RUMStopViewCommand
+        let startCommand2 = commandSubscriber.receivedCommands[2] as? RUMStartViewCommand
+        XCTAssertTrue(startCommand1?.identity === view1)
+        XCTAssertTrue(stopCommand?.identity === view1)
+        XCTAssertTrue(startCommand2?.identity === view2)
+    }
+
+    func testGivenAcceptingPredicate_whenViewDidAppear_itDoesNotStartTheSameRUMViewTwice() {
+        let view = createMockViewInWindow()
+
+        // Given
+        predicate.result = .init(path: "Foo")
+
+        // When
+        handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
+        handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 1)
+        XCTAssertTrue(commandSubscriber.receivedCommands[0] is RUMStartViewCommand)
+    }
+
+    func testGivenRejectingPredicate_whenViewDidAppear_itDoesNotStartAnyRUMView() {
+        let view = createMockViewInWindow()
+
         // Given
         predicate.result = nil
 
         // When
-        handler.notify_viewWillAppear(viewController: mockView, animated: .mockAny())
+        handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
 
         // Then
-        XCTAssertNil(commandSubscriber.receivedCommand)
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)
     }
 
-    func testGivenAcceptingPredicate_whenViewWillDisappear_itSendsRUMStopViewCommand() {
+    // MARK: - Handling `viewDidDisappear`
+
+    func testGivenAcceptingPredicate_whenViewDidDisappear_itStartsRUMViewForTopViewController() {
+        let view = createMockViewInWindow()
+        let topViewController = createMockViewInWindow()
+        uiKitHierarchyInspector.mockTopViewController = topViewController
+
         // Given
-        predicate.result = .init(path: "Foo", attributes: ["foo": "bar"])
+        predicate.resultByViewController = [
+            topViewController: .init(path: "Top")
+        ]
 
         // When
-        handler.notify_viewWillDisappear(viewController: mockView, animated: .mockAny())
+        handler.notify_viewDidDisappear(viewController: view, animated: .mockAny())
 
         // Then
-        let command = commandSubscriber.receivedCommand as? RUMStopViewCommand
-        XCTAssertTrue(command?.identity === mockView)
-        XCTAssertEqual(command?.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 1)
+
+        let command = commandSubscriber.receivedCommands[0] as? RUMStartViewCommand
+        XCTAssertTrue(command?.identity === topViewController)
+        XCTAssertEqual(command?.path, "Top")
         XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
     }
 
-    func testGivenRejectingPredicate_whenViewWillDisappear_itSendsRUMStopViewCommand() {
+    func testGivenAcceptingPredicate_whenViewDidDisappearButThereIsNoTopViewController_itDoesNotStartAnyRUMView() {
+        let view = createMockViewInWindow()
+        uiKitHierarchyInspector.mockTopViewController = nil
+
+        // Given
+        predicate.result = .init(path: "Foo")
+
+        // When
+        handler.notify_viewDidDisappear(viewController: view, animated: .mockAny())
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)
+    }
+
+    func testGivenRejectingPredicate_whenViewDidDisappear_itDoesNotStartAnyRUMView() {
+        let view = createMockViewInWindow()
+        let topViewController = createMockViewInWindow()
+        uiKitHierarchyInspector.mockTopViewController = topViewController
+
         // Given
         predicate.result = nil
 
         // When
-        handler.notify_viewWillDisappear(viewController: mockView, animated: .mockAny())
+        handler.notify_viewDidDisappear(viewController: view, animated: .mockAny())
 
         // Then
-        XCTAssertNil(commandSubscriber.receivedCommand)
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
@@ -69,11 +69,11 @@ class RUMCurrentContextTests: XCTestCase {
         let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
-        let firstView = createMockView()
+        let firstView = createMockViewInWindow()
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: firstView))
         let firstContext = provider.context
 
-        let secondView = createMockView()
+        let secondView = createMockViewInWindow()
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: secondView))
         let secondContext = provider.context
 
@@ -96,7 +96,7 @@ class RUMCurrentContextTests: XCTestCase {
         let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
-        let view = createMockView()
+        let view = createMockViewInWindow()
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: view))
         let firstContext = provider.context
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -34,7 +34,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny(), samplingRate: 100)
         var currentTime = Date()
 
-        let view = createMockView()
+        let view = createMockViewInWindow()
         _ = scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: view))
         let firstSessionUUID = try XCTUnwrap(scope.sessionScope?.context.sessionID)
         let firstsSessionViewScopes = try XCTUnwrap(scope.sessionScope?.viewScopes)


### PR DESCRIPTION
### What and why?

🚚 This PR updates RUM Views auto instrumentation to also cover modal view controller presentation.

### How?

As discussed, we intercept significant `UIViewController` callbacks:
* `viewDidAppear()`
* `viewDidDisappear()`

and decide on started / stopped RUM View by inspecting the `UIKit` views hierarchy.

I've also updated the integration test, to cover 2 different `modalPresentationStyles`: `.fullScreen` and `.pageSheet`, as both lead to receiving different `UIViewController` callbacks.

<img width="388" alt="Screenshot 2020-10-13 at 17 16 25" src="https://user-images.githubusercontent.com/2358722/95880564-ef2e7280-0d77-11eb-98e7-e495a1dc93e5.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
