### PR TITLE
RUMM-719 Collect advanced temporal metrics for RUM Resources

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -116,17 +116,42 @@ internal class RUMResourceScope: RUMScope {
                 statusCode: command.httpStatusCode?.toInt64,
                 duration: resourceDuration.toInt64Nanoseconds,
                 size: size ?? 0,
-                redirect: nil,
-                dns: resourceMetrics?.dns.flatMap { dns in
-                    RUMDataDNS(
-                        duration: dns.duration.toInt64Nanoseconds,
-                        start: dns.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
+                redirect: resourceMetrics?.redirection.flatMap { metric in
+                    RUMDataRedirect(
+                        duration: metric.duration.toInt64Nanoseconds,
+                        start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
                     )
                 },
-                connect: nil,
-                ssl: nil,
-                firstByte: nil,
-                download: nil
+                dns: resourceMetrics?.dns.flatMap { metric in
+                    RUMDataDNS(
+                        duration: metric.duration.toInt64Nanoseconds,
+                        start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
+                    )
+                },
+                connect: resourceMetrics?.connect.flatMap { metric in
+                    RUMDataConnect(
+                        duration: metric.duration.toInt64Nanoseconds,
+                        start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
+                    )
+                },
+                ssl: resourceMetrics?.ssl.flatMap { metric in
+                    RUMDataSSL(
+                        duration: metric.duration.toInt64Nanoseconds,
+                        start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
+                    )
+                },
+                firstByte: resourceMetrics?.firstByte.flatMap { metric in
+                    RUMDataFirstByte(
+                        duration: metric.duration.toInt64Nanoseconds,
+                        start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
+                    )
+                },
+                download: resourceMetrics?.download.flatMap { metric in
+                    RUMDataDownload(
+                        duration: metric.duration.toInt64Nanoseconds,
+                        start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
+                    )
+                }
             ),
             action: context.activeUserActionID.flatMap { rumUUID in
                 .init(id: rumUUID.toRUMDataFormat)

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
@@ -56,13 +56,35 @@ internal struct ResourceCompletion {
 /// Encapsulates key metrics retrieved from `URLSessionTaskMetrics`.
 /// Reference: https://developer.apple.com/documentation/foundation/urlsessiontasktransactionmetrics
 internal struct ResourceMetrics {
+    struct DateInterval {
+        let start, end: Date
+        var duration: TimeInterval { end.timeIntervalSince(start) }
+    }
+
     /// Properties of the fetch phase for the resource:
     /// - `start` -  the time when the task started fetching the resource from the server,
     /// - `end` - the time immediately after the task received the last byte of the resource.
-    let fetch: (start: Date, end: Date)
+    let fetch: DateInterval
+
+    /// Properties of the redirection phase for the resource. If the resource is retrieved in multiple transactions,
+    /// only the last one is used to track detailed metrics (`dns`, `connect` etc.).
+    /// All but last are described as a single "redirection" phase.
+    let redirection: DateInterval?
 
     /// Properties of the name lookup phase for the resource.
-    let dns: (start: Date, duration: TimeInterval)?
+    let dns: DateInterval?
+
+    /// Properties of the connect phase for the resource.
+    let connect: DateInterval?
+
+    /// Properties of the secure connect phase for the resource.
+    let ssl: DateInterval?
+
+    /// Properties of the TTFB phase for the resource.
+    let firstByte: DateInterval?
+
+    /// Properties of the download phase for the resource.
+    let download: DateInterval?
 
     /// The size of data delivered to delegate or completion handler.
     let responseSize: Int64?
@@ -70,30 +92,83 @@ internal struct ResourceMetrics {
 
 extension ResourceMetrics {
     init(taskMetrics: URLSessionTaskMetrics) {
-        // Set default values
-        var fetch = (start: taskMetrics.taskInterval.start, end: taskMetrics.taskInterval.end)
-        var dns: (start: Date, duration: TimeInterval)? = nil
-        var responseSize: Int64? = nil
+        let fetch = DateInterval(
+            start: taskMetrics.taskInterval.start,
+            end: taskMetrics.taskInterval.end
+        )
 
-        // Capture more precise values
-        if let lastTransactionMetrics = taskMetrics.transactionMetrics.last {
-            // TODO: RUMM-719 When computing other timings, check if it's correct to only depend on the last `transactionMetrics`
+        let transactions = taskMetrics.transactionMetrics
+            .filter { $0.resourceFetchType != .localCache } // ignore loads from cache
 
-            if let fetchStart = lastTransactionMetrics.fetchStartDate,
-               let fetchEnd = lastTransactionMetrics.responseEndDate {
-                fetch = (start: fetchStart, end: fetchEnd)
-            }
+        // Note: `transactions` contain metrics for each individual
+        // `request → response` transaction done for given resource, e.g.:
+        // * if `200 OK` was received, it will contain 1 transaction,
+        // * if `200 OK` was preceeded by `301` redirection, it will contain 2 transactions.
+        let mainTransaction = transactions.last
+        let redirectionTransactions = transactions.dropLast()
 
-            if let dnsStart = lastTransactionMetrics.domainLookupStartDate,
-               let dnsEnd = lastTransactionMetrics.domainLookupEndDate {
-                dns = (start: dnsStart, duration: dnsEnd.timeIntervalSince(dnsStart))
-            }
+        var redirection: DateInterval? = nil
 
-            if #available(iOS 13.0, *) {
-                responseSize = lastTransactionMetrics.countOfResponseBodyBytesAfterDecoding
+        if redirectionTransactions.count > 0 {
+            let redirectionStarts = redirectionTransactions.compactMap { $0.fetchStartDate }
+            let redirectionEnds = redirectionTransactions.compactMap { $0.responseEndDate }
+
+            // If several redirections were made, we model them as a single "redirection"
+            // phase starting in the first moment of the youngest and ending
+            // in the last moment of the oldest.
+            if let redirectionPhaseStart = redirectionStarts.first,
+               let redirectionPhaseEnd = redirectionEnds.last {
+                redirection = DateInterval(start: redirectionPhaseStart, end: redirectionPhaseEnd)
             }
         }
 
-        self.init(fetch: fetch, dns: dns, responseSize: responseSize)
+        var dns: DateInterval? = nil
+        var connect: DateInterval? = nil
+        var ssl: DateInterval? = nil
+        var firstByte: DateInterval? = nil
+        var download: DateInterval? = nil
+        var responseSize: Int64? = nil
+
+        if let mainTransaction = mainTransaction {
+            if let dnsStart = mainTransaction.domainLookupStartDate,
+               let dnsEnd = mainTransaction.domainLookupEndDate {
+                dns = DateInterval(start: dnsStart, end: dnsEnd)
+            }
+
+            if let connectStart = mainTransaction.connectStartDate,
+               let connectEnd = mainTransaction.connectEndDate {
+                connect = DateInterval(start: connectStart, end: connectEnd)
+            }
+
+            if let sslStart = mainTransaction.secureConnectionStartDate,
+               let sslEnd = mainTransaction.secureConnectionEndDate {
+                ssl = DateInterval(start: sslStart, end: sslEnd)
+            }
+
+            if let firstByteStart = mainTransaction.requestStartDate, // Time from start requesting the resource ...
+               let firstByteEnd = mainTransaction.responseStartDate { // ... to receiving the first byte of the response
+                firstByte = DateInterval(start: firstByteStart, end: firstByteEnd)
+            }
+
+            if let downloadStart = mainTransaction.responseStartDate, // Time from the first byte of the response ...
+               let downloadEnd = mainTransaction.responseEndDate {    // ... to receiving the last byte.
+                download = DateInterval(start: downloadStart, end: downloadEnd)
+            }
+
+            if #available(iOS 13.0, *) {
+                responseSize = mainTransaction.countOfResponseBodyBytesAfterDecoding
+            }
+        }
+
+        self.init(
+            fetch: fetch,
+            redirection: redirection,
+            dns: dns,
+            connect: connect,
+            ssl: ssl,
+            firstByte: firstByte,
+            download: download,
+            responseSize: responseSize
+        )
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -188,7 +188,23 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts, TracingComm
 
         XCTAssertTrue(
             thirdPartyResource1.resource.dns != nil || thirdPartyResource2.resource.dns != nil,
-            "At leas one of the third party resources should lead to DNS resolution phase"
+            "At least one 3rd party resource should track DNS resolution phase"
+        )
+        XCTAssertTrue(
+            thirdPartyResource1.resource.connect != nil || thirdPartyResource2.resource.connect != nil,
+            "At least one 3rd party resource should track connect phase"
+        )
+        XCTAssertTrue(
+            thirdPartyResource1.resource.ssl != nil || thirdPartyResource2.resource.ssl != nil,
+            "At least one 3rd party resource should track secure connect phase"
+        )
+        XCTAssertTrue(
+            thirdPartyResource1.resource.firstByte != nil && thirdPartyResource2.resource.firstByte != nil,
+            "Both 3rd party resources should track TTFB phase"
+        )
+        XCTAssertTrue(
+            thirdPartyResource1.resource.download != nil && thirdPartyResource2.resource.download != nil,
+            "Both 3rd party resources should track download phase"
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -313,19 +313,71 @@ extension URLSessionTaskTransactionMetrics {
         return URLSessionTaskTransactionMetrics()
     }
 
+    /// Mocks `URLSessionTaskTransactionMetrics` by spreading out detailed values between `start` and `end`.
+    @available(iOS 13, *)
+    static func mockBySpreadingDetailsBetween(
+        start: Date,
+        end: Date,
+        resourceFetchType: URLSessionTaskMetrics.ResourceFetchType = .networkLoad
+    ) -> URLSessionTaskTransactionMetrics {
+        let spread = end.timeIntervalSince(start)
+
+        let fetchStartDate = start
+        let domainLookupStartDate = start.addingTimeInterval(spread * 0.05) // 5%
+        let domainLookupEndDate = start.addingTimeInterval(spread * 0.15) // 15%
+        let connectStartDate = start.addingTimeInterval(spread * 0.15) // 15%
+        let secureConnectionStartDate = start.addingTimeInterval(spread * 0.20) // 20%
+        let secureConnectionEndDate = start.addingTimeInterval(spread * 0.35) // 35%
+        let connectEndDate = secureConnectionEndDate
+        let requestStartDate = start.addingTimeInterval(spread * 0.40) // 40%
+        let responseStartDate = start.addingTimeInterval(spread * 0.50) // 50%
+        let responseEndDate = end
+
+        let countOfResponseBodyBytesAfterDecoding: Int64 = .random(in: 512..<1_024)
+
+        return URLSessionTaskTransactionMetricsMock(
+            resourceFetchType: resourceFetchType,
+            fetchStartDate: fetchStartDate,
+            domainLookupStartDate: domainLookupStartDate,
+            domainLookupEndDate: domainLookupEndDate,
+            connectStartDate: connectStartDate,
+            connectEndDate: connectEndDate,
+            secureConnectionStartDate: secureConnectionStartDate,
+            secureConnectionEndDate: secureConnectionEndDate,
+            requestStartDate: requestStartDate,
+            responseStartDate: responseStartDate,
+            responseEndDate: responseEndDate,
+            countOfResponseBodyBytesAfterDecoding: countOfResponseBodyBytesAfterDecoding
+        )
+    }
+
     @available(iOS 13, *)
     static func mockWith(
+        resourceFetchType: URLSessionTaskMetrics.ResourceFetchType = .networkLoad,
         fetchStartDate: Date? = nil,
-        responseEndDate: Date? = nil,
         domainLookupStartDate: Date? = nil,
         domainLookupEndDate: Date? = nil,
+        connectStartDate: Date? = nil,
+        connectEndDate: Date? = nil,
+        secureConnectionStartDate: Date? = nil,
+        secureConnectionEndDate: Date? = nil,
+        requestStartDate: Date? = nil,
+        responseStartDate: Date? = nil,
+        responseEndDate: Date? = nil,
         countOfResponseBodyBytesAfterDecoding: Int64 = 0
     ) -> URLSessionTaskTransactionMetrics {
         return URLSessionTaskTransactionMetricsMock(
+            resourceFetchType: resourceFetchType,
             fetchStartDate: fetchStartDate,
-            responseEndDate: responseEndDate,
             domainLookupStartDate: domainLookupStartDate,
             domainLookupEndDate: domainLookupEndDate,
+            connectStartDate: connectStartDate,
+            connectEndDate: connectEndDate,
+            secureConnectionStartDate: secureConnectionStartDate,
+            secureConnectionEndDate: secureConnectionEndDate,
+            requestStartDate: requestStartDate,
+            responseStartDate: responseStartDate,
+            responseEndDate: responseEndDate,
             countOfResponseBodyBytesAfterDecoding: countOfResponseBodyBytesAfterDecoding
         )
     }
@@ -360,11 +412,11 @@ private class URLSessionTaskMetricsMock: URLSessionTaskMetrics {
 
 @available(iOS 13, *) // We can't rely on subclassing the `URLSessionTaskTransactionMetrics` prior to iOS 13.0
 private class URLSessionTaskTransactionMetricsMock: URLSessionTaskTransactionMetrics {
+    private let _resourceFetchType: URLSessionTaskMetrics.ResourceFetchType
+    override var resourceFetchType: URLSessionTaskMetrics.ResourceFetchType { _resourceFetchType }
+
     private let _fetchStartDate: Date?
     override var fetchStartDate: Date? { _fetchStartDate }
-
-    private let _responseEndDate: Date?
-    override var responseEndDate: Date? { _responseEndDate }
 
     private let _domainLookupStartDate: Date?
     override var domainLookupStartDate: Date? { _domainLookupStartDate }
@@ -372,20 +424,55 @@ private class URLSessionTaskTransactionMetricsMock: URLSessionTaskTransactionMet
     private let _domainLookupEndDate: Date?
     override var domainLookupEndDate: Date? { _domainLookupEndDate }
 
+    private let _connectStartDate: Date?
+    override var connectStartDate: Date? { _connectStartDate }
+
+    private let _connectEndDate: Date?
+    override var connectEndDate: Date? { _connectEndDate }
+
+    private let _secureConnectionStartDate: Date?
+    override var secureConnectionStartDate: Date? { _secureConnectionStartDate }
+
+    private let _secureConnectionEndDate: Date?
+    override var secureConnectionEndDate: Date? { _secureConnectionEndDate }
+
+    private let _requestStartDate: Date?
+    override var requestStartDate: Date? { _requestStartDate }
+
+    private let _responseStartDate: Date?
+    override var responseStartDate: Date? { _responseStartDate }
+
+    private let _responseEndDate: Date?
+    override var responseEndDate: Date? { _responseEndDate }
+
     private let _countOfResponseBodyBytesAfterDecoding: Int64
     override var countOfResponseBodyBytesAfterDecoding: Int64 { _countOfResponseBodyBytesAfterDecoding }
 
     init(
+        resourceFetchType: URLSessionTaskMetrics.ResourceFetchType,
         fetchStartDate: Date?,
-        responseEndDate: Date?,
         domainLookupStartDate: Date?,
         domainLookupEndDate: Date?,
+        connectStartDate: Date?,
+        connectEndDate: Date?,
+        secureConnectionStartDate: Date?,
+        secureConnectionEndDate: Date?,
+        requestStartDate: Date?,
+        responseStartDate: Date?,
+        responseEndDate: Date?,
         countOfResponseBodyBytesAfterDecoding: Int64
     ) {
+        self._resourceFetchType = resourceFetchType
         self._fetchStartDate = fetchStartDate
-        self._responseEndDate = responseEndDate
         self._domainLookupStartDate = domainLookupStartDate
         self._domainLookupEndDate = domainLookupEndDate
+        self._connectStartDate = connectStartDate
+        self._connectEndDate = connectEndDate
+        self._secureConnectionStartDate = secureConnectionStartDate
+        self._secureConnectionEndDate = secureConnectionEndDate
+        self._requestStartDate = requestStartDate
+        self._responseStartDate = responseStartDate
+        self._responseEndDate = responseEndDate
         self._countOfResponseBodyBytesAfterDecoding = countOfResponseBodyBytesAfterDecoding
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
@@ -59,10 +59,24 @@ extension ResourceMetrics {
     }
 
     static func mockWith(
-        fetch: (start: Date, end: Date) = (start: Date(), end: Date(timeIntervalSinceNow: 1)),
-        dns: (start: Date, duration: TimeInterval)? = nil,
+        fetch: DateInterval = .init(start: Date(), end: Date(timeIntervalSinceNow: 1)),
+        redirection: DateInterval? = nil,
+        dns: DateInterval? = nil,
+        connect: DateInterval? = nil,
+        ssl: DateInterval? = nil,
+        firstByte: DateInterval? = nil,
+        download: DateInterval? = nil,
         responseSize: Int64? = nil
     ) -> Self {
-        return .init(fetch: fetch, dns: dns, responseSize: responseSize)
+        return .init(
+            fetch: fetch,
+            redirection: redirection,
+            dns: dns,
+            connect: connect,
+            ssl: ssl,
+            firstByte: firstByte,
+            download: download,
+            responseSize: responseSize
+        )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -168,8 +168,34 @@ class RUMResourceScopeTests: XCTestCase {
             time: currentTime,
             attributes: [:],
             metrics: .mockWith(
-                fetch: (start: resourceFetchStart, end: resourceFetchStart.addingTimeInterval(10)),
-                dns: (start: resourceFetchStart.addingTimeInterval(1), duration: 2),
+                fetch: .init(
+                    start: resourceFetchStart,
+                    end: resourceFetchStart.addingTimeInterval(10)
+                ),
+                redirection: .init(
+                    start: resourceFetchStart.addingTimeInterval(1),
+                    end: resourceFetchStart.addingTimeInterval(2)
+                ),
+                dns: .init(
+                    start: resourceFetchStart.addingTimeInterval(3),
+                    end: resourceFetchStart.addingTimeInterval(4)
+                ),
+                connect: .init(
+                    start: resourceFetchStart.addingTimeInterval(5),
+                    end: resourceFetchStart.addingTimeInterval(7)
+                ),
+                ssl: .init(
+                    start: resourceFetchStart.addingTimeInterval(6),
+                    end: resourceFetchStart.addingTimeInterval(7)
+                ),
+                firstByte: .init(
+                    start: resourceFetchStart.addingTimeInterval(8),
+                    end: resourceFetchStart.addingTimeInterval(9)
+                ),
+                download: .init(
+                    start: resourceFetchStart.addingTimeInterval(9),
+                    end: resourceFetchStart.addingTimeInterval(10)
+                ),
                 responseSize: 2_048
             )
         )
@@ -205,17 +231,20 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.resource.method, .post)
         XCTAssertEqual(event.model.resource.url, "https://foo.com/resource/1")
         XCTAssertEqual(event.model.resource.statusCode, 200)
-        XCTAssertEqual(event.model.resource.duration, metrics.fetch.end.timeIntervalSince(metrics.fetch.start).toInt64Nanoseconds)
-        XCTAssertEqual(event.model.resource.size, metrics.responseSize!)
-        XCTAssertNil(event.model.resource.redirect)
-        XCTAssertEqual(event.model.resource.dns?.start, 1_000_000_000, "DNS should start 1s after resource has started")
-        XCTAssertEqual(
-            event.model.resource.dns?.duration, metrics.dns!.duration.toInt64Nanoseconds
-        )
-        XCTAssertNil(event.model.resource.connect)
-        XCTAssertNil(event.model.resource.ssl)
-        XCTAssertNil(event.model.resource.firstByte)
-        XCTAssertNil(event.model.resource.download)
+        XCTAssertEqual(event.model.resource.duration, 10_000_000_000)
+        XCTAssertEqual(event.model.resource.size, 2_048)
+        XCTAssertEqual(event.model.resource.redirect?.start, 1_000_000_000)
+        XCTAssertEqual(event.model.resource.redirect?.duration, 1_000_000_000)
+        XCTAssertEqual(event.model.resource.dns?.start, 3_000_000_000)
+        XCTAssertEqual(event.model.resource.dns?.duration, 1_000_000_000)
+        XCTAssertEqual(event.model.resource.connect?.start, 5_000_000_000)
+        XCTAssertEqual(event.model.resource.connect?.duration, 2_000_000_000)
+        XCTAssertEqual(event.model.resource.ssl?.start, 6_000_000_000)
+        XCTAssertEqual(event.model.resource.ssl?.duration, 1_000_000_000)
+        XCTAssertEqual(event.model.resource.firstByte?.start, 8_000_000_000)
+        XCTAssertEqual(event.model.resource.firstByte?.duration, 1_000_000_000)
+        XCTAssertEqual(event.model.resource.download?.start, 9_000_000_000)
+        XCTAssertEqual(event.model.resource.download?.duration, 1_000_000_000)
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), context.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
         XCTAssertNil(event.model.dd.traceID)

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -21,7 +21,10 @@ class URLSessionTracingHandlerTests: XCTestCase {
         interception.register(completion: .mockAny())
         interception.register(
             metrics: .mockWith(
-                fetch: (start: .mockDecember15th2019At10AMUTC(), end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1)
+                )
             )
         )
         interception.register(
@@ -52,7 +55,10 @@ class URLSessionTracingHandlerTests: XCTestCase {
         interception.register(completion: .mockWith(response: .mockResponseWith(statusCode: 200), error: nil))
         interception.register(
             metrics: .mockWith(
-                fetch: (start: .mockDecember15th2019At10AMUTC(), end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 2))
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 2)
+                )
             )
         )
 
@@ -84,7 +90,10 @@ class URLSessionTracingHandlerTests: XCTestCase {
         interception.register(completion: .mockWith(response: nil, error: error))
         interception.register(
             metrics: .mockWith(
-                fetch: (start: .mockDecember15th2019At10AMUTC(), end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 30))
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 30)
+                )
             )
         )
 
@@ -121,7 +130,10 @@ class URLSessionTracingHandlerTests: XCTestCase {
         interception.register(completion: .mockWith(response: .mockResponseWith(statusCode: 404), error: nil))
         interception.register(
             metrics: .mockWith(
-                fetch: (start: .mockDecember15th2019At10AMUTC(), end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 2))
+                fetch: .init(
+                    start: .mockDecember15th2019At10AMUTC(),
+                    end: .mockDecember15th2019At10AMUTC(addingTimeInterval: 2)
+                )
             )
         )
 


### PR DESCRIPTION
### What and why?

📦 This PR adds collection of advanced temporal metrics for auto-instrumented RUM Resources. Example:

<img width="970" alt="Screenshot 2020-10-26 at 15 13 55" src="https://user-images.githubusercontent.com/2358722/97302790-d20aa100-1859-11eb-9bae-b0e0db93761d.png">

### How?

More values are captured from `URLSessionTaskMetrics` object. If task execution required more than one transaction, the last transaction is used to compute detailed values and all leading transactions are described as "redirection" phase, e.g. in such case:
```bash
→ Transaction 1: 301 redirect
   → Transaction 2: 301 redirect
      → Transaction 3: 200 OK
```
the "redirection" phase spans from T1 start to T2 end and T3 is used to track `dns`, `connect`, ...

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
