### PR TITLE
RUMM-882 Improve documentation and console warnings

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
 		61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */; };
 		611720D52524D9FB00634D9E /* DDURLSessionDelegate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */; };
+		611F82032563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611F82022563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift */; };
 		61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */; };
 		6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */; };
 		612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612983CC2449E62E00D4424B /* LoggingFeature.swift */; };
@@ -475,6 +476,7 @@
 		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
 		61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMModalViewsScenarioTests.swift; sourceTree = "<group>"; };
 		611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDURLSessionDelegate+objc.swift"; sourceTree = "<group>"; };
+		611F82022563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
 		61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapter.swift; sourceTree = "<group>"; };
 		61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapterTests.swift; sourceTree = "<group>"; };
 		612983CC2449E62E00D4424B /* LoggingFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeature.swift; sourceTree = "<group>"; };
@@ -2027,6 +2029,7 @@
 				616A9CD02535D36A00DB83CF /* UIKitHierarchyInspection */,
 				61F3CDAA25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift */,
 				61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */,
+				611F82022563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2634,6 +2637,7 @@
 				61C5A89E24509C1100DA608C /* WarningsTests.swift in Sources */,
 				9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */,
 				614B0A5124EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift in Sources */,
+				611F82032563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift in Sources */,
 				61133C652423990D00786299 /* LogBuilderTests.swift in Sources */,
 				61F8CC092469295500FE2908 /* DatadogConfigurationBuilderTests.swift in Sources */,
 				61F1A623249B811200075390 /* Encoding.swift in Sources */,

--- a/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/NSURLSessionScenario.storyboard
+++ b/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/NSURLSessionScenario.storyboard
@@ -59,9 +59,6 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Qm7-yo-KBb"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="SendFirstPartyRequestsVC"/>
-                    </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Oen-FV-lkc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -91,9 +88,6 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="l9O-6V-fPH"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="SendThirdPartyRequestsVC"/>
-                    </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mxG-kz-TZ0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/URLSessionScenario.storyboard
+++ b/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/URLSessionScenario.storyboard
@@ -59,9 +59,6 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="SNE-bd-2E0"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="SendFirstPartyRequestsVC"/>
-                    </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="K2M-RX-OGI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -91,9 +88,6 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="pco-Xb-WYO"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="SendThirdPartyRequestsVC"/>
-                    </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="y0Y-8k-ipJ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Datadog/Example/TestScenarios.swift
+++ b/Datadog/Example/TestScenarios.swift
@@ -285,19 +285,9 @@ class RUMResourcesScenario: URLSessionBaseScenario, TestScenario {
     static let storyboardName = "URLSessionScenario"
     static func envIdentifier() -> String { "RUMResourcesScenario" }
 
-    private class Predicate: UIKitRUMViewsPredicate {
-        func rumView(for viewController: UIViewController) -> RUMView? {
-            if let viewName = viewController.accessibilityLabel {
-                return .init(path: viewName)
-            } else {
-                return nil
-            }
-        }
-    }
-
     override func configureSDK(builder: Datadog.Configuration.Builder) {
         _ = builder
-            .trackUIKitRUMViews(using: Predicate())
+            .trackUIKitRUMViews(using: DefaultUIKitRUMViewsPredicate())
 
         super.configureSDK(builder: builder) // applies the `track(firstPartyHosts:)`
     }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Actions/UIKitRUMUserActionsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Actions/UIKitRUMUserActionsHandler.swift
@@ -38,7 +38,12 @@ internal class UIKitRUMUserActionsHandler: UIKitRUMUserActionsHandlerType {
         }
 
         if subscriber == nil {
-            userLogger.warn("RUM Action was detected, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.")
+            userLogger.warn(
+                """
+                RUM Action was detected, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.
+                Make sure `Global.rum = RUMMonitor.initialize()` is called before any action happens.
+                """
+            )
         }
 
         subscriber?.process(

--- a/Sources/Datadog/RUM/AutoInstrumentation/Actions/UIKitRUMUserActionsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Actions/UIKitRUMUserActionsHandler.swift
@@ -37,6 +37,10 @@ internal class UIKitRUMUserActionsHandler: UIKitRUMUserActionsHandlerType {
             return // Tapped view is not eligible for producing RUM Action
         }
 
+        if subscriber == nil {
+            userLogger.warn("RUM Action was detected, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.")
+        }
+
         subscriber?.process(
             command: RUMAddUserActionCommand(
                 time: dateProvider.currentDate(),

--- a/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -54,6 +54,10 @@ internal class URLSessionRUMResourcesHandler: URLSessionRUMResourcesHandlerType 
     }
 
     func notify_taskInterceptionCompleted(interception: TaskInterception) {
+        if subscriber == nil {
+            userLogger.warn("RUM Resource was completed, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.")
+        }
+
         if let resourceMetrics = interception.metrics {
             subscriber?.process(
                 command: RUMAddResourceMetricsCommand(

--- a/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -55,7 +55,12 @@ internal class URLSessionRUMResourcesHandler: URLSessionRUMResourcesHandlerType 
 
     func notify_taskInterceptionCompleted(interception: TaskInterception) {
         if subscriber == nil {
-            userLogger.warn("RUM Resource was completed, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.")
+            userLogger.warn(
+                """
+                RUM Resource was completed, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.
+                Make sure `Global.rum = RUMMonitor.initialize()` is called before any network request is send.
+                """
+            )
         }
 
         if let resourceMetrics = interception.metrics {

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -72,6 +72,10 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
             return
         }
 
+        if subscriber == nil {
+            userLogger.warn("RUM View was started, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.")
+        }
+
         if let lastStartedViewController = lastStartedViewController {
             subscriber?.process(
                 command: RUMStopViewCommand(

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -73,7 +73,12 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
         }
 
         if subscriber == nil {
-            userLogger.warn("RUM View was started, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.")
+            userLogger.warn(
+                """
+                RUM View was started, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.
+                Make sure `Global.rum = RUMMonitor.initialize()` is called before any `UIViewController` is presented.
+                """
+            )
         }
 
         if let lastStartedViewController = lastStartedViewController {

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -38,20 +38,33 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
     }
 
     func notify_viewDidAppear(viewController: UIViewController, animated: Bool) {
-        if let rumView = predicate.rumView(for: viewController) {
+        if let rumView = rumView(for: viewController) {
             startIfNotStarted(rumView: rumView, for: viewController)
         }
     }
 
     func notify_viewDidDisappear(viewController: UIViewController, animated: Bool) {
         if let topViewController = inspector.topViewController(),
-           let rumView = predicate.rumView(for: topViewController) {
+           let rumView = rumView(for: topViewController) {
             startIfNotStarted(rumView: rumView, for: topViewController)
         }
     }
 
     // MARK: - Private
 
+    /// The `UIViewController` recently asked in `UIKitRUMViewsPredicate`.
+    private weak var recentlyAskedViewController: UIViewController?
+
+    private func rumView(for viewController: UIViewController) -> RUMView? {
+        if viewController === recentlyAskedViewController {
+            return nil
+        }
+
+        recentlyAskedViewController = viewController
+        return predicate.rumView(for: viewController)
+    }
+
+    /// The `UIViewController` indicating the active `RUMView`.
     private weak var lastStartedViewController: UIViewController?
 
     private func startIfNotStarted(rumView: RUMView, for viewController: UIViewController) {

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
@@ -35,3 +35,16 @@ public protocol UIKitRUMViewsPredicate {
     /// - Returns: RUM View parameters if received view controller should start/end the RUM View, `nil` otherwise.
     func rumView(for viewController: UIViewController) -> RUMView?
 }
+
+/// Default implementation of `UIKitRUMViewsPredicate`.
+/// It names  RUM Views by the names of their `UIViewController` subclasses.
+public struct DefaultUIKitRUMViewsPredicate: UIKitRUMViewsPredicate {
+    public init () {}
+
+    public func rumView(for viewController: UIViewController) -> RUMView? {
+        let className = NSStringFromClass(type(of: viewController))
+        let isCustomClass = className.contains(".") // custom class contains module prefix
+
+        return isCustomClass ? RUMView(path: className) : nil
+    }
+}

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -20,8 +20,9 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate {
         if interceptor == nil {
             let error = ProgrammerError(
                 description: """
-                To use `DDURLSessionDelegate` you must specify first party hosts in `Datadog.Configuration` -
-                use `track(firstPartyHosts:)` to define which requests should be tracked.
+                `Datadog.initialize()` must be called before initializing the `DDURLSessionDelegate` and
+                first party hosts must be specified in `Datadog.Configuration`: `track(firstPartyHosts:)`
+                to enable network requests tracking.
                 """
             )
             consolePrint("\(error)")

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -116,9 +116,10 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts, TracingComm
         assertRUM(requests: rumRequests)
 
         let session = try XCTUnwrap(try RUMSessionMatcher.from(requests: rumRequests))
+        XCTAssertEqual(session.viewVisits.count, 2)
 
         // Asserts in `SendFirstPartyRequestsVC` RUM View
-        XCTAssertEqual(session.viewVisits[0].path, "SendFirstPartyRequestsVC")
+        XCTAssertEqual(session.viewVisits[0].path, "Example.SendFirstPartyRequestsViewController")
         XCTAssertEqual(session.viewVisits[0].resourceEvents.count, 2, "1st screen should track 2 RUM Resources")
         XCTAssertEqual(session.viewVisits[0].errorEvents.count, 2, "1st screen should track 2 RUM Errors")
 
@@ -164,7 +165,7 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts, TracingComm
         )
 
         // Asserts in `SendThirdPartyRequestsVC` RUM View
-        XCTAssertEqual(session.viewVisits[1].path, "SendThirdPartyRequestsVC")
+        XCTAssertEqual(session.viewVisits[1].path, "Example.SendThirdPartyRequestsViewController")
         XCTAssertEqual(session.viewVisits[1].resourceEvents.count, 2, "2nd screen should track 2 RUM Resources")
         XCTAssertEqual(session.viewVisits[1].errorEvents.count, 0, "2nd screen should track no RUM Errors")
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -455,6 +455,10 @@ class UIKitRUMViewsPredicateMock: UIKitRUMViewsPredicate {
     var resultByViewController: [UIViewController: RUMView] = [:]
     var result: RUMView?
 
+    init(result: RUMView? = nil) {
+        self.result = result
+    }
+
     func rumView(for viewController: UIViewController) -> RUMView? {
         return resultByViewController[viewController] ?? result
     }

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/UIKitMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/UIKitMocks.swift
@@ -53,6 +53,10 @@ class UIDeviceMock: UIDevice {
 }
 
 extension UIEvent {
+    static func mockAny() -> UIEvent {
+        return .mockWith(touches: [.mockAny()])
+    }
+
     static func mockWith(touches: Set<UITouch>?) -> UIEvent {
         return UIEventMock(allTouches: touches)
     }
@@ -69,6 +73,10 @@ private class UIEventMock: UIEvent {
 }
 
 extension UITouch {
+    static func mockAny() -> UITouch {
+        return mockWith(phase: .ended, view: UIView())
+    }
+
     static func mockWith(phase: UITouch.Phase, view: UIView?) -> UITouch {
         return UITouchMock(phase: phase, view: view)
     }

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicateTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicateTests.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import Datadog
+
+class UIKitRUMViewsPredicateTests: XCTestCase {
+    func testGivenDefaultPredicate_whenAskingForCustomViewController_itNamesTheViewByItsClassName() {
+        // Given
+        let predicate = DefaultUIKitRUMViewsPredicate()
+
+        // When
+        let customViewController = createMockView(viewControllerClassName: "Module.CustomViewController")
+        let rumView = predicate.rumView(for: customViewController)
+
+        // Then
+        XCTAssertEqual(rumView?.path, "Module.CustomViewController")
+        XCTAssertTrue(rumView!.attributes.isEmpty)
+    }
+
+    func testGivenDefaultPredicate_whenAskingUIKitViewController_itReturnsNoView() {
+        // Given
+        let predicate = DefaultUIKitRUMViewsPredicate()
+
+        // When
+        let uiKitViewController = UIViewController()
+        let rumView = predicate.rumView(for: uiKitViewController)
+
+        // Then
+        XCTAssertNil(rumView)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -760,21 +760,36 @@ class RUMMonitorTests: XCTestCase {
         XCTAssertEqual(output.recordedLog?.level, .warn)
         XCTAssertEqual(
             output.recordedLog?.message,
-            "RUM Resource was completed, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work."
+            """
+            RUM Resource was completed, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.
+            Make sure `Global.rum = RUMMonitor.initialize()` is called before any network request is send.
+            """
         )
 
         viewsHandler.notify_viewDidAppear(viewController: mockView, animated: .mockAny())
         XCTAssertEqual(output.recordedLog?.level, .warn)
         XCTAssertEqual(
             output.recordedLog?.message,
-            "RUM View was started, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work."
+            """
+            RUM View was started, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.
+            Make sure `Global.rum = RUMMonitor.initialize()` is called before any `UIViewController` is presented.
+            """
         )
 
-        userActionsHandler.notify_sendEvent(application: .shared, event: .mockAny())
+        let mockWindow = UIWindow(frame: .zero)
+        let mockUIControl = UIControl()
+        mockWindow.addSubview(mockUIControl)
+        userActionsHandler.notify_sendEvent(
+            application: .shared,
+            event: .mockWith(touches: [.mockWith(phase: .ended, view: mockUIControl)])
+        )
         XCTAssertEqual(output.recordedLog?.level, .warn)
         XCTAssertEqual(
             output.recordedLog?.message,
-            "RUM View was started, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work."
+            """
+            RUM Action was detected, but no `RUMMonitor` is registered on `Global.rum`. RUM auto instrumentation will not work.
+            Make sure `Global.rum = RUMMonitor.initialize()` is called before any action happens.
+            """
         )
 
         URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
@@ -168,8 +168,9 @@ class DDURLSessionDelegateTests: XCTestCase {
         XCTAssertEqual(
             printFunction.printedMessage,
             """
-            🔥 Datadog SDK usage error: To use `DDURLSessionDelegate` you must specify first party hosts in `Datadog.Configuration` -
-            use `track(firstPartyHosts:)` to define which requests should be tracked.
+            🔥 Datadog SDK usage error: `Datadog.initialize()` must be called before initializing the `DDURLSessionDelegate` and
+            first party hosts must be specified in `Datadog.Configuration`: `track(firstPartyHosts:)`
+            to enable network requests tracking.
             """
         )
     }

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -166,6 +166,9 @@ public struct RUMView
  public init(path: String, attributes: [AttributeKey: AttributeValue] = [:])
 public protocol UIKitRUMViewsPredicate
  func rumView(for viewController: UIViewController) -> RUMView?
+public struct DefaultUIKitRUMViewsPredicate: UIKitRUMViewsPredicate
+ public init ()
+ public func rumView(for viewController: UIViewController) -> RUMView?
 public enum RUMUserActionType
  case tap
  case scroll

--- a/docs/rum_collection.md
+++ b/docs/rum_collection.md
@@ -110,6 +110,8 @@ Datadog.Configuration
    .builderUsing(...)
    .trackUIKitRUMViews(using: predicate)
    .build()
+
+Global.rum = RUMMonitor.initialize()
 ```
 
 `predicate` must be a type that conforms to `UIKitRUMViewsPredicate` protocol:
@@ -131,6 +133,8 @@ Datadog.Configuration
    .builderUsing(...)
    .track(firstPartyHosts: ["your.domain.com"])
    .build()
+
+Global.rum = RUMMonitor.initialize()
 ```
 Also, assign `DDURLSessionDelegate()` as a `delegate` of the `URLSession` you want to monitor, for example:
 ```swift
@@ -151,6 +155,8 @@ Datadog.Configuration
    .builderUsing(...)
    .trackUIKitActions(true)
    .build()
+
+Global.rum = RUMMonitor.initialize()
 ```
 
 This makes the SDK track all significant taps occurring in the app. For privacy reasons, all interactions with the on-screen keyboard are ignored.


### PR DESCRIPTION
### What and why?

📦 This PR applies bunch of small improvements noticed when testing our SDK in open source projects.

### How?

Each improvement is delivered in a separate commit:
* Do not duplicate calls to `UIKitRUMViewsPredicate` when hierarchy's top view does not change.
* Add `DefaultUIKitRUMViewsPredicate` which names RUM Views by the class name.
* Print the console warning if any RUM View / Resource / Action is noticed but `Global.rum` is not registered.
* Make it cleaner in `rum_collecting.md` that `Global.rum` must be registered for each auto instrumentation.
* Improve the `DDURLSessionDelegate` initialisation warning if it's initialised before `Datadog.initialize()` is called.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
