### PR TITLE
remove beta warning from tracing docs

### DIFF
--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -1,7 +1,5 @@
 # iOS Trace Collection
 
-<div class="alert alert-info">The iOS Trace collection is in public beta. If you have any questions, contact our <a href="https://docs.datadoghq.com/help/" target="_blank">support team</a>.</div>
-
 Send [traces][1] to Datadog from your iOS applications with [Datadog's `dd-sdk-ios` client-side tracing library][2] and leverage the following features:
 
 * Create custom [spans][3] for various operations in your app.


### PR DESCRIPTION
Duplicate of https://github.com/DataDog/dd-sdk-ios/pull/296

Original PR didn't trigger CI, I'm duplicating it from the upstream