### PR TITLE
RUMM-832 Only authorized data can be uploaded

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -223,6 +223,8 @@
 		61940C7C25668EC600A20043 /* URLSessionInterceptionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61940C7B25668EC600A20043 /* URLSessionInterceptionHandler.swift */; };
 		6198D27124C6E3B700493501 /* RUMViewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */; };
 		619E16D82577C1CB00B2516B /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16D72577C1CB00B2516B /* DataProcessor.swift */; };
+		619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16E82578E73E00B2516B /* DataMigrator.swift */; };
+		619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */; };
 		61A763DC252DB2B3005A23F2 /* NSURLSessionBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */; };
 		61A9238E256FCAA2009B9667 /* DateCorrectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A9238D256FCAA2009B9667 /* DateCorrectionTests.swift */; };
 		61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */; };
@@ -317,6 +319,10 @@
 		61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917CE2464270500E6C631 /* EncodableValueTests.swift */; };
 		61E917D12465423600E6C631 /* TracerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D02465423600E6C631 /* TracerConfiguration.swift */; };
 		61E917D3246546BF00E6C631 /* TracerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D2246546BF00E6C631 /* TracerConfigurationTests.swift */; };
+		61EF7890257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EF788F257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift */; };
+		61EF789B257E2B0200EDCCB3 /* DataMigratorBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EF789A257E2B0200EDCCB3 /* DataMigratorBenchmarkTests.swift */; };
+		61EF78B1257E2E7A00EDCCB3 /* MoveDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EF78B0257E2E7A00EDCCB3 /* MoveDataMigrator.swift */; };
+		61EF78B7257E37D500EDCCB3 /* MoveDataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EF78B6257E37D500EDCCB3 /* MoveDataMigratorTests.swift */; };
 		61F1A61A2498A51700075390 /* CoreMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A6192498A51700075390 /* CoreMocks.swift */; };
 		61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A620249A45E400075390 /* DDSpanContextTests.swift */; };
 		61F1A623249B811200075390 /* Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A622249B811200075390 /* Encoding.swift */; };
@@ -655,6 +661,8 @@
 		61940C7B25668EC600A20043 /* URLSessionInterceptionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionInterceptionHandler.swift; sourceTree = "<group>"; };
 		6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewScopeTests.swift; sourceTree = "<group>"; };
 		619E16D72577C1CB00B2516B /* DataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProcessor.swift; sourceTree = "<group>"; };
+		619E16E82578E73E00B2516B /* DataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrator.swift; sourceTree = "<group>"; };
+		619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllDataMigrator.swift; sourceTree = "<group>"; };
 		61A763D9252DB2B3005A23F2 /* DatadogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DatadogTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		61A763DA252DB2B3005A23F2 /* NSURLSessionBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionBridge.h; sourceTree = "<group>"; };
 		61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionBridge.m; sourceTree = "<group>"; };
@@ -744,6 +752,10 @@
 		61E917CE2464270500E6C631 /* EncodableValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodableValueTests.swift; sourceTree = "<group>"; };
 		61E917D02465423600E6C631 /* TracerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracerConfiguration.swift; sourceTree = "<group>"; };
 		61E917D2246546BF00E6C631 /* TracerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracerConfigurationTests.swift; sourceTree = "<group>"; };
+		61EF788F257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllDataMigratorTests.swift; sourceTree = "<group>"; };
+		61EF789A257E2B0200EDCCB3 /* DataMigratorBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorBenchmarkTests.swift; sourceTree = "<group>"; };
+		61EF78B0257E2E7A00EDCCB3 /* MoveDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveDataMigrator.swift; sourceTree = "<group>"; };
+		61EF78B6257E37D500EDCCB3 /* MoveDataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveDataMigratorTests.swift; sourceTree = "<group>"; };
 		61F1A6192498A51700075390 /* CoreMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMocks.swift; sourceTree = "<group>"; };
 		61F1A620249A45E400075390 /* DDSpanContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanContextTests.swift; sourceTree = "<group>"; };
 		61F1A622249B811200075390 /* Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encoding.swift; sourceTree = "<group>"; };
@@ -966,6 +978,7 @@
 				61133BA92423979B00786299 /* FilesOrchestrator.swift */,
 				613E79412577C08900DFCC17 /* Writting */,
 				613E79422577C09B00DFCC17 /* Reading */,
+				619E16EF2578E81900B2516B /* Migrating */,
 				6114FE0D257667AD0084E372 /* Privacy */,
 				61133BAA2423979B00786299 /* Files */,
 			);
@@ -1193,6 +1206,7 @@
 				61133C2A2423990D00786299 /* FilesOrchestratorTests.swift */,
 				619E16D42577C11B00B2516B /* Writting */,
 				619E16D52577C12100B2516B /* Reading */,
+				61EF788E257E287B00EDCCB3 /* Migrating */,
 				6114FE21257671CB0084E372 /* Privacy */,
 				61133C2B2423990D00786299 /* Files */,
 			);
@@ -1456,6 +1470,7 @@
 				61441C792461A204003D8BB8 /* LoggingStorageBenchmarkTests.swift */,
 				E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */,
 				613BE06125642F790015216C /* RUMStorageBenchmarkTests.swift */,
+				61EF789A257E2B0200EDCCB3 /* DataMigratorBenchmarkTests.swift */,
 			);
 			path = DataStorage;
 			sourceTree = "<group>";
@@ -1845,14 +1860,6 @@
 			path = TapActionAutoInstrumentation;
 			sourceTree = "<group>";
 		};
-		61A9238C256FCA92009B9667 /* Time */ = {
-			isa = PBXGroup;
-			children = (
-				61A9238D256FCAA2009B9667 /* DateCorrectionTests.swift */,
-			);
-			path = Time;
-			sourceTree = "<group>";
-		};
 		619E16D42577C11B00B2516B /* Writting */ = {
 			isa = PBXGroup;
 			children = (
@@ -1876,6 +1883,24 @@
 				619E16D72577C1CB00B2516B /* DataProcessor.swift */,
 			);
 			path = Processing;
+			sourceTree = "<group>";
+		};
+		619E16EF2578E81900B2516B /* Migrating */ = {
+			isa = PBXGroup;
+			children = (
+				619E16E82578E73E00B2516B /* DataMigrator.swift */,
+				619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */,
+				61EF78B0257E2E7A00EDCCB3 /* MoveDataMigrator.swift */,
+			);
+			path = Migrating;
+			sourceTree = "<group>";
+		};
+		61A9238C256FCA92009B9667 /* Time */ = {
+			isa = PBXGroup;
+			children = (
+				61A9238D256FCAA2009B9667 /* DateCorrectionTests.swift */,
+			);
+			path = Time;
 			sourceTree = "<group>";
 		};
 		61B03872252724AB00518F3C /* URLSessionAutoInstrumentation */ = {
@@ -2117,6 +2142,15 @@
 				61E917CE2464270500E6C631 /* EncodableValueTests.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		61EF788E257E287B00EDCCB3 /* Migrating */ = {
+			isa = PBXGroup;
+			children = (
+				61EF788F257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift */,
+				61EF78B6257E37D500EDCCB3 /* MoveDataMigratorTests.swift */,
+			);
+			path = Migrating;
 			sourceTree = "<group>";
 		};
 		61F1A61B2498AD2C00075390 /* SystemFrameworks */ = {
@@ -2611,6 +2645,7 @@
 				61E909EF24A24DD3005EA2DE /* Global.swift in Sources */,
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,
 				6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */,
+				61EF78B1257E2E7A00EDCCB3 /* MoveDataMigrator.swift in Sources */,
 				61133BDC2423979B00786299 /* Logger.swift in Sources */,
 				6114FE1625766B310084E372 /* TrackingConsent.swift in Sources */,
 				61F3C9712535AE9400E2F8C4 /* UIKitHierarchyInspector.swift in Sources */,
@@ -2646,6 +2681,7 @@
 				61940C7C25668EC600A20043 /* URLSessionInterceptionHandler.swift in Sources */,
 				61F3CDA3251118FB00C816E5 /* UIKitRUMViewsHandler.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
+				619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */,
 				618DCFD924C7269500589570 /* RUMUUIDGenerator.swift in Sources */,
 				9EFD112C24B32D29003A1A2B /* FirstPartyURLsFilter.swift in Sources */,
 				61B0386C2527247B00518F3C /* TaskInterception.swift in Sources */,
@@ -2681,6 +2717,7 @@
 				61E5333624B84B43003D6C4E /* RUMMonitor.swift in Sources */,
 				6156CB9824DEFD44008CB2B2 /* LoggingWithRUMIntegration.swift in Sources */,
 				61133BD62423979B00786299 /* DataUploader.swift in Sources */,
+				619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */,
 				61494CBA24CB126F0082C633 /* RUMUserActionScope.swift in Sources */,
 				61C5A88724509A0C00DA608C /* Casting.swift in Sources */,
 				61C3E63724BF191F008053F2 /* RUMScope.swift in Sources */,
@@ -2771,6 +2808,7 @@
 				61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */,
 				615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */,
 				615A4A8724A3452800233986 /* DDTracerConfigurationTests.swift in Sources */,
+				61EF78B7257E37D500EDCCB3 /* MoveDataMigratorTests.swift in Sources */,
 				61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */,
 				615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */,
 				61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */,
@@ -2816,6 +2854,7 @@
 				61F1A61A2498A51700075390 /* CoreMocks.swift in Sources */,
 				61E45BD22450F65B00F2C652 /* SpanBuilderTests.swift in Sources */,
 				61A9238E256FCAA2009B9667 /* DateCorrectionTests.swift in Sources */,
+				61EF7890257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift in Sources */,
 				61E45BCF2450A6EC00F2C652 /* TracingUUIDTests.swift in Sources */,
 				614AD086254C3027004999A3 /* LaunchTimeProviderTests.swift in Sources */,
 				61133C482423990D00786299 /* DDDatadogTests.swift in Sources */,
@@ -2956,6 +2995,7 @@
 				613BE0432563FB9E0015216C /* RUMBenchmarkTests.swift in Sources */,
 				E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */,
 				613BE04A25640FF80015216C /* BenchmarkTests.swift in Sources */,
+				61EF789B257E2B0200EDCCB3 /* DataMigratorBenchmarkTests.swift in Sources */,
 				61441C7C2461A244003D8BB8 /* TestsDirectory.swift in Sources */,
 				613BE06225642F790015216C /* RUMStorageBenchmarkTests.swift in Sources */,
 				61D6FF7E24E53D3B00D0E375 /* BenchmarkMocks.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		61EF789B257E2B0200EDCCB3 /* DataMigratorBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EF789A257E2B0200EDCCB3 /* DataMigratorBenchmarkTests.swift */; };
 		61EF78B1257E2E7A00EDCCB3 /* MoveDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EF78B0257E2E7A00EDCCB3 /* MoveDataMigrator.swift */; };
 		61EF78B7257E37D500EDCCB3 /* MoveDataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EF78B6257E37D500EDCCB3 /* MoveDataMigratorTests.swift */; };
+		61EF78C1257F842000EDCCB3 /* FeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EF78C0257F842000EDCCB3 /* FeatureTests.swift */; };
 		61F1A61A2498A51700075390 /* CoreMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A6192498A51700075390 /* CoreMocks.swift */; };
 		61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A620249A45E400075390 /* DDSpanContextTests.swift */; };
 		61F1A623249B811200075390 /* Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F1A622249B811200075390 /* Encoding.swift */; };
@@ -756,6 +757,7 @@
 		61EF789A257E2B0200EDCCB3 /* DataMigratorBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorBenchmarkTests.swift; sourceTree = "<group>"; };
 		61EF78B0257E2E7A00EDCCB3 /* MoveDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveDataMigrator.swift; sourceTree = "<group>"; };
 		61EF78B6257E37D500EDCCB3 /* MoveDataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveDataMigratorTests.swift; sourceTree = "<group>"; };
+		61EF78C0257F842000EDCCB3 /* FeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureTests.swift; sourceTree = "<group>"; };
 		61F1A6192498A51700075390 /* CoreMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMocks.swift; sourceTree = "<group>"; };
 		61F1A620249A45E400075390 /* DDSpanContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanContextTests.swift; sourceTree = "<group>"; };
 		61F1A622249B811200075390 /* Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encoding.swift; sourceTree = "<group>"; };
@@ -1175,6 +1177,8 @@
 		61133C212423990D00786299 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				61EF78C0257F842000EDCCB3 /* FeatureTests.swift */,
+				61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */,
 				61345612244756E300E7DA6B /* PerformancePresetTests.swift */,
 				618C365D248E858200520CDE /* Utils */,
 				9E5D2D4B2491382800763FE4 /* Swizzling */,
@@ -1182,7 +1186,6 @@
 				61133C272423990D00786299 /* Persistence */,
 				61133C2E2423990D00786299 /* Upload */,
 				61E917CD246426E000E6C631 /* Utils */,
-				61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -2784,6 +2787,7 @@
 				61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */,
 				61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */,
 				6198D27124C6E3B700493501 /* RUMViewScopeTests.swift in Sources */,
+				61EF78C1257F842000EDCCB3 /* FeatureTests.swift in Sources */,
 				61133C5D2423990D00786299 /* DataUploadConditionsTests.swift in Sources */,
 				618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */,
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -109,6 +109,8 @@
 		61363D9D24D999F70084CD6F /* DDError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61363D9C24D999F70084CD6F /* DDError.swift */; };
 		61363D9F24D99BAA0084CD6F /* DDErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */; };
 		6137E649252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6137E648252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard */; };
+		6139CD712589FAFD007E8BB7 /* Retrying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6139CD702589FAFD007E8BB7 /* Retrying.swift */; };
+		6139CD772589FEE3007E8BB7 /* RetryingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6139CD762589FEE3007E8BB7 /* RetryingTests.swift */; };
 		613B77382521E80800155458 /* RUMTabBarControllerScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */; };
 		613BE0432563FB9E0015216C /* RUMBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613BE0422563FB9E0015216C /* RUMBenchmarkTests.swift */; };
 		613BE04A25640FF80015216C /* BenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613BE04925640FF80015216C /* BenchmarkTests.swift */; };
@@ -543,6 +545,8 @@
 		61378BA72555329E00F28837 /* DatadogTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogTests.xcconfig; sourceTree = "<group>"; };
 		61378BB22555337900F28837 /* DatadogSDKTesting.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogSDKTesting.local.xcconfig; sourceTree = "<group>"; };
 		6137E648252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMModalViewsAutoInstrumentationScenario.storyboard; sourceTree = "<group>"; };
+		6139CD702589FAFD007E8BB7 /* Retrying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Retrying.swift; sourceTree = "<group>"; };
+		6139CD762589FEE3007E8BB7 /* RetryingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryingTests.swift; sourceTree = "<group>"; };
 		613B77372521E80800155458 /* RUMTabBarControllerScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTabBarControllerScenarioTests.swift; sourceTree = "<group>"; };
 		613BE0422563FB9E0015216C /* RUMBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMBenchmarkTests.swift; sourceTree = "<group>"; };
 		613BE04925640FF80015216C /* BenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkTests.swift; sourceTree = "<group>"; };
@@ -956,6 +960,7 @@
 				61133BA02423979B00786299 /* EncodableValue.swift */,
 				9E58E8E024615C75008E5063 /* JSONEncoder.swift */,
 				61363D9C24D999F70084CD6F /* DDError.swift */,
+				6139CD702589FAFD007E8BB7 /* Retrying.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2143,6 +2148,7 @@
 			isa = PBXGroup;
 			children = (
 				61E917CE2464270500E6C631 /* EncodableValueTests.swift */,
+				6139CD762589FEE3007E8BB7 /* RetryingTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2666,6 +2672,7 @@
 				61AD4E3824531500006E34EA /* DataFormat.swift in Sources */,
 				9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */,
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
+				6139CD712589FAFD007E8BB7 /* Retrying.swift in Sources */,
 				61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */,
 				6114FE2F257687310084E372 /* ConsentProvider.swift in Sources */,
 				61F3CDA52511190E00C816E5 /* UIViewControllerSwizzler.swift in Sources */,
@@ -2861,6 +2868,7 @@
 				61EF7890257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift in Sources */,
 				61E45BCF2450A6EC00F2C652 /* TracingUUIDTests.swift in Sources */,
 				614AD086254C3027004999A3 /* LaunchTimeProviderTests.swift in Sources */,
+				6139CD772589FEE3007E8BB7 /* RetryingTests.swift in Sources */,
 				61133C482423990D00786299 /* DDDatadogTests.swift in Sources */,
 				613F23FD252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift in Sources */,
 				61133C522423990D00786299 /* FoundationMocks.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -72,6 +72,9 @@ internal struct FeatureStorage {
                     dataFormat: dataFormat,
                     orchestrator: authorizedFilesOrchestrator
                 )
+            ),
+            dataMigratorFactory: DataMigratorFactory(
+                directories: directories
             )
         )
 

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -19,6 +19,7 @@ internal struct FeatureDirectories {
 
 /// Container with dependencies common to all features (Logging, Tracing and RUM).
 internal struct FeaturesCommonDependencies {
+    let consentProvider: ConsentProvider
     let performance: PerformancePreset
     let httpClient: HTTPClient
     let mobileDevice: MobileDevice
@@ -57,11 +58,8 @@ internal struct FeatureStorage {
             dateProvider: commonDependencies.dateProvider
         )
 
-        // TODO: RUMM-833 Share consent provider among all features
-        let consentProvider = ConsentProvider(initialConsent: .granted)
-
         let consentAwareDataWriter = ConsentAwareDataWriter(
-            consentProvider: consentProvider,
+            consentProvider: commonDependencies.consentProvider,
             readWriteQueue: readWriteQueue,
             dataProcessorFactory: DataProcessorFactory(
                 unauthorizedFileWriter: FileWriter(

--- a/Sources/Datadog/Core/Persistence/Files/Directory.swift
+++ b/Sources/Datadog/Core/Persistence/Files/Directory.swift
@@ -55,7 +55,7 @@ internal struct Directory {
     }
 
     /// Moves all files from this directory to `destinationDirectory`.
-    func moveAllFilesTo(_ destinationDirectory: Directory) throws {
+    func moveAllFiles(to destinationDirectory: Directory) throws {
         try files().forEach { file in
             let destinationFileURL = destinationDirectory.url.appendingPathComponent(file.name)
             try? FileManager.default.moveItem(at: file.url, to: destinationFileURL)

--- a/Sources/Datadog/Core/Persistence/Migrating/DataMigrator.swift
+++ b/Sources/Datadog/Core/Persistence/Migrating/DataMigrator.swift
@@ -1,0 +1,10 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+/// A type performing data migration.
+internal protocol DataMigrator {
+    func migrate()
+}

--- a/Sources/Datadog/Core/Persistence/Migrating/DataMigrator.swift
+++ b/Sources/Datadog/Core/Persistence/Migrating/DataMigrator.swift
@@ -8,3 +8,28 @@
 internal protocol DataMigrator {
     func migrate()
 }
+
+internal struct DataMigratorFactory {
+    /// Data directories for the feature.
+    let directories: FeatureDirectories
+
+    /// Resolves migrator to use when the SDK is started.
+    func resolveInitialMigrator() -> DataMigrator {
+        return DeleteAllDataMigrator(directory: directories.unauthorized)
+    }
+
+    /// Resolves migrator to use when consent value changes.
+    func resolveMigratorForConsentChange(from previousValue: TrackingConsent, to newValue: TrackingConsent) -> DataMigrator? {
+        switch (previousValue, newValue) {
+        case (.pending, .notGranted):
+            return DeleteAllDataMigrator(directory: directories.unauthorized)
+        case (.pending, .granted):
+            return MoveDataMigrator(
+                sourceDirectory: directories.unauthorized,
+                destinationDirectory: directories.authorized
+            )
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/Datadog/Core/Persistence/Migrating/DeleteAllDataMigrator.swift
+++ b/Sources/Datadog/Core/Persistence/Migrating/DeleteAllDataMigrator.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Data migrator which deletes all files in given directory.
+internal struct DeleteAllDataMigrator: DataMigrator {
+    private let directory: Directory
+
+    init(directory: Directory) {
+        self.directory = directory
+    }
+
+    func migrate() {
+        do {
+            try directory.deleteAllFiles()
+        } catch {
+            developerLogger?.error(
+                "🔥 Failed to use `DeleteAllDataMigrator` in directory \(directory.url) due to: \(error)"
+            )
+        }
+    }
+}

--- a/Sources/Datadog/Core/Persistence/Migrating/MoveDataMigrator.swift
+++ b/Sources/Datadog/Core/Persistence/Migrating/MoveDataMigrator.swift
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Data migrator which moves files from source directory to destination directory.
+/// Existing files in target direcory remain untouched.
+internal struct MoveDataMigrator: DataMigrator {
+    private let sourceDirectory: Directory
+    private let destinationDirectory: Directory
+
+    init(sourceDirectory: Directory, destinationDirectory: Directory) {
+        self.sourceDirectory = sourceDirectory
+        self.destinationDirectory = destinationDirectory
+    }
+
+    func migrate() {
+        do {
+            try sourceDirectory.moveAllFilesTo(destinationDirectory)
+        } catch {
+            developerLogger?.error(
+                """
+                🔥 Failed to use `MoveDataMigrator` for source directory \(sourceDirectory.url)
+                and destination directory \(destinationDirectory.url) due to: \(error)
+                """
+            )
+        }
+    }
+}

--- a/Sources/Datadog/Core/Persistence/Migrating/MoveDataMigrator.swift
+++ b/Sources/Datadog/Core/Persistence/Migrating/MoveDataMigrator.swift
@@ -19,7 +19,7 @@ internal struct MoveDataMigrator: DataMigrator {
 
     func migrate() {
         do {
-            try sourceDirectory.moveAllFilesTo(destinationDirectory)
+            try sourceDirectory.moveAllFiles(to: destinationDirectory)
         } catch {
             developerLogger?.error(
                 """

--- a/Sources/Datadog/Core/Utils/Retrying.swift
+++ b/Sources/Datadog/Core/Utils/Retrying.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Retries given `block` several `times` in predefined `delay` until it does not throw an error.
+/// If all tries resulted with error, the last `Error` is thrown from this function.
+internal func retry<R>(times: UInt, delay: TimeInterval, block: () throws -> R) throws -> R {
+    for _ in (1..<times) {
+        do {
+            return try block()
+        } catch {
+            Thread.sleep(forTimeInterval: delay)
+        }
+    }
+
+    return try block()
+}

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -141,6 +141,7 @@ public class Datadog {
         var rumAutoInstrumentation: RUMAutoInstrumentation?
 
         let commonDependencies = FeaturesCommonDependencies(
+            consentProvider: ConsentProvider(initialConsent: .granted),
             performance: configuration.common.performance,
             httpClient: HTTPClient(),
             mobileDevice: MobileDevice.current,

--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -15,6 +15,7 @@ private struct DateCorrectorMock: DateCorrectorType {
 extension FeaturesCommonDependencies {
     static func mockAny() -> Self {
         return .init(
+            consentProvider: ConsentProvider(initialConsent: .granted),
             performance: .default,
             httpClient: HTTPClient(),
             mobileDevice: .current,

--- a/Tests/DatadogBenchmarkTests/DataStorage/DataMigratorBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/DataMigratorBenchmarkTests.swift
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+@available(iOS 13.0, *)
+class DataMigratorBenchmarkTests: XCTestCase {
+    private let benchmarkOptions: XCTMeasureOptions = {
+        let options = XCTMeasureOptions()
+        options.invocationOptions = [.manuallyStart, .manuallyStop]
+        options.iterationCount = 5
+        return options
+    }()
+    private let benchmarkMetrics: [XCTMetric] = [XCTClockMetric(), XCTMemoryMetric()]
+
+    func testMigrating500FilesWithDeleteAllDataMigrator() throws {
+        let directory = try Directory(withSubdirectoryPath: UUID().uuidString)
+        defer { directory.delete() }
+
+        measure(metrics: benchmarkMetrics, options: benchmarkOptions) {
+            createFiles(in: directory, count: 500)
+
+            self.startMeasuring()
+            let migrator = DeleteAllDataMigrator(directory: directory)
+            migrator.migrate()
+            self.stopMeasuring()
+        }
+    }
+
+    func testMigrating500FilesWithMoveDataMigratorTests() throws {
+        let sourceDirectory = try Directory(withSubdirectoryPath: UUID().uuidString)
+        let destinationDirectory = try Directory(withSubdirectoryPath: UUID().uuidString)
+        defer {
+            sourceDirectory.delete()
+            destinationDirectory.delete()
+        }
+
+        measure(metrics: benchmarkMetrics, options: benchmarkOptions) {
+            createFiles(in: sourceDirectory, count: 500)
+
+            self.startMeasuring()
+            let migrator = MoveDataMigrator(sourceDirectory: sourceDirectory, destinationDirectory: destinationDirectory)
+            migrator.migrate()
+            self.stopMeasuring()
+        }
+    }
+
+    private func createFiles(in directory: Directory, count: Int) {
+        (0..<count).forEach { iteration in
+            _ = try! directory.createFile(named: "file\(iteration)")
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
@@ -1,0 +1,81 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class FeatureStorageTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        temporaryFeatureDirectories.create()
+    }
+
+    override func tearDown() {
+        temporaryFeatureDirectories.delete()
+        super.tearDown()
+    }
+
+    func testGivenAnyFeatureStorage_whenWrittingDataAndChangingConsent_thenOnlyAuthorizedDataCanBeRead() {
+        let consentProvider = ConsentProvider(initialConsent: randomConsent())
+
+        // Given
+        let storage = FeatureStorage(
+            featureName: .mockAny(),
+            dataFormat: DataFormat(prefix: "", suffix: "", separator: "#"),
+            directories: temporaryFeatureDirectories,
+            commonDependencies: .mockWith(consentProvider: consentProvider)
+        )
+
+        // When
+        (0..<100).forEach { _ in
+            let currentConsent = consentProvider.currentValue
+            let nextConsent = randomConsent(otherThan: currentConsent)
+
+            let stringValue = "current consent: \(currentConsent), next consent: \(nextConsent)"
+            storage.writer.write(value: stringValue)
+
+            consentProvider.changeConsent(to: nextConsent)
+        }
+
+        // Then
+        var dataAuthorizedForUpload: [Data] = []
+
+        while true {
+            if let nextBatch = storage.reader.readNextBatch() {
+                dataAuthorizedForUpload.append(nextBatch.data)
+                storage.reader.markBatchAsRead(nextBatch)
+            } else {
+                break
+            }
+        }
+
+        let authorizedValues = dataAuthorizedForUpload.map { $0.utf8String }
+        let expectedAuthorizedValues = [
+            // Data collected with `.granted` consent is allowed no matter of the next consent
+            "\"current consent: \(TrackingConsent.granted), next consent: \(TrackingConsent.pending)\"",
+            "\"current consent: \(TrackingConsent.granted), next consent: \(TrackingConsent.notGranted)\"",
+            // Data collected with `.pending` consent is allowed only if the next consent was `.granted`
+            "\"current consent: \(TrackingConsent.pending), next consent: \(TrackingConsent.granted)\"",
+        ]
+
+        XCTAssertEqual(
+            Set(authorizedValues),
+            Set(expectedAuthorizedValues)
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Returns random consent value other than the given one.
+    private func randomConsent(otherThan consent: TrackingConsent? = nil) -> TrackingConsent {
+        while true {
+            let randomConsent: TrackingConsent = [.granted, .pending, .notGranted].randomElement()!
+            if randomConsent != consent {
+                return randomConsent
+            }
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Files/DirectoryTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Files/DirectoryTests.swift
@@ -104,7 +104,7 @@ class DirectoryTests: XCTestCase {
         XCTAssertEqual(try sourceDirectory.files().count, 3)
         XCTAssertEqual(try destinationDirectory.files().count, 0)
 
-        try sourceDirectory.moveAllFilesTo(destinationDirectory)
+        try sourceDirectory.moveAllFiles(to: destinationDirectory)
 
         XCTAssertEqual(try sourceDirectory.files().count, 0)
         XCTAssertEqual(try destinationDirectory.files().count, 3)

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Migrating/DeleteAllDataMigratorTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Migrating/DeleteAllDataMigratorTests.swift
@@ -1,0 +1,50 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class DeleteAllDataMigratorTests: XCTestCase {
+    private var directory: Directory! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = try Directory(withSubdirectoryPath: UUID().uuidString)
+    }
+
+    override func tearDown() {
+        directory.delete()
+        super.tearDown()
+    }
+
+    func testGivenEmptyDirectory_whenRunningMigrator_itKeepsTheDirectoryEmpty() throws {
+        // Given
+        XCTAssertEqual(try directory.files().count, 0)
+
+        // When
+        let migrator = DeleteAllDataMigrator(directory: directory)
+        migrator.migrate()
+
+        // Then
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.url.path))
+        XCTAssertEqual(try directory.files().count, 0)
+    }
+
+    func testGivenNonEmptyDirectory_whenRunningMigrator_itDeletesAllFiles() throws {
+        // Given
+        let filesCount = 50
+        try (0..<filesCount).forEach { iteration in _ = try directory.createFile(named: "file\(iteration)") }
+        XCTAssertEqual(try directory.files().count, filesCount)
+
+        // When
+        let migrator = DeleteAllDataMigrator(directory: directory)
+        migrator.migrate()
+
+        // Then
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.url.path))
+        XCTAssertEqual(try directory.files().count, 0)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Migrating/MoveDataMigratorTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Migrating/MoveDataMigratorTests.swift
@@ -1,0 +1,137 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class MoveDataMigratorTests: XCTestCase {
+    private var sourceDirectory: Directory! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var destinationDirectory: Directory! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sourceDirectory = try Directory(withSubdirectoryPath: UUID().uuidString)
+        destinationDirectory = try Directory(withSubdirectoryPath: UUID().uuidString)
+    }
+
+    override func tearDown() {
+        sourceDirectory.delete()
+        destinationDirectory.delete()
+        super.tearDown()
+    }
+
+    func testGivenEmptySourceAndEmptyDestination_whenRunningMigrator_itKeepsDirectoriesEmpty() throws {
+        // Given
+        XCTAssertEqual(try sourceDirectory.files().count, 0)
+        XCTAssertEqual(try destinationDirectory.files().count, 0)
+
+        // When
+        let migrator = MoveDataMigrator(sourceDirectory: sourceDirectory, destinationDirectory: destinationDirectory)
+        migrator.migrate()
+
+        // Then
+        XCTAssertEqual(try sourceDirectory.files().count, 0)
+        XCTAssertEqual(try destinationDirectory.files().count, 0)
+    }
+
+    func testGivenEmptySourceAndNonEmptyDestination_whenRunningMigrator_itKeepsDestinationContents() throws {
+        // Given
+        XCTAssertEqual(try sourceDirectory.files().count, 0)
+        _ = try destinationDirectory.createFile(named: "destination1")
+        _ = try destinationDirectory.createFile(named: "destination2")
+        _ = try destinationDirectory.createFile(named: "destination3")
+        XCTAssertEqual(try destinationDirectory.files().count, 3)
+
+        // When
+        let migrator = MoveDataMigrator(sourceDirectory: sourceDirectory, destinationDirectory: destinationDirectory)
+        migrator.migrate()
+
+        // Then
+        XCTAssertEqual(try sourceDirectory.files().count, 0)
+        XCTAssertEqual(try destinationDirectory.files().count, 3)
+    }
+
+    func testGivenNonEmptySourceAndEmptyDestination_whenRunningMigrator_itMovesSourceFiles() throws {
+        // Given
+        _ = try sourceDirectory.createFile(named: "source1")
+        _ = try sourceDirectory.createFile(named: "source2")
+        _ = try sourceDirectory.createFile(named: "source3")
+        XCTAssertEqual(try sourceDirectory.files().count, 3)
+        XCTAssertEqual(try destinationDirectory.files().count, 0)
+
+        // When
+        let migrator = MoveDataMigrator(sourceDirectory: sourceDirectory, destinationDirectory: destinationDirectory)
+        migrator.migrate()
+
+        // Then
+        XCTAssertEqual(try sourceDirectory.files().count, 0)
+        XCTAssertEqual(try destinationDirectory.files().count, 3)
+        XCTAssertNoThrow(try destinationDirectory.file(named: "source1"))
+        XCTAssertNoThrow(try destinationDirectory.file(named: "source2"))
+        XCTAssertNoThrow(try destinationDirectory.file(named: "source3"))
+    }
+
+    func testGivenNonEmptySourceAndNonEmptyDestination_whenRunningMigrator_itMovesSourceFilesAndKeepsDestinationContents() throws {
+        // Given
+        _ = try sourceDirectory.createFile(named: "source1")
+        _ = try sourceDirectory.createFile(named: "source2")
+        _ = try sourceDirectory.createFile(named: "source3")
+        _ = try destinationDirectory.createFile(named: "destination1")
+        _ = try destinationDirectory.createFile(named: "destination2")
+        _ = try destinationDirectory.createFile(named: "destination3")
+        XCTAssertEqual(try sourceDirectory.files().count, 3)
+        XCTAssertEqual(try destinationDirectory.files().count, 3)
+
+        // When
+        let migrator = MoveDataMigrator(sourceDirectory: sourceDirectory, destinationDirectory: destinationDirectory)
+        migrator.migrate()
+
+        // Then
+        XCTAssertEqual(try sourceDirectory.files().count, 0)
+        XCTAssertEqual(try destinationDirectory.files().count, 6)
+        XCTAssertNoThrow(try destinationDirectory.file(named: "source1"))
+        XCTAssertNoThrow(try destinationDirectory.file(named: "source2"))
+        XCTAssertNoThrow(try destinationDirectory.file(named: "source3"))
+        XCTAssertNoThrow(try destinationDirectory.file(named: "destination1"))
+        XCTAssertNoThrow(try destinationDirectory.file(named: "destination2"))
+        XCTAssertNoThrow(try destinationDirectory.file(named: "destination3"))
+    }
+
+    func testGivenFilesToMigrate_whenMigrationFailsForSomeFiles_itContinuesMigratingAllOthers() throws {
+        let numberOfFiles = 10
+        let numberOfFailedMigrations = 4
+
+        // Given
+        try (0..<numberOfFiles).forEach { index in
+            _ = try sourceDirectory.createFile(named: "file\(index)")
+        }
+        XCTAssertEqual(try sourceDirectory.files().count, numberOfFiles)
+        XCTAssertEqual(try destinationDirectory.files().count, 0)
+
+        // When
+        let allSourceFiles = try sourceDirectory.files().shuffled()
+        let skippedFiles = allSourceFiles[..<numberOfFailedMigrations]
+        let expectedSourceFileNames = skippedFiles.map { $0.name }
+        let expectedDestinationFileNames = allSourceFiles[numberOfFailedMigrations...].map { $0.name }
+
+        try skippedFiles.forEach { try $0.makeReadonly() } // read-only files will raise exception on migration
+
+        let migrator = MoveDataMigrator(sourceDirectory: sourceDirectory, destinationDirectory: destinationDirectory)
+        migrator.migrate()
+
+        // Then
+        XCTAssertEqual(try sourceDirectory.files().count, numberOfFailedMigrations)
+        XCTAssertEqual(try destinationDirectory.files().count, (numberOfFiles - numberOfFailedMigrations))
+        try expectedSourceFileNames.forEach { fileName in
+            XCTAssertNoThrow(try sourceDirectory.file(named: fileName))
+        }
+        try expectedDestinationFileNames.forEach { fileName in
+            XCTAssertNoThrow(try destinationDirectory.file(named: fileName))
+        }
+
+        try skippedFiles.forEach { try $0.makeReadWrite() }
+    }
+}

--- a/Tests/DatadogTests/Datadog/Core/Utils/RetryingTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Utils/RetryingTests.swift
@@ -1,0 +1,75 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+private class OperationMock {
+    private let succeedingCallResults: [Result<Int, Error>]
+    private(set) var callsReceived = 0
+
+    init(_ succeedingCallResults: [Result<Int, Error>]) {
+        self.succeedingCallResults = succeedingCallResults
+    }
+
+    func operation() throws -> Int {
+        let result = succeedingCallResults[callsReceived]
+        callsReceived += 1
+        return try result.get()
+    }
+}
+
+class RetryingTests: XCTestCase {
+    func testWhenBlockSucceedsRightAway() throws {
+        let randomValue: Int = .random(in: 0..<100)
+
+        // When
+        let mock = OperationMock([.success(randomValue)])
+        let result = try retry(times: 3, delay: 0.001, block: mock.operation)
+
+        // Then
+        XCTAssertEqual(mock.callsReceived, 1)
+        XCTAssertEqual(result, randomValue)
+    }
+
+    func testWhenBlockSucceedsInFirstRetry() throws {
+        let randomValue: Int = .random(in: 0..<100)
+
+        // When
+        let mock = OperationMock([.failure(ErrorMock()), .success(randomValue)])
+        let result = try retry(times: 3, delay: 0.001, block: mock.operation)
+
+        // Then
+        XCTAssertEqual(mock.callsReceived, 2)
+        XCTAssertEqual(result, randomValue)
+    }
+
+    func testWhenBlockSucceedsInLastRetry() throws {
+        let randomValue: Int = .random(in: 0..<100)
+
+        // When
+        let mock = OperationMock([.failure(ErrorMock()), .failure(ErrorMock()), .success(randomValue)])
+        let result = try retry(times: 3, delay: 0.001, block: mock.operation)
+
+        // Then
+        XCTAssertEqual(mock.callsReceived, 3)
+        XCTAssertEqual(result, randomValue)
+    }
+
+    func testWhenBlockDoesNotSucceedInRetry() throws {
+        let anyError = ErrorMock(.mockAny())
+        let lastError = ErrorMock(.mockRandom())
+
+        // When
+        let mock = OperationMock([.failure(anyError), .failure(anyError), .failure(lastError)])
+        XCTAssertThrowsError(try retry(times: 3, delay: 0.001, block: mock.operation)) { error in
+            XCTAssertEqual((error as? ErrorMock)?.description, lastError.description)
+        }
+
+        // Then
+        XCTAssertEqual(mock.callsReceived, 3)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -363,6 +363,14 @@ extension FeaturesCommonDependencies {
     }
 }
 
+class FileWriterMock: Writer {
+    var dataWritten: Encodable?
+
+    func write<T>(value: T) where T: Encodable {
+        dataWritten = value
+    }
+}
+
 class NoOpFileWriter: Writer {
     func write<T>(value: T) where T: Encodable {}
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -298,6 +298,7 @@ extension FeaturesCommonDependencies {
     /// Mocks features common dependencies.
     /// Default values describe the environment setup where data can be uploaded to the server (device is online and battery is full).
     static func mockWith(
+        consentProvider: ConsentProvider = ConsentProvider(initialConsent: .granted),
         performance: PerformancePreset = .combining(
             storagePerformance: .writeEachObjectToNewFileAndReadAllFiles,
             uploadPerformance: .veryQuick
@@ -325,6 +326,7 @@ extension FeaturesCommonDependencies {
         launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock()
     ) -> FeaturesCommonDependencies {
         return FeaturesCommonDependencies(
+            consentProvider: consentProvider,
             performance: performance,
             httpClient: HTTPClient(session: .serverMockURLSession),
             mobileDevice: mobileDevice,
@@ -339,6 +341,7 @@ extension FeaturesCommonDependencies {
 
     /// Creates new instance of `FeaturesCommonDependencies` by replacing individual dependencies.
     func replacing(
+        consentProvider: ConsentProvider? = nil,
         performance: PerformancePreset? = nil,
         httpClient: HTTPClient? = nil,
         mobileDevice: MobileDevice? = nil,
@@ -350,6 +353,7 @@ extension FeaturesCommonDependencies {
         launchTimeProvider: LaunchTimeProviderType? = nil
     ) -> FeaturesCommonDependencies {
         return FeaturesCommonDependencies(
+            consentProvider: consentProvider ?? self.consentProvider,
             performance: performance ?? self.performance,
             httpClient: httpClient ?? self.httpClient,
             mobileDevice: mobileDevice ?? self.mobileDevice,

--- a/Tests/DatadogTests/Helpers/TestsDirectory.swift
+++ b/Tests/DatadogTests/Helpers/TestsDirectory.swift
@@ -45,4 +45,10 @@ extension Directory {
             }
         }
     }
+
+    func createMockFiles(count: Int, prefix: String = "file") {
+        (0..<count).forEach { index in
+            _ = try! createFile(named: "\(prefix)\(index)")
+        }
+    }
 }


### PR DESCRIPTION
### What and why?

📦 As part of tracking consent feature, this PR makes sure that only authorized data can be uploaded. This means:
* all data collected with `.granted` consent,
* all data collected with `.pending` consent if it was then changed to `.granted`.

### How?

As in `dd-sdk-android`, `DataMigrator` type is introduced. There are two migrators implemented:
* `DeleteAllDataMigrator` - deletes all data in given folder,
* `MoveDataMigrator` - moves all data from source directory do destination folder.

Migrators are resolved in `ConsentAwareDataWriter` and their `migrate()` work is dispatched to the read/write queue, which keeps all writes (on collection) and reads (on upload) synchronized on the background thread.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
