### PR TITLE
RUMM-851 Missing expectation added to flaky test case

### DIFF
--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -210,6 +210,9 @@ class URLSessionSwizzlerTests: XCTestCase {
     func testGivenSuccessfulTask_whenUsingSwizzledAPIs_itPassessAllValuesToTheInterceptor() {
         let completionHandlersCalled = expectation(description: "Call completion handlers")
         completionHandlersCalled.expectedFulfillmentCount = 2
+        let notifyTaskCompleted = expectation(description: "Notify task completion")
+        notifyTaskCompleted.expectedFulfillmentCount = 4
+        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
         let expectedResponse: HTTPURLResponse = .mockResponseWith(statusCode: 200)


### PR DESCRIPTION
### What and why?

`testGivenSuccessfulTask_whenUsingSwizzledAPIs_itPassessAllValuesToTheInterceptor` case wasn't waiting for 4 task completions.
As the test continues without that expectation, `interceptor.tasksCompleted.count == 4` assertion was failing; although `tasksCompleted[3]` was not causing index out of range right after `count` assertion because it was just a matter of time for tasks to be completed.

### How?

Missing expectation added

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
