### PR TITLE
RUMM-880 RUM attributes moved under context key

### DIFF
--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -28,13 +28,13 @@ internal struct RUMEventEncoder {
         init?(stringValue: String) { self.stringValue = stringValue }
         init?(intValue: Int) { return nil }
         init(_ string: String) { self.stringValue = string }
-}
+    }
 
     func encode<DM: RUMDataModel>(_ event: RUMEvent<DM>, to encoder: Encoder) throws {
         // Encode attributes
         var attributesContainer = encoder.container(keyedBy: DynamicCodingKey.self)
         try event.attributes.forEach { attributeName, attributeValue in
-            try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey(attributeName))
+            try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("context.\(attributeName)"))
         }
 
         // Encode `RUMDataModel`

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -66,7 +66,7 @@ class RUMEventFileOutputTests: XCTestCase {
             jsonString: """
             {
                 "attribute": "foo",
-                "custom.attribute": "value"
+                "context.custom.attribute": "value"
             }
             """
         )

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -540,14 +540,17 @@ class RUMMonitorTests: XCTestCase {
         let firstViewEvent = try rumEventMatchers
             .lastRUMEvent(ofType: RUMDataView.self) { rumModel in rumModel.view.url == "FirstViewController" }
 
-        XCTAssertEqual(try firstViewEvent.attribute(forKeyPath: "attribute1") as String, "changed value 1")
-        XCTAssertEqual(try firstViewEvent.attribute(forKeyPath: "attribute2") as String, "value 2")
+        XCTAssertNil(try? firstViewEvent.attribute(forKeyPath: "attribute1") as String)
+        XCTAssertNil(try? firstViewEvent.attribute(forKeyPath: "attribute2") as String)
+        XCTAssertEqual(try firstViewEvent.attribute(forKeyPath: "context.attribute1") as String, "changed value 1")
+        XCTAssertEqual(try firstViewEvent.attribute(forKeyPath: "context.attribute2") as String, "value 2")
 
         let secondViewEvent = try rumEventMatchers
             .lastRUMEvent(ofType: RUMDataView.self) { rumModel in rumModel.view.url == "SecondViewController" }
 
-        XCTAssertEqual(try secondViewEvent.attribute(forKeyPath: "attribute1") as String, "changed value 1")
+        XCTAssertNil(try? secondViewEvent.attribute(forKeyPath: "attribute1") as String)
         XCTAssertNil(try? secondViewEvent.attribute(forKeyPath: "attribute2") as String)
+        XCTAssertEqual(try secondViewEvent.attribute(forKeyPath: "context.attribute1") as String, "changed value 1")
     }
 
     func testWhenViewIsStarted_attributesCanBeAddedOrUpdatedButNotRemoved() throws {
@@ -570,9 +573,12 @@ class RUMMonitorTests: XCTestCase {
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
         let lastViewUpdate = try rumEventMatchers.lastRUMEvent(ofType: RUMDataView.self)
 
-        try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "a1"), "bar1", "The value should be updated")
-        try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "a2"), "foo2", "The attribute should not be removed")
-        try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "a3"), "foo3", "The attribute should be added")
+        XCTAssertNil(try? lastViewUpdate.attribute(forKeyPath: "a1") as String)
+        XCTAssertNil(try? lastViewUpdate.attribute(forKeyPath: "a2") as String)
+        XCTAssertNil(try? lastViewUpdate.attribute(forKeyPath: "a3") as String)
+        try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "context.a1"), "bar1", "The value should be updated")
+        try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "context.a2"), "foo2", "The attribute should not be removed")
+        try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "context.a3"), "foo3", "The attribute should be added")
     }
 
     // MARK: - Thread safety
@@ -712,10 +718,10 @@ class RUMMonitorTests: XCTestCase {
 
     private var expectedAttributes = [String: String]()
     private func setGlobalAttributes(of monitor: DDRUMMonitor) {
-        expectedAttributes = [String.mockRandom(): String.mockRandom()]
-        expectedAttributes.forEach {
-            monitor.addAttribute(forKey: $0, value: $1)
-        }
+        let key = String.mockRandom()
+        let value = String.mockRandom()
+        monitor.addAttribute(forKey: key, value: value)
+        expectedAttributes = ["context.\(key)": value]
     }
 
     private func verifyGlobalAttributes(in matchers: [RUMEventMatcher]) {

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -549,8 +549,8 @@ class RUMMonitorTests: XCTestCase {
             .lastRUMEvent(ofType: RUMDataView.self) { rumModel in rumModel.view.url == "SecondViewController" }
 
         XCTAssertNil(try? secondViewEvent.attribute(forKeyPath: "attribute1") as String)
-        XCTAssertNil(try? secondViewEvent.attribute(forKeyPath: "attribute2") as String)
         XCTAssertEqual(try secondViewEvent.attribute(forKeyPath: "context.attribute1") as String, "changed value 1")
+        XCTAssertNil(try? secondViewEvent.attribute(forKeyPath: "context.attribute2") as String)
     }
 
     func testWhenViewIsStarted_attributesCanBeAddedOrUpdatedButNotRemoved() throws {


### PR DESCRIPTION
### What and why?

RUM v2 requires all custom attributes to be within `context` key in json

### How?

We keep the current data model as is
We add `context.*` prefix during encoding of the data model

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
