### PR TITLE
RUMM-904 First party hosts are sanitized

### DIFF
--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -173,7 +173,7 @@ extension FeaturesConfiguration {
         if let firstPartyHosts = configuration.firstPartyHosts, !firstPartyHosts.isEmpty {
             if configuration.tracingEnabled || configuration.rumEnabled {
                 urlSessionAutoInstrumentation = URLSessionAutoInstrumentation(
-                    userDefinedFirstPartyHosts: firstPartyHosts,
+                    userDefinedFirstPartyHosts: sanitized(firstPartyHosts: firstPartyHosts),
                     sdkInternalURLs: [
                         logsEndpoint.url,
                         tracesEndpoint.url,
@@ -223,4 +223,30 @@ private func ifValid(endpointURLString: String, clientToken: String) throws -> U
         throw ProgrammerError(description: "Cannot build upload URL.")
     }
     return url
+}
+
+private func sanitized(firstPartyHosts: Set<String>) -> Set<String> {
+    let urlRegex = #"^(http|https)://(.*)"#
+    let hostRegex = #"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)+([A-Za-z]|[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9])$"#
+    let ipRegex = #"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"#
+
+    let array: [String] = firstPartyHosts.compactMap { host in
+        if host.range(of: urlRegex, options: .regularExpression) != nil {
+            // if an URL is given instead of the host, take its `host` part
+            return URL(string: host)?.host
+        } else if host.range(of: hostRegex, options: .regularExpression) != nil {
+            // if a valid host name is given, accept it
+            return host
+        } else if host.range(of: ipRegex, options: .regularExpression) != nil {
+            // if a valid IP address is given, accept it
+            return host
+        } else if host == "localhost" {
+            // if "localhost" given, accept it
+            return host
+        } else {
+            // otherwise, drop
+            return nil
+        }
+    }
+    return Set(array)
 }

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -516,7 +516,31 @@ class FeaturesConfigurationTests: XCTestCase {
             ]
         )
 
-        // TODO: RUMM-904 Check if warning is printed
+        XCTAssertTrue(
+            printFunction.printedMessages.contains("⚠️ The first party host configured for Datadog SDK is not valid: '192.168.0.3:8080' is not a valid host name and will be dropped.")
+        )
+        XCTAssertTrue(
+            printFunction.printedMessages.contains("⚠️ The first party host configured for Datadog SDK is not valid: '' is not a valid host name and will be dropped.")
+        )
+        XCTAssertTrue(
+            printFunction.printedMessages.contains("⚠️ The first party host configured for Datadog SDK is not valid: 'https://first-party.com' is an url and will be sanitized to: 'first-party.com'.")
+        )
+        XCTAssertTrue(
+            printFunction.printedMessages.contains("⚠️ The first party host configured for Datadog SDK is not valid: 'https://192.168.0.1/api' is an url and will be sanitized to: '192.168.0.1'.")
+        )
+        XCTAssertTrue(
+            printFunction.printedMessages.contains("⚠️ The first party host configured for Datadog SDK is not valid: 'http://api.first-party.com' is an url and will be sanitized to: 'api.first-party.com'.")
+        )
+        XCTAssertTrue(
+            printFunction.printedMessages.contains("⚠️ The first party host configured for Datadog SDK is not valid: 'https://first-party.com/v2/api' is an url and will be sanitized to: 'first-party.com'.")
+        )
+        XCTAssertTrue(
+            printFunction.printedMessages.contains("⚠️ The first party host configured for Datadog SDK is not valid: 'invalid-host-name' is not a valid host name and will be dropped.")
+        )
+        XCTAssertTrue(
+            printFunction.printedMessages.contains("⚠️ The first party host configured for Datadog SDK is not valid: 'https://192.168.0.2' is an url and will be sanitized to: '192.168.0.2'.")
+        )
+        XCTAssertEqual(printFunction.printedMessages.count, 8)
     }
 
     // MARK: - Helpers

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -710,9 +710,10 @@ extension EncodableValue {
 ///     consolePrint = printFunction.print
 ///
 class PrintFunctionMock {
-    private(set) var printedMessage: String?
+    private(set) var printedMessages: [String] = []
+    var printedMessage: String? { printedMessages.last }
 
     func print(message: String) {
-        printedMessage = message
+        printedMessages.append(message)
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR adds additional check to the `firstPartyHosts` configured by the user. If the host is invalid, it may get sanitized or dropped - both with appropriate warning.

### How?

Similar to https://github.com/DataDog/dd-sdk-android/pull/447 URL, host and IP regexes were used to validate the input `host`.

Example behaviours:
```swift
"https://first-party.com", // sanitize to → "first-party.com"
"http://api.first-party.com", // sanitize to → "api.first-party.com"
"https://first-party.com/v2/api", // sanitize to → "first-party.com"
"https://192.168.0.1/api", // sanitize to → "192.168.0.1"
"https://192.168.0.2", // sanitize to → "192.168.0.2"
"invalid-host-name", // drop
"192.168.0.3:8080", // drop
"", // drop
"localhost", // accept
"192.168.0.4", // accept
"valid-host-name.com", // accept
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
