### PR TITLE
RUMM-917 Release version 1.5.0-alpha1

### DIFF
--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
   s.module_name  = "Datadog"
-  s.version      = "1.4.0"
+  s.version      = "1.5.0-alpha1"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKAlamofireExtension.podspec
+++ b/DatadogSDKAlamofireExtension.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
 
   s.source_files = ["Sources/DatadogExtensions/Alamofire/**/*.swift"]
-  s.dependency 'DatadogSDK', '~> 1.4'
-  s.dependency 'Alamofire', '~> 5.4'
+  s.dependency 'DatadogSDK', '~> 1.5.0-alpha1'
+  s.dependency 'Alamofire', '~> 5.0'
 end

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
 
   s.source_files = "Sources/DatadogObjc/**/*.swift"
-  s.dependency 'DatadogSDK'
+  s.dependency 'DatadogSDK', '1.5.0-alpha1'
 end

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKObjc"
   s.module_name  = "DatadogObjc"
-  s.version      = "1.4.0"
+  s.version      = "1.5.0-alpha1"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKObjc.podspec.src
+++ b/DatadogSDKObjc.podspec.src
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
 
   s.source_files = "Sources/DatadogObjc/**/*.swift"
-  s.dependency 'DatadogSDK'
+  s.dependency 'DatadogSDK', '__DATADOG_VERSION__'
 end

--- a/Sources/Datadog/Versioning.swift
+++ b/Sources/Datadog/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let sdkVersion = "1.4.0"
+internal let sdkVersion = "1.5.0-alpha1"

--- a/Sources/DatadogExtensions/Alamofire/README.md
+++ b/Sources/DatadogExtensions/Alamofire/README.md
@@ -12,7 +12,7 @@ following to your `Podfile`:
 ```ruby
 pod 'DatadogSDKAlamofireExtension'
 ```
-`DatadogSDKAlamofireExtension` requires Datadog SDK `1.4.0` (or higher).
+`DatadogSDKAlamofireExtension` requires Datadog SDK `1.5.0` or higher and `Alamofire 5.0` or higher.
 
 ### Carthage and SPM
 

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -59,8 +59,8 @@ public class DDConfigurationBuilder: NSObject
  public func set(uploadFrequency: DDUploadFrequency)
  public func build() -> DDConfiguration
 public class DDGlobal: NSObject
- public static var sharedTracer = DatadogObjc.DDTracer(swiftTracer: Datadog.Global.sharedTracer)
- public static var rum = DatadogObjc.DDRUMMonitor(swiftRUMMonitor: Datadog.Global.rum)
+ @objc public static var sharedTracer = DatadogObjc.DDTracer(swiftTracer: Datadog.Global.sharedTracer)
+ @objc public static var rum = DatadogObjc.DDRUMMonitor(swiftRUMMonitor: Datadog.Global.rum)
 public enum DDSDKVerbosityLevel: Int
  case none
  case debug
@@ -102,7 +102,7 @@ public class DDLoggerBuilder: NSObject
  public func sendLogsToDatadog(_ enabled: Bool)
  public func printLogsToConsole(_ enabled: Bool)
  public func build() -> DDLogger
-public protocol OTSpan
+@objc public protocol OTSpan
  var context: OTSpanContext
  var tracer: OTTracer
  func setOperationName(_ operationName: String)
@@ -116,10 +116,11 @@ public protocol OTSpan
  func finish()
  func finishWithTime(_ finishTime: Date?)
  func setActive() -> OTSpan
-public protocol OTSpanContext
+@objc public protocol OTSpanContext
  func forEachBaggageItem(_ callback: (_ key: String, _ value: String) -> Bool)
-public let OTFormatHTTPHeaders = "OTFormatHTTPHeaders"
-public protocol OTTracer
+public class OT: NSObject
+ @objc public static let formatTextMap = "OTFormatTextMap"
+@objc public protocol OTTracer
  func startSpan(_ operationName: String) -> OTSpan
  func startSpan(_ operationName: String, tags: NSDictionary?) -> OTSpan
  func startSpan(_ operationName: String, childOf parent: OTSpanContext?) -> OTSpan
@@ -128,8 +129,8 @@ public protocol OTTracer
  func inject(_ spanContext: OTSpanContext, format: String, carrier: Any) throws
  func extractWithFormat(_ format: String, carrier: Any) throws
 public class DDRUMView: NSObject
- public var path: String
- public var attributes: [String: Any]
+ @objc public var path: String
+ @objc public var attributes: [String: Any]
  public init(path: String, attributes: [String: Any])
 public protocol DDUIKitRUMViewsPredicate: AnyObject
  func rumView(for viewController: UIViewController) -> DDRUMView?
@@ -152,7 +153,7 @@ public class DDRUMMonitor: NSObject
  public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [String: Any])
  public func startResourceLoading(resourceKey: String,url: URL,attributes: [String: Any])
  public func addResourceMetrics(resourceKey: String,metrics: URLSessionTaskMetrics,attributes: [String: Any])
- public func stopResourceLoading(resourceKey: String,response: URLResponse,size: Int64?,attributes: [String: Any])
+ public func stopResourceLoading(resourceKey: String,response: URLResponse,attributes: [String: Any])
  public func stopResourceLoadingWithError(resourceKey: String,error: Error,response: URLResponse?,attributes: [String: Any])
  public func stopResourceLoadingWithError(resourceKey: String,errorMessage: String,response: URLResponse?,attributes: [String: Any])
  public func startUserAction(type: DDRUMUserActionType,name: String,attributes: [String: Any])


### PR DESCRIPTION
### What and why?

We need this alpha version for other internal projects until public release

After approval, `make ship` will be run

### `DatadogAlamofireExtension`

This new pod is being shipped with `DatadogSDK: 1.5.0-alpha1` and `Alamofire: 5.0` dependencies.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
