### PR TITLE
RUMM-922 Do not start another RUM View if `path` did not change

### DIFF
--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -66,9 +66,11 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
 
     /// The `UIViewController` indicating the active `RUMView`.
     private weak var lastStartedViewController: UIViewController?
+    /// The last started `RUMView`.
+    private var lastStartedRUMView: RUMView?
 
     private func startIfNotStarted(rumView: RUMView, for viewController: UIViewController) {
-        if viewController === lastStartedViewController {
+        if viewController === lastStartedViewController || rumView.path == lastStartedRUMView?.path {
             return
         }
 
@@ -101,5 +103,6 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
         )
 
         lastStartedViewController = viewController
+        lastStartedRUMView = rumView
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR addresses the feedback learned when watching the user's RUM views predicate instrumentation.

The user was using such `UIKitRUMViewsPredicate `:

```swift
class Predicate: UIKitRUMViewsPredicate {
    func rumView(for viewController: UIViewController) -> RUMView? {
        return RUMView(path: "single-view")
    }
}
```

This leads to very bad and counter-intuitive results. For every new view controller captured by the RUM auto instrumentation, the SDK starts new RUM View:

<img width="969" alt="Screenshot 2020-12-10 at 11 31 29" src="https://user-images.githubusercontent.com/2358722/101770753-32436280-3ae9-11eb-8abc-1526905df38d.png">

The user's expectation is to have only one single view for this session and group all actions and resources under it.

This PR changes the behaviour of SDK so that it does not start another RUM View, when the `view.path` retrieved from predicate does not change. It gives expected result:

<img width="837" alt="Screenshot 2020-12-10 at 11 33 22" src="https://user-images.githubusercontent.com/2358722/101771110-ba296c80-3ae9-11eb-87cf-e58cbb6b0ba7.png">


### How?

Basic check was installed in `UIKitRUMViewsHandler` to not send start view commands if `path` does not change.

#### Alternative: ignoring `commands` in `RUMViewScope`

As an alternative, we could also compare `command.path` in `RUMViewScope` (with `scope.path`) and ignore if it's equal. This would change the behaviour for both manual and auto-instrumentation. I didn't pick this solution, as IMO it is too strict. IMO this manual instrumentation code:
```swift
Global.rum.startView(viewController: vc1, path: "path1")
Global.rum.startView(viewController: vc2, path: "path1")
```
shows a clear user's intent to start another RUM View with the same `path` name.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
