### PR TITLE
RUMM-894 URLProvider fixed for illegal chars

### DIFF
--- a/Sources/Datadog/Core/Upload/DataUploader.swift
+++ b/Sources/Datadog/Core/Upload/DataUploader.swift
@@ -41,7 +41,7 @@ internal class UploadURLProvider {
 
     var url: URL {
         var urlComponents = URLComponents(url: urlWithClientToken, resolvingAgainstBaseURL: false)
-        urlComponents?.percentEncodedQueryItems = queryItemProviders.map { $0.value() }
+        urlComponents?.queryItems = queryItemProviders.map { $0.value() }
 
         guard let url = urlComponents?.url else {
             userLogger.error("🔥 Failed to create URL from \(urlWithClientToken) with \(queryItemProviders)")

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -46,6 +46,15 @@ class DataUploadURLProviderTests: XCTestCase {
         dateProvider.advance(bySeconds: 9.999)
         XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=ios&batch_time=1576404009999"))
     }
+
+    func testIllegalCharactersInQueryItemsDontCrash() throws {
+        let urlProvider = UploadURLProvider(
+            urlWithClientToken: URL(string: "https://api.example.com/v1/endpoint/abc")!,
+            queryItemProviders: [.ddtags(tags: ["some string with whitespace"])]
+        )
+
+        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddtags=some%20string%20with%20whitespace"))
+    }
 }
 
 class DataUploaderTests: XCTestCase {

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -47,7 +47,7 @@ class DataUploadURLProviderTests: XCTestCase {
         XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=ios&batch_time=1576404009999"))
     }
 
-    func testIllegalCharactersInQueryItemsDontCrash() throws {
+    func testItEscapesWhitespacesInQueryItems() throws {
         let urlProvider = UploadURLProvider(
             urlWithClientToken: URL(string: "https://api.example.com/v1/endpoint/abc")!,
             queryItemProviders: [.ddtags(tags: ["some string with whitespace"])]


### PR DESCRIPTION
### What and why?

Fixes #316 

### How?

Wrong property of `URLComponents` (`percentEncodedQueryItems`) was used in `URLProvider`
It is fixed by being replaced with the correct method (`queryItems`)

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
