### PR TITLE
RUMM-788 Add data scrubbing API

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -128,6 +128,9 @@
 		613E79282577B0EE00DFCC17 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E79272577B0EE00DFCC17 /* Writer.swift */; };
 		613E792F2577B0F900DFCC17 /* Reader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E792E2577B0F900DFCC17 /* Reader.swift */; };
 		613E793B2577B6EE00DFCC17 /* DataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E793A2577B6EE00DFCC17 /* DataReader.swift */; };
+		613E81F025A740140084B751 /* RUMEventsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E81EF25A740140084B751 /* RUMEventsMapper.swift */; };
+		613E81F725A743600084B751 /* RUMEventsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E81F625A743600084B751 /* RUMEventsMapperTests.swift */; };
+		613E820525A879AF0084B751 /* RUMDataModelMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E820425A879AF0084B751 /* RUMDataModelMocks.swift */; };
 		613F23E4252B062F006CD2D7 /* TaskInterceptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23E3252B062F006CD2D7 /* TaskInterceptionTests.swift */; };
 		613F23F1252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23F0252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift */; };
 		613F23FD252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23FC252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift */; };
@@ -270,6 +273,7 @@
 		61BBD19724ED50040023E65F /* FeaturesConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */; };
 		61BCB81F256EB77F0039887B /* ServerDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BCB81E256EB77F0039887B /* ServerDateProvider.swift */; };
 		61C1510D25AC8C1B00362D4B /* RUMViewIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C1510C25AC8C1B00362D4B /* RUMViewIdentityTests.swift */; };
+		61C1513125ADC68D00362D4B /* DataProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C1513025ADC68D00362D4B /* DataProcessorTests.swift */; };
 		61C2C20724C098FC00C0321C /* RUMSessionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20624C098FC00C0321C /* RUMSessionScope.swift */; };
 		61C2C20924C0C75500C0321C /* RUMSessionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */; };
 		61C2C20B24C1045300C0321C /* SendRUMFixture1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C2C20A24C1045300C0321C /* SendRUMFixture1ViewController.swift */; };
@@ -578,6 +582,9 @@
 		613E79272577B0EE00DFCC17 /* Writer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
 		613E792E2577B0F900DFCC17 /* Reader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reader.swift; sourceTree = "<group>"; };
 		613E793A2577B6EE00DFCC17 /* DataReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataReader.swift; sourceTree = "<group>"; };
+		613E81EF25A740140084B751 /* RUMEventsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventsMapper.swift; sourceTree = "<group>"; };
+		613E81F625A743600084B751 /* RUMEventsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventsMapperTests.swift; sourceTree = "<group>"; };
+		613E820425A879AF0084B751 /* RUMDataModelMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelMocks.swift; sourceTree = "<group>"; };
 		613F23E3252B062F006CD2D7 /* TaskInterceptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInterceptionTests.swift; sourceTree = "<group>"; };
 		613F23F0252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionRUMResourcesHandlerTests.swift; sourceTree = "<group>"; };
 		613F23FC252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionAutoInstrumentationTests.swift; sourceTree = "<group>"; };
@@ -721,6 +728,7 @@
 		61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesConfigurationTests.swift; sourceTree = "<group>"; };
 		61BCB81E256EB77F0039887B /* ServerDateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerDateProvider.swift; sourceTree = "<group>"; };
 		61C1510C25AC8C1B00362D4B /* RUMViewIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewIdentityTests.swift; sourceTree = "<group>"; };
+		61C1513025ADC68D00362D4B /* DataProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProcessorTests.swift; sourceTree = "<group>"; };
 		61C2C20624C098FC00C0321C /* RUMSessionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionScope.swift; sourceTree = "<group>"; };
 		61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionScopeTests.swift; sourceTree = "<group>"; };
 		61C2C20A24C1045300C0321C /* SendRUMFixture1ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendRUMFixture1ViewController.swift; sourceTree = "<group>"; };
@@ -1211,6 +1219,7 @@
 				61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */,
 				61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */,
 				61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */,
+				613E820425A879AF0084B751 /* RUMDataModelMocks.swift */,
 				61B038B92527257B00518F3C /* URLSessionAutoInstrumentationMocks.swift */,
 				61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */,
 				61F1A61B2498AD2C00075390 /* SystemFrameworks */,
@@ -1572,6 +1581,22 @@
 				61133BAD2423979B00786299 /* FileReader.swift */,
 			);
 			path = Reading;
+			sourceTree = "<group>";
+		};
+		613E81EE25A73FB90084B751 /* Scrubbing */ = {
+			isa = PBXGroup;
+			children = (
+				613E81EF25A740140084B751 /* RUMEventsMapper.swift */,
+			);
+			path = Scrubbing;
+			sourceTree = "<group>";
+		};
+		613E81F525A743470084B751 /* Scrubbing */ = {
+			isa = PBXGroup;
+			children = (
+				613E81F625A743600084B751 /* RUMEventsMapperTests.swift */,
+			);
+			path = Scrubbing;
 			sourceTree = "<group>";
 		};
 		613F23DC252B05BD006CD2D7 /* URLFiltering */ = {
@@ -1944,6 +1969,7 @@
 			children = (
 				6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */,
 				61133C292423990D00786299 /* FileWriterTests.swift */,
+				61C1512F25ADC67500362D4B /* Processing */,
 			);
 			path = Writting;
 			sourceTree = "<group>";
@@ -2010,6 +2036,14 @@
 				61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */,
 			);
 			path = Debugging;
+			sourceTree = "<group>";
+		};
+		61C1512F25ADC67500362D4B /* Processing */ = {
+			isa = PBXGroup;
+			children = (
+				61C1513025ADC68D00362D4B /* DataProcessorTests.swift */,
+			);
+			path = Processing;
 			sourceTree = "<group>";
 		};
 		61C3637E2436163400C4D4E6 /* DatadogPrivate */ = {
@@ -2169,6 +2203,7 @@
 				6156CB8A24DDA186008CB2B2 /* RUMContext */,
 				61E5333B24B87908003D6C4E /* RUMEvent */,
 				61FF282224B8A1AE000B3D9B /* RUMEventOutputs */,
+				613E81EE25A73FB90084B751 /* Scrubbing */,
 				616CCE11250A181C009FED46 /* AutoInstrumentation */,
 				618DCFD524C7264100589570 /* UUIDs */,
 				61B22E5824F3E6A700DC26D2 /* Debugging */,
@@ -2185,6 +2220,7 @@
 				6156CB9124DDAA13008CB2B2 /* RUMContext */,
 				61FF281F24B89807000B3D9B /* RUMEvent */,
 				61FF282E24BC5E0E000B3D9B /* RUMEventOutputs */,
+				613E81F525A743470084B751 /* Scrubbing */,
 				61F3CDA825121F8F00C816E5 /* AutoInstrumentation */,
 				61786F7524FCDDE2009E6BAB /* Debugging */,
 				61411B0E24EC15940012EAB2 /* Utils */,
@@ -2832,6 +2868,7 @@
 				61B22E5A24F3E6B700DC26D2 /* RUMDebugging.swift in Sources */,
 				61C5A88B24509A0C00DA608C /* SpanOutput.swift in Sources */,
 				61133BE42423979B00786299 /* LogEncoder.swift in Sources */,
+				613E81F025A740140084B751 /* RUMEventsMapper.swift in Sources */,
 				61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */,
 				61C5A88424509A0C00DA608C /* DDSpan.swift in Sources */,
 				61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */,
@@ -2904,6 +2941,7 @@
 				61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */,
 				615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */,
 				615A4A8724A3452800233986 /* DDTracerConfigurationTests.swift in Sources */,
+				613E81F725A743600084B751 /* RUMEventsMapperTests.swift in Sources */,
 				61EF78B7257E37D500EDCCB3 /* MoveDataMigratorTests.swift in Sources */,
 				61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */,
 				615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */,
@@ -2911,6 +2949,7 @@
 				61133C542423990D00786299 /* NetworkConnectionInfoProviderTests.swift in Sources */,
 				616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */,
 				61B558CF2469561C001460D3 /* LoggerBuilderTests.swift in Sources */,
+				61C1513125ADC68D00362D4B /* DataProcessorTests.swift in Sources */,
 				61133C4A2423990D00786299 /* DDConfigurationTests.swift in Sources */,
 				61C5A89F24509C1100DA608C /* UUID.swift in Sources */,
 				613F23F1252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,
@@ -2946,6 +2985,7 @@
 				61133C6C2423990D00786299 /* SwiftExtensions.swift in Sources */,
 				61A763DC252DB2B3005A23F2 /* NSURLSessionBridge.m in Sources */,
 				61C1510D25AC8C1B00362D4B /* RUMViewIdentityTests.swift in Sources */,
+				613E820525A879AF0084B751 /* RUMDataModelMocks.swift in Sources */,
 				61133C492423990D00786299 /* DDLoggerBuilderTests.swift in Sources */,
 				61133C4B2423990D00786299 /* DDLoggerTests.swift in Sources */,
 				618715FC24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -41,6 +41,7 @@ internal struct FeatureStorage {
         featureName: String,
         dataFormat: DataFormat,
         directories: FeatureDirectories,
+        eventMapper: EventMapper?,
         commonDependencies: FeaturesCommonDependencies
     ) {
         let readWriteQueue = DispatchQueue(
@@ -69,7 +70,8 @@ internal struct FeatureStorage {
                 authorizedFileWriter: FileWriter(
                     dataFormat: dataFormat,
                     orchestrator: authorizedFilesOrchestrator
-                )
+                ),
+                eventMapper: eventMapper
             ),
             dataMigratorFactory: DataMigratorFactory(
                 directories: directories

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -40,6 +40,7 @@ internal struct FeaturesConfiguration {
         let uploadURLWithClientToken: URL
         let applicationID: String
         let sessionSamplingRate: Float
+        let eventMapper: RUMEventsMapper
         /// RUM auto instrumentation configuration, `nil` if not enabled.
         let autoInstrumentation: AutoInstrumentation?
     }
@@ -161,6 +162,12 @@ extension FeaturesConfiguration {
                     ),
                     applicationID: rumApplicationID,
                     sessionSamplingRate: configuration.rumSessionsSamplingRate,
+                    eventMapper: RUMEventsMapper(
+                        viewEventMapper: configuration.rumViewEventMapper,
+                        errorEventMapper: configuration.rumErrorEventMapper,
+                        resourceEventMapper: configuration.rumResourceEventMapper,
+                        actionEventMapper: configuration.rumActionEventMapper
+                    ),
                     autoInstrumentation: autoInstrumentation
                 )
             } else {

--- a/Sources/Datadog/Core/Persistence/Writting/Processing/DataProcessor.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/Processing/DataProcessor.swift
@@ -6,17 +6,26 @@
 
 import Foundation
 
+/// Data scrubbing interface.
+/// It takes an `event` and returns its modified representation or `nil` (for dropping the event).
+internal protocol EventMapper {
+    func map<T: Encodable>(event: T) -> T?
+}
+
 internal struct DataProcessorFactory {
     /// File writer writting unauthorized data when consent is `.pending`.
     let unauthorizedFileWriter: Writer
     /// File writer writting authorized data when consent is `.granted`.
     let authorizedFileWriter: Writer
+    /// Event mapper performing eventual modification (or dropping) the event before it gets written.
+    /// It may be `nil` if not available for this feature.
+    let eventMapper: EventMapper?
 
     func resolveProcessor(for consent: TrackingConsent) -> DataProcessor? {
         switch consent {
-        case .granted: return DataProcessor(fileWriter: authorizedFileWriter)
+        case .granted: return DataProcessor(fileWriter: authorizedFileWriter, eventMapper: eventMapper)
         case .notGranted: return nil
-        case .pending: return DataProcessor(fileWriter: unauthorizedFileWriter)
+        case .pending: return DataProcessor(fileWriter: unauthorizedFileWriter, eventMapper: eventMapper)
         }
     }
 }
@@ -24,14 +33,22 @@ internal struct DataProcessorFactory {
 /// The processing pipeline for writing data.
 internal final class DataProcessor: Writer {
     private let fileWriter: Writer
+    private let eventMapper: EventMapper?
 
-    init(fileWriter: Writer) {
+    init(fileWriter: Writer, eventMapper: EventMapper?) {
         self.fileWriter = fileWriter
+        self.eventMapper = eventMapper
     }
 
     // MARK: - Writer
 
     func write<T>(value: T) where T: Encodable {
-        fileWriter.write(value: value)
+        if let eventMapper = eventMapper {
+            if let mappedValue = eventMapper.map(event: value) {
+                fileWriter.write(value: mappedValue)
+            }
+        } else {
+            fileWriter.write(value: value)
+        }
     }
 }

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -173,6 +173,10 @@ extension Datadog {
         private(set) var rumSessionsSamplingRate: Float
         private(set) var rumUIKitViewsPredicate: UIKitRUMViewsPredicate?
         private(set) var rumUIKitActionsTrackingEnabled: Bool
+        private(set) var rumViewEventMapper: RUMViewEventMapper?
+        private(set) var rumResourceEventMapper: RUMResourceEventMapper?
+        private(set) var rumActionEventMapper: RUMActionEventMapper?
+        private(set) var rumErrorEventMapper: RUMErrorEventMapper?
         private(set) var batchSize: BatchSize
         private(set) var uploadFrequency: UploadFrequency
 
@@ -233,6 +237,10 @@ extension Datadog {
                     rumSessionsSamplingRate: 100.0,
                     rumUIKitViewsPredicate: nil,
                     rumUIKitActionsTrackingEnabled: false,
+                    rumViewEventMapper: nil,
+                    rumResourceEventMapper: nil,
+                    rumActionEventMapper: nil,
+                    rumErrorEventMapper: nil,
                     batchSize: .medium,
                     uploadFrequency: .average
                 )
@@ -437,6 +445,42 @@ extension Datadog {
             /// - Parameter enabled: `true` by default
             public func trackUIKitActions(_ enabled: Bool = true) -> Builder {
                 configuration.rumUIKitActionsTrackingEnabled = enabled
+                return self
+            }
+
+            /// Sets the custom mapper for `RUMViewEvent`. This can be used to modify RUM View events before they are send to Datadog.
+            /// - Parameter mapper: the closure taking `RUMViewEvent` as input and expecting `RUMViewEvent` or `nil` as output.
+            /// The implementation should obtain a mutable version of the `RUMViewEvent`, modify it and return. Returning `nil` will result
+            /// with dropping the RUM View event entirely, so it won't be send to Datadog.
+            public func setRUMViewEventMapper(_ mapper: @escaping (RUMViewEvent) -> RUMViewEvent?) -> Builder {
+                configuration.rumViewEventMapper = mapper
+                return self
+            }
+
+            /// Sets the custom mapper for `RUMResourceEvent`. This can be used to modify RUM Resource events before they are send to Datadog.
+            /// - Parameter mapper: the closure taking `RUMResourceEvent` as input and expecting `RUMResourceEvent` or `nil` as output.
+            /// The implementation should obtain a mutable version of the `RUMResourceEvent`, modify it and return. Returning `nil` will result
+            /// with dropping the RUM Resource event entirely, so it won't be send to Datadog.
+            public func setRUMResourceEventMapper(_ mapper: @escaping (RUMResourceEvent) -> RUMResourceEvent?) -> Builder {
+                configuration.rumResourceEventMapper = mapper
+                return self
+            }
+
+            /// Sets the custom mapper for `RUMActionEvent`. This can be used to modify RUM Action events before they are send to Datadog.
+            /// - Parameter mapper: the closure taking `RUMActionEvent` as input and expecting `RUMActionEvent` or `nil` as output.
+            /// The implementation should obtain a mutable version of the `RUMActionEvent`, modify it and return. Returning `nil` will result
+            /// with dropping the RUM Action event entirely, so it won't be send to Datadog.
+            public func setRUMActionEventMapper(_ mapper: @escaping (RUMActionEvent) -> RUMActionEvent?) -> Builder {
+                configuration.rumActionEventMapper = mapper
+                return self
+            }
+
+            /// Sets the custom mapper for `RUMErrorEvent`. This can be used to modify RUM Error events before they are send to Datadog.
+            /// - Parameter mapper: the closure taking `RUMErrorEvent` as input and expecting `RUMErrorEvent` or `nil` as output.
+            /// The implementation should obtain a mutable version of the `RUMErrorEvent`, modify it and return. Returning `nil` will result
+            /// with dropping the RUM Error event entirely, so it won't be send to Datadog.
+            public func setRUMErrorEventMapper(_ mapper: @escaping (RUMErrorEvent) -> RUMErrorEvent?) -> Builder {
+                configuration.rumErrorEventMapper = mapper
                 return self
             }
 

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -54,6 +54,7 @@ internal final class LoggingFeature {
             featureName: LoggingFeature.featureName,
             dataFormat: LoggingFeature.dataFormat,
             directories: directories,
+            eventMapper: nil,
             commonDependencies: commonDependencies
         )
     }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -9,7 +9,8 @@ import Foundation
 /// `Encodable` representation of RUM event.
 internal struct RUMEvent<DM: RUMDataModel>: Encodable {
     /// The actual RUM event model created by `RUMMonitor`
-    let model: DM
+    /// It's mutable as it may be redacted by the user through data scrubbing API.
+    var model: DM
 
     /// Custom attributes set by the user
     let attributes: [String: Encodable]

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -55,6 +55,7 @@ internal final class RUMFeature {
             featureName: RUMFeature.featureName,
             dataFormat: RUMFeature.dataFormat,
             directories: directories,
+            eventMapper: nil,
             commonDependencies: commonDependencies
         )
     }

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -50,12 +50,16 @@ internal final class RUMFeature {
 
     // MARK: - Initialization
 
-    static func createStorage(directories: FeatureDirectories, commonDependencies: FeaturesCommonDependencies) -> FeatureStorage {
+    static func createStorage(
+        directories: FeatureDirectories,
+        eventMapper: RUMEventsMapper,
+        commonDependencies: FeaturesCommonDependencies
+    ) -> FeatureStorage {
         return FeatureStorage(
             featureName: RUMFeature.featureName,
             dataFormat: RUMFeature.dataFormat,
             directories: directories,
-            eventMapper: nil,
+            eventMapper: eventMapper,
             commonDependencies: commonDependencies
         )
     }
@@ -101,7 +105,11 @@ internal final class RUMFeature {
         configuration: FeaturesConfiguration.RUM,
         commonDependencies: FeaturesCommonDependencies
     ) {
-        let storage = RUMFeature.createStorage(directories: directories, commonDependencies: commonDependencies)
+        let storage = RUMFeature.createStorage(
+            directories: directories,
+            eventMapper: configuration.eventMapper,
+            commonDependencies: commonDependencies
+        )
         let upload = RUMFeature.createUpload(storage: storage, configuration: configuration, commonDependencies: commonDependencies)
         self.init(
             storage: storage,

--- a/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
+++ b/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
@@ -1,0 +1,65 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal typealias RUMViewEventMapper = (RUMViewEvent) -> RUMViewEvent?
+internal typealias RUMErrorEventMapper = (RUMErrorEvent) -> RUMErrorEvent?
+internal typealias RUMResourceEventMapper = (RUMResourceEvent) -> RUMResourceEvent?
+internal typealias RUMActionEventMapper = (RUMActionEvent) -> RUMActionEvent?
+
+/// The `EventMapper` for RUM events.
+internal struct RUMEventsMapper: EventMapper {
+    private let viewEventMapper: RUMViewEventMapper
+    private let errorEventMapper: RUMErrorEventMapper
+    private let resourceEventMapper: RUMResourceEventMapper
+    private let actionEventMapper: RUMActionEventMapper
+
+    init(
+        viewEventMapper: RUMViewEventMapper?,
+        errorEventMapper: RUMErrorEventMapper?,
+        resourceEventMapper: RUMResourceEventMapper?,
+        actionEventMapper: RUMActionEventMapper?
+    ) {
+        self.viewEventMapper = viewEventMapper ?? RUMEventsMapper.noOpMapper(_:)
+        self.errorEventMapper = errorEventMapper ?? RUMEventsMapper.noOpMapper(_:)
+        self.resourceEventMapper = resourceEventMapper ?? RUMEventsMapper.noOpMapper(_:)
+        self.actionEventMapper = actionEventMapper ?? RUMEventsMapper.noOpMapper(_:)
+    }
+
+    // MARK: - EventMapper
+
+    func map<T>(event: T) -> T? {
+        switch event {
+        case let viewEvent as RUMEvent<RUMViewEvent>:
+            return map(rumEvent: viewEvent, using: viewEventMapper) as? T
+        case let errorEvent as RUMEvent<RUMErrorEvent>:
+            return map(rumEvent: errorEvent, using: errorEventMapper) as? T
+        case let resourceEvent as RUMEvent<RUMResourceEvent>:
+            return map(rumEvent: resourceEvent, using: resourceEventMapper) as? T
+        case let actionEvent as RUMEvent<RUMActionEvent>:
+            return map(rumEvent: actionEvent, using: actionEventMapper) as? T
+        default:
+            developerLogger?.warn("No `RUMEventsMapper` is registered for \(type(of: event))")
+            return event
+        }
+    }
+
+    private func map<DM: RUMDataModel>(rumEvent: RUMEvent<DM>, using mapper: (DM) -> DM?) -> RUMEvent<DM>? {
+        if let mappedModel = mapper(rumEvent.model) {
+            var mutableRUMEvent = rumEvent
+            mutableRUMEvent.model = mappedModel
+            return mutableRUMEvent
+        } else {
+            return nil
+        }
+    }
+
+    // MARK: - Private
+
+    /// Generic mapping function which returns the `event` with no change.
+    private static func noOpMapper<T: Encodable>(_ event: T) -> T { event }
+}

--- a/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
+++ b/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
@@ -13,22 +13,10 @@ internal typealias RUMActionEventMapper = (RUMActionEvent) -> RUMActionEvent?
 
 /// The `EventMapper` for RUM events.
 internal struct RUMEventsMapper: EventMapper {
-    private let viewEventMapper: RUMViewEventMapper
-    private let errorEventMapper: RUMErrorEventMapper
-    private let resourceEventMapper: RUMResourceEventMapper
-    private let actionEventMapper: RUMActionEventMapper
-
-    init(
-        viewEventMapper: RUMViewEventMapper?,
-        errorEventMapper: RUMErrorEventMapper?,
-        resourceEventMapper: RUMResourceEventMapper?,
-        actionEventMapper: RUMActionEventMapper?
-    ) {
-        self.viewEventMapper = viewEventMapper ?? RUMEventsMapper.noOpMapper(_:)
-        self.errorEventMapper = errorEventMapper ?? RUMEventsMapper.noOpMapper(_:)
-        self.resourceEventMapper = resourceEventMapper ?? RUMEventsMapper.noOpMapper(_:)
-        self.actionEventMapper = actionEventMapper ?? RUMEventsMapper.noOpMapper(_:)
-    }
+    let viewEventMapper: RUMViewEventMapper?
+    let errorEventMapper: RUMErrorEventMapper?
+    let resourceEventMapper: RUMResourceEventMapper?
+    let actionEventMapper: RUMActionEventMapper?
 
     // MARK: - EventMapper
 
@@ -48,7 +36,11 @@ internal struct RUMEventsMapper: EventMapper {
         }
     }
 
-    private func map<DM: RUMDataModel>(rumEvent: RUMEvent<DM>, using mapper: (DM) -> DM?) -> RUMEvent<DM>? {
+    private func map<DM: RUMDataModel>(rumEvent: RUMEvent<DM>, using mapper: ((DM) -> DM?)?) -> RUMEvent<DM>? {
+        guard let mapper = mapper else {
+            return rumEvent // if no mapper is provided, do not modify the `rumEvent`
+        }
+
         if let mappedModel = mapper(rumEvent.model) {
             var mutableRUMEvent = rumEvent
             mutableRUMEvent.model = mappedModel
@@ -57,9 +49,4 @@ internal struct RUMEventsMapper: EventMapper {
             return nil
         }
     }
-
-    // MARK: - Private
-
-    /// Generic mapping function which returns the `event` with no change.
-    private static func noOpMapper<T: Encodable>(_ event: T) -> T { event }
 }

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -61,6 +61,7 @@ internal final class TracingFeature {
             featureName: TracingFeature.featureName,
             dataFormat: TracingFeature.dataFormat,
             directories: directories,
+            eventMapper: nil,
             commonDependencies: commonDependencies
         )
     }

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -24,6 +24,12 @@ class RUMStorageBenchmarkTests: XCTestCase {
                 unauthorized: obtainUniqueTemporaryDirectory(),
                 authorized: directory
             ),
+            eventMapper: RUMEventsMapper(
+                viewEventMapper: nil,
+                errorEventMapper: nil,
+                resourceEventMapper: nil,
+                actionEventMapper: nil
+            ),
             commonDependencies: .mockAny()
         )
         self.writer = storage.writer

--- a/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
@@ -26,6 +26,7 @@ class FeatureStorageTests: XCTestCase {
             featureName: .mockAny(),
             dataFormat: DataFormat(prefix: "", suffix: "", separator: "#"),
             directories: temporaryFeatureDirectories,
+            eventMapper: nil,
             commonDependencies: .mockWith(consentProvider: consentProvider)
         )
 

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writting/ConsentAwareDataWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writting/ConsentAwareDataWriterTests.swift
@@ -13,7 +13,8 @@ class ConsentAwareDataWriterTests: XCTestCase {
     private let authorizedWriter = FileWriterMock()
     private lazy var dataProcessorFactory = DataProcessorFactory(
         unauthorizedFileWriter: unauthorizedWriter,
-        authorizedFileWriter: authorizedWriter
+        authorizedFileWriter: authorizedWriter,
+        eventMapper: nil
     )
     private lazy var dataMigratorFactory = DataMigratorFactory(
         directories: temporaryFeatureDirectories

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writting/Processing/DataProcessorTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writting/Processing/DataProcessorTests.swift
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class DataProcessorTests: XCTestCase {
+    private struct EventMock: Encodable, Equatable {
+        let value: String
+    }
+
+    func testGivenDataProcessorWithEventMapper_whenEventIsModified_itWritesModifiedEvent() {
+        let originalEvent = EventMock(value: "original-event")
+        let modifiedEvent = EventMock(value: "modified-event")
+
+        let eventMapper = EventMapperMock(mappedEvent: modifiedEvent)
+        let writer = FileWriterMock()
+
+        // Given
+        let processor = DataProcessor(fileWriter: writer, eventMapper: eventMapper)
+
+        // When
+        processor.write(value: originalEvent)
+
+        // Then
+        XCTAssertEqual(writer.dataWritten as? EventMock, modifiedEvent)
+    }
+
+    func testGivenDataProcessorWithEventMapper_whenEventIsDropped_itDoesNotWriteAnything() {
+        let originalEvent = EventMock(value: "original-event")
+
+        let eventMapper = EventMapperMock(mappedEvent: nil)
+        let writer = FileWriterMock()
+
+        // Given
+        let processor = DataProcessor(fileWriter: writer, eventMapper: eventMapper)
+
+        // When
+        processor.write(value: originalEvent)
+
+        // Then
+        XCTAssertNil(writer.dataWritten)
+    }
+
+    func testGivenDataProcessorWithNoEventMapper_whenProcessingEvent_itWritesOriginalEvent() {
+        let originalEvent = EventMock(value: "original-event")
+        let writer = FileWriterMock()
+
+        // Given
+        let processor = DataProcessor(fileWriter: writer, eventMapper: nil)
+
+        // When
+        processor.write(value: originalEvent)
+
+        // Then
+        XCTAssertEqual(writer.dataWritten as? EventMock, originalEvent)
+    }
+}

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -45,12 +45,21 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 100.0)
             XCTAssertNil(configuration.rumUIKitViewsPredicate)
             XCTAssertFalse(configuration.rumUIKitActionsTrackingEnabled)
+            XCTAssertNil(configuration.rumViewEventMapper)
+            XCTAssertNil(configuration.rumResourceEventMapper)
+            XCTAssertNil(configuration.rumActionEventMapper)
+            XCTAssertNil(configuration.rumErrorEventMapper)
             XCTAssertEqual(configuration.batchSize, .medium)
             XCTAssertEqual(configuration.uploadFrequency, .average)
         }
     }
 
     func testCustomizedBuilder() {
+        let mockRUMViewEvent: RUMViewEvent = .mockRandom()
+        let mockRUMErrorEvent: RUMErrorEvent = .mockRandom()
+        let mockRUMResourceEvent: RUMResourceEvent = .mockRandom()
+        let mockRUMActionEvent: RUMActionEvent = .mockRandom()
+
         func customized(_ builder: Datadog.Configuration.Builder) -> Datadog.Configuration.Builder {
             _ = builder
                 .set(serviceName: "service-name")
@@ -65,6 +74,10 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .track(firstPartyHosts: ["example.com"])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock())
                 .trackUIKitActions(false)
+                .setRUMViewEventMapper { _ in mockRUMViewEvent }
+                .setRUMErrorEventMapper { _ in mockRUMErrorEvent }
+                .setRUMResourceEventMapper { _ in mockRUMResourceEvent }
+                .setRUMActionEventMapper { _ in mockRUMActionEvent }
                 .set(batchSize: .small)
                 .set(uploadFrequency: .frequent)
 
@@ -102,6 +115,10 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 42.5)
             XCTAssertTrue(configuration.rumUIKitViewsPredicate is UIKitRUMViewsPredicateMock)
             XCTAssertFalse(configuration.rumUIKitActionsTrackingEnabled)
+            XCTAssertEqual(configuration.rumViewEventMapper?(.mockRandom()), mockRUMViewEvent)
+            XCTAssertEqual(configuration.rumResourceEventMapper?(.mockRandom()), mockRUMResourceEvent)
+            XCTAssertEqual(configuration.rumActionEventMapper?(.mockRandom()), mockRUMActionEvent)
+            XCTAssertEqual(configuration.rumErrorEventMapper?(.mockRandom()), mockRUMErrorEvent)
             XCTAssertEqual(configuration.batchSize, .small)
             XCTAssertEqual(configuration.uploadFrequency, .frequent)
         }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -401,6 +401,14 @@ extension FeaturesCommonDependencies {
     }
 }
 
+struct EventMapperMock: EventMapper {
+    let mappedEvent: Any?
+
+    func map<T>(event: T) -> T? {
+        return mappedEvent as? T
+    }
+}
+
 class FileWriterMock: Writer {
     var dataWritten: Encodable?
 

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -187,6 +187,7 @@ extension FeaturesConfiguration.RUM {
         uploadURLWithClientToken: URL = .mockAny(),
         applicationID: String = .mockAny(),
         sessionSamplingRate: Float = 100.0,
+        eventMapper: RUMEventsMapper = .mockNoOp(),
         autoInstrumentation: FeaturesConfiguration.RUM.AutoInstrumentation? = nil
     ) -> Self {
         return .init(
@@ -194,6 +195,7 @@ extension FeaturesConfiguration.RUM {
             uploadURLWithClientToken: uploadURLWithClientToken,
             applicationID: applicationID,
             sessionSamplingRate: sessionSamplingRate,
+            eventMapper: eventMapper,
             autoInstrumentation: autoInstrumentation
         )
     }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -37,6 +37,7 @@ extension LoggingFeature {
         // Get the full feature mock:
         let fullFeature: LoggingFeature = .mockWith(
             directories: directories,
+            configuration: configuration,
             dependencies: dependencies.replacing(
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
             )

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -1,0 +1,199 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+@testable import Datadog
+
+extension RUMUser: EquatableInTests {}
+extension RUMConnectivity: EquatableInTests {}
+extension RUMViewEvent: EquatableInTests {}
+extension RUMResourceEvent: EquatableInTests {}
+extension RUMActionEvent: EquatableInTests {}
+extension RUMErrorEvent: EquatableInTests {}
+
+extension RUMUser {
+    static func mockRandom() -> RUMUser {
+        return RUMUser(
+            email: .mockRandom(),
+            id: .mockRandom(),
+            name: .mockRandom()
+        )
+    }
+}
+
+extension RUMConnectivity {
+    static func mockRandom() -> RUMConnectivity {
+        return RUMConnectivity(
+            cellular: .init(
+                carrierName: .mockRandom(),
+                technology: .mockRandom()
+            ),
+            interfaces: [.bluetooth, .cellular].randomElements(),
+            status: [.connected, .maybe, .notConnected].randomElement()!
+        )
+    }
+}
+
+extension RUMMethod {
+    static func mockRandom() -> RUMMethod {
+        return [.post, .get, .head, .put, .delete, .patch].randomElement()!
+    }
+}
+
+extension RUMViewEvent {
+    static func mockRandom() -> RUMViewEvent {
+        return RUMViewEvent(
+            dd: .init(documentVersion: .mockRandom()),
+            application: .init(id: .mockRandom()),
+            connectivity: .mockRandom(),
+            date: .mockRandom(),
+            service: .mockRandom(),
+            session: .init(
+                id: .mockRandom(),
+                type: .user
+            ),
+            usr: .mockRandom(),
+            view: .init(
+                action: .init(count: .mockRandom()),
+                crash: .init(count: .mockRandom()),
+                cumulativeLayoutShift: .mockRandom(),
+                domComplete: .mockRandom(),
+                domContentLoaded: .mockRandom(),
+                domInteractive: .mockRandom(),
+                error: .init(count: .mockRandom()),
+                firstContentfulPaint: .mockRandom(),
+                firstInputDelay: .mockRandom(),
+                id: .mockRandom(),
+                isActive: .random(),
+                largestContentfulPaint: .mockRandom(),
+                loadEvent: .mockRandom(),
+                loadingTime: .mockRandom(),
+                loadingType: nil,
+                longTask: .init(count: .mockRandom()),
+                referrer: .mockRandom(),
+                resource: .init(count: .mockRandom()),
+                timeSpent: .mockRandom(),
+                url: .mockRandom()
+            )
+        )
+    }
+}
+
+extension RUMResourceEvent {
+    static func mockRandom() -> RUMResourceEvent {
+        return RUMResourceEvent(
+            dd: .init(
+                spanId: .mockRandom(),
+                traceId: .mockRandom()
+            ),
+            action: .init(id: .mockRandom()),
+            application: .init(id: .mockRandom()),
+            connectivity: .mockRandom(),
+            date: .mockRandom(),
+            resource: .init(
+                connect: .init(duration: .mockRandom(), start: .mockRandom()),
+                dns: .init(duration: .mockRandom(), start: .mockRandom()),
+                download: .init(duration: .mockRandom(), start: .mockRandom()),
+                duration: .mockRandom(),
+                firstByte: .init(duration: .mockRandom(), start: .mockRandom()),
+                id: .mockRandom(),
+                method: .mockRandom(),
+                provider: .init(
+                    domain: .mockRandom(),
+                    name: .mockRandom(),
+                    type: Bool.random() ? .firstParty : nil
+                ),
+                redirect: .init(duration: .mockRandom(), start: .mockRandom()),
+                size: .mockRandom(),
+                ssl: .init(duration: .mockRandom(), start: .mockRandom()),
+                statusCode: .mockRandom(),
+                type: [.xhr, .fetch, .image].randomElement()!,
+                url: .mockRandom()
+            ),
+            service: .mockRandom(),
+            session: .init(
+                id: .mockRandom(),
+                type: .user
+            ),
+            usr: .mockRandom(),
+            view: .init(
+                id: .mockRandom(),
+                referrer: .mockRandom(),
+                url: .mockRandom()
+            )
+        )
+    }
+}
+
+extension RUMActionEvent {
+    static func mockRandom() -> RUMActionEvent {
+        return RUMActionEvent(
+            dd: .init(),
+            action: .init(
+                crash: .init(count: .mockRandom()),
+                error: .init(count: .mockRandom()),
+                id: .mockRandom(),
+                loadingTime: .mockRandom(),
+                longTask: .init(count: .mockRandom()),
+                resource: .init(count: .mockRandom()),
+                target: .init(name: .mockRandom()),
+                type: [.tap, .swipe, .scroll].randomElement()!
+            ),
+            application: .init(id: .mockRandom()),
+            connectivity: .mockRandom(),
+            date: .mockRandom(),
+            service: .mockRandom(),
+            session: .init(
+                id: .mockRandom(),
+                type: .user
+            ),
+            usr: .mockRandom(),
+            view: .init(
+                id: .mockRandom(),
+                referrer: .mockRandom(),
+                url: .mockRandom()
+            )
+        )
+    }
+}
+
+extension RUMErrorEvent {
+    static func mockRandom() -> RUMErrorEvent {
+        return RUMErrorEvent(
+            dd: .init(),
+            action: .init(id: .mockRandom()),
+            application: .init(id: .mockRandom()),
+            connectivity: .mockRandom(),
+            date: .mockRandom(),
+            error: .init(
+                isCrash: .random(),
+                message: .mockRandom(),
+                resource: .init(
+                    method: .mockRandom(),
+                    provider: .init(
+                        domain: .mockRandom(),
+                        name: .mockRandom(),
+                        type: Bool.random() ? .firstParty : nil
+                    ),
+                    statusCode: .mockRandom(),
+                    url: .mockRandom()
+                ),
+                source: [.source, .network, .custom].randomElement()!,
+                stack: .mockRandom()
+            ),
+            service: .mockRandom(),
+            session: .init(
+                id: .mockRandom(),
+                type: .user
+            ),
+            usr: .mockRandom(),
+            view: .init(
+                id: .mockRandom(),
+                referrer: .mockRandom(),
+                url: .mockRandom()
+            )
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -38,6 +38,7 @@ extension RUMFeature {
         // Get the full feature mock:
         let fullFeature: RUMFeature = .mockWith(
             directories: directories,
+            configuration: configuration,
             dependencies: dependencies.replacing(
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
             )

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -83,6 +83,43 @@ struct RUMDataModelMock: RUMDataModel, Equatable {
 
 // MARK: - Component Mocks
 
+extension RUMEvent {
+    static func mockWith<DM: RUMDataModel>(
+        model: DM,
+        attributes: [String: Encodable] = [:],
+        userInfoAttributes: [String: Encodable] = [:],
+        customViewTimings: [String: Int64]? = nil
+    ) -> RUMEvent<DM> {
+        return RUMEvent<DM>(
+            model: model,
+            attributes: attributes,
+            userInfoAttributes: userInfoAttributes,
+            customViewTimings: customViewTimings
+        )
+    }
+
+    static func mockRandomWith<DM: RUMDataModel>(model: DM) -> RUMEvent<DM> {
+        func randomAttributes(prefixed prefix: String) -> [String: Encodable] {
+            var attributes: [String: String] = [:]
+            (0..<10).forEach { index in attributes["\(prefix)\(index)"] = "value\(index)" }
+            return attributes
+        }
+
+        func randomTimings() -> [String: Int64] {
+            var timings: [String: Int64] = [:]
+            (0..<10).forEach { index in timings["timing\(index)"] = .mockRandom() }
+            return timings
+        }
+
+        return RUMEvent<DM>(
+            model: model,
+            attributes: randomAttributes(prefixed: "event-attribute"),
+            userInfoAttributes: randomAttributes(prefixed: "user-attribute"),
+            customViewTimings: randomTimings()
+        )
+    }
+}
+
 extension RUMEventBuilder {
     static func mockAny() -> RUMEventBuilder {
         return RUMEventBuilder(userInfoProvider: UserInfoProvider.mockAny())

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -141,6 +141,17 @@ class RUMEventOutputMock: RUMEventOutput {
     }
 }
 
+extension RUMEventsMapper {
+    static func mockNoOp() -> RUMEventsMapper {
+        return RUMEventsMapper(
+            viewEventMapper: nil,
+            errorEventMapper: nil,
+            resourceEventMapper: nil,
+            actionEventMapper: nil
+        )
+    }
+}
+
 // MARK: - RUMCommand Mocks
 
 struct RUMCommandMock: RUMCommand {

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -65,6 +65,12 @@ extension Array where Element == Data {
     }
 }
 
+extension Array {
+    func randomElements() -> [Element] {
+        return compactMap { Bool.random() ? $0 : nil }
+    }
+}
+
 extension Date {
     static func mockAny() -> Date {
         return Date(timeIntervalSinceReferenceDate: 1)
@@ -154,9 +160,8 @@ extension Int {
 }
 
 extension Int64 {
-    static func mockAny() -> Int64 {
-        return 0
-    }
+    static func mockAny() -> Int64 { 0 }
+    static func mockRandom() -> Int64 { Int64.random(in: Int64.min..<Int64.max) }
 }
 
 extension UInt64 {
@@ -174,6 +179,12 @@ extension Bool {
 extension Float {
     static func mockAny() -> Float {
         return 0
+    }
+}
+
+extension Double {
+    static func mockRandom() -> Double {
+        return Double.random(in: 0..<Double.greatestFiniteMagnitude)
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -49,10 +49,12 @@ extension TracingFeature {
         // Get the full feature mock:
         let fullFeature: TracingFeature = .mockWith(
             directories: directories,
+            configuration: configuration,
             dependencies: dependencies.replacing(
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
             ),
-            loggingFeature: loggingFeature, tracingUUIDGenerator: tracingUUIDGenerator
+            loggingFeature: loggingFeature,
+            tracingUUIDGenerator: tracingUUIDGenerator
         )
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMConnectivityInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMConnectivityInfoProviderTests.swift
@@ -7,8 +7,6 @@
 import XCTest
 @testable import Datadog
 
-extension RUMConnectivity: EquatableInTests {}
-
 class RUMConnectivityInfoProviderTests: XCTestCase {
     private let networkInfoProvider = NetworkConnectionInfoProviderMock(networkConnectionInfo: .mockAny())
     private let carrierInfoProvider = CarrierInfoProviderMock(carrierInfo: .mockAny())

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
@@ -7,8 +7,6 @@
 import XCTest
 @testable import Datadog
 
-extension RUMUser: EquatableInTests {}
-
 class RUMUserInfoProviderTests: XCTestCase {
     private let userInfoProvider = UserInfoProvider()
     private lazy var rumUserInfoProvider = RUMUserInfoProvider(userInfoProvider: userInfoProvider)

--- a/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
@@ -54,6 +54,43 @@ class RUMEventsMapperTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(mappedActionEvent), modifiedActionEvent, "Mapper should return modified event.")
     }
 
+    func testGivenMappersEnabled_whenModifyingEvents_itDoesNotModifyCustomAttributes() throws {
+        // Given
+        let mapper = RUMEventsMapper(
+            viewEventMapper: { _ in .mockRandom() },
+            errorEventMapper: { _ in .mockRandom() },
+            resourceEventMapper: { _ in .mockRandom() },
+            actionEventMapper: { _ in .mockRandom() }
+        )
+
+        // When
+        let rumEvent1: RUMEvent<RUMViewEvent> = .mockRandomWith(model: .mockRandom())
+        let rumEvent2: RUMEvent<RUMErrorEvent> = .mockRandomWith(model: .mockRandom())
+        let rumEvent3: RUMEvent<RUMResourceEvent> = .mockRandomWith(model: .mockRandom())
+        let rumEvent4: RUMEvent<RUMActionEvent> = .mockRandomWith(model: .mockRandom())
+        let mappedRUMEvent1 = try XCTUnwrap(mapper.map(event: rumEvent1))
+        let mappedRUMEvent2 = try XCTUnwrap(mapper.map(event: rumEvent2))
+        let mappedRUMEvent3 = try XCTUnwrap(mapper.map(event: rumEvent3))
+        let mappedRUMEvent4 = try XCTUnwrap(mapper.map(event: rumEvent4))
+
+        // Then
+        XCTAssertEqual(rumEvent1.attributes as! [String: String], mappedRUMEvent1.attributes as! [String: String])
+        XCTAssertEqual(rumEvent1.userInfoAttributes as! [String: String], mappedRUMEvent1.userInfoAttributes as! [String: String])
+        XCTAssertEqual(rumEvent1.customViewTimings, mappedRUMEvent1.customViewTimings)
+
+        XCTAssertEqual(rumEvent2.attributes as! [String: String], mappedRUMEvent2.attributes as! [String: String])
+        XCTAssertEqual(rumEvent2.userInfoAttributes as! [String: String], mappedRUMEvent2.userInfoAttributes as! [String: String])
+        XCTAssertEqual(rumEvent2.customViewTimings, mappedRUMEvent2.customViewTimings)
+
+        XCTAssertEqual(rumEvent3.attributes as! [String: String], mappedRUMEvent3.attributes as! [String: String])
+        XCTAssertEqual(rumEvent3.userInfoAttributes as! [String: String], mappedRUMEvent3.userInfoAttributes as! [String: String])
+        XCTAssertEqual(rumEvent3.customViewTimings, mappedRUMEvent3.customViewTimings)
+
+        XCTAssertEqual(rumEvent4.attributes as! [String: String], mappedRUMEvent4.attributes as! [String: String])
+        XCTAssertEqual(rumEvent4.userInfoAttributes as! [String: String], mappedRUMEvent4.userInfoAttributes as! [String: String])
+        XCTAssertEqual(rumEvent4.customViewTimings, mappedRUMEvent4.customViewTimings)
+    }
+
     func testGivenMappersEnabled_whenDroppingEvents_itReturnsNil() {
         let originalViewEvent: RUMViewEvent = .mockRandom()
         let originalErrorEvent: RUMErrorEvent = .mockRandom()

--- a/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
@@ -1,0 +1,144 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMEventsMapperTests: XCTestCase {
+    func testGivenMappersEnabled_whenModifyingEvents_itReturnsTheirNewRepresentation() throws {
+        let originalViewEvent: RUMViewEvent = .mockRandom()
+        let modifiedViewEvent: RUMViewEvent = .mockRandom()
+
+        let originalErrorEvent: RUMErrorEvent = .mockRandom()
+        let modifiedErrorEvent: RUMErrorEvent = .mockRandom()
+
+        let originalResourceEvent: RUMResourceEvent = .mockRandom()
+        let modifiedResourceEvent: RUMResourceEvent = .mockRandom()
+
+        let originalActionEvent: RUMActionEvent = .mockRandom()
+        let modifiedActionEvent: RUMActionEvent = .mockRandom()
+
+        // Given
+        let mapper = RUMEventsMapper(
+            viewEventMapper: { viewEvent in
+                XCTAssertEqual(viewEvent, originalViewEvent, "Mapper should be called with the original event.")
+                return modifiedViewEvent
+            },
+            errorEventMapper: { errorEvent in
+                XCTAssertEqual(errorEvent, originalErrorEvent, "Mapper should be called with the original event.")
+                return modifiedErrorEvent
+            },
+            resourceEventMapper: { resourceEvent in
+                XCTAssertEqual(resourceEvent, originalResourceEvent, "Mapper should be called with the original event.")
+                return modifiedResourceEvent
+            },
+            actionEventMapper: { actionEvent in
+                XCTAssertEqual(actionEvent, originalActionEvent, "Mapper should be called with the original event.")
+                return modifiedActionEvent
+            }
+        )
+
+        // When
+        let mappedViewEvent = mapper.map(event: RUMEvent<RUMViewEvent>.mockWith(model: originalViewEvent))?.model
+        let mappedErrorEvent = mapper.map(event: RUMEvent<RUMErrorEvent>.mockWith(model: originalErrorEvent))?.model
+        let mappedResourceEvent = mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: originalResourceEvent))?.model
+        let mappedActionEvent = mapper.map(event: RUMEvent<RUMActionEvent>.mockWith(model: originalActionEvent))?.model
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(mappedViewEvent), modifiedViewEvent, "Mapper should return modified event.")
+        XCTAssertEqual(try XCTUnwrap(mappedErrorEvent), modifiedErrorEvent, "Mapper should return modified event.")
+        XCTAssertEqual(try XCTUnwrap(mappedResourceEvent), modifiedResourceEvent, "Mapper should return modified event.")
+        XCTAssertEqual(try XCTUnwrap(mappedActionEvent), modifiedActionEvent, "Mapper should return modified event.")
+    }
+
+    func testGivenMappersEnabled_whenDroppingEvents_itReturnsNil() {
+        let originalViewEvent: RUMViewEvent = .mockRandom()
+        let originalErrorEvent: RUMErrorEvent = .mockRandom()
+        let originalResourceEvent: RUMResourceEvent = .mockRandom()
+        let originalActionEvent: RUMActionEvent = .mockRandom()
+
+        // Given
+        let mapper = RUMEventsMapper(
+            viewEventMapper: { viewEvent in
+                XCTAssertEqual(viewEvent, originalViewEvent, "Mapper should be called with the original event.")
+                return nil
+            },
+            errorEventMapper: { errorEvent in
+                XCTAssertEqual(errorEvent, originalErrorEvent, "Mapper should be called with the original event.")
+                return nil
+            },
+            resourceEventMapper: { resourceEvent in
+                XCTAssertEqual(resourceEvent, originalResourceEvent, "Mapper should be called with the original event.")
+                return nil
+            },
+            actionEventMapper: { actionEvent in
+                XCTAssertEqual(actionEvent, originalActionEvent, "Mapper should be called with the original event.")
+                return nil
+            }
+        )
+
+        // When
+        let mappedViewEvent = mapper.map(event: RUMEvent<RUMViewEvent>.mockWith(model: originalViewEvent))?.model
+        let mappedErrorEvent = mapper.map(event: RUMEvent<RUMErrorEvent>.mockWith(model: originalErrorEvent))?.model
+        let mappedResourceEvent = mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: originalResourceEvent))?.model
+        let mappedActionEvent = mapper.map(event: RUMEvent<RUMActionEvent>.mockWith(model: originalActionEvent))?.model
+
+        // Then
+        XCTAssertNil(mappedViewEvent, "Mapper should return nil.")
+        XCTAssertNil(mappedErrorEvent, "Mapper should return nil.")
+        XCTAssertNil(mappedResourceEvent, "Mapper should return nil.")
+        XCTAssertNil(mappedActionEvent, "Mapper should return nil.")
+    }
+
+    func testGivenMappersDisabled_whenMappingEvents_itReturnsTheirOriginalRepresentation() throws {
+        let originalViewEvent: RUMViewEvent = .mockRandom()
+        let originalErrorEvent: RUMErrorEvent = .mockRandom()
+        let originalResourceEvent: RUMResourceEvent = .mockRandom()
+        let originalActionEvent: RUMActionEvent = .mockRandom()
+
+        // Given
+        let mapper = RUMEventsMapper(
+            viewEventMapper: nil,
+            errorEventMapper: nil,
+            resourceEventMapper: nil,
+            actionEventMapper: nil
+        )
+
+        // When
+        let mappedViewEvent = mapper.map(event: RUMEvent<RUMViewEvent>.mockWith(model: originalViewEvent))?.model
+        let mappedErrorEvent = mapper.map(event: RUMEvent<RUMErrorEvent>.mockWith(model: originalErrorEvent))?.model
+        let mappedResourceEvent = mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: originalResourceEvent))?.model
+        let mappedActionEvent = mapper.map(event: RUMEvent<RUMActionEvent>.mockWith(model: originalActionEvent))?.model
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(mappedViewEvent), originalViewEvent, "Mapper should return the original event.")
+        XCTAssertEqual(try XCTUnwrap(mappedErrorEvent), originalErrorEvent, "Mapper should return the original event.")
+        XCTAssertEqual(try XCTUnwrap(mappedResourceEvent), originalResourceEvent, "Mapper should return the original event.")
+        XCTAssertEqual(try XCTUnwrap(mappedActionEvent), originalActionEvent, "Mapper should return the original event.")
+    }
+
+    func testGivenUnrecognizedEvent_whenMapping_itReturnsItsOriginalImplementation() throws {
+        // Given
+        struct UnrecognizedEvent: Encodable {
+            let value: String
+        }
+
+        let originalEvent = UnrecognizedEvent(value: .mockRandom())
+
+        // When
+        let mapper = RUMEventsMapper(
+            viewEventMapper: { _ in nil },
+            errorEventMapper: { _ in nil },
+            resourceEventMapper: { _ in nil },
+            actionEventMapper: { _ in nil }
+        )
+
+        let mappedEvent = try XCTUnwrap(mapper.map(event: originalEvent))
+
+        // Then
+        XCTAssertEqual(mappedEvent.value, originalEvent.value)
+    }
+}


### PR DESCRIPTION
### What and why?

🚚 This PR adds RUM events scrubbing feature with set of 4 new public APIs:
```swift
public func setRUMViewEventMapper(_ mapper: @escaping (RUMViewEvent) -> RUMViewEvent?)
public func setRUMResourceEventMapper(_ mapper: @escaping (RUMResourceEvent) -> RUMResourceEvent?)
public func setRUMActionEventMapper(_ mapper: @escaping (RUMActionEvent) -> RUMActionEvent?)
public func setRUMErrorEventMapper(_ mapper: @escaping (RUMErrorEvent) -> RUMErrorEvent?)
```

Each API allows the user to inspect and modify RUM events before they get send. Returning `nil` drops the event.

### How?

A basic interface of `EventMapper` is introduced:
```swift
internal protocol EventMapper {
    func map<T: Encodable>(event: T) -> T?
}
```
and plugged into `DataProcessor's` pipeline, just before writing the event to the file.

It is implemented by `RUMEventsMapper` which intercepts each value using closures configured by the user in the public interface.

In the next PR I will also add test scenario to `Example` application with the integration test for scrubbing API.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
