### PR TITLE
RUMM-974 Allow referencing RUM Views by String key

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBD19424ED4E9E0023E65F /* FeaturesConfiguration.swift */; };
 		61BBD19724ED50040023E65F /* FeaturesConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */; };
 		61BCB81F256EB77F0039887B /* ServerDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BCB81E256EB77F0039887B /* ServerDateProvider.swift */; };
+		61C1510D25AC8C1B00362D4B /* RUMViewIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C1510C25AC8C1B00362D4B /* RUMViewIdentityTests.swift */; };
 		61C2C20724C098FC00C0321C /* RUMSessionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20624C098FC00C0321C /* RUMSessionScope.swift */; };
 		61C2C20924C0C75500C0321C /* RUMSessionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */; };
 		61C2C20B24C1045300C0321C /* SendRUMFixture1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20A24C1045300C0321C /* SendRUMFixture1ViewController.swift */; };
@@ -368,6 +369,7 @@
 		61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */; };
 		61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */; };
 		61FF283024BC5E2D000B3D9B /* RUMEventFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */; };
+		61FF9A4525AC5DEA001058CC /* RUMViewIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF9A4425AC5DEA001058CC /* RUMViewIdentity.swift */; };
 		9E26E6B924C87693000B3270 /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
 		9E307C3224C8846D0039607E /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
 		9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */; };
@@ -718,6 +720,7 @@
 		61BBD19424ED4E9E0023E65F /* FeaturesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesConfiguration.swift; sourceTree = "<group>"; };
 		61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesConfigurationTests.swift; sourceTree = "<group>"; };
 		61BCB81E256EB77F0039887B /* ServerDateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerDateProvider.swift; sourceTree = "<group>"; };
+		61C1510C25AC8C1B00362D4B /* RUMViewIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewIdentityTests.swift; sourceTree = "<group>"; };
 		61C2C20624C098FC00C0321C /* RUMSessionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionScope.swift; sourceTree = "<group>"; };
 		61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionScopeTests.swift; sourceTree = "<group>"; };
 		61C2C20A24C1045300C0321C /* SendRUMFixture1ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendRUMFixture1ViewController.swift; sourceTree = "<group>"; };
@@ -813,6 +816,7 @@
 		61FF282524B8A248000B3D9B /* RUMEventOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventOutput.swift; sourceTree = "<group>"; };
 		61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventMatcher.swift; sourceTree = "<group>"; };
 		61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutputTests.swift; sourceTree = "<group>"; };
+		61FF9A4425AC5DEA001058CC /* RUMViewIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewIdentity.swift; sourceTree = "<group>"; };
 		9E26E6B824C87693000B3270 /* RUMDataModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMDataModels.swift; sourceTree = "<group>"; };
 		9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionsTests.swift; sourceTree = "<group>"; };
 		9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzler.swift; sourceTree = "<group>"; };
@@ -1857,6 +1861,7 @@
 		617B953E24BF4D9D00E6F443 /* Scopes */ = {
 			isa = PBXGroup;
 			children = (
+				61C1510C25AC8C1B00362D4B /* RUMViewIdentityTests.swift */,
 				617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */,
 				61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */,
 				6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */,
@@ -2028,6 +2033,7 @@
 		61C3E63C24BF1B7F008053F2 /* Scopes */ = {
 			isa = PBXGroup;
 			children = (
+				61FF9A4425AC5DEA001058CC /* RUMViewIdentity.swift */,
 				61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */,
 				61C2C20624C098FC00C0321C /* RUMSessionScope.swift */,
 				61C2C21124C5951400C0321C /* RUMViewScope.swift */,
@@ -2724,6 +2730,7 @@
 				61C576C6256E65BD00295F7C /* DateCorrector.swift in Sources */,
 				61E909ED24A24DD3005EA2DE /* OTSpan.swift in Sources */,
 				61133BDE2423979B00786299 /* CompilationConditions.swift in Sources */,
+				61FF9A4525AC5DEA001058CC /* RUMViewIdentity.swift in Sources */,
 				61E909F324A24DD3005EA2DE /* OTSpanContext.swift in Sources */,
 				61E909F024A24DD3005EA2DE /* OTTracer.swift in Sources */,
 				61E909F124A24DD3005EA2DE /* OTReference.swift in Sources */,
@@ -2938,6 +2945,7 @@
 				61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */,
 				61133C6C2423990D00786299 /* SwiftExtensions.swift in Sources */,
 				61A763DC252DB2B3005A23F2 /* NSURLSessionBridge.m in Sources */,
+				61C1510D25AC8C1B00362D4B /* RUMViewIdentityTests.swift in Sources */,
 				61133C492423990D00786299 /* DDLoggerBuilderTests.swift in Sources */,
 				61133C4B2423990D00786299 /* DDLoggerTests.swift in Sources */,
 				618715FC24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift in Sources */,

--- a/Datadog/Example/Scenarios/RUM/ManualInstrumentation/SendRUMFixture3ViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/ManualInstrumentation/SendRUMFixture3ViewController.swift
@@ -10,12 +10,12 @@ internal class SendRUMFixture3ViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        rumMonitor.startView(viewController: self)
+        rumMonitor.startView(key: "fixture3-vc", path: "SendRUMFixture3ViewController")
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        rumMonitor.stopView(viewController: self)
+        rumMonitor.stopView(key: "fixture3-vc")
     }
 }

--- a/Sources/Datadog/DDRUMMonitor.swift
+++ b/Sources/Datadog/DDRUMMonitor.swift
@@ -33,6 +33,26 @@ public class DDRUMMonitor {
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {}
 
+    /// Notifies that the View starts being presented to the user.
+    /// - Parameters:
+    ///   - key: a `String` value identifying this View. It must match the `key` passed later to `stopView(key:attributes:)`.
+    ///   - path: the View path used for RUM Explorer. If not provided, the `key` name will be used.
+    ///   - attributes: custom attributes to attach to the View.
+    public func startView(
+        key: String,
+        path: String? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {}
+
+    /// Notifies that the View stops being presented to the user.
+    /// - Parameters:
+    ///   - key: a `String` value identifying this View. It must match the `key` passed earlier to `startView(key:path:attributes:)`.
+    ///   - attributes: custom attributes to attach to the View.
+    public func stopView(
+        key: String,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {}
+
     /// Adds a specific timing in the currently presented View. The timing duration will be computed as the
     /// number of nanoseconds between the time the View was started and the time the timing was added.
     /// - Parameters:

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -20,8 +20,8 @@ internal struct RUMStartViewCommand: RUMCommand {
     let time: Date
     var attributes: [AttributeKey: AttributeValue]
 
-    /// The object (typically `UIViewController`) identifying the RUM View.
-    let identity: AnyObject
+    /// The value holding stable identity of the RUM View.
+    let identity: RUMViewIdentifiable
 
     /// The path of this View, rendered in RUM Explorer.
     let path: String
@@ -31,15 +31,11 @@ internal struct RUMStartViewCommand: RUMCommand {
     /// * it can be set to `true` by the `RUMApplicationScope` which tracks this state.
     var isInitialView = false
 
-    init(time: Date, identity: AnyObject, path: String?, attributes: [AttributeKey: AttributeValue]) {
+    init(time: Date, identity: RUMViewIdentifiable, path: String?, attributes: [AttributeKey: AttributeValue]) {
         self.time = time
         self.attributes = attributes
         self.identity = identity
-        self.path = path ?? RUMStartViewCommand.viewPath(from: identity)
-    }
-
-    private static func viewPath(from id: AnyObject) -> String {
-        return "\(type(of: id))"
+        self.path = path ?? identity.defaultViewPath
     }
 }
 
@@ -47,8 +43,8 @@ internal struct RUMStopViewCommand: RUMCommand {
     let time: Date
     var attributes: [AttributeKey: AttributeValue]
 
-    /// The object (typically `UIViewController`) identifying the RUM View.
-    let identity: AnyObject
+    /// The value holding stable identity of the RUM View.
+    let identity: RUMViewIdentifiable
 }
 
 internal struct RUMAddCurrentViewErrorCommand: RUMCommand {

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -65,13 +65,13 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
         // Transfer active Views by creating new `RUMViewScopes` for their identity objects:
         self.viewScopes = expiredSession.viewScopes.compactMap { expiredView in
-            guard let expiredViewIdentity = expiredView.identity else {
-                return nil // if the underlying `UIVIewController` no longer exists, skip transferring its scope
+            guard let expiredViewIdentifiable = expiredView.identity.identifiable else {
+                return nil // if the underlying identifiable (`UIVIewController`) no longer exists, skip transferring its scope
             }
             return RUMViewScope(
                 parent: self,
                 dependencies: dependencies,
-                identity: expiredViewIdentity,
+                identity: expiredViewIdentifiable,
                 uri: expiredView.viewURI,
                 attributes: expiredView.attributes,
                 customTimings: expiredView.customTimings,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewIdentity.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewIdentity.swift
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+/// A type providing stable identity for a RUM View.
+/// Based on the `equals(_:)` implementation, it decides if two `RUMViewIdentifiables` identify the same
+/// RUM View or not. Each implementation of the `RUMViewIdentifiable` decides by its own if it should use
+/// reference or value semantic for the comparison.
+internal protocol RUMViewIdentifiable {
+    /// Compares the instance of this identifiable with another `RUMViewIdentifiable`.
+    /// It returns `true` if both identify the same RUM View and `false` otherwise.
+    func equals(_ otherIdentifiable: RUMViewIdentifiable) -> Bool
+
+    /// Converts the instance of this type to `RUMViewIdentity`.
+    func asRUMViewIdentity() -> RUMViewIdentity
+
+    /// If the RUM View's path name is not given explicitly by the user, each implementation of the `RUMViewIdentifiable`
+    /// must return a default path name.
+    var defaultViewPath: String { get }
+}
+
+// MARK: - Supported `RUMViewIdentifiables`
+
+/// Extends `UIViewController` with the ability to identify the RUM View.
+extension UIViewController: RUMViewIdentifiable {
+    func equals(_ otherIdentifiable: RUMViewIdentifiable) -> Bool {
+        if let otherViewController = otherIdentifiable as? UIViewController {
+            // Two `UIViewController` identifiables indicate the same RUM View only if their references are equal.
+            return self === otherViewController
+        } else {
+            return false
+        }
+    }
+
+    func asRUMViewIdentity() -> RUMViewIdentity {
+        return RUMViewIdentity(object: self)
+    }
+
+    var defaultViewPath: String { "\(type(of: self))" }
+}
+
+/// Extends `String` with the ability to identify the RUM View.
+extension String: RUMViewIdentifiable {
+    func equals(_ otherIdentifiable: RUMViewIdentifiable) -> Bool {
+        if let otherString = otherIdentifiable as? String {
+            // Two `String` identifiables indicate the same RUM View only if their values are equal.
+            return self == otherString
+        } else {
+            return false
+        }
+    }
+
+    func asRUMViewIdentity() -> RUMViewIdentity {
+        return RUMViewIdentity(value: self)
+    }
+
+    var defaultViewPath: String { self }
+}
+
+// MARK: - `RUMViewIdentity`
+
+/// Manages the `RUMViewIdentifiable` by using either reference or value semantic.
+internal struct RUMViewIdentity {
+    private weak var object: AnyObject?
+    private let value: Any?
+
+    /// Initializes the `RUMViewIdentity` using reference semantic.
+    /// A weak reference to given `object` is stored internally.
+    fileprivate init(object: RUMViewIdentifiable) {
+        self.object = object as AnyObject
+        self.value = nil
+    }
+
+    /// Initializes the `RUMViewIdentity` using value semantic.
+    /// A copy of the given `value` is stored internally.
+    fileprivate init(value: RUMViewIdentifiable) {
+        self.object = nil
+        self.value = value
+    }
+
+    /// Returns `true` if a given identifiable indicates the same RUM View as the identifiable managed internally.
+    func equals(_ identifiable: RUMViewIdentifiable) -> Bool {
+        if let selfObject = object as? RUMViewIdentifiable {
+            return selfObject.equals(identifiable)
+        } else if let selfValue = value as? RUMViewIdentifiable {
+            return selfValue.equals(identifiable)
+        } else {
+            return false
+        }
+    }
+
+    /// Returns the managed identifiable.
+    var identifiable: RUMViewIdentifiable? {
+        return (object as? RUMViewIdentifiable) ?? (value as? RUMViewIdentifiable)
+    }
+}

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -240,6 +240,34 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         )
     }
 
+    override public func startView(
+        key: String,
+        path: String?,
+        attributes: [AttributeKey: AttributeValue]
+    ) {
+        process(
+            command: RUMStartViewCommand(
+                time: dateProvider.currentDate(),
+                identity: key,
+                path: path,
+                attributes: attributes
+            )
+        )
+    }
+
+    override public func stopView(
+        key: String,
+        attributes: [AttributeKey: AttributeValue]
+    ) {
+        process(
+            command: RUMStopViewCommand(
+                time: dateProvider.currentDate(),
+                attributes: attributes,
+                identity: key
+            )
+        )
+    }
+
     override public func addTiming(
         name: String
     ) {

--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -124,6 +124,23 @@ public class DDRUMMonitor: NSObject {
     }
 
     @objc
+    public func startView(
+        key: String,
+        path: String?,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.startView(key: key, path: path, attributes: castAttributesToSwift(attributes))
+    }
+
+    @objc
+    public func stopView(
+        key: String,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.stopView(key: key, attributes: castAttributesToSwift(attributes))
+    }
+
+    @objc
     public func addTiming(name: String) {
         swiftRUMMonitor.addTiming(name: name)
     }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -116,7 +116,7 @@ extension RUMStartViewCommand {
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
-        identity: AnyObject = mockView,
+        identity: RUMViewIdentifiable = mockView,
         path: String? = nil,
         isInitialView: Bool = false
     ) -> RUMStartViewCommand {
@@ -137,7 +137,7 @@ extension RUMStopViewCommand {
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
-        identity: AnyObject = mockView
+        identity: RUMViewIdentifiable = mockView
     ) -> RUMStopViewCommand {
         return RUMStopViewCommand(
             time: time, attributes: attributes, identity: identity
@@ -454,7 +454,7 @@ extension RUMViewScope {
     static func mockWith(
         parent: RUMContextProvider = RUMContextProviderMock(),
         dependencies: RUMScopeDependencies = .mockAny(),
-        identity: AnyObject = mockView,
+        identity: RUMViewIdentifiable = mockView,
         uri: String = .mockAny(),
         attributes: [AttributeKey: AttributeValue] = [:],
         customTimings: [String: Int64] = [:],

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
@@ -31,7 +31,7 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
 
     // MARK: - Handling `viewDidAppear`
 
-    func testGivenAcceptingPredicate_whenViewDidAppear_itStartsRUMView() {
+    func testGivenAcceptingPredicate_whenViewDidAppear_itStartsRUMView() throws {
         let view = createMockViewInWindow()
 
         // Given
@@ -43,14 +43,14 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(commandSubscriber.receivedCommands.count, 1)
 
-        let command = commandSubscriber.receivedCommands[0] as? RUMStartViewCommand
-        XCTAssertTrue(command?.identity === view)
-        XCTAssertEqual(command?.path, "Foo")
-        XCTAssertEqual(command?.attributes as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
+        let command = try XCTUnwrap(commandSubscriber.receivedCommands[0] as? RUMStartViewCommand)
+        XCTAssertTrue(command.identity.equals(view))
+        XCTAssertEqual(command.path, "Foo")
+        XCTAssertEqual(command.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(command.time, .mockDecember15th2019At10AMUTC())
     }
 
-    func testGivenAcceptingPredicate_whenViewDidAppear_itStopsPreviousRUMView() {
+    func testGivenAcceptingPredicate_whenViewDidAppear_itStopsPreviousRUMView() throws {
         let view1 = createMockViewInWindow()
         let view2 = createMockViewInWindow()
 
@@ -67,12 +67,12 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(commandSubscriber.receivedCommands.count, 3)
 
-        let startCommand1 = commandSubscriber.receivedCommands[0] as? RUMStartViewCommand
-        let stopCommand = commandSubscriber.receivedCommands[1] as? RUMStopViewCommand
-        let startCommand2 = commandSubscriber.receivedCommands[2] as? RUMStartViewCommand
-        XCTAssertTrue(startCommand1?.identity === view1)
-        XCTAssertTrue(stopCommand?.identity === view1)
-        XCTAssertTrue(startCommand2?.identity === view2)
+        let startCommand1 = try XCTUnwrap(commandSubscriber.receivedCommands[0] as? RUMStartViewCommand)
+        let stopCommand = try XCTUnwrap(commandSubscriber.receivedCommands[1] as? RUMStopViewCommand)
+        let startCommand2 = try XCTUnwrap(commandSubscriber.receivedCommands[2] as? RUMStartViewCommand)
+        XCTAssertTrue(startCommand1.identity.equals(view1))
+        XCTAssertTrue(stopCommand.identity.equals(view1))
+        XCTAssertTrue(startCommand2.identity.equals(view2))
     }
 
     func testGivenAcceptingPredicate_whenViewDidAppear_itDoesNotStartTheSameRUMViewTwice() {
@@ -105,7 +105,7 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
 
     // MARK: - Handling `viewDidDisappear`
 
-    func testGivenAcceptingPredicate_whenViewDidDisappear_itStartsRUMViewForTopViewController() {
+    func testGivenAcceptingPredicate_whenViewDidDisappear_itStartsRUMViewForTopViewController() throws {
         let view = createMockViewInWindow()
         let topViewController = createMockViewInWindow()
         uiKitHierarchyInspector.mockTopViewController = topViewController
@@ -121,10 +121,10 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(commandSubscriber.receivedCommands.count, 1)
 
-        let command = commandSubscriber.receivedCommands[0] as? RUMStartViewCommand
-        XCTAssertTrue(command?.identity === topViewController)
-        XCTAssertEqual(command?.path, "Top")
-        XCTAssertEqual(command?.time, .mockDecember15th2019At10AMUTC())
+        let command = try XCTUnwrap(commandSubscriber.receivedCommands[0] as? RUMStartViewCommand)
+        XCTAssertTrue(command.identity.equals(topViewController))
+        XCTAssertEqual(command.path, "Top")
+        XCTAssertEqual(command.time, .mockDecember15th2019At10AMUTC())
     }
 
     func testGivenAcceptingPredicate_whenViewDidDisappearButThereIsNoTopViewController_itDoesNotStartAnyRUMView() {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -45,10 +45,11 @@ class RUMApplicationScopeTests: XCTestCase {
         _ = scope.process(command: RUMAddUserActionCommand.mockWith(time: currentTime))
         let secondSessionUUID = try XCTUnwrap(scope.sessionScope?.context.sessionID)
         let secondSessionViewScopes = try XCTUnwrap(scope.sessionScope?.viewScopes)
+        let secondSessionViewScope = try XCTUnwrap(secondSessionViewScopes.first)
 
         XCTAssertNotEqual(firstSessionUUID, secondSessionUUID)
         XCTAssertEqual(firstsSessionViewScopes.count, secondSessionViewScopes.count)
-        XCTAssertTrue(secondSessionViewScopes.first?.identity === view)
+        XCTAssertTrue(secondSessionViewScope.identity.equals(view))
     }
 
     func testUntilSessionIsStarted_itIgnoresOtherCommands() {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewIdentityTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewIdentityTests.swift
@@ -1,0 +1,92 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import UIKit
+@testable import Datadog
+
+class RUMViewIdentityTests: XCTestCase {
+    // MARK: - Comparing identifiables
+
+    func testGivenTwoUIViewControllers_whenComparingTheirRUMViewIdentity_itEqualsOnlyForTheSameInstance() {
+        // Given
+        let vc1 = createMockView(viewControllerClassName: .mockRandom(among: "abcdefghijklmnopqrstuvwxyz"))
+        let vc2 = createMockView(viewControllerClassName: .mockRandom(among: "abcdefghijklmnopqrstuvwxyz"))
+
+        // When
+        let identity1 = vc1.asRUMViewIdentity()
+        let identity2 = vc2.asRUMViewIdentity()
+
+        // Then
+        XCTAssertTrue(identity1.equals(vc1))
+        XCTAssertTrue(identity2.equals(vc2))
+        XCTAssertFalse(identity1.equals(vc2))
+        XCTAssertFalse(identity2.equals(vc1))
+    }
+
+    func testGivenTwoStringKeys_whenComparingTheirRUMViewIdentity_itEqualsOnlyForTheSameInstance() {
+        // Given
+        let key1: String = .mockRandom()
+        let key2: String = .mockRandom()
+
+        // When
+        let identity1 = key1.asRUMViewIdentity()
+        let identity2 = key2.asRUMViewIdentity()
+
+        // Then
+        XCTAssertTrue(identity1.equals(key1))
+        XCTAssertTrue(identity2.equals(key2))
+        XCTAssertFalse(identity1.equals(key2))
+        XCTAssertFalse(identity2.equals(key1))
+    }
+
+    func testGivenTwoRUMViewIdentitiesOfDifferentKind_whenComparing_theyDoNotEqual() {
+        // Given
+        let vc = createMockView(viewControllerClassName: .mockRandom(among: "abcdefghijklmnopqrstuvwxyz"))
+        let key: String = .mockRandom()
+
+        // When
+        let identity1 = vc.asRUMViewIdentity()
+        let identity2 = key.asRUMViewIdentity()
+
+        // Then
+        XCTAssertFalse(identity1.equals(key))
+        XCTAssertFalse(identity2.equals(vc))
+    }
+
+    // MARK: - Retrieving properties
+
+    func testItReturnsDefaultViewPath() {
+        let vc = createMockView(viewControllerClassName: "SomeViewController")
+        let key = "SomeKey"
+
+        XCTAssertEqual(vc.defaultViewPath, "SomeViewController")
+        XCTAssertEqual(key.defaultViewPath, "SomeKey")
+    }
+
+    func testItReturnsManagedIdentifiable() {
+        let vc = createMockView(viewControllerClassName: "SomeViewController")
+        let key = "SomeKey"
+
+        let identity1 = vc.asRUMViewIdentity()
+        let identity2 = key.asRUMViewIdentity()
+
+        XCTAssertTrue(identity1.identifiable as? UIViewController === vc)
+        XCTAssertEqual(identity2.identifiable as? String, key)
+    }
+
+    // MARK: - Memory management
+
+    func testItStoresWeakReferenceToUIViewController() throws {
+        var vc: UIViewController? = UIViewController()
+
+        let identity = try XCTUnwrap(vc?.asRUMViewIdentity())
+
+        XCTAssertNotNil(identity.identifiable, "Reference should be available while `vc` is alive.")
+        vc = nil
+        XCTAssertNil(identity.identifiable, "Reference should not be available after `vc` was deallocated.")
+    }
+}

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -148,6 +148,8 @@ public class DDRUMMonitor: NSObject
  override public convenience init()
  public func startView(viewController: UIViewController,path: String?,attributes: [String: Any])
  public func stopView(viewController: UIViewController,attributes: [String: Any])
+ public func startView(key: String,path: String?,attributes: [String: Any])
+ public func stopView(key: String,attributes: [String: Any])
  public func addTiming(name: String)
  public func addError(error: Error,source: DDRUMErrorSource,attributes: [String: Any])
  public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [String: Any])

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -7,6 +7,8 @@ public enum TrackingConsent
 public class DDRUMMonitor
  public func startView(viewController: UIViewController,path: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  public func stopView(viewController: UIViewController,attributes: [AttributeKey: AttributeValue] = [:])
+ public func startView(key: String,path: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
+ public func stopView(key: String,attributes: [AttributeKey: AttributeValue] = [:])
  public func addTiming(name: String)
  public func addError(message: String,source: RUMErrorSource = .custom,attributes: [AttributeKey: AttributeValue] = [:],file: StaticString? = #file,line: UInt? = #line)
  public func addError(error: Error,source: RUMErrorSource = .custom,attributes: [AttributeKey: AttributeValue] = [:])
@@ -209,6 +211,8 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber
  public static func initialize() -> DDRUMMonitor
  override public func startView(viewController: UIViewController,path: String?,attributes: [AttributeKey: AttributeValue])
  override public func stopView(viewController: UIViewController,attributes: [AttributeKey: AttributeValue])
+ override public func startView(key: String,path: String?,attributes: [AttributeKey: AttributeValue])
+ override public func stopView(key: String,attributes: [AttributeKey: AttributeValue])
  override public func addTiming(name: String)
  override public func addError(message: String,source: RUMErrorSource,attributes: [AttributeKey: AttributeValue],file: StaticString?,line: UInt?)
  override public func addError(error: Error,source: RUMErrorSource,attributes: [AttributeKey: AttributeValue])


### PR DESCRIPTION
### What and why?

📦 This PR introduces two additional APIs for RUM Views manual instrumentation. Now it is possible to use `String` key to mark the view start and view end:
```swift
// New APIs:
Global.rum.startView(key: "view1", path: "NameOfTheView")
Global.rum.stopView(key: "view1")
```
This builds up an alternative for use cases where `UIViewController` cannot be referenced using existing APIs:
```swift
// Existing APIs
Global.rum.startView(viewController: self, path: "NameOfTheView")
Global.rum.stopView(viewController: self)
```

### How?

I introduced a single interface for any kind of RUM View reference:
```swift
internal protocol RUMViewIdentifiable {
    func equals(_ otherIdentifiable: RUMViewIdentifiable) -> Bool
}
```
It's implemented by `UIViewController` and `String` types and can be extended any further in the future (e.g. for `SwiftUI`).

Additional `RUMViewIdentity` wrapper-type is introduced to manage the reference lifecycle. It ensures that the `UIViewController` is captured as a weak reference (so we don't leak it) and translates `String` into plain value. It provides basic interface for comparing identities:
```swift
let vc = UIViewController()
let otherVC = UIViewController()

let identity: RUMViewIdentity = vc.asRUMViewIdentity()

print(identity.equals(vc)) // true
print(identity.equals(otherVC)) // false
```
```swift
let key = "foo"
let otherKey = "bar"

let identity: RUMViewIdentity = key.asRUMViewIdentity()
print(identity.equals(key)) // true
print(identity.equals(otherKey)) // false
```

### Another option for new public API

Instead of providing two distinct sets of public APIs:
* `Global.rum.startView(key: String)`
* `Global.rum.stopView(key: String)`
* `Global.rum.startView(viewController: UIViewController)`
* `Global.rum.stopView(viewController: UIViewController)`

we can merge them into single, generic one:
* `Global.rum.startView(identity: RUMViewIdentifiable)`
* `Global.rum.stopView(identity: RUMViewIdentifiable)`

which will work automatically for both `UIViewController` and `String`. That would require deprecating the existing API, but I don't have any strong opinion on having 2 vs 1 set of the APIs. WDYT @xgouchet @mariusc83 @buranmert ?

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
