### PR TITLE
RUMM-824 Add API for customizing batch size and upload frequency

### DIFF
--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -36,6 +36,8 @@ struct ExampleAppConfiguration: AppConfiguration {
                 environment: "tests"
             )
             .set(serviceName: serviceName)
+            .set(batchSize: .small)
+            .set(uploadFrequency: .frequent)
 
         // If the app was launched with test scenarion ENV, apply the scenario configuration
         if let testScenario = testScenario {
@@ -75,6 +77,8 @@ struct UITestsAppConfiguration: AppConfiguration {
                 environment: "integration"
             )
             .set(serviceName: "ui-tests-service-name")
+            .set(batchSize: .small)
+            .set(uploadFrequency: .frequent)
 
         let serverMockConfiguration = Environment.serverMockConfiguration()
 

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -115,7 +115,11 @@ extension FeaturesConfiguration {
             applicationBundleIdentifier: appContext.bundleIdentifier ?? "unknown",
             serviceName: configuration.serviceName ?? appContext.bundleIdentifier ?? "ios",
             environment: try ifValid(environment: configuration.environment),
-            performance: .best(for: appContext.bundleType)
+            performance: PerformancePreset(
+                batchSize: configuration.batchSize,
+                uploadFrequency: configuration.uploadFrequency,
+                bundleType: appContext.bundleType
+            )
         )
 
         if configuration.loggingEnabled {

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -14,6 +14,27 @@ extension Datadog {
 
     /// Datadog SDK configuration.
     public struct Configuration {
+        /// Defines the Datadog SDK policy when batching data together before uploading it to Datadog servers.
+        /// Smaller batches mean smaller but more network requests, whereas larger batches mean fewer but larger network requests.
+        public enum BatchSize {
+            /// Prefer small sized data batches.
+            case small
+            /// Prefer medium sized data batches.
+            case medium
+            /// Prefer large sized data batches.
+            case large
+        }
+
+        /// Defines the frequency at which Datadog SDK will try to upload data batches.
+        public enum UploadFrequency {
+            /// Try to upload batched data frequently.
+            case frequent
+            /// Try to upload batched data with a medium frequency.
+            case average
+            /// Try to upload batched data rarely.
+            case rare
+        }
+
         public enum DatadogEndpoint {
             /// US based servers.
             /// Sends data to [app.datadoghq.com](https://app.datadoghq.com/).
@@ -152,6 +173,8 @@ extension Datadog {
         private(set) var rumSessionsSamplingRate: Float
         private(set) var rumUIKitViewsPredicate: UIKitRUMViewsPredicate?
         private(set) var rumUIKitActionsTrackingEnabled: Bool
+        private(set) var batchSize: BatchSize
+        private(set) var uploadFrequency: UploadFrequency
 
         /// Creates the builder for configuring the SDK to work with RUM, Logging and Tracing features.
         /// - Parameter rumApplicationID: RUM Application ID obtained on Datadog website.
@@ -209,7 +232,9 @@ extension Datadog {
                     firstPartyHosts: nil,
                     rumSessionsSamplingRate: 100.0,
                     rumUIKitViewsPredicate: nil,
-                    rumUIKitActionsTrackingEnabled: false
+                    rumUIKitActionsTrackingEnabled: false,
+                    batchSize: .medium,
+                    uploadFrequency: .average
                 )
             }
 
@@ -422,6 +447,22 @@ extension Datadog {
             /// - Parameter serviceName: the service name (default value is set to application bundle identifier)
             public func set(serviceName: String) -> Builder {
                 configuration.serviceName = serviceName
+                return self
+            }
+
+            /// Sets the preferred size of batched data uploaded to Datadog servers.
+            /// This value impacts the size and number of requests performed by the SDK.
+            /// - Parameter batchSize: `.medium` by default.
+            public func set(batchSize: BatchSize) -> Builder {
+                configuration.batchSize = batchSize
+                return self
+            }
+
+            /// Sets the preferred frequency of uploading data to Datadog servers.
+            /// This value impacts the frequency of performing network requests by the SDK.
+            /// - Parameter uploadFrequency: `.average` by default.
+            public func set(uploadFrequency: UploadFrequency) -> Builder {
+                configuration.uploadFrequency = uploadFrequency
                 return self
             }
 

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -54,6 +54,36 @@ public class DDTracesEndpoint: NSObject {
     public static func custom(url: String) -> DDTracesEndpoint { .init(sdkEndpoint: .custom(url: url)) }
 }
 
+@objc
+public enum DDBatchSize: Int {
+    case small
+    case medium
+    case large
+
+    internal var swiftType: Datadog.Configuration.BatchSize {
+        switch self {
+        case .small: return .small
+        case .medium: return .medium
+        case .large: return .large
+        }
+    }
+}
+
+@objc
+public enum DDUploadFrequency: Int {
+    case frequent
+    case average
+    case rare
+
+    internal var swiftType: Datadog.Configuration.UploadFrequency {
+        switch self {
+        case .frequent: return .frequent
+        case .average: return .average
+        case .rare: return .rare
+        }
+    }
+}
+
 @objcMembers
 public class DDConfiguration: NSObject {
     internal let sdkConfiguration: Datadog.Configuration
@@ -155,6 +185,14 @@ public class DDConfigurationBuilder: NSObject {
 
     public func trackUIKitActions() {
         _ = sdkBuilder.trackUIKitActions(true)
+    }
+
+    public func set(batchSize: DDBatchSize) {
+        _ = sdkBuilder.set(batchSize: batchSize.swiftType)
+    }
+
+    public func set(uploadFrequency: DDUploadFrequency) {
+        _ = sdkBuilder.set(uploadFrequency: uploadFrequency.swiftType)
     }
 
     public func build() -> DDConfiguration {

--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -12,11 +12,15 @@ private struct DateCorrectorMock: DateCorrectorType {
     }
 }
 
+extension PerformancePreset {
+    static let benchmarksPreset = PerformancePreset(batchSize: .small, uploadFrequency: .frequent, bundleType: .iOSApp)
+}
+
 extension FeaturesCommonDependencies {
     static func mockAny() -> Self {
         return .init(
             consentProvider: ConsentProvider(initialConsent: .granted),
-            performance: .default,
+            performance: .benchmarksPreset,
             httpClient: HTTPClient(),
             mobileDevice: .current,
             dateProvider: SystemDateProvider(),

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -58,7 +58,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
         }
 
         // Wait enough time for `reader` to accept the youngest batch file
-        Thread.sleep(forTimeInterval: PerformancePreset.default.minFileAgeForRead + 0.1)
+        Thread.sleep(forTimeInterval: PerformancePreset.benchmarksPreset.minFileAgeForRead + 0.1)
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -58,7 +58,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
         }
 
         // Wait enough time for `reader` to accept the youngest batch file
-        Thread.sleep(forTimeInterval: PerformancePreset.default.minFileAgeForRead + 0.1)
+        Thread.sleep(forTimeInterval: PerformancePreset.benchmarksPreset.minFileAgeForRead + 0.1)
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -58,7 +58,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
         }
 
         // Wait enough time for `reader` to accept the youngest batch file
-        Thread.sleep(forTimeInterval: PerformancePreset.default.minFileAgeForRead + 0.1)
+        Thread.sleep(forTimeInterval: PerformancePreset.benchmarksPreset.minFileAgeForRead + 0.1)
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
             self.startMeasuring()

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -104,16 +104,21 @@ class FeaturesConfigurationTests: XCTestCase {
         verify(invalidEnvironmentName: String(repeating: "a", count: 197))
     }
 
-    func testPerformance() throws {
-        let iOSAppConfiguration = try FeaturesConfiguration(
-            configuration: .mockAny(), appContext: .mockWith(bundleType: .iOSApp)
-        )
-        XCTAssertEqual(iOSAppConfiguration.common.performance, .lowRuntimeImpact)
+    func testPerformancePreset() throws {
+        try BatchSize.allCases
+            .combined(with: UploadFrequency.allCases)
+            .combined(with: BundleType.allCases)
+            .map { ($0.0, $0.1, $1) }
+            .forEach { batchSize, uploadFrequency, bundleType in
+                let actualPerformancePreset = try FeaturesConfiguration(
+                    configuration: .mockWith(batchSize: batchSize,uploadFrequency: uploadFrequency),
+                    appContext: .mockWith(bundleType: bundleType)
+                ).common.performance
 
-        let iOSAppExtensionConfiguration = try FeaturesConfiguration(
-            configuration: .mockAny(), appContext: .mockWith(bundleType: .iOSAppExtension)
-        )
-        XCTAssertEqual(iOSAppExtensionConfiguration.common.performance, .instantDataDelivery)
+                let expectedPerformancePreset = PerformancePreset(batchSize: batchSize, uploadFrequency: uploadFrequency, bundleType: bundleType)
+
+                XCTAssertEqual(actualPerformancePreset, expectedPerformancePreset)
+            }
     }
 
     func testEndpoint() throws {

--- a/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
@@ -8,19 +8,103 @@ import XCTest
 @testable import Datadog
 
 class PerformancePresetTests: XCTestCase {
-    func testDefaultPreset() {
-        XCTAssertEqual(PerformancePreset.default, .lowRuntimeImpact)
+    func testIOSAppPresets() {
+        let smallBatchAnyFrequency = PerformancePreset(batchSize: .small, uploadFrequency: .mockRandom(), bundleType: .iOSApp)
+        XCTAssertEqual(smallBatchAnyFrequency.maxFileAgeForWrite, 4.75)
+        XCTAssertEqual(smallBatchAnyFrequency.minFileAgeForRead, 5.25)
+        assertPresetCommonValues(in: smallBatchAnyFrequency)
+
+        let mediumBatchAnyFrequency = PerformancePreset(batchSize: .medium, uploadFrequency: .mockRandom(), bundleType: .iOSApp)
+        XCTAssertEqual(mediumBatchAnyFrequency.maxFileAgeForWrite, 14.25)
+        XCTAssertEqual(mediumBatchAnyFrequency.minFileAgeForRead, 15.75)
+        assertPresetCommonValues(in: mediumBatchAnyFrequency)
+
+        let largeBatchAnyFrequency = PerformancePreset(batchSize: .large, uploadFrequency: .mockRandom(), bundleType: .iOSApp)
+        XCTAssertEqual(largeBatchAnyFrequency.maxFileAgeForWrite, 57.0)
+        XCTAssertEqual(largeBatchAnyFrequency.minFileAgeForRead, 63.0)
+        assertPresetCommonValues(in: largeBatchAnyFrequency)
+
+        let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSApp)
+        XCTAssertEqual(frequentUploadAnyBatch.initialUploadDelay, 5.0)
+        XCTAssertEqual(frequentUploadAnyBatch.defaultUploadDelay, 5.0)
+        XCTAssertEqual(frequentUploadAnyBatch.minUploadDelay, 1.0)
+        XCTAssertEqual(frequentUploadAnyBatch.maxUploadDelay, 10.0)
+        XCTAssertEqual(frequentUploadAnyBatch.uploadDelayChangeRate, 0.1)
+        assertPresetCommonValues(in: frequentUploadAnyBatch)
+
+        let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSApp)
+        XCTAssertEqual(averageUploadAnyBatch.initialUploadDelay, 25.0)
+        XCTAssertEqual(averageUploadAnyBatch.defaultUploadDelay, 25.0)
+        XCTAssertEqual(averageUploadAnyBatch.minUploadDelay, 5.0)
+        XCTAssertEqual(averageUploadAnyBatch.maxUploadDelay, 50.0)
+        XCTAssertEqual(averageUploadAnyBatch.uploadDelayChangeRate, 0.1)
+        assertPresetCommonValues(in: averageUploadAnyBatch)
+
+        let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSApp)
+        XCTAssertEqual(rareUploadAnyBatch.initialUploadDelay, 50.0)
+        XCTAssertEqual(rareUploadAnyBatch.defaultUploadDelay, 50.0)
+        XCTAssertEqual(rareUploadAnyBatch.minUploadDelay, 10.0)
+        XCTAssertEqual(rareUploadAnyBatch.maxUploadDelay, 100.0)
+        XCTAssertEqual(rareUploadAnyBatch.uploadDelayChangeRate, 0.1)
+        assertPresetCommonValues(in: rareUploadAnyBatch)
     }
 
-    func testBestPresetsForEnvironment() {
-        XCTAssertEqual(PerformancePreset.best(for: .iOSApp), PerformancePreset.lowRuntimeImpact)
-        XCTAssertEqual(PerformancePreset.best(for: .iOSAppExtension), PerformancePreset.instantDataDelivery)
+    func testIOSAppExtensionPresets() {
+        let smallBatchAnyFrequency = PerformancePreset(batchSize: .small, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension)
+        XCTAssertEqual(smallBatchAnyFrequency.maxFileAgeForWrite, 0.95)
+        XCTAssertEqual(smallBatchAnyFrequency.minFileAgeForRead, 1.05)
+        assertPresetCommonValues(in: smallBatchAnyFrequency)
+
+        let mediumBatchAnyFrequency = PerformancePreset(batchSize: .medium, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension)
+        XCTAssertEqual(mediumBatchAnyFrequency.maxFileAgeForWrite, 2.85, accuracy: 0.01)
+        XCTAssertEqual(mediumBatchAnyFrequency.minFileAgeForRead, 3.15, accuracy: 0.01)
+        assertPresetCommonValues(in: mediumBatchAnyFrequency)
+
+        let largeBatchAnyFrequency = PerformancePreset(batchSize: .large, uploadFrequency: .mockRandom(), bundleType: .iOSAppExtension)
+        XCTAssertEqual(largeBatchAnyFrequency.maxFileAgeForWrite, 11.4, accuracy: 0.01)
+        XCTAssertEqual(largeBatchAnyFrequency.minFileAgeForRead, 12.6, accuracy: 0.01)
+        assertPresetCommonValues(in: largeBatchAnyFrequency)
+
+        let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSAppExtension)
+        XCTAssertEqual(frequentUploadAnyBatch.initialUploadDelay, 0.25)
+        XCTAssertEqual(frequentUploadAnyBatch.defaultUploadDelay, 1.5)
+        XCTAssertEqual(frequentUploadAnyBatch.minUploadDelay, 0.5)
+        XCTAssertEqual(frequentUploadAnyBatch.maxUploadDelay, 2.5)
+        XCTAssertEqual(frequentUploadAnyBatch.uploadDelayChangeRate, 0.5)
+        assertPresetCommonValues(in: frequentUploadAnyBatch)
+
+        let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSAppExtension)
+        XCTAssertEqual(averageUploadAnyBatch.initialUploadDelay, 0.5)
+        XCTAssertEqual(averageUploadAnyBatch.defaultUploadDelay, 3.0)
+        XCTAssertEqual(averageUploadAnyBatch.minUploadDelay, 1.0)
+        XCTAssertEqual(averageUploadAnyBatch.maxUploadDelay, 5.0)
+        XCTAssertEqual(averageUploadAnyBatch.uploadDelayChangeRate, 0.5)
+        assertPresetCommonValues(in: averageUploadAnyBatch)
+
+        let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSAppExtension)
+        XCTAssertEqual(rareUploadAnyBatch.initialUploadDelay, 2.5)
+        XCTAssertEqual(rareUploadAnyBatch.defaultUploadDelay, 15.0)
+        XCTAssertEqual(rareUploadAnyBatch.minUploadDelay, 5.0)
+        XCTAssertEqual(rareUploadAnyBatch.maxUploadDelay, 25.0)
+        XCTAssertEqual(rareUploadAnyBatch.uploadDelayChangeRate, 0.5)
+        assertPresetCommonValues(in: rareUploadAnyBatch)
+    }
+
+    private func assertPresetCommonValues(in preset: PerformancePreset) {
+        XCTAssertEqual(preset.maxFileSize, 4 * 1_024 * 1_024) // 4MB
+        XCTAssertEqual(preset.maxDirectorySize, 512 * 1_024 * 1_024) // 512 MB
+        XCTAssertEqual(preset.maxFileAgeForRead, 18 * 60 * 60) // 18h
+        XCTAssertEqual(preset.maxObjectsInFile, 500)
+        XCTAssertEqual(preset.maxObjectSize, 256 * 1_024) // 256KB
     }
 
     func testPresetsConsistency() {
-        let presets: [PerformancePreset] = [.lowRuntimeImpact, .instantDataDelivery]
+        let allPossiblePresets: [PerformancePreset] = BatchSize.allCases
+            .combined(with: UploadFrequency.allCases)
+            .combined(with: BundleType.allCases)
+            .map { PerformancePreset(batchSize: $0.0, uploadFrequency: $0.1, bundleType: $1) }
 
-        presets.forEach { preset in
+        allPossiblePresets.forEach { preset in
             XCTAssertLessThan(
                 preset.maxFileSize,
                 preset.maxDirectorySize,
@@ -49,7 +133,7 @@ class PerformancePresetTests: XCTestCase {
             XCTAssertLessThanOrEqual(
                 preset.uploadDelayChangeRate,
                 1,
-                "Upload delay should not change by more than %100 at once."
+                "Upload delay should not change by more than 100% at once."
             )
             XCTAssertGreaterThan(
                 preset.uploadDelayChangeRate,

--- a/Tests/DatadogTests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/FilesOrchestratorTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import Datadog
 
 class FilesOrchestratorTests: XCTestCase {
-    private let performance: PerformancePreset = .default
+    private let performance = PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp)
 
     override func setUp() {
         super.setUp()

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writting/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writting/FileWriterTests.swift
@@ -23,7 +23,7 @@ class FileWriterTests: XCTestCase {
             dataFormat: DataFormat(prefix: "[", suffix: "]", separator: ","),
             orchestrator: FilesOrchestrator(
                 directory: temporaryDirectory,
-                performance: PerformancePreset.default,
+                performance: PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
                 dateProvider: SystemDateProvider()
             )
         )
@@ -85,7 +85,7 @@ class FileWriterTests: XCTestCase {
             dataFormat: .mockAny(),
             orchestrator: FilesOrchestrator(
                 directory: temporaryDirectory,
-                performance: PerformancePreset.default,
+                performance: PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
                 dateProvider: SystemDateProvider()
             )
         )
@@ -107,7 +107,7 @@ class FileWriterTests: XCTestCase {
             dataFormat: .mockAny(),
             orchestrator: FilesOrchestrator(
                 directory: temporaryDirectory,
-                performance: PerformancePreset.default,
+                performance: PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
                 dateProvider: SystemDateProvider()
             )
         )

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -45,6 +45,8 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 100.0)
             XCTAssertNil(configuration.rumUIKitViewsPredicate)
             XCTAssertFalse(configuration.rumUIKitActionsTrackingEnabled)
+            XCTAssertEqual(configuration.batchSize, .medium)
+            XCTAssertEqual(configuration.uploadFrequency, .average)
         }
     }
 
@@ -63,6 +65,8 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .track(firstPartyHosts: ["example.com"])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock())
                 .trackUIKitActions(false)
+                .set(batchSize: .small)
+                .set(uploadFrequency: .frequent)
 
             return builder
         }
@@ -98,6 +102,8 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 42.5)
             XCTAssertTrue(configuration.rumUIKitViewsPredicate is UIKitRUMViewsPredicateMock)
             XCTAssertFalse(configuration.rumUIKitActionsTrackingEnabled)
+            XCTAssertEqual(configuration.batchSize, .small)
+            XCTAssertEqual(configuration.uploadFrequency, .frequent)
         }
 
         XCTAssertTrue(rumConfigurationWithDefaultValues.rumUIKitViewsPredicate is DefaultUIKitRUMViewsPredicate)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -35,7 +35,9 @@ extension Datadog.Configuration {
         firstPartyHosts: Set<String>? = nil,
         rumSessionsSamplingRate: Float = 100.0,
         rumUIKitViewsPredicate: UIKitRUMViewsPredicate? = nil,
-        rumUIKitActionsTrackingEnabled: Bool = false
+        rumUIKitActionsTrackingEnabled: Bool = false,
+        batchSize: BatchSize = .medium,
+        uploadFrequency: UploadFrequency = .average
     ) -> Datadog.Configuration {
         return Datadog.Configuration(
             rumApplicationID: rumApplicationID,
@@ -55,9 +57,35 @@ extension Datadog.Configuration {
             firstPartyHosts: firstPartyHosts,
             rumSessionsSamplingRate: rumSessionsSamplingRate,
             rumUIKitViewsPredicate: rumUIKitViewsPredicate,
-            rumUIKitActionsTrackingEnabled: rumUIKitActionsTrackingEnabled
+            rumUIKitActionsTrackingEnabled: rumUIKitActionsTrackingEnabled,
+            batchSize: batchSize,
+            uploadFrequency: uploadFrequency
         )
     }
+}
+
+typealias BatchSize = Datadog.Configuration.BatchSize
+
+extension BatchSize: CaseIterable {
+    public static var allCases: [Self] { [.small, .medium, .large] }
+
+    static func mockRandom() -> Self {
+        allCases.randomElement()!
+    }
+}
+
+typealias UploadFrequency = Datadog.Configuration.UploadFrequency
+
+extension UploadFrequency: CaseIterable {
+    public static var allCases: [Self] { [.frequent, .average, .rare] }
+
+    static func mockRandom() -> Self {
+        allCases.randomElement()!
+    }
+}
+
+extension BundleType: CaseIterable {
+    public static var allCases: [Self] { [.iOSApp, iOSAppExtension] }
 }
 
 extension Datadog.Configuration.DatadogEndpoint {
@@ -113,7 +141,7 @@ extension FeaturesConfiguration.Common {
         applicationBundleIdentifier: String = .mockAny(),
         serviceName: String = .mockAny(),
         environment: String = .mockAny(),
-        performance: PerformancePreset = .best(for: .iOSApp)
+        performance: PerformancePreset = .init(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp)
     ) -> Self {
         return .init(
             applicationName: applicationName,

--- a/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
@@ -25,7 +25,7 @@ class SpanFileOutputTests: XCTestCase {
                 dataFormat: TracingFeature.dataFormat,
                 orchestrator: FilesOrchestrator(
                     directory: temporaryDirectory,
-                    performance: PerformancePreset.default,
+                    performance: PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
                     dateProvider: SystemDateProvider()
                 )
             )

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -56,6 +56,8 @@ class DDConfigurationTests: XCTestCase {
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 100.0)
             XCTAssertNil(configuration.rumUIKitViewsPredicate)
             XCTAssertFalse(configuration.rumUIKitActionsTrackingEnabled)
+            XCTAssertEqual(configuration.batchSize, .medium)
+            XCTAssertEqual(configuration.uploadFrequency, .average)
         }
     }
 
@@ -116,5 +118,17 @@ class DDConfigurationTests: XCTestCase {
 
         objcBuilder.set(rumSessionsSamplingRate: 42.5)
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.rumSessionsSamplingRate, 42.5)
+
+        objcBuilder.set(batchSize: .small)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.batchSize, .small)
+
+        objcBuilder.set(batchSize: .large)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.batchSize, .large)
+
+        objcBuilder.set(uploadFrequency: .frequent)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.uploadFrequency, .frequent)
+
+        objcBuilder.set(uploadFrequency: .rare)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.uploadFrequency, .rare)
     }
 }

--- a/Tests/DatadogTests/Helpers/SwiftExtensions.swift
+++ b/Tests/DatadogTests/Helpers/SwiftExtensions.swift
@@ -96,3 +96,11 @@ extension URLRequest {
         return request
     }
 }
+
+/// Combines two arrays together, e.g. `["a", "b"].combined(with: [1, 2, 3])` gives
+/// `[("a", 1), ("a", 2), ("a", 3), ("b", 1), ("b", 2), ("b", 3)]`.
+extension Array {
+    func combined<B>(with other: [B]) -> [(Element, B)] {
+        return self.flatMap { a in other.map { b in (a, b) } }
+    }
+}

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -27,6 +27,14 @@ public class DDTracesEndpoint: NSObject
  public static func us() -> DDTracesEndpoint
  public static func gov() -> DDTracesEndpoint
  public static func custom(url: String) -> DDTracesEndpoint
+public enum DDBatchSize: Int
+ case small
+ case medium
+ case large
+public enum DDUploadFrequency: Int
+ case frequent
+ case average
+ case rare
 public class DDConfiguration: NSObject
  public static func builder(clientToken: String, environment: String) -> DDConfigurationBuilder
  public static func builder(rumApplicationID: String, clientToken: String, environment: String) -> DDConfigurationBuilder
@@ -47,10 +55,12 @@ public class DDConfigurationBuilder: NSObject
  public func trackUIKitRUMViews()
  public func trackUIKitRUMViews(using predicate: DDUIKitRUMViewsPredicate)
  public func trackUIKitActions()
+ public func set(batchSize: DDBatchSize)
+ public func set(uploadFrequency: DDUploadFrequency)
  public func build() -> DDConfiguration
 public class DDGlobal: NSObject
- public static var sharedTracer: DatadogObjc.OTTracer = noopTracer
- public static var rum: DatadogObjc.DDRUMMonitor = noopRUMMonitor
+ public static var sharedTracer = DatadogObjc.DDTracer(swiftTracer: Datadog.Global.sharedTracer)
+ public static var rum = DatadogObjc.DDRUMMonitor(swiftRUMMonitor: Datadog.Global.rum)
 public enum DDSDKVerbosityLevel: Int
  case none
  case debug
@@ -92,9 +102,6 @@ public class DDLoggerBuilder: NSObject
  public func sendLogsToDatadog(_ enabled: Bool)
  public func printLogsToConsole(_ enabled: Bool)
  public func build() -> DDLogger
-public class OTGlobal: NSObject
- public static func initSharedTracer(_ tracer: OTTracer)
- public internal(set) static var sharedTracer: OTTracer
 public protocol OTSpan
  var context: OTSpanContext
  var tracer: OTTracer

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -31,6 +31,14 @@ public class Datadog
  public static func setUserInfo(id: String? = nil,name: String? = nil,email: String? = nil,extraInfo: [AttributeKey: AttributeValue] = [:])
  public static func set(trackingConsent: TrackingConsent)
  public struct Configuration
+  public enum BatchSize
+   case small
+   case medium
+   case large
+  public enum UploadFrequency
+   case frequent
+   case average
+   case rare
   public enum DatadogEndpoint
    case us
    case eu
@@ -69,6 +77,8 @@ public class Datadog
    public func trackUIKitRUMViews(using predicate: UIKitRUMViewsPredicate = DefaultUIKitRUMViewsPredicate()) -> Builder
    public func trackUIKitActions(_ enabled: Bool = true) -> Builder
    public func set(serviceName: String) -> Builder
+   public func set(batchSize: BatchSize) -> Builder
+   public func set(uploadFrequency: UploadFrequency) -> Builder
    public func build() -> Configuration
 public typealias DDGlobal = Global
 public struct Global
@@ -234,8 +244,8 @@ public class HTTPHeadersWriter: OTHTTPHeadersWriter
  public private(set) var tracePropagationHTTPHeaders: [String: String] = [:]
  public func inject(spanContext: OTSpanContext)
  override public init()
-public class DDURLSessionInterceptor: URLSessionInterceptorType
- public static var shared: DDURLSessionInterceptor?
+public class URLSessionInterceptor: URLSessionInterceptorType
+ public static var shared: URLSessionInterceptor?
  public func modify(request: URLRequest) -> URLRequest
  public func taskCreated(task: URLSessionTask)
  public func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics)


### PR DESCRIPTION
### What and why?

📦 This PR adds two new public APIs, so that the user can customize the size and frequency of requests made by the SDK.

### How?

The write / upload settings were already abstracted by `PerformancePreset` type, so this PR just configures its values depending on the `BatchSize` and `UploadFrequency` received from the user with two new public APIs:

```swift
public func set(batchSize: BatchSize)
public func set(uploadFrequency: UploadFrequency)
```

Because the iOS SDK provides different presets for iOS apps and iOS app extensions, the values computed for `PerformancePreset` are additionally customized to work well in short-lived app extension environment.

The `PerformancePreset` computed for iOS app is unified with the values introduced for Android SDK https://github.com/DataDog/dd-sdk-android/pull/454 and https://github.com/DataDog/dd-sdk-android/pull/453.

The new APIs are also exposed for Objc SDK.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
