### PR TITLE
RUMM-694 Add Trace information to RUM Resources

### DIFF
--- a/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -42,10 +42,10 @@ internal class URLSessionRUMResourcesHandler: URLSessionRUMResourcesHandlerType 
                 attributes: [:],
                 url: url,
                 httpMethod: RUMHTTPMethod(request: interception.request),
-                spanContext: interception.spanContext.map { spanContext in
+                spanContext: interception.spanContext.flatMap { spanContext in
                     .init(
-                        traceID: spanContext.traceID.rawValue,
-                        spanID: spanContext.spanID.rawValue
+                        traceID: String(spanContext.traceID.rawValue),
+                        spanID: String(spanContext.spanID.rawValue)
                     )
                 }
             )

--- a/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -41,7 +41,13 @@ internal class URLSessionRUMResourcesHandler: URLSessionRUMResourcesHandlerType 
                 time: dateProvider.currentDate(),
                 attributes: [:],
                 url: url,
-                httpMethod: RUMHTTPMethod(request: interception.request)
+                httpMethod: RUMHTTPMethod(request: interception.request),
+                spanContext: interception.spanContext.map { spanContext in
+                    .init(
+                        traceID: spanContext.traceID.rawValue,
+                        spanID: spanContext.spanID.rawValue
+                    )
+                }
             )
         )
     }

--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -20,6 +20,8 @@ internal struct RUMAction: RUMDataModel {
     let date: Int64
     /// Application properties
     let application: RUMApplication
+    /// The service name for this application
+    let service: String?
     /// Session properties
     let session: RUMSession
     /// View properties
@@ -38,6 +40,7 @@ internal struct RUMAction: RUMDataModel {
     enum CodingKeys: String, CodingKey {
         case date = "date"
         case application = "application"
+        case service = "service"
         case session = "session"
         case view = "view"
         case usr = "usr"
@@ -295,6 +298,8 @@ internal struct RUMError: RUMDataModel {
     let date: Int64
     /// Application properties
     let application: RUMApplication
+    /// The service name for this application
+    let service: String?
     /// Session properties
     let session: RUMSession
     /// View properties
@@ -315,6 +320,7 @@ internal struct RUMError: RUMDataModel {
     enum CodingKeys: String, CodingKey {
         case date = "date"
         case application = "application"
+        case service = "service"
         case session = "session"
         case view = "view"
         case usr = "usr"
@@ -410,6 +416,8 @@ internal struct RUMLongTask: RUMDataModel {
     let date: Int64
     /// Application properties
     let application: RUMApplication
+    /// The service name for this application
+    let service: String?
     /// Session properties
     let session: RUMSession
     /// View properties
@@ -430,6 +438,7 @@ internal struct RUMLongTask: RUMDataModel {
     enum CodingKeys: String, CodingKey {
         case date = "date"
         case application = "application"
+        case service = "service"
         case session = "session"
         case view = "view"
         case usr = "usr"
@@ -475,6 +484,8 @@ internal struct RUMResource: RUMDataModel {
     let date: Int64
     /// Application properties
     let application: RUMApplication
+    /// The service name for this application
+    let service: String?
     /// Session properties
     let session: RUMSession
     /// View properties
@@ -484,7 +495,7 @@ internal struct RUMResource: RUMDataModel {
     /// Device connectivity properties
     let connectivity: RUMConnectivity?
     /// Internal properties
-    let dd: RUMActionDD
+    let dd: RUMResourceDD
     /// RUM event type
     let type = "resource"
     /// Resource properties
@@ -495,6 +506,7 @@ internal struct RUMResource: RUMDataModel {
     enum CodingKeys: String, CodingKey {
         case date = "date"
         case application = "application"
+        case service = "service"
         case session = "session"
         case view = "view"
         case usr = "usr"
@@ -518,10 +530,30 @@ internal struct RUMResourceAction: Codable {
     }
 }
 
+// MARK: - RUMResourceDD
+
+/// Internal properties
+internal struct RUMResourceDD: Codable {
+    /// Version of the RUM event format
+    let formatVersion = 2
+    /// span identifier in decimal format
+    let spanID: String?
+    /// trace identifier in decimal format
+    let traceID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case formatVersion = "format_version"
+        case spanID = "span_id"
+        case traceID = "trace_id"
+    }
+}
+
 // MARK: - RUMResourceResource
 
 /// Resource properties
 internal struct RUMResourceResource: Codable {
+    /// UUID of the resource
+    let id: String?
     /// Resource type
     let type: RUMResourceType
     /// HTTP method of the resource
@@ -548,6 +580,7 @@ internal struct RUMResourceResource: Codable {
     let download: RUMDownload?
 
     enum CodingKeys: String, CodingKey {
+        case id = "id"
         case type = "type"
         case method = "method"
         case url = "url"
@@ -677,6 +710,8 @@ internal struct RUMView: RUMDataModel {
     let date: Int64
     /// Application properties
     let application: RUMApplication
+    /// The service name for this application
+    let service: String?
     /// Session properties
     let session: RUMSession
     /// View properties
@@ -693,6 +728,7 @@ internal struct RUMView: RUMDataModel {
     enum CodingKeys: String, CodingKey {
         case date = "date"
         case application = "application"
+        case service = "service"
         case session = "session"
         case view = "view"
         case usr = "usr"
@@ -819,6 +855,8 @@ internal enum RUMLoadingType: String, Codable {
     case fragmentRedisplay = "fragment_redisplay"
     case initialLoad = "initial_load"
     case routeChange = "route_change"
+    case viewControllerDisplay = "view_controller_display"
+    case viewControllerRedisplay = "view_controller_redisplay"
 }
 
 // MARK: - RUMViewLongTask
@@ -844,4 +882,4 @@ internal struct RUMViewResource: Codable {
         case count = "count"
     }
 }
-// b6eb2bf04511aa22db9b73ba0d195ee9c365bee7
+// c84571fec8cbb47cf0fb30b0f476a0d4d09d7262

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -99,6 +99,13 @@ internal protocol RUMResourceCommand: RUMCommand {
     var resourceName: String { get }
 }
 
+/// Tracing information propagated by Tracing to the underlying `URLRequest`. It is passed to the RUM backend
+/// in order to create the APM span. The actual `Span` is not send by the SDK.
+internal struct RUMSpanContext {
+    let traceID: UInt64
+    let spanID: UInt64
+}
+
 internal struct RUMStartResourceCommand: RUMResourceCommand {
     let resourceName: String
     let time: Date
@@ -108,6 +115,8 @@ internal struct RUMStartResourceCommand: RUMResourceCommand {
     let url: String
     /// HTTP method used to load the Resource
     let httpMethod: RUMHTTPMethod
+    /// Span context passed to the RUM backend in order to generate the APM span for underlying resource.
+    let spanContext: RUMSpanContext?
 }
 
 internal struct RUMAddResourceMetricsCommand: RUMResourceCommand {

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -102,8 +102,8 @@ internal protocol RUMResourceCommand: RUMCommand {
 /// Tracing information propagated by Tracing to the underlying `URLRequest`. It is passed to the RUM backend
 /// in order to create the APM span. The actual `Span` is not send by the SDK.
 internal struct RUMSpanContext {
-    let traceID: UInt64
-    let spanID: UInt64
+    let traceID: String
+    let spanID: String
 }
 
 internal struct RUMStartResourceCommand: RUMResourceCommand {

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -13,7 +13,7 @@ internal class RUMResourceScope: RUMScope {
     private let dependencies: RUMScopeDependencies
 
     /// This Resource's UUID.
-    let resourceUUID: RUMUUID
+    private let resourceUUID: RUMUUID
     /// The name used to identify this Resource.
     private let resourceName: String
     /// Resource attributes.

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -30,6 +30,9 @@ internal class RUMResourceScope: RUMScope {
     /// take precedence over other values collected for this Resource.
     private var resourceMetrics: ResourceMetrics?
 
+    /// Span context passed to the RUM backend in order to generate the APM span for underlying resource.
+    private let spanContext: RUMSpanContext?
+
     init(
         context: RUMContext,
         dependencies: RUMScopeDependencies,
@@ -37,7 +40,8 @@ internal class RUMResourceScope: RUMScope {
         attributes: [AttributeKey: AttributeValue],
         startTime: Date,
         url: String,
-        httpMethod: RUMHTTPMethod
+        httpMethod: RUMHTTPMethod,
+        spanContext: RUMSpanContext?
     ) {
         self.context = context
         self.dependencies = dependencies
@@ -47,6 +51,7 @@ internal class RUMResourceScope: RUMScope {
         self.resourceURL = url
         self.resourceLoadingStartTime = startTime
         self.resourceHTTPMethod = httpMethod
+        self.spanContext = spanContext
     }
 
     // MARK: - RUMScope
@@ -100,8 +105,8 @@ internal class RUMResourceScope: RUMScope {
             usr: dependencies.userInfoProvider.current,
             connectivity: dependencies.connectivityInfoProvider.current,
             dd: .init(
-                spanID: nil,
-                traceID: nil
+                spanID: spanContext.flatMap { String($0.spanID) },
+                traceID: spanContext.flatMap { String($0.traceID) }
             ),
             resource: .init(
                 id: resourceUUID.toRUMDataFormat,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -105,8 +105,8 @@ internal class RUMResourceScope: RUMScope {
             usr: dependencies.userInfoProvider.current,
             connectivity: dependencies.connectivityInfoProvider.current,
             dd: .init(
-                spanID: spanContext.flatMap { String($0.spanID) },
-                traceID: spanContext.flatMap { String($0.traceID) }
+                spanID: spanContext?.spanID,
+                traceID: spanContext?.traceID
             ),
             resource: .init(
                 id: resourceUUID.toRUMDataFormat,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -12,10 +12,12 @@ internal class RUMResourceScope: RUMScope {
     let context: RUMContext
     private let dependencies: RUMScopeDependencies
 
+    /// This Resource's UUID.
+    let resourceUUID: RUMUUID
     /// The name used to identify this Resource.
-    internal let resourceName: String
+    private let resourceName: String
     /// Resource attributes.
-    private(set) var attributes: [AttributeKey: AttributeValue]
+    private var attributes: [AttributeKey: AttributeValue]
 
     /// The Resource url.
     private var resourceURL: String
@@ -39,6 +41,7 @@ internal class RUMResourceScope: RUMScope {
     ) {
         self.context = context
         self.dependencies = dependencies
+        self.resourceUUID = dependencies.rumUUIDGenerator.generateUnique()
         self.resourceName = resourceName
         self.attributes = attributes
         self.resourceURL = url
@@ -87,6 +90,7 @@ internal class RUMResourceScope: RUMScope {
         let eventData = RUMResource(
             date: resourceStartTime.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
+            service: nil,
             session: .init(id: context.sessionID.toRUMDataFormat, type: .user),
             view: .init(
                 id: context.activeViewID.orNull.toRUMDataFormat,
@@ -95,8 +99,12 @@ internal class RUMResourceScope: RUMScope {
             ),
             usr: dependencies.userInfoProvider.current,
             connectivity: dependencies.connectivityInfoProvider.current,
-            dd: .init(),
+            dd: .init(
+                spanID: nil,
+                traceID: nil
+            ),
             resource: .init(
+                id: resourceUUID.toRUMDataFormat,
                 type: command.kind.toRUMDataFormat,
                 method: resourceHTTPMethod.toRUMDataFormat,
                 url: resourceURL,
@@ -130,6 +138,7 @@ internal class RUMResourceScope: RUMScope {
         let eventData = RUMError(
             date: command.time.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
+            service: nil,
             session: .init(id: context.sessionID.toRUMDataFormat, type: .user),
             view: .init(
                 id: context.activeViewID.orNull.toRUMDataFormat,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -113,6 +113,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         let eventData = RUMAction(
             date: actionStartTime.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
+            service: nil,
             session: .init(id: context.sessionID.toRUMDataFormat, type: .user),
             view: .init(
                 id: context.activeViewID.orNull.toRUMDataFormat,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -211,6 +211,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let eventData = RUMAction(
             date: viewStartTime.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
+            service: nil,
             session: .init(id: context.sessionID.toRUMDataFormat, type: .user),
             view: .init(
                 id: viewUUID.toRUMDataFormat,
@@ -243,6 +244,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let eventData = RUMView(
             date: viewStartTime.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
+            service: nil,
             session: .init(id: context.sessionID.toRUMDataFormat, type: .user),
             view: .init(
                 id: viewUUID.toRUMDataFormat,
@@ -277,6 +279,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let eventData = RUMError(
             date: command.time.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
+            service: nil,
             session: .init(id: context.sessionID.toRUMDataFormat, type: .user),
             view: .init(
                 id: context.activeViewID.orNull.toRUMDataFormat,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -177,7 +177,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             attributes: command.attributes,
             startTime: command.time,
             url: command.url,
-            httpMethod: command.httpMethod
+            httpMethod: command.httpMethod,
+            spanContext: command.spanContext
         )
     }
 

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -240,7 +240,8 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 time: dateProvider.currentDate(),
                 attributes: attributes,
                 url: url.absoluteString,
-                httpMethod: httpMethod
+                httpMethod: httpMethod,
+                spanContext: nil
             )
         )
     }

--- a/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
+++ b/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
@@ -23,14 +23,14 @@ internal class URLSessionTracingHandler: URLSessionTracingHandlerType {
 
         let span: OTSpan
 
-        if let spanContext = extractSpanContext(from: interception.request, using: tracer) {
+        if let spanContext = interception.spanContext {
             span = tracer.startSpan(
                 spanContext: spanContext,
                 operationName: "urlsession.request",
                 startTime: resourceMetrics.fetch.start
             )
         } else {
-            // Span context may not be injected on some versions of iOS if `URLSession.dataTask(...)` for `URL`
+            // Span context may not be injected on iOS13+ if `URLSession.dataTask(...)` for `URL`
             // was used to create the session task.
             span = tracer.startSpan(
                 operationName: "urlsession.request",
@@ -65,12 +65,5 @@ internal class URLSessionTracingHandler: URLSessionTracingHandlerType {
         }
 
         span.finish(at: resourceMetrics.fetch.end)
-    }
-
-    // MARK: - SpanContext Extraction
-
-    private func extractSpanContext(from request: URLRequest, using tracer: Tracer) -> DDSpanContext? {
-        let reader = HTTPHeadersReader(httpHeaderFields: request.allHTTPHeaderFields ?? [:])
-        return tracer.extract(reader: reader) as? DDSpanContext
     }
 }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
@@ -16,6 +16,9 @@ internal class TaskInterception {
     private(set) var metrics: ResourceMetrics?
     /// Task completion collected during this interception.
     private(set) var completion: ResourceCompletion?
+    /// Trace information propagated with the task. Not available when Tracing is disabled
+    /// or when the task was created through `URLSession.dataTask(with:url)` on some iOS13+.
+    private(set) var spanContext: DDSpanContext?
 
     init(request: URLRequest) {
         self.identifier = UUID()
@@ -28,6 +31,10 @@ internal class TaskInterception {
 
     func register(completion: ResourceCompletion) {
         self.completion = completion
+    }
+
+    func register(spanContext: DDSpanContext) {
+        self.spanContext = spanContext
     }
 
     /// Tells if the interception is done (mean: both metrics and completion were collected).

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -172,7 +172,10 @@ internal class URLSessionInterceptor: URLSessionInterceptorType {
     }
 
     private func extractSpanContext(from request: URLRequest, using tracer: Tracer) -> DDSpanContext? {
-        let reader = HTTPHeadersReader(httpHeaderFields: request.allHTTPHeaderFields ?? [:])
+        guard let headers = request.allHTTPHeaderFields else {
+            return nil
+        }
+        let reader = HTTPHeadersReader(httpHeaderFields: headers)
         return tracer.extract(reader: reader) as? DDSpanContext
     }
 }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -94,6 +94,11 @@ internal class URLSessionInterceptor: URLSessionInterceptorType {
             let interception = TaskInterception(request: request)
             self.interceptionByTask[task] = interception
 
+            if let tracer = Global.sharedTracer as? Tracer,
+               let spanContext = self.extractSpanContext(from: request, using: tracer) {
+                interception.register(spanContext: spanContext)
+            }
+
             self.rumResourceHandler?.notify_taskInterceptionStarted(interception: interception)
         }
     }
@@ -151,7 +156,7 @@ internal class URLSessionInterceptor: URLSessionInterceptorType {
         self.rumResourceHandler?.notify_taskInterceptionCompleted(interception: interception)
     }
 
-    // MARK: - SpanContext Injection
+    // MARK: - SpanContext Injection & Extraction
 
     private func injectSpanContext(into request: URLRequest, using tracer: Tracer) -> URLRequest {
         let writer = HTTPHeadersWriter()
@@ -164,5 +169,10 @@ internal class URLSessionInterceptor: URLSessionInterceptorType {
             newRequest.setValue(value, forHTTPHeaderField: field)
         }
         return newRequest
+    }
+
+    private func extractSpanContext(from request: URLRequest, using tracer: Tracer) -> DDSpanContext? {
+        let reader = HTTPHeadersReader(httpHeaderFields: request.allHTTPHeaderFields ?? [:])
+        return tracer.extract(reader: reader) as? DDSpanContext
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -173,10 +173,16 @@ extension RUMStartResourceCommand {
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
         url: String = .mockAny(),
-        httpMethod: RUMHTTPMethod = .mockAny()
+        httpMethod: RUMHTTPMethod = .mockAny(),
+        spanContext: RUMSpanContext? = nil
     ) -> RUMStartResourceCommand {
         return RUMStartResourceCommand(
-            resourceName: resourceName, time: time, attributes: attributes, url: url, httpMethod: httpMethod
+            resourceName: resourceName,
+            time: time,
+            attributes: attributes,
+            url: url,
+            httpMethod: httpMethod,
+            spanContext: spanContext
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -60,8 +60,8 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
 
         let resourceStartCommand = try XCTUnwrap(commandSubscriber.lastReceivedCommand as? RUMStartResourceCommand)
-        XCTAssertEqual(resourceStartCommand.spanContext?.traceID, 1)
-        XCTAssertEqual(resourceStartCommand.spanContext?.spanID, 2)
+        XCTAssertEqual(resourceStartCommand.spanContext?.traceID, "1")
+        XCTAssertEqual(resourceStartCommand.spanContext?.spanID, "2")
     }
 
     func testGivenTaskInterceptionWithMetricsAndCompletion_whenInterceptionCompletes_itStopsRUMResourceWithMetrics() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -69,7 +69,7 @@ class RUMResourceScopeTests: XCTestCase {
             startTime: currentTime,
             url: "https://foo.com/resource/1",
             httpMethod: .POST,
-            spanContext: .init(traceID: 100, spanID: 200)
+            spanContext: .init(traceID: "100", spanID: "200")
         )
 
         currentTime.addTimeInterval(2)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -53,24 +53,6 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(scope.context.activeUserActionID, try XCTUnwrap(scope.userActionScope?.actionUUID))
     }
 
-    func testWhenScopeIsCreated_itReceivesRandomUUID() {
-        func createScope() -> RUMViewScope {
-            RUMViewScope(
-                parent: parent,
-                dependencies: .mockAny(),
-                identity: mockView,
-                uri: "UIViewController",
-                attributes: [:],
-                startTime: .mockAny()
-            )
-        }
-
-        let scope1 = createScope()
-        let scope2 = createScope()
-
-        XCTAssertNotEqual(scope1.viewUUID, scope2.viewUUID)
-    }
-
     func testWhenInitialViewIsStarted_itSendsApplicationStartAction() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
@@ -264,6 +246,39 @@ class RUMViewScopeTests: XCTestCase {
         let event = try XCTUnwrap(viewEvents.first)
         XCTAssertEqual(event.model.view.url, "FirstViewController")
         XCTAssertEqual(event.model.view.timeSpent, TimeInterval(1).toInt64Nanoseconds, "The View should last for 1 second")
+    }
+
+    func testGivenMultipleViewScopes_whenSendingViewEvent_eachScopeUsesUniqueViewID() throws {
+        func createScope(uri: String) -> RUMViewScope {
+            RUMViewScope(
+                parent: parent,
+                dependencies: dependencies,
+                identity: mockView,
+                uri: uri,
+                attributes: [:],
+                startTime: .mockAny()
+            )
+        }
+
+        // Given
+        let scope1 = createScope(uri: "View1")
+        let scope2 = createScope(uri: "View2")
+
+        // When
+        [scope1, scope2].forEach { scope in
+            _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
+            _ = scope.process(command: RUMStopViewCommand.mockWith(identity: mockView))
+        }
+
+        // Then
+        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMView>.self)
+        let view1Events = viewEvents.filter { $0.model.view.url == "View1" }
+        let view2Events = viewEvents.filter { $0.model.view.url == "View2" }
+        XCTAssertEqual(view1Events.count, 2)
+        XCTAssertEqual(view2Events.count, 2)
+        XCTAssertEqual(view1Events[0].model.view.id, view1Events[1].model.view.id)
+        XCTAssertEqual(view2Events[0].model.view.id, view2Events[1].model.view.id)
+        XCTAssertNotEqual(view1Events[0].model.view.id, view2Events[0].model.view.id)
     }
 
     // MARK: - Resources Tracking

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -53,6 +53,24 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(scope.context.activeUserActionID, try XCTUnwrap(scope.userActionScope?.actionUUID))
     }
 
+    func testWhenScopeIsCreated_itReceivesRandomUUID() {
+        func createScope() -> RUMViewScope {
+            RUMViewScope(
+                parent: parent,
+                dependencies: .mockAny(),
+                identity: mockView,
+                uri: "UIViewController",
+                attributes: [:],
+                startTime: .mockAny()
+            )
+        }
+
+        let scope1 = createScope()
+        let scope2 = createScope()
+
+        XCTAssertNotEqual(scope1.viewUUID, scope2.viewUUID)
+    }
+
     func testWhenInitialViewIsStarted_itSendsApplicationStartAction() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -17,16 +17,15 @@ class URLSessionTracingHandlerTests: XCTestCase {
         spanOutput.onSpanRecorded = { _ in spanSentExpectation.fulfill() }
 
         // Given
-        var requestWithSpanContext = URLRequest(url: .mockAny())
-        requestWithSpanContext.addValue("100", forHTTPHeaderField: TracingHTTPHeaders.traceIDField)
-        requestWithSpanContext.addValue("200", forHTTPHeaderField: TracingHTTPHeaders.parentSpanIDField)
-
-        let interception = TaskInterception(request: requestWithSpanContext)
+        let interception = TaskInterception(request: .mockAny())
         interception.register(completion: .mockAny())
         interception.register(
             metrics: .mockWith(
                 fetch: (start: .mockDecember15th2019At10AMUTC(), end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
             )
+        )
+        interception.register(
+            spanContext: .mockWith(traceID: 100, spanID: 200, parentSpanID: nil)
         )
 
         // When

--- a/Tests/DatadogTests/Helpers/SwiftExtensions.swift
+++ b/Tests/DatadogTests/Helpers/SwiftExtensions.swift
@@ -100,3 +100,11 @@ extension InputStream {
         return data
     }
 }
+
+extension URLRequest {
+    func removing(httpHeaderField: String) -> URLRequest {
+        var request = self
+        request.setValue(nil, forHTTPHeaderField: httpHeaderField)
+        return request
+    }
+}

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -93,6 +93,9 @@ internal class RUMSessionMatcher {
         let errorEvents: [RUMError] = try (eventsMatchersByType["error"] ?? [])
             .map { matcher in try matcher.model() }
 
+        // Validate each group of events individually
+        try validate(rumResourceEvents: resourceEvents)
+
         // Group RUMView events into ViewVisits:
         let uniqueViewIDs = Set(viewEvents.map { $0.view.id })
         let visits = uniqueViewIDs.map { viewID in ViewVisit(viewID: viewID) }
@@ -156,5 +159,15 @@ internal class RUMSessionMatcher {
         }
 
         self.viewVisits = visitsEventOrderedByTime
+    }
+}
+
+private func validate(rumResourceEvents: [RUMResource]) throws {
+    // Each `RUMResource` should have unique ID
+    let ids = Set(rumResourceEvents.map { $0.resource.id })
+    if ids.count != rumResourceEvents.count {
+        throw RUMSessionConsistencyException(
+            description: "`resource.id` should be unique - found at least two RUMResource events with the same `resource.id`."
+        )
     }
 }


### PR DESCRIPTION
### What and why?

🚚 This PR adds `trace_id`, `span_id` and `id` information to RUM Resource events. Soon (`RUMM-696`) the `Span` won't be sent from the mobile SDK, but instead the RUM backend will generate it.

### How?

Recap: session interceptor manages the `URLRequest` mutation and notifies both, tracing and RUM handlers with different states of the `TaskInterception`.

Now,  the `SpanContext` is attached to `TaskInterception`. Each handler reads the `SpanContext` and processes it accordingly (tracing handler sends the `Span`, RUM handler encodes `trace_id` and `span_id` in RUM Resource event).

This required updating data models to recent `rum-events-format`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
