### PR TITLE
RUMM-801 Mute flakiness by retrying unit tests once after first failure

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -83,6 +83,7 @@ workflows:
         - scheme: Datadog
         - simulator_device: iPhone 11
         - is_clean_build: 'yes'
+        - should_retry_test_on_fail: 'yes'
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests.html"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -83,7 +83,7 @@ workflows:
         - scheme: Datadog
         - simulator_device: iPhone 11
         - is_clean_build: 'yes'
-        - should_retry_test_on_fail: 'yes'
+        - should_retry_test_on_fail: 'yes' # temporarily mutes flakiness until we collect more info (in RUMM-839) then fix it
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests.html"


### PR DESCRIPTION
### What and why?

🧪 This PR addresses recent tests flakiness by enabling `retry_test_on_fail` flag in Bitrise config. This is only a quick fix to solve the problem until we develop the solution to measure and fix flaky tests one by one (`RUMM-839`).

### How?

I enabled the `should_retry_test_on_fail` flag ([doc](https://github.com/bitrise-steplib/steps-xcode-test/blob/c5bca453fef5ea652139eb3ea0e41f594fc2a51d/step.yml#L262-L271)).

For the record - I also tried disabling the [`headless_mode` flag](https://github.com/bitrise-steplib/steps-xcode-test/blob/c5bca453fef5ea652139eb3ea0e41f594fc2a51d/step.yml#L169-L181), but the improvement was not very visible:
* `headless_mode: yes` → 5 failures / 60 runs,
* `headless_mode: no` → 3 failures / 60 runs.

For what I observed, consecutive test runs in a workflow are quite stable (hot start), but the first one seems to fail often (cold start). IMO we definitely need more aggregated metrics among our ~450 unit tests, to decide on next steps (thus: `RUMM-839`).

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
