### PR TITLE
RUMM-976 GH Issue #363

### DIFF
--- a/Sources/Datadog/Tracing/DDSpanContext.swift
+++ b/Sources/Datadog/Tracing/DDSpanContext.swift
@@ -49,7 +49,7 @@ internal class BaggageItems {
     }
 
     func get(key: String) -> String? {
-        queue.sync { self.unsafeItems[key] }
+        queue.sync { self.unsafeAll[key] }
     }
 
     var all: [String: String] {

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanContextTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanContextTests.swift
@@ -49,4 +49,17 @@ class DDSpanContextTests: XCTestCase {
         XCTAssertEqual(parentBaggageItems.all["foo"], "a")
         XCTAssertEqual(childBaggageItems.all["foo"], "b")
     }
+
+    func testChildItemsGetParentItems() {
+        let parentBaggageItems = BaggageItems(targetQueue: queue, parentSpanItems: nil)
+        let childBaggageItems = BaggageItems(targetQueue: queue, parentSpanItems: parentBaggageItems)
+
+        parentBaggageItems.set(key: "foo", value: "a")
+        childBaggageItems.set(key: "bar", value: "b")
+
+        XCTAssertEqual(childBaggageItems.get(key: "foo"), "a")
+
+        XCTAssertNil(parentBaggageItems.get(key: "bar"))
+        XCTAssertEqual(childBaggageItems.get(key: "bar"), "b")
+    }
 }


### PR DESCRIPTION
Fixes #363 

### What and why?

Baggage items were not propagated to span's children
A great explanation can be found in #363 

### How?

Now `BaggageItems.get(key)` searches in `parent.baggageItems` recursively

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
