### PR TITLE
RUMM-917 Non-exposed ObjC public API is fixed

### DIFF
--- a/Sources/DatadogObjc/Datadog+objc.swift
+++ b/Sources/DatadogObjc/Datadog+objc.swift
@@ -7,7 +7,7 @@
 import Foundation
 import Datadog
 
-@objcMembers
+@objc
 public class DDTrackingConsent: NSObject {
     internal let sdkConsent: TrackingConsent
 
@@ -17,27 +17,34 @@ public class DDTrackingConsent: NSObject {
 
     // MARK: - Public
 
+    @objc
     public static func granted() -> DDTrackingConsent { .init(sdkConsent: .granted) }
+
+    @objc
     public static func notGranted() -> DDTrackingConsent { .init(sdkConsent: .notGranted) }
+
+    @objc
     public static func pending() -> DDTrackingConsent { .init(sdkConsent: .pending) }
 }
 
-@objcMembers
+@objc
 public class DDAppContext: NSObject {
     internal let sdkAppContext: Datadog.AppContext
 
     // MARK: - Public
 
+    @objc
     public init(mainBundle: Bundle) {
         self.sdkAppContext = Datadog.AppContext(mainBundle: mainBundle)
     }
 
+    @objc
     override public init() {
         self.sdkAppContext = Datadog.AppContext()
     }
 }
 
-@objcMembers
+@objc
 public class DDDatadog: NSObject {
     // MARK: - Public
 
@@ -47,6 +54,7 @@ public class DDDatadog: NSObject {
 
     Use `DDDatadog.initialize(appContext:trackingConsent:configuration:)` and set consent to `granted()` to preserve previous behaviour.
     """)
+    @objc
     public static func initialize(appContext: DDAppContext, configuration: DDConfiguration) {
         Datadog.initialize(
             appContext: appContext.sdkAppContext,
@@ -54,6 +62,7 @@ public class DDDatadog: NSObject {
         )
     }
 
+    @objc
     public static func initialize(
         appContext: DDAppContext,
         trackingConsent: DDTrackingConsent,
@@ -66,6 +75,7 @@ public class DDDatadog: NSObject {
         )
     }
 
+    @objc
     public static func setVerbosityLevel(_ verbosityLevel: DDSDKVerbosityLevel) {
         switch verbosityLevel {
         case .debug: Datadog.verbosityLevel = .debug
@@ -78,6 +88,7 @@ public class DDDatadog: NSObject {
         }
     }
 
+    @objc
     public static func verbosityLevel() -> DDSDKVerbosityLevel {
         switch Datadog.verbosityLevel {
         case .debug: return .debug
@@ -90,12 +101,12 @@ public class DDDatadog: NSObject {
         }
     }
 
-    // swiftlint:disable identifier_name
+    @objc
     public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil) {
         Datadog.setUserInfo(id: id, name: name, email: email)
     }
-    // swiftlint:enable identifier_name
 
+    @objc
     public static func setTrackingConsent(consent: DDTrackingConsent) {
         Datadog.set(trackingConsent: consent.sdkConsent)
     }

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -7,7 +7,7 @@
 import Foundation
 import Datadog
 
-@objcMembers
+@objc
 public class DDEndpoint: NSObject {
     internal let sdkEndpoint: Datadog.Configuration.DatadogEndpoint
 
@@ -17,12 +17,17 @@ public class DDEndpoint: NSObject {
 
     // MARK: - Public
 
+    @objc
     public static func eu() -> DDEndpoint { .init(sdkEndpoint: .eu) }
+
+    @objc
     public static func us() -> DDEndpoint { .init(sdkEndpoint: .us) }
+
+    @objc
     public static func gov() -> DDEndpoint { .init(sdkEndpoint: .gov) }
 }
 
-@objcMembers
+@objc
 public class DDLogsEndpoint: NSObject {
     internal let sdkEndpoint: Datadog.Configuration.LogsEndpoint
 
@@ -32,13 +37,20 @@ public class DDLogsEndpoint: NSObject {
 
     // MARK: - Public
 
+    @objc
     public static func eu() -> DDLogsEndpoint { .init(sdkEndpoint: .eu) }
+
+    @objc
     public static func us() -> DDLogsEndpoint { .init(sdkEndpoint: .us) }
+
+    @objc
     public static func gov() -> DDLogsEndpoint { .init(sdkEndpoint: .gov) }
+
+    @objc
     public static func custom(url: String) -> DDLogsEndpoint { .init(sdkEndpoint: .custom(url: url)) }
 }
 
-@objcMembers
+@objc
 public class DDTracesEndpoint: NSObject {
     internal let sdkEndpoint: Datadog.Configuration.TracesEndpoint
 
@@ -48,9 +60,16 @@ public class DDTracesEndpoint: NSObject {
 
     // MARK: - Public
 
+    @objc
     public static func eu() -> DDTracesEndpoint { .init(sdkEndpoint: .eu) }
+
+    @objc
     public static func us() -> DDTracesEndpoint { .init(sdkEndpoint: .us) }
+
+    @objc
     public static func gov() -> DDTracesEndpoint { .init(sdkEndpoint: .gov) }
+
+    @objc
     public static func custom(url: String) -> DDTracesEndpoint { .init(sdkEndpoint: .custom(url: url)) }
 }
 
@@ -84,7 +103,7 @@ public enum DDUploadFrequency: Int {
     }
 }
 
-@objcMembers
+@objc
 public class DDConfiguration: NSObject {
     internal let sdkConfiguration: Datadog.Configuration
 
@@ -94,12 +113,14 @@ public class DDConfiguration: NSObject {
 
     // MARK: - Public
 
+    @objc
     public static func builder(clientToken: String, environment: String) -> DDConfigurationBuilder {
         return DDConfigurationBuilder(
             sdkBuilder: Datadog.Configuration.builderUsing(clientToken: clientToken, environment: environment)
         )
     }
 
+    @objc
     public static func builder(rumApplicationID: String, clientToken: String, environment: String) -> DDConfigurationBuilder {
         return DDConfigurationBuilder(
             sdkBuilder: Datadog.Configuration
@@ -108,7 +129,7 @@ public class DDConfiguration: NSObject {
     }
 }
 
-@objcMembers
+@objc
 public class DDConfigurationBuilder: NSObject {
     internal let sdkBuilder: Datadog.Configuration.Builder
 
@@ -118,83 +139,102 @@ public class DDConfigurationBuilder: NSObject {
 
     // MARK: - Public
 
+    @objc
     public func enableLogging(_ enabled: Bool) {
         _ = sdkBuilder.enableLogging(enabled)
     }
 
+    @objc
     public func enableTracing(_ enabled: Bool) {
         _ = sdkBuilder.enableTracing(enabled)
     }
 
+    @objc
     public func enableRUM(_ enabled: Bool) {
         _ = sdkBuilder.enableRUM(enabled)
     }
 
+    @objc
     public func set(endpoint: DDEndpoint) {
         _ = sdkBuilder.set(endpoint: endpoint.sdkEndpoint)
     }
 
+    @objc
     public func set(customLogsEndpoint: URL) {
         _ = sdkBuilder.set(customLogsEndpoint: customLogsEndpoint)
     }
 
+    @objc
     public func set(customTracesEndpoint: URL) {
         _ = sdkBuilder.set(customTracesEndpoint: customTracesEndpoint)
     }
 
+    @objc
     public func set(customRUMEndpoint: URL) {
         _ = sdkBuilder.set(customRUMEndpoint: customRUMEndpoint)
     }
 
     @available(*, deprecated, message: "This option is replaced by `set(endpoint:)`. Refer to the new API comment for details.")
+    @objc
     public func set(logsEndpoint: DDLogsEndpoint) {
         _ = sdkBuilder.set(logsEndpoint: logsEndpoint.sdkEndpoint)
     }
 
     @available(*, deprecated, message: "This option is replaced by `set(endpoint:)`. Refer to the new API comment for details.")
+    @objc
     public func set(tracesEndpoint: DDTracesEndpoint) {
         _ = sdkBuilder.set(tracesEndpoint: tracesEndpoint.sdkEndpoint)
     }
 
     @available(*, deprecated, message: "This option is replaced by `track(firstPartyHosts:)`. Refer to the new API comment for important details.")
+    @objc
     public func set(tracedHosts: Set<String>) {
         track(firstPartyHosts: tracedHosts)
     }
 
+    @objc
     public func track(firstPartyHosts: Set<String>) {
         _ = sdkBuilder.track(firstPartyHosts: firstPartyHosts)
     }
 
+    @objc
     public func set(serviceName: String) {
         _ = sdkBuilder.set(serviceName: serviceName)
     }
 
+    @objc
     public func set(rumSessionsSamplingRate: Float) {
         _ = sdkBuilder.set(rumSessionsSamplingRate: rumSessionsSamplingRate)
     }
 
+    @objc
     public func trackUIKitRUMViews() {
         let defaultPredicate = DefaultUIKitRUMViewsPredicate()
         _ = sdkBuilder.trackUIKitRUMViews(using: defaultPredicate)
     }
 
+    @objc
     public func trackUIKitRUMViews(using predicate: DDUIKitRUMViewsPredicate) {
         let predicateBridge = UIKitRUMViewsPredicateBridge(objcPredicate: predicate)
         _ = sdkBuilder.trackUIKitRUMViews(using: predicateBridge)
     }
 
+    @objc
     public func trackUIKitActions() {
         _ = sdkBuilder.trackUIKitActions(true)
     }
 
+    @objc
     public func set(batchSize: DDBatchSize) {
         _ = sdkBuilder.set(batchSize: batchSize.swiftType)
     }
 
+    @objc
     public func set(uploadFrequency: DDUploadFrequency) {
         _ = sdkBuilder.set(uploadFrequency: uploadFrequency.swiftType)
     }
 
+    @objc
     public func build() -> DDConfiguration {
         return DDConfiguration(sdkConfiguration: sdkBuilder.build())
     }

--- a/Sources/DatadogObjc/Global+objc.swift
+++ b/Sources/DatadogObjc/Global+objc.swift
@@ -7,9 +7,9 @@
 import Foundation
 import struct Datadog.Global
 
-@objcMembers
+@objc
 public class DDGlobal: NSObject {
-    public static var sharedTracer = DatadogObjc.DDTracer(swiftTracer: Datadog.Global.sharedTracer) {
+    @objc public static var sharedTracer = DatadogObjc.DDTracer(swiftTracer: Datadog.Global.sharedTracer) {
         didSet {
             // We must also set the Swift `Global.tracer`
             // as it's used internally by auto-instrumentation feature.
@@ -17,7 +17,7 @@ public class DDGlobal: NSObject {
         }
     }
 
-    public static var rum = DatadogObjc.DDRUMMonitor(swiftRUMMonitor: Datadog.Global.rum) {
+    @objc public static var rum = DatadogObjc.DDRUMMonitor(swiftRUMMonitor: Datadog.Global.rum) {
         didSet {
             // We must also set the Swift `Global.rum`
             // as it's used internally by auto-instrumentation feature.

--- a/Sources/DatadogObjc/Logger+objc.swift
+++ b/Sources/DatadogObjc/Logger+objc.swift
@@ -18,7 +18,7 @@ public enum DDSDKVerbosityLevel: Int {
     case critical
 }
 
-@objcMembers
+@objc
 public class DDLogger: NSObject {
     internal let sdkLogger: Logger
 
@@ -28,108 +28,133 @@ public class DDLogger: NSObject {
 
     // MARK: - Public
 
+    @objc
     public func debug(_ message: String) {
         sdkLogger.debug(message)
     }
 
+    @objc
     public func debug(_ message: String, attributes: [String: Any]) {
         sdkLogger.debug(message, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func debug(_ message: String, error: NSError, attributes: [String: Any]) {
         sdkLogger.debug(message, error: error, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func info(_ message: String) {
         sdkLogger.info(message)
     }
 
+    @objc
     public func info(_ message: String, attributes: [String: Any]) {
         sdkLogger.info(message, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func info(_ message: String, error: NSError, attributes: [String: Any]) {
         sdkLogger.info(message, error: error, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func notice(_ message: String) {
         sdkLogger.notice(message)
     }
 
+    @objc
     public func notice(_ message: String, attributes: [String: Any]) {
         sdkLogger.notice(message, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func notice(_ message: String, error: NSError, attributes: [String: Any]) {
         sdkLogger.notice(message, error: error, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func warn(_ message: String) {
         sdkLogger.warn(message)
     }
 
+    @objc
     public func warn(_ message: String, attributes: [String: Any]) {
         sdkLogger.warn(message, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func warn(_ message: String, error: NSError, attributes: [String: Any]) {
         sdkLogger.warn(message, error: error, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func error(_ message: String) {
         sdkLogger.error(message)
     }
 
+    @objc
     public func error(_ message: String, attributes: [String: Any]) {
         sdkLogger.error(message, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func error(_ message: String, error: NSError, attributes: [String: Any]) {
         sdkLogger.error(message, error: error, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func critical(_ message: String) {
         sdkLogger.critical(message)
     }
 
+    @objc
     public func critical(_ message: String, attributes: [String: Any]) {
         sdkLogger.critical(message, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func critical(_ message: String, error: NSError, attributes: [String: Any]) {
         sdkLogger.critical(message, error: error, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func addAttribute(forKey key: String, value: Any) {
         sdkLogger.addAttribute(forKey: key, value: AnyEncodable(value))
     }
 
+    @objc
     public func removeAttribute(forKey key: String) {
         sdkLogger.removeAttribute(forKey: key)
     }
 
+    @objc
     public func addTag(withKey key: String, value: String) {
         sdkLogger.addTag(withKey: key, value: value)
     }
 
+    @objc
     public func removeTag(withKey key: String) {
         sdkLogger.removeTag(withKey: key)
     }
 
+    @objc
     public func add(tag: String) {
         sdkLogger.add(tag: tag)
     }
 
+    @objc
     public func remove(tag: String) {
         sdkLogger.remove(tag: tag)
     }
 
+    @objc
     public static func builder() -> DDLoggerBuilder {
         return DDLoggerBuilder(sdkBuilder: Logger.builder)
     }
 }
 
-@objcMembers
+@objc
 public class DDLoggerBuilder: NSObject {
     internal let sdkBuilder: Logger.Builder
 
@@ -139,26 +164,32 @@ public class DDLoggerBuilder: NSObject {
 
     // MARK: - Public
 
+    @objc
     public func set(serviceName: String) {
         _ = sdkBuilder.set(serviceName: serviceName)
     }
 
+    @objc
     public func set(loggerName: String) {
         _ = sdkBuilder.set(loggerName: loggerName)
     }
 
+    @objc
     public func sendNetworkInfo(_ enabled: Bool) {
         _ = sdkBuilder.sendNetworkInfo(enabled)
     }
 
+    @objc
     public func sendLogsToDatadog(_ enabled: Bool) {
         _ = sdkBuilder.sendLogsToDatadog(enabled)
     }
 
+    @objc
     public func printLogsToConsole(_ enabled: Bool) {
         _ = sdkBuilder.printLogsToConsole(enabled)
     }
 
+    @objc
     public func build() -> DDLogger {
         return DDLogger(sdkLogger: sdkBuilder.build())
     }

--- a/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
@@ -6,9 +6,8 @@
 
 import Foundation
 
-@objc
 /// Corresponds to: https://github.com/opentracing/opentracing-objc/blob/master/Pod/Classes/OTSpan.h
-public protocol OTSpan {
+@objc public protocol OTSpan {
     var context: OTSpanContext { get }
     var tracer: OTTracer { get }
 

--- a/Sources/DatadogObjc/OpenTracing/OTSpanContext+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTSpanContext+objc.swift
@@ -6,8 +6,7 @@
 
 import Foundation
 
-@objc
 /// Corresponds to: https://github.com/opentracing/opentracing-objc/blob/master/Pod/Classes/OTSpanContext.h
-public protocol OTSpanContext {
+@objc public protocol OTSpanContext {
     func forEachBaggageItem(_ callback: (_ key: String, _ value: String) -> Bool)
 }

--- a/Sources/DatadogObjc/OpenTracing/OTTracer+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTTracer+objc.swift
@@ -5,11 +5,14 @@
  */
 
 import Foundation
-public let OTFormatHTTPHeaders = "OTFormatHTTPHeaders"
 
 @objc
+public class OT: NSObject {
+    @objc public static let formatTextMap = "OTFormatTextMap"
+}
+
 /// Corresponds to: https://github.com/opentracing/opentracing-objc/blob/master/Pod/Classes/OTTracer.h
-public protocol OTTracer {
+@objc public protocol OTTracer {
     func startSpan(_ operationName: String) -> OTSpan
     func startSpan(_ operationName: String, tags: NSDictionary?) -> OTSpan
     func startSpan(_ operationName: String, childOf parent: OTSpanContext?) -> OTSpan

--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -21,17 +21,18 @@ internal struct UIKitRUMViewsPredicateBridge: UIKitRUMViewsPredicate {
     }
 }
 
-@objcMembers
+@objc
 public class DDRUMView: NSObject {
     let swiftView: RUMView
 
-    public var path: String { swiftView.path }
-    public var attributes: [String: Any] { swiftView.attributes }
+    @objc public var path: String { swiftView.path }
+    @objc public var attributes: [String: Any] { swiftView.attributes }
 
     /// Initializes the RUM View description.
     /// - Parameters:
     ///   - path: the RUM View path, appearing as "PATH" in RUM Explorer.
     ///   - attributes: additional attributes to associate with the RUM View.
+    @objc
     public init(path: String, attributes: [String: Any]) {
         swiftView = RUMView(
             path: path,
@@ -88,7 +89,7 @@ public enum DDRUMUserActionType: Int {
     }
 }
 
-@objcMembers
+@objc
 public class DDRUMMonitor: NSObject {
     // MARK: - Internal
 
@@ -100,10 +101,12 @@ public class DDRUMMonitor: NSObject {
 
     // MARK: - Public
 
+    @objc
     override public convenience init() {
         self.init(swiftRUMMonitor: RUMMonitor.initialize())
     }
 
+    @objc
     public func startView(
         viewController: UIViewController,
         path: String?,
@@ -112,6 +115,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.startView(viewController: viewController, path: path, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func stopView(
         viewController: UIViewController,
         attributes: [String: Any]
@@ -119,10 +123,12 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.stopView(viewController: viewController, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func addTiming(name: String) {
         swiftRUMMonitor.addTiming(name: name)
     }
 
+    @objc
     public func addError(
         error: Error,
         source: DDRUMErrorSource,
@@ -131,6 +137,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.addError(error: error, source: source.swiftType, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func startResourceLoading(
         resourceKey: String,
         request: URLRequest,
@@ -139,6 +146,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.startResourceLoading(resourceKey: resourceKey, request: request, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func startResourceLoading(
         resourceKey: String,
         url: URL,
@@ -147,6 +155,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.startResourceLoading(resourceKey: resourceKey, url: url, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func addResourceMetrics(
         resourceKey: String,
         metrics: URLSessionTaskMetrics,
@@ -155,6 +164,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.addResourceMetrics(resourceKey: resourceKey, metrics: metrics, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func stopResourceLoading(
         resourceKey: String,
         response: URLResponse,
@@ -163,6 +173,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.stopResourceLoading(resourceKey: resourceKey, response: response, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func stopResourceLoadingWithError(
         resourceKey: String,
         error: Error,
@@ -172,6 +183,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.stopResourceLoadingWithError(resourceKey: resourceKey, error: error, response: response, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func stopResourceLoadingWithError(
         resourceKey: String,
         errorMessage: String,
@@ -181,6 +193,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.stopResourceLoadingWithError(resourceKey: resourceKey, errorMessage: errorMessage, response: response, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func startUserAction(
         type: DDRUMUserActionType,
         name: String,
@@ -189,6 +202,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.startUserAction(type: type.swiftType, name: name, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func stopUserAction(
         type: DDRUMUserActionType,
         name: String?,
@@ -197,6 +211,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.stopUserAction(type: type.swiftType, name: name, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func addUserAction(
         type: DDRUMUserActionType,
         name: String,
@@ -205,6 +220,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.addUserAction(type: type.swiftType, name: name, attributes: castAttributesToSwift(attributes))
     }
 
+    @objc
     public func addAttribute(
         forKey key: String,
         value: Any
@@ -212,6 +228,7 @@ public class DDRUMMonitor: NSObject {
         swiftRUMMonitor.addAttribute(forKey: key, value: AnyEncodable(value))
     }
 
+    @objc
     public func removeAttribute(forKey key: String) {
         swiftRUMMonitor.removeAttribute(forKey: key)
     }

--- a/Sources/DatadogObjc/Tracer+objc.swift
+++ b/Sources/DatadogObjc/Tracer+objc.swift
@@ -10,9 +10,10 @@ import protocol Datadog.OTTracer
 import struct Datadog.OTReference
 import class Datadog.HTTPHeadersWriter
 
-@objcMembers
+@objc
 public class DDTracer: NSObject, DatadogObjc.OTTracer {
     @available(*, deprecated, message: "Use `DDTracer(configuration:)`.")
+    @objc
     public static func initialize(configuration: DDTracerConfiguration) -> DatadogObjc.OTTracer {
         return DDTracer(configuration: configuration)
     }
@@ -27,6 +28,7 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
 
     // MARK: - Public
 
+    @objc
     public convenience init(configuration: DDTracerConfiguration) {
         self.init(
             swiftTracer: Datadog.Tracer.initialize(
@@ -35,6 +37,7 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
         )
     }
 
+    @objc
     public func startSpan(_ operationName: String) -> OTSpan {
         return DDSpanObjc(
             objcTracer: self,
@@ -42,6 +45,7 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
         )
     }
 
+    @objc
     public func startSpan(_ operationName: String, tags: NSDictionary?) -> OTSpan {
         return DDSpanObjc(
             objcTracer: self,
@@ -52,6 +56,7 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
         )
     }
 
+    @objc
     public func startSpan(_ operationName: String, childOf parent: OTSpanContext?) -> OTSpan {
         let ddspanContext = parent?.dd
         return DDSpanObjc(
@@ -63,6 +68,7 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
         )
     }
 
+    @objc
     public func startSpan(
         _ operationName: String,
         childOf parent: OTSpanContext?,
@@ -79,6 +85,7 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
         )
     }
 
+    @objc
     public func startSpan(
         _ operationName: String,
         childOf parent: OTSpanContext?,
@@ -97,14 +104,15 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
         )
     }
 
+    @objc
     public func inject(_ spanContext: OTSpanContext, format: String, carrier: Any) throws {
-        guard format == OTFormatHTTPHeaders, let objcWriter = carrier as? DDHTTPHeadersWriter else {
+        guard format == OT.formatTextMap, let objcWriter = carrier as? DDHTTPHeadersWriter else {
             let error = NSError(
                 domain: "DDTracer",
                 code: 0,
                 userInfo: [
-                    NSLocalizedDescriptionKey: "Trying to inject `OTSpanContext` using wrong format or carrier.",
-                    NSLocalizedRecoverySuggestionErrorKey: "Use `DDHTTPHeadersWriter` carrier with `OTFormatHTTPHeaders` format."
+                    NSLocalizedDescriptionKey: "Trying to inject `OTSpanContext` using wrong format and/or carrier.",
+                    NSLocalizedRecoverySuggestionErrorKey: "Use `DDHTTPHeadersWriter` carrier with `OT.formatTextMap` format."
                 ]
             )
             throw error
@@ -118,6 +126,7 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
         )
     }
 
+    @objc
     public func extractWithFormat(_ format: String, carrier: Any) throws {
         // TODO: RUMM-385 - we don't need to support it now
     }

--- a/Sources/DatadogObjc/TracerConfiguration+objc.swift
+++ b/Sources/DatadogObjc/TracerConfiguration+objc.swift
@@ -7,18 +7,21 @@
 import Foundation
 import Datadog
 
-@objcMembers
+@objc
 public class DDTracerConfiguration: NSObject {
     internal var swiftConfiguration = Tracer.Configuration()
 
+    @objc
     override public init() {}
 
     // MARK: - Public
 
+    @objc
     public func set(serviceName: String) {
         swiftConfiguration.serviceName = serviceName
     }
 
+    @objc
     public func sendNetworkInfo(_ enabled: Bool) {
         swiftConfiguration.sendNetworkInfo = enabled
     }

--- a/Sources/DatadogObjc/Tracing/Propagation/HTTPHeadersWriter+objc.swift
+++ b/Sources/DatadogObjc/Tracing/Propagation/HTTPHeadersWriter+objc.swift
@@ -7,9 +7,10 @@
 import Foundation
 import class Datadog.HTTPHeadersWriter
 
-@objcMembers
+@objc
 public class DDHTTPHeadersWriter: NSObject {
     let swiftHTTPHeadersWriter = HTTPHeadersWriter()
 
+    @objc
     override public init() {}
 }

--- a/Tests/DatadogTests/Datadog/Core/Swizzling/MethodSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Swizzling/MethodSwizzlerTests.swift
@@ -17,12 +17,14 @@ extension MethodSwizzler {
     }
 }
 
-@objcMembers
+@objc
 private class EmptySubclass: BaseClass { }
 
-@objcMembers
+@objc
 private class BaseClass: NSObject {
-    static let returnValue = "this is base class"
+    @objc static let returnValue = "this is base class"
+
+    @objc
     func methodToSwizzle() -> String {
         return Self.returnValue
     }

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -153,7 +153,7 @@ class DDTracerTests: XCTestCase {
         )
 
         let objcWriter = DDHTTPHeadersWriter()
-        try objcTracer.inject(objcSpanContext, format: OTFormatHTTPHeaders, carrier: objcWriter)
+        try objcTracer.inject(objcSpanContext, format: OT.formatTextMap, carrier: objcWriter)
 
         let expectedHTTPHeaders = [
             "x-datadog-trace-id": "1",
@@ -174,7 +174,7 @@ class DDTracerTests: XCTestCase {
         )
 
         let objcInvalidWriter = NSObject()
-        let objcValidFormat = OTFormatHTTPHeaders
+        let objcValidFormat = OT.formatTextMap
         XCTAssertThrowsError(
             try objcTracer.inject(objcSpanContext, format: objcValidFormat, carrier: objcInvalidWriter)
         )


### PR DESCRIPTION
### What and why?

@objcMembers tries to expose all members; in case of failure, fails silently.
As we don't have tests calling the API from ObjC, we don't make sure `DatadogSDKObjc` is exposed to Obj-C

### How?

@objc doesn't compile in case of failure and gives errors

`public let OTFormatHTTPHeaders = "OTFormatHTTPHeaders"` is exposed as `OT.formatTextMap`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
