### PR TITLE
RUMM-829 Add consent-aware data writer

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -82,6 +82,9 @@
 		61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C472423990D00786299 /* DatadogExtensions.swift */; };
 		61133C702423993200786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		6114FDEC257659E90084E372 /* FeatureDirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FDEB257659E90084E372 /* FeatureDirectoriesMock.swift */; };
+		6114FE0F257667D40084E372 /* ConsentAwareDataWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */; };
+		6114FE1625766B310084E372 /* TrackingConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE1525766B310084E372 /* TrackingConsent.swift */; };
+		6114FE23257671F00084E372 /* ConsentAwareDataWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */; };
 		61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */; };
 		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
 		61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */; };
@@ -479,6 +482,9 @@
 		61133C462423990D00786299 /* TestsDirectory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestsDirectory.swift; sourceTree = "<group>"; };
 		61133C472423990D00786299 /* DatadogExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogExtensions.swift; sourceTree = "<group>"; };
 		6114FDEB257659E90084E372 /* FeatureDirectoriesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureDirectoriesMock.swift; sourceTree = "<group>"; };
+		6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentAwareDataWriter.swift; sourceTree = "<group>"; };
+		6114FE1525766B310084E372 /* TrackingConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingConsent.swift; sourceTree = "<group>"; };
+		6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentAwareDataWriterTests.swift; sourceTree = "<group>"; };
 		61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSViewController.swift; sourceTree = "<group>"; };
 		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
 		61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMModalViewsScenarioTests.swift; sourceTree = "<group>"; };
@@ -915,6 +921,7 @@
 				61133BA92423979B00786299 /* FilesOrchestrator.swift */,
 				61133BA72423979B00786299 /* FileWriter.swift */,
 				61133BAD2423979B00786299 /* FileReader.swift */,
+				6114FE0D257667AD0084E372 /* Privacy */,
 				61133BAA2423979B00786299 /* Files */,
 			);
 			path = Persistence;
@@ -1140,6 +1147,7 @@
 				61133C2A2423990D00786299 /* FilesOrchestratorTests.swift */,
 				61133C292423990D00786299 /* FileWriterTests.swift */,
 				61133C282423990D00786299 /* FileReaderTests.swift */,
+				6114FE21257671CB0084E372 /* Privacy */,
 				61133C2B2423990D00786299 /* Files */,
 			);
 			path = Persistence;
@@ -1236,6 +1244,23 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6114FE0D257667AD0084E372 /* Privacy */ = {
+			isa = PBXGroup;
+			children = (
+				6114FE1525766B310084E372 /* TrackingConsent.swift */,
+				6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */,
+			);
+			path = Privacy;
+			sourceTree = "<group>";
+		};
+		6114FE21257671CB0084E372 /* Privacy */ = {
+			isa = PBXGroup;
+			children = (
+				6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */,
+			);
+			path = Privacy;
 			sourceTree = "<group>";
 		};
 		61216277247D1F2100AC5D67 /* FeaturesIntegration */ = {
@@ -2472,6 +2497,7 @@
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,
 				6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */,
 				61133BDC2423979B00786299 /* Logger.swift in Sources */,
+				6114FE1625766B310084E372 /* TrackingConsent.swift in Sources */,
 				61F3C9712535AE9400E2F8C4 /* UIKitHierarchyInspector.swift in Sources */,
 				61133BD02423979B00786299 /* DateProvider.swift in Sources */,
 				6156CB8E24DDA1B5008CB2B2 /* RUMContextProvider.swift in Sources */,
@@ -2575,6 +2601,7 @@
 				61E5332C24B75C51003D6C4E /* RUMFeature.swift in Sources */,
 				61E5333D24B8791A003D6C4E /* RUMEventEncoder.swift in Sources */,
 				6156CB9D24E18600008CB2B2 /* TracingWithRUMIntegration.swift in Sources */,
+				6114FE0F257667D40084E372 /* ConsentAwareDataWriter.swift in Sources */,
 				61C5A88624509A0C00DA608C /* TracingUUIDGenerator.swift in Sources */,
 				61133BD92423979B00786299 /* DataUploadDelay.swift in Sources */,
 				61C5A88C24509A0C00DA608C /* HTTPHeadersWriter.swift in Sources */,
@@ -2592,6 +2619,7 @@
 				617CD0DD24CEDDD300B0B557 /* RUMUserActionScopeTests.swift in Sources */,
 				61C5A8A024509C1100DA608C /* Casting+Tracing.swift in Sources */,
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
+				6114FE23257671F00084E372 /* ConsentAwareDataWriterTests.swift in Sources */,
 				61410167251A661D00E3C2D9 /* UIApplicationSwizzlerTests.swift in Sources */,
 				61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61C2C20924C0C75500C0321C /* RUMSessionScopeTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C462423990D00786299 /* TestsDirectory.swift */; };
 		61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C472423990D00786299 /* DatadogExtensions.swift */; };
 		61133C702423993200786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
+		6114FDEC257659E90084E372 /* FeatureDirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FDEB257659E90084E372 /* FeatureDirectoriesMock.swift */; };
 		61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */; };
 		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
 		61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */; };
@@ -477,6 +478,7 @@
 		61133C452423990D00786299 /* SwiftExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExtensions.swift; sourceTree = "<group>"; };
 		61133C462423990D00786299 /* TestsDirectory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestsDirectory.swift; sourceTree = "<group>"; };
 		61133C472423990D00786299 /* DatadogExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogExtensions.swift; sourceTree = "<group>"; };
+		6114FDEB257659E90084E372 /* FeatureDirectoriesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureDirectoriesMock.swift; sourceTree = "<group>"; };
 		61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSViewController.swift; sourceTree = "<group>"; };
 		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
 		61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMModalViewsScenarioTests.swift; sourceTree = "<group>"; };
@@ -1094,6 +1096,7 @@
 				61C3646F243B5C8300C4D4E6 /* ServerMock.swift */,
 				61D6FF7824E42A2900D0E375 /* DataUploadWorkerMock.swift */,
 				61F1A6192498A51700075390 /* CoreMocks.swift */,
+				6114FDEB257659E90084E372 /* FeatureDirectoriesMock.swift */,
 				61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */,
 				61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */,
 				61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */,
@@ -2611,6 +2614,7 @@
 				61C5A89D24509C1100DA608C /* DDSpanTests.swift in Sources */,
 				61B038BA2527257B00518F3C /* URLSessionAutoInstrumentationMocks.swift in Sources */,
 				61133C672423990D00786299 /* LogConsoleOutputTests.swift in Sources */,
+				6114FDEC257659E90084E372 /* FeatureDirectoriesMock.swift in Sources */,
 				61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */,
 				617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */,
 				61F9CABA2513A7F5000A5E61 /* RUMSessionMatcher.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -50,9 +50,29 @@ internal struct FeatureStorage {
             performance: commonDependencies.performance,
             dateProvider: commonDependencies.dateProvider
         )
+        let unauthorizedFilesOrchestrator = FilesOrchestrator(
+            directory: directories.unauthorized,
+            performance: commonDependencies.performance,
+            dateProvider: commonDependencies.dateProvider
+        )
+
+        let consentAwareDataWriter = ConsentAwareDataWriter(
+            initialConsent: .granted, // TODO: RUMM-830 Inject `ConsentProvider`
+            queue: readWriteQueue,
+            unauthorizedFileWriter: FileWriter(
+                dataFormat: dataFormat,
+                orchestrator: unauthorizedFilesOrchestrator,
+                queue: readWriteQueue
+            ),
+            authorizedFileWriter: FileWriter(
+                dataFormat: dataFormat,
+                orchestrator: authorizedFilesOrchestrator,
+                queue: readWriteQueue
+            )
+        )
 
         self.init(
-            writer: FileWriter(dataFormat: dataFormat, orchestrator: authorizedFilesOrchestrator, queue: readWriteQueue),
+            writer: consentAwareDataWriter,
             reader: FileReader(dataFormat: dataFormat, orchestrator: authorizedFilesOrchestrator, queue: readWriteQueue)
         )
     }

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -6,6 +6,17 @@
 
 import Foundation
 
+/// Lists different types of data directories used by the feature.
+internal struct FeatureDirectories {
+    /// Data directory for storing unauthorized data collected without knowing the tracking consent value.
+    /// Due to the consent change, data in this directory may be either moved to `authorized` folder or entirely deleted.
+    let unauthorized: Directory
+    /// Data directory for storing authorized data collected when tracking consent is granted.
+    /// Consent change does not impact data already stored in this folder.
+    /// Data in this folder gets uploaded to the server.
+    let authorized: Directory
+}
+
 /// Container with dependencies common to all features (Logging, Tracing and RUM).
 internal struct FeaturesCommonDependencies {
     let performance: PerformancePreset
@@ -27,22 +38,22 @@ internal struct FeatureStorage {
     init(
         featureName: String,
         dataFormat: DataFormat,
-        directory: Directory,
+        directories: FeatureDirectories,
         commonDependencies: FeaturesCommonDependencies
     ) {
         let readWriteQueue = DispatchQueue(
             label: "com.datadoghq.ios-sdk-\(featureName)-read-write",
             target: .global(qos: .utility)
         )
-        let orchestrator = FilesOrchestrator(
-            directory: directory,
+        let authorizedFilesOrchestrator = FilesOrchestrator(
+            directory: directories.authorized,
             performance: commonDependencies.performance,
             dateProvider: commonDependencies.dateProvider
         )
 
         self.init(
-            writer: FileWriter(dataFormat: dataFormat, orchestrator: orchestrator, queue: readWriteQueue),
-            reader: FileReader(dataFormat: dataFormat, orchestrator: orchestrator, queue: readWriteQueue)
+            writer: FileWriter(dataFormat: dataFormat, orchestrator: authorizedFilesOrchestrator, queue: readWriteQueue),
+            reader: FileReader(dataFormat: dataFormat, orchestrator: authorizedFilesOrchestrator, queue: readWriteQueue)
         )
     }
 

--- a/Sources/Datadog/Core/Persistence/Privacy/ConsentAwareDataWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Privacy/ConsentAwareDataWriter.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// File writer which writes data to different folders depending on the tracking consent value.
+internal class ConsentAwareDataWriter: FileWriterType {
+    /// Queue used to synchronize reads and writes for the feature.
+    /// TODO: RUMM-777 will be used synchronize `activeFileWriter` swaps on consent change.
+    internal let queue: DispatchQueue
+    /// File writer writting unauthorized data when consent is `.pending`.
+    private let unauthorizedFileWriter: FileWriterType
+    /// File writer writting authorized data when consent is `.granted`.
+    private let authorizedFileWriter: FileWriterType
+
+    /// File writer for current consent value (including `nil` if consent is `.notGranted`).
+    private var activeFileWriter: FileWriterType?
+
+    init(
+        initialConsent: TrackingConsent,
+        queue: DispatchQueue,
+        unauthorizedFileWriter: FileWriterType,
+        authorizedFileWriter: FileWriterType
+    ) {
+        self.queue = queue
+        self.unauthorizedFileWriter = unauthorizedFileWriter
+        self.authorizedFileWriter = authorizedFileWriter
+
+        switch initialConsent {
+        case .granted: self.activeFileWriter = authorizedFileWriter
+        case .notGranted: self.activeFileWriter = nil
+        case .pending: self.activeFileWriter = unauthorizedFileWriter
+        }
+    }
+
+    func write<T>(value: T) where T: Encodable {
+        activeFileWriter?.write(value: value)
+    }
+}

--- a/Sources/Datadog/Core/Persistence/Privacy/TrackingConsent.swift
+++ b/Sources/Datadog/Core/Persistence/Privacy/TrackingConsent.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Possible values for the Data Tracking Consent.
+internal enum TrackingConsent {
+    /// The permission to persist and send data to the Datadog servers was granted.
+    /// Any previously stored pending data will be marked as ready for sent.
+    case granted
+    /// Any previously stored pending data will be deleted and all Logging, RUM and Tracing events will
+    /// be dropped from now on, without persisting it in any way.
+    case notGranted
+    /// All Logging, RUM and Tracing events will be persisted in an intermediate location and will be pending there
+    /// until `.granted` or `.notGranted` consent value is set.
+    /// Based on the next consent value, intermediate data will be send to Datadog or deleted.
+    case pending
+}

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -149,7 +149,7 @@ public class Datadog {
 
         if let loggingConfiguration = configuration.logging {
             logging = LoggingFeature(
-                directory: try obtainLoggingFeatureDirectory(),
+                directories: try obtainLoggingFeatureDirectories(),
                 configuration: loggingConfiguration,
                 commonDependencies: commonDependencies
             )
@@ -157,7 +157,7 @@ public class Datadog {
 
         if let tracingConfiguration = configuration.tracing {
             tracing = TracingFeature(
-                directory: try obtainTracingFeatureDirectory(),
+                directories: try obtainTracingFeatureDirectories(),
                 configuration: tracingConfiguration,
                 commonDependencies: commonDependencies,
                 loggingFeatureAdapter: logging.flatMap { LoggingForTracingAdapter(loggingFeature: $0) },
@@ -167,7 +167,7 @@ public class Datadog {
 
         if let rumConfiguration = configuration.rum {
             rum = RUMFeature(
-                directory: try obtainRUMFeatureDirectory(),
+                directories: try obtainRUMFeatureDirectories(),
                 configuration: rumConfiguration,
                 commonDependencies: commonDependencies
             )

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -6,9 +6,13 @@
 
 import Foundation
 
-/// Obtains a subdirectory in `/Library/Caches` where log files are stored.
-internal func obtainLoggingFeatureDirectory() throws -> Directory {
-    return try Directory(withSubdirectoryPath: "com.datadoghq.logs/v1")
+/// Obtains subdirectories in `/Library/Caches` where logging data is stored.
+internal func obtainLoggingFeatureDirectories() throws -> FeatureDirectories {
+    let version = "v1"
+    return FeatureDirectories(
+        unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.logs/intermediate-\(version)"),
+        authorized: try Directory(withSubdirectoryPath: "com.datadoghq.logs/\(version)")
+    )
 }
 
 /// Creates and owns componetns enabling logging feature.
@@ -44,18 +48,17 @@ internal final class LoggingFeature {
 
     // MARK: - Initialization
 
-    static func createStorage(directory: Directory, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
+    static func createStorage(directories: FeatureDirectories, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
         return FeatureStorage(
             featureName: LoggingFeature.featureName,
             dataFormat: LoggingFeature.dataFormat,
-            directory: directory,
+            directories: directories,
             commonDependencies: commonDependencies
         )
     }
 
     static func createUpload(
         storage: FeatureStorage,
-        directory: Directory,
         configuration: FeaturesConfiguration.Logging,
         commonDependencies: FeaturesCommonDependencies
     ) -> FeatureUpload {
@@ -84,12 +87,12 @@ internal final class LoggingFeature {
     }
 
     convenience init(
-        directory: Directory,
+        directories: FeatureDirectories,
         configuration: FeaturesConfiguration.Logging,
         commonDependencies: FeaturesCommonDependencies
     ) {
-        let storage = LoggingFeature.createStorage(directory: directory, commonDependencies: commonDependencies)
-        let upload = LoggingFeature.createUpload(storage: storage, directory: directory, configuration: configuration, commonDependencies: commonDependencies)
+        let storage = LoggingFeature.createStorage(directories: directories, commonDependencies: commonDependencies)
+        let upload = LoggingFeature.createUpload(storage: storage, configuration: configuration, commonDependencies: commonDependencies)
         self.init(
             storage: storage,
             upload: upload,

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -6,9 +6,13 @@
 
 import Foundation
 
-/// Obtains a subdirectory in `/Library/Caches` for writting RUM events.
-internal func obtainRUMFeatureDirectory() throws -> Directory {
-    return try Directory(withSubdirectoryPath: "com.datadoghq.rum/v1")
+/// Obtains subdirectories in `/Library/Caches` where RUM data is stored.
+internal func obtainRUMFeatureDirectories() throws -> FeatureDirectories {
+    let version = "v1"
+    return FeatureDirectories(
+        unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.rum/intermediate-\(version)"),
+        authorized: try Directory(withSubdirectoryPath: "com.datadoghq.rum/\(version)")
+    )
 }
 
 /// Creates and owns componetns enabling RUM feature.
@@ -45,18 +49,17 @@ internal final class RUMFeature {
 
     // MARK: - Initialization
 
-    static func createStorage(directory: Directory, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
+    static func createStorage(directories: FeatureDirectories, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
         return FeatureStorage(
             featureName: RUMFeature.featureName,
             dataFormat: RUMFeature.dataFormat,
-            directory: directory,
+            directories: directories,
             commonDependencies: commonDependencies
         )
     }
 
     static func createUpload(
         storage: FeatureStorage,
-        directory: Directory,
         configuration: FeaturesConfiguration.RUM,
         commonDependencies: FeaturesCommonDependencies
     ) -> FeatureUpload {
@@ -93,12 +96,12 @@ internal final class RUMFeature {
     }
 
     convenience init(
-        directory: Directory,
+        directories: FeatureDirectories,
         configuration: FeaturesConfiguration.RUM,
         commonDependencies: FeaturesCommonDependencies
     ) {
-        let storage = RUMFeature.createStorage(directory: directory, commonDependencies: commonDependencies)
-        let upload = RUMFeature.createUpload(storage: storage, directory: directory, configuration: configuration, commonDependencies: commonDependencies)
+        let storage = RUMFeature.createStorage(directories: directories, commonDependencies: commonDependencies)
+        let upload = RUMFeature.createUpload(storage: storage, configuration: configuration, commonDependencies: commonDependencies)
         self.init(
             storage: storage,
             upload: upload,

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -6,9 +6,13 @@
 
 import Foundation
 
-/// Obtains a subdirectory in `/Library/Caches` where span files are stored.
-internal func obtainTracingFeatureDirectory() throws -> Directory {
-    return try Directory(withSubdirectoryPath: "com.datadoghq.traces/v1")
+/// Obtains subdirectories in `/Library/Caches` where tracing data is stored.
+internal func obtainTracingFeatureDirectories() throws -> FeatureDirectories {
+    let version = "v1"
+    return FeatureDirectories(
+        unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.traces/intermediate-\(version)"),
+        authorized: try Directory(withSubdirectoryPath: "com.datadoghq.traces/\(version)")
+    )
 }
 
 /// Creates and owns componetns enabling tracing feature.
@@ -51,18 +55,17 @@ internal final class TracingFeature {
 
     // MARK: - Initialization
 
-    static func createStorage(directory: Directory, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
+    static func createStorage(directories: FeatureDirectories, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
         return FeatureStorage(
             featureName: TracingFeature.featureName,
             dataFormat: TracingFeature.dataFormat,
-            directory: directory,
+            directories: directories,
             commonDependencies: commonDependencies
         )
     }
 
     static func createUpload(
         storage: FeatureStorage,
-        directory: Directory,
         configuration: FeaturesConfiguration.Tracing,
         commonDependencies: FeaturesCommonDependencies
     ) -> FeatureUpload {
@@ -90,14 +93,14 @@ internal final class TracingFeature {
     }
 
     convenience init(
-        directory: Directory,
+        directories: FeatureDirectories,
         configuration: FeaturesConfiguration.Tracing,
         commonDependencies: FeaturesCommonDependencies,
         loggingFeatureAdapter: LoggingForTracingAdapter?,
         tracingUUIDGenerator: TracingUUIDGenerator
     ) {
-        let storage = TracingFeature.createStorage(directory: directory, commonDependencies: commonDependencies)
-        let upload = TracingFeature.createUpload(storage: storage, directory: directory, configuration: configuration, commonDependencies: commonDependencies)
+        let storage = TracingFeature.createStorage(directories: directories, commonDependencies: commonDependencies)
+        let upload = TracingFeature.createUpload(storage: storage, configuration: configuration, commonDependencies: commonDependencies)
         self.init(
             storage: storage,
             upload: upload,

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -19,7 +19,13 @@ class LoggingStorageBenchmarkTests: XCTestCase {
         try super.setUpWithError()
         self.directory = try Directory(withSubdirectoryPath: "logging-benchmark")
 
-        let storage = LoggingFeature.createStorage(directory: directory, commonDependencies: .mockAny())
+        let storage = LoggingFeature.createStorage(
+            directories: FeatureDirectories(
+                unauthorized: obtainUniqueTemporaryDirectory(),
+                authorized: directory
+            ),
+            commonDependencies: .mockAny()
+        )
         self.writer = storage.writer as? FileWriter
         self.reader = storage.reader as? FileReader
         self.queue = self.writer.queue

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -11,7 +11,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
     private var queue: DispatchQueue!
     private var directory: Directory!
-    private var writer: FileWriter!
+    private var writer: ConsentAwareDataWriter!
     private var reader: FileReader!
     // swiftlint:enable implicitly_unwrapped_optional
 
@@ -26,7 +26,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
             ),
             commonDependencies: .mockAny()
         )
-        self.writer = storage.writer as? FileWriter
+        self.writer = storage.writer as? ConsentAwareDataWriter
         self.reader = storage.reader as? FileReader
         self.queue = self.writer.queue
 

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -19,7 +19,13 @@ class RUMStorageBenchmarkTests: XCTestCase {
         try super.setUpWithError()
         self.directory = try Directory(withSubdirectoryPath: "rum-benchmark")
 
-        let storage = RUMFeature.createStorage(directory: directory, commonDependencies: .mockAny())
+        let storage = RUMFeature.createStorage(
+            directories: FeatureDirectories(
+                unauthorized: obtainUniqueTemporaryDirectory(),
+                authorized: directory
+            ),
+            commonDependencies: .mockAny()
+        )
         self.writer = storage.writer as? FileWriter
         self.reader = storage.reader as? FileReader
         self.queue = self.writer.queue

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -11,7 +11,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
     private var queue: DispatchQueue!
     private var directory: Directory!
-    private var writer: FileWriter!
+    private var writer: ConsentAwareDataWriter!
     private var reader: FileReader!
     // swiftlint:enable implicitly_unwrapped_optional
 
@@ -26,7 +26,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
             ),
             commonDependencies: .mockAny()
         )
-        self.writer = storage.writer as? FileWriter
+        self.writer = storage.writer as? ConsentAwareDataWriter
         self.reader = storage.reader as? FileReader
         self.queue = self.writer.queue
 

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -19,7 +19,13 @@ class TracingStorageBenchmarkTests: XCTestCase {
         try super.setUpWithError()
         self.directory = try Directory(withSubdirectoryPath: "tracing-benchmark")
 
-        let storage = TracingFeature.createStorage(directory: directory, commonDependencies: .mockAny())
+        let storage = TracingFeature.createStorage(
+            directories: FeatureDirectories(
+                unauthorized: obtainUniqueTemporaryDirectory(),
+                authorized: directory
+            ),
+            commonDependencies: .mockAny()
+        )
         self.writer = storage.writer as? FileWriter
         self.reader = storage.reader as? FileReader
         self.queue = self.writer.queue

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -11,7 +11,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
     private var queue: DispatchQueue!
     private var directory: Directory!
-    private var writer: FileWriter!
+    private var writer: ConsentAwareDataWriter!
     private var reader: FileReader!
     // swiftlint:enable implicitly_unwrapped_optional
 
@@ -26,7 +26,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
             ),
             commonDependencies: .mockAny()
         )
-        self.writer = storage.writer as? FileWriter
+        self.writer = storage.writer as? ConsentAwareDataWriter
         self.reader = storage.reader as? FileReader
         self.queue = self.writer.queue
 

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Privacy/ConsentAwareDataWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Privacy/ConsentAwareDataWriterTests.swift
@@ -1,0 +1,87 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+private class FileWriterMock: FileWriterType {
+    var dataWritten: Encodable?
+
+    func write<T>(value: T) where T: Encodable {
+        dataWritten = value
+    }
+}
+
+class ConsentAwareDataWriterTests: XCTestCase {
+    private let queue = DispatchQueue(label: "dd-tests-write", target: .global(qos: .utility))
+
+    override func setUp() {
+        super.setUp()
+        temporaryFeatureDirectories.create()
+    }
+
+    override func tearDown() {
+        temporaryFeatureDirectories.delete()
+        super.tearDown()
+    }
+
+    func testWhenInitializedWithConsentGranted_thenItWritesDataToAuthorizedFolder() {
+        let unauthorizedWriter = FileWriterMock()
+        let authorizedWriter = FileWriterMock()
+
+        // When
+        let writer = ConsentAwareDataWriter(
+            initialConsent: .granted,
+            queue: queue,
+            unauthorizedFileWriter: unauthorizedWriter,
+            authorizedFileWriter: authorizedWriter
+        )
+
+        // Then
+        writer.write(value: "abc")
+
+        XCTAssertNil(unauthorizedWriter.dataWritten)
+        XCTAssertEqual(authorizedWriter.dataWritten as? String, "abc")
+    }
+
+    func testWhenInitializedWithConsentPending_thenItWritesDataToUnauthorizedFolder() {
+        let unauthorizedWriter = FileWriterMock()
+        let authorizedWriter = FileWriterMock()
+
+        // When
+        let writer = ConsentAwareDataWriter(
+            initialConsent: .pending,
+            queue: queue,
+            unauthorizedFileWriter: unauthorizedWriter,
+            authorizedFileWriter: authorizedWriter
+        )
+
+        // Then
+        writer.write(value: "abc")
+
+        XCTAssertNil(authorizedWriter.dataWritten)
+        XCTAssertEqual(unauthorizedWriter.dataWritten as? String, "abc")
+    }
+
+    func testWhenInitializedWithConsentNotGranted_thenItDoesNotWriteDataToAnyFolder() {
+        let unauthorizedWriter = FileWriterMock()
+        let authorizedWriter = FileWriterMock()
+
+        // When
+        let writer = ConsentAwareDataWriter(
+            initialConsent: .notGranted,
+            queue: queue,
+            unauthorizedFileWriter: unauthorizedWriter,
+            authorizedFileWriter: authorizedWriter
+        )
+
+        // Then
+        writer.write(value: "abc")
+
+        XCTAssertNil(unauthorizedWriter.dataWritten)
+        XCTAssertNil(authorizedWriter.dataWritten)
+    }
+}

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -68,16 +68,16 @@ class RUMErrorsIntegrationTests: XCTestCase {
 
     override class func setUp() {
         super.setUp()
-        temporaryDirectory.create()
+        temporaryFeatureDirectories.create()
     }
 
     override class func tearDown() {
         super.tearDown()
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
     }
 
     func testGivenRUMMonitorRegistered_whenAddingErrorMessage_itSendsRUMErrorForCurrentView() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         // given

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithRUMErrorsIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithRUMErrorsIntegrationTests.swift
@@ -10,14 +10,14 @@ import XCTest
 class TracingWithRUMErrorsIntegrationTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        temporaryDirectory.create()
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        temporaryFeatureDirectories.create()
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         Global.rum = RUMMonitor.initialize()
         Global.rum.startView(viewController: mockView)
     }
 
     override func tearDown() {
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
         RUMFeature.instance = nil
         Global.rum = DDNoopRUMMonitor()
         super.tearDown()

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -14,7 +14,7 @@ class LoggerBuilderTests: XCTestCase {
     override func setUp() {
         super.setUp()
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationVersion: "1.2.3",

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -13,13 +13,13 @@ class LoggerTests: XCTestCase {
         super.setUp()
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(LoggingFeature.instance)
-        temporaryDirectory.create()
+        temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(LoggingFeature.instance)
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 
@@ -27,7 +27,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingLogWithDefaultLogger() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationVersion: "1.0.0",
@@ -62,7 +62,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testSendingLogWithCustomizedLogger() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         let logger = Logger.builder
@@ -94,7 +94,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingLogsWithDifferentDates() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC(), advancingBySeconds: 1)
             )
@@ -115,7 +115,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testSendingLogsWithDifferentLevels() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         let logger = Logger.builder.build()
@@ -138,7 +138,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Logging an error
 
     func testLoggingError() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         struct TestError: Error {
@@ -173,7 +173,7 @@ class LoggerTests: XCTestCase {
         defer { Datadog.instance = nil }
 
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 userInfoProvider: Datadog.instance!.userInfoProvider
             )
@@ -225,7 +225,7 @@ class LoggerTests: XCTestCase {
     func testSendingCarrierInfoWhenEnteringAndLeavingCellularServiceRange() throws {
         let carrierInfoProvider = CarrierInfoProviderMock(carrierInfo: nil)
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 carrierInfoProvider: carrierInfoProvider
             )
@@ -266,7 +266,7 @@ class LoggerTests: XCTestCase {
     func testSendingNetworkConnectionInfoWhenReachabilityChanges() throws {
         let networkConnectionInfoProvider = NetworkConnectionInfoProviderMock.mockAny()
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 networkConnectionInfoProvider: networkConnectionInfoProvider
             )
@@ -324,7 +324,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Sending attributes
 
     func testSendingLoggerAttributesOfDifferentEncodableValues() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         let logger = Logger.builder.build()
@@ -388,7 +388,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testSendingMessageAttributes() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         let logger = Logger.builder.build()
@@ -418,7 +418,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingTags() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
         defer { LoggingFeature.instance = nil }
@@ -457,7 +457,7 @@ class LoggerTests: XCTestCase {
     func testGivenBadBatteryConditions_itDoesNotTryToSendLogs() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 mobileDevice: .mockWith(
                     currentBatteryStatus: { () -> MobileDevice.BatteryStatus in
@@ -477,7 +477,7 @@ class LoggerTests: XCTestCase {
     func testGivenNoNetworkConnection_itDoesNotTryToSendLogs() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
                     networkConnectionInfo: .mockWith(reachability: .no)
@@ -496,7 +496,7 @@ class LoggerTests: XCTestCase {
 
     func testGivenBundlingWithRUMEnabledAndRUMMonitorRegistered_whenSendingLog_itContainsCurrentRUMContext() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
         defer { LoggingFeature.instance = nil }
@@ -531,7 +531,7 @@ class LoggerTests: XCTestCase {
 
     func testGivenBundlingWithRUMEnabledButRUMMonitorNotRegistered_whenSendingLog_itPrintsWarning() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
         defer { LoggingFeature.instance = nil }
@@ -569,7 +569,7 @@ class LoggerTests: XCTestCase {
         LoggingFeature.instance = .mockNoOp()
         defer { LoggingFeature.instance = nil }
 
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         // given
@@ -606,7 +606,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Integration With Active Span
 
     func testGivenBundlingWithTraceEnabledAndTracerRegistered_whenSendingLog_itContainsActiveSpanAttributes() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         TracingFeature.instance = .mockNoOp()
@@ -638,7 +638,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testGivenBundlingWithTraceEnabledButTracerNotRegistered_whenSendingLog_itPrintsWarning() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         TracingFeature.instance = .mockNoOp()

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -12,13 +12,13 @@ class LoggingFeatureTests: XCTestCase {
         super.setUp()
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(LoggingFeature.instance)
-        temporaryDirectory.create()
+        temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(LoggingFeature.instance)
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 
@@ -27,7 +27,7 @@ class LoggingFeatureTests: XCTestCase {
     func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationName: "FoobarApp",
@@ -56,7 +56,7 @@ class LoggingFeatureTests: XCTestCase {
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(
                     storagePerformance: StoragePerformanceMock(

--- a/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
@@ -10,10 +10,10 @@ import XCTest
 
 /// Observers the `FileWriter` and notifies when data was written, so `DataUploaderMock` can read it immediatelly.
 private class FileWriterObserver: FileWriterType {
-    let observedWriter: FileWriter
+    let observedWriter: ConsentAwareDataWriter
     let writeCallback: (() -> Void)
 
-    init(_ observedWriter: FileWriter, writeCallback: @escaping (() -> Void)) {
+    init(_ observedWriter: ConsentAwareDataWriter, writeCallback: @escaping (() -> Void)) {
         self.observedWriter = observedWriter
         self.writeCallback = writeCallback
     }
@@ -37,7 +37,7 @@ class DataUploadWorkerMock: DataUploadWorkerType {
     /// Observes the `FeatureStorage` to immediately capture written data.
     /// Returns new instance of the `FeatureStorage` which shuold be used instead of the original one.
     func observe(featureStorage: FeatureStorage) -> FeatureStorage {
-        let fileWriter = featureStorage.writer as! FileWriter
+        let fileWriter = featureStorage.writer as! ConsentAwareDataWriter
         let observedFileWriter = FileWriterObserver(fileWriter) { [weak self] in
             self?.readNextBatch()
         }

--- a/Tests/DatadogTests/Datadog/Mocks/FeatureDirectoriesMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/FeatureDirectoriesMock.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+@testable import Datadog
+
+/// `FeatureDirectories` pointing to subfolders in `/var/folders/`.
+/// Those subfolders do not exist by default and should be created and deleted by calling `.create()` and `.delete()` in each test,
+/// which guarantees clear state before and after test.
+let temporaryFeatureDirectories = FeatureDirectories(
+    unauthorized: obtainUniqueTemporaryDirectory(),
+    authorized: obtainUniqueTemporaryDirectory()
+)
+
+extension FeatureDirectories {
+    /// Creates temporary folder for each directory.
+    func create() {
+        authorized.create()
+        unauthorized.create()
+    }
+
+    /// Deletes each temporary folder.
+    func delete() {
+        authorized.delete()
+        unauthorized.delete()
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -20,22 +20,22 @@ extension LoggingFeature {
     /// Mocks the feature instance which performs uploads to `URLSession`.
     /// Use `ServerMock` to inspect and assert recorded `URLRequests`.
     static func mockWith(
-        directory: Directory,
+        directories: FeatureDirectories,
         configuration: FeaturesConfiguration.Logging = .mockAny(),
         dependencies: FeaturesCommonDependencies = .mockAny()
     ) -> LoggingFeature {
-        return LoggingFeature(directory: directory, configuration: configuration, commonDependencies: dependencies)
+        return LoggingFeature(directories: directories, configuration: configuration, commonDependencies: dependencies)
     }
 
     /// Mocks the feature instance which performs uploads to mocked `DataUploadWorker`.
     /// Use `LogFeature.waitAndReturnLogMatchers()` to inspect and assert recorded `Logs`.
     static func mockByRecordingLogMatchers(
-        directory: Directory,
+        directories: FeatureDirectories,
         configuration: FeaturesConfiguration.Logging = .mockAny(),
         dependencies: FeaturesCommonDependencies = .mockAny()
     ) -> LoggingFeature {
         // Get the full feature mock:
-        let fullFeature: LoggingFeature = .mockWith(directory: directory, dependencies: dependencies)
+        let fullFeature: LoggingFeature = .mockWith(directories: directories, dependencies: dependencies)
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -21,22 +21,22 @@ extension RUMFeature {
     /// Mocks the feature instance which performs uploads to `URLSession`.
     /// Use `ServerMock` to inspect and assert recorded `URLRequests`.
     static func mockWith(
-        directory: Directory,
+        directories: FeatureDirectories,
         configuration: FeaturesConfiguration.RUM = .mockAny(),
         dependencies: FeaturesCommonDependencies = .mockAny()
     ) -> RUMFeature {
-        return RUMFeature(directory: directory, configuration: configuration, commonDependencies: dependencies)
+        return RUMFeature(directories: directories, configuration: configuration, commonDependencies: dependencies)
     }
 
     /// Mocks the feature instance which performs uploads to mocked `DataUploadWorker`.
     /// Use `RUMFeature.waitAndReturnRUMEventMatchers()` to inspect and assert recorded `RUMEvents`.
     static func mockByRecordingRUMEventMatchers(
-        directory: Directory,
+        directories: FeatureDirectories,
         configuration: FeaturesConfiguration.RUM = .mockAny(),
         dependencies: FeaturesCommonDependencies = .mockAny()
     ) -> RUMFeature {
         // Get the full feature mock:
-        let fullFeature: RUMFeature = .mockWith(directory: directory, dependencies: dependencies)
+        let fullFeature: RUMFeature = .mockWith(directories: directories, dependencies: dependencies)
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -22,14 +22,14 @@ extension TracingFeature {
     /// Mocks the feature instance which performs uploads to `URLSession`.
     /// Use `ServerMock` to inspect and assert recorded `URLRequests`.
     static func mockWith(
-        directory: Directory,
+        directories: FeatureDirectories,
         configuration: FeaturesConfiguration.Tracing = .mockAny(),
         dependencies: FeaturesCommonDependencies = .mockAny(),
         loggingFeature: LoggingFeature? = nil,
         tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator()
     ) -> TracingFeature {
         return TracingFeature(
-            directory: directory,
+            directories: directories,
             configuration: configuration,
             commonDependencies: dependencies,
             loggingFeatureAdapter: loggingFeature.flatMap { LoggingForTracingAdapter(loggingFeature: $0) },
@@ -40,7 +40,7 @@ extension TracingFeature {
     /// Mocks the feature instance which performs uploads to mocked `DataUploadWorker`.
     /// Use `TracingFeature.waitAndReturnSpanMatchers()` to inspect and assert recorded `Spans`.
     static func mockByRecordingSpanMatchers(
-        directory: Directory,
+        directories: FeatureDirectories,
         configuration: FeaturesConfiguration.Tracing = .mockAny(),
         dependencies: FeaturesCommonDependencies = .mockAny(),
         loggingFeature: LoggingFeature? = nil,
@@ -48,7 +48,7 @@ extension TracingFeature {
     ) -> TracingFeature {
         // Get the full feature mock:
         let fullFeature: TracingFeature = .mockWith(
-            directory: directory, dependencies: dependencies, loggingFeature: loggingFeature, tracingUUIDGenerator: tracingUUIDGenerator
+            directories: directories, dependencies: dependencies, loggingFeature: loggingFeature, tracingUUIDGenerator: tracingUUIDGenerator
         )
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -12,13 +12,13 @@ class RUMFeatureTests: XCTestCase {
         super.setUp()
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(RUMFeature.instance)
-        temporaryDirectory.create()
+        temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(RUMFeature.instance)
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 
@@ -27,7 +27,7 @@ class RUMFeatureTests: XCTestCase {
     func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         RUMFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationName: "FoobarApp",
@@ -65,7 +65,7 @@ class RUMFeatureTests: XCTestCase {
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         RUMFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(
                     storagePerformance: StoragePerformanceMock(

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -13,7 +13,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
 
     func testRUMMonitorConfiguration() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationVersion: "1.2.3",

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -13,13 +13,13 @@ class RUMMonitorTests: XCTestCase {
         super.setUp()
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(RUMFeature.instance)
-        temporaryDirectory.create()
+        temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(RUMFeature.instance)
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 
@@ -28,7 +28,7 @@ class RUMMonitorTests: XCTestCase {
     func testStartingView() throws {
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 dateProvider: dateProvider
             )
@@ -60,7 +60,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingImageResourceWithRequest() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize()
@@ -94,7 +94,7 @@ class RUMMonitorTests: XCTestCase {
             return // `URLSessionTaskMetrics` mocking doesn't work prior to iOS 13.0
         }
 
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize()
@@ -129,7 +129,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingResourceWithURL() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize()
@@ -151,7 +151,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenTappingButton() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
@@ -186,7 +186,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingResources_whileScrolling() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize()
@@ -245,7 +245,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenIssuingAnError_whileScrolling() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0.01)
             )
@@ -294,7 +294,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingAnotherViewBeforeFirstIsStopped_thenLoadingResourcesAfterTapingButton() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(
                     startingFrom: Date(),
@@ -347,7 +347,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingLoadingResourcesFromTheFirstView_thenStartingAnotherViewWhichAlsoLoadsResources() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize()
@@ -409,7 +409,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenTappingButton_thenTappingAnotherButton() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
@@ -442,7 +442,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testWhenUserInfoIsProvided_itIsSendWithAllEvents() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 userInfoProvider: .mockWith(
                     userInfo: UserInfo(
@@ -497,7 +497,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testWhenNetworkAndCarrierInfoAreProvided_thenConnectivityInfoIsSendWithAllEvents() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 networkConnectionInfoProvider: NetworkConnectionInfoProviderMock(
                     networkConnectionInfo: .mockWith(reachability: .yes, availableInterfaces: [.cellular])
@@ -544,7 +544,7 @@ class RUMMonitorTests: XCTestCase {
     // MARK: - Sending Attributes
 
     func testSendingAttributes() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         let view1 = createMockView(viewControllerClassName: "FirstViewController")
@@ -587,7 +587,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testWhenViewIsStarted_attributesCanBeAddedOrUpdatedButNotRemoved() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         let monitor = RUMMonitor.initialize()

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -14,7 +14,7 @@ class TracerConfigurationTests: XCTestCase {
     override func setUp() {
         super.setUp()
         TracingFeature.instance = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationVersion: "1.2.3",

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -13,13 +13,13 @@ class TracerTests: XCTestCase {
         super.setUp()
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(LoggingFeature.instance)
-        temporaryDirectory.create()
+        temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(LoggingFeature.instance)
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 
@@ -27,7 +27,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithDefaultTracer() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationVersion: "1.0.0",
@@ -76,7 +76,7 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanWithCustomizedTracer() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         let tracer = Tracer.initialize(
@@ -106,7 +106,7 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanWithGlobalTags() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         let tracer = Tracer.initialize(
@@ -132,7 +132,7 @@ class TracerTests: XCTestCase {
     // MARK: - Sending Customized Spans
 
     func testSendingCustomizedSpan() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
@@ -160,7 +160,7 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanWithParentAndBaggageItems() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
@@ -220,7 +220,7 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanWithActiveSpanAsAParent() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
@@ -252,7 +252,7 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpansWithNoParent() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
@@ -281,7 +281,7 @@ class TracerTests: XCTestCase {
     }
 
     func testStartingRootActiveSpanInAsynchronousJobs() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         let tracer = Tracer.initialize(configuration: .init())
@@ -321,7 +321,7 @@ class TracerTests: XCTestCase {
         defer { Datadog.instance = nil }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 userInfoProvider: Datadog.instance!.userInfoProvider
             )
@@ -376,7 +376,7 @@ class TracerTests: XCTestCase {
     func testSendingCarrierInfoWhenEnteringAndLeavingCellularServiceRange() throws {
         let carrierInfoProvider = CarrierInfoProviderMock(carrierInfo: nil)
         TracingFeature.instance = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 carrierInfoProvider: carrierInfoProvider
             )
@@ -421,7 +421,7 @@ class TracerTests: XCTestCase {
     func testSendingNetworkConnectionInfoWhenReachabilityChanges() throws {
         let networkConnectionInfoProvider = NetworkConnectionInfoProviderMock.mockAny()
         TracingFeature.instance = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 networkConnectionInfoProvider: networkConnectionInfoProvider
             )
@@ -481,7 +481,7 @@ class TracerTests: XCTestCase {
     func testGivenBadBatteryConditions_itDoesNotTryToSendTraces() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 mobileDevice: .mockWith(
                     currentBatteryStatus: { () -> MobileDevice.BatteryStatus in
@@ -502,7 +502,7 @@ class TracerTests: XCTestCase {
     func testGivenNoNetworkConnection_itDoesNotTryToSendTraces() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
                     networkConnectionInfo: .mockWith(reachability: .no)
@@ -521,7 +521,7 @@ class TracerTests: XCTestCase {
     // MARK: - Sending tags
 
     func testSendingSpanTagsOfDifferentEncodableValues() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
@@ -592,7 +592,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanLogs() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
@@ -600,7 +600,7 @@ class TracerTests: XCTestCase {
         defer { LoggingFeature.instance = nil }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             ),
@@ -636,7 +636,7 @@ class TracerTests: XCTestCase {
     // MARK: - Integration With RUM Feature
 
     func testGivenBundlingWithRUMEnabledAndRUMMonitorRegistered_whenSendingSpan_itContainsCurrentRUMContext() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         RUMFeature.instance = .mockNoOp()
@@ -663,7 +663,7 @@ class TracerTests: XCTestCase {
     }
 
     func testGivenBundlingWithRUMEnabledButRUMMonitorNotRegistered_whenSendingSpan_itPrintsWarning() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         RUMFeature.instance = .mockNoOp()
@@ -700,7 +700,7 @@ class TracerTests: XCTestCase {
         TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance = nil }
 
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         // given
@@ -728,7 +728,7 @@ class TracerTests: XCTestCase {
         TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance = nil }
 
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 
         // given

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -12,13 +12,13 @@ class TracingFeatureTests: XCTestCase {
         super.setUp()
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(TracingFeature.instance)
-        temporaryDirectory.create()
+        temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
         XCTAssertNil(Datadog.instance)
         XCTAssertNil(TracingFeature.instance)
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 
@@ -27,7 +27,7 @@ class TracingFeatureTests: XCTestCase {
     func testItUsesExpectedHTTPMessage() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationName: "FoobarApp",
@@ -58,7 +58,7 @@ class TracingFeatureTests: XCTestCase {
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         TracingFeature.instance = .mockWith(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(
                     storagePerformance: StoragePerformanceMock(

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -14,17 +14,17 @@ class DDLoggerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         XCTAssertNil(LoggingFeature.instance)
-        temporaryDirectory.create()
+        temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
         XCTAssertNil(LoggingFeature.instance)
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 
     func testSendingLogsWithDifferentLevels() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         let objcLogger = DDLogger.builder().build()
@@ -46,7 +46,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSendingNSError() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         let objcLogger = DDLogger.builder().build()
@@ -78,7 +78,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSendingMessageAttributes() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         let objcLogger = DDLogger.builder().build()
@@ -103,7 +103,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSendingLoggerAttributes() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         let objcLogger = DDLogger.builder().build()
@@ -141,7 +141,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSettingTagsAndAttributes() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "test"))
         )
         defer { LoggingFeature.instance = nil }

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -12,17 +12,17 @@ class DDTracerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         XCTAssertNil(TracingFeature.instance)
-        temporaryDirectory.create()
+        temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
         XCTAssertNil(TracingFeature.instance)
-        temporaryDirectory.delete()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 
     func testSendingCustomizedSpans() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         let objcTracer = DDTracer.initialize(configuration: DDTracerConfiguration()).dd!
@@ -115,7 +115,7 @@ class DDTracerTests: XCTestCase {
 
     func testSendingSpanLogs() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
@@ -123,7 +123,7 @@ class DDTracerTests: XCTestCase {
         defer { LoggingFeature.instance = nil }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
+            directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             ),


### PR DESCRIPTION
### What and why?

📦 As the first part of tracking consent feature, this PR introduces the `ConsentAwareDataWriter`.

### How?

Each feature is now configured with two distinct directories, instead of one:
```swift
internal struct FeatureDirectories {
    let unauthorized: Directory
    let authorized: Directory
}
```

This is followed by the update to storage layer: `Feature` → `FeatureStorage` → `FileWriter: FileWriterType`,
which was was replaced with: `Feature` → `FeatureStorage` → `ConsentAwareDataWriter: FileWriterType`.

The `ConsentAwareDataWriter` will manage different instances of `FileWriter`, each writing to different directory.

In next PRs, more components will be added, towards the model we use in `dd-sdk-android`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
