### PR TITLE
RUMM-655 Add `lyft/Kronos` dependency for NTP time sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /build
 /.build
 /.swiftpm
+Carthage/Build
+Carthage/Checkouts
+
 xcuserdata/
 instrumented-tests/DatadogSDKTesting.framework
 instrumented-tests/DatadogSDKTesting.framework-iphonesimulator.zip

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "lyft/Kronos" ~> 4.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "lyft/Kronos" "4.1.1"

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -155,6 +155,10 @@
 		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		6152C83E24BE1C91006A1679 /* HTTPServerMock in Frameworks */ = {isa = PBXBuildFile; productRef = 6152C83D24BE1C91006A1679 /* HTTPServerMock */; };
 		6152C84024BE1CC8006A1679 /* DataUploaderBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6152C83F24BE1CC8006A1679 /* DataUploaderBenchmarkTests.swift */; };
+		61569795256CF6D400C6AADA /* Kronos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61569794256CF6D400C6AADA /* Kronos.framework */; };
+		615697E3256CFB4700C6AADA /* Kronos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61569794256CF6D400C6AADA /* Kronos.framework */; };
+		615697E4256CFB4700C6AADA /* Kronos.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61569794256CF6D400C6AADA /* Kronos.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		615698AF256D101800C6AADA /* Kronos.framework in ⚙️ Embed 3rd Party Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61569794256CF6D400C6AADA /* Kronos.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6156CB8E24DDA1B5008CB2B2 /* RUMContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156CB8D24DDA1B5008CB2B2 /* RUMContextProvider.swift */; };
 		6156CB9024DDA8BE008CB2B2 /* RUMCurrentContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156CB8F24DDA8BE008CB2B2 /* RUMCurrentContext.swift */; };
 		6156CB9324DDAA34008CB2B2 /* RUMCurrentContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6156CB9224DDAA34008CB2B2 /* RUMCurrentContextTests.swift */; };
@@ -391,8 +395,20 @@
 			files = (
 				61441C4E24619498003D8BB8 /* Datadog.framework in ⚙️ Embed Framework Dependencies */,
 				61570006246AAE5E00E96950 /* DatadogObjc.framework in ⚙️ Embed Framework Dependencies */,
+				615697E4256CFB4700C6AADA /* Kronos.framework in ⚙️ Embed Framework Dependencies */,
 			);
 			name = "⚙️ Embed Framework Dependencies";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		615698AE256D100700C6AADA /* ⚙️ Embed 3rd Party Framework Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				615698AF256D101800C6AADA /* Kronos.framework in ⚙️ Embed 3rd Party Framework Dependencies */,
+			);
+			name = "⚙️ Embed 3rd Party Framework Dependencies";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -553,6 +569,8 @@
 		6152C84224BE2165006A1679 /* MockServerAddress.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MockServerAddress.local.xcconfig; sourceTree = "<group>"; };
 		615519252461BCE7002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519262461BCE7002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
+		61569794256CF6D400C6AADA /* Kronos.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kronos.framework; path = ../Carthage/Build/iOS/Kronos.framework; sourceTree = "<group>"; };
+		61569894256D0E9A00C6AADA /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		6156CB8D24DDA1B5008CB2B2 /* RUMContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMContextProvider.swift; sourceTree = "<group>"; };
 		6156CB8F24DDA8BE008CB2B2 /* RUMCurrentContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCurrentContext.swift; sourceTree = "<group>"; };
 		6156CB9224DDAA34008CB2B2 /* RUMCurrentContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCurrentContextTests.swift; sourceTree = "<group>"; };
@@ -764,6 +782,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				615697E3256CFB4700C6AADA /* Kronos.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -782,6 +801,14 @@
 				6152C83E24BE1C91006A1679 /* HTTPServerMock in Frameworks */,
 				61441C6D24619FE4003D8BB8 /* Datadog.framework in Frameworks */,
 				61570007246AAED100E96950 /* DatadogObjc.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61569793256CF6C300C6AADA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61569795256CF6D400C6AADA /* Kronos.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1229,6 +1256,7 @@
 		61133C6F2423993200786299 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				61569794256CF6D400C6AADA /* Kronos.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1545,6 +1573,7 @@
 			isa = PBXGroup;
 			children = (
 				6152C84224BE2165006A1679 /* MockServerAddress.local.xcconfig */,
+				61569894256D0E9A00C6AADA /* Base.xcconfig */,
 				615519252461BCE7002A85CF /* Datadog.xcconfig */,
 				615519262461BCE7002A85CF /* Datadog.local.xcconfig */,
 				61378BB22555337900F28837 /* DatadogSDKTesting.local.xcconfig */,
@@ -2183,6 +2212,7 @@
 				61133B7E242393DE00786299 /* Sources */,
 				61133B80242393DE00786299 /* Resources */,
 				61133C772423A4C300786299 /* ⚙️ Run linter */,
+				61569793256CF6C300C6AADA /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2259,6 +2289,7 @@
 				61441C2624616F1D003D8BB8 /* Sources */,
 				61441C2724616F1D003D8BB8 /* Frameworks */,
 				61441C2824616F1D003D8BB8 /* Resources */,
+				615698AE256D100700C6AADA /* ⚙️ Embed 3rd Party Framework Dependencies */,
 			);
 			buildRules = (
 			);
@@ -2979,12 +3010,17 @@
 		};
 		61133B97242393DE00786299 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/Datadog/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3004,12 +3040,17 @@
 		};
 		61133B98242393DE00786299 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/Datadog/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3076,6 +3117,7 @@
 		};
 		61133C02242397DA00786299 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -3100,6 +3142,7 @@
 		};
 		61133C03242397DA00786299 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -3129,6 +3172,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3150,6 +3197,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3169,6 +3220,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3355,12 +3410,17 @@
 		};
 		9E2FB28324476765001C9B7B /* Integration */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = TargetSupport/Datadog/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3380,6 +3440,7 @@
 		};
 		9E2FB28424476765001C9B7B /* Integration */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;

--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -24,4 +24,5 @@ Pod::Spec.new do |s|
   s.public_header_files = "Datadog/TargetSupport/Datadog/Datadog.h"
   s.private_header_files = "Sources/_Datadog_Private/include/*.h"
   s.module_map = "Sources/Datadog/Datadog.modulemap"
+  s.dependency 'Kronos', '~> 4.1'
 end

--- a/DatadogSDK.podspec.src
+++ b/DatadogSDK.podspec.src
@@ -24,4 +24,5 @@ Pod::Spec.new do |s|
   s.public_header_files = "Datadog/TargetSupport/Datadog/Datadog.h"
   s.private_header_files = "Sources/_Datadog_Private/include/*.h"
   s.module_map = "Sources/Datadog/Datadog.modulemap"
+  s.dependency 'Kronos', '~> 4.1'
 end

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,5 +1,6 @@
 Component,Origin,License,Copyright
 import,io.opentracing,MIT,Copyright 2018 LightStep
+import,com.Lyft.Kronos,Apache-2.0,Copyright (C) 2016 Lyft Inc.
 import (tools),https://github.com/jpsim/SourceKitten,MIT,Copyright (c) 2014 JP Simard
 import (tools),https://github.com/apple/swift-argument-parser,Apache-2.0,(c) 2020 Apple Inc. and the Swift project authors
 import (tools),https://github.com/quicktype/quicktype,Apache-2.0,(c) 2020 Quicktype

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,11 @@ export DD_SDK_TESTING_XCCONFIG_CI
 
 dependencies:
 		@echo "⚙️  Installing dependencies..."
+		@carthage bootstrap --platform iOS
 ifeq (${ci}, true)
 		@echo $$DD_SDK_TESTING_XCCONFIG_CI > xcconfigs/DatadogSDKTesting.local.xcconfig;
 endif
-		@brew install gh
+		@brew list gh &>/dev/null || brew install gh
 		@rm -rf instrumented-tests/DatadogSDKTesting.framework-iphonesimulator.zip
 		@rm -rf instrumented-tests/DatadogSDKTesting.framework
 		@gh release download ${DD_SDK_SWIFT_TESTING_VERSION} -D instrumented-tests -R https://github.com/DataDog/dd-sdk-swift-testing -p "DatadogSDKTesting.framework-iphonesimulator.zip"

--- a/Package.swift
+++ b/Package.swift
@@ -17,11 +17,13 @@ let package = Package(
             type: .dynamic,
             targets: ["DatadogObjc"]),
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/lyft/Kronos.git", .upToNextMinor(from: "4.1.0"))
+    ],
     targets: [
         .target(
             name: "Datadog",
-            dependencies: ["_Datadog_Private"]),
+            dependencies: ["_Datadog_Private", "Kronos"]),
         .target(
             name: "DatadogObjc",
             dependencies: ["Datadog"]),

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import Kronos
 
 /// Datadog SDK configuration object.
 public class Datadog {
@@ -47,6 +48,10 @@ public class Datadog {
     ///   - appContext: context passing information about the app.
     ///   - configuration: the SDK configuration obtained using `Datadog.Configuration.builderUsing(clientToken:)`.
     public static func initialize(appContext: AppContext, configuration: Configuration) {
+        // TODO: RUMM-655 This is only to check at runtime if `lyft/Kronos` is properly linked. Will be removed before
+        // merging to `master` branch.
+        _ = Clock.now
+
         // TODO: RUMM-511 remove this warning
         #if targetEnvironment(macCatalyst)
         consolePrint("⚠️ Catalyst is not officially supported by Datadog SDK: some features may NOT be functional!")

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -21,21 +21,12 @@ workflows:
         Does `make dependencies` to prepare source code in repo for building and testing.
     steps:
     - script:
-        run_if: .IsCI
-        title: Do `make dependencies` for CI.
+        title: Do `make dependencies`
         inputs:
         - content: |-
             #!/usr/bin/env bash
             set -e
-            make dependencies ci=true
-    - script:
-        run_if: not .IsCI
-        title: Do `make dependencies` for local machine.
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -e
-            make dependencies
+            make dependencies ci=${CI}
 
   _deploy_artifacts:
     description: |-
@@ -145,7 +136,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -e
-            make test-spm ci=true
+            make test-spm ci=${CI}
     - xcodebuild:
         title: Build SPMProject for tests - Catalyst
         inputs:
@@ -169,7 +160,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -e
-            make test-carthage ci=true
+            make test-carthage ci=${CI}
     - xcode-test:
         title: Run CTProject tests
         inputs:
@@ -185,7 +176,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -e
-            make test-cocoapods ci=true
+            make test-cocoapods ci=${CI}
     - xcodebuild:
         title: Build CPProject for tests - Catalyst
         inputs:

--- a/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Datadog.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/Kronos.framework",
 			);
 			name = "⚙️ Carthage";
 			outputFileListPaths = (

--- a/dependency-manager-tests/carthage/Makefile
+++ b/dependency-manager-tests/carthage/Makefile
@@ -1,4 +1,4 @@
-ifdef ci
+ifeq (${ci}, true)
 		GIT_BRANCH := ${BITRISE_GIT_BRANCH}
 else
 		GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/dependency-manager-tests/carthage/Makefile
+++ b/dependency-manager-tests/carthage/Makefile
@@ -18,4 +18,5 @@ test:
 		@echo "🧪 Check if expected frameworks exist in $(PWD)/Carthage/Build/iOS"
 		@[ -e "Carthage/Build/iOS/Datadog.framework" ] && echo "Datadog.framework - OK" || { echo "Datadog.framework - missing"; false; }
 		@[ -e "Carthage/Build/iOS/DatadogObjc.framework" ] && echo "DatadogObjc.framework - OK" || { echo "DatadogObjc.framework - missing"; false; }
+		@[ -e "Carthage/Build/iOS/Kronos.framework" ] && echo "Kronos.framework - OK" || { echo "Kronos.framework - missing"; false; }
 		@echo "🧪 SUCCEEDED"

--- a/dependency-manager-tests/cocoapods/Makefile
+++ b/dependency-manager-tests/cocoapods/Makefile
@@ -1,4 +1,4 @@
-ifdef ci
+ifeq (${ci}, true)
 		GIT_BRANCH := ${BITRISE_GIT_BRANCH}
 else
 		GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/dependency-manager-tests/spm/Makefile
+++ b/dependency-manager-tests/spm/Makefile
@@ -1,4 +1,4 @@
-ifdef ci
+ifeq (${ci}, true)
 		GIT_BRANCH := ${BITRISE_GIT_BRANCH}
 else
 		GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/xcconfigs/Base.xcconfig
+++ b/xcconfigs/Base.xcconfig
@@ -1,0 +1,5 @@
+// Base configuration file, included by all targets.
+
+// Required after adding `lyft/Kronos` dependency through Carthage.
+// Otherwise build fails with "module 'Kronos' was created for incompatible target arm64-apple-ios8.0"
+EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64

--- a/xcconfigs/Datadog.xcconfig
+++ b/xcconfigs/Datadog.xcconfig
@@ -1,3 +1,6 @@
+// Include base config
+#include "Base.xcconfig"
+
 RUM_APPLICATION_ID=// use your own RUM Application ID obtained on datadoghq.com
 DATADOG_CLIENT_TOKEN=// use your own Client Token, generated for RUM_APPLICATION_ID
 DEVELOPMENT_TEAM[sdk=iphoneos*]=// use your own Development Team


### PR DESCRIPTION
### What and why?

📦 We want to use NTP to compute the real time of writing events (logs, spans, rum). In this PR I'm adding the [lyft/Kronos](https://github.com/lyft/Kronos) dependency which does the NTP sync. It is not yet used in SDK code, as I wanted to separate project configuration from the actual work in SDK. This PR is not targeting the `master` branch yet.

### How?

**Cocoapods** :
```ruby
# Datadog.podspec + Datadog.podspec.src
s.dependency 'Kronos', '~> 4.1'
```
**SPM**:
```swift
// Package.swift
.package(url: "https://github.com/lyft/Kronos.git", .upToNextMinor(from: "4.1.0"))
```

**Carthage** required few changes to the project (and the update in `dependency-manager-tests/carthage/CTProject`). As it was quite strenuous, I'm leaving the note on what was changed (it's also written in commit messages):

Things change fast in Carthage (their guides are outdated), but this is how it worked in Xcode 12.0 (12A7209), target by target:
* `Datadog`:
   * Add `Kronos.framework` to Datadog > Build Phases > Link Binary With Libraries.
   * Add Datadog > Build Settings > Frameworks Search Path: `$(SRCROOT)/../Carthage/Build/iOS`
* `Example`:
   * Add `Kronos.framework` to Example > Frameworks, Libraries and Embedded Content.
   * Add Example > Build Settings > Frameworks Search Path: `$(SRCROOT)/../Carthage/Build/iOS`
* `DatadogIntegrationTests`:
   * Add 'Copy Files' build phase, coping `Kronos.framework` into `Frameworks` folder
* `DatadogTests`, `DatadogBenchmarkTests`:
   * no changes

Also, I had to exclude the `arm64` architecture for iOS Simulator builds (done through `.xcconfig`) due to getting:
> error: module 'Kronos' was created for incompatible target arm64-apple-ios8.0

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
