### PR TITLE
Fix unit tests compilation after merging Tracking Consent feature

### DIFF
--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -673,7 +673,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Integration With Environment Context
 
     func testGivenBundlingWithTraceEnabledAndTracerRegisteredAndEnvironmentContext_whenSendingLog_itContainsEnvironmentContextAttributes() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { LoggingFeature.instance = nil }
 
         setenv("x-datadog-trace-id", "111111", 1)

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -1067,7 +1067,7 @@ class TracerTests: XCTestCase {
     // MARK: - Environment Context
 
     func testSendingSpansWithNoDirectParentAndEnvironmentContext() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         setenv("x-datadog-trace-id", "111111", 1)
@@ -1104,7 +1104,7 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanWithActiveSpanAsAParentAndEnvironmentContext() throws {
-        TracingFeature.instance = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
+        TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
         defer { TracingFeature.instance = nil }
 
         setenv("x-datadog-trace-id", "111111", 1)


### PR DESCRIPTION
### What and why?

⚙️ This PR fixes unit tests compilation issue after merging #347.

### How?

Recently merged #347 was quite outdated comparing to the main branch, and it was not rebased before the merge. Because of this, updates to unit tests API introduced in NTP time sync feature were not applied in #347, causing the compiler issue on `master`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
~- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference~
