### PR TITLE
RUMM-927 Use default value for `trackUIKitRUMViews()` public API

### DIFF
--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -407,10 +407,10 @@ extension Datadog {
             /// **NOTE:** Enabling this option will install swizzlings on `UIApplication.sendEvent(_:)` method. Refer
             /// to `UIApplicationSwizzler.swift` for implementation details.
             ///
-            /// By default, automatic tracking of `UIEvents` is disabled and no swizzling is installed on the `UIApplication` class.
+            /// Until this option is enabled, automatic tracking of `UIEvents` is disabled and no swizzling is installed on the `UIApplication` class.
             ///
-            /// - Parameter enabled: `false` by default
-            public func trackUIKitActions(_ enabled: Bool) -> Builder {
+            /// - Parameter enabled: `true` by default
+            public func trackUIKitActions(_ enabled: Bool = true) -> Builder {
                 configuration.rumUIKitActionsTrackingEnabled = enabled
                 return self
             }

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -388,10 +388,11 @@ extension Datadog {
             /// **NOTE:** Enabling this option will install swizzlings on `UIViewController's` lifecycle methods. Refer
             /// to `UIViewControllerSwizzler.swift` for implementation details.
             ///
-            /// By default, automatic tracking of `UIViewControllers` is disabled and no swizzlings are installed on the `UIViewController` class.
+            /// Until this option is enabled, automatic tracking of `UIViewControllers` is disabled and no swizzlings are installed on the `UIViewController` class.
             ///
             /// - Parameter predicate: the predicate deciding if a given `UIViewController` marks the beginning or end of the RUM View.
-            public func trackUIKitRUMViews(using predicate: UIKitRUMViewsPredicate) -> Builder {
+            /// Defaults to `DefaultUIKitRUMViewsPredicate` instance.
+            public func trackUIKitRUMViews(using predicate: UIKitRUMViewsPredicate = DefaultUIKitRUMViewsPredicate()) -> Builder {
                 configuration.rumUIKitViewsPredicate = predicate
                 return self
             }

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -62,7 +62,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .set(rumSessionsSamplingRate: 42.5)
                 .track(firstPartyHosts: ["example.com"])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock())
-                .trackUIKitActions(true)
+                .trackUIKitActions(false)
 
             return builder
         }
@@ -71,13 +71,14 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             .builderUsing(clientToken: "abc-123", environment: "tests")
         let defaultRUMBuilder = Datadog.Configuration
             .builderUsing(rumApplicationID: "rum-app-id", clientToken: "abc-123", environment: "tests")
-        let rumBuilderWithDefaultPredicate = Datadog.Configuration
+        let rumBuilderWithDefaultValues = Datadog.Configuration
             .builderUsing(rumApplicationID: "rum-app-id", clientToken: "abc-123", environment: "tests")
             .trackUIKitRUMViews()
+            .trackUIKitActions()
 
         let configuration = customized(defaultBuilder).build()
         let rumConfiguration = customized(defaultRUMBuilder).build()
-        let rumConfigurationWithDefaultPredicate = rumBuilderWithDefaultPredicate.build()
+        let rumConfigurationWithDefaultValues = rumBuilderWithDefaultValues.build()
 
         XCTAssertNil(configuration.rumApplicationID)
         XCTAssertEqual(rumConfiguration.rumApplicationID, "rum-app-id")
@@ -96,10 +97,11 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.firstPartyHosts, ["example.com"])
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 42.5)
             XCTAssertTrue(configuration.rumUIKitViewsPredicate is UIKitRUMViewsPredicateMock)
-            XCTAssertTrue(configuration.rumUIKitActionsTrackingEnabled)
+            XCTAssertFalse(configuration.rumUIKitActionsTrackingEnabled)
         }
 
-        XCTAssertTrue(rumConfigurationWithDefaultPredicate.rumUIKitViewsPredicate is DefaultUIKitRUMViewsPredicate)
+        XCTAssertTrue(rumConfigurationWithDefaultValues.rumUIKitViewsPredicate is DefaultUIKitRUMViewsPredicate)
+        XCTAssertTrue(rumConfigurationWithDefaultValues.rumUIKitActionsTrackingEnabled)
     }
 
     func testDeprecatedAPIs() {

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -59,8 +59,8 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .set(customLogsEndpoint: URL(string: "https://api.custom.logs/")!)
                 .set(customTracesEndpoint: URL(string: "https://api.custom.traces/")!)
                 .set(customRUMEndpoint: URL(string: "https://api.custom.rum/")!)
-                .track(firstPartyHosts: ["example.com"])
                 .set(rumSessionsSamplingRate: 42.5)
+                .track(firstPartyHosts: ["example.com"])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock())
                 .trackUIKitActions(true)
 
@@ -71,9 +71,13 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             .builderUsing(clientToken: "abc-123", environment: "tests")
         let defaultRUMBuilder = Datadog.Configuration
             .builderUsing(rumApplicationID: "rum-app-id", clientToken: "abc-123", environment: "tests")
+        let rumBuilderWithDefaultPredicate = Datadog.Configuration
+            .builderUsing(rumApplicationID: "rum-app-id", clientToken: "abc-123", environment: "tests")
+            .trackUIKitRUMViews()
 
         let configuration = customized(defaultBuilder).build()
         let rumConfiguration = customized(defaultRUMBuilder).build()
+        let rumConfigurationWithDefaultPredicate = rumBuilderWithDefaultPredicate.build()
 
         XCTAssertNil(configuration.rumApplicationID)
         XCTAssertEqual(rumConfiguration.rumApplicationID, "rum-app-id")
@@ -91,9 +95,11 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.customRUMEndpoint, URL(string: "https://api.custom.rum/")!)
             XCTAssertEqual(configuration.firstPartyHosts, ["example.com"])
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 42.5)
-            XCTAssertNotNil(configuration.rumUIKitViewsPredicate)
+            XCTAssertTrue(configuration.rumUIKitViewsPredicate is UIKitRUMViewsPredicateMock)
             XCTAssertTrue(configuration.rumUIKitActionsTrackingEnabled)
         }
+
+        XCTAssertTrue(rumConfigurationWithDefaultPredicate.rumUIKitViewsPredicate is DefaultUIKitRUMViewsPredicate)
     }
 
     func testDeprecatedAPIs() {

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -59,7 +59,7 @@ public class Datadog
    public func enableRUM(_ enabled: Bool) -> Builder
    public func set(rumEndpoint: RUMEndpoint) -> Builder
    public func set(rumSessionsSamplingRate: Float) -> Builder
-   public func trackUIKitRUMViews(using predicate: UIKitRUMViewsPredicate) -> Builder
+   public func trackUIKitRUMViews(using predicate: UIKitRUMViewsPredicate = DefaultUIKitRUMViewsPredicate()) -> Builder
    public func trackUIKitActions(_ enabled: Bool) -> Builder
    public func set(serviceName: String) -> Builder
    public func build() -> Configuration


### PR DESCRIPTION
### What and why?

📦 To simplify the usage of `DefaultUIKitRUMViewsPredicate`, this PR mades it a default value for `trackUIKitRUMViews()` API.

### How?

Instead of calling:
```swift
.trackUIKitRUMViews(using: DefaultUIKitRUMViewsPredicate())
```
now, users just use:
```swift
.trackUIKitRUMViews()
```
when initialising the SDK.

Customisation is still possible:
```swift
.trackUIKitRUMViews(using: MyCustomPredicate())
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
