### PR TITLE
RUMM-886 `setUserInfo(..., extraInfo)` added

### DIFF
--- a/Datadog/Example/Debugging/DebugRUMViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMViewController.swift
@@ -156,8 +156,12 @@ class DebugRUMViewController: UIViewController {
 
 /// Creates an instance of `UIViewController` subclass with a given name.
 private func createUIViewControllerSubclassInstance(named viewControllerClassName: String) -> UIViewController {
-    let theClass: AnyClass = objc_allocateClassPair(UIViewController.classForCoder(), viewControllerClassName, 0)!
-    objc_registerClassPair(theClass)
+    let theClass: AnyClass = NSClassFromString(viewControllerClassName) ?? {
+        let cls: AnyClass
+        cls = objc_allocateClassPair(UIViewController.classForCoder(), viewControllerClassName, 0)!
+        objc_registerClassPair(cls)
+        return cls
+    }()
     return theClass.alloc() as! UIViewController
 }
 

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -33,7 +33,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
         )
 
         // Set user information
-        Datadog.setUserInfo(id: "abcd-1234", name: "foo", email: "foo@example.com")
+        Datadog.setUserInfo(id: "abcd-1234", name: "foo", email: "foo@example.com", extraInfo: ["key-extraUserInfo": "value-extraUserInfo"])
 
         // Create Logger
         logger = Logger.builder

--- a/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
+++ b/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
@@ -12,11 +12,11 @@ internal class UserInfoProvider {
     /// `UserInfo` can be mutated by any user thread with `Datadog.setUserInfo(id:name:email:)` - at the same
     /// time it might be accessed by different queues running in the SDK.
     private let queue = DispatchQueue(label: "com.datadoghq.user-info-provider", qos: .userInteractive)
-    private var current = UserInfo(id: nil, name: nil, email: nil)
+    private var _value = UserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
 
     var value: UserInfo {
-        set { queue.async { self.current = newValue } }
-        get { queue.sync { self.current } }
+        set { queue.async { self._value = newValue } }
+        get { queue.sync { self._value } }
     }
 }
 
@@ -25,4 +25,5 @@ internal struct UserInfo {
     let id: String?
     let name: String?
     let email: String?
+    let extraInfo: [AttributeKey: AttributeValue]
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -75,6 +75,13 @@ public class Datadog {
         }
     }
 
+    /// Sets current user information.
+    /// Those will be added to logs, traces and RUM events automatically.
+    /// - Parameters:
+    ///   - id: User ID, if any
+    ///   - name: Name representing the user, if any
+    ///   - email: User's email, if any
+    ///   - extraInfo: User's custom attributes, if any
     public static func setUserInfo(
         id: String? = nil,
         name: String? = nil,

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -78,9 +78,15 @@ public class Datadog {
     public static func setUserInfo(
         id: String? = nil,
         name: String? = nil,
-        email: String? = nil
+        email: String? = nil,
+        extraInfo: [AttributeKey: AttributeValue] = [:]
     ) {
-        instance?.userInfoProvider.value = UserInfo(id: id, name: name, email: email)
+        instance?.userInfoProvider.value = UserInfo(
+            id: id,
+            name: name,
+            email: email,
+            extraInfo: extraInfo
+        )
     }
 
     // MARK: - Internal

--- a/Sources/Datadog/Logging/Log/LogEncoder.swift
+++ b/Sources/Datadog/Logging/Log/LogEncoder.swift
@@ -137,13 +137,19 @@ internal struct LogEncoder {
         // Encode attributes...
         var attributesContainer = encoder.container(keyedBy: DynamicCodingKey.self)
 
-        // ... first, user attributes ...
+        // 1. user info attributes
+        try log.userInfo.extraInfo.forEach {
+            let key = DynamicCodingKey("usr.\($0)")
+            try attributesContainer.encode(EncodableValue($1), forKey: key)
+        }
+
+        // 2. user attributes
         let encodableUserAttributes = Dictionary(
             uniqueKeysWithValues: log.attributes.userAttributes.map { name, value in (name, EncodableValue(value)) }
         )
         try encodableUserAttributes.forEach { try attributesContainer.encode($0.value, forKey: DynamicCodingKey($0.key)) }
 
-        // ... then, internal attributes:
+        // 3. internal attributes
         if let internalAttributes = log.attributes.internalAttributes {
             let encodableInternalAttributes = Dictionary(
                 uniqueKeysWithValues: internalAttributes.map { name, value in (name, EncodableValue(value)) }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -6,8 +6,18 @@
 
 import Foundation
 
-internal struct RUMEventBuilder {
+internal class RUMEventBuilder {
+    let userInfoProvider: UserInfoProvider
+
+    init(userInfoProvider: UserInfoProvider) {
+        self.userInfoProvider = userInfoProvider
+    }
+
     func createRUMEvent<DM: RUMDataModel>(with model: DM, attributes: [String: Encodable]) -> RUMEvent<DM> {
-        return RUMEvent(model: model, attributes: attributes)
+        return RUMEvent(
+            model: model,
+            attributes: attributes,
+            userInfoAttributes: userInfoProvider.value.extraInfo
+        )
     }
 }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -13,6 +13,7 @@ internal struct RUMEvent<DM: RUMDataModel>: Encodable {
 
     /// Custom attributes set by the user
     let attributes: [String: Encodable]
+    let userInfoAttributes: [String: Encodable]
 
     func encode(to encoder: Encoder) throws {
         try RUMEventEncoder().encode(self, to: encoder)
@@ -35,6 +36,9 @@ internal struct RUMEventEncoder {
         var attributesContainer = encoder.container(keyedBy: DynamicCodingKey.self)
         try event.attributes.forEach { attributeName, attributeValue in
             try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("context.\(attributeName)"))
+        }
+        try event.userInfoAttributes.forEach { attributeName, attributeValue in
+            try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("context.usr.\(attributeName)"))
         }
 
         // Encode `RUMDataModel`

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -182,7 +182,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                         networkConnectionInfoProvider: rumFeature.networkConnectionInfoProvider,
                         carrierInfoProvider: rumFeature.carrierInfoProvider
                     ),
-                    eventBuilder: RUMEventBuilder(),
+                    eventBuilder: RUMEventBuilder(userInfoProvider: rumFeature.userInfoProvider),
                     eventOutput: RUMEventFileOutput(
                         fileWriter: rumFeature.storage.writer
                     ),

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -27,14 +27,12 @@ internal struct SpanBuilder {
     func createSpan(from ddspan: DDSpan, finishTime: Date) -> Span {
         let tagsReducer = SpanTagsReducer(spanTags: ddspan.tags, logFields: ddspan.logFields)
 
-        var jsonStringEncodedTags: [String: JSONStringEncodableValue] = [:]
-
-        // First, add baggage items as tags...
+        var jsonStringEncodedTags = [String: JSONStringEncodableValue]()
+        // 1. add baggage items as tags
         for (itemKey, itemValue) in ddspan.ddContext.baggageItems.all {
             jsonStringEncodedTags[itemKey] = JSONStringEncodableValue(itemValue, encodedUsing: tagsJSONEncoder)
         }
-
-        // ... then, add regular tags
+        // 2. add regular tags
         for (tagName, tagValue) in tagsReducer.reducedSpanTags {
             jsonStringEncodedTags[tagName] = JSONStringEncodableValue(tagValue, encodedUsing: tagsJSONEncoder)
         }

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -28,11 +28,17 @@ internal struct SpanBuilder {
         let tagsReducer = SpanTagsReducer(spanTags: ddspan.tags, logFields: ddspan.logFields)
 
         var jsonStringEncodedTags = [String: JSONStringEncodableValue]()
-        // 1. add baggage items as tags
+        // 1. add user info attributes as tags
+        for (itemKey, itemValue) in userInfoProvider.value.extraInfo {
+            let encodedKey = "usr.\(itemKey)"
+            let encodableValue = JSONStringEncodableValue(itemValue, encodedUsing: tagsJSONEncoder)
+            jsonStringEncodedTags[encodedKey] = encodableValue
+        }
+        // 2. add baggage items as tags
         for (itemKey, itemValue) in ddspan.ddContext.baggageItems.all {
             jsonStringEncodedTags[itemKey] = JSONStringEncodableValue(itemValue, encodedUsing: tagsJSONEncoder)
         }
-        // 2. add regular tags
+        // 3. add regular tags
         for (tagName, tagValue) in tagsReducer.reducedSpanTags {
             jsonStringEncodedTags[tagName] = JSONStringEncodableValue(tagValue, encodedUsing: tagsJSONEncoder)
         }

--- a/Sources/Datadog/Tracing/Span/SpanEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEncoder.swift
@@ -198,5 +198,8 @@ internal struct SpanEncoder {
             let metaKey = "meta.\($0.key)"
             try container.encode($0.value, forKey: DynamicCodingKey(metaKey))
         }
+        try span.userInfo.extraInfo.forEach {
+            try container.encode(EncodableValue($1), forKey: DynamicCodingKey("meta.usr.\($0)"))
+        }
     }
 }

--- a/Sources/Datadog/Tracing/Span/SpanEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEncoder.swift
@@ -198,8 +198,5 @@ internal struct SpanEncoder {
             let metaKey = "meta.\($0.key)"
             try container.encode($0.value, forKey: DynamicCodingKey(metaKey))
         }
-        try span.userInfo.extraInfo.forEach {
-            try container.encode(EncodableValue($1), forKey: DynamicCodingKey("meta.usr.\($0)"))
-        }
     }
 }

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -80,7 +80,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
             loggerVersion: "0.0.0",
             threadName: "main",
             applicationVersion: "0.0.0",
-            userInfo: .init(id: "abc-123", name: "foo", email: "foo@bar.com"),
+            userInfo: .init(id: "abc-123", name: "foo", email: "foo@bar.com", extraInfo: ["str": "value", "int": 11_235, "bool": true]),
             networkConnectionInfo: .init(
                 reachability: .yes,
                 availableInterfaces: [.cellular],

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -105,7 +105,8 @@ class RUMStorageBenchmarkTests: XCTestCase {
                 connectivity: nil,
                 dd: .init(documentVersion: .mockAny())
             ),
-            attributes: ["attribute": "value"]
+            attributes: ["attribute": "value"],
+            userInfoAttributes: ["str": "value", "int": 11_235, "bool": true]
         )
     }
 }

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -92,7 +92,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
                 isConstrained: false
             ),
             mobileCarrierInfo: nil,
-            userInfo: .init(id: "abc-123", name: "foo", email: "foo@bar.com"),
+            userInfo: .init(id: "abc-123", name: "foo", email: "foo@bar.com", extraInfo: ["str": "value", "int": 11_235, "bool": true]),
             tags: [
                 "tag": JSONStringEncodableValue("value", encodedUsing: JSONEncoder())
             ]

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -186,16 +186,16 @@ class LoggerTests: XCTestCase {
         Datadog.setUserInfo(id: "abc-123", name: "Foo")
         logger.debug("message with user `id` and `name`")
 
-        Datadog.setUserInfo(id: "abc-123", name: "Foo", email: "foo@example.com")
-        logger.debug("message with user `id`, `name` and `email`")
+        Datadog.setUserInfo(id: "abc-123", name: "Foo", email: "foo@example.com", extraInfo: ["extra_key": "extra_value"])
+        logger.debug("message with user `id`, `name`, `email` and `extraInfo`")
 
         Datadog.setUserInfo(id: nil, name: nil, email: nil)
         logger.debug("message with no user info")
 
         let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 4)
         logMatchers[0].assertUserInfo(equals: nil)
-        logMatchers[1].assertUserInfo(equals: (id: "abc-123", name: "Foo", email: nil))
-        logMatchers[2].assertUserInfo(equals: (id: "abc-123", name: "Foo", email: "foo@example.com"))
+        logMatchers[1].assertUserInfo(equals: (id: "abc-123", name: "Foo", email: nil, extraInfo: nil))
+        logMatchers[2].assertUserInfo(equals: (id: "abc-123", name: "Foo", email: "foo@example.com", extraInfo: ["extra_key": "extra_value"]))
         logMatchers[3].assertUserInfo(equals: nil)
     }
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -186,7 +186,16 @@ class LoggerTests: XCTestCase {
         Datadog.setUserInfo(id: "abc-123", name: "Foo")
         logger.debug("message with user `id` and `name`")
 
-        Datadog.setUserInfo(id: "abc-123", name: "Foo", email: "foo@example.com", extraInfo: ["extra_key": "extra_value"])
+        Datadog.setUserInfo(
+            id: "abc-123",
+            name: "Foo",
+            email: "foo@example.com",
+            extraInfo: [
+                "str": "value",
+                "int": 11_235,
+                "bool": true
+            ]
+        )
         logger.debug("message with user `id`, `name`, `email` and `extraInfo`")
 
         Datadog.setUserInfo(id: nil, name: nil, email: nil)
@@ -194,8 +203,20 @@ class LoggerTests: XCTestCase {
 
         let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 4)
         logMatchers[0].assertUserInfo(equals: nil)
-        logMatchers[1].assertUserInfo(equals: (id: "abc-123", name: "Foo", email: nil, extraInfo: nil))
-        logMatchers[2].assertUserInfo(equals: (id: "abc-123", name: "Foo", email: "foo@example.com", extraInfo: ["extra_key": "extra_value"]))
+
+        logMatchers[1].assertUserInfo(equals: (id: "abc-123", name: "Foo", email: nil))
+
+        logMatchers[2].assertUserInfo(
+            equals: (
+                id: "abc-123",
+                name: "Foo",
+                email: "foo@example.com"
+            )
+        )
+        logMatchers[2].assertValue(forKey: "usr.str", equals: "value")
+        logMatchers[2].assertValue(forKey: "usr.int", equals: 11_235)
+        logMatchers[2].assertValue(forKey: "usr.bool", equals: true)
+
         logMatchers[3].assertUserInfo(equals: nil)
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -382,7 +382,7 @@ extension UserInfo {
     }
 
     static func mockEmpty() -> UserInfo {
-        return UserInfo(id: nil, name: nil, email: nil)
+        return UserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -80,7 +80,7 @@ struct RUMDataModelMock: RUMDataModel, Equatable {
 
 extension RUMEventBuilder {
     static func mockAny() -> RUMEventBuilder {
-        return RUMEventBuilder()
+        return RUMEventBuilder(userInfoProvider: UserInfoProvider.mockAny())
     }
 }
 
@@ -323,7 +323,7 @@ extension RUMScopeDependencies {
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock(networkConnectionInfo: nil),
             carrierInfoProvider: CarrierInfoProviderMock(carrierInfo: nil)
         ),
-        eventBuilder: RUMEventBuilder = RUMEventBuilder(),
+        eventBuilder: RUMEventBuilder = RUMEventBuilder(userInfoProvider: UserInfoProvider.mockAny()),
         eventOutput: RUMEventOutput = RUMEventOutputMock(),
         rumUUIDGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator()
     ) -> RUMScopeDependencies {

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 class RUMEventBuilderTests: XCTestCase {
     func testItBuildsRUMEvent() {
-        let builder = RUMEventBuilder()
+        let builder = RUMEventBuilder(userInfoProvider: UserInfoProvider.mockAny())
         let event = builder.createRUMEvent(
             with: RUMDataModelMock(attribute: "foo"),
             attributes: ["foo": "bar", "fizz": "buzz"]

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
@@ -19,13 +19,16 @@ class RUMUserInfoProviderTests: XCTestCase {
     }
 
     func testWhenUserInfoIsAvailable_itReturnsRUMUserInfo() {
-        userInfoProvider.value = UserInfo(id: "abc-123", name: nil, email: nil)
+        userInfoProvider.value = UserInfo(id: "abc-123", name: nil, email: nil, extraInfo: [:])
         XCTAssertEqual(rumUserInfoProvider.current, RUMDataUSR(id: "abc-123", name: nil, email: nil))
 
-        userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: nil)
+        userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: nil, extraInfo: [:])
         XCTAssertEqual(rumUserInfoProvider.current, RUMDataUSR(id: "abc-123", name: "Foo", email: nil))
 
-        userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com")
+        userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com", extraInfo: [:])
+        XCTAssertEqual(rumUserInfoProvider.current, RUMDataUSR(id: "abc-123", name: "Foo", email: "foo@bar.com"))
+
+        userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com", extraInfo: [:])
         XCTAssertEqual(rumUserInfoProvider.current, RUMDataUSR(id: "abc-123", name: "Foo", email: "foo@bar.com"))
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -21,7 +21,7 @@ class RUMEventFileOutputTests: XCTestCase {
     func testItWritesRUMEventToFileAsJSON() throws {
         let fileCreationDateProvider = RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC())
         let queue = DispatchQueue(label: "com.datadohq.testItWritesRUMEventToFileAsJSON")
-        let builder = RUMEventBuilder()
+        let builder = RUMEventBuilder(userInfoProvider: UserInfoProvider.mockAny())
         let output = RUMEventFileOutput(
             fileWriter: FileWriter(
                 dataFormat: RUMFeature.dataFormat,

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -445,7 +445,12 @@ class RUMMonitorTests: XCTestCase {
             directory: temporaryDirectory,
             dependencies: .mockWith(
                 userInfoProvider: .mockWith(
-                    userInfo: UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com")
+                    userInfo: UserInfo(
+                        id: "abc-123",
+                        name: "Foo",
+                        email: "foo@bar.com",
+                        extraInfo: ["extra_key": "extra_value"]
+                    )
                 )
             )
         )
@@ -465,6 +470,9 @@ class RUMMonitorTests: XCTestCase {
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 11)
         let expectedUserInfo = RUMDataUSR(id: "abc-123", name: "Foo", email: "foo@bar.com")
+        rumEventMatchers.forEach { event in
+            event.jsonMatcher.assertValue(forKey: "context.usr.extra_key", equals: "extra_value")
+        }
         try rumEventMatchers.forEachRUMEvent(ofType: RUMDataAction.self) { action in
             XCTAssertEqual(action.usr, expectedUserInfo)
         }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -449,7 +449,11 @@ class RUMMonitorTests: XCTestCase {
                         id: "abc-123",
                         name: "Foo",
                         email: "foo@bar.com",
-                        extraInfo: ["extra_key": "extra_value"]
+                        extraInfo: [
+                            "str": "value",
+                            "int": 11_235,
+                            "bool": true
+                        ]
                     )
                 )
             )
@@ -471,7 +475,9 @@ class RUMMonitorTests: XCTestCase {
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 11)
         let expectedUserInfo = RUMDataUSR(id: "abc-123", name: "Foo", email: "foo@bar.com")
         rumEventMatchers.forEach { event in
-            event.jsonMatcher.assertValue(forKey: "context.usr.extra_key", equals: "extra_value")
+            event.jsonMatcher.assertValue(forKey: "context.usr.str", equals: "value")
+            event.jsonMatcher.assertValue(forKey: "context.usr.int", equals: 11_235)
+            event.jsonMatcher.assertValue(forKey: "context.usr.bool", equals: true)
         }
         try rumEventMatchers.forEachRUMEvent(ofType: RUMDataAction.self) { action in
             XCTAssertEqual(action.usr, expectedUserInfo)

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -335,7 +335,16 @@ class TracerTests: XCTestCase {
         Datadog.setUserInfo(id: "abc-123", name: "Foo")
         tracer.startSpan(operationName: "span with user `id` and `name`").finish()
 
-        Datadog.setUserInfo(id: "abc-123", name: "Foo", email: "foo@example.com", extraInfo: ["extra_key": "extra_value"])
+        Datadog.setUserInfo(
+            id: "abc-123",
+            name: "Foo",
+            email: "foo@example.com",
+            extraInfo: [
+                "str": "value",
+                "int": 11_235,
+                "bool": true
+            ]
+        )
         tracer.startSpan(operationName: "span with user `id`, `name`, `email` and `extraInfo`").finish()
 
         Datadog.setUserInfo(id: nil, name: nil, email: nil)
@@ -353,12 +362,13 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(try spanMatchers[2].meta.userID(), "abc-123")
         XCTAssertEqual(try spanMatchers[2].meta.userName(), "Foo")
         XCTAssertEqual(try spanMatchers[2].meta.userEmail(), "foo@example.com")
-        XCTAssertEqual(try spanMatchers[2].meta.custom(keyPath: "meta.usr.extra_key"), "extra_value")
+        XCTAssertEqual(try spanMatchers[2].meta.custom(keyPath: "meta.usr.str"), "value")
+        XCTAssertEqual(try spanMatchers[2].meta.custom(keyPath: "meta.usr.int"), "11235")
+        XCTAssertEqual(try spanMatchers[2].meta.custom(keyPath: "meta.usr.bool"), "true")
 
         XCTAssertNil(try? spanMatchers[3].meta.userID())
         XCTAssertNil(try? spanMatchers[3].meta.userName())
         XCTAssertNil(try? spanMatchers[3].meta.userEmail())
-        XCTAssertNil(try? spanMatchers[3].meta.custom(keyPath: "meta.usr.extra_key"))
     }
 
     // MARK: - Sending carrier info

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -335,8 +335,8 @@ class TracerTests: XCTestCase {
         Datadog.setUserInfo(id: "abc-123", name: "Foo")
         tracer.startSpan(operationName: "span with user `id` and `name`").finish()
 
-        Datadog.setUserInfo(id: "abc-123", name: "Foo", email: "foo@example.com")
-        tracer.startSpan(operationName: "span with user `id`, `name` and `email`").finish()
+        Datadog.setUserInfo(id: "abc-123", name: "Foo", email: "foo@example.com", extraInfo: ["extra_key": "extra_value"])
+        tracer.startSpan(operationName: "span with user `id`, `name`, `email` and `extraInfo`").finish()
 
         Datadog.setUserInfo(id: nil, name: nil, email: nil)
         tracer.startSpan(operationName: "span with no user info").finish()
@@ -353,10 +353,12 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(try spanMatchers[2].meta.userID(), "abc-123")
         XCTAssertEqual(try spanMatchers[2].meta.userName(), "Foo")
         XCTAssertEqual(try spanMatchers[2].meta.userEmail(), "foo@example.com")
+        XCTAssertEqual(try spanMatchers[2].meta.custom(keyPath: "meta.usr.extra_key"), "extra_value")
 
         XCTAssertNil(try? spanMatchers[3].meta.userID())
         XCTAssertNil(try? spanMatchers[3].meta.userName())
         XCTAssertNil(try? spanMatchers[3].meta.userEmail())
+        XCTAssertNil(try? spanMatchers[3].meta.custom(keyPath: "meta.usr.extra_key"))
     }
 
     // MARK: - Sending carrier info

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -112,7 +112,7 @@ internal class LogMatcher: JSONDataMatcher {
         assertValue(forKey: JSONKey.message, equals: message, file: file, line: line)
     }
 
-    func assertUserInfo(equals userInfo: (id: String?, name: String?, email: String?)?, file: StaticString = #file, line: UInt = #line) {
+    func assertUserInfo(equals userInfo: (id: String?, name: String?, email: String?, extraInfo: [String: String]?)?, file: StaticString = #file, line: UInt = #line) {
         if let id = userInfo?.id {
             assertValue(forKey: JSONKey.userId, equals: id, file: file, line: line)
         } else {
@@ -127,6 +127,9 @@ internal class LogMatcher: JSONDataMatcher {
             assertValue(forKey: JSONKey.userEmail, equals: email, file: file, line: line)
         } else {
             assertNoValue(forKey: JSONKey.userEmail, file: file, line: line)
+        }
+        userInfo?.extraInfo?.forEach {
+            assertValue(forKey: "usr.\($0)", equals: $1)
         }
     }
 

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -112,7 +112,7 @@ internal class LogMatcher: JSONDataMatcher {
         assertValue(forKey: JSONKey.message, equals: message, file: file, line: line)
     }
 
-    func assertUserInfo(equals userInfo: (id: String?, name: String?, email: String?, extraInfo: [String: String]?)?, file: StaticString = #file, line: UInt = #line) {
+    func assertUserInfo(equals userInfo: (id: String?, name: String?, email: String?)?, file: StaticString = #file, line: UInt = #line) {
         if let id = userInfo?.id {
             assertValue(forKey: JSONKey.userId, equals: id, file: file, line: line)
         } else {
@@ -127,9 +127,6 @@ internal class LogMatcher: JSONDataMatcher {
             assertValue(forKey: JSONKey.userEmail, equals: email, file: file, line: line)
         } else {
             assertNoValue(forKey: JSONKey.userEmail, file: file, line: line)
-        }
-        userInfo?.extraInfo?.forEach {
-            assertValue(forKey: "usr.\($0)", equals: $1)
         }
     }
 


### PR DESCRIPTION
### What and why?

`Datadog.UserInfo` has arbitrary attributes via `extraInfo`

### How?

`UserInfoProvider` keeps `extraInfo` dictionary along with `userInfo`
Features (Logs, APM and RUM) encode `extraInfo` according to their own rules
#### Logs:

```swift
extraInfo: ["key": "value"] -> "usr.key: value"
```

#### APM:

```swift
extraInfo: ["key": "value"] -> "meta.usr.key: value"
```

#### RUM:

```swift
extraInfo: ["key": "value"] -> "context.usr.key: value"
```

### Discussion 💭

In this PR, I put `usr.` prefix to `extraInfo` within `UserInfoProvider` and pass it to features as regular attributes.
But `UserInfoProvider` passes `UserInfo` value without encoding and the features (`LogEncoder` and `SpanEncoder`) are responsible for its encoding.
This is some sort of inconsistency in `UserInfoProvider`, I didn't like that ❌ 

Can't we make `UserInfo: Encodable` to de-duplicate its encoding logic?

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
