### PR TITLE
RUMM-831 Add `DataProcessor`

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		6193DCE8251B9AB1009B8011 /* RUMTASCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCE7251B9AB1009B8011 /* RUMTASCollectionViewController.swift */; };
 		61940C7C25668EC600A20043 /* URLSessionInterceptionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61940C7B25668EC600A20043 /* URLSessionInterceptionHandler.swift */; };
 		6198D27124C6E3B700493501 /* RUMViewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */; };
+		619E16D82577C1CB00B2516B /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16D72577C1CB00B2516B /* DataProcessor.swift */; };
 		61A763DC252DB2B3005A23F2 /* NSURLSessionBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */; };
 		61A9238E256FCAA2009B9667 /* DateCorrectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A9238D256FCAA2009B9667 /* DateCorrectionTests.swift */; };
 		61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */; };
@@ -653,6 +654,7 @@
 		6193DCE7251B9AB1009B8011 /* RUMTASCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASCollectionViewController.swift; sourceTree = "<group>"; };
 		61940C7B25668EC600A20043 /* URLSessionInterceptionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionInterceptionHandler.swift; sourceTree = "<group>"; };
 		6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewScopeTests.swift; sourceTree = "<group>"; };
+		619E16D72577C1CB00B2516B /* DataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProcessor.swift; sourceTree = "<group>"; };
 		61A763D9252DB2B3005A23F2 /* DatadogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DatadogTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		61A763DA252DB2B3005A23F2 /* NSURLSessionBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionBridge.h; sourceTree = "<group>"; };
 		61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionBridge.m; sourceTree = "<group>"; };
@@ -1464,6 +1466,7 @@
 				613E79272577B0EE00DFCC17 /* Writer.swift */,
 				6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */,
 				61133BA72423979B00786299 /* FileWriter.swift */,
+				619E16D62577C19F00B2516B /* Processing */,
 			);
 			path = Writting;
 			sourceTree = "<group>";
@@ -1865,6 +1868,14 @@
 				61133C282423990D00786299 /* FileReaderTests.swift */,
 			);
 			path = Reading;
+			sourceTree = "<group>";
+		};
+		619E16D62577C19F00B2516B /* Processing */ = {
+			isa = PBXGroup;
+			children = (
+				619E16D72577C1CB00B2516B /* DataProcessor.swift */,
+			);
+			path = Processing;
 			sourceTree = "<group>";
 		};
 		61B03872252724AB00518F3C /* URLSessionAutoInstrumentation */ = {
@@ -2697,6 +2708,7 @@
 				61133BD82423979B00786299 /* HTTPClient.swift in Sources */,
 				61B038542527246D00518F3C /* URLSessionSwizzler.swift in Sources */,
 				61133BDB2423979B00786299 /* DatadogConfiguration.swift in Sources */,
+				619E16D82577C1CB00B2516B /* DataProcessor.swift in Sources */,
 				614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */,
 				61F3CDA72512144600C816E5 /* UIKitRUMViewsPredicate.swift in Sources */,
 				61133BCE2423979B00786299 /* BatteryStatusProvider.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -114,6 +114,9 @@
 		613BE04A25640FF80015216C /* BenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613BE04925640FF80015216C /* BenchmarkTests.swift */; };
 		613BE06225642F790015216C /* RUMStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613BE06125642F790015216C /* RUMStorageBenchmarkTests.swift */; };
 		613BE073256431960015216C /* FoundationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C202423990D00786299 /* FoundationMocks.swift */; };
+		613E79282577B0EE00DFCC17 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E79272577B0EE00DFCC17 /* Writer.swift */; };
+		613E792F2577B0F900DFCC17 /* Reader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E792E2577B0F900DFCC17 /* Reader.swift */; };
+		613E793B2577B6EE00DFCC17 /* DataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E793A2577B6EE00DFCC17 /* DataReader.swift */; };
 		613F23E4252B062F006CD2D7 /* TaskInterceptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23E3252B062F006CD2D7 /* TaskInterceptionTests.swift */; };
 		613F23F1252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23F0252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift */; };
 		613F23FD252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23FC252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift */; };
@@ -536,6 +539,9 @@
 		613BE0422563FB9E0015216C /* RUMBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMBenchmarkTests.swift; sourceTree = "<group>"; };
 		613BE04925640FF80015216C /* BenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkTests.swift; sourceTree = "<group>"; };
 		613BE06125642F790015216C /* RUMStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMStorageBenchmarkTests.swift; sourceTree = "<group>"; };
+		613E79272577B0EE00DFCC17 /* Writer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
+		613E792E2577B0F900DFCC17 /* Reader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reader.swift; sourceTree = "<group>"; };
+		613E793A2577B6EE00DFCC17 /* DataReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataReader.swift; sourceTree = "<group>"; };
 		613F23E3252B062F006CD2D7 /* TaskInterceptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInterceptionTests.swift; sourceTree = "<group>"; };
 		613F23F0252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionRUMResourcesHandlerTests.swift; sourceTree = "<group>"; };
 		613F23FC252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionAutoInstrumentationTests.swift; sourceTree = "<group>"; };
@@ -956,8 +962,8 @@
 			children = (
 				61AD4E3724531500006E34EA /* DataFormat.swift */,
 				61133BA92423979B00786299 /* FilesOrchestrator.swift */,
-				61133BA72423979B00786299 /* FileWriter.swift */,
-				61133BAD2423979B00786299 /* FileReader.swift */,
+				613E79412577C08900DFCC17 /* Writting */,
+				613E79422577C09B00DFCC17 /* Reading */,
 				6114FE0D257667AD0084E372 /* Privacy */,
 				61133BAA2423979B00786299 /* Files */,
 			);
@@ -1183,8 +1189,8 @@
 			isa = PBXGroup;
 			children = (
 				61133C2A2423990D00786299 /* FilesOrchestratorTests.swift */,
-				61133C292423990D00786299 /* FileWriterTests.swift */,
-				61133C282423990D00786299 /* FileReaderTests.swift */,
+				619E16D42577C11B00B2516B /* Writting */,
+				619E16D52577C12100B2516B /* Reading */,
 				6114FE21257671CB0084E372 /* Privacy */,
 				61133C2B2423990D00786299 /* Files */,
 			);
@@ -1290,7 +1296,6 @@
 			children = (
 				6114FE1525766B310084E372 /* TrackingConsent.swift */,
 				6114FE2E257687300084E372 /* ConsentProvider.swift */,
-				6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */,
 			);
 			path = Privacy;
 			sourceTree = "<group>";
@@ -1298,7 +1303,6 @@
 		6114FE21257671CB0084E372 /* Privacy */ = {
 			isa = PBXGroup;
 			children = (
-				6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */,
 				6114FE3A25768AA90084E372 /* ConsentProviderTests.swift */,
 			);
 			path = Privacy;
@@ -1452,6 +1456,26 @@
 				613BE06125642F790015216C /* RUMStorageBenchmarkTests.swift */,
 			);
 			path = DataStorage;
+			sourceTree = "<group>";
+		};
+		613E79412577C08900DFCC17 /* Writting */ = {
+			isa = PBXGroup;
+			children = (
+				613E79272577B0EE00DFCC17 /* Writer.swift */,
+				6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */,
+				61133BA72423979B00786299 /* FileWriter.swift */,
+			);
+			path = Writting;
+			sourceTree = "<group>";
+		};
+		613E79422577C09B00DFCC17 /* Reading */ = {
+			isa = PBXGroup;
+			children = (
+				613E792E2577B0F900DFCC17 /* Reader.swift */,
+				613E793A2577B6EE00DFCC17 /* DataReader.swift */,
+				61133BAD2423979B00786299 /* FileReader.swift */,
+			);
+			path = Reading;
 			sourceTree = "<group>";
 		};
 		613F23DC252B05BD006CD2D7 /* URLFiltering */ = {
@@ -1824,6 +1848,23 @@
 				61A9238D256FCAA2009B9667 /* DateCorrectionTests.swift */,
 			);
 			path = Time;
+			sourceTree = "<group>";
+		};
+		619E16D42577C11B00B2516B /* Writting */ = {
+			isa = PBXGroup;
+			children = (
+				6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */,
+				61133C292423990D00786299 /* FileWriterTests.swift */,
+			);
+			path = Writting;
+			sourceTree = "<group>";
+		};
+		619E16D52577C12100B2516B /* Reading */ = {
+			isa = PBXGroup;
+			children = (
+				61133C282423990D00786299 /* FileReaderTests.swift */,
+			);
+			path = Reading;
 			sourceTree = "<group>";
 		};
 		61B03872252724AB00518F3C /* URLSessionAutoInstrumentation */ = {
@@ -2598,6 +2639,7 @@
 				9EFD112C24B32D29003A1A2B /* FirstPartyURLsFilter.swift in Sources */,
 				61B0386C2527247B00518F3C /* TaskInterception.swift in Sources */,
 				61B03892252724D900518F3C /* HTTPHeadersReader.swift in Sources */,
+				613E79282577B0EE00DFCC17 /* Writer.swift in Sources */,
 				61B0384E2527246900518F3C /* URLSessionAutoInstrumentation.swift in Sources */,
 				61C5A88924509A0C00DA608C /* DDSpanContext.swift in Sources */,
 				6141015B251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift in Sources */,
@@ -2606,6 +2648,7 @@
 				616CCE13250A1868009FED46 /* RUMCommandSubscriber.swift in Sources */,
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
 				614D812C24E3EA15004C9C5D /* Feature.swift in Sources */,
+				613E792F2577B0F900DFCC17 /* Reader.swift in Sources */,
 				61B0385A2527247000518F3C /* DDURLSessionDelegate.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
 				6149FB3A2529D17F00EE387A /* InternalURLsFilter.swift in Sources */,
@@ -2618,6 +2661,7 @@
 				61C5A88E24509A1F00DA608C /* Tracer.swift in Sources */,
 				61E909EE24A24DD3005EA2DE /* OTFormat.swift in Sources */,
 				9E26E6B924C87693000B3270 /* RUMDataModels.swift in Sources */,
+				613E793B2577B6EE00DFCC17 /* DataReader.swift in Sources */,
 				614B0A5324EBFE5500A2A780 /* DDRUMMonitor.swift in Sources */,
 				61133BE32423979B00786299 /* UserInfoProvider.swift in Sources */,
 				61133BE02423979B00786299 /* Datadog.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -63,13 +63,15 @@ internal struct FeatureStorage {
         let consentAwareDataWriter = ConsentAwareDataWriter(
             consentProvider: consentProvider,
             readWriteQueue: readWriteQueue,
-            unauthorizedFileWriter: FileWriter(
-                dataFormat: dataFormat,
-                orchestrator: unauthorizedFilesOrchestrator
-            ),
-            authorizedFileWriter: FileWriter(
-                dataFormat: dataFormat,
-                orchestrator: authorizedFilesOrchestrator
+            dataProcessorFactory: DataProcessorFactory(
+                unauthorizedFileWriter: FileWriter(
+                    dataFormat: dataFormat,
+                    orchestrator: unauthorizedFilesOrchestrator
+                ),
+                authorizedFileWriter: FileWriter(
+                    dataFormat: dataFormat,
+                    orchestrator: authorizedFilesOrchestrator
+                )
             )
         )
 

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -32,9 +32,9 @@ internal struct FeaturesCommonDependencies {
 
 internal struct FeatureStorage {
     /// Writes data to files.
-    let writer: FileWriterType
+    let writer: Writer
     /// Reads data from files.
-    let reader: FileReaderType
+    let reader: Reader
 
     init(
         featureName: String,
@@ -62,26 +62,29 @@ internal struct FeatureStorage {
 
         let consentAwareDataWriter = ConsentAwareDataWriter(
             consentProvider: consentProvider,
-            queue: readWriteQueue,
+            readWriteQueue: readWriteQueue,
             unauthorizedFileWriter: FileWriter(
                 dataFormat: dataFormat,
-                orchestrator: unauthorizedFilesOrchestrator,
-                queue: readWriteQueue
+                orchestrator: unauthorizedFilesOrchestrator
             ),
             authorizedFileWriter: FileWriter(
                 dataFormat: dataFormat,
-                orchestrator: authorizedFilesOrchestrator,
-                queue: readWriteQueue
+                orchestrator: authorizedFilesOrchestrator
             )
+        )
+
+        let dataReader = DataReader(
+            readWriteQueue: readWriteQueue,
+            fileReader: FileReader(dataFormat: dataFormat, orchestrator: authorizedFilesOrchestrator)
         )
 
         self.init(
             writer: consentAwareDataWriter,
-            reader: FileReader(dataFormat: dataFormat, orchestrator: authorizedFilesOrchestrator, queue: readWriteQueue)
+            reader: dataReader
         )
     }
 
-    init(writer: FileWriterType, reader: FileReaderType) {
+    init(writer: Writer, reader: Reader) {
         self.writer = writer
         self.reader = reader
     }

--- a/Sources/Datadog/Core/Persistence/Reading/DataReader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/DataReader.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Synchronizes the work of `FileReader` on given read/write queue.
+internal final class DataReader: Reader {
+    /// Queue used to synchronize reads and writes for the feature.
+    private let readWriteQueue: DispatchQueue
+    private let fileReader: Reader
+
+    init(readWriteQueue: DispatchQueue, fileReader: Reader) {
+        self.readWriteQueue = readWriteQueue
+        self.fileReader = fileReader
+    }
+
+    func readNextBatch() -> Batch? {
+        readWriteQueue.sync {
+            self.fileReader.readNextBatch()
+        }
+    }
+
+    func markBatchAsRead(_ batch: Batch) {
+        readWriteQueue.sync {
+            self.fileReader.markBatchAsRead(batch)
+        }
+    }
+}

--- a/Sources/Datadog/Core/Persistence/Reading/Reader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/Reader.swift
@@ -6,10 +6,14 @@
 
 import Foundation
 
-internal struct RUMEventFileOutput: RUMEventOutput {
-    let fileWriter: Writer
+internal struct Batch {
+    let data: Data
+    /// File from which `data` was read.
+    let file: ReadableFile
+}
 
-    func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {
-        fileWriter.write(value: rumEvent)
-    }
+/// A type, reading batched data.
+internal protocol Reader {
+    func readNextBatch() -> Batch?
+    func markBatchAsRead(_ batch: Batch)
 }

--- a/Sources/Datadog/Core/Persistence/Writting/ConsentAwareDataWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/ConsentAwareDataWriter.swift
@@ -6,26 +6,26 @@
 
 import Foundation
 
-/// File writer which writes data to different folders depending on the tracking consent value.
-internal class ConsentAwareDataWriter: FileWriterType, ConsentSubscriber {
+/// Writes data to different folders depending on the tracking consent value.
+/// It synchronizes the work of underlying `FileWriters` on given read/write queue.
+internal class ConsentAwareDataWriter: Writer, ConsentSubscriber {
     /// Queue used to synchronize reads and writes for the feature.
-    /// TODO: RUMM-832 will be used to synchornize data migration with reads and writes.
-    internal let queue: DispatchQueue
+    internal let readWriteQueue: DispatchQueue
     /// File writer writting unauthorized data when consent is `.pending`.
-    private let unauthorizedFileWriter: FileWriterType
+    private let unauthorizedFileWriter: Writer
     /// File writer writting authorized data when consent is `.granted`.
-    private let authorizedFileWriter: FileWriterType
+    private let authorizedFileWriter: Writer
 
     /// File writer for current consent value (including `nil` if consent is `.notGranted`).
-    private var activeFileWriter: FileWriterType?
+    private var activeFileWriter: Writer?
 
     init(
         consentProvider: ConsentProvider,
-        queue: DispatchQueue,
-        unauthorizedFileWriter: FileWriterType,
-        authorizedFileWriter: FileWriterType
+        readWriteQueue: DispatchQueue,
+        unauthorizedFileWriter: Writer,
+        authorizedFileWriter: Writer
     ) {
-        self.queue = queue
+        self.readWriteQueue = readWriteQueue
         self.unauthorizedFileWriter = unauthorizedFileWriter
         self.authorizedFileWriter = authorizedFileWriter
         self.activeFileWriter = resolveActiveFileWriter(
@@ -37,41 +37,33 @@ internal class ConsentAwareDataWriter: FileWriterType, ConsentSubscriber {
         consentProvider.subscribe(consentSubscriber: self)
     }
 
-    // MARK: - FileWriterType
+    // MARK: - Writer
 
     func write<T>(value: T) where T: Encodable {
-        synchronized {
-            activeFileWriter?.write(value: value)
+        readWriteQueue.async {
+            self.activeFileWriter?.write(value: value)
         }
     }
 
     // MARK: - ConsentSubscriber
 
     func consentChanged(from oldValue: TrackingConsent, to newValue: TrackingConsent) {
-        synchronized {
-            activeFileWriter = resolveActiveFileWriter(
+        readWriteQueue.async {
+            self.activeFileWriter = resolveActiveFileWriter(
                 for: newValue,
-                unauthorizedWriter: unauthorizedFileWriter,
-                authorizedWriter: authorizedFileWriter
+                unauthorizedWriter: self.unauthorizedFileWriter,
+                authorizedWriter: self.authorizedFileWriter
             )
         }
-    }
-
-    // MARK: - Private
-
-    private func synchronized(block: () -> Void) {
-        objc_sync_enter(self)
-        block()
-        objc_sync_exit(self)
     }
 }
 
 // TODO: RUMM-831 Move writer resolution to `DataProcessorFactory`
 private func resolveActiveFileWriter(
     for consent: TrackingConsent,
-    unauthorizedWriter: FileWriterType,
-    authorizedWriter: FileWriterType
-) -> FileWriterType? {
+    unauthorizedWriter: Writer,
+    authorizedWriter: Writer
+) -> Writer? {
     switch consent {
     case .granted: return authorizedWriter
     case .notGranted: return nil

--- a/Sources/Datadog/Core/Persistence/Writting/ConsentAwareDataWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/ConsentAwareDataWriter.swift
@@ -11,28 +11,20 @@ import Foundation
 internal class ConsentAwareDataWriter: Writer, ConsentSubscriber {
     /// Queue used to synchronize reads and writes for the feature.
     internal let readWriteQueue: DispatchQueue
-    /// File writer writting unauthorized data when consent is `.pending`.
-    private let unauthorizedFileWriter: Writer
-    /// File writer writting authorized data when consent is `.granted`.
-    private let authorizedFileWriter: Writer
+    /// Creates data processors depending on the tracking consent value.
+    private let dataProcessorFactory: DataProcessorFactory
 
-    /// File writer for current consent value (including `nil` if consent is `.notGranted`).
-    private var activeFileWriter: Writer?
+    /// Data processor for current tracking consent.
+    private var processor: DataProcessor?
 
     init(
         consentProvider: ConsentProvider,
         readWriteQueue: DispatchQueue,
-        unauthorizedFileWriter: Writer,
-        authorizedFileWriter: Writer
+        dataProcessorFactory: DataProcessorFactory
     ) {
         self.readWriteQueue = readWriteQueue
-        self.unauthorizedFileWriter = unauthorizedFileWriter
-        self.authorizedFileWriter = authorizedFileWriter
-        self.activeFileWriter = resolveActiveFileWriter(
-            for: consentProvider.currentValue,
-            unauthorizedWriter: unauthorizedFileWriter,
-            authorizedWriter: authorizedFileWriter
-        )
+        self.dataProcessorFactory = dataProcessorFactory
+        self.processor = dataProcessorFactory.resolveProcessor(for: consentProvider.currentValue)
 
         consentProvider.subscribe(consentSubscriber: self)
     }
@@ -41,7 +33,7 @@ internal class ConsentAwareDataWriter: Writer, ConsentSubscriber {
 
     func write<T>(value: T) where T: Encodable {
         readWriteQueue.async {
-            self.activeFileWriter?.write(value: value)
+            self.processor?.write(value: value)
         }
     }
 
@@ -49,24 +41,7 @@ internal class ConsentAwareDataWriter: Writer, ConsentSubscriber {
 
     func consentChanged(from oldValue: TrackingConsent, to newValue: TrackingConsent) {
         readWriteQueue.async {
-            self.activeFileWriter = resolveActiveFileWriter(
-                for: newValue,
-                unauthorizedWriter: self.unauthorizedFileWriter,
-                authorizedWriter: self.authorizedFileWriter
-            )
+            self.processor = self.dataProcessorFactory.resolveProcessor(for: newValue)
         }
-    }
-}
-
-// TODO: RUMM-831 Move writer resolution to `DataProcessorFactory`
-private func resolveActiveFileWriter(
-    for consent: TrackingConsent,
-    unauthorizedWriter: Writer,
-    authorizedWriter: Writer
-) -> Writer? {
-    switch consent {
-    case .granted: return authorizedWriter
-    case .notGranted: return nil
-    case .pending: return unauthorizedWriter
     }
 }

--- a/Sources/Datadog/Core/Persistence/Writting/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/FileWriter.swift
@@ -6,39 +6,25 @@
 
 import Foundation
 
-/// Abstracts the `FileWriter`, so we can have no-op writer in tests.
-internal protocol FileWriterType {
-    func write<T: Encodable>(value: T)
-}
-
-internal final class FileWriter: FileWriterType {
+/// Writes data to files.
+internal final class FileWriter: Writer {
     /// Data writting format.
     private let dataFormat: DataFormat
     /// Orchestrator producing reference to writable file.
     private let orchestrator: FilesOrchestrator
     /// JSON encoder used to encode data.
     private let jsonEncoder: JSONEncoder
-    /// Queue used to synchronize files access (read / write) and perform decoding on background thread.
-    internal let queue: DispatchQueue
 
-    init(dataFormat: DataFormat, orchestrator: FilesOrchestrator, queue: DispatchQueue) {
+    init(dataFormat: DataFormat, orchestrator: FilesOrchestrator) {
         self.dataFormat = dataFormat
         self.orchestrator = orchestrator
-        self.queue = queue
         self.jsonEncoder = JSONEncoder.default()
     }
 
     // MARK: - Writing data
 
-    /// Encodes given value to JSON data and writes it to file.
-    /// Comma is used to separate consecutive values in the file.
+    /// Encodes given value to JSON data and writes it to the file.
     func write<T: Encodable>(value: T) {
-        queue.async { [weak self] in
-            self?.synchronizedWrite(value: value)
-        }
-    }
-
-    private func synchronizedWrite<T: Encodable>(value: T) {
         do {
             let data = try jsonEncoder.encode(value)
             let file = try orchestrator.getWritableFile(writeSize: UInt64(data.count))

--- a/Sources/Datadog/Core/Persistence/Writting/Processing/DataProcessor.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/Processing/DataProcessor.swift
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct DataProcessorFactory {
+    /// File writer writting unauthorized data when consent is `.pending`.
+    let unauthorizedFileWriter: Writer
+    /// File writer writting authorized data when consent is `.granted`.
+    let authorizedFileWriter: Writer
+
+    func resolveProcessor(for consent: TrackingConsent) -> DataProcessor? {
+        switch consent {
+        case .granted: return DataProcessor(fileWriter: authorizedFileWriter)
+        case .notGranted: return nil
+        case .pending: return DataProcessor(fileWriter: unauthorizedFileWriter)
+        }
+    }
+}
+
+/// The processing pipeline for writing data.
+internal final class DataProcessor: Writer {
+    private let fileWriter: Writer
+
+    init(fileWriter: Writer) {
+        self.fileWriter = fileWriter
+    }
+
+    // MARK: - Writer
+
+    func write<T>(value: T) where T: Encodable {
+        fileWriter.write(value: value)
+    }
+}

--- a/Sources/Datadog/Core/Persistence/Writting/Writer.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/Writer.swift
@@ -6,10 +6,7 @@
 
 import Foundation
 
-internal struct RUMEventFileOutput: RUMEventOutput {
-    let fileWriter: Writer
-
-    func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>) {
-        fileWriter.write(value: rumEvent)
-    }
+/// A type, writting data.
+internal protocol Writer {
+    func write<T: Encodable>(value: T)
 }

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -13,7 +13,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
     /// Queue to execute uploads.
     private let queue: DispatchQueue
     /// File reader providing data to upload.
-    private let fileReader: FileReaderType
+    private let fileReader: Reader
     /// Data uploader sending data to server.
     private let dataUploader: DataUploader
     /// Variable system conditions determining if upload should be performed.
@@ -31,7 +31,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
     init(
         queue: DispatchQueue,
-        fileReader: FileReaderType,
+        fileReader: Reader,
         dataUploader: DataUploader,
         uploadConditions: DataUploadConditions,
         delay: Delay,

--- a/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
@@ -9,7 +9,7 @@ import Foundation
 /// `LogOutput` which saves logs to file.
 internal struct LogFileOutput: LogOutput {
     let logBuilder: LogBuilder
-    let fileWriter: FileWriterType
+    let fileWriter: Writer
     /// Integration with RUM Errors.
     let rumErrorsIntegration: LoggingWithRUMErrorsIntegration?
 

--- a/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
+++ b/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
@@ -9,7 +9,7 @@ import Foundation
 /// `SpanOutput` which saves spans to file.
 internal struct SpanFileOutput: SpanOutput {
     let spanBuilder: SpanBuilder
-    let fileWriter: FileWriterType
+    let fileWriter: Writer
     /// Integration with RUM Errors.
     let rumErrorsIntegration = TracingWithRUMErrorsIntegration()
 

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -11,8 +11,8 @@ class LoggingStorageBenchmarkTests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
     private var queue: DispatchQueue!
     private var directory: Directory!
-    private var writer: ConsentAwareDataWriter!
-    private var reader: FileReader!
+    private var writer: Writer!
+    private var reader: Reader!
     // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUpWithError() throws {
@@ -26,9 +26,9 @@ class LoggingStorageBenchmarkTests: XCTestCase {
             ),
             commonDependencies: .mockAny()
         )
-        self.writer = storage.writer as? ConsentAwareDataWriter
-        self.reader = storage.reader as? FileReader
-        self.queue = self.writer.queue
+        self.writer = storage.writer
+        self.reader = storage.reader
+        self.queue = (storage.writer as! ConsentAwareDataWriter).readWriteQueue
 
         XCTAssertTrue(try directory.files().count == 0)
     }

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -11,8 +11,8 @@ class RUMStorageBenchmarkTests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
     private var queue: DispatchQueue!
     private var directory: Directory!
-    private var writer: ConsentAwareDataWriter!
-    private var reader: FileReader!
+    private var writer: Writer!
+    private var reader: Reader!
     // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUpWithError() throws {
@@ -26,9 +26,9 @@ class RUMStorageBenchmarkTests: XCTestCase {
             ),
             commonDependencies: .mockAny()
         )
-        self.writer = storage.writer as? ConsentAwareDataWriter
-        self.reader = storage.reader as? FileReader
-        self.queue = self.writer.queue
+        self.writer = storage.writer
+        self.reader = storage.reader
+        self.queue = (storage.writer as! ConsentAwareDataWriter).readWriteQueue
 
         XCTAssertTrue(try directory.files().count == 0)
     }

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -11,8 +11,8 @@ class TracingStorageBenchmarkTests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
     private var queue: DispatchQueue!
     private var directory: Directory!
-    private var writer: ConsentAwareDataWriter!
-    private var reader: FileReader!
+    private var writer: Writer!
+    private var reader: Reader!
     // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUpWithError() throws {
@@ -26,9 +26,9 @@ class TracingStorageBenchmarkTests: XCTestCase {
             ),
             commonDependencies: .mockAny()
         )
-        self.writer = storage.writer as? ConsentAwareDataWriter
-        self.reader = storage.reader as? FileReader
-        self.queue = self.writer.queue
+        self.writer = storage.writer
+        self.reader = storage.reader
+        self.queue = (storage.writer as! ConsentAwareDataWriter).readWriteQueue
 
         XCTAssertTrue(try directory.files().count == 0)
     }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -8,8 +8,6 @@ import XCTest
 @testable import Datadog
 
 class FileReaderTests: XCTestCase {
-    private let queue = DispatchQueue(label: "dd-tests-read", target: .global(qos: .utility))
-
     override func setUp() {
         super.setUp()
         temporaryDirectory.create()
@@ -27,8 +25,7 @@ class FileReaderTests: XCTestCase {
                 directory: temporaryDirectory,
                 performance: StoragePerformanceMock.readAllFiles,
                 dateProvider: SystemDateProvider()
-            ),
-            queue: queue
+            )
         )
         _ = try temporaryDirectory
             .createFile(named: Date.mockAny().toFileName)
@@ -48,8 +45,7 @@ class FileReaderTests: XCTestCase {
                 directory: temporaryDirectory,
                 performance: StoragePerformanceMock.readAllFiles,
                 dateProvider: dateProvider
-            ),
-            queue: queue
+            )
         )
         let file1 = try temporaryDirectory.createFile(named: dateProvider.currentDate().toFileName)
         try file1.append(data: "1".utf8Data)

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writting/ConsentAwareDataWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writting/ConsentAwareDataWriterTests.swift
@@ -19,6 +19,10 @@ class ConsentAwareDataWriterTests: XCTestCase {
     private let queue = DispatchQueue(label: "dd-tests-write", target: .global(qos: .utility))
     private let unauthorizedWriter = FileWriterMock()
     private let authorizedWriter = FileWriterMock()
+    private lazy var dataProcessorFactory = DataProcessorFactory(
+        unauthorizedFileWriter: unauthorizedWriter,
+        authorizedFileWriter: authorizedWriter
+    )
 
     override func setUp() {
         super.setUp()
@@ -37,8 +41,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let writer = ConsentAwareDataWriter(
             consentProvider: ConsentProvider(initialConsent: .granted),
             readWriteQueue: queue,
-            unauthorizedFileWriter: unauthorizedWriter,
-            authorizedFileWriter: authorizedWriter
+            dataProcessorFactory: dataProcessorFactory
         )
 
         // Then
@@ -54,8 +57,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let writer = ConsentAwareDataWriter(
             consentProvider: ConsentProvider(initialConsent: .pending),
             readWriteQueue: queue,
-            unauthorizedFileWriter: unauthorizedWriter,
-            authorizedFileWriter: authorizedWriter
+            dataProcessorFactory: dataProcessorFactory
         )
 
         // Then
@@ -71,8 +73,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let writer = ConsentAwareDataWriter(
             consentProvider: ConsentProvider(initialConsent: .notGranted),
             readWriteQueue: queue,
-            unauthorizedFileWriter: unauthorizedWriter,
-            authorizedFileWriter: authorizedWriter
+            dataProcessorFactory: dataProcessorFactory
         )
 
         // Then
@@ -91,8 +92,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let writer = ConsentAwareDataWriter(
             consentProvider: consentProvider,
             readWriteQueue: queue,
-            unauthorizedFileWriter: unauthorizedWriter,
-            authorizedFileWriter: authorizedWriter
+            dataProcessorFactory: dataProcessorFactory
         )
 
         // When
@@ -112,8 +112,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let writer = ConsentAwareDataWriter(
             consentProvider: consentProvider,
             readWriteQueue: queue,
-            unauthorizedFileWriter: unauthorizedWriter,
-            authorizedFileWriter: authorizedWriter
+            dataProcessorFactory: dataProcessorFactory
         )
 
         // When
@@ -133,8 +132,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let writer = ConsentAwareDataWriter(
             consentProvider: consentProvider,
             readWriteQueue: queue,
-            unauthorizedFileWriter: unauthorizedWriter,
-            authorizedFileWriter: authorizedWriter
+            dataProcessorFactory: dataProcessorFactory
         )
 
         // When
@@ -159,8 +157,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let writer = ConsentAwareDataWriter(
             consentProvider: consentProvider,
             readWriteQueue: queue,
-            unauthorizedFileWriter: unauthorizedWriter,
-            authorizedFileWriter: authorizedWriter
+            dataProcessorFactory: dataProcessorFactory
         )
 
         DispatchQueue.concurrentPerform(iterations: 10_000) { iteration in

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writting/ConsentAwareDataWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writting/ConsentAwareDataWriterTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 @testable import Datadog
 
-private class FileWriterMock: FileWriterType {
+private class FileWriterMock: Writer {
     var dataWritten: Encodable?
 
     func write<T>(value: T) where T: Encodable {
@@ -36,7 +36,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         // When
         let writer = ConsentAwareDataWriter(
             consentProvider: ConsentProvider(initialConsent: .granted),
-            queue: queue,
+            readWriteQueue: queue,
             unauthorizedFileWriter: unauthorizedWriter,
             authorizedFileWriter: authorizedWriter
         )
@@ -53,7 +53,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         // When
         let writer = ConsentAwareDataWriter(
             consentProvider: ConsentProvider(initialConsent: .pending),
-            queue: queue,
+            readWriteQueue: queue,
             unauthorizedFileWriter: unauthorizedWriter,
             authorizedFileWriter: authorizedWriter
         )
@@ -70,7 +70,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         // When
         let writer = ConsentAwareDataWriter(
             consentProvider: ConsentProvider(initialConsent: .notGranted),
-            queue: queue,
+            readWriteQueue: queue,
             unauthorizedFileWriter: unauthorizedWriter,
             authorizedFileWriter: authorizedWriter
         )
@@ -90,7 +90,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let consentProvider = ConsentProvider(initialConsent: initialConsent)
         let writer = ConsentAwareDataWriter(
             consentProvider: consentProvider,
-            queue: queue,
+            readWriteQueue: queue,
             unauthorizedFileWriter: unauthorizedWriter,
             authorizedFileWriter: authorizedWriter
         )
@@ -111,7 +111,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let consentProvider = ConsentProvider(initialConsent: initialConsent)
         let writer = ConsentAwareDataWriter(
             consentProvider: consentProvider,
-            queue: queue,
+            readWriteQueue: queue,
             unauthorizedFileWriter: unauthorizedWriter,
             authorizedFileWriter: authorizedWriter
         )
@@ -132,7 +132,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let consentProvider = ConsentProvider(initialConsent: initialConsent)
         let writer = ConsentAwareDataWriter(
             consentProvider: consentProvider,
-            queue: queue,
+            readWriteQueue: queue,
             unauthorizedFileWriter: unauthorizedWriter,
             authorizedFileWriter: authorizedWriter
         )
@@ -158,7 +158,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         let consentProvider = ConsentProvider(initialConsent: randomConsent())
         let writer = ConsentAwareDataWriter(
             consentProvider: consentProvider,
-            queue: queue,
+            readWriteQueue: queue,
             unauthorizedFileWriter: unauthorizedWriter,
             authorizedFileWriter: authorizedWriter
         )

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -8,7 +8,6 @@ import XCTest
 @testable import Datadog
 
 class DataUploadWorkerTests: XCTestCase {
-    private let fileReadWriteQueue = DispatchQueue(label: "dd-tests-read-write", target: .global(qos: .utility))
     private let uploaderQueue = DispatchQueue(label: "dd-tests-uploader", target: .global(qos: .utility))
 
     lazy var dateProvider = RelativeDateProvider(advancingBySeconds: 1)
@@ -19,13 +18,11 @@ class DataUploadWorkerTests: XCTestCase {
     )
     lazy var writer = FileWriter(
         dataFormat: .mockWith(prefix: "[", suffix: "]"),
-        orchestrator: orchestrator,
-        queue: fileReadWriteQueue
+        orchestrator: orchestrator
     )
     lazy var reader = FileReader(
         dataFormat: .mockWith(prefix: "[", suffix: "]"),
-        orchestrator: orchestrator,
-        queue: fileReadWriteQueue
+        orchestrator: orchestrator
     )
 
     override func setUp() {
@@ -66,7 +63,6 @@ class DataUploadWorkerTests: XCTestCase {
             XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k3":"v3"}]"#.utf8Data })
 
             uploaderQueue.sync {} // wait until last "process upload" operation completes (to make sure "delete file" was requested)
-            fileReadWriteQueue.sync {} // wait until last scheduled "delete file" operation completed
 
             XCTAssertEqual(try temporaryDirectory.files().count, 0)
         }

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
@@ -20,7 +20,6 @@ class LogFileOutputTests: XCTestCase {
 
     func testItWritesLogToFileAsJSON() throws {
         let fileCreationDateProvider = RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC())
-        let queue = DispatchQueue(label: "com.datadohq.testItWritesCurrentDateToLogs")
         let output = LogFileOutput(
             logBuilder: .mockAny(),
             fileWriter: FileWriter(
@@ -32,19 +31,16 @@ class LogFileOutputTests: XCTestCase {
                         uploadPerformance: .noOp
                     ),
                     dateProvider: fileCreationDateProvider
-                ),
-                queue: queue
+                )
             ),
             rumErrorsIntegration: nil
         )
 
         output.writeLogWith(level: .info, message: "log message 1", date: .mockAny(), attributes: .mockAny(), tags: [])
-        queue.sync {} // wait on writter queue
 
         fileCreationDateProvider.advance(bySeconds: 1)
 
         output.writeLogWith(level: .info, message: "log message 2", date: .mockAny(), attributes: .mockAny(), tags: [])
-        queue.sync {} // wait on writter queue
 
         let log1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())
         let log1Data = try temporaryDirectory.file(named: log1FileName).read()

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -363,11 +363,11 @@ extension FeaturesCommonDependencies {
     }
 }
 
-class NoOpFileWriter: FileWriterType {
+class NoOpFileWriter: Writer {
     func write<T>(value: T) where T: Encodable {}
 }
 
-class NoOpFileReader: FileReaderType {
+class NoOpFileReader: Reader {
     func readNextBatch() -> Batch? { return nil }
     func markBatchAsRead(_ batch: Batch) {}
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -20,7 +20,6 @@ class RUMEventFileOutputTests: XCTestCase {
 
     func testItWritesRUMEventToFileAsJSON() throws {
         let fileCreationDateProvider = RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC())
-        let queue = DispatchQueue(label: "com.datadohq.testItWritesRUMEventToFileAsJSON")
         let builder = RUMEventBuilder(userInfoProvider: UserInfoProvider.mockAny())
         let output = RUMEventFileOutput(
             fileWriter: FileWriter(
@@ -32,8 +31,7 @@ class RUMEventFileOutputTests: XCTestCase {
                         uploadPerformance: .noOp
                     ),
                     dateProvider: fileCreationDateProvider
-                ),
-                queue: queue
+                )
             )
         )
 
@@ -43,12 +41,10 @@ class RUMEventFileOutputTests: XCTestCase {
         let event2 = builder.createRUMEvent(with: dataModel2, attributes: [:])
 
         output.write(rumEvent: event1)
-        queue.sync {} // wait on writter queue
 
         fileCreationDateProvider.advance(bySeconds: 1)
 
         output.write(rumEvent: event2)
-        queue.sync {} // wait on writter queue
 
         let event1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())
         let event1Data = try temporaryDirectory.file(named: event1FileName).read()

--- a/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
@@ -19,7 +19,6 @@ class SpanFileOutputTests: XCTestCase {
     }
 
     func testItWritesSpanToFileAsJSON() throws {
-        let queue = DispatchQueue(label: "any")
         let output = SpanFileOutput(
             spanBuilder: .mockAny(),
             fileWriter: FileWriter(
@@ -28,8 +27,7 @@ class SpanFileOutputTests: XCTestCase {
                     directory: temporaryDirectory,
                     performance: PerformancePreset.default,
                     dateProvider: SystemDateProvider()
-                ),
-                queue: queue
+                )
             )
         )
 
@@ -44,8 +42,6 @@ class SpanFileOutputTests: XCTestCase {
         )
 
         output.write(ddspan: ddspan, finishTime: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5))
-
-        queue.sync {} // wait on writter queue
 
         let fileData = try temporaryDirectory.files()[0].read()
         let matcher = try SpanMatcher.fromJSONObjectData(fileData)


### PR DESCRIPTION
### What and why?

📦 As the next part of tracking consent feature, this PR introduces the `DataProcessor`.

### How?

In its current shape, `DataProcessor` may look unnecessary, as it just duplicates the interface of `Writer` and delegates the call to writer. The main motivation of introducing it now is to:
* stay aligned with Android SDK delayed batching architecture,
* have the same foundation as Android SDK for implementing upcoming processing pipelines (scrubbing / sampling).

Another important thing in this PR is the change of `FileWriter` and `FileReader` synchronisation. Before, both were using single `queue` to make sure their calls are synchronised. This was changed towards having synchronous, but not synchronised writers. The synchronisation is now done in `DataWriter` and `DataReader` using shared `queue`:
```swift
// writing flow:
→ DataWriter.write(data)
   → queue.async { fileWriter.write(data) } // `fileWriter.write` is synchronous

// reading flow:
→ DataReader.readNextBatch() -> T?
   → queue.sync { fileReader.readNextBatch() } // `fileReader.readNextBatch` is synchronous
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
