### PR TITLE
RUMM-883 Add support for 3rd party networking libraries (including Alamofire)

### DIFF
--- a/DatadogSDKAlamofireExtension.podspec
+++ b/DatadogSDKAlamofireExtension.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name         = "DatadogSDKAlamofireExtension"
+  s.module_name  = "DatadogAlamofireExtension"
+  s.version      = "1.0.0"
+  s.summary      = "An Official Extensions of Datadog Swift SDK for Alamofire."
+  
+  s.homepage     = "https://www.datadoghq.com"
+  s.social_media_url   = "https://twitter.com/datadoghq"
+
+  s.license            = { :type => "Apache", :file => 'LICENSE' }
+  s.authors            = { 
+    "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
+    "Mert Buran" => "mert.buran@datadoghq.com"
+  }
+
+  s.swift_version      = '5.1'
+  s.ios.deployment_target = '11.0'
+
+  s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
+
+  s.source_files = ["Sources/DatadogExtensions/Alamofire/**/*.swift"]
+  s.dependency 'DatadogSDK', '~> 1.4'
+  s.dependency 'Alamofire', '~> 5.4'
+end

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [Datadog iOS Trace Collection](https://docs.datadoghq.com/tracing/setup/ios/
 
 ### Alamofire
 
-If you use [Alamofire](https://github.com/Alamofire/Alamofire), take a look at [`DatadogAlamofireExtension` library](Sources/DatadogExtensions/Alamofire/) to learn how to auto instrument your requests with Datadog SDK.
+If you use [Alamofire](https://github.com/Alamofire/Alamofire), review the [`DatadogAlamofireExtension` library](Sources/DatadogExtensions/Alamofire/) to learn how to automatically instrument requests with Datadog SDK.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ See [Datadog iOS Trace Collection](https://docs.datadoghq.com/tracing/setup/ios/
 
 ![Datadog iOS Log Collection](docs/images/tracing.png)
 
+## Integrations
+
+### Alamofire
+
+If you use [Alamofire](https://github.com/Alamofire/Alamofire), take a look at [`DatadogAlamofireExtension` library](Sources/DatadogExtensions/Alamofire/) to learn how to auto instrument your requests with Datadog SDK.
+
 ## Contributing
 
 Pull requests are welcome. First, open an issue to discuss what you would like to change. For more information, read the [Contributing Guide](CONTRIBUTING.md).

--- a/Sources/Datadog/FeaturesIntegration/EnvironmentSpanIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/EnvironmentSpanIntegration.swift
@@ -8,7 +8,7 @@ import Foundation
 
 fileprivate struct EnvironmentSpanIntegration {
     /// Tracing context read from environment variables if injected
-    internal static var environmentContext: (spanID: String, traceID: String)? {
+    static var environmentContext: (spanID: String, traceID: String)? {
         guard let spanIDValue = ProcessInfo.processInfo.environment[TracingHTTPHeaders.parentSpanIDField] ,
               let traceIDValue = ProcessInfo.processInfo.environment[TracingHTTPHeaders.traceIDField] else {
             return nil

--- a/Sources/Datadog/TracerConfiguration.swift
+++ b/Sources/Datadog/TracerConfiguration.swift
@@ -30,6 +30,9 @@ extension Tracer {
         /// Initializes the Datadog Tracer configuration.
         /// - Parameter serviceName: the service name that will appear in traces (if not provided or `nil`, the SDK default `serviceName` will be used).
         /// - Parameter sendNetworkInfo: adds network connection info to every span and span logs (`false` by default).
+        /// - Parameter bundleWithRUM: enables the tracing integration with RUM. If enabled all the Spans will be enriched with the current RUM View information and
+        /// it will be possible to see all the Spans sent during a specific View lifespan in the RUM Explorer (`true` by default).
+        /// - Parameter globalTags: sets global tags for all Spans (`nil` by default).
         public init(
             serviceName: String? = nil,
             sendNetworkInfo: Bool = false,

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -30,14 +30,12 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate {
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        interceptor?
-            .taskMetricsCollected(urlSession: session, task: task, metrics: metrics)
+        interceptor?.taskMetricsCollected(task: task, metrics: metrics)
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
 
-        interceptor?
-            .taskCompleted(urlSession: session, task: task, error: error)
+        interceptor?.taskCompleted(task: task, error: error)
     }
 }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
@@ -78,7 +78,7 @@ internal class URLSessionSwizzler {
                         var taskReference: URLSessionDataTask?
                         let newCompletionHandler: CompletionHandler = { data, response, error in
                             if let task = taskReference { // sanity check, should always succeed
-                                interceptor.taskCompleted(urlSession: session, task: task, error: error)
+                                interceptor.taskCompleted(task: task, error: error)
                             }
                             completionHandler?(data, response, error)
                         }
@@ -95,7 +95,7 @@ internal class URLSessionSwizzler {
                         //   `nil` as the `completionHandler` (it produces a warning, but compiles).
                         task = previousImplementation(session, Self.selector, urlRequest, completionHandler)
                     }
-                    interceptor.taskCreated(urlSession: session, task: task)
+                    interceptor.taskCreated(task: task)
                     return task
                 }
             }
@@ -137,7 +137,7 @@ internal class URLSessionSwizzler {
                         var taskReference: URLSessionDataTask?
                         let newCompletionHandler: CompletionHandler = { data, response, error in
                             if let task = taskReference { // sanity check, should always succeed
-                                interceptor.taskCompleted(urlSession: session, task: task, error: error)
+                                interceptor.taskCompleted(task: task, error: error)
                             }
                             completionHandler?(data, response, error)
                         }
@@ -149,7 +149,7 @@ internal class URLSessionSwizzler {
                         //   `nil` as the `completionHandler` (it produces a warning, but compiles).
                         task = previousImplementation(session, Self.selector, url, completionHandler)
                     }
-                    interceptor.taskCreated(urlSession: session, task: task)
+                    interceptor.taskCreated(task: task)
                     return task
                 }
             }
@@ -192,7 +192,7 @@ internal class URLSessionSwizzler {
                         // Prior to iOS 13.0, `dataTask(with:)` (for `URLRequest`) calls the
                         // the `dataTask(with:completionHandler:)` (for `URLRequest`) internally,
                         // so the task creation will be notified from `dataTaskWithURLRequestAndCompletion` swizzling.
-                        interceptor.taskCreated(urlSession: session, task: task)
+                        interceptor.taskCreated(task: task)
                     }
                     return task
                 }
@@ -231,7 +231,7 @@ internal class URLSessionSwizzler {
                         return previousImplementation(session, Self.selector, url)
                     }
                     let task = previousImplementation(session, Self.selector, url)
-                    interceptor.taskCreated(urlSession: session, task: task)
+                    interceptor.taskCreated(task: task)
                     return task
                 }
             }

--- a/Sources/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
+++ b/Sources/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import class Datadog.URLSessionInterceptor
+import Alamofire
+
+/// An `Alamofire.EventMonitor` which instruments `Alamofire.Session` with Datadog RUM and Tracing.
+public class DDEventMonitor: EventMonitor {
+    public init() {}
+
+    public func request(_ request: Request, didCreateTask task: URLSessionTask) {
+        URLSessionInterceptor.shared?.taskCreated(task: task)
+    }
+
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        URLSessionInterceptor.shared?.taskMetricsCollected(task: task, metrics: metrics)
+    }
+
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        URLSessionInterceptor.shared?.taskCompleted(task: task, error: error)
+    }
+}
+
+/// An `Alamofire.RequestInterceptor` which instruments `Alamofire.Session` with Datadog RUM and Tracing.
+public class DDRequestInterceptor: RequestInterceptor {
+    public init() {}
+
+    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        let instrumentedRequest = URLSessionInterceptor.shared?.modify(request: urlRequest)
+        completion(.success(instrumentedRequest ?? urlRequest))
+    }
+}

--- a/Sources/DatadogExtensions/Alamofire/README.md
+++ b/Sources/DatadogExtensions/Alamofire/README.md
@@ -1,14 +1,14 @@
 # Datadog Integration for Alamofire
 
 `DatadogAlamofireExtension` enables `Alamofire.Session` auto instrumentation with Datadog SDK.
-It's a counterpart of `DDURLSessionDelegate` which we provide for native `URLSession` instrumentation.
+It's a counterpart of `DDURLSessionDelegate`, which is provided for native `URLSession` instrumentation.
 
-## Getting Started
+## Getting started
 
 ### CocoaPods
 
 To include the Datadog integration for [Alamofire][1] in your project, add the
-following to your `Podfile`.
+following to your `Podfile`:
 ```ruby
 pod 'DatadogSDKAlamofireExtension'
 ```
@@ -16,7 +16,7 @@ pod 'DatadogSDKAlamofireExtension'
 
 ### Carthage and SPM
 
-Although our [Alamofire][1] integration doesn't currently support [Carthage][2] nor [SPM][3], the number of code needed to set it up is very low and you may want to just include the source files from this folder directly in your project.
+The Datadog [Alamofire][1] integration doesn't support [Carthage][2] or [SPM][3], however, the code needed for set up is very low. You may want to include the source files from this folder directly in your project.
 
 ### Initial setup
 
@@ -34,7 +34,7 @@ let alamofireSession = Session(
 )
 ```
 
-This will make the Datadog SDK track requests sent from this instance of the `Alamofire.Session`.
+Using this setup makes the Datadog SDK track requests from this instance of the `Alamofire.Session`.
 
 ## Contributing
 

--- a/Sources/DatadogExtensions/Alamofire/README.md
+++ b/Sources/DatadogExtensions/Alamofire/README.md
@@ -1,0 +1,51 @@
+# Datadog Integration for Alamofire
+
+`DatadogAlamofireExtension` enables `Alamofire.Session` auto instrumentation with Datadog SDK.
+It's a counterpart of `DDURLSessionDelegate` which we provide for native `URLSession` instrumentation.
+
+## Getting Started
+
+### CocoaPods
+
+To include the Datadog integration for [Alamofire][1] in your project, add the
+following to your `Podfile`.
+```ruby
+pod 'DatadogSDKAlamofireExtension'
+```
+`DatadogSDKAlamofireExtension` requires Datadog SDK `1.4.0` (or higher).
+
+### Carthage and SPM
+
+Although our [Alamofire][1] integration doesn't currently support [Carthage][2] nor [SPM][3], the number of code needed to set it up is very low and you may want to just include the source files from this folder directly in your project.
+
+### Initial setup
+
+Follow the regular steps for initializing Datadog SDK for [Tracing][4] or [RUM][5].
+
+Instead of using `DDURLSessionDelegate` for `URLSession`, use `DDEventMonitor` and `DDRequestInterceptor` for `Alamofire.Session`:
+
+```swift
+import DatadogAlamofireExtension
+import Alamofire
+
+let alamofireSession = Session(
+   interceptor: DDRequestInterceptor(),
+   eventMonitors: [DDEventMonitor()]
+)
+```
+
+This will make the Datadog SDK track requests sent from this instance of the `Alamofire.Session`.
+
+## Contributing
+
+Pull requests are welcome. First, open an issue to discuss what you would like to change. For more information, read the [Contributing Guide](../../../CONTRIBUTING.md).
+
+## License
+
+[Apache License, v2.0](../../../LICENSE)
+
+[1]: https://github.com/Alamofire/Alamofire
+[2]: https://github.com/Carthage/Carthage
+[3]: https://swift.org/package-manager/
+[4]: https://docs.datadoghq.com/tracing/setup/ios/
+[5]: https://docs.datadoghq.com/real_user_monitoring/ios

--- a/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
@@ -11,32 +11,32 @@ class URLSessionInterceptorMock: URLSessionInterceptorType {
     var modifiedRequest: URLRequest?
 
     var onRequestModified: ((URLRequest) -> Void)?
-    var onTaskCreated: ((URLSession, URLSessionTask) -> Void)?
-    var onTaskCompleted: ((URLSession, URLSessionTask, Error?) -> Void)?
-    var onTaskMetricsCollected: ((URLSession, URLSessionTask, URLSessionTaskMetrics) -> Void)?
+    var onTaskCreated: ((URLSessionTask) -> Void)?
+    var onTaskCompleted: ((URLSessionTask, Error?) -> Void)?
+    var onTaskMetricsCollected: ((URLSessionTask, URLSessionTaskMetrics) -> Void)?
 
-    var tasksCreated: [(session: URLSession, task: URLSessionTask)] = []
-    var tasksCompleted: [(session: URLSession, task: URLSessionTask, error: Error?)] = []
-    var taskMetrics: [(session: URLSession, task: URLSessionTask, metrics: URLSessionTaskMetrics)] = []
+    var tasksCreated: [URLSessionTask] = []
+    var tasksCompleted: [(task: URLSessionTask, error: Error?)] = []
+    var taskMetrics: [(task: URLSessionTask, metrics: URLSessionTaskMetrics)] = []
 
     func modify(request: URLRequest) -> URLRequest {
         onRequestModified?(request)
         return modifiedRequest ?? request
     }
 
-    func taskCreated(urlSession: URLSession, task: URLSessionTask) {
-        tasksCreated.append((session: urlSession, task: task))
-        onTaskCreated?(urlSession, task)
+    func taskCreated(task: URLSessionTask) {
+        tasksCreated.append(task)
+        onTaskCreated?(task)
     }
 
-    func taskCompleted(urlSession: URLSession, task: URLSessionTask, error: Error?) {
-        tasksCompleted.append((session: urlSession, task: task, error: error))
-        onTaskCompleted?(urlSession, task, error)
+    func taskCompleted(task: URLSessionTask, error: Error?) {
+        tasksCompleted.append((task: task, error: error))
+        onTaskCompleted?(task, error)
     }
 
-    func taskMetricsCollected(urlSession: URLSession, task: URLSessionTask, metrics: URLSessionTaskMetrics) {
-        taskMetrics.append((session: urlSession, task: task, metrics: metrics))
-        onTaskMetricsCollected?(urlSession, task, metrics)
+    func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics) {
+        taskMetrics.append((task: task, metrics: metrics))
+        onTaskMetricsCollected?(task, metrics)
     }
 }
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
@@ -22,8 +22,8 @@ class DDURLSessionDelegateTests: XCTestCase {
         let notifyTaskMetricsCollected = expectation(description: "Notify task metrics collection")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
-        interceptor.onTaskMetricsCollected = { _, _, _ in notifyTaskMetricsCollected.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskMetricsCollected = { _, _ in notifyTaskMetricsCollected.fulfill() }
 
         // Given
         let session = URLSession.createServerMockURLSession(delegate: delegate)
@@ -42,8 +42,8 @@ class DDURLSessionDelegateTests: XCTestCase {
         let notifyTaskMetricsCollected = expectation(description: "Notify task metrics collection")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
-        interceptor.onTaskMetricsCollected = { _, _, _ in notifyTaskMetricsCollected.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskMetricsCollected = { _, _ in notifyTaskMetricsCollected.fulfill() }
 
         // Given
         let session = URLSession.createServerMockURLSession(delegate: delegate)
@@ -68,8 +68,8 @@ class DDURLSessionDelegateTests: XCTestCase {
         let expectedError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "some error"])
         let server = ServerMock(delivery: .failure(error: expectedError))
 
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
-        interceptor.onTaskMetricsCollected = { _, _, _ in notifyTaskMetricsCollected.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskMetricsCollected = { _, _ in notifyTaskMetricsCollected.fulfill() }
 
         let dateBeforeAnyRequests = Date()
 
@@ -88,19 +88,15 @@ class DDURLSessionDelegateTests: XCTestCase {
         _ = server.waitAndReturnRequests(count: 1)
 
         let dateAfterAllRequests = Date()
-        XCTAssertTrue(interceptor.taskMetrics[0].session === session)
         XCTAssertTrue(interceptor.taskMetrics[0].task === taskWithURL)
         XCTAssertGreaterThan(interceptor.taskMetrics[0].metrics.taskInterval.start, dateBeforeAnyRequests)
         XCTAssertLessThan(interceptor.taskMetrics[0].metrics.taskInterval.end, dateAfterAllRequests)
-        XCTAssertTrue(interceptor.tasksCompleted[0].session === session)
         XCTAssertTrue(interceptor.tasksCompleted[0].task === taskWithURL)
         XCTAssertEqual((interceptor.tasksCompleted[0].error! as NSError).localizedDescription, "some error")
 
-        XCTAssertTrue(interceptor.taskMetrics[1].session === session)
         XCTAssertTrue(interceptor.taskMetrics[1].task === taskWithURLRequest)
         XCTAssertGreaterThan(interceptor.taskMetrics[1].metrics.taskInterval.start, dateBeforeAnyRequests)
         XCTAssertLessThan(interceptor.taskMetrics[1].metrics.taskInterval.end, dateAfterAllRequests)
-        XCTAssertTrue(interceptor.tasksCompleted[1].session === session)
         XCTAssertTrue(interceptor.tasksCompleted[1].task === taskWithURLRequest)
         XCTAssertEqual((interceptor.tasksCompleted[1].error! as NSError).localizedDescription, "some error")
     }
@@ -113,8 +109,8 @@ class DDURLSessionDelegateTests: XCTestCase {
 
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
-        interceptor.onTaskMetricsCollected = { _, _, _ in notifyTaskMetricsCollected.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskMetricsCollected = { _, _ in notifyTaskMetricsCollected.fulfill() }
 
         let dateBeforeAnyRequests = Date()
 
@@ -133,19 +129,15 @@ class DDURLSessionDelegateTests: XCTestCase {
         _ = server.waitAndReturnRequests(count: 1)
 
         let dateAfterAllRequests = Date()
-        XCTAssertTrue(interceptor.taskMetrics[0].session === session)
         XCTAssertTrue(interceptor.taskMetrics[0].task === taskWithURL)
         XCTAssertGreaterThan(interceptor.taskMetrics[0].metrics.taskInterval.start, dateBeforeAnyRequests)
         XCTAssertLessThan(interceptor.taskMetrics[0].metrics.taskInterval.end, dateAfterAllRequests)
-        XCTAssertTrue(interceptor.tasksCompleted[0].session === session)
         XCTAssertTrue(interceptor.tasksCompleted[0].task === taskWithURL)
         XCTAssertNil(interceptor.tasksCompleted[0].error)
 
-        XCTAssertTrue(interceptor.taskMetrics[1].session === session)
         XCTAssertTrue(interceptor.taskMetrics[1].task === taskWithURLRequest)
         XCTAssertGreaterThan(interceptor.taskMetrics[1].metrics.taskInterval.start, dateBeforeAnyRequests)
         XCTAssertLessThan(interceptor.taskMetrics[1].metrics.taskInterval.end, dateAfterAllRequests)
-        XCTAssertTrue(interceptor.tasksCompleted[1].session === session)
         XCTAssertTrue(interceptor.tasksCompleted[1].task === taskWithURLRequest)
         XCTAssertNil(interceptor.tasksCompleted[1].error)
     }

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
@@ -254,17 +254,17 @@ class URLSessionInterceptorTests: XCTestCase {
 
         // swiftlint:disable opening_brace
         callConcurrently(
-            { interceptor.taskCreated(urlSession: .mockAny(), task: firstPartyTask) },
-            { interceptor.taskCreated(urlSession: .mockAny(), task: thirdPartyTask) },
-            { interceptor.taskCreated(urlSession: .mockAny(), task: internalTask) }
+            { interceptor.taskCreated(task: firstPartyTask) },
+            { interceptor.taskCreated(task: thirdPartyTask) },
+            { interceptor.taskCreated(task: internalTask) }
         )
         callConcurrently(
-            { interceptor.taskCompleted(urlSession: .mockAny(), task: firstPartyTask, error: nil) },
-            { interceptor.taskCompleted(urlSession: .mockAny(), task: thirdPartyTask, error: nil) },
-            { interceptor.taskCompleted(urlSession: .mockAny(), task: internalTask, error: nil) },
-            { interceptor.taskMetricsCollected(urlSession: .mockAny(), task: firstPartyTask, metrics: .mockAny()) },
-            { interceptor.taskMetricsCollected(urlSession: .mockAny(), task: thirdPartyTask, metrics: .mockAny()) },
-            { interceptor.taskMetricsCollected(urlSession: .mockAny(), task: internalTask, metrics: .mockAny()) }
+            { interceptor.taskCompleted(task: firstPartyTask, error: nil) },
+            { interceptor.taskCompleted(task: thirdPartyTask, error: nil) },
+            { interceptor.taskCompleted(task: internalTask, error: nil) },
+            { interceptor.taskMetricsCollected(task: firstPartyTask, metrics: .mockAny()) },
+            { interceptor.taskMetricsCollected(task: thirdPartyTask, metrics: .mockAny()) },
+            { interceptor.taskMetricsCollected(task: internalTask, metrics: .mockAny()) }
         )
         // swiftlint:enable opening_brace
 
@@ -329,17 +329,17 @@ class URLSessionInterceptorTests: XCTestCase {
 
         // swiftlint:disable opening_brace
         callConcurrently(
-            { interceptor.taskCreated(urlSession: .mockAny(), task: firstPartyTask) },
-            { interceptor.taskCreated(urlSession: .mockAny(), task: thirdPartyTask) },
-            { interceptor.taskCreated(urlSession: .mockAny(), task: internalTask) }
+            { interceptor.taskCreated(task: firstPartyTask) },
+            { interceptor.taskCreated(task: thirdPartyTask) },
+            { interceptor.taskCreated(task: internalTask) }
         )
         callConcurrently(
-            { interceptor.taskCompleted(urlSession: .mockAny(), task: firstPartyTask, error: nil) },
-            { interceptor.taskCompleted(urlSession: .mockAny(), task: thirdPartyTask, error: nil) },
-            { interceptor.taskCompleted(urlSession: .mockAny(), task: internalTask, error: nil) },
-            { interceptor.taskMetricsCollected(urlSession: .mockAny(), task: firstPartyTask, metrics: .mockAny()) },
-            { interceptor.taskMetricsCollected(urlSession: .mockAny(), task: thirdPartyTask, metrics: .mockAny()) },
-            { interceptor.taskMetricsCollected(urlSession: .mockAny(), task: internalTask, metrics: .mockAny()) }
+            { interceptor.taskCompleted(task: firstPartyTask, error: nil) },
+            { interceptor.taskCompleted(task: thirdPartyTask, error: nil) },
+            { interceptor.taskCompleted(task: internalTask, error: nil) },
+            { interceptor.taskMetricsCollected(task: firstPartyTask, metrics: .mockAny()) },
+            { interceptor.taskMetricsCollected(task: thirdPartyTask, metrics: .mockAny()) },
+            { interceptor.taskMetricsCollected(task: internalTask, metrics: .mockAny()) }
         )
         // swiftlint:enable opening_brace
 
@@ -387,9 +387,9 @@ class URLSessionInterceptorTests: XCTestCase {
         callConcurrently(
             closures: [
                 { _ = interceptor.modify(request: requests.randomElement()!) },
-                { interceptor.taskCreated(urlSession: .mockAny(), task: tasks.randomElement()!) },
-                { interceptor.taskMetricsCollected(urlSession: .mockAny(), task: tasks.randomElement()!, metrics: .mockAny()) },
-                { interceptor.taskCompleted(urlSession: .mockAny(), task: tasks.randomElement()!, error: nil) }
+                { interceptor.taskCreated(task: tasks.randomElement()!) },
+                { interceptor.taskMetricsCollected(task: tasks.randomElement()!, metrics: .mockAny()) },
+                { interceptor.taskCompleted(task: tasks.randomElement()!, error: nil) }
             ],
             iterations: 50
         )

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
@@ -18,6 +18,23 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
         super.tearDown()
     }
 
+    func testWhenURLSessionAutoInstrumentationIsEnabled_thenSharedIntrceptorIsAvailable() {
+        XCTAssertNil(URLSessionInterceptor.shared)
+
+        // When
+        URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
+            configuration: .mockAny(),
+            dateProvider: SystemDateProvider()
+        )
+        defer {
+            URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
+            URLSessionAutoInstrumentation.instance = nil
+        }
+
+        // Then
+        XCTAssertNotNil(URLSessionInterceptor.shared)
+    }
+
     func testGivenURLSessionAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsResourcesHandler() throws {
         // Given
         RUMFeature.instance = .mockNoOp()

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -48,8 +48,8 @@ class URLSessionSwizzlerTests: XCTestCase {
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
         interceptor.onRequestModified = { _ in requestModified.fulfill() }
-        interceptor.onTaskCreated = { _, _ in notifyTaskCreated.fulfill() }
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
         let session = interceptedSession()
@@ -79,8 +79,8 @@ class URLSessionSwizzlerTests: XCTestCase {
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
         interceptor.onRequestModified = { _ in requestModified.fulfill() }
-        interceptor.onTaskCreated = { _, _ in notifyTaskCreated.fulfill() }
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
         let session = interceptedSession()
@@ -110,8 +110,8 @@ class URLSessionSwizzlerTests: XCTestCase {
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
         interceptor.onRequestModified = { _ in requestModified.fulfill() }
-        interceptor.onTaskCreated = { _, _ in notifyTaskCreated.fulfill() }
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
         let session = interceptedSession()
@@ -136,8 +136,8 @@ class URLSessionSwizzlerTests: XCTestCase {
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
         interceptor.onRequestModified = { _ in requestNotModified.fulfill() }
-        interceptor.onTaskCreated = { _, _ in notifyTaskCreated.fulfill() }
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
         let session = interceptedSession()
@@ -161,8 +161,8 @@ class URLSessionSwizzlerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
-        interceptor.onTaskCreated = { _, _ in notifyTaskCreated.fulfill() }
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
         let nsSession = NSURLSessionBridge(interceptedSession())!
@@ -186,7 +186,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         interceptor.onRequestModified = { _ in doNotModifyRequest.fulfill() }
         let doNotNotifyTaskCreated = expectation(description: "Notify task creation")
         doNotNotifyTaskCreated.isInverted = true
-        interceptor.onTaskCreated = { _, _ in doNotNotifyTaskCreated.fulfill() }
+        interceptor.onTaskCreated = { _ in doNotNotifyTaskCreated.fulfill() }
 
         // Given
         let session = URLSession(configuration: .default)
@@ -212,7 +212,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         completionHandlersCalled.expectedFulfillmentCount = 2
         let notifyTaskCompleted = expectation(description: "Notify task completion")
         notifyTaskCompleted.expectedFulfillmentCount = 4
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
         let expectedResponse: HTTPURLResponse = .mockResponseWith(statusCode: 200)
@@ -250,27 +250,19 @@ class URLSessionSwizzlerTests: XCTestCase {
         XCTAssertEqual(interceptor.tasksCreated.count, 4, "Interceptor should record all 4 tasks created.")
         XCTAssertEqual(interceptor.tasksCompleted.count, 4, "Interceptor should record all 4 tasks completed.")
 
-        XCTAssertTrue(interceptor.tasksCreated[0].session === session)
-        XCTAssertTrue(interceptor.tasksCreated[0].task === taskWithURLRequestAndCompletion)
-        XCTAssertTrue(interceptor.tasksCompleted[0].session === session)
+        XCTAssertTrue(interceptor.tasksCreated[0] === taskWithURLRequestAndCompletion)
         XCTAssertTrue(interceptor.tasksCompleted[0].task === taskWithURLRequestAndCompletion)
         XCTAssertNil(interceptor.tasksCompleted[0].error)
 
-        XCTAssertTrue(interceptor.tasksCreated[1].session === session)
-        XCTAssertTrue(interceptor.tasksCreated[1].task === taskWithURLAndCompletion)
-        XCTAssertTrue(interceptor.tasksCompleted[1].session === session)
+        XCTAssertTrue(interceptor.tasksCreated[1] === taskWithURLAndCompletion)
         XCTAssertTrue(interceptor.tasksCompleted[1].task === taskWithURLAndCompletion)
         XCTAssertNil(interceptor.tasksCompleted[1].error)
 
-        XCTAssertTrue(interceptor.tasksCreated[2].session === session)
-        XCTAssertTrue(interceptor.tasksCreated[2].task === taskWithURLRequest)
-        XCTAssertTrue(interceptor.tasksCompleted[2].session === session)
+        XCTAssertTrue(interceptor.tasksCreated[2] === taskWithURLRequest)
         XCTAssertTrue(interceptor.tasksCompleted[2].task === taskWithURLRequest)
         XCTAssertNil(interceptor.tasksCompleted[2].error)
 
-        XCTAssertTrue(interceptor.tasksCreated[3].session === session)
-        XCTAssertTrue(interceptor.tasksCreated[3].task === taskWithURL)
-        XCTAssertTrue(interceptor.tasksCompleted[3].session === session)
+        XCTAssertTrue(interceptor.tasksCreated[3] === taskWithURL)
         XCTAssertTrue(interceptor.tasksCompleted[3].task === taskWithURL)
         XCTAssertNil(interceptor.tasksCompleted[3].error)
     }
@@ -280,7 +272,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         completionHandlersCalled.expectedFulfillmentCount = 2
         let notifyTaskCompleted = expectation(description: "Notify task completion")
         notifyTaskCompleted.expectedFulfillmentCount = 4
-        interceptor.onTaskCompleted = { _, _, _ in notifyTaskCompleted.fulfill() }
+        interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
         let expectedError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "some error"])
@@ -317,27 +309,19 @@ class URLSessionSwizzlerTests: XCTestCase {
         XCTAssertEqual(interceptor.tasksCreated.count, 4, "Interceptor should record all 4 tasks created.")
         XCTAssertEqual(interceptor.tasksCompleted.count, 4, "Interceptor should record all 4 tasks completed.")
 
-        XCTAssertTrue(interceptor.tasksCreated[0].session === session)
-        XCTAssertTrue(interceptor.tasksCreated[0].task === taskWithURLRequestAndCompletion)
-        XCTAssertTrue(interceptor.tasksCompleted[0].session === session)
+        XCTAssertTrue(interceptor.tasksCreated[0] === taskWithURLRequestAndCompletion)
         XCTAssertTrue(interceptor.tasksCompleted[0].task === taskWithURLRequestAndCompletion)
         XCTAssertEqual((interceptor.tasksCompleted[0].error! as NSError).localizedDescription, "some error")
 
-        XCTAssertTrue(interceptor.tasksCreated[1].session === session)
-        XCTAssertTrue(interceptor.tasksCreated[1].task === taskWithURLAndCompletion)
-        XCTAssertTrue(interceptor.tasksCompleted[1].session === session)
+        XCTAssertTrue(interceptor.tasksCreated[1] === taskWithURLAndCompletion)
         XCTAssertTrue(interceptor.tasksCompleted[1].task === taskWithURLAndCompletion)
         XCTAssertEqual((interceptor.tasksCompleted[1].error! as NSError).localizedDescription, "some error")
 
-        XCTAssertTrue(interceptor.tasksCreated[2].session === session)
-        XCTAssertTrue(interceptor.tasksCreated[2].task === taskWithURLRequest)
-        XCTAssertTrue(interceptor.tasksCompleted[2].session === session)
+        XCTAssertTrue(interceptor.tasksCreated[2] === taskWithURLRequest)
         XCTAssertTrue(interceptor.tasksCompleted[2].task === taskWithURLRequest)
         XCTAssertEqual((interceptor.tasksCompleted[2].error! as NSError).localizedDescription, "some error")
 
-        XCTAssertTrue(interceptor.tasksCreated[3].session === session)
-        XCTAssertTrue(interceptor.tasksCreated[3].task === taskWithURL)
-        XCTAssertTrue(interceptor.tasksCompleted[3].session === session)
+        XCTAssertTrue(interceptor.tasksCreated[3] === taskWithURL)
         XCTAssertTrue(interceptor.tasksCompleted[3].task === taskWithURL)
         XCTAssertEqual((interceptor.tasksCompleted[3].error! as NSError).localizedDescription, "some error")
     }

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -234,3 +234,14 @@ public class HTTPHeadersWriter: OTHTTPHeadersWriter
  public private(set) var tracePropagationHTTPHeaders: [String: String] = [:]
  public func inject(spanContext: OTSpanContext)
  override public init()
+public protocol URLSessionInterceptorType: class
+ func modify(request: URLRequest) -> URLRequest
+ func taskCreated(task: URLSessionTask)
+ func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics)
+ func taskCompleted(task: URLSessionTask, error: Error?)
+public class URLSessionInterceptor: URLSessionInterceptorType
+ public static var shared: URLSessionInterceptor?
+ public func modify(request: URLRequest) -> URLRequest
+ public func taskCreated(task: URLSessionTask)
+ public func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics)
+ public func taskCompleted(task: URLSessionTask, error: Error?)

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -234,13 +234,8 @@ public class HTTPHeadersWriter: OTHTTPHeadersWriter
  public private(set) var tracePropagationHTTPHeaders: [String: String] = [:]
  public func inject(spanContext: OTSpanContext)
  override public init()
-public protocol URLSessionInterceptorType: class
- func modify(request: URLRequest) -> URLRequest
- func taskCreated(task: URLSessionTask)
- func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics)
- func taskCompleted(task: URLSessionTask, error: Error?)
-public class URLSessionInterceptor: URLSessionInterceptorType
- public static var shared: URLSessionInterceptor?
+public class DDURLSessionInterceptor: URLSessionInterceptorType
+ public static var shared: DDURLSessionInterceptor?
  public func modify(request: URLRequest) -> URLRequest
  public func taskCreated(task: URLSessionTask)
  public func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics)

--- a/dependency-manager-tests/cocoapods/CPProject/ViewController.swift
+++ b/dependency-manager-tests/cocoapods/CPProject/ViewController.swift
@@ -6,6 +6,8 @@
 
 import UIKit
 import Datadog
+import DatadogAlamofireExtension
+import Alamofire
 
 internal class ViewController: UIViewController {
     private var logger: Logger! // swiftlint:disable:this implicitly_unwrapped_optional
@@ -15,6 +17,7 @@ internal class ViewController: UIViewController {
 
         Datadog.initialize(
             appContext: .init(),
+            trackingConsent: .pending,
             configuration: Datadog.Configuration
                 .builderUsing(clientToken: "abc", environment: "tests")
                 .build()
@@ -27,9 +30,19 @@ internal class ViewController: UIViewController {
 
         Global.sharedTracer = Tracer.initialize(configuration: .init())
 
-        logger.info("It works")
+        Global.rum = RUMMonitor.initialize()
 
-        // Start span, but never finish it (no upload)
+        logger.info("It works")
         _ = Global.sharedTracer.startSpan(operationName: "This too")
+        Global.rum.startView(viewController: self)
+
+        createInstrumentedAlamofireSession()
+    }
+
+    private func createInstrumentedAlamofireSession() {
+        _ = Session(
+            interceptor: DDRequestInterceptor(),
+            eventMonitors: [DDEventMonitor()]
+        )
     }
 }

--- a/dependency-manager-tests/cocoapods/Podfile.src
+++ b/dependency-manager-tests/cocoapods/Podfile.src
@@ -3,4 +3,6 @@ platform :ios, '12.0'
 target 'CPProject' do
   use_frameworks!
   pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :branch => 'REMOTE_GIT_BRANCH'
+  pod 'DatadogSDKAlamofireExtension', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :branch => 'REMOTE_GIT_BRANCH'
+  pod 'Alamofire'
 end


### PR DESCRIPTION
### What and why?

📦 This PR makes it possible to add integrations with 3rd party networking libraries (including [Alamofire](https://github.com/Alamofire/Alamofire)).

### How?

Our network interceptor is pretty straightforward and follows the interception model in Alamofire:
* modify request;
* process task creation;
* process task metrics;
* process task completion (with optional error).

By polishing its interface and making the `URLSessionInterceptor` public, now it is possible to use our SDK with `Alamofire` by implementing custom AF's `EventMonitor` (for task start, metrics and completion) and AF's `RequestInterceptor` (for request modification).

Implementations of `DDEventMonitor` and `DDRequestInterceptor` are provided in `Sources/DatadogExtensions/Alamofire/`.

Those implementations are delivered in `DatadogSDKAlamofireExtension` pod:
```ruby
pod 'DatadogSDKAlamofireExtension'
```
```swift
import DatadogAlamofireExtension
import Alamofire

let alamofireSession = Session(
   interceptor: DDRequestInterceptor(),
   eventMonitors: [DDEventMonitor()]
)
```

### `DatadogAlamofireExtension ` for Carthage and SPM

It is not yet possible to distribute `DatadogAlamofireExtension` as SPM package, because [dynamic frameworks are still broken in SPM](https://forums.swift.org/t/how-to-link-a-swift-package-as-dynamic/32062). Doing so, raises the compiler warning of duplicated symbols for `Datadog` and `Kronos` (as those two are (in-)directly linked to the app by both `Datadog` and `DatadogAlamofireExtension` dependencies).

Distributing `DatadogAlamofireExtension` through Carthage is very inconvenient and may be error-prone for non-Alamofire users, as both `DatadogAlamofireExtension.framework` and `Alamofire.framework` will appear in `Carthage/Build/iOS` folder. This would require additional explanation in Carthage installation steps for the SDK.

### Note on `DatadogSDKAlamofireExtension.podspec`

Instead of creating separate podspec, I've also considered also adding `AlamofireExtension` subspec to `DatadogSDK.podspec` or creating `DatadogSDKExtensions/Alamofire` spec. Neither of this seems valid, as it doesn't scale for other integrations and eventual SPM / Carthage support.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
