### PR TITLE
RUMM-851 Fix: Tests flakiness

### DIFF
--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -76,6 +76,9 @@ class DatadogTests: XCTestCase {
         func verify(configuration: Datadog.Configuration, verificationBlock: () -> Void) throws {
             Datadog.initialize(appContext: .mockAny(), configuration: configuration)
             verificationBlock()
+
+            RUMAutoInstrumentation.instance?.views?.swizzler.unswizzle()
+            URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
             try Datadog.deinitializeOrThrow()
         }
 

--- a/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
@@ -25,18 +25,18 @@ class URLSessionInterceptorMock: URLSessionInterceptorType {
     }
 
     func taskCreated(urlSession: URLSession, task: URLSessionTask) {
-        onTaskCreated?(urlSession, task)
         tasksCreated.append((session: urlSession, task: task))
+        onTaskCreated?(urlSession, task)
     }
 
     func taskCompleted(urlSession: URLSession, task: URLSessionTask, error: Error?) {
-        onTaskCompleted?(urlSession, task, error)
         tasksCompleted.append((session: urlSession, task: task, error: error))
+        onTaskCompleted?(urlSession, task, error)
     }
 
     func taskMetricsCollected(urlSession: URLSession, task: URLSessionTask, metrics: URLSessionTaskMetrics) {
-        onTaskMetricsCollected?(urlSession, task, metrics)
         taskMetrics.append((session: urlSession, task: task, metrics: metrics))
+        onTaskMetricsCollected?(urlSession, task, metrics)
     }
 }
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
@@ -27,7 +27,10 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
             configuration: .mockAny(),
             dateProvider: SystemDateProvider()
         )
-        defer { URLSessionAutoInstrumentation.instance = nil }
+        defer {
+            URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
+            URLSessionAutoInstrumentation.instance = nil
+        }
 
         // When
         Global.rum = RUMMonitor.initialize()


### PR DESCRIPTION
### What and why?

`URLSessionSwizzlerTests` started giving non-deterministic results.

Problems:
1. According to logs, some expectations are fulfilled multiple times.
2. `interceptor.tasksCompleted.count` is 3 during assertion (it must be 4) but a few lines later it becomes 4

Reasons:
1. In another, unrelated place SDK swizzles a method without unswizzling it later. Then, when this particular test case swizzles it becomes double-swizzled.
2. `InterceptorMock` fulfills its expectation before adding new item to its storage

### How?

Reasons are fixed

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
