### PR TITLE
RUMM-776 Add custom timings API for RUM Views

### DIFF
--- a/Datadog/Example/Scenarios/RUM/ManualInstrumentation/SendRUMFixture1ViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/ManualInstrumentation/SendRUMFixture1ViewController.swift
@@ -20,6 +20,10 @@ internal class SendRUMFixture1ViewController: UIViewController {
         super.viewDidAppear(animated)
 
         rumMonitor.startView(viewController: self)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            rumMonitor.addTiming(name: "content-ready")
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -29,6 +33,8 @@ internal class SendRUMFixture1ViewController: UIViewController {
     }
 
     @IBAction func didTapDownloadResourceButton(_ sender: Any) {
+        rumMonitor.addTiming(name: "first-interaction")
+
         let simulatedResourceKey1 = "/resource/1"
         let simulatedResourceRequest1 = URLRequest(url: URL(string: "https://foo.com/resource/1")!)
         let simulatedResourceKey2 = "/resource/2"

--- a/Sources/Datadog/Core/Utils/JSONEncoder.swift
+++ b/Sources/Datadog/Core/Utils/JSONEncoder.swift
@@ -15,7 +15,9 @@ extension JSONEncoder {
             try container.encode(formatted)
         }
         if #available(iOS 13.0, OSX 10.15, *) {
-            encoder.outputFormatting = [.withoutEscapingSlashes]
+            encoder.outputFormatting = [.withoutEscapingSlashes, .sortedKeys]
+        } else {
+            encoder.outputFormatting = [.sortedKeys]
         }
         return encoder
     }

--- a/Sources/Datadog/DDRUMMonitor.swift
+++ b/Sources/Datadog/DDRUMMonitor.swift
@@ -33,6 +33,14 @@ public class DDRUMMonitor {
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {}
 
+    /// Adds a specific timing in the currently presented View. The timing duration will be computed as the
+    /// number of nanoseconds between the time the View was started and the time the timing was added.
+    /// - Parameters:
+    ///   - name: the name of the custom timing attribute.
+    public func addTiming(
+        name: String
+    ) {}
+
     /// Notifies that an Error occurred in currently presented View.
     /// - Parameters:
     ///   - message: a message explaining the Error.

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -13,11 +13,16 @@ internal class RUMEventBuilder {
         self.userInfoProvider = userInfoProvider
     }
 
-    func createRUMEvent<DM: RUMDataModel>(with model: DM, attributes: [String: Encodable]) -> RUMEvent<DM> {
+    func createRUMEvent<DM: RUMDataModel>(
+        with model: DM,
+        attributes: [String: Encodable],
+        customTimings: [RUMViewCustomTiming]? = nil
+    ) -> RUMEvent<DM> {
         return RUMEvent(
             model: model,
             attributes: attributes,
-            userInfoAttributes: userInfoProvider.value.extraInfo
+            userInfoAttributes: userInfoProvider.value.extraInfo,
+            customViewTimings: customTimings
         )
     }
 }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -16,7 +16,7 @@ internal class RUMEventBuilder {
     func createRUMEvent<DM: RUMDataModel>(
         with model: DM,
         attributes: [String: Encodable],
-        customTimings: [RUMViewCustomTiming]? = nil
+        customTimings: [String: Int64]? = nil
     ) -> RUMEvent<DM> {
         return RUMEvent(
             model: model,

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -16,7 +16,7 @@ internal struct RUMEvent<DM: RUMDataModel>: Encodable {
     let userInfoAttributes: [String: Encodable]
 
     /// Custom View timings (only available if `DM` is a RUM View model)
-    let customViewTimings: [RUMViewCustomTiming]?
+    let customViewTimings: [String: Int64]?
 
     func encode(to encoder: Encoder) throws {
         try RUMEventEncoder().encode(self, to: encoder)
@@ -43,8 +43,8 @@ internal struct RUMEventEncoder {
         try event.userInfoAttributes.forEach { attributeName, attributeValue in
             try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("context.usr.\(attributeName)"))
         }
-        try event.customViewTimings?.forEach { customTiming in
-            try attributesContainer.encode(customTiming.duration, forKey: DynamicCodingKey("view.custom_timings.\(customTiming.name)"))
+        try event.customViewTimings?.forEach { timingName, timingDuration in
+            try attributesContainer.encode(timingDuration, forKey: DynamicCodingKey("view.custom_timings.\(timingName)"))
         }
 
         // Encode `RUMDataModel`

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -15,6 +15,9 @@ internal struct RUMEvent<DM: RUMDataModel>: Encodable {
     let attributes: [String: Encodable]
     let userInfoAttributes: [String: Encodable]
 
+    /// Custom View timings (only available if `DM` is a RUM View model)
+    let customViewTimings: [RUMViewCustomTiming]?
+
     func encode(to encoder: Encoder) throws {
         try RUMEventEncoder().encode(self, to: encoder)
     }
@@ -39,6 +42,9 @@ internal struct RUMEventEncoder {
         }
         try event.userInfoAttributes.forEach { attributeName, attributeValue in
             try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("context.usr.\(attributeName)"))
+        }
+        try event.customViewTimings?.forEach { customTiming in
+            try attributesContainer.encode(customTiming.duration, forKey: DynamicCodingKey("view.custom_timings.\(customTiming.name)"))
         }
 
         // Encode `RUMDataModel`

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -92,6 +92,15 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
     }
 }
 
+internal struct RUMAddViewTimingCommand: RUMCommand {
+    let time: Date
+    var attributes: [AttributeKey: AttributeValue]
+
+    /// The name of the timing. It will be used as a JSON key, whereas the value will be the timing duration,
+    /// measured since the start of the View.
+    let timingName: String
+}
+
 // MARK: - RUM Resource related commands
 
 internal protocol RUMResourceCommand: RUMCommand {

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -74,6 +74,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 identity: expiredViewIdentity,
                 uri: expiredView.viewURI,
                 attributes: expiredView.attributes,
+                customTimings: expiredView.customTimings,
                 startTime: startTime
             )
         }
@@ -123,6 +124,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 identity: command.identity,
                 uri: command.path,
                 attributes: command.attributes,
+                customTimings: [],
                 startTime: command.time
             )
         )

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -124,7 +124,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 identity: command.identity,
                 uri: command.path,
                 attributes: command.attributes,
-                customTimings: [],
+                customTimings: [:],
                 startTime: command.time
             )
         )

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -6,13 +6,6 @@
 
 import Foundation
 
-internal struct RUMViewCustomTiming: Encodable {
-    /// Timing name.
-    let name: String
-    /// Timing duration (in nanoseconds).
-    let duration: Int64
-}
-
 internal class RUMViewScope: RUMScope, RUMContextProvider {
     // MARK: - Child Scopes
 
@@ -30,8 +23,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     private(set) weak var identity: AnyObject?
     /// View attributes.
     private(set) var attributes: [AttributeKey: AttributeValue]
-    /// View custom timings.
-    private(set) var customTimings: [RUMViewCustomTiming] = []
+    /// View custom timings, keyed by name. The value of timing is given in nanoseconds.
+    private(set) var customTimings: [String: Int64] = [:]
 
     /// This View's UUID.
     let viewUUID: RUMUUID
@@ -63,7 +56,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         identity: AnyObject,
         uri: String,
         attributes: [AttributeKey: AttributeValue],
-        customTimings: [RUMViewCustomTiming],
+        customTimings: [String: Int64],
         startTime: Date
     ) {
         self.parent = parent
@@ -125,7 +118,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             needsViewUpdate = true
 
         case let command as RUMAddViewTimingCommand where isActiveView:
-            addCustomTiming(on: command)
+            customTimings[command.timingName] = command.time.timeIntervalSince(viewStartTime).toInt64Nanoseconds
             needsViewUpdate = true
 
         // Resource commands
@@ -219,15 +212,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             attributes: command.attributes,
             startTime: command.time,
             isContinuous: false
-        )
-    }
-
-    private func addCustomTiming(on command: RUMAddViewTimingCommand) {
-        customTimings.append(
-            RUMViewCustomTiming(
-                name: command.timingName,
-                duration: command.time.timeIntervalSince(viewStartTime).toInt64Nanoseconds
-            )
         )
     }
 

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -239,6 +239,18 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         )
     }
 
+    override public func addTiming(
+        name: String
+    ) {
+        process(
+            command: RUMAddViewTimingCommand(
+                time: dateProvider.currentDate(),
+                attributes: [:],
+                timingName: name
+            )
+        )
+    }
+
     override public func addError(
         message: String,
         source: RUMErrorSource,

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -54,7 +54,7 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
 
         let view1 = session.viewVisits[0]
         XCTAssertEqual(view1.path, "SendRUMFixture1ViewController")
-        XCTAssertEqual(view1.viewEvents.count, 4, "First view should receive 4 updates")
+        XCTAssertEqual(view1.viewEvents.count, 6, "First view should receive 6 updates")
         XCTAssertEqual(view1.viewEvents.last?.view.action.count, 2)
         XCTAssertEqual(view1.viewEvents.last?.view.resource.count, 1)
         XCTAssertEqual(view1.viewEvents.last?.view.error.count, 1)
@@ -76,6 +76,13 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view1.errorEvents[0].error.resource?.url, "https://foo.com/resource/2")
         XCTAssertEqual(view1.errorEvents[0].error.resource?.method, .methodGET)
         XCTAssertEqual(view1.errorEvents[0].error.resource?.statusCode, 400)
+
+        let contentReadyTiming = try XCTUnwrap(view1.viewEventMatchers.last?.timing(named: "content-ready"))
+        let firstInteractionTiming = try XCTUnwrap(view1.viewEventMatchers.last?.timing(named: "first-interaction"))
+        XCTAssertGreaterThanOrEqual(contentReadyTiming, 50_000)
+        XCTAssertLessThan(contentReadyTiming, 1_000_000_000)
+        XCTAssertGreaterThan(firstInteractionTiming, 0)
+        XCTAssertLessThan(firstInteractionTiming, 5_000_000_000)
 
         let view2 = session.viewVisits[1]
         XCTAssertEqual(view2.path, "SendRUMFixture2ViewController")

--- a/Tests/DatadogTests/Datadog/Core/Utils/JSONEncoderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Utils/JSONEncoderTests.swift
@@ -29,4 +29,26 @@ class JSONEncoderTests: XCTestCase {
             XCTAssertEqual(encodedURL.utf8String, #"{"value":"https:\/\/example.com\/foo"}"#)
         }
     }
+
+    func testWhenEncoding_thenKeysFollowLexicographicOrder() throws {
+        struct Foo: Codable {
+            var one = 1
+            var two = 1
+            var three = 1
+            var four = 1
+
+            enum CodingKeys: String, CodingKey {
+                case one = "aaaaaa"
+                case two = "bb"
+                case three = "aaa"
+                case four = "bbb"
+            }
+        }
+
+        // When
+        let encodedFoo = try jsonEncoder.encode(Foo())
+
+        // Then
+        XCTAssertEqual(encodedFoo.utf8String, #"{"aaa":1,"aaaaaa":1,"bb":1,"bbb":1}"#)
+    }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -302,6 +302,29 @@ extension FeaturesCommonDependencies {
             launchTimeProvider: launchTimeProvider
         )
     }
+
+    /// Creates new instance of `FeaturesCommonDependencies` by replacing individual dependencies.
+    func replacing(
+        performance: PerformancePreset? = nil,
+        httpClient: HTTPClient? = nil,
+        mobileDevice: MobileDevice? = nil,
+        dateProvider: DateProvider? = nil,
+        userInfoProvider: UserInfoProvider? = nil,
+        networkConnectionInfoProvider: NetworkConnectionInfoProviderType? = nil,
+        carrierInfoProvider: CarrierInfoProviderType? = nil,
+        launchTimeProvider: LaunchTimeProviderType? = nil
+    ) -> FeaturesCommonDependencies {
+        return FeaturesCommonDependencies(
+            performance: performance ?? self.performance,
+            httpClient: httpClient ?? self.httpClient,
+            mobileDevice: mobileDevice ?? self.mobileDevice,
+            dateProvider: dateProvider ?? self.dateProvider,
+            userInfoProvider: userInfoProvider ?? self.userInfoProvider,
+            networkConnectionInfoProvider: networkConnectionInfoProvider ?? self.networkConnectionInfoProvider,
+            carrierInfoProvider: carrierInfoProvider ?? self.carrierInfoProvider,
+            launchTimeProvider: launchTimeProvider ?? self.launchTimeProvider
+        )
+    }
 }
 
 class NoOpFileWriter: FileWriterType {

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -35,7 +35,12 @@ extension LoggingFeature {
         dependencies: FeaturesCommonDependencies = .mockAny()
     ) -> LoggingFeature {
         // Get the full feature mock:
-        let fullFeature: LoggingFeature = .mockWith(directory: directory, dependencies: dependencies)
+        let fullFeature: LoggingFeature = .mockWith(
+            directory: directory,
+            dependencies: dependencies.replacing(
+                dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
+            )
+        )
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -434,7 +434,7 @@ extension RUMViewScope {
         identity: AnyObject = mockView,
         uri: String = .mockAny(),
         attributes: [AttributeKey: AttributeValue] = [:],
-        customTimings: [RUMViewCustomTiming] = [],
+        customTimings: [String: Int64] = [:],
         startTime: Date = .mockAny()
     ) -> RUMViewScope {
         return RUMViewScope(

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -36,7 +36,12 @@ extension RUMFeature {
         dependencies: FeaturesCommonDependencies = .mockAny()
     ) -> RUMFeature {
         // Get the full feature mock:
-        let fullFeature: RUMFeature = .mockWith(directory: directory, dependencies: dependencies)
+        let fullFeature: RUMFeature = .mockWith(
+            directory: directory,
+            dependencies: dependencies.replacing(
+                dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
+            )
+        )
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:
@@ -161,6 +166,18 @@ extension RUMAddCurrentViewErrorCommand {
     ) -> RUMAddCurrentViewErrorCommand {
         return RUMAddCurrentViewErrorCommand(
             time: time, message: message, stack: stack, source: source, attributes: attributes
+        )
+    }
+}
+
+extension RUMAddViewTimingCommand {
+    static func mockWith(
+        time: Date = Date(),
+        attributes: [AttributeKey: AttributeValue] = [:],
+        timingName: String = .mockAny()
+    ) -> RUMAddViewTimingCommand {
+        return RUMAddViewTimingCommand(
+            time: time, attributes: attributes, timingName: timingName
         )
     }
 }
@@ -417,6 +434,7 @@ extension RUMViewScope {
         identity: AnyObject = mockView,
         uri: String = .mockAny(),
         attributes: [AttributeKey: AttributeValue] = [:],
+        customTimings: [RUMViewCustomTiming] = [],
         startTime: Date = .mockAny()
     ) -> RUMViewScope {
         return RUMViewScope(
@@ -425,6 +443,7 @@ extension RUMViewScope {
             identity: identity,
             uri: uri,
             attributes: attributes,
+            customTimings: customTimings,
             startTime: startTime
         )
     }

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -48,7 +48,11 @@ extension TracingFeature {
     ) -> TracingFeature {
         // Get the full feature mock:
         let fullFeature: TracingFeature = .mockWith(
-            directory: directory, dependencies: dependencies, loggingFeature: loggingFeature, tracingUUIDGenerator: tracingUUIDGenerator
+            directory: directory,
+            dependencies: dependencies.replacing(
+                dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
+            ),
+            loggingFeature: loggingFeature, tracingUUIDGenerator: tracingUUIDGenerator
         )
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -8,6 +8,8 @@ import XCTest
 import UIKit
 @testable import Datadog
 
+extension RUMViewCustomTiming: EquatableInTests {}
+
 class RUMViewScopeTests: XCTestCase {
     private let output = RUMEventOutputMock()
     private let parent = RUMContextProviderMock()
@@ -22,6 +24,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: .mockAny()
         )
 
@@ -41,6 +44,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: .mockAny()
         )
 
@@ -64,6 +68,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: currentTime
         )
 
@@ -93,6 +98,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: currentTime
         )
 
@@ -125,6 +131,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: ["foo": "bar", "fizz": "buzz"],
+            customTimings: [],
             startTime: currentTime
         )
 
@@ -157,6 +164,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: currentTime
         )
 
@@ -204,6 +212,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: view1,
             uri: "FirstViewController",
             attributes: [:],
+            customTimings: [],
             startTime: currentTime
         )
 
@@ -232,6 +241,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "FirstViewController",
             attributes: [:],
+            customTimings: [],
             startTime: currentTime
         )
 
@@ -260,6 +270,7 @@ class RUMViewScopeTests: XCTestCase {
                 identity: mockView,
                 uri: uri,
                 attributes: [:],
+                customTimings: [],
                 startTime: .mockAny()
             )
         }
@@ -294,6 +305,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: Date()
         )
         XCTAssertTrue(
@@ -341,6 +353,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: Date()
         )
 
@@ -385,6 +398,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: Date()
         )
         XCTAssertTrue(
@@ -424,6 +438,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: currentTime
         )
         XCTAssertTrue(
@@ -464,6 +479,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: currentTime
         )
 
@@ -509,6 +525,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
+            customTimings: [],
             startTime: Date()
         )
 
@@ -533,5 +550,87 @@ class RUMViewScopeTests: XCTestCase {
         let viewUpdate = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).last)
         XCTAssertEqual(viewUpdate.model.view.resource.count, 0, "Failed Resource should not be counted")
         XCTAssertEqual(viewUpdate.model.view.error.count, 1, "Failed Resource should be counted as Error")
+    }
+
+    // MARK: - Custom Timings Tracking
+
+    func testGivenActiveView_whenCustomTimingIsRegistered_itSendsViewUpdateEvent() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMViewScope(
+            parent: parent,
+            dependencies: dependencies,
+            identity: mockView,
+            uri: "UIViewController",
+            attributes: [:],
+            customTimings: [],
+            startTime: currentTime
+        )
+        XCTAssertTrue(
+            scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
+        )
+
+        // Given
+        XCTAssertTrue(scope.isActiveView)
+        XCTAssertEqual(scope.customTimings.count, 0)
+
+        // When
+        currentTime.addTimeInterval(0.5)
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddViewTimingCommand.mockWith(time: currentTime, timingName: "timing-after-500000000ns")
+            )
+        )
+        XCTAssertEqual(scope.customTimings.count, 1)
+
+        currentTime.addTimeInterval(0.5)
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddViewTimingCommand.mockWith(time: currentTime, timingName: "timing-after-1000000000ns")
+            )
+        )
+        XCTAssertEqual(scope.customTimings.count, 2)
+
+        // Then
+        let events = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self))
+        let expectedTiming1 = RUMViewCustomTiming(name: "timing-after-500000000ns", duration: 500_000_000)
+        let expectedTiming2 = RUMViewCustomTiming(name: "timing-after-1000000000ns", duration: 1_000_000_000)
+
+        XCTAssertEqual(events.count, 3, "There should be 3 View updates sent")
+        XCTAssertEqual(events[0].customViewTimings, [])
+        XCTAssertEqual(events[1].customViewTimings, [expectedTiming1])
+        XCTAssertEqual(events[2].customViewTimings, [expectedTiming1, expectedTiming2])
+    }
+
+    func testGivenInactiveView_whenCustomTimingIsRegistered_itDoesNotSendViewUpdateEvent() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let scope = RUMViewScope(
+            parent: parent,
+            dependencies: dependencies,
+            identity: mockView,
+            uri: "UIViewController",
+            attributes: [:],
+            customTimings: [],
+            startTime: currentTime
+        )
+        XCTAssertTrue(
+            scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
+        )
+        XCTAssertFalse(
+            scope.process(command: RUMStopViewCommand.mockWith(identity: mockView))
+        )
+
+        // Given
+        XCTAssertFalse(scope.isActiveView)
+
+        // When
+        currentTime.addTimeInterval(0.5)
+
+        _ = scope.process(
+            command: RUMAddViewTimingCommand.mockWith(time: currentTime, timingName: "timing-after-500000000ns")
+        )
+
+        // Then
+        let lastEvent = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).last)
+        XCTAssertEqual(lastEvent.customViewTimings, [])
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -8,8 +8,6 @@ import XCTest
 import UIKit
 @testable import Datadog
 
-extension RUMViewCustomTiming: EquatableInTests {}
-
 class RUMViewScopeTests: XCTestCase {
     private let output = RUMEventOutputMock()
     private let parent = RUMContextProviderMock()
@@ -24,7 +22,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: .mockAny()
         )
 
@@ -44,7 +42,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: .mockAny()
         )
 
@@ -68,7 +66,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
 
@@ -98,7 +96,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
 
@@ -131,7 +129,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: ["foo": "bar", "fizz": "buzz"],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
 
@@ -164,7 +162,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
 
@@ -212,7 +210,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: view1,
             uri: "FirstViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
 
@@ -241,7 +239,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "FirstViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
 
@@ -270,7 +268,7 @@ class RUMViewScopeTests: XCTestCase {
                 identity: mockView,
                 uri: uri,
                 attributes: [:],
-                customTimings: [],
+                customTimings: [:],
                 startTime: .mockAny()
             )
         }
@@ -305,7 +303,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: Date()
         )
         XCTAssertTrue(
@@ -353,7 +351,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: Date()
         )
 
@@ -398,7 +396,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: Date()
         )
         XCTAssertTrue(
@@ -438,7 +436,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
         XCTAssertTrue(
@@ -479,7 +477,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
 
@@ -525,7 +523,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: Date()
         )
 
@@ -562,7 +560,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
         XCTAssertTrue(
@@ -592,13 +590,17 @@ class RUMViewScopeTests: XCTestCase {
 
         // Then
         let events = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self))
-        let expectedTiming1 = RUMViewCustomTiming(name: "timing-after-500000000ns", duration: 500_000_000)
-        let expectedTiming2 = RUMViewCustomTiming(name: "timing-after-1000000000ns", duration: 1_000_000_000)
 
         XCTAssertEqual(events.count, 3, "There should be 3 View updates sent")
-        XCTAssertEqual(events[0].customViewTimings, [])
-        XCTAssertEqual(events[1].customViewTimings, [expectedTiming1])
-        XCTAssertEqual(events[2].customViewTimings, [expectedTiming1, expectedTiming2])
+        XCTAssertEqual(events[0].customViewTimings, [:])
+        XCTAssertEqual(
+            events[1].customViewTimings,
+            ["timing-after-500000000ns": 500_000_000]
+        )
+        XCTAssertEqual(
+            events[2].customViewTimings,
+            ["timing-after-500000000ns": 500_000_000, "timing-after-1000000000ns": 1_000_000_000]
+        )
     }
 
     func testGivenInactiveView_whenCustomTimingIsRegistered_itDoesNotSendViewUpdateEvent() throws {
@@ -609,7 +611,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             uri: "UIViewController",
             attributes: [:],
-            customTimings: [],
+            customTimings: [:],
             startTime: currentTime
         )
         XCTAssertTrue(
@@ -631,6 +633,6 @@ class RUMViewScopeTests: XCTestCase {
 
         // Then
         let lastEvent = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMDataView>.self).last)
-        XCTAssertEqual(lastEvent.customViewTimings, [])
+        XCTAssertEqual(lastEvent.customViewTimings, [:])
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -638,8 +638,8 @@ class RUMMonitorTests: XCTestCase {
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
         verifyGlobalAttributes(in: rumEventMatchers)
         let lastViewUpdate = try rumEventMatchers.lastRUMEvent(ofType: RUMDataView.self)
-        XCTAssertEqual(try lastViewUpdate.attribute(forKeyPath: "view.custom_timings.timing1"), 1_000_000_000)
-        XCTAssertEqual(try lastViewUpdate.attribute(forKeyPath: "view.custom_timings.timing2"), 2_000_000_000)
+        XCTAssertEqual(try lastViewUpdate.timing(named: "timing1"), 1_000_000_000)
+        XCTAssertEqual(try lastViewUpdate.timing(named: "timing2"), 2_000_000_000)
     }
 
     // MARK: - Thread safety

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -474,10 +474,10 @@ class RUMMonitorTests: XCTestCase {
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 11)
         let expectedUserInfo = RUMDataUSR(id: "abc-123", name: "Foo", email: "foo@bar.com")
-        rumEventMatchers.forEach { event in
-            event.jsonMatcher.assertValue(forKey: "context.usr.str", equals: "value")
-            event.jsonMatcher.assertValue(forKey: "context.usr.int", equals: 11_235)
-            event.jsonMatcher.assertValue(forKey: "context.usr.bool", equals: true)
+        try rumEventMatchers.forEach { event in
+            XCTAssertEqual(try event.attribute(forKeyPath: "context.usr.str"), "value")
+            XCTAssertEqual(try event.attribute(forKeyPath: "context.usr.int"), 11_235)
+            XCTAssertEqual(try event.attribute(forKeyPath: "context.usr.bool"), true) // swiftlint:disable:this xct_specific_matcher
         }
         try rumEventMatchers.forEachRUMEvent(ofType: RUMDataAction.self) { action in
             XCTAssertEqual(action.usr, expectedUserInfo)
@@ -612,6 +612,34 @@ class RUMMonitorTests: XCTestCase {
         try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "context.a1"), "bar1", "The value should be updated")
         try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "context.a2"), "foo2", "The attribute should not be removed")
         try XCTAssertEqual(lastViewUpdate.attribute(forKeyPath: "context.a3"), "foo3", "The attribute should be added")
+    }
+
+    // MARK: - Sending Custom Timings
+
+    func testStartingView_thenAddingTiming() throws {
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(
+            directory: temporaryDirectory,
+            dependencies: .mockWith(
+                dateProvider: RelativeDateProvider(
+                    startingFrom: Date(),
+                    advancingBySeconds: 1
+                )
+            )
+        )
+        defer { RUMFeature.instance = nil }
+
+        let monitor = RUMMonitor.initialize()
+        setGlobalAttributes(of: monitor)
+
+        monitor.startView(viewController: mockView)
+        monitor.addTiming(name: "timing1")
+        monitor.addTiming(name: "timing2")
+
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
+        verifyGlobalAttributes(in: rumEventMatchers)
+        let lastViewUpdate = try rumEventMatchers.lastRUMEvent(ofType: RUMDataView.self)
+        XCTAssertEqual(try lastViewUpdate.attribute(forKeyPath: "view.custom_timings.timing1"), 1_000_000_000)
+        XCTAssertEqual(try lastViewUpdate.attribute(forKeyPath: "view.custom_timings.timing2"), 2_000_000_000)
     }
 
     // MARK: - Thread safety

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -582,7 +582,7 @@ class TracerTests: XCTestCase {
         )
         XCTAssertEqual(
             try spanMatcher.meta.custom(keyPath: "meta.person"),
-            #"{"name":"Adam","age":30,"nationality":"Polish"}"#
+            #"{"age":30,"name":"Adam","nationality":"Polish"}"#
         )
         XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.nested.string"), "hello")
         XCTAssertEqual(try spanMatcher.meta.custom(keyPath: "meta.url"), "https://example.com/image.png")

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -95,6 +95,10 @@ internal class RUMEventMatcher {
     func attribute<T: Equatable>(forKeyPath keyPath: String) throws -> T {
         return try jsonMatcher.value(forKeyPath: keyPath)
     }
+
+    func timing(named timingName: String) throws -> Int64 {
+        return try attribute(forKeyPath: "view.custom_timings.\(timingName)")
+    }
 }
 
 extension RUMEventMatcher: CustomStringConvertible {

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -53,6 +53,9 @@ internal class RUMSessionMatcher {
         /// `RUMView` events tracked during this visit.
         fileprivate(set) var viewEvents: [RUMDataView] = []
 
+        /// `RUMEventMatchers` corresponding to item in `viewEvents`.
+        fileprivate(set) var viewEventMatchers: [RUMEventMatcher] = []
+
         /// `RUMAction` events tracked during this visit.
         fileprivate(set) var actionEvents: [RUMDataAction] = []
 
@@ -81,8 +84,8 @@ internal class RUMSessionMatcher {
 
         // Get RUM Events by kind:
 
-        let viewEvents: [RUMDataView] = try (eventsMatchersByType["view"] ?? [])
-            .map { matcher in try matcher.model() }
+        let viewEventMatchers = eventsMatchersByType["view"] ?? []
+        let viewEvents: [RUMDataView] = try viewEventMatchers.map { matcher in try matcher.model() }
 
         let actionEvents: [RUMDataAction] = try (eventsMatchersByType["action"] ?? [])
             .map { matcher in try matcher.model() }
@@ -103,10 +106,11 @@ internal class RUMSessionMatcher {
         var visitsByViewID: [String: ViewVisit] = [:]
         visits.forEach { visit in visitsByViewID[visit.viewID] = visit }
 
-        // Group RUM Events by View Visits:
-        try viewEvents.forEach { rumEvent in
+        // Group RUM Events and their matchers by View Visits:
+        try zip(viewEvents, viewEventMatchers).forEach { rumEvent, matcher in
             if let visit = visitsByViewID[rumEvent.view.id] {
                 visit.viewEvents.append(rumEvent)
+                visit.viewEventMatchers.append(matcher)
                 if visit.path.isEmpty {
                     visit.path = rumEvent.view.url
                 } else if visit.path != rumEvent.view.url {


### PR DESCRIPTION
### What and why?

📦 This PR introduces custom timings API for RUM:
```swift
Global.rum.addTiming(name: "content-ready")
```
<img width="450" alt="Screenshot 2020-11-30 at 15 16 12" src="https://user-images.githubusercontent.com/2358722/100620696-ffe27a00-331e-11eb-9fbb-b2d2e8053db4.png">


### How?

Timing is measured as the number of nanoseconds since the start of the current view.

Timings are encoded as `view.custom_timings.<name-of-the-timing>` values in RUM event JSON. To make it work, I had to apply workaround for backend issue: we must enforce that `view.custom_timings.*` appears **after** the `view.` object (achieved by enabling `.sortedKeys` option in JSON encoder).

To test timings with mocked `RelativeDateProvider`, I had to ensure that it is not used by the storage part of the mocked feature. This is done by injecting `SystemDateProvider` when partially mocking each feature.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
