### PR TITLE
RUMM-696 Stop sending tracing `Span` for RUM Resources

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		6193DCCE251B6201009B8011 /* RUMTASScreen1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCCD251B6201009B8011 /* RUMTASScreen1ViewController.swift */; };
 		6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCE0251B692C009B8011 /* RUMTASTableViewController.swift */; };
 		6193DCE8251B9AB1009B8011 /* RUMTASCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCE7251B9AB1009B8011 /* RUMTASCollectionViewController.swift */; };
+		61940C7C25668EC600A20043 /* URLSessionInterceptionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61940C7B25668EC600A20043 /* URLSessionInterceptionHandler.swift */; };
 		6198D27124C6E3B700493501 /* RUMViewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */; };
 		61A763DC252DB2B3005A23F2 /* NSURLSessionBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */; };
 		61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */; };
@@ -611,6 +612,7 @@
 		6193DCCD251B6201009B8011 /* RUMTASScreen1ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASScreen1ViewController.swift; sourceTree = "<group>"; };
 		6193DCE0251B692C009B8011 /* RUMTASTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASTableViewController.swift; sourceTree = "<group>"; };
 		6193DCE7251B9AB1009B8011 /* RUMTASCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASCollectionViewController.swift; sourceTree = "<group>"; };
+		61940C7B25668EC600A20043 /* URLSessionInterceptionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionInterceptionHandler.swift; sourceTree = "<group>"; };
 		6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewScopeTests.swift; sourceTree = "<group>"; };
 		61A763D9252DB2B3005A23F2 /* DatadogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DatadogTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		61A763DA252DB2B3005A23F2 /* NSURLSessionBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionBridge.h; sourceTree = "<group>"; };
@@ -1455,6 +1457,7 @@
 			children = (
 				613F23DC252B05BD006CD2D7 /* URLFiltering */,
 				618E1337252340810098C6B0 /* URLSessionInterceptor.swift */,
+				61940C7B25668EC600A20043 /* URLSessionInterceptionHandler.swift */,
 				61417DC52525CDDE00E2D55C /* TaskInterception.swift */,
 			);
 			path = Interception;
@@ -2492,6 +2495,7 @@
 				618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				E1D202EA24C065CF00D1AF3A /* ActiveSpansPool.swift in Sources */,
+				61940C7C25668EC600A20043 /* URLSessionInterceptionHandler.swift in Sources */,
 				61F3CDA3251118FB00C816E5 /* UIKitRUMViewsHandler.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
 				618DCFD924C7269500589570 /* RUMUUIDGenerator.swift in Sources */,

--- a/Datadog/Example/TestScenarios.swift
+++ b/Datadog/Example/TestScenarios.swift
@@ -80,6 +80,9 @@ class TracingURLSessionScenario: URLSessionBaseScenario, TestScenario {
     static func envIdentifier() -> String { "TracingURLSessionScenario" }
 
     override func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder
+            .enableRUM(false)
+
         super.configureSDK(builder: builder)
     }
 }
@@ -92,6 +95,9 @@ class TracingNSURLSessionScenario: URLSessionBaseScenario, TestScenario {
     static func envIdentifier() -> String { "TracingNSURLSessionScenario" }
 
     override func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder
+            .enableRUM(false)
+
         super.configureSDK(builder: builder)
     }
 }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -6,16 +6,7 @@
 
 import Foundation
 
-/// An interface for sending Tracing `Spans` for given `URLSession` task interception.
-internal protocol URLSessionRUMResourcesHandlerType {
-    func subscribe(commandsSubscriber: RUMCommandSubscriber)
-    /// Notifies the `URLSessionTask` interception start.
-    func notify_taskInterceptionStarted(interception: TaskInterception)
-    /// Notifies the `URLSessionTask` interception completion.
-    func notify_taskInterceptionCompleted(interception: TaskInterception)
-}
-
-internal class URLSessionRUMResourcesHandler: URLSessionRUMResourcesHandlerType {
+internal class URLSessionRUMResourcesHandler: URLSessionInterceptionHandler {
     private let dateProvider: DateProvider
 
     // MARK: - Initialization
@@ -24,13 +15,15 @@ internal class URLSessionRUMResourcesHandler: URLSessionRUMResourcesHandlerType 
         self.dateProvider = dateProvider
     }
 
-    // MARK: - URLSessionRUMResourcesHandlerType
+    // MARK: - Internal
 
     weak var subscriber: RUMCommandSubscriber?
 
     func subscribe(commandsSubscriber: RUMCommandSubscriber) {
         self.subscriber = commandsSubscriber
     }
+
+    // MARK: - URLSessionInterceptionHandler
 
     func notify_taskInterceptionStarted(interception: TaskInterception) {
         let url = interception.request.url?.absoluteString ?? "unknown_url"

--- a/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
+++ b/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
@@ -6,16 +6,20 @@
 
 import Foundation
 
-/// An interface for sending Tracing `Spans` for given `URLSession` task interception.
-internal protocol URLSessionTracingHandlerType {
-    /// Sends `Span` for given `TaskInterception`.
-    func sendSpan(for interception: TaskInterception, using tracer: Tracer)
-}
+internal class URLSessionTracingHandler: URLSessionInterceptionHandler {
+    // MARK: - URLSessionInterceptionHandler
 
-internal class URLSessionTracingHandler: URLSessionTracingHandlerType {
-    // MARK: - URLSessionTracingHandlerType
+    func notify_taskInterceptionStarted(interception: TaskInterception) {
+        /* no-op */
+    }
 
-    func sendSpan(for interception: TaskInterception, using tracer: Tracer) {
+    func notify_taskInterceptionCompleted(interception: TaskInterception) {
+        if !interception.isFirstPartyRequets {
+            return // `Span` should be only send for 1st party requests
+        }
+        guard let tracer = Global.sharedTracer as? Tracer else {
+            return // TODO: RUMM-696 Print the warning
+        }
         guard let resourceMetrics = interception.metrics,
               let resourceCompletion = interception.completion else {
             return

--- a/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
+++ b/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
@@ -18,7 +18,13 @@ internal class URLSessionTracingHandler: URLSessionInterceptionHandler {
             return // `Span` should be only send for 1st party requests
         }
         guard let tracer = Global.sharedTracer as? Tracer else {
-            return // TODO: RUMM-696 Print the warning
+            userLogger.warn(
+                """
+                `URLSession` request was completed, but no `Tracer` is registered on `Global.sharedTracer`. Tracing auto instrumentation will not work.
+                Make sure `Global.sharedTracer = Tracer.initialize()` is called before any network request is send.
+                """
+            )
+            return
         }
         guard let resourceMetrics = interception.metrics,
               let resourceCompletion = interception.completion else {

--- a/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
+++ b/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
@@ -14,7 +14,7 @@ internal class URLSessionTracingHandler: URLSessionInterceptionHandler {
     }
 
     func notify_taskInterceptionCompleted(interception: TaskInterception) {
-        if !interception.isFirstPartyRequets {
+        if !interception.isFirstPartyRequest {
             return // `Span` should be only send for 1st party requests
         }
         guard let tracer = Global.sharedTracer as? Tracer else {

--- a/Sources/Datadog/Tracing/Propagation/TracingHTTPHeaders.swift
+++ b/Sources/Datadog/Tracing/Propagation/TracingHTTPHeaders.swift
@@ -9,6 +9,10 @@ import Foundation
 internal struct TracingHTTPHeaders {
     static let traceIDField = "x-datadog-trace-id"
     static let parentSpanIDField = "x-datadog-parent-id"
+    static let originField = "x-datadog-origin"
+    /// Value for `originField` header field, indicating that the request is tracked as RUM Resource by the client.
+    static let rumOriginValue = "rum"
+
     // TODO: RUMM-338 support `x-datadog-sampling-priority`. `dd-trace-ot` reference:
     // https://github.com/DataDog/dd-trace-java/blob/4ba0ca0f9da748d4018310d026b1a72b607947f1/dd-trace-ot/src/main/java/datadog/opentracing/propagation/DatadogHttpCodec.java#L23
 }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
@@ -13,7 +13,7 @@ internal class TaskInterception {
     /// given by the user (as the request could have been modified in `URLSessionSwizzler`).
     internal let request: URLRequest
     /// Tells if the `request` is send to a 1st party host.
-    internal let isFirstPartyRequets: Bool
+    internal let isFirstPartyRequest: Bool
     /// Task metrics collected during this interception.
     private(set) var metrics: ResourceMetrics?
     /// Task completion collected during this interception.
@@ -25,7 +25,7 @@ internal class TaskInterception {
     init(request: URLRequest, isFirstParty: Bool) {
         self.identifier = UUID()
         self.request = request
-        self.isFirstPartyRequets = isFirstParty
+        self.isFirstPartyRequest = isFirstParty
     }
 
     func register(metrics: ResourceMetrics) {

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
@@ -12,6 +12,8 @@ internal class TaskInterception {
     /// The initial request send during this interception. It is, the request send from `URLSession`, not the one
     /// given by the user (as the request could have been modified in `URLSessionSwizzler`).
     internal let request: URLRequest
+    /// Tells if the `request` is send to a 1st party host.
+    internal let isFirstPartyRequets: Bool
     /// Task metrics collected during this interception.
     private(set) var metrics: ResourceMetrics?
     /// Task completion collected during this interception.
@@ -20,9 +22,10 @@ internal class TaskInterception {
     /// or when the task was created through `URLSession.dataTask(with:url)` on some iOS13+.
     private(set) var spanContext: DDSpanContext?
 
-    init(request: URLRequest) {
+    init(request: URLRequest, isFirstParty: Bool) {
         self.identifier = UUID()
         self.request = request
+        self.isFirstPartyRequets = isFirstParty
     }
 
     func register(metrics: ResourceMetrics) {

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptionHandler.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptionHandler.swift
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// An interface for handling `URLSession` interceptions.
+internal protocol URLSessionInterceptionHandler {
+    /// Notifies the `URLSessionTask` interception start.
+    func notify_taskInterceptionStarted(interception: TaskInterception)
+    /// Notifies the `URLSessionTask` interception completion.
+    func notify_taskInterceptionCompleted(interception: TaskInterception)
+}

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -198,10 +198,8 @@ internal class URLSessionInterceptor: URLSessionInterceptorType {
     }
 
     private func extractSpanContext(from request: URLRequest) -> DDSpanContext? {
-        guard let tracer = Global.sharedTracer as? Tracer else {
-            return nil
-        }
-        guard let headers = request.allHTTPHeaderFields else {
+        guard let tracer = Global.sharedTracer as? Tracer,
+              let headers = request.allHTTPHeaderFields else {
             return nil
         }
 

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
@@ -33,6 +33,7 @@ internal class URLSessionAutoInstrumentation {
     }
 
     func subscribe(commandSubscriber: RUMCommandSubscriber) {
-        interceptor.rumResourceHandler?.subscribe(commandsSubscriber: commandSubscriber)
+        let rumResourceHandler = interceptor.handler as? URLSessionRUMResourcesHandler
+        rumResourceHandler?.subscribe(commandsSubscriber: commandSubscriber)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -26,7 +26,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         // Given
         var request = URLRequest(url: .mockRandom())
         request.httpMethod = ["GET", "POST", "PUT", "DELETE"].randomElement()!
-        let taskInterception = TaskInterception(request: request)
+        let taskInterception = TaskInterception(request: request, isFirstParty: .random())
         XCTAssertNil(taskInterception.spanContext)
 
         // When
@@ -49,7 +49,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         commandSubscriber.onCommandReceived = { _ in receiveCommand.fulfill() }
 
         // Given
-        let taskInterception = TaskInterception(request: .mockAny())
+        let taskInterception = TaskInterception(request: .mockAny(), isFirstParty: .random())
         taskInterception.register(spanContext: .mockWith(traceID: 1, spanID: 2))
         XCTAssertNotNil(taskInterception.spanContext)
 
@@ -74,7 +74,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         }
 
         // Given
-        let taskInterception = TaskInterception(request: .mockAny())
+        let taskInterception = TaskInterception(request: .mockAny(), isFirstParty: .random())
         let resourceMetrics: ResourceMetrics = .mockAny()
         let resourceCompletion: ResourceCompletion = .mockWith(response: .mockResponseWith(statusCode: 200), error: nil)
         taskInterception.register(metrics: resourceMetrics)
@@ -111,7 +111,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         }
 
         // Given
-        let taskInterception = TaskInterception(request: .mockAny())
+        let taskInterception = TaskInterception(request: .mockAny(), isFirstParty: .random())
         let taskError = NSError(domain: "domain", code: 123, userInfo: [NSLocalizedDescriptionKey: "network error"])
         let resourceMetrics: ResourceMetrics = .mockAny()
         let resourceCompletion: ResourceCompletion = .mockWith(response: nil, error: taskError)

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -748,7 +748,7 @@ class RUMMonitorTests: XCTestCase {
         userLogger = .mockWith(logOutput: output)
 
         // Given
-        let resourcesHandler = try XCTUnwrap(URLSessionAutoInstrumentation.instance?.interceptor.rumResourceHandler)
+        let resourcesHandler = try XCTUnwrap(URLSessionAutoInstrumentation.instance?.interceptor.handler)
         let viewsHandler = try XCTUnwrap(RUMAutoInstrumentation.instance?.views?.handler)
         let userActionsHandler = try XCTUnwrap(RUMAutoInstrumentation.instance?.userActions?.handler)
 
@@ -756,7 +756,7 @@ class RUMMonitorTests: XCTestCase {
         XCTAssertTrue(Global.rum is DDNoopRUMMonitor)
 
         // Then
-        resourcesHandler.notify_taskInterceptionCompleted(interception: TaskInterception(request: .mockAny()))
+        resourcesHandler.notify_taskInterceptionCompleted(interception: TaskInterception(request: .mockAny(), isFirstParty: .mockAny()))
         XCTAssertEqual(output.recordedLog?.level, .warn)
         XCTAssertEqual(
             output.recordedLog?.message,

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterceptionTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterceptionTests.swift
@@ -15,8 +15,8 @@ class TaskInterceptionTests: XCTestCase {
 
         // Then
         XCTAssertNotEqual(interception1.identifier, interception2.identifier)
-        XCTAssertTrue(interception1.isFirstPartyRequets)
-        XCTAssertFalse(interception2.isFirstPartyRequets)
+        XCTAssertTrue(interception1.isFirstPartyRequest)
+        XCTAssertFalse(interception2.isFirstPartyRequest)
     }
 
     func testWhenInterceptionReceivesBothMetricsAndCompletion_itIsConsideredDone() {

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterceptionTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterceptionTests.swift
@@ -10,15 +10,17 @@ import XCTest
 class TaskInterceptionTests: XCTestCase {
     func testWhenInterceptionIsCreated_itHasUniqueIdentifier() {
         // When
-        let interception1 = TaskInterception(request: .mockAny())
-        let interception2 = TaskInterception(request: .mockAny())
+        let interception1 = TaskInterception(request: .mockAny(), isFirstParty: true)
+        let interception2 = TaskInterception(request: .mockAny(), isFirstParty: false)
 
         // Then
         XCTAssertNotEqual(interception1.identifier, interception2.identifier)
+        XCTAssertTrue(interception1.isFirstPartyRequets)
+        XCTAssertFalse(interception2.isFirstPartyRequets)
     }
 
     func testWhenInterceptionReceivesBothMetricsAndCompletion_itIsConsideredDone() {
-        let interception = TaskInterception(request: .mockAny())
+        let interception = TaskInterception(request: .mockAny(), isFirstParty: .mockAny())
 
         // When
         interception.register(completion: .mockAny())

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
@@ -138,18 +138,7 @@ class URLSessionInterceptorTests: XCTestCase {
         XCTAssertNotNil(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
         XCTAssertNotNil(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
         XCTAssertEqual(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField], TracingHTTPHeaders.rumOriginValue)
-        XCTAssertNil(interceptedThirdPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
-        XCTAssertNil(interceptedThirdPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
-        XCTAssertNil(interceptedThirdPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField])
-        XCTAssertNil(interceptedInternalRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
-        XCTAssertNil(interceptedInternalRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
-        XCTAssertNil(interceptedInternalRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField])
-
-        XCTAssertNotEqual(firstPartyRequest, interceptedFirstPartyRequest, "Intercepted 1st party request should be modified.")
-        XCTAssertEqual(thirdPartyRequest, interceptedThirdPartyRequest, "Intercepted 3rd party request should not be modified.")
-        XCTAssertEqual(internalRequest, interceptedInternalRequest, "Intercepted internal request should not be modified.")
-
-        XCTAssertEqual(
+        assertRequestsEqual(
             interceptedFirstPartyRequest
                 .removing(httpHeaderField: TracingHTTPHeaders.traceIDField)
                 .removing(httpHeaderField: TracingHTTPHeaders.parentSpanIDField)
@@ -157,6 +146,8 @@ class URLSessionInterceptorTests: XCTestCase {
             firstPartyRequest,
             "The only modification of the original requests should be the addition of 3 tracing headers."
         )
+        assertRequestsEqual(thirdPartyRequest, interceptedThirdPartyRequest, "Intercepted 3rd party request should not be modified.")
+        assertRequestsEqual(internalRequest, interceptedInternalRequest, "Intercepted internal request should not be modified.")
     }
 
     func testGivenOnlyTracingInstrumentationEnabled_whenInterceptingRequests_itInjectsTracingContextToFirstPartyRequests() throws {
@@ -177,24 +168,15 @@ class URLSessionInterceptorTests: XCTestCase {
         XCTAssertNotNil(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
         XCTAssertNotNil(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
         XCTAssertNil(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField], "Origin header should not be added if RUM is disabled.")
-        XCTAssertNil(interceptedThirdPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
-        XCTAssertNil(interceptedThirdPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
-        XCTAssertNil(interceptedThirdPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField])
-        XCTAssertNil(interceptedInternalRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
-        XCTAssertNil(interceptedInternalRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
-        XCTAssertNil(interceptedInternalRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField])
-
-        XCTAssertNotEqual(firstPartyRequest, interceptedFirstPartyRequest, "Intercepted 1st party request should be modified.")
-        XCTAssertEqual(thirdPartyRequest, interceptedThirdPartyRequest, "Intercepted 3rd party request should not be modified.")
-        XCTAssertEqual(internalRequest, interceptedInternalRequest, "Intercepted internal request should not be modified.")
-
-        XCTAssertEqual(
+        assertRequestsEqual(
             interceptedFirstPartyRequest
                 .removing(httpHeaderField: TracingHTTPHeaders.traceIDField)
                 .removing(httpHeaderField: TracingHTTPHeaders.parentSpanIDField),
             firstPartyRequest,
             "The only modification of the original requests should be the addition of 2 tracing headers."
         )
+        assertRequestsEqual(thirdPartyRequest, interceptedThirdPartyRequest, "Intercepted 3rd party request should not be modified.")
+        assertRequestsEqual(internalRequest, interceptedInternalRequest, "Intercepted internal request should not be modified.")
     }
 
     func testGivenOnlyRUMInstrumentationEnabled_whenInterceptingRequests_itDoesNotModifyThem() throws {
@@ -212,19 +194,9 @@ class URLSessionInterceptorTests: XCTestCase {
         let interceptedInternalRequest = interceptor.modify(request: internalRequest)
 
         // Then
-        XCTAssertNil(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
-        XCTAssertNil(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
-        XCTAssertNil(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField])
-        XCTAssertNil(interceptedThirdPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
-        XCTAssertNil(interceptedThirdPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
-        XCTAssertNil(interceptedThirdPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField])
-        XCTAssertNil(interceptedInternalRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
-        XCTAssertNil(interceptedInternalRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
-        XCTAssertNil(interceptedInternalRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField])
-
-        XCTAssertEqual(firstPartyRequest, interceptedFirstPartyRequest, "Intercepted 1st party request should not be modified.")
-        XCTAssertEqual(thirdPartyRequest, interceptedThirdPartyRequest, "Intercepted 3rd party request should not be modified.")
-        XCTAssertEqual(internalRequest, interceptedInternalRequest, "Intercepted internal request should not be modified.")
+        assertRequestsEqual(firstPartyRequest, interceptedFirstPartyRequest, "Intercepted 1st party request should not be modified.")
+        assertRequestsEqual(thirdPartyRequest, interceptedThirdPartyRequest, "Intercepted 3rd party request should not be modified.")
+        assertRequestsEqual(internalRequest, interceptedInternalRequest, "Intercepted internal request should not be modified.")
     }
 
     func testGivenTracingInstrumentationEnabledButTracerNotRegistered_whenInterceptingRequests_itDoesNotInjectTracingContextToAnyRequest() throws {
@@ -241,9 +213,9 @@ class URLSessionInterceptorTests: XCTestCase {
         let interceptedInternalRequest = interceptor.modify(request: internalRequest)
 
         // Then
-        XCTAssertEqual(firstPartyRequest, interceptedFirstPartyRequest, "Intercepted 1st party request should not be modified.")
-        XCTAssertEqual(thirdPartyRequest, interceptedThirdPartyRequest, "Intercepted 3rd party request should not be modified.")
-        XCTAssertEqual(internalRequest, interceptedInternalRequest, "Intercepted internal request should not be modified.")
+        assertRequestsEqual(firstPartyRequest, interceptedFirstPartyRequest, "Intercepted 1st party request should not be modified.")
+        assertRequestsEqual(thirdPartyRequest, interceptedThirdPartyRequest, "Intercepted 3rd party request should not be modified.")
+        assertRequestsEqual(internalRequest, interceptedInternalRequest, "Intercepted internal request should not be modified.")
     }
 
     // MARK: - URLSessionTask Interception
@@ -422,5 +394,23 @@ class URLSessionInterceptorTests: XCTestCase {
             iterations: 50
         )
         // swiftlint:enable opening_brace
+    }
+
+    // MARK: - Helpers
+
+    /// Because of https://openradar.appspot.com/radar?id=4988276943355904
+    /// it is not always reliable to compare `URLRequests` using in-build equality operator (`r1 == r2`).
+    /// This method implements a workaround by comparing request HTTP headers before checking equality.
+    private func assertRequestsEqual(
+        _ request1: URLRequest,
+        _ request2: URLRequest,
+        _ message: String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let headers1 = request1.allHTTPHeaderFields ?? [:]
+        let headers2 = request2.allHTTPHeaderFields ?? [:]
+        XCTAssertEqual(headers1, headers2, message, file: file, line: line)
+        XCTAssertEqual(request1, request2, message, file: file, line: line)
     }
 }

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
@@ -37,7 +37,7 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
         defer { Global.rum = DDNoopRUMMonitor() }
 
         // Then
-        let resourcesHandler = URLSessionAutoInstrumentation.instance?.interceptor.rumResourceHandler as? URLSessionRUMResourcesHandler
+        let resourcesHandler = URLSessionAutoInstrumentation.instance?.interceptor.handler as? URLSessionRUMResourcesHandler
         XCTAssertTrue(resourcesHandler?.subscriber === Global.rum)
     }
 }


### PR DESCRIPTION
### What and why?

🚚 This PR changes the logic of auto-instrumented, network `Span` generation depending of which feature (RUM or Tracing) is enabled. This is because recently our RUM backend started generating spans for RUM Resources on behalf of the SDK.

New behaviour, assuming that `set(firstPartyHosts:)` is set and `DDURLSessionDelegate()` is installed:
| Tracing feature  | RUM feature | `Global.sharedTracer` | `Global.rum` | 1st party request | 3rd party request |
| :--------------: | :----------: | :--------: | :-------------: | :----------------: | :----------------: |
| ✅ | ❌ | registered | - | send `Span` + inject tracing headers | - |
| ❌ | ✅ | - | registered | send RUM Resource | send RUM Resource |
| ✅ | ✅ | registered | registered | send RUM Resource with `trace_id` and `span_id` + inject tracing headers + inject `x-datadog-origin: rum` header | send RUM Resource |

Also, appropriate warnings are printed on different misconfiguration, e.g. _when Tracing auto-instrumentation is enabled, and a first party request is sent while `Global.sharedTracer` is not registered_.

### How?

Continuing what was started in #262, the logic of `interceptor` was simplified. Now, instead of two distinct handlers (for RUM and Tracing), it takes only one interface:
```swift
internal protocol URLSessionInterceptionHandler {
    func notify_taskInterceptionStarted(interception: TaskInterception)
    func notify_taskInterceptionCompleted(interception: TaskInterception)
}
```
implemented by `URLSessionRUMResourceHandler` and `URLSessionTracingHandler`.

**Interceptor:**
* injects / extracts `SpanContext` and custom `x-datadog-origin: rum` header into/from 1st party requests,
* notifies handler on interception start and completion.

**Handler:**
* `URLSessionRUMResourceHandler` - send RUM Resources and associate `RUMSpanContext` if set for the `interception`,
* `URLSessionTracingHandler` - send `Span` only for interceptions flagged as `interception.isFirstPartyRequest`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
