### PR TITLE
RUMM-726: Renaming RUM models

### DIFF
--- a/Datadog/Example/TestScenarios.swift
+++ b/Datadog/Example/TestScenarios.swift
@@ -177,7 +177,7 @@ struct RUMNavigationControllerScenario: TestScenario {
     static let storyboardName = "RUMNavigationControllerScenario"
 
     private class Predicate: UIKitRUMViewsPredicate {
-        func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+        func rumView(for viewController: UIViewController) -> RUMView? {
             switch viewController.accessibilityLabel {
             case "Screen 1":
                 return .init(path: "Screen1")
@@ -207,7 +207,7 @@ struct RUMTabBarAutoInstrumentationScenario: TestScenario {
     static var storyboardName: String = "RUMTabBarAutoInstrumentationScenario"
 
     private class Predicate: UIKitRUMViewsPredicate {
-        func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+        func rumView(for viewController: UIViewController) -> RUMView? {
             if let viewName = viewController.accessibilityLabel {
                 return .init(path: viewName)
             } else {
@@ -230,7 +230,7 @@ struct RUMModalViewsAutoInstrumentationScenario: TestScenario {
     static var storyboardName: String = "RUMModalViewsAutoInstrumentationScenario"
 
     private class Predicate: UIKitRUMViewsPredicate {
-        func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+        func rumView(for viewController: UIViewController) -> RUMView? {
             if let viewName = viewController.accessibilityLabel {
                 return .init(path: viewName)
             } else {
@@ -254,7 +254,7 @@ struct RUMTapActionScenario: TestScenario {
     static var storyboardName: String = "RUMTapActionScenario"
 
     private class Predicate: UIKitRUMViewsPredicate {
-        func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+        func rumView(for viewController: UIViewController) -> RUMView? {
             switch NSStringFromClass(type(of: viewController)) {
             case "Example.RUMTASScreen1ViewController":
                 return .init(path: "MenuViewController")
@@ -286,7 +286,7 @@ class RUMResourcesScenario: URLSessionBaseScenario, TestScenario {
     static func envIdentifier() -> String { "RUMResourcesScenario" }
 
     private class Predicate: UIKitRUMViewsPredicate {
-        func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+        func rumView(for viewController: UIViewController) -> RUMView? {
             if let viewName = viewController.accessibilityLabel {
                 return .init(path: viewName)
             } else {

--- a/Shopist/Shopist/AppDelegate.swift
+++ b/Shopist/Shopist/AppDelegate.swift
@@ -44,13 +44,13 @@ private struct User {
 }
 
 internal struct ShopistPredicate: UIKitRUMViewsPredicate {
-    func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+    func rumView(for viewController: UIViewController) -> RUMView? {
         if viewController is HomeViewController ||
             viewController is CatalogViewController ||
             viewController is ProductViewController ||
             viewController is CheckoutViewController {
             let attributes = viewController.isMovingToParent ? ["info": "Redisplay"] : [:]
-            return RUMViewFromPredicate(
+            return RUMView(
                 path: "\(type(of: viewController))",
                 attributes: attributes
             )

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -54,7 +54,7 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
 
     private weak var lastStartedViewController: UIViewController?
 
-    private func startIfNotStarted(rumView: RUMViewFromPredicate, for viewController: UIViewController) {
+    private func startIfNotStarted(rumView: RUMView, for viewController: UIViewController) {
         if viewController === lastStartedViewController {
             return
         }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 /// A description of the RUM View returned from the `UIKitRUMViewsPredicate`.
-public struct RUMViewFromPredicate {
+public struct RUMView {
     // TODO: RUMM-726 Rename to `RUMView` when this name is no longer taken by auto-generated model(s).
 
     /// The RUM View path, appearing as `PATH` in RUM Explorer.
@@ -35,5 +35,5 @@ public protocol UIKitRUMViewsPredicate {
     /// The predicate deciding if the RUM View should be started or ended for given instance of the `UIViewController`.
     /// - Parameter viewController: an instance of the view controller noticed by the SDK.
     /// - Returns: RUM View parameters if received view controller should start/end the RUM View, `nil` otherwise.
-    func rumView(for viewController: UIViewController) -> RUMViewFromPredicate?
+    func rumView(for viewController: UIViewController) -> RUMView?
 }

--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -6,7 +6,7 @@
 
 // This file was generated from JSON Schema using quicktype, do not modify it directly.
 
-// MARK: - RUMAction
+// MARK: - RUMDataAction
 
 import Foundation
 
@@ -15,27 +15,27 @@ internal protocol RUMDataModel: Codable { }
 /// Schema of all properties of an Action event
 ///
 /// Schema of common properties of RUM events
-internal struct RUMAction: RUMDataModel {
+internal struct RUMDataAction: RUMDataModel {
     /// Start of the event in ms from epoch
     let date: Int64
     /// Application properties
-    let application: RUMApplication
+    let application: RUMDataApplication
     /// The service name for this application
     let service: String?
     /// Session properties
-    let session: RUMSession
+    let session: RUMDataSession
     /// View properties
-    let view: RUMActionView
+    let view: RUMDataActionView
     /// User properties
-    let usr: RUMUSR?
+    let usr: RUMDataUSR?
     /// Device connectivity properties
-    let connectivity: RUMConnectivity?
+    let connectivity: RUMDataConnectivity?
     /// Internal properties
-    let dd: RUMActionDD
+    let dd: RUMDataActionDD
     /// RUM event type
     let type = "action"
     /// Action properties
-    let action: RUMActionAction
+    let action: RUMDataActionAction
 
     enum CodingKeys: String, CodingKey {
         case date = "date"
@@ -51,26 +51,26 @@ internal struct RUMAction: RUMDataModel {
     }
 }
 
-// MARK: - RUMActionAction
+// MARK: - RUMDataActionAction
 
 /// Action properties
-internal struct RUMActionAction: Codable {
+internal struct RUMDataActionAction: Codable {
     /// Type of the action
-    let type: RUMActionType
+    let type: RUMDataActionType
     /// UUID of the action
     let id: String?
     /// Duration in ns to the action is considered loaded
     let loadingTime: Int64?
     /// Action target properties
-    let target: RUMTarget?
+    let target: RUMDataTarget?
     /// Properties of the errors of the action
-    let error: RUMActionError?
+    let error: RUMDataActionError?
     /// Properties of the crashes of the action
-    let crash: RUMActionCrash?
+    let crash: RUMDataActionCrash?
     /// Properties of the long tasks of the action
-    let longTask: RUMActionLongTask?
+    let longTask: RUMDataActionLongTask?
     /// Properties of the resources of the action
-    let resource: RUMActionResource?
+    let resource: RUMDataActionResource?
 
     enum CodingKeys: String, CodingKey {
         case type = "type"
@@ -84,10 +84,10 @@ internal struct RUMActionAction: Codable {
     }
 }
 
-// MARK: - RUMActionCrash
+// MARK: - RUMDataActionCrash
 
 /// Properties of the crashes of the action
-internal struct RUMActionCrash: Codable {
+internal struct RUMDataActionCrash: Codable {
     /// Number of crashes that occurred on the action
     let count: Int64
 
@@ -96,10 +96,10 @@ internal struct RUMActionCrash: Codable {
     }
 }
 
-// MARK: - RUMActionError
+// MARK: - RUMDataActionError
 
 /// Properties of the errors of the action
-internal struct RUMActionError: Codable {
+internal struct RUMDataActionError: Codable {
     /// Number of errors that occurred on the action
     let count: Int64
 
@@ -108,10 +108,10 @@ internal struct RUMActionError: Codable {
     }
 }
 
-// MARK: - RUMActionLongTask
+// MARK: - RUMDataActionLongTask
 
 /// Properties of the long tasks of the action
-internal struct RUMActionLongTask: Codable {
+internal struct RUMDataActionLongTask: Codable {
     /// Number of long tasks that occurred on the action
     let count: Int64
 
@@ -120,10 +120,10 @@ internal struct RUMActionLongTask: Codable {
     }
 }
 
-// MARK: - RUMActionResource
+// MARK: - RUMDataActionResource
 
 /// Properties of the resources of the action
-internal struct RUMActionResource: Codable {
+internal struct RUMDataActionResource: Codable {
     /// Number of resources that occurred on the action
     let count: Int64
 
@@ -132,10 +132,10 @@ internal struct RUMActionResource: Codable {
     }
 }
 
-// MARK: - RUMTarget
+// MARK: - RUMDataTarget
 
 /// Action target properties
-internal struct RUMTarget: Codable {
+internal struct RUMDataTarget: Codable {
     /// Target name
     let name: String
 
@@ -145,7 +145,7 @@ internal struct RUMTarget: Codable {
 }
 
 /// Type of the action
-internal enum RUMActionType: String, Codable {
+internal enum RUMDataActionType: String, Codable {
     case applicationStart = "application_start"
     case back = "back"
     case click = "click"
@@ -155,10 +155,10 @@ internal enum RUMActionType: String, Codable {
     case tap = "tap"
 }
 
-// MARK: - RUMApplication
+// MARK: - RUMDataApplication
 
 /// Application properties
-internal struct RUMApplication: Codable {
+internal struct RUMDataApplication: Codable {
     /// UUID of the application
     let id: String
 
@@ -167,16 +167,16 @@ internal struct RUMApplication: Codable {
     }
 }
 
-// MARK: - RUMConnectivity
+// MARK: - RUMDataConnectivity
 
 /// Device connectivity properties
-internal struct RUMConnectivity: Codable {
+internal struct RUMDataConnectivity: Codable {
     /// Status of the device connectivity
-    let status: RUMStatus
+    let status: RUMDataStatus
     /// The list of available network interfaces
-    let interfaces: [RUMInterface]
+    let interfaces: [RUMDataInterface]
     /// Cellular connectivity properties
-    let cellular: RUMCellular?
+    let cellular: RUMDataCellular?
 
     enum CodingKeys: String, CodingKey {
         case status = "status"
@@ -185,10 +185,10 @@ internal struct RUMConnectivity: Codable {
     }
 }
 
-// MARK: - RUMCellular
+// MARK: - RUMDataCellular
 
 /// Cellular connectivity properties
-internal struct RUMCellular: Codable {
+internal struct RUMDataCellular: Codable {
     /// The type of a radio technology used for cellular connection
     let technology: String?
     /// The name of the SIM carrier
@@ -200,7 +200,7 @@ internal struct RUMCellular: Codable {
     }
 }
 
-internal enum RUMInterface: String, Codable {
+internal enum RUMDataInterface: String, Codable {
     case bluetooth = "bluetooth"
     case cellular = "cellular"
     case ethernet = "ethernet"
@@ -213,16 +213,16 @@ internal enum RUMInterface: String, Codable {
 }
 
 /// Status of the device connectivity
-internal enum RUMStatus: String, Codable {
+internal enum RUMDataStatus: String, Codable {
     case connected = "connected"
     case maybe = "maybe"
     case notConnected = "not_connected"
 }
 
-// MARK: - RUMActionDD
+// MARK: - RUMDataActionDD
 
 /// Internal properties
-internal struct RUMActionDD: Codable {
+internal struct RUMDataActionDD: Codable {
     /// Version of the RUM event format
     let formatVersion = 2
 
@@ -231,14 +231,14 @@ internal struct RUMActionDD: Codable {
     }
 }
 
-// MARK: - RUMSession
+// MARK: - RUMDataSession
 
 /// Session properties
-internal struct RUMSession: Codable {
+internal struct RUMDataSession: Codable {
     /// UUID of the session
     let id: String
     /// Type of the session
-    let type: RUMSessionType
+    let type: RUMDataSessionType
 
     enum CodingKeys: String, CodingKey {
         case id = "id"
@@ -247,15 +247,15 @@ internal struct RUMSession: Codable {
 }
 
 /// Type of the session
-internal enum RUMSessionType: String, Codable {
+internal enum RUMDataSessionType: String, Codable {
     case synthetics = "synthetics"
     case user = "user"
 }
 
-// MARK: - RUMUSR
+// MARK: - RUMDataUSR
 
 /// User properties
-internal struct RUMUSR: Codable {
+internal struct RUMDataUSR: Codable {
     /// Identifier of the user
     let id: String?
     /// Name of the user
@@ -270,10 +270,10 @@ internal struct RUMUSR: Codable {
     }
 }
 
-// MARK: - RUMActionView
+// MARK: - RUMDataActionView
 
 /// View properties
-internal struct RUMActionView: Codable {
+internal struct RUMDataActionView: Codable {
     /// UUID of the view
     let id: String
     /// URL that linked to the initial view of the page
@@ -288,34 +288,34 @@ internal struct RUMActionView: Codable {
     }
 }
 
-// MARK: - RUMError
+// MARK: - RUMDataError
 
 /// Schema of all properties of an Error event
 ///
 /// Schema of common properties of RUM events
-internal struct RUMError: RUMDataModel {
+internal struct RUMDataError: RUMDataModel {
     /// Start of the event in ms from epoch
     let date: Int64
     /// Application properties
-    let application: RUMApplication
+    let application: RUMDataApplication
     /// The service name for this application
     let service: String?
     /// Session properties
-    let session: RUMSession
+    let session: RUMDataSession
     /// View properties
-    let view: RUMActionView
+    let view: RUMDataActionView
     /// User properties
-    let usr: RUMUSR?
+    let usr: RUMDataUSR?
     /// Device connectivity properties
-    let connectivity: RUMConnectivity?
+    let connectivity: RUMDataConnectivity?
     /// Internal properties
-    let dd: RUMActionDD
+    let dd: RUMDataActionDD
     /// RUM event type
     let type = "error"
     /// Error properties
-    let error: RUMErrorError
+    let error: RUMDataErrorError
     /// Action properties
-    let action: RUMErrorAction?
+    let action: RUMDataErrorAction?
 
     enum CodingKeys: String, CodingKey {
         case date = "date"
@@ -332,10 +332,10 @@ internal struct RUMError: RUMDataModel {
     }
 }
 
-// MARK: - RUMErrorAction
+// MARK: - RUMDataErrorAction
 
 /// Action properties
-internal struct RUMErrorAction: Codable {
+internal struct RUMDataErrorAction: Codable {
     /// UUID of the action
     let id: String
 
@@ -344,20 +344,20 @@ internal struct RUMErrorAction: Codable {
     }
 }
 
-// MARK: - RUMErrorError
+// MARK: - RUMDataErrorError
 
 /// Error properties
-internal struct RUMErrorError: Codable {
+internal struct RUMDataErrorError: Codable {
     /// Error message
     let message: String
     /// Source of the error
-    let source: RUMSource
+    let source: RUMDataSource
     /// Stacktrace of the error
     let stack: String?
     /// Whether this error crashed the host application
     let isCrash: Bool?
     /// Resource properties of the error
-    let resource: RUMErrorResource?
+    let resource: RUMDataErrorResource?
 
     enum CodingKeys: String, CodingKey {
         case message = "message"
@@ -368,12 +368,12 @@ internal struct RUMErrorError: Codable {
     }
 }
 
-// MARK: - RUMErrorResource
+// MARK: - RUMDataErrorResource
 
 /// Resource properties of the error
-internal struct RUMErrorResource: Codable {
+internal struct RUMDataErrorResource: Codable {
     /// HTTP method of the resource
-    let method: RUMMethod
+    let method: RUMDataMethod
     /// HTTP Status code of the resource
     let statusCode: Int64
     /// URL of the resource
@@ -387,7 +387,7 @@ internal struct RUMErrorResource: Codable {
 }
 
 /// HTTP method of the resource
-internal enum RUMMethod: String, Codable {
+internal enum RUMDataMethod: String, Codable {
     case delete = "DELETE"
     case head = "HEAD"
     case methodGET = "GET"
@@ -397,43 +397,44 @@ internal enum RUMMethod: String, Codable {
 }
 
 /// Source of the error
-internal enum RUMSource: String, Codable {
+internal enum RUMDataSource: String, Codable {
     case agent = "agent"
     case console = "console"
+    case custom = "custom"
     case logger = "logger"
     case network = "network"
     case source = "source"
     case webview = "webview"
 }
 
-// MARK: - RUMLongTask
+// MARK: - RUMDataLongTask
 
 /// Schema of all properties of a Long Task event
 ///
 /// Schema of common properties of RUM events
-internal struct RUMLongTask: RUMDataModel {
+internal struct RUMDataLongTask: RUMDataModel {
     /// Start of the event in ms from epoch
     let date: Int64
     /// Application properties
-    let application: RUMApplication
+    let application: RUMDataApplication
     /// The service name for this application
     let service: String?
     /// Session properties
-    let session: RUMSession
+    let session: RUMDataSession
     /// View properties
-    let view: RUMActionView
+    let view: RUMDataActionView
     /// User properties
-    let usr: RUMUSR?
+    let usr: RUMDataUSR?
     /// Device connectivity properties
-    let connectivity: RUMConnectivity?
+    let connectivity: RUMDataConnectivity?
     /// Internal properties
-    let dd: RUMActionDD
+    let dd: RUMDataActionDD
     /// RUM event type
     let type = "long_task"
     /// Long Task properties
-    let longTask: RUMLongTaskLongTask
+    let longTask: RUMDataLongTaskLongTask
     /// Action properties
-    let action: RUMLongTaskAction?
+    let action: RUMDataLongTaskAction?
 
     enum CodingKeys: String, CodingKey {
         case date = "date"
@@ -450,10 +451,10 @@ internal struct RUMLongTask: RUMDataModel {
     }
 }
 
-// MARK: - RUMLongTaskAction
+// MARK: - RUMDataLongTaskAction
 
 /// Action properties
-internal struct RUMLongTaskAction: Codable {
+internal struct RUMDataLongTaskAction: Codable {
     /// UUID of the action
     let id: String
 
@@ -462,10 +463,10 @@ internal struct RUMLongTaskAction: Codable {
     }
 }
 
-// MARK: - RUMLongTaskLongTask
+// MARK: - RUMDataLongTaskLongTask
 
 /// Long Task properties
-internal struct RUMLongTaskLongTask: Codable {
+internal struct RUMDataLongTaskLongTask: Codable {
     /// Duration in ns of the long task
     let duration: Int64
 
@@ -474,34 +475,34 @@ internal struct RUMLongTaskLongTask: Codable {
     }
 }
 
-// MARK: - RUMResource
+// MARK: - RUMDataResource
 
 /// Schema of all properties of a Resource event
 ///
 /// Schema of common properties of RUM events
-internal struct RUMResource: RUMDataModel {
+internal struct RUMDataResource: RUMDataModel {
     /// Start of the event in ms from epoch
     let date: Int64
     /// Application properties
-    let application: RUMApplication
+    let application: RUMDataApplication
     /// The service name for this application
     let service: String?
     /// Session properties
-    let session: RUMSession
+    let session: RUMDataSession
     /// View properties
-    let view: RUMActionView
+    let view: RUMDataActionView
     /// User properties
-    let usr: RUMUSR?
+    let usr: RUMDataUSR?
     /// Device connectivity properties
-    let connectivity: RUMConnectivity?
+    let connectivity: RUMDataConnectivity?
     /// Internal properties
-    let dd: RUMResourceDD
+    let dd: RUMDataResourceDD
     /// RUM event type
     let type = "resource"
     /// Resource properties
-    let resource: RUMResourceResource
+    let resource: RUMDataResourceResource
     /// Action properties
-    let action: RUMResourceAction?
+    let action: RUMDataResourceAction?
 
     enum CodingKeys: String, CodingKey {
         case date = "date"
@@ -518,10 +519,10 @@ internal struct RUMResource: RUMDataModel {
     }
 }
 
-// MARK: - RUMResourceAction
+// MARK: - RUMDataResourceAction
 
 /// Action properties
-internal struct RUMResourceAction: Codable {
+internal struct RUMDataResourceAction: Codable {
     /// UUID of the action
     let id: String
 
@@ -530,10 +531,10 @@ internal struct RUMResourceAction: Codable {
     }
 }
 
-// MARK: - RUMResourceDD
+// MARK: - RUMDataResourceDD
 
 /// Internal properties
-internal struct RUMResourceDD: Codable {
+internal struct RUMDataResourceDD: Codable {
     /// Version of the RUM event format
     let formatVersion = 2
     /// span identifier in decimal format
@@ -548,16 +549,16 @@ internal struct RUMResourceDD: Codable {
     }
 }
 
-// MARK: - RUMResourceResource
+// MARK: - RUMDataResourceResource
 
 /// Resource properties
-internal struct RUMResourceResource: Codable {
+internal struct RUMDataResourceResource: Codable {
     /// UUID of the resource
     let id: String?
     /// Resource type
-    let type: RUMResourceType
+    let type: RUMDataResourceType
     /// HTTP method of the resource
-    let method: RUMMethod?
+    let method: RUMDataMethod?
     /// URL of the resource
     let url: String
     /// HTTP status code of the resource
@@ -567,17 +568,17 @@ internal struct RUMResourceResource: Codable {
     /// Size in octet of the resource response body
     let size: Int64?
     /// Redirect phase properties
-    let redirect: RUMRedirect?
+    let redirect: RUMDataRedirect?
     /// DNS phase properties
-    let dns: RUMDNS?
+    let dns: RUMDataDNS?
     /// Connect phase properties
-    let connect: RUMConnect?
+    let connect: RUMDataConnect?
     /// SSL phase properties
-    let ssl: RUMSSL?
+    let ssl: RUMDataSSL?
     /// First Byte phase properties
-    let firstByte: RUMFirstByte?
+    let firstByte: RUMDataFirstByte?
     /// Download phase properties
-    let download: RUMDownload?
+    let download: RUMDataDownload?
 
     enum CodingKeys: String, CodingKey {
         case id = "id"
@@ -596,10 +597,10 @@ internal struct RUMResourceResource: Codable {
     }
 }
 
-// MARK: - RUMConnect
+// MARK: - RUMDataConnect
 
 /// Connect phase properties
-internal struct RUMConnect: Codable {
+internal struct RUMDataConnect: Codable {
     /// Duration in ns of the resource connect phase
     let duration: Int64
     /// Duration in ns between start of the request and start of the connect phase
@@ -611,10 +612,10 @@ internal struct RUMConnect: Codable {
     }
 }
 
-// MARK: - RUMDNS
+// MARK: - RUMDataDNS
 
 /// DNS phase properties
-internal struct RUMDNS: Codable {
+internal struct RUMDataDNS: Codable {
     /// Duration in ns of the resource dns phase
     let duration: Int64
     /// Duration in ns between start of the request and start of the dns phase
@@ -626,10 +627,10 @@ internal struct RUMDNS: Codable {
     }
 }
 
-// MARK: - RUMDownload
+// MARK: - RUMDataDownload
 
 /// Download phase properties
-internal struct RUMDownload: Codable {
+internal struct RUMDataDownload: Codable {
     /// Duration in ns of the resource download phase
     let duration: Int64
     /// Duration in ns between start of the request and start of the download phase
@@ -641,10 +642,10 @@ internal struct RUMDownload: Codable {
     }
 }
 
-// MARK: - RUMFirstByte
+// MARK: - RUMDataFirstByte
 
 /// First Byte phase properties
-internal struct RUMFirstByte: Codable {
+internal struct RUMDataFirstByte: Codable {
     /// Duration in ns of the resource first byte phase
     let duration: Int64
     /// Duration in ns between start of the request and start of the first byte phase
@@ -656,10 +657,10 @@ internal struct RUMFirstByte: Codable {
     }
 }
 
-// MARK: - RUMRedirect
+// MARK: - RUMDataRedirect
 
 /// Redirect phase properties
-internal struct RUMRedirect: Codable {
+internal struct RUMDataRedirect: Codable {
     /// Duration in ns of the resource redirect phase
     let duration: Int64
     /// Duration in ns between start of the request and start of the redirect phase
@@ -671,10 +672,10 @@ internal struct RUMRedirect: Codable {
     }
 }
 
-// MARK: - RUMSSL
+// MARK: - RUMDataSSL
 
 /// SSL phase properties
-internal struct RUMSSL: Codable {
+internal struct RUMDataSSL: Codable {
     /// Duration in ns of the resource ssl phase
     let duration: Int64
     /// Duration in ns between start of the request and start of the ssl phase
@@ -687,7 +688,7 @@ internal struct RUMSSL: Codable {
 }
 
 /// Resource type
-internal enum RUMResourceType: String, Codable {
+internal enum RUMDataResourceType: String, Codable {
     case beacon = "beacon"
     case css = "css"
     case document = "document"
@@ -700,28 +701,28 @@ internal enum RUMResourceType: String, Codable {
     case xhr = "xhr"
 }
 
-// MARK: - RUMView
+// MARK: - RUMDataView
 
 /// Schema of all properties of a View event
 ///
 /// Schema of common properties of RUM events
-internal struct RUMView: RUMDataModel {
+internal struct RUMDataView: RUMDataModel {
     /// Start of the event in ms from epoch
     let date: Int64
     /// Application properties
-    let application: RUMApplication
+    let application: RUMDataApplication
     /// The service name for this application
     let service: String?
     /// Session properties
-    let session: RUMSession
+    let session: RUMDataSession
     /// View properties
-    let view: RUMViewView
+    let view: RUMDataViewView
     /// User properties
-    let usr: RUMUSR?
+    let usr: RUMDataUSR?
     /// Device connectivity properties
-    let connectivity: RUMConnectivity?
+    let connectivity: RUMDataConnectivity?
     /// Internal properties
-    let dd: RUMViewDD
+    let dd: RUMDataViewDD
     /// RUM event type
     let type = "view"
 
@@ -738,10 +739,10 @@ internal struct RUMView: RUMDataModel {
     }
 }
 
-// MARK: - RUMViewDD
+// MARK: - RUMDataViewDD
 
 /// Internal properties
-internal struct RUMViewDD: Codable {
+internal struct RUMDataViewDD: Codable {
     /// Version of the RUM event format
     let formatVersion = 2
     /// Version of the update of the view event
@@ -753,10 +754,10 @@ internal struct RUMViewDD: Codable {
     }
 }
 
-// MARK: - RUMViewView
+// MARK: - RUMDataViewView
 
 /// View properties
-internal struct RUMViewView: Codable {
+internal struct RUMDataViewView: Codable {
     /// UUID of the view
     let id: String
     /// URL that linked to the initial view of the page
@@ -766,7 +767,7 @@ internal struct RUMViewView: Codable {
     /// Duration in ns to the view is considered loaded
     let loadingTime: Int64?
     /// Type of the loading of the view
-    let loadingType: RUMLoadingType?
+    let loadingType: RUMDataLoadingType?
     /// Time spent on the view in ns
     let timeSpent: Int64
     /// Duration in ns to the first rendering
@@ -781,15 +782,15 @@ internal struct RUMViewView: Codable {
     /// Duration in ns to the end of the load event handler execution
     let loadEvent: Int64?
     /// Properties of the actions of the view
-    let action: RUMViewAction
+    let action: RUMDataViewAction
     /// Properties of the errors of the view
-    let error: RUMViewError
+    let error: RUMDataViewError
     /// Properties of the crashes of the view
-    let crash: RUMViewCrash?
+    let crash: RUMDataViewCrash?
     /// Properties of the long tasks of the view
-    let longTask: RUMViewLongTask?
+    let longTask: RUMDataViewLongTask?
     /// Properties of the resources of the view
-    let resource: RUMViewResource
+    let resource: RUMDataViewResource
 
     enum CodingKeys: String, CodingKey {
         case id = "id"
@@ -811,10 +812,10 @@ internal struct RUMViewView: Codable {
     }
 }
 
-// MARK: - RUMViewAction
+// MARK: - RUMDataViewAction
 
 /// Properties of the actions of the view
-internal struct RUMViewAction: Codable {
+internal struct RUMDataViewAction: Codable {
     /// Number of actions that occurred on the view
     let count: Int64
 
@@ -823,10 +824,10 @@ internal struct RUMViewAction: Codable {
     }
 }
 
-// MARK: - RUMViewCrash
+// MARK: - RUMDataViewCrash
 
 /// Properties of the crashes of the view
-internal struct RUMViewCrash: Codable {
+internal struct RUMDataViewCrash: Codable {
     /// Number of crashes that occurred on the view
     let count: Int64
 
@@ -835,10 +836,10 @@ internal struct RUMViewCrash: Codable {
     }
 }
 
-// MARK: - RUMViewError
+// MARK: - RUMDataViewError
 
 /// Properties of the errors of the view
-internal struct RUMViewError: Codable {
+internal struct RUMDataViewError: Codable {
     /// Number of errors that occurred on the view
     let count: Int64
 
@@ -848,7 +849,7 @@ internal struct RUMViewError: Codable {
 }
 
 /// Type of the loading of the view
-internal enum RUMLoadingType: String, Codable {
+internal enum RUMDataLoadingType: String, Codable {
     case activityDisplay = "activity_display"
     case activityRedisplay = "activity_redisplay"
     case fragmentDisplay = "fragment_display"
@@ -859,10 +860,10 @@ internal enum RUMLoadingType: String, Codable {
     case viewControllerRedisplay = "view_controller_redisplay"
 }
 
-// MARK: - RUMViewLongTask
+// MARK: - RUMDataViewLongTask
 
 /// Properties of the long tasks of the view
-internal struct RUMViewLongTask: Codable {
+internal struct RUMDataViewLongTask: Codable {
     /// Number of long tasks that occurred on the view
     let count: Int64
 
@@ -871,10 +872,10 @@ internal struct RUMViewLongTask: Codable {
     }
 }
 
-// MARK: - RUMViewResource
+// MARK: - RUMDataViewResource
 
 /// Properties of the resources of the view
-internal struct RUMViewResource: Codable {
+internal struct RUMDataViewResource: Codable {
     /// Number of resources that occurred on the view
     let count: Int64
 
@@ -882,4 +883,4 @@ internal struct RUMViewResource: Codable {
         case count = "count"
     }
 }
-// c84571fec8cbb47cf0fb30b0f476a0d4d09d7262
+// 0ae8f253c60662158a1342d8b680243a14d03578

--- a/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
@@ -21,7 +21,7 @@ internal extension RUMUUID {
 }
 
 internal extension RUMHTTPMethod {
-    var toRUMDataFormat: RUMMethod {
+    var toRUMDataFormat: RUMDataMethod {
         switch self {
         case .GET: return .methodGET
         case .POST: return .post
@@ -34,7 +34,7 @@ internal extension RUMHTTPMethod {
 }
 
 internal extension RUMResourceKind {
-    var toRUMDataFormat: RUMResourceType {
+    var toRUMDataFormat: RUMDataResourceType {
         switch self {
         case .image: return .image
         case .xhr: return .xhr
@@ -51,7 +51,7 @@ internal extension RUMResourceKind {
 }
 
 internal extension RUMErrorSource {
-    var toRUMDataFormat: RUMSource {
+    var toRUMDataFormat: RUMDataSource {
         switch self {
         case .source: return .source
         case .console: return .console
@@ -64,7 +64,7 @@ internal extension RUMErrorSource {
 }
 
 internal extension RUMUserActionType {
-    var toRUMDataFormat: RUMActionType {
+    var toRUMDataFormat: RUMDataActionType {
         switch self {
         case .tap: return .tap
         case .scroll: return .scroll

--- a/Sources/Datadog/RUM/RUMEvent/RUMConnectivityInfoProvider.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMConnectivityInfoProvider.swift
@@ -13,13 +13,13 @@ internal struct RUMConnectivityInfoProvider {
     /// Shared mobile carrier info provider.
     let carrierInfoProvider: CarrierInfoProviderType
 
-    var current: RUMConnectivity? {
+    var current: RUMDataConnectivity? {
         guard let networkInfo = networkConnectionInfoProvider.current else {
             return nil
         }
         let carrierInfo = carrierInfoProvider.current
 
-        return RUMConnectivity(
+        return RUMDataConnectivity(
             status: connectivityStatus(for: networkInfo),
             interfaces: connectivityInterfaces(for: networkInfo),
             cellular: carrierInfo.flatMap { connectivityCellularInfo(for: $0) }
@@ -28,7 +28,7 @@ internal struct RUMConnectivityInfoProvider {
 
     // MARK: - Private
 
-    private func connectivityStatus(for networkInfo: NetworkConnectionInfo) -> RUMStatus {
+    private func connectivityStatus(for networkInfo: NetworkConnectionInfo) -> RUMDataStatus {
         switch networkInfo.reachability {
         case .yes:   return .connected
         case .maybe: return .maybe
@@ -36,7 +36,7 @@ internal struct RUMConnectivityInfoProvider {
         }
     }
 
-    private func connectivityInterfaces(for networkInfo: NetworkConnectionInfo) -> [RUMInterface] {
+    private func connectivityInterfaces(for networkInfo: NetworkConnectionInfo) -> [RUMDataInterface] {
         guard let availableInterfaces = networkInfo.availableInterfaces, !availableInterfaces.isEmpty else {
             return [.none]
         }
@@ -51,7 +51,7 @@ internal struct RUMConnectivityInfoProvider {
         }
     }
 
-    private func connectivityCellularInfo(for carrierInfo: CarrierInfo) -> RUMCellular {
+    private func connectivityCellularInfo(for carrierInfo: CarrierInfo) -> RUMDataCellular {
         return .init(
             technology: carrierInfo.radioAccessTechnology.rawValue,
             carrierName: carrierInfo.carrierName

--- a/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
@@ -11,13 +11,13 @@ internal struct RUMUserInfoProvider {
     /// Shared user info provider.
     let userInfoProvider: UserInfoProvider
 
-    var current: RUMUSR? {
+    var current: RUMDataUSR? {
         let userInfo = userInfoProvider.value
 
         if userInfo.id == nil && userInfo.name == nil && userInfo.email == nil {
             return nil
         } else {
-            return RUMUSR(id: userInfo.id, name: userInfo.name, email: userInfo.email)
+            return RUMDataUSR(id: userInfo.id, name: userInfo.name, email: userInfo.email)
         }
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -92,7 +92,7 @@ internal class RUMResourceScope: RUMScope {
             size = command.size
         }
 
-        let eventData = RUMResource(
+        let eventData = RUMDataResource(
             date: resourceStartTime.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
             service: nil,
@@ -118,7 +118,7 @@ internal class RUMResourceScope: RUMScope {
                 size: size ?? 0,
                 redirect: nil,
                 dns: resourceMetrics?.dns.flatMap { dns in
-                    RUMDNS(
+                    RUMDataDNS(
                         duration: dns.duration.toInt64Nanoseconds,
                         start: dns.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
                     )
@@ -140,7 +140,7 @@ internal class RUMResourceScope: RUMScope {
     private func sendErrorEvent(on command: RUMStopResourceWithErrorCommand) {
         attributes.merge(rumCommandAttributes: command.attributes)
 
-        let eventData = RUMError(
+        let eventData = RUMDataError(
             date: command.time.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
             service: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -110,7 +110,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             attributes.merge(rumCommandAttributes: commandAttributes)
         }
 
-        let eventData = RUMAction(
+        let eventData = RUMDataAction(
             date: actionStartTime.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
             service: nil,
@@ -127,7 +127,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 type: actionType.toRUMDataFormat,
                 id: actionUUID.toRUMDataFormat,
                 loadingTime: completionTime.timeIntervalSince(actionStartTime).toInt64Nanoseconds,
-                target: RUMTarget(name: name),
+                target: RUMDataTarget(name: name),
                 error: .init(count: errorsCount.toInt64),
                 crash: nil,
                 longTask: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -209,7 +209,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     // MARK: - Sending RUM Events
 
     private func sendApplicationStartAction(on command: RUMCommand) {
-        let eventData = RUMAction(
+        let eventData = RUMDataAction(
             date: viewStartTime.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
             service: nil,
@@ -242,7 +242,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         version += 1
         attributes.merge(rumCommandAttributes: command.attributes)
 
-        let eventData = RUMView(
+        let eventData = RUMDataView(
             date: viewStartTime.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
             service: nil,
@@ -277,7 +277,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     private func sendErrorEvent(on command: RUMAddCurrentViewErrorCommand) {
         attributes.merge(rumCommandAttributes: command.attributes)
 
-        let eventData = RUMError(
+        let eventData = RUMDataError(
             date: command.time.timeIntervalSince1970.toInt64Milliseconds,
             application: .init(id: context.rumApplicationID),
             service: nil,

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -31,11 +31,11 @@ extension Array where Element == RUMEventMatcher {
     ///
     /// Example output:
     ///
-    ///     [0] - RUMEventMatcher<RUMAction>
-    ///     [1] - RUMEventMatcher<RUMView>
-    ///     [2] - RUMEventMatcher<RUMResource>
-    ///     [3] - RUMEventMatcher<RUMView>
-    ///     [4] - RUMEventMatcher<RUMAction>
+    ///     [0] - RUMEventMatcher<RUMDataAction>
+    ///     [1] - RUMEventMatcher<RUMDataView>
+    ///     [2] - RUMEventMatcher<RUMDataResource>
+    ///     [3] - RUMEventMatcher<RUMDataView>
+    ///     [4] - RUMEventMatcher<RUMDataAction>
     ///
     func inspect() {
         enumerated().forEach { index, matcher in
@@ -45,10 +45,10 @@ extension Array where Element == RUMEventMatcher {
 
     private func getTypeOf(matcher: RUMEventMatcher) -> String {
         let allPossibleMatchers: [String: (RUMEventMatcher) -> Bool] = [
-            "RUMEventMatcher<RUMView>": { matcher in matcher.model(isTypeOf: RUMView.self) },
-            "RUMEventMatcher<RUMAction>": { matcher in matcher.model(isTypeOf: RUMAction.self) },
-            "RUMEventMatcher<RUMResource>": { matcher in matcher.model(isTypeOf: RUMResource.self) },
-            "RUMEventMatcher<RUMError>": { matcher in matcher.model(isTypeOf: RUMError.self) }
+            "RUMEventMatcher<RUMDataView>": { matcher in matcher.model(isTypeOf: RUMDataView.self) },
+            "RUMEventMatcher<RUMDataAction>": { matcher in matcher.model(isTypeOf: RUMDataAction.self) },
+            "RUMEventMatcher<RUMDataResource>": { matcher in matcher.model(isTypeOf: RUMDataResource.self) },
+            "RUMEventMatcher<RUMDataError>": { matcher in matcher.model(isTypeOf: RUMDataError.self) }
         ]
 
         let bestMatcherEntry = allPossibleMatchers

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -90,8 +90,8 @@ class RUMErrorsIntegrationTests: XCTestCase {
 
         // then
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3) // [RUMView, RUMAction, RUMError] events sent
-        let rumErrorMatcher = rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) }
-        try XCTUnwrap(rumErrorMatcher).model(ofType: RUMError.self) { rumModel in
+        let rumErrorMatcher = rumEventMatchers.first { $0.model(isTypeOf: RUMDataError.self) }
+        try XCTUnwrap(rumErrorMatcher).model(ofType: RUMDataError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "error message")
             XCTAssertEqual(rumModel.error.source, .logger)
             XCTAssertEqual(rumModel.error.stack, "Foo.swift:10")

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithRUMErrorsIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithRUMErrorsIntegrationTests.swift
@@ -79,10 +79,10 @@ class TracingWithRUMErrorsIntegrationTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func waitAndReturnRUMErrorSent() throws -> RUMError {
+    private func waitAndReturnRUMErrorSent() throws -> RUMDataError {
         // [RUMView, RUMAction, RUMError] events sent:
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
-        let rumErrorMatcher = try XCTUnwrap(rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) })
+        let rumErrorMatcher = try XCTUnwrap(rumEventMatchers.first { $0.model(isTypeOf: RUMDataError.self) })
         return try rumErrorMatcher.model()
     }
 }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -539,14 +539,14 @@ class LoggerTests: XCTestCase {
         // then
         // [RUMView, RUMAction, RUMError, RUMView, RUMError, RUMView] events sent:
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 6)
-        let rumErrorMatcher1 = rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) }
-        let rumErrorMatcher2 = rumEventMatchers.last { $0.model(isTypeOf: RUMError.self) }
-        try XCTUnwrap(rumErrorMatcher1).model(ofType: RUMError.self) { rumModel in
+        let rumErrorMatcher1 = rumEventMatchers.first { $0.model(isTypeOf: RUMDataError.self) }
+        let rumErrorMatcher2 = rumEventMatchers.last { $0.model(isTypeOf: RUMDataError.self) }
+        try XCTUnwrap(rumErrorMatcher1).model(ofType: RUMDataError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "error message")
             XCTAssertEqual(rumModel.error.source, .logger)
             XCTAssertNil(rumModel.error.stack)
         }
-        try XCTUnwrap(rumErrorMatcher2).model(ofType: RUMError.self) { rumModel in
+        try XCTUnwrap(rumErrorMatcher2).model(ofType: RUMDataError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "critical message")
             XCTAssertEqual(rumModel.error.source, .logger)
             XCTAssertNil(rumModel.error.stack)

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -448,10 +448,10 @@ class RUMCommandSubscriberMock: RUMCommandSubscriber {
 }
 
 class UIKitRUMViewsPredicateMock: UIKitRUMViewsPredicate {
-    var resultByViewController: [UIViewController: RUMViewFromPredicate] = [:]
-    var result: RUMViewFromPredicate?
+    var resultByViewController: [UIViewController: RUMView] = [:]
+    var result: RUMView?
 
-    func rumView(for viewController: UIViewController) -> RUMViewFromPredicate? {
+    func rumView(for viewController: UIViewController) -> RUMView? {
         return resultByViewController[viewController] ?? result
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMConnectivityInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMConnectivityInfoProviderTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 @testable import Datadog
 
-extension RUMConnectivity: EquatableInTests {}
+extension RUMDataConnectivity: EquatableInTests {}
 
 class RUMConnectivityInfoProviderTests: XCTestCase {
     private let networkInfoProvider = NetworkConnectionInfoProviderMock(networkConnectionInfo: .mockAny())
@@ -21,7 +21,7 @@ class RUMConnectivityInfoProviderTests: XCTestCase {
         func verifyConnectivity(
             networkInfo: NetworkConnectionInfo,
             carrierInfo: CarrierInfo,
-            verification: (RUMConnectivity) -> Void
+            verification: (RUMDataConnectivity) -> Void
         ) throws {
             networkInfoProvider.set(current: networkInfo)
             carrierInfoProvider.set(current: carrierInfo)

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 @testable import Datadog
 
-extension RUMUSR: EquatableInTests {}
+extension RUMDataUSR: EquatableInTests {}
 
 class RUMUserInfoProviderTests: XCTestCase {
     private let userInfoProvider = UserInfoProvider()
@@ -20,12 +20,12 @@ class RUMUserInfoProviderTests: XCTestCase {
 
     func testWhenUserInfoIsAvailable_itReturnsRUMUserInfo() {
         userInfoProvider.value = UserInfo(id: "abc-123", name: nil, email: nil)
-        XCTAssertEqual(rumUserInfoProvider.current, RUMUSR(id: "abc-123", name: nil, email: nil))
+        XCTAssertEqual(rumUserInfoProvider.current, RUMDataUSR(id: "abc-123", name: nil, email: nil))
 
         userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: nil)
-        XCTAssertEqual(rumUserInfoProvider.current, RUMUSR(id: "abc-123", name: "Foo", email: nil))
+        XCTAssertEqual(rumUserInfoProvider.current, RUMDataUSR(id: "abc-123", name: "Foo", email: nil))
 
         userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com")
-        XCTAssertEqual(rumUserInfoProvider.current, RUMUSR(id: "abc-123", name: "Foo", email: "foo@bar.com"))
+        XCTAssertEqual(rumUserInfoProvider.current, RUMDataUSR(id: "abc-123", name: "Foo", email: "foo@bar.com"))
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -71,7 +71,7 @@ class RUMApplicationScopeTests: XCTestCase {
         _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
         _ = scope.process(command: RUMStopViewCommand.mockWith(identity: mockView))
 
-        XCTAssertEqual(try output.recordedEvents(ofType: RUMEvent<RUMView>.self).count, 2)
+        XCTAssertEqual(try output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).count, 2)
     }
 
     func testWhenSamplingRateIs0_noEventsAreSent() {
@@ -83,7 +83,7 @@ class RUMApplicationScopeTests: XCTestCase {
         _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
         _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
 
-        XCTAssertEqual(try output.recordedEvents(ofType: RUMEvent<RUMView>.self).count, 0)
+        XCTAssertEqual(try output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).count, 0)
     }
 
     func testWhenSamplingRateIs50_onlyHalfOfTheEventsAreSent() throws {
@@ -100,7 +100,7 @@ class RUMApplicationScopeTests: XCTestCase {
             currentTime.addTimeInterval(RUMSessionScope.Constants.sessionTimeoutDuration) // force the Session to be re-created
         }
 
-        let viewEventsCount = try output.recordedEvents(ofType: RUMEvent<RUMView>.self).count
+        let viewEventsCount = try output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).count
         let trackedSessionsCount = Double(viewEventsCount) / 2 // each Session should send 2 View updates
 
         XCTAssertGreaterThan(trackedSessionsCount, 100 * 0.8) // -20%

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -69,7 +69,7 @@ class RUMResourceScopeTests: XCTestCase {
         )
 
         // Then
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMResource>.self).first)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataResource>.self).first)
         XCTAssertEqual(event.model.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.model.session.id, scope.context.sessionID.toRUMDataFormat)
@@ -127,7 +127,7 @@ class RUMResourceScopeTests: XCTestCase {
         )
 
         // Then
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMError>.self).first)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataError>.self).first)
         XCTAssertEqual(event.model.date, currentTime.timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.model.session.id, scope.context.sessionID.toRUMDataFormat)
@@ -193,7 +193,7 @@ class RUMResourceScopeTests: XCTestCase {
 
         // Then
         let metrics = metricsCommand.metrics
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMResource>.self).first)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataResource>.self).first)
         XCTAssertEqual(event.model.date, metrics.fetch.start.timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.model.session.id, scope.context.sessionID.toRUMDataFormat)
@@ -245,7 +245,7 @@ class RUMResourceScopeTests: XCTestCase {
         _ = scope2.process(command: RUMStopResourceCommand.mockWith(resourceName: resourceName))
 
         // Then
-        let resourceEvents = try output.recordedEvents(ofType: RUMEvent<RUMResource>.self)
+        let resourceEvents = try output.recordedEvents(ofType: RUMEvent<RUMDataResource>.self)
         let resource1Events = resourceEvents.filter { $0.model.resource.url == "/r/1" }
         let resource2Events = resourceEvents.filter { $0.model.resource.url == "/r/2" }
         XCTAssertEqual(resource1Events.count, 1)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -51,7 +51,7 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertTrue(scope.process(command: mockUserActionCmd))
         XCTAssertFalse(scope.process(command: RUMStopViewCommand.mockWith(identity: mockView)))
 
-        let recordedActionEvents = try output.recordedEvents(ofType: RUMEvent<RUMAction>.self)
+        let recordedActionEvents = try output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self)
         XCTAssertEqual(recordedActionEvents.count, 1)
         let recordedAction = try XCTUnwrap(recordedActionEvents.last)
         XCTAssertEqual(recordedAction.model.action.type.rawValue, String(describing: mockUserActionCmd.actionType))
@@ -84,7 +84,7 @@ class RUMUserActionScopeTests: XCTestCase {
             )
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).first)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self).first)
         XCTAssertEqual(event.model.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.model.session.id, scope.context.sessionID.toRUMDataFormat)
@@ -119,7 +119,7 @@ class RUMUserActionScopeTests: XCTestCase {
         currentTime = .mockDecember15th2019At10AMUTC(addingTimeInterval: expirationInterval * 2.0)
         XCTAssertFalse(scope.process(command: RUMCommandMock(time: currentTime)), "Continuous User Action should expire after \(expirationInterval)s")
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).first)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self).first)
         XCTAssertEqual(event.model.action.loadingTime, 10_000_000_000, "Loading time should not exceed expirationInterval")
     }
 
@@ -169,7 +169,7 @@ class RUMUserActionScopeTests: XCTestCase {
             )
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).last)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self).last)
         XCTAssertEqual(event.model.action.resource?.count, 1, "User Action should track first succesfull Resource")
         XCTAssertEqual(event.model.action.error?.count, 1, "User Action should track second Resource failure as Error")
     }
@@ -202,7 +202,7 @@ class RUMUserActionScopeTests: XCTestCase {
             )
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).last)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self).last)
         XCTAssertEqual(event.model.action.error?.count, 1)
     }
 
@@ -230,7 +230,7 @@ class RUMUserActionScopeTests: XCTestCase {
             )
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).last)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self).last)
         XCTAssertEqual(event.model.action.target?.name, differentName)
     }
 
@@ -256,7 +256,7 @@ class RUMUserActionScopeTests: XCTestCase {
         currentTime.addTimeInterval(timeOutInterval)
         XCTAssertFalse(scope.process(command: RUMCommandMock(time: currentTime)), "Discrete User Action should time out after \(timeOutInterval)s")
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).first)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self).first)
         let nanosecondsInSecond: Double = 1_000_000_000
         let actionLoadingTimeInSeconds = Double(try XCTUnwrap(event.model.action.loadingTime)) / nanosecondsInSecond
         XCTAssertEqual(actionLoadingTimeInSeconds, RUMUserActionScope.Constants.discreteActionTimeoutDuration, accuracy: 0.1)
@@ -311,7 +311,7 @@ class RUMUserActionScopeTests: XCTestCase {
             "Discrete User Action should complete as it has no more pending Resources and it reached the timeout duration"
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).last)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self).last)
         XCTAssertEqual(event.model.action.resource?.count, 1, "User Action should track first succesfull Resource")
         XCTAssertEqual(event.model.action.error?.count, 1, "User Action should track second Resource failure as Error")
     }
@@ -343,7 +343,7 @@ class RUMUserActionScopeTests: XCTestCase {
             "Discrete User Action should complete as it reached the timeout duration"
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).last)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self).last)
         XCTAssertEqual(event.model.action.error?.count, 1)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -70,7 +70,7 @@ class RUMViewScopeTests: XCTestCase {
             )
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMAction>.self).first)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataAction>.self).first)
         XCTAssertEqual(event.model.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.model.session.id, scope.context.sessionID.toRUMDataFormat)
@@ -98,7 +98,7 @@ class RUMViewScopeTests: XCTestCase {
             )
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).first)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).first)
         XCTAssertEqual(event.model.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.model.session.id, scope.context.sessionID.toRUMDataFormat)
@@ -130,7 +130,7 @@ class RUMViewScopeTests: XCTestCase {
             )
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).first)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).first)
         XCTAssertEqual(event.model.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(event.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.model.session.id, scope.context.sessionID.toRUMDataFormat)
@@ -165,7 +165,7 @@ class RUMViewScopeTests: XCTestCase {
             "The scope should end."
         )
 
-        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMView>.self)
+        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMDataView>.self)
         XCTAssertEqual(viewEvents.count, 2)
         viewEvents.forEach { viewEvent in
             XCTAssertEqual(
@@ -214,7 +214,7 @@ class RUMViewScopeTests: XCTestCase {
             "The scope should end as another View is started."
         )
 
-        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMView>.self)
+        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMDataView>.self)
         let event = try XCTUnwrap(viewEvents.dropFirst().first)
         XCTAssertEqual(event.model.view.url, "FirstViewController")
         XCTAssertEqual(event.model.view.timeSpent, TimeInterval(1).toInt64Nanoseconds, "The View should last for 1 second")
@@ -242,7 +242,7 @@ class RUMViewScopeTests: XCTestCase {
             "The scope should end as the View was started for another time."
         )
 
-        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMView>.self)
+        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMDataView>.self)
         let event = try XCTUnwrap(viewEvents.first)
         XCTAssertEqual(event.model.view.url, "FirstViewController")
         XCTAssertEqual(event.model.view.timeSpent, TimeInterval(1).toInt64Nanoseconds, "The View should last for 1 second")
@@ -271,7 +271,7 @@ class RUMViewScopeTests: XCTestCase {
         }
 
         // Then
-        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMView>.self)
+        let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMDataView>.self)
         let view1Events = viewEvents.filter { $0.model.view.url == "View1" }
         let view2Events = viewEvents.filter { $0.model.view.url == "View2" }
         XCTAssertEqual(view1Events.count, 2)
@@ -325,7 +325,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertFalse(
             scope.process(command: RUMStopViewCommand.mockWith(identity: mockView))
         )
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).last)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).last)
         XCTAssertEqual(event.model.view.resource.count, 1, "View should record 1 successfull Resource")
         XCTAssertEqual(event.model.view.error.count, 1, "View should record 1 error due to second Resource failure")
     }
@@ -367,7 +367,7 @@ class RUMViewScopeTests: XCTestCase {
             "The View should stop as all its Resources finished loading"
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).last)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).last)
         XCTAssertEqual(event.model.view.resource.count, 1, "View should record 1 successfull Resource")
         XCTAssertEqual(event.model.view.error.count, 1, "View should record 1 error due to second Resource failure")
     }
@@ -408,7 +408,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertFalse(
             scope.process(command: RUMStopViewCommand.mockWith(identity: mockView))
         )
-        let viewEvent = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).last)
+        let viewEvent = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).last)
         XCTAssertEqual(viewEvent.model.view.action.count, 1, "View should record 1 action")
     }
 
@@ -446,7 +446,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertFalse(
             scope.process(command: RUMStopViewCommand.mockWith(time: currentTime, identity: mockView))
         )
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).last)
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).last)
         XCTAssertEqual(event.model.view.action.count, 1, "View should record 1 action")
     }
 
@@ -477,7 +477,7 @@ class RUMViewScopeTests: XCTestCase {
             )
         )
 
-        let error = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMError>.self).last)
+        let error = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataError>.self).last)
         XCTAssertEqual(error.model.date, Date.mockDecember15th2019At10AMUTC(addingTimeInterval: 1).timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(error.model.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(error.model.session.id, scope.context.sessionID.toRUMDataFormat)
@@ -494,7 +494,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertNil(error.model.action)
         XCTAssertEqual(error.attributes as? [String: String], ["foo": "bar"])
 
-        let viewUpdate = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).last)
+        let viewUpdate = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).last)
         XCTAssertEqual(viewUpdate.model.view.error.count, 1)
     }
 
@@ -526,7 +526,7 @@ class RUMViewScopeTests: XCTestCase {
             )
         )
 
-        let viewUpdate = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMView>.self).last)
+        let viewUpdate = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).last)
         XCTAssertEqual(viewUpdate.model.view.resource.count, 0, "Failed Resource should not be counted")
         XCTAssertEqual(viewUpdate.model.view.error.count, 1, "Failed Resource should be counted as Error")
     }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -44,17 +44,17 @@ class RUMMonitorTests: XCTestCase {
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
         verifyGlobalAttributes(in: rumEventMatchers)
-        try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers[0].model(ofType: RUMDataAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
-        try rumEventMatchers[1].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[1].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
         }
-        try rumEventMatchers[2].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[2].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.timeSpent, 1_000_000_000)
         }
-        try rumEventMatchers[3].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[3].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 0)
         }
     }
@@ -72,18 +72,18 @@ class RUMMonitorTests: XCTestCase {
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
         verifyGlobalAttributes(in: rumEventMatchers)
-        try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers[0].model(ofType: RUMDataAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
-        try rumEventMatchers[1].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[1].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.resource.count, 0)
         }
-        try rumEventMatchers[2].model(ofType: RUMResource.self) { rumModel in
+        try rumEventMatchers[2].model(ofType: RUMDataResource.self) { rumModel in
             XCTAssertEqual(rumModel.resource.type, .image)
             XCTAssertEqual(rumModel.resource.statusCode, 200)
         }
-        try rumEventMatchers[3].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[3].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.resource.count, 1)
         }
@@ -108,18 +108,18 @@ class RUMMonitorTests: XCTestCase {
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
         verifyGlobalAttributes(in: rumEventMatchers)
-        try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers[0].model(ofType: RUMDataAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
-        try rumEventMatchers[1].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[1].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.resource.count, 0)
         }
-        try rumEventMatchers[2].model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers[2].model(ofType: RUMDataAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .tap)
             XCTAssertEqual(rumModel.action.target?.name, actionName)
         }
-        try rumEventMatchers[3].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[3].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 2)
             XCTAssertEqual(rumModel.view.resource.count, 0)
         }
@@ -142,39 +142,39 @@ class RUMMonitorTests: XCTestCase {
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 8)
         verifyGlobalAttributes(in: rumEventMatchers)
-        try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers[0].model(ofType: RUMDataAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
-        try rumEventMatchers[1].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[1].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.resource.count, 0)
             XCTAssertEqual(rumModel.view.error.count, 0)
         }
         var userActionID: String?
-        try rumEventMatchers[2].model(ofType: RUMResource.self) { rumModel in
+        try rumEventMatchers[2].model(ofType: RUMDataResource.self) { rumModel in
             userActionID = rumModel.action?.id
             XCTAssertEqual(rumModel.resource.statusCode, 200)
         }
         XCTAssertNotNil(userActionID, "Resource should be associated with the User Action that issued its loading")
-        try rumEventMatchers[3].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[3].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.resource.count, 1)
             XCTAssertEqual(rumModel.view.error.count, 0)
         }
-        try rumEventMatchers[4].model(ofType: RUMResource.self) { rumModel in
+        try rumEventMatchers[4].model(ofType: RUMDataResource.self) { rumModel in
             XCTAssertEqual(rumModel.resource.statusCode, 202)
         }
-        try rumEventMatchers[5].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[5].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.resource.count, 2)
             XCTAssertEqual(rumModel.view.error.count, 0)
         }
-        try rumEventMatchers[6].model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers[6].model(ofType: RUMDataAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.resource?.count, 2)
             XCTAssertEqual(rumModel.action.error?.count, 0)
             XCTAssertEqual(rumModel.action.id, userActionID)
         }
-        try rumEventMatchers[7].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[7].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 2)
             XCTAssertEqual(rumModel.view.resource.count, 2)
             XCTAssertEqual(rumModel.view.error.count, 0)
@@ -202,28 +202,28 @@ class RUMMonitorTests: XCTestCase {
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 6)
         verifyGlobalAttributes(in: rumEventMatchers)
-        try rumEventMatchers[0].model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers[0].model(ofType: RUMDataAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .applicationStart)
         }
-        try rumEventMatchers[1].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[1].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.resource.count, 0)
         }
-        try rumEventMatchers[2].model(ofType: RUMError.self) { rumModel in
+        try rumEventMatchers[2].model(ofType: RUMDataError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "View error message")
             XCTAssertEqual(rumModel.error.stack, "Foo.swift:100")
             XCTAssertEqual(rumModel.error.source, .source)
         }
-        try rumEventMatchers[3].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[3].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 1)
             XCTAssertEqual(rumModel.view.resource.count, 0)
             XCTAssertEqual(rumModel.view.error.count, 1)
         }
-        try rumEventMatchers[4].model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers[4].model(ofType: RUMDataAction.self) { rumModel in
             XCTAssertEqual(rumModel.action.type, .scroll)
             XCTAssertEqual(rumModel.action.error?.count, 1)
         }
-        try rumEventMatchers[5].model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers[5].model(ofType: RUMDataView.self) { rumModel in
             XCTAssertEqual(rumModel.view.action.count, 2)
             XCTAssertEqual(rumModel.view.resource.count, 0)
             XCTAssertEqual(rumModel.view.error.count, 1)
@@ -258,28 +258,28 @@ class RUMMonitorTests: XCTestCase {
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 9)
         verifyGlobalAttributes(in: rumEventMatchers)
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMView.self) { rumModel in rumModel.view.url == "FirstViewController" }
-            .model(ofType: RUMView.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataView.self) { rumModel in rumModel.view.url == "FirstViewController" }
+            .model(ofType: RUMDataView.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "FirstViewController")
                 XCTAssertEqual(rumModel.view.action.count, 1, "First View should track only the 'applicationStart' Action")
                 XCTAssertEqual(rumModel.view.resource.count, 0)
             }
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMView.self) { rumModel in rumModel.view.url == "SecondViewController" }
-            .model(ofType: RUMView.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataView.self) { rumModel in rumModel.view.url == "SecondViewController" }
+            .model(ofType: RUMDataView.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "SecondViewController")
                 XCTAssertEqual(rumModel.view.action.count, 1, "Second View should track the 'tap' Action")
                 XCTAssertEqual(rumModel.view.resource.count, 1, "Second View should track the Resource")
             }
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMAction.self)
-            .model(ofType: RUMAction.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataAction.self)
+            .model(ofType: RUMDataAction.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "SecondViewController", "Action should be associated with the second View")
                 XCTAssertEqual(rumModel.action.type, .tap)
             }
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMResource.self)
-            .model(ofType: RUMResource.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataResource.self)
+            .model(ofType: RUMDataResource.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "SecondViewController", "Resource should be associated with the second View")
             }
     }
@@ -310,36 +310,36 @@ class RUMMonitorTests: XCTestCase {
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 13)
         verifyGlobalAttributes(in: rumEventMatchers)
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMView.self) { rumModel in rumModel.view.url == "FirstViewController" }
-            .model(ofType: RUMView.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataView.self) { rumModel in rumModel.view.url == "FirstViewController" }
+            .model(ofType: RUMDataView.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "FirstViewController")
                 XCTAssertEqual(rumModel.view.resource.count, 1, "First View should track 1 Resource")
                 XCTAssertEqual(rumModel.view.error.count, 1, "First View should track 1 Resource Error")
             }
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMView.self) { rumModel in rumModel.view.url == "SecondViewController" }
-            .model(ofType: RUMView.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataView.self) { rumModel in rumModel.view.url == "SecondViewController" }
+            .model(ofType: RUMDataView.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "SecondViewController")
                 XCTAssertEqual(rumModel.view.resource.count, 2, "Second View should track 2 Resources")
             }
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMResource.self) { rumModel in rumModel.resource.url.contains("/resource/1") }
-            .model(ofType: RUMResource.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataResource.self) { rumModel in rumModel.resource.url.contains("/resource/1") }
+            .model(ofType: RUMDataResource.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "FirstViewController", "Resource should be associated with the first View")
             }
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMError.self) { rumModel in rumModel.error.resource?.url.contains("/resource/2") ?? false }
-            .model(ofType: RUMError.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataError.self) { rumModel in rumModel.error.resource?.url.contains("/resource/2") ?? false }
+            .model(ofType: RUMDataError.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "FirstViewController", "Resource should be associated with the first View")
             }
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMResource.self) { rumModel in rumModel.resource.url.contains("/resource/3") }
-            .model(ofType: RUMResource.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataResource.self) { rumModel in rumModel.resource.url.contains("/resource/3") }
+            .model(ofType: RUMDataResource.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "SecondViewController", "Resource should be associated with the second View")
             }
         try rumEventMatchers
-            .lastRUMEvent(ofType: RUMResource.self) { rumModel in rumModel.resource.url.contains("/resource/4") }
-            .model(ofType: RUMResource.self) { rumModel in
+            .lastRUMEvent(ofType: RUMDataResource.self) { rumModel in rumModel.resource.url.contains("/resource/4") }
+            .model(ofType: RUMDataResource.self) { rumModel in
                 XCTAssertEqual(rumModel.view.url, "SecondViewController", "Resource should be associated with the second View")
             }
     }
@@ -361,16 +361,16 @@ class RUMMonitorTests: XCTestCase {
         monitor.stopView(viewController: mockView)
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
-        try rumEventMatchers.lastRUMEvent(ofType: RUMAction.self) { $0.action.target?.name == "1st action" }
-            .model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers.lastRUMEvent(ofType: RUMDataAction.self) { $0.action.target?.name == "1st action" }
+            .model(ofType: RUMDataAction.self) { rumModel in
                 XCTAssertEqual(rumModel.action.type, .tap)
             }
-        try rumEventMatchers.lastRUMEvent(ofType: RUMAction.self) { $0.action.target?.name == "2nd action" }
-            .model(ofType: RUMAction.self) { rumModel in
+        try rumEventMatchers.lastRUMEvent(ofType: RUMDataAction.self) { $0.action.target?.name == "2nd action" }
+            .model(ofType: RUMDataAction.self) { rumModel in
                 XCTAssertEqual(rumModel.action.type, .swipe)
             }
-        try rumEventMatchers.lastRUMEvent(ofType: RUMView.self)
-            .model(ofType: RUMView.self) { rumModel in
+        try rumEventMatchers.lastRUMEvent(ofType: RUMDataView.self)
+            .model(ofType: RUMDataView.self) { rumModel in
                 XCTAssertEqual(rumModel.view.action.count, 3)
             }
     }
@@ -401,17 +401,17 @@ class RUMMonitorTests: XCTestCase {
         monitor.stopView(viewController: mockView)
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 11)
-        let expectedUserInfo = RUMUSR(id: "abc-123", name: "Foo", email: "foo@bar.com")
-        try rumEventMatchers.forEachRUMEvent(ofType: RUMAction.self) { action in
+        let expectedUserInfo = RUMDataUSR(id: "abc-123", name: "Foo", email: "foo@bar.com")
+        try rumEventMatchers.forEachRUMEvent(ofType: RUMDataAction.self) { action in
             XCTAssertEqual(action.usr, expectedUserInfo)
         }
-        try rumEventMatchers.forEachRUMEvent(ofType: RUMView.self) { view in
+        try rumEventMatchers.forEachRUMEvent(ofType: RUMDataView.self) { view in
             XCTAssertEqual(view.usr, expectedUserInfo)
         }
-        try rumEventMatchers.forEachRUMEvent(ofType: RUMResource.self) { resource in
+        try rumEventMatchers.forEachRUMEvent(ofType: RUMDataResource.self) { resource in
             XCTAssertEqual(resource.usr, expectedUserInfo)
         }
-        try rumEventMatchers.forEachRUMEvent(ofType: RUMError.self) { error in
+        try rumEventMatchers.forEachRUMEvent(ofType: RUMDataError.self) { error in
             XCTAssertEqual(error.usr, expectedUserInfo)
         }
     }
@@ -445,21 +445,21 @@ class RUMMonitorTests: XCTestCase {
         monitor.stopView(viewController: mockView)
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 11)
-        let expectedConnectivityInfo = RUMConnectivity(
+        let expectedConnectivityInfo = RUMDataConnectivity(
             status: .connected,
             interfaces: [.cellular],
-            cellular: RUMCellular(technology: "GPRS", carrierName: "Carrier Name")
+            cellular: RUMDataCellular(technology: "GPRS", carrierName: "Carrier Name")
         )
-        try rumEventMatchers.forEachRUMEvent(ofType: RUMAction.self) { action in
+        try rumEventMatchers.forEachRUMEvent(ofType: RUMDataAction.self) { action in
             XCTAssertEqual(action.connectivity, expectedConnectivityInfo)
         }
-        try rumEventMatchers.forEachRUMEvent(ofType: RUMView.self) { view in
+        try rumEventMatchers.forEachRUMEvent(ofType: RUMDataView.self) { view in
             XCTAssertEqual(view.connectivity, expectedConnectivityInfo)
         }
-        try rumEventMatchers.forEachRUMEvent(ofType: RUMResource.self) { resource in
+        try rumEventMatchers.forEachRUMEvent(ofType: RUMDataResource.self) { resource in
             XCTAssertEqual(resource.connectivity, expectedConnectivityInfo)
         }
-        try rumEventMatchers.forEachRUMEvent(ofType: RUMError.self) { error in
+        try rumEventMatchers.forEachRUMEvent(ofType: RUMDataError.self) { error in
             XCTAssertEqual(error.connectivity, expectedConnectivityInfo)
         }
     }
@@ -494,13 +494,13 @@ class RUMMonitorTests: XCTestCase {
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
         let firstViewEvent = try rumEventMatchers
-            .lastRUMEvent(ofType: RUMView.self) { rumModel in rumModel.view.url == "FirstViewController" }
+            .lastRUMEvent(ofType: RUMDataView.self) { rumModel in rumModel.view.url == "FirstViewController" }
 
         XCTAssertEqual(try firstViewEvent.attribute(forKeyPath: "attribute1") as String, "changed value 1")
         XCTAssertEqual(try firstViewEvent.attribute(forKeyPath: "attribute2") as String, "value 2")
 
         let secondViewEvent = try rumEventMatchers
-            .lastRUMEvent(ofType: RUMView.self) { rumModel in rumModel.view.url == "SecondViewController" }
+            .lastRUMEvent(ofType: RUMDataView.self) { rumModel in rumModel.view.url == "SecondViewController" }
 
         XCTAssertEqual(try secondViewEvent.attribute(forKeyPath: "attribute1") as String, "changed value 1")
         XCTAssertNil(try? secondViewEvent.attribute(forKeyPath: "attribute2") as String)
@@ -524,7 +524,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.stopView(viewController: mockView)
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
-        let lastViewUpdate = try rumEventMatchers.lastRUMEvent(ofType: RUMView.self)
+        let lastViewUpdate = try rumEventMatchers.lastRUMEvent(ofType: RUMDataView.self)
 
         try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "a1"), "bar1", "The value should be updated")
         try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "a2"), "foo2", "The attribute should not be removed")

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -703,8 +703,8 @@ class TracerTests: XCTestCase {
         // then
         // [RUMView, RUMAction, RUMError] events sent:
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
-        let rumErrorMatcher = rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) }
-        try XCTUnwrap(rumErrorMatcher).model(ofType: RUMError.self) { rumModel in
+        let rumErrorMatcher = rumEventMatchers.first { $0.model(isTypeOf: RUMDataError.self) }
+        try XCTUnwrap(rumErrorMatcher).model(ofType: RUMDataError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, #"Span error (operation name)"#)
             XCTAssertEqual(rumModel.error.source, .source)
             XCTAssertNil(rumModel.error.stack)
@@ -740,8 +740,8 @@ class TracerTests: XCTestCase {
         // then
         // [RUMView, RUMAction, RUMError] events sent:
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
-        let rumErrorMatcher = try XCTUnwrap(rumEventMatchers.first { $0.model(isTypeOf: RUMError.self) })
-        try rumErrorMatcher.model(ofType: RUMError.self) { rumModel in
+        let rumErrorMatcher = try XCTUnwrap(rumEventMatchers.first { $0.model(isTypeOf: RUMDataError.self) })
+        try rumErrorMatcher.model(ofType: RUMDataError.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, #"Span error (operation name): Swift error | span error message"#)
             XCTAssertEqual(rumModel.error.source, .source)
             XCTAssertEqual(rumModel.error.stack, "Foo.swift:123")

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -51,16 +51,16 @@ internal class RUMSessionMatcher {
         fileprivate(set) var path: String = ""
 
         /// `RUMView` events tracked during this visit.
-        fileprivate(set) var viewEvents: [RUMView] = []
+        fileprivate(set) var viewEvents: [RUMDataView] = []
 
         /// `RUMAction` events tracked during this visit.
-        fileprivate(set) var actionEvents: [RUMAction] = []
+        fileprivate(set) var actionEvents: [RUMDataAction] = []
 
         /// `RUMResource` events tracked during this visit.
-        fileprivate(set) var resourceEvents: [RUMResource] = []
+        fileprivate(set) var resourceEvents: [RUMDataResource] = []
 
         /// `RUMError` events tracked during this visit.
-        fileprivate(set) var errorEvents: [RUMError] = []
+        fileprivate(set) var errorEvents: [RUMDataError] = []
     }
 
     /// An array of view visits tracked during this RUM Session.
@@ -81,16 +81,16 @@ internal class RUMSessionMatcher {
 
         // Get RUM Events by kind:
 
-        let viewEvents: [RUMView] = try (eventsMatchersByType["view"] ?? [])
+        let viewEvents: [RUMDataView] = try (eventsMatchersByType["view"] ?? [])
             .map { matcher in try matcher.model() }
 
-        let actionEvents: [RUMAction] = try (eventsMatchersByType["action"] ?? [])
+        let actionEvents: [RUMDataAction] = try (eventsMatchersByType["action"] ?? [])
             .map { matcher in try matcher.model() }
 
-        let resourceEvents: [RUMResource] = try (eventsMatchersByType["resource"] ?? [])
+        let resourceEvents: [RUMDataResource] = try (eventsMatchersByType["resource"] ?? [])
             .map { matcher in try matcher.model() }
 
-        let errorEvents: [RUMError] = try (eventsMatchersByType["error"] ?? [])
+        let errorEvents: [RUMDataError] = try (eventsMatchersByType["error"] ?? [])
             .map { matcher in try matcher.model() }
 
         // Validate each group of events individually
@@ -162,7 +162,7 @@ internal class RUMSessionMatcher {
     }
 }
 
-private func validate(rumResourceEvents: [RUMResource]) throws {
+private func validate(rumResourceEvents: [RUMDataResource]) throws {
     // Each `RUMResource` should have unique ID
     let ids = Set(rumResourceEvents.map { $0.resource.id })
     if ids.count != rumResourceEvents.count {

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -158,12 +158,12 @@ public protocol OTTracer
 public extension OTTracer
  func startSpan(operationName: String,childOf parent: OTSpanContext? = nil,tags: [String: Encodable]? = nil,startTime: Date? = nil) -> OTSpan
  func startRootSpan(operationName: String,tags: [String: Encodable]? = nil,startTime: Date? = nil) -> OTSpan
-public struct RUMViewFromPredicate
+public struct RUMView
  public var path: String
  public var attributes: [AttributeKey: AttributeValue]
  public init(path: String, attributes: [AttributeKey: AttributeValue] = [:])
 public protocol UIKitRUMViewsPredicate
- func rumView(for viewController: UIViewController) -> RUMViewFromPredicate?
+ func rumView(for viewController: UIViewController) -> RUMView?
 public enum RUMHTTPMethod: String
  case GET
  case POST
@@ -232,4 +232,4 @@ public class HTTPHeadersWriter: OTHTTPHeadersWriter
  public init()
  public private(set) var tracePropagationHTTPHeaders: [String: String] = [:]
  public func inject(spanContext: OTSpanContext)
- override public convenience init()
+ override public init()

--- a/docs/rum_collection.md
+++ b/docs/rum_collection.md
@@ -115,11 +115,11 @@ Datadog.Configuration
 `predicate` must be a type that conforms to `UIKitRUMViewsPredicate` protocol:
 ```swift
 public protocol UIKitRUMViewsPredicate {
-    func rumView(for viewController: UIViewController) -> RUMViewFromPredicate?
+    func rumView(for viewController: UIViewController) -> RUMView?
 }
 ```
 
-Inside the `rumView(for:)` implementation, your app should decide if a given `UIViewController` instance should start the RUM view or not (and return `nil` in this case). The returned value of `RUMViewFromPredicate` should specify at least the `path` for created the RUM view. Refer to code documentation comments for more details.
+Inside the `rumView(for:)` implementation, your app should decide if a given `UIViewController` instance should start the RUM view or not (and return `nil` in this case). The returned value of `RUMView` should specify at least the `path` for created the RUM view. Refer to code documentation comments for more details.
 
 **Note**: The SDK calls `rumView(for:)` many times while your app is running. Your implementation of the predicate should not depend on the order of SDK calls.
 

--- a/tools/generate-models/run.sh
+++ b/tools/generate-models/run.sh
@@ -48,7 +48,7 @@ cd ..
 if [[ ! -a $(npm bin)/quicktype ]]; then
     npm install DataDog/quicktype
 fi
-$(npm bin)/quicktype --lang swift --src-lang schema -o "$OUTPUT_FILE".bak --type-prefix RUM --src rum-events-format/schemas
+$(npm bin)/quicktype --lang swift --src-lang schema -o "$OUTPUT_FILE".bak --type-prefix RUMData --src rum-events-format/schemas
 echo "// $SHA" >> "$OUTPUT_FILE".bak
 
 LICENSE_HEADER="/*


### PR DESCRIPTION
### What and why?

We had `RUMViewFromPredicate` type in our public API
This was not the ideal name for this type, it was supposed to be `RUMView` yet this name was taken by a `RUMDataModel`
We make this change in order to improve our public API

### How?

We rename related types
Prefix in `RUMDataModels.swift`: `RUM` -> `RUMData` (eg: `RUMView` -> `RUMDataView`)
Type name: `RUMViewFromPredicate` -> `RUMView`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference


# NOTE

CI will probably fail now but this will be fixed by https://github.com/DataDog/dd-sdk-ios/pull/290