### PR TITLE
RUMM-917 Fix Objc API visibility in `RUMMonitor`

### DIFF
--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -158,10 +158,9 @@ public class DDRUMMonitor: NSObject {
     public func stopResourceLoading(
         resourceKey: String,
         response: URLResponse,
-        size: Int64?,
         attributes: [String: Any]
     ) {
-        swiftRUMMonitor.stopResourceLoading(resourceKey: resourceKey, response: response, size: size, attributes: castAttributesToSwift(attributes))
+        swiftRUMMonitor.stopResourceLoading(resourceKey: resourceKey, response: response, attributes: castAttributesToSwift(attributes))
     }
 
     public func stopResourceLoadingWithError(

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -116,7 +116,7 @@ class DDRUMMonitorTests: XCTestCase {
             ),
             attributes: ["event-attribute2": "foo2"]
         )
-        objcRUMMonitor.stopResourceLoading(resourceKey: "/resource1", response: .mockAny(), size: 42, attributes: ["event-attribute3": "foo3"])
+        objcRUMMonitor.stopResourceLoading(resourceKey: "/resource1", response: .mockAny(), attributes: ["event-attribute3": "foo3"])
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
 


### PR DESCRIPTION
### What and why?

🐞 The `[DDGlobal.rum stopResourceLoadingWithResourceKey:response:attributes:]` public API was not visible for Objective-C.

### How?

This API was using `size: Int64?` parameter which can't be translated to Objective-C so it was not generated into Obj-C interface. I removed it, as we infer this information any way from the `HTTPURLResponse`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
