### PR TITLE
RUMM-833 Add public API for Data Tracking Consent

### DIFF
--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -29,6 +29,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
         // Initialize Datadog SDK
         Datadog.initialize(
             appContext: .init(),
+            trackingConsent: .granted,
             configuration: appConfiguration.sdkConfiguration()
         )
 

--- a/Sources/Datadog/Core/Persistence/Privacy/TrackingConsent.swift
+++ b/Sources/Datadog/Core/Persistence/Privacy/TrackingConsent.swift
@@ -6,8 +6,11 @@
 
 import Foundation
 
-/// Possible values for the Data Tracking Consent.
-internal enum TrackingConsent {
+/// Possible values for the Data Tracking Consent given by the user of the app.
+///
+/// This value should be used to grant the permission for Datadog SDK to store data collected in
+/// Logging, Tracing or RUM and upload it to Datadog servers.
+public enum TrackingConsent {
     /// The permission to persist and send data to the Datadog servers was granted.
     /// Any previously stored pending data will be marked as ready for sent.
     case granted

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -49,6 +49,8 @@ public class Datadog {
     @available(*, deprecated, message: """
     This method is deprecated and uses the `TrackingConsent.granted` value as a default privacy consent.
     This means that the SDK will start recording and sending data immediately after initialisation without waiting for the user's consent to be given.
+
+    Use `Datadog.initialize(appContext:trackingConsent:configuration:)` and set consent to `.granted` to preserve previous behaviour.
     """)
     public static func initialize(appContext: AppContext, configuration: Configuration) {
         initialize(

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -45,15 +45,40 @@ public class Datadog {
     /// Initializes the Datadog SDK.
     /// - Parameters:
     ///   - appContext: context passing information about the app.
-    ///   - configuration: the SDK configuration obtained using `Datadog.Configuration.builderUsing(clientToken:)`.
+    ///   - configuration: the SDK configuration obtained using `Datadog.Configuration.builderUsing(...)`.
+    @available(*, deprecated, message: """
+    This method is deprecated and uses the `TrackingConsent.granted` value as a default privacy consent.
+    This means that the SDK will start recording and sending data immediately after initialisation without waiting for the user's consent to be given.
+    """)
     public static func initialize(appContext: AppContext, configuration: Configuration) {
+        initialize(
+            appContext: appContext,
+            trackingConsent: .granted,
+            configuration: configuration
+        )
+    }
+
+    /// Initializes the Datadog SDK.
+    /// - Parameters:
+    ///   - appContext: context passing information about the app.
+    ///   - trackingConsent: the initial state of the Data Tracking Consent given by the user of the app.
+    ///   - configuration: the SDK configuration obtained using `Datadog.Configuration.builderUsing(...)`.
+    public static func initialize(
+        appContext: AppContext,
+        trackingConsent: TrackingConsent,
+        configuration: Configuration
+    ) {
         // TODO: RUMM-511 remove this warning
         #if targetEnvironment(macCatalyst)
         consolePrint("⚠️ Catalyst is not officially supported by Datadog SDK: some features may NOT be functional!")
         #endif
         do {
             try initializeOrThrow(
-                configuration: try FeaturesConfiguration(configuration: configuration, appContext: appContext)
+                initialTrackingConsent: trackingConsent,
+                configuration: try FeaturesConfiguration(
+                    configuration: configuration,
+                    appContext: appContext
+                )
             )
         } catch {
             consolePrint("\(error)")
@@ -96,18 +121,29 @@ public class Datadog {
         )
     }
 
+    /// Sets the tracking consent regarding the data collection for the Datadog SDK.
+    /// - Parameter trackingConsent: new consent value, which will be applied for all data collected from now on
+    public static func set(trackingConsent: TrackingConsent) {
+        instance?.consentProvider.changeConsent(to: trackingConsent)
+    }
+
     // MARK: - Internal
 
     internal static var instance: Datadog?
 
+    internal let consentProvider: ConsentProvider
     internal let userInfoProvider: UserInfoProvider
     internal let launchTimeProvider: LaunchTimeProviderType
 
-    private static func initializeOrThrow(configuration: FeaturesConfiguration) throws {
+    private static func initializeOrThrow(
+        initialTrackingConsent: TrackingConsent,
+        configuration: FeaturesConfiguration
+    ) throws {
         guard Datadog.instance == nil else {
             throw ProgrammerError(description: "SDK is already initialized.")
         }
 
+        let consentProvider = ConsentProvider(initialConsent: initialTrackingConsent)
         let dateProvider = SystemDateProvider()
         let dateCorrector = DateCorrector(
             deviceDateProvider: dateProvider,
@@ -141,7 +177,7 @@ public class Datadog {
         var rumAutoInstrumentation: RUMAutoInstrumentation?
 
         let commonDependencies = FeaturesCommonDependencies(
-            consentProvider: ConsentProvider(initialConsent: .granted),
+            consentProvider: consentProvider,
             performance: configuration.common.performance,
             httpClient: HTTPClient(),
             mobileDevice: MobileDevice.current,
@@ -204,15 +240,18 @@ public class Datadog {
 
         // Only after all features were initialized with no error thrown:
         self.instance = Datadog(
+            consentProvider: consentProvider,
             userInfoProvider: userInfoProvider,
             launchTimeProvider: launchTimeProvider
         )
     }
 
     internal init(
+        consentProvider: ConsentProvider,
         userInfoProvider: UserInfoProvider,
         launchTimeProvider: LaunchTimeProviderType
     ) {
+        self.consentProvider = consentProvider
         self.userInfoProvider = userInfoProvider
         self.launchTimeProvider = launchTimeProvider
     }

--- a/Sources/DatadogObjc/Datadog+objc.swift
+++ b/Sources/DatadogObjc/Datadog+objc.swift
@@ -8,6 +8,21 @@ import Foundation
 import Datadog
 
 @objcMembers
+public class DDTrackingConsent: NSObject {
+    internal let sdkConsent: TrackingConsent
+
+    internal init(sdkConsent: TrackingConsent) {
+        self.sdkConsent = sdkConsent
+    }
+
+    // MARK: - Public
+
+    public static func granted() -> DDTrackingConsent { .init(sdkConsent: .granted) }
+    public static func notGranted() -> DDTrackingConsent { .init(sdkConsent: .notGranted) }
+    public static func pending() -> DDTrackingConsent { .init(sdkConsent: .pending) }
+}
+
+@objcMembers
 public class DDAppContext: NSObject {
     internal let sdkAppContext: Datadog.AppContext
 
@@ -26,9 +41,27 @@ public class DDAppContext: NSObject {
 public class DDDatadog: NSObject {
     // MARK: - Public
 
+    @available(*, deprecated, message: """
+    This method is deprecated and uses the `DDTrackingConsent.granted()` value as a default privacy consent.
+    This means that the SDK will start recording and sending data immediately after initialisation without waiting for the user's consent to be given.
+
+    Use `DDDatadog.initialize(appContext:trackingConsent:configuration:)` and set consent to `granted()` to preserve previous behaviour.
+    """)
     public static func initialize(appContext: DDAppContext, configuration: DDConfiguration) {
         Datadog.initialize(
             appContext: appContext.sdkAppContext,
+            configuration: configuration.sdkConfiguration
+        )
+    }
+
+    public static func initialize(
+        appContext: DDAppContext,
+        trackingConsent: DDTrackingConsent,
+        configuration: DDConfiguration
+    ) {
+        Datadog.initialize(
+            appContext: appContext.sdkAppContext,
+            trackingConsent: trackingConsent.sdkConsent,
             configuration: configuration.sdkConfiguration
         )
     }
@@ -62,4 +95,8 @@ public class DDDatadog: NSObject {
         Datadog.setUserInfo(id: id, name: name, email: email)
     }
     // swiftlint:enable identifier_name
+
+    public static func setTrackingConsent(consent: DDTrackingConsent) {
+        Datadog.set(trackingConsent: consent.sdkConsent)
+    }
 }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -167,6 +167,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingUserInfo() throws {
         Datadog.instance = Datadog(
+            consentProvider: ConsentProvider(initialConsent: .granted),
             userInfoProvider: UserInfoProvider(),
             launchTimeProvider: LaunchTimeProviderMock()
         )
@@ -758,6 +759,7 @@ class LoggerTests: XCTestCase {
         // given
         Datadog.initialize(
             appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration.builderUsing(clientToken: "abc.def", environment: "tests")
                 .enableLogging(false)
                 .build()

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -8,6 +8,12 @@
 
 // MARK: - Configuration Mocks
 
+extension TrackingConsent {
+    static func mockRandom() -> TrackingConsent {
+        return [.granted, .notGranted, .pending].randomElement()!
+    }
+}
+
 extension Datadog.Configuration {
     static func mockAny() -> Datadog.Configuration { .mockWith() }
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -767,6 +767,7 @@ class RUMMonitorTests: XCTestCase {
         // given
         Datadog.initialize(
             appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration.builderUsing(clientToken: "abc-def", environment: "tests").build()
         )
 
@@ -791,6 +792,7 @@ class RUMMonitorTests: XCTestCase {
         // given
         Datadog.initialize(
             appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration.builderUsing(rumApplicationID: .mockAny(), clientToken: .mockAny(), environment: .mockAny()).build()
         )
         Global.rum = RUMMonitor.initialize()
@@ -814,6 +816,7 @@ class RUMMonitorTests: XCTestCase {
         // given
         Datadog.initialize(
             appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
             configuration: .mockWith(rumApplicationID: "rum-123", rumEnabled: true)
         )
         Global.rum = RUMMonitor.initialize()
@@ -841,6 +844,7 @@ class RUMMonitorTests: XCTestCase {
     func testGivenRUMAutoInstrumentationEnabled_whenRUMMonitorIsNotRegistered_itPrintsWarningsOnEachEvent() throws {
         Datadog.initialize(
             appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration
                 .builderUsing(rumApplicationID: .mockAny(), clientToken: .mockAny(), environment: .mockAny())
                 .track(firstPartyHosts: [.mockAny()])

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -705,6 +705,46 @@ class RUMMonitorTests: XCTestCase {
         }
     }
 
+    // MARK: - Tracking Consent
+
+    func testWhenChangingConsentValues_itUploadsOnlyAuthorizedRUMEvents() throws {
+        let consentProvider = ConsentProvider(initialConsent: .pending)
+
+        // Given
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(
+            directories: temporaryFeatureDirectories,
+            dependencies: .mockWith(consentProvider: consentProvider)
+        )
+        defer { RUMFeature.instance = nil }
+
+        let monitor = RUMMonitor.initialize()
+
+        // When
+        monitor.startView(viewController: mockView, path: "view in `.pending` consent changed to `.granted`")
+        monitor.stopView(viewController: mockView)
+        monitor.dd.queue.sync {} // wait for processing the event in `RUMMonitor`
+        consentProvider.changeConsent(to: .granted)
+        monitor.startView(viewController: mockView, path: "view in `.granted` consent")
+        monitor.stopView(viewController: mockView)
+        monitor.dd.queue.sync {}
+        consentProvider.changeConsent(to: .notGranted)
+        monitor.startView(viewController: mockView, path: "view in `.notGranted` consent")
+        monitor.stopView(viewController: mockView)
+        monitor.dd.queue.sync {}
+        consentProvider.changeConsent(to: .granted)
+        monitor.startView(viewController: mockView, path: "another view in `.granted` consent")
+        monitor.stopView(viewController: mockView)
+
+        // Then
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 7)
+        let session = try RUMSessionMatcher.groupMatchersBySessions(rumEventMatchers)[0]
+
+        XCTAssertEqual(session.viewVisits.count, 3, "Only 3 RUM Views were visited in authorized consent.")
+        XCTAssertEqual(session.viewVisits[0].path, "view in `.pending` consent changed to `.granted`")
+        XCTAssertEqual(session.viewVisits[1].path, "view in `.granted` consent")
+        XCTAssertEqual(session.viewVisits[2].path, "another view in `.granted` consent")
+    }
+
     // MARK: - Thread safety
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -315,6 +315,7 @@ class TracerTests: XCTestCase {
 
     func testSendingUserInfo() throws {
         Datadog.instance = Datadog(
+            consentProvider: ConsentProvider(initialConsent: .granted),
             userInfoProvider: UserInfoProvider(),
             launchTimeProvider: LaunchTimeProviderMock()
         )
@@ -926,6 +927,7 @@ class TracerTests: XCTestCase {
         // given
         Datadog.initialize(
             appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration.builderUsing(clientToken: "abc.def", environment: "tests")
                 .enableTracing(false)
                 .build()
@@ -948,6 +950,7 @@ class TracerTests: XCTestCase {
         // given
         Datadog.initialize(
             appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration.builderUsing(clientToken: "abc.def", environment: "tests")
                 .enableLogging(false)
                 .build()
@@ -976,6 +979,7 @@ class TracerTests: XCTestCase {
         // given
         Datadog.initialize(
             appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration.builderUsing(clientToken: .mockAny(), environment: .mockAny()).build()
         )
         Global.sharedTracer = Tracer.initialize(configuration: .init())
@@ -998,6 +1002,7 @@ class TracerTests: XCTestCase {
     func testGivenOnlyTracingAutoInstrumentationEnabled_whenTracerIsNotRegistered_itPrintsWarningsOnEachFirstPartyRequest() throws {
         Datadog.initialize(
             appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration
                 .builderUsing(clientToken: .mockAny(), environment: .mockAny())
                 .track(firstPartyHosts: [.mockAny()])

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -24,13 +24,21 @@ class InternalLoggersTests: XCTestCase {
 
     func testGivenDefaultSDKConfiguration_whenInitialized_itUsesWorkingUserLogger() throws {
         let defaultSDKConfiguration = Datadog.Configuration.builderUsing(clientToken: "abc", environment: "test").build()
-        Datadog.initialize(appContext: .mockAny(), configuration: defaultSDKConfiguration)
+        Datadog.initialize(
+            appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
+            configuration: defaultSDKConfiguration
+        )
         XCTAssertTrue((userLogger.logOutput as? ConditionalLogOutput)?.conditionedOutput is LogConsoleOutput)
         try Datadog.deinitializeOrThrow()
     }
 
     func testGivenLoggingFeatureDisabled_whenSDKisInitialized_itUsesWorkingUserLogger() throws {
-        Datadog.initialize(appContext: .mockAny(), configuration: .mockWith(loggingEnabled: false))
+        Datadog.initialize(
+            appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
+            configuration: .mockWith(loggingEnabled: false)
+        )
         XCTAssertTrue((userLogger.logOutput as? ConditionalLogOutput)?.conditionedOutput is LogConsoleOutput)
         try Datadog.deinitializeOrThrow()
     }
@@ -104,7 +112,11 @@ class InternalLoggersTests: XCTestCase {
         let originalValue = CompilationConditions.isSDKCompiledForDevelopment
         defer { CompilationConditions.isSDKCompiledForDevelopment = originalValue }
 
-        Datadog.initialize(appContext: .mockAny(), configuration: .mockAny())
+        Datadog.initialize(
+            appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
+            configuration: .mockAny()
+        )
         XCTAssertNotNil(developerLogger)
         try Datadog.deinitializeOrThrow()
     }
@@ -113,7 +125,11 @@ class InternalLoggersTests: XCTestCase {
         let originalValue = CompilationConditions.isSDKCompiledForDevelopment
         defer { CompilationConditions.isSDKCompiledForDevelopment = originalValue }
 
-        Datadog.initialize(appContext: .mockAny(), configuration: .mockWith(loggingEnabled: false))
+        Datadog.initialize(
+            appContext: .mockAny(),
+            trackingConsent: .mockRandom(),
+            configuration: .mockWith(loggingEnabled: false)
+        )
         XCTAssertNotNil(developerLogger)
         try Datadog.deinitializeOrThrow()
     }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -1,12 +1,18 @@
 public class DDNSURLSessionDelegate: DDURLSessionDelegate
+public class DDTrackingConsent: NSObject
+ public static func granted() -> DDTrackingConsent
+ public static func notGranted() -> DDTrackingConsent
+ public static func pending() -> DDTrackingConsent
 public class DDAppContext: NSObject
  public init(mainBundle: Bundle)
  override public init()
 public class DDDatadog: NSObject
  public static func initialize(appContext: DDAppContext, configuration: DDConfiguration)
+ public static func initialize(appContext: DDAppContext,trackingConsent: DDTrackingConsent,configuration: DDConfiguration)
  public static func setVerbosityLevel(_ verbosityLevel: DDSDKVerbosityLevel)
  public static func verbosityLevel() -> DDSDKVerbosityLevel
  public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil)
+ public static func setTrackingConsent(consent: DDTrackingConsent)
 public class DDEndpoint: NSObject
  public static func eu() -> DDEndpoint
  public static func us() -> DDEndpoint

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -1,8 +1,13 @@
 public typealias AttributeKey = String
 public typealias AttributeValue = Encodable
+public enum TrackingConsent
+ case granted
+ case notGranted
+ case pending
 public class DDRUMMonitor
  public func startView(viewController: UIViewController,path: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  public func stopView(viewController: UIViewController,attributes: [AttributeKey: AttributeValue] = [:])
+ public func addTiming(name: String)
  public func addError(message: String,source: RUMErrorSource = .custom,attributes: [AttributeKey: AttributeValue] = [:],file: StaticString? = #file,line: UInt? = #line)
  public func addError(error: Error,source: RUMErrorSource = .custom,attributes: [AttributeKey: AttributeValue] = [:])
  public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [AttributeKey: AttributeValue] = [:])
@@ -20,9 +25,11 @@ public class Datadog
  public struct AppContext
   public init(mainBundle: Bundle = Bundle.main)
  public static func initialize(appContext: AppContext, configuration: Configuration)
+ public static func initialize(appContext: AppContext,trackingConsent: TrackingConsent,configuration: Configuration)
  public static var verbosityLevel: LogLevel? = nil
  public static var debugRUM: Bool = false
  public static func setUserInfo(id: String? = nil,name: String? = nil,email: String? = nil,extraInfo: [AttributeKey: AttributeValue] = [:])
+ public static func set(trackingConsent: TrackingConsent)
  public struct Configuration
   public enum DatadogEndpoint
    case us
@@ -191,6 +198,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber
  public static func initialize() -> DDRUMMonitor
  override public func startView(viewController: UIViewController,path: String?,attributes: [AttributeKey: AttributeValue])
  override public func stopView(viewController: UIViewController,attributes: [AttributeKey: AttributeValue])
+ override public func addTiming(name: String)
  override public func addError(message: String,source: RUMErrorSource,attributes: [AttributeKey: AttributeValue],file: StaticString?,line: UInt?)
  override public func addError(error: Error,source: RUMErrorSource,attributes: [AttributeKey: AttributeValue])
  override public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [AttributeKey: AttributeValue])


### PR DESCRIPTION
### What and why?

📦 This PR adds the public API for configuring tracking consent:
```swift
Datadog.initialize(
   appContext: ...,
   trackingConsent: .pending,
   configuration: ....
)

Datadog.set(trackingConsent: .granted)
```

### How?

New public APIs were introduced both for `Datadog` and `DatadogObjc`. 

The previous variant of `Datadog.initialize()` is marked deprecated.

I also added tests for `Logger`, `Tracer` and `RUMMonitor` to assert they respect the consent value when collecting data.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
