### PR TITLE
RUMM-830 Add consent provider

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		6114FE0F257667D40084E372 /* ConsentAwareDataWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */; };
 		6114FE1625766B310084E372 /* TrackingConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE1525766B310084E372 /* TrackingConsent.swift */; };
 		6114FE23257671F00084E372 /* ConsentAwareDataWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */; };
+		6114FE2F257687310084E372 /* ConsentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE2E257687300084E372 /* ConsentProvider.swift */; };
+		6114FE3B25768AA90084E372 /* ConsentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE3A25768AA90084E372 /* ConsentProviderTests.swift */; };
 		61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */; };
 		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
 		61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */; };
@@ -485,6 +487,8 @@
 		6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentAwareDataWriter.swift; sourceTree = "<group>"; };
 		6114FE1525766B310084E372 /* TrackingConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingConsent.swift; sourceTree = "<group>"; };
 		6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentAwareDataWriterTests.swift; sourceTree = "<group>"; };
+		6114FE2E257687300084E372 /* ConsentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentProvider.swift; sourceTree = "<group>"; };
+		6114FE3A25768AA90084E372 /* ConsentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentProviderTests.swift; sourceTree = "<group>"; };
 		61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSViewController.swift; sourceTree = "<group>"; };
 		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
 		61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMModalViewsScenarioTests.swift; sourceTree = "<group>"; };
@@ -1250,6 +1254,7 @@
 			isa = PBXGroup;
 			children = (
 				6114FE1525766B310084E372 /* TrackingConsent.swift */,
+				6114FE2E257687300084E372 /* ConsentProvider.swift */,
 				6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */,
 			);
 			path = Privacy;
@@ -1259,6 +1264,7 @@
 			isa = PBXGroup;
 			children = (
 				6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */,
+				6114FE3A25768AA90084E372 /* ConsentProviderTests.swift */,
 			);
 			path = Privacy;
 			sourceTree = "<group>";
@@ -2514,6 +2520,7 @@
 				9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */,
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
 				61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */,
+				6114FE2F257687310084E372 /* ConsentProvider.swift in Sources */,
 				61F3CDA52511190E00C816E5 /* UIViewControllerSwizzler.swift in Sources */,
 				6156CB9024DDA8BE008CB2B2 /* RUMCurrentContext.swift in Sources */,
 				614B0A4F24EBDC6B00A2A780 /* RUMConnectivityInfoProvider.swift in Sources */,
@@ -2713,6 +2720,7 @@
 				61133C652423990D00786299 /* LogBuilderTests.swift in Sources */,
 				61F8CC092469295500FE2908 /* DatadogConfigurationBuilderTests.swift in Sources */,
 				61F1A623249B811200075390 /* Encoding.swift in Sources */,
+				6114FE3B25768AA90084E372 /* ConsentProviderTests.swift in Sources */,
 				61133C642423990D00786299 /* LoggerTests.swift in Sources */,
 				617B953D24BF4D8F00E6F443 /* RUMMonitorTests.swift in Sources */,
 				61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -56,8 +56,11 @@ internal struct FeatureStorage {
             dateProvider: commonDependencies.dateProvider
         )
 
+        // TODO: RUMM-833 Share consent provider among all features
+        let consentProvider = ConsentProvider(initialConsent: .granted)
+
         let consentAwareDataWriter = ConsentAwareDataWriter(
-            initialConsent: .granted, // TODO: RUMM-830 Inject `ConsentProvider`
+            consentProvider: consentProvider,
             queue: readWriteQueue,
             unauthorizedFileWriter: FileWriter(
                 dataFormat: dataFormat,

--- a/Sources/Datadog/Core/Persistence/Privacy/ConsentProvider.swift
+++ b/Sources/Datadog/Core/Persistence/Privacy/ConsentProvider.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal protocol ConsentSubscriber: class {
+    func consentChanged(from oldValue: TrackingConsent, to newValue: TrackingConsent)
+}
+
+/// Provides the current `TrackingConsent` value and notifies all subscribers on its change.
+internal class ConsentProvider {
+    private var subscribers: [ConsentSubscriber] = []
+
+    init(initialConsent: TrackingConsent) {
+        self.currentValue = initialConsent
+    }
+
+    // MARK: - Consent Value
+
+    /// The current value of `TrackingConsent`.
+    private(set) var currentValue: TrackingConsent {
+        didSet {
+            subscribers.forEach { subscriber in
+                subscriber.consentChanged(from: oldValue, to: currentValue)
+            }
+        }
+    }
+
+    /// Sets the new value of `TrackingConsent` and notifies all subscribers.
+    func changeConsent(to newValue: TrackingConsent) {
+        self.currentValue = newValue
+    }
+
+    // MARK: - Managing Subscribers
+
+    func subscribe(consentSubscriber: ConsentSubscriber) {
+        subscribers.append(consentSubscriber)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Privacy/ConsentProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Privacy/ConsentProviderTests.swift
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+private class ConsentSubscriberMock: ConsentSubscriber {
+    var consentChange: (oldValue: TrackingConsent, newValue: TrackingConsent)?
+
+    func consentChanged(from oldValue: TrackingConsent, to newValue: TrackingConsent) {
+        consentChange = (oldValue: oldValue, newValue: newValue)
+    }
+}
+
+class ConsentProviderTests: XCTestCase {
+    func testGivenInitialConsentSet_whenTheValueChanges_itCanBeRetrieved() {
+        let initialConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
+        let newConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
+
+        // Given
+        let provider = ConsentProvider(initialConsent: initialConsent)
+        XCTAssertEqual(provider.currentValue, initialConsent)
+
+        // When
+        provider.changeConsent(to: newConsent)
+
+        // Then
+        XCTAssertEqual(provider.currentValue, newConsent)
+    }
+
+    func testGivenInitialConsentSet_whenTheValueChanges_itNotifiesAllSubscribers() {
+        let initialConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
+        let newConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
+        let subscribers = (0..<5).map { _ in ConsentSubscriberMock() }
+
+        // Given
+        let provider = ConsentProvider(initialConsent: initialConsent)
+        subscribers.forEach { subscriber in
+            provider.subscribe(consentSubscriber: subscriber)
+        }
+
+        // When
+        provider.changeConsent(to: newConsent)
+
+        // Then
+        subscribers.forEach { subscriber in
+            XCTAssertEqual(subscriber.consentChange?.oldValue, initialConsent)
+            XCTAssertEqual(subscriber.consentChange?.newValue, newConsent)
+        }
+    }
+}


### PR DESCRIPTION
### What and why?

📦 As the next part of tracking consent feature, this PR introduces the `ConsentProvider`.

### How?

`ConsentProvider` implements basic subscription model. The `ConsentAwareDataWriter` reads the consent value and subscribes to its updates.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
