### PR TITLE
Update to DataDogSDKTesting 0.4.0

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
@@ -69,7 +69,7 @@
          <EnvironmentVariable
             key = "DD_DISABLE_NETWORK_INSTRUMENTATION"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_DISABLE_HEADERS_INJECTION"
@@ -89,11 +89,6 @@
          <EnvironmentVariable
             key = "BITRISE_SOURCE_DIR"
             value = "$(BITRISE_SOURCE_DIR)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_TRIGGERED_WORKFLOW_ID"
-            value = "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -129,6 +124,16 @@
          <EnvironmentVariable
             key = "GIT_CLONE_COMMIT_HASH"
             value = "$(GIT_CLONE_COMMIT_HASH)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_APP_TITLE"
+            value = "$(BITRISE_APP_TITLE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_SLUG"
+            value = "$(BITRISE_BUILD_SLUG)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
@@ -127,11 +127,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "BITRISE_TRIGGERED_WORKFLOW_ID"
-            value = "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
             key = "BITRISE_BUILD_NUMBER"
             value = "$(BITRISE_BUILD_NUMBER)"
             isEnabled = "YES">
@@ -164,6 +159,16 @@
          <EnvironmentVariable
             key = "GIT_CLONE_COMMIT_HASH"
             value = "$(GIT_CLONE_COMMIT_HASH)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_APP_TITLE"
+            value = "$(BITRISE_APP_TITLE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_SLUG"
+            value = "$(BITRISE_BUILD_SLUG)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
@@ -128,11 +128,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "BITRISE_TRIGGERED_WORKFLOW_ID"
-            value = "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
             key = "BITRISE_BUILD_NUMBER"
             value = "$(BITRISE_BUILD_NUMBER)"
             isEnabled = "YES">
@@ -165,6 +160,16 @@
          <EnvironmentVariable
             key = "GIT_CLONE_COMMIT_HASH"
             value = "$(GIT_CLONE_COMMIT_HASH)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_APP_TITLE"
+            value = "$(BITRISE_APP_TITLE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_SLUG"
+            value = "$(BITRISE_BUILD_SLUG)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc.xcscheme
@@ -68,7 +68,7 @@
          <EnvironmentVariable
             key = "DD_DISABLE_NETWORK_INSTRUMENTATION"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_DISABLE_HEADERS_INJECTION"
@@ -88,11 +88,6 @@
          <EnvironmentVariable
             key = "BITRISE_SOURCE_DIR"
             value = "$(BITRISE_SOURCE_DIR)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "BITRISE_TRIGGERED_WORKFLOW_ID"
-            value = "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -128,6 +123,16 @@
          <EnvironmentVariable
             key = "GIT_CLONE_COMMIT_HASH"
             value = "$(GIT_CLONE_COMMIT_HASH)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_APP_TITLE"
+            value = "$(BITRISE_APP_TITLE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_SLUG"
+            value = "$(BITRISE_BUILD_SLUG)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ tools:
 		@echo "OK 👌"
 
 # The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
-DD_SDK_SWIFT_TESTING_VERSION = 0.3.0
+DD_SDK_SWIFT_TESTING_VERSION = 0.4.0
 
 define DD_SDK_TESTING_XCCONFIG_CI
-FRAMEWORK_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/\n
-LD_RUNPATH_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/\n
+FRAMEWORK_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
+LD_RUNPATH_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
 OTHER_LDFLAGS=$$(inherited) -framework DatadogSDKTesting\n
 DD_TEST_RUNNER=1\n
 DD_SDK_SWIFT_TESTING_SERVICE=dd-sdk-ios\n
@@ -26,11 +26,12 @@ ifeq (${ci}, true)
 		@echo $$DD_SDK_TESTING_XCCONFIG_CI > xcconfigs/DatadogSDKTesting.local.xcconfig;
 endif
 		@brew install gh
-		@rm -rf instrumented-tests/DatadogSDKTesting.framework-iphonesimulator.zip
-		@rm -rf instrumented-tests/DatadogSDKTesting.framework
-		@gh release download ${DD_SDK_SWIFT_TESTING_VERSION} -D instrumented-tests -R https://github.com/DataDog/dd-sdk-swift-testing -p "DatadogSDKTesting.framework-iphonesimulator.zip"
-		@unzip instrumented-tests/DatadogSDKTesting.framework-iphonesimulator.zip -d instrumented-tests
-		@[ -e "instrumented-tests/DatadogSDKTesting.framework" ] && echo "DatadogSDKTesting.framework - OK" || { echo "DatadogSDKTesting.framework - missing"; exit 1; }
+		@rm -rf instrumented-tests/DatadogSDKTesting.xcframework
+		@rm -rf instrumented-tests/DatadogSDKTesting.zip
+		@rm -rf instrumented-tests/LICENSE
+		@gh release download ${DD_SDK_SWIFT_TESTING_VERSION} -D instrumented-tests -R https://github.com/DataDog/dd-sdk-swift-testing -p "DatadogSDKTesting.zip"
+		@unzip instrumented-tests/DatadogSDKTesting.zip -d instrumented-tests
+		@[ -e "instrumented-tests/DatadogSDKTesting.xcframework" ] && echo "DatadogSDKTesting.xcframework - OK" || { echo "DatadogSDKTesting.xcframework - missing"; exit 1; }
 
 xcodeproj-httpservermock:
 		@echo "⚙️  Generating 'HTTPServerMock.xcodeproj'..."

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -99,11 +99,8 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
         XCTAssertEqual(firstPartyResource1.resource.method, .methodGET)
         XCTAssertGreaterThan(firstPartyResource1.resource.duration, 0)
 
-        //TEMPORARY workaround for dd-sdk-testing
-        if ProcessInfo.processInfo.environment["DD_TEST_RUNNER"] == nil {
-            XCTAssertNil(firstPartyResource1.dd.traceID, "`firstPartyGETResourceURL` should not be traced")
-            XCTAssertNil(firstPartyResource1.dd.spanID, "`firstPartyGETResourceURL` should not be traced")
-        }
+        XCTAssertNil(firstPartyResource1.dd.traceID, "`firstPartyGETResourceURL` should not be traced")
+        XCTAssertNil(firstPartyResource1.dd.spanID, "`firstPartyGETResourceURL` should not be traced")
 
         let firstPartyResource2 = try XCTUnwrap(
             session.viewVisits[0].resourceEvents.first { $0.resource.url == firstPartyPOSTResourceURL.absoluteString },

--- a/tools/license/check-license.sh
+++ b/tools/license/check-license.sh
@@ -17,7 +17,7 @@ function files {
 		-not -path "*Carthage/Build/*" \
 		-not -path "*Carthage/Checkouts/*" \
 		-not -path "./tools/generate-models/rum-events-format/*" \
-		-not -path "./instrumented-tests/DatadogSDKTesting.framework/*" \
+		-not -path "./instrumented-tests/DatadogSDKTesting.xcframework/*" \
 		-not -name "OTSpan.swift" \
 		-not -name "OTFormat.swift" \
 		-not -name "OTTracer.swift" \


### PR DESCRIPTION
### What and why?

Update to DataDogSDKTesting 0.4.0

### How?

* Update to DataDogSDKTesting 0.4.0
* Modify makefile for XCFramework format
* Modify check-license for change to xcframework
* Update Bitrise environment variables
* Don't disable network instrumentation in Datadog and DatadogObjc
* Re-enable test that was not working with previous version

