### PR TITLE
RUMS-132 Allow data uploads if battery status is `.unknown`

### DIFF
--- a/Sources/Datadog/Core/Upload/DataUploadConditions.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadConditions.swift
@@ -30,6 +30,13 @@ internal struct DataUploadConditions {
     }
 
     private func shouldUploadFor(batteryStatus: BatteryStatus) -> Bool {
+        if batteryStatus.state == .unknown {
+            // Note: in RUMS-132 we got the report on `.unknown` battery state reporing `-1` battery level on iPad device
+            // plugged to Mac through lightning cable. As `.unkown` may lead to other unreliable values,
+            // it seems safer to arbitrary allow uploads in such case.
+            return true
+        }
+
         let batteryFullOrCharging = batteryStatus.state == .full || batteryStatus.state == .charging
         let batteryLevelIsEnough = batteryStatus.level > Constants.minBatteryLevel
         let isLowPowerModeEnabled = batteryStatus.isLowPowerModeEnabled

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadConditionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadConditionsTests.swift
@@ -50,7 +50,7 @@ class DataUploadConditionsTests: XCTestCase {
                 canPerformUploadReturns: false,
                 forBattery: .mockWith(
                     status: BatteryStatus(
-                        state: .mockRandom(), level: .random(in: 0...100), isLowPowerModeEnabled: .random()
+                        state: .mockRandom(within: [.unplugged, .charging, .full]), level: .random(in: 0...100), isLowPowerModeEnabled: .random()
                     )
                 ),
                 forNetwork: .mockWith(
@@ -61,7 +61,7 @@ class DataUploadConditionsTests: XCTestCase {
                 canPerformUploadReturns: false,
                 forBattery: .mockWith(
                     status: BatteryStatus(
-                        state: .mockRandom(), level: .random(in: 0...100), isLowPowerModeEnabled: .random()
+                        state: .mockRandom(within: [.unplugged, .charging, .full]), level: .random(in: 0...100), isLowPowerModeEnabled: .random()
                     )
                 ),
                 forNetwork: .mockWith(networkConnectionInfo: nil)
@@ -70,7 +70,7 @@ class DataUploadConditionsTests: XCTestCase {
                 canPerformUploadReturns: false,
                 forBattery: .mockWith(
                     status: BatteryStatus(
-                        state: .mockRandom(), level: .random(in: 0...100), isLowPowerModeEnabled: true
+                        state: .mockRandom(within: [.unplugged, .charging, .full]), level: .random(in: 0...100), isLowPowerModeEnabled: true
                     )
                 ),
                 forNetwork: .mockWith(
@@ -81,7 +81,7 @@ class DataUploadConditionsTests: XCTestCase {
                 canPerformUploadReturns: false,
                 forBattery: .mockWith(
                     status: BatteryStatus(
-                        state: .mockRandom(within: [.unknown, .unplugged]), level: Constants.minBatteryLevel - 0.01, isLowPowerModeEnabled: .random()
+                        state: .unplugged, level: Constants.minBatteryLevel - 0.01, isLowPowerModeEnabled: .random()
                     )
                 ),
                 forNetwork: .mockWith(
@@ -93,6 +93,22 @@ class DataUploadConditionsTests: XCTestCase {
                 forBattery: nil,
                 forNetwork: .mockWith(
                     networkConnectionInfo: .mockWith(reachability: .no)
+                )
+            )
+        }
+    }
+
+    func testItSaysToUploadIfTheBatteryStatusIsUnknown() {
+        `repeat`(times: 10) {
+            assert(
+                canPerformUploadReturns: true,
+                forBattery: .mockWith(
+                    status: BatteryStatus(
+                        state: .unknown, level: .random(in: -100...100), isLowPowerModeEnabled: .random()
+                    )
+                ),
+                forNetwork: .mockWith(
+                    networkConnectionInfo: .mockWith(reachability: .mockRandom(within: [.yes, .maybe]))
                 )
             )
         }


### PR DESCRIPTION
### What and why?

🚚 This PR fixes an issue reported as data being not uploaded from iPad (6th gen) iOS 14.0.1, when it is connected to MacBook through a lightning cable.

### How?

The investigation nailed this issue down to receiving `batteryStatus: unknown` with `batteryLevel: -1`. Given existing logic in `DataUploadConditions`, this clearly evaluated to `false` (no upload).

This fix returns arbitrary `true` value if battery status is undetermined. As we can see from RUMS-132, this may lead to making assumptions on unreliable values. 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
