### PR TITLE
RUMM-921 Add `DDGlobal` typealias to avoid compiler ambiguity

### DIFF
--- a/Sources/Datadog/Global.swift
+++ b/Sources/Datadog/Global.swift
@@ -4,6 +4,10 @@
 * Copyright 2019-2020 Datadog, Inc.
 */
 
+/// Because `Global` is a common name widely used across different projects,
+/// `DDGlobal` typealias can be used to avoid compiler ambiguity.
+public typealias DDGlobal = Global
+
 /// Namespace storing global Datadog components.
 public struct Global {
     /// Shared tracer instance to use throughout the app.

--- a/Tests/DatadogTests/Datadog/GlobalTests.swift
+++ b/Tests/DatadogTests/Datadog/GlobalTests.swift
@@ -15,4 +15,8 @@ class GlobalTests: XCTestCase {
     func testWhenRUMMonitorIsNotInitialized_itGivesNoOpImplementation() {
         XCTAssertTrue(Global.rum is DDNoopRUMMonitor)
     }
+
+    func testDDGlobalIsGlobalTypealias() {
+        XCTAssertTrue(DDGlobal.self == Global.self)
+    }
 }

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -63,6 +63,7 @@ public class Datadog
    public func trackUIKitActions(_ enabled: Bool) -> Builder
    public func set(serviceName: String) -> Builder
    public func build() -> Configuration
+public typealias DDGlobal = Global
 public struct Global
  public static var sharedTracer: OTTracer = DDNoopGlobals.tracer
  public static var rum: DDRUMMonitor = DDNoopRUMMonitor()


### PR DESCRIPTION
### What and why?

📦 This PR introduces `DDGlobal` convenience typealias, to avoid compiler ambiguity with user-defined `Global` constructs.

Solves #333 

### How?

```swift
/// Because `Global` is a common name widely used across different projects,
/// `DDGlobal` typealias can be used to avoid compiler ambiguity.
public typealias DDGlobal = Global
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
