### PR TITLE
RUMM-812 DDURLSessionDelegate is made subclassable

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		9E58E8E324615EDA008E5063 /* JSONEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8E224615EDA008E5063 /* JSONEncoderTests.swift */; };
 		9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */; };
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9EF963E82537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EF963E72537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift */; };
 		9EFD112C24B32D29003A1A2B /* FirstPartyURLsFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFD112B24B32D29003A1A2B /* FirstPartyURLsFilter.swift */; };
 		E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */; };
 		E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */; };
@@ -706,6 +707,7 @@
 		9E9EB37624468CE90002C80B /* Datadog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Datadog.modulemap; sourceTree = "<group>"; };
 		9EF49F1624476FBD004F2CA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9EF49F17244770AD004F2CA0 /* DatadogIntegrationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogIntegrationTests.xcconfig; sourceTree = "<group>"; };
+		9EF963E72537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDURLSessionDelegateAsSuperclassTests.swift; sourceTree = "<group>"; };
 		9EFD112B24B32D29003A1A2B /* FirstPartyURLsFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstPartyURLsFilter.swift; sourceTree = "<group>"; };
 		E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingBenchmarkTests.swift; sourceTree = "<group>"; };
 		E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingStorageBenchmarkTests.swift; sourceTree = "<group>"; };
@@ -1684,6 +1686,7 @@
 				61B03878252724AB00518F3C /* URLSessionSwizzlerTests.swift */,
 				61B03877252724AB00518F3C /* DDURLSessionDelegateTests.swift */,
 				61B03873252724AB00518F3C /* Interception */,
+				9EF963E72537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift */,
 			);
 			path = URLSessionAutoInstrumentation;
 			sourceTree = "<group>";
@@ -2599,6 +2602,7 @@
 				61B0387B252724AB00518F3C /* URLSessionTracingHandlerTests.swift in Sources */,
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
 				614B0A4D24EBD71500A2A780 /* RUMUserInfoProviderTests.swift in Sources */,
+				9EF963E82537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift in Sources */,
 				61133C552423990D00786299 /* BatteryStatusProviderTests.swift in Sources */,
 				61F3CDAB25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift in Sources */,
 				617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */,

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -11,11 +11,8 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate {
     private let interceptor: URLSessionInterceptorType?
 
     @objc
-    override public convenience init() {
-        self.init(interceptor: URLSessionAutoInstrumentation.instance?.interceptor)
-    }
-
-    internal init(interceptor: URLSessionInterceptorType?) {
+    override public init() {
+        self.interceptor = URLSessionAutoInstrumentation.instance?.interceptor
         if interceptor == nil {
             let error = ProgrammerError(
                 description: """
@@ -25,7 +22,19 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate {
             )
             consolePrint("\(error)")
         }
+    }
+
+    internal init(interceptor: URLSessionInterceptorType?) {
         self.interceptor = interceptor
+        if interceptor == nil {
+            let error = ProgrammerError(
+                description: """
+                To use `DDURLSessionDelegate` you must specify first party hosts in `Datadog.Configuration` -
+                use `track(firstPartyHosts:)` to define which requests should be tracked.
+                """
+            )
+            consolePrint("\(error)")
+        }
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -8,24 +8,11 @@ import Foundation
 
 @objc
 open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate {
-    private let interceptor: URLSessionInterceptorType?
+    var interceptor: URLSessionInterceptorType?
 
     @objc
     override public init() {
-        self.interceptor = URLSessionAutoInstrumentation.instance?.interceptor
-        if interceptor == nil {
-            let error = ProgrammerError(
-                description: """
-                To use `DDURLSessionDelegate` you must specify first party hosts in `Datadog.Configuration` -
-                use `track(firstPartyHosts:)` to define which requests should be tracked.
-                """
-            )
-            consolePrint("\(error)")
-        }
-    }
-
-    internal init(interceptor: URLSessionInterceptorType?) {
-        self.interceptor = interceptor
+        interceptor = URLSessionAutoInstrumentation.instance?.interceptor
         if interceptor == nil {
             let error = ProgrammerError(
                 description: """

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateAsSuperclassTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateAsSuperclassTests.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import Datadog
+
+internal final class SubDDURLSessionDelegate: DDURLSessionDelegate {
+    let someProp: String
+    override init() {
+        someProp = "someProp"
+        super.init()
+    }
+    override func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        super.urlSession(session, task: task, didCompleteWithError: error)
+    }
+}
+
+class DDURLSessionDelegateAsSuperclassTests: XCTestCase {
+    func testSubclassability() {
+        // Success: tests compile, failure: compilation error
+        _ = SubDDURLSessionDelegate()
+    }
+}

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateAsSuperclassTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateAsSuperclassTests.swift
@@ -8,9 +8,9 @@ import XCTest
 import Datadog
 
 internal final class SubDDURLSessionDelegate: DDURLSessionDelegate {
-    let someProp: String
+    let property: String
     override init() {
-        someProp = "someProp"
+        property = "someProp"
         super.init()
     }
     override func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {


### PR DESCRIPTION
### What and why?

`DDURLSessionDelegate` is supposed to be subclassable
The users may need to change its behavior to their own needs
Yet, it was not possible to subclass it practically due to lack of public designated initilalizer

It was possible to create a new class `class MyDelegate: DDURLSessionDelegate { ... }`
It was not possible to create an instance of it:
```swift
delegate = MyDelegate() // cannot be constructed because it has no accessible initializers
```
It was also not possible to override `init` methods because
1. superclass does not have a public designated init
2. overridden init needs to call super's designated init at some point


### How?

`DDURLSessionDelegate` now has a `public` (also overrideable) designated initializer

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
