### PR TITLE
RUMM-817 Error can be logged

### DIFF
--- a/Datadog/Example/Debugging/DebugLoggingViewController.swift
+++ b/Datadog/Example/Debugging/DebugLoggingViewController.swift
@@ -14,6 +14,19 @@ class DebugLoggingViewController: UIViewController {
     @IBOutlet weak var send10xButton: UIButton!
     @IBOutlet weak var consoleTextView: UITextView!
 
+    struct StructError: Error {
+        let property: String
+    }
+    enum EnumError: Error {
+        case caseWithProperty(property: String)
+    }
+    class ClassError: Error {
+        let property: String
+        init(_ prop: String) {
+            property = prop
+        }
+    }
+
     enum LogLevelSegment: Int {
         case debug = 0, info, notice, warn, error, critical
     }
@@ -32,13 +45,18 @@ class DebugLoggingViewController: UIViewController {
     @IBAction func didTapSendSingleLog(_ sender: Any) {
         sendOnceButton.disableFor(seconds: 0.5)
 
+        let structError = StructError(property: "some value")
+        let enumError = EnumError.caseWithProperty(property: "some value")
+        let classError = ClassError("some value")
+        let nsError = NSError(domain: "ExampleApp", code: 999, userInfo: [NSLocalizedDescriptionKey: "some value"])
+
         switch LogLevelSegment(rawValue: logLevelSegmentedControl.selectedSegmentIndex) {
-        case .debug:    logger.debug(message)
-        case .info:     logger.info(message)
-        case .notice:   logger.notice(message)
-        case .warn:     logger.warn(message)
-        case .error:    logger.error(message)
-        case .critical: logger.critical(message)
+        case .debug:    logger.debug(message, error: structError)
+        case .info:     logger.info(message, error: enumError)
+        case .notice:   logger.notice(message, error: classError)
+        case .warn:     logger.warn(message, error: nsError)
+        case .error:    logger.error(message, error: structError)
+        case .critical: logger.critical(message, error: enumError)
         default:        assertionFailure("Unsupported `.selectedSegmentIndex` value: \(logLevelSegmentedControl.selectedSegmentIndex)")
         }
     }

--- a/Sources/Datadog/Logging/Log/LogSanitizer.swift
+++ b/Sources/Datadog/Logging/Log/LogSanitizer.swift
@@ -12,8 +12,7 @@ internal struct LogSanitizer {
         /// Attribute names reserved for Datadog.
         /// If any of those is used by the user, the attribute will be ignored.
         static let reservedAttributeNames: Set<String> = [
-            "host", "message", "status", "service", "source", "error.message", "error.stack", "ddtags",
-            OTLogFields.errorKind,
+            "host", "message", "status", "service", "source", "ddtags",
             LoggingForTracingAdapter.TracingAttributes.traceID,
             LoggingForTracingAdapter.TracingAttributes.spanID,
             RUMContextIntegration.Attributes.applicationID,

--- a/Sources/DatadogObjc/Logger+objc.swift
+++ b/Sources/DatadogObjc/Logger+objc.swift
@@ -36,12 +36,20 @@ public class DDLogger: NSObject {
         sdkLogger.debug(message, attributes: castAttributesToSwift(attributes))
     }
 
+    public func debug(_ message: String, error: NSError, attributes: [String: Any]) {
+        sdkLogger.debug(message, error: error, attributes: castAttributesToSwift(attributes))
+    }
+
     public func info(_ message: String) {
         sdkLogger.info(message)
     }
 
     public func info(_ message: String, attributes: [String: Any]) {
         sdkLogger.info(message, attributes: castAttributesToSwift(attributes))
+    }
+
+    public func info(_ message: String, error: NSError, attributes: [String: Any]) {
+        sdkLogger.info(message, error: error, attributes: castAttributesToSwift(attributes))
     }
 
     public func notice(_ message: String) {
@@ -52,12 +60,20 @@ public class DDLogger: NSObject {
         sdkLogger.notice(message, attributes: castAttributesToSwift(attributes))
     }
 
+    public func notice(_ message: String, error: NSError, attributes: [String: Any]) {
+        sdkLogger.notice(message, error: error, attributes: castAttributesToSwift(attributes))
+    }
+
     public func warn(_ message: String) {
         sdkLogger.warn(message)
     }
 
     public func warn(_ message: String, attributes: [String: Any]) {
         sdkLogger.warn(message, attributes: castAttributesToSwift(attributes))
+    }
+
+    public func warn(_ message: String, error: NSError, attributes: [String: Any]) {
+        sdkLogger.warn(message, error: error, attributes: castAttributesToSwift(attributes))
     }
 
     public func error(_ message: String) {
@@ -68,12 +84,20 @@ public class DDLogger: NSObject {
         sdkLogger.error(message, attributes: castAttributesToSwift(attributes))
     }
 
+    public func error(_ message: String, error: NSError, attributes: [String: Any]) {
+        sdkLogger.error(message, error: error, attributes: castAttributesToSwift(attributes))
+    }
+
     public func critical(_ message: String) {
         sdkLogger.critical(message)
     }
 
     public func critical(_ message: String, attributes: [String: Any]) {
         sdkLogger.critical(message, attributes: castAttributesToSwift(attributes))
+    }
+
+    public func critical(_ message: String, error: NSError, attributes: [String: Any]) {
+        sdkLogger.critical(message, error: error, attributes: castAttributesToSwift(attributes))
     }
 
     public func addAttribute(forKey key: String, value: Any) {

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -135,6 +135,33 @@ class LoggerTests: XCTestCase {
         logMatchers[5].assertStatus(equals: "critical")
     }
 
+    // MARK: - Logging an error
+
+    func testLoggingError() throws {
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        defer { LoggingFeature.instance = nil }
+
+        struct TestError: Error {
+            var description = "Test description"
+        }
+        let error = TestError()
+
+        let logger = Logger.builder.build()
+        logger.debug("message", error: error)
+        logger.info("message", error: error)
+        logger.notice("message", error: error)
+        logger.warn("message", error: error)
+        logger.error("message", error: error)
+        logger.critical("message", error: error)
+
+        let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 6)
+        for matcher in logMatchers {
+            matcher.assertValue(forKeyPath: "error.stack", equals: "TestError(description: \"Test description\")")
+            matcher.assertValue(forKeyPath: "error.message", equals: "TestError(description: \"Test description\")")
+            matcher.assertValue(forKeyPath: "error.kind", equals: "TestError")
+        }
+    }
+
     // MARK: - Sending user info
 
     func testSendingUserInfo() throws {

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -145,19 +145,20 @@ class LoggerTests: XCTestCase {
             var description = "Test description"
         }
         let error = TestError()
+        let customAttributes = [ErrorAttributes.message: "custom message"]
 
         let logger = Logger.builder.build()
-        logger.debug("message", error: error)
-        logger.info("message", error: error)
-        logger.notice("message", error: error)
-        logger.warn("message", error: error)
-        logger.error("message", error: error)
-        logger.critical("message", error: error)
+        logger.debug("message", error: error, attributes: customAttributes)
+        logger.info("message", error: error, attributes: customAttributes)
+        logger.notice("message", error: error, attributes: customAttributes)
+        logger.warn("message", error: error, attributes: customAttributes)
+        logger.error("message", error: error, attributes: customAttributes)
+        logger.critical("message", error: error, attributes: customAttributes)
 
         let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 6)
         for matcher in logMatchers {
             matcher.assertValue(forKeyPath: "error.stack", equals: "TestError(description: \"Test description\")")
-            matcher.assertValue(forKeyPath: "error.message", equals: "TestError(description: \"Test description\")")
+            matcher.assertValue(forKeyPath: "error.message", equals: "custom message")
             matcher.assertValue(forKeyPath: "error.kind", equals: "TestError")
         }
     }

--- a/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
@@ -20,11 +20,12 @@ class LogSanitizerTests: XCTestCase {
                     "status": mockValue(),
                     "service": mockValue(),
                     "source": mockValue(),
-                    "error.message": mockValue(),
-                    "error.stack": mockValue(),
                     "ddtags": mockValue(),
 
                     // valid attributes:
+                    "error.kind": mockValue(),
+                    "error.message": mockValue(),
+                    "error.stack": mockValue(),
                     "attribute1": mockValue(),
                     "attribute2": mockValue(),
                     "date": mockValue(),
@@ -34,7 +35,7 @@ class LogSanitizerTests: XCTestCase {
 
         let sanitized = LogSanitizer().sanitize(log: log)
 
-        XCTAssertEqual(sanitized.attributes.userAttributes.count, 3)
+        XCTAssertEqual(sanitized.attributes.userAttributes.count, 6)
         XCTAssertNotNil(sanitized.attributes.userAttributes["attribute1"])
         XCTAssertNotNil(sanitized.attributes.userAttributes["attribute2"])
         XCTAssertNotNil(sanitized.attributes.userAttributes["date"])


### PR DESCRIPTION
### What and why?

fix #276 
There was no way to log an `Error`

### How?

1. `Error` parameter added to logging methods
2. `error.stack/kind/message` keywords are removed from `reservedAttributes` set

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
