### PR TITLE
RUMM-788 Add data scrubbing integration test

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -106,6 +106,8 @@
 		61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */; };
 		6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */; };
 		612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612983CC2449E62E00D4424B /* LoggingFeature.swift */; };
+		612D8F6925AEE68F000E2E09 /* RUMScrubbingScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 612D8F6825AEE68F000E2E09 /* RUMScrubbingScenario.storyboard */; };
+		612D8F6F25AEE6A7000E2E09 /* RUMScrubbingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612D8F6E25AEE6A7000E2E09 /* RUMScrubbingViewController.swift */; };
 		6132BF4224A38D2400D7BD17 /* OTTracer+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6132BF4124A38D2400D7BD17 /* OTTracer+objc.swift */; };
 		6132BF4724A498D800D7BD17 /* DDSpan+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6132BF4624A498D800D7BD17 /* DDSpan+objc.swift */; };
 		6132BF4924A49B6800D7BD17 /* DDSpanContext+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6132BF4824A49B6800D7BD17 /* DDSpanContext+objc.swift */; };
@@ -559,6 +561,8 @@
 		61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapter.swift; sourceTree = "<group>"; };
 		61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapterTests.swift; sourceTree = "<group>"; };
 		612983CC2449E62E00D4424B /* LoggingFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeature.swift; sourceTree = "<group>"; };
+		612D8F6825AEE68F000E2E09 /* RUMScrubbingScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMScrubbingScenario.storyboard; sourceTree = "<group>"; };
+		612D8F6E25AEE6A7000E2E09 /* RUMScrubbingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMScrubbingViewController.swift; sourceTree = "<group>"; };
 		6132BF4124A38D2400D7BD17 /* OTTracer+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTTracer+objc.swift"; sourceTree = "<group>"; };
 		6132BF4624A498D800D7BD17 /* DDSpan+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDSpan+objc.swift"; sourceTree = "<group>"; };
 		6132BF4824A49B6800D7BD17 /* DDSpanContext+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDSpanContext+objc.swift"; sourceTree = "<group>"; };
@@ -1431,6 +1435,15 @@
 			path = FeaturesIntegration;
 			sourceTree = "<group>";
 		};
+		612D8F6725AEE65F000E2E09 /* Scrubbing */ = {
+			isa = PBXGroup;
+			children = (
+				612D8F6825AEE68F000E2E09 /* RUMScrubbingScenario.storyboard */,
+				612D8F6E25AEE6A7000E2E09 /* RUMScrubbingViewController.swift */,
+			);
+			path = Scrubbing;
+			sourceTree = "<group>";
+		};
 		6132BF4024A38D0600D7BD17 /* OpenTracing */ = {
 			isa = PBXGroup;
 			children = (
@@ -1508,6 +1521,7 @@
 				615AAC34251E34EF00C89EE9 /* TabBarAutoInstrumentation */,
 				6137E647252DD85400720485 /* ModalViewsAutoInstrumentation */,
 				6193DCA2251B5669009B8011 /* TapActionAutoInstrumentation */,
+				612D8F6725AEE65F000E2E09 /* Scrubbing */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -2685,6 +2699,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61337032250F82AE00236D58 /* LoggingManualInstrumentationScenario.storyboard in Resources */,
+				612D8F6925AEE68F000E2E09 /* RUMScrubbingScenario.storyboard in Resources */,
 				611EA13C2580F77400BC0E56 /* TrackingConsentScenario.storyboard in Resources */,
 				61441C1124616DEC003D8BB8 /* LaunchScreen.storyboard in Resources */,
 				61337039250F852E00236D58 /* RUMManualInstrumentationScenario.storyboard in Resources */,
@@ -3070,6 +3085,7 @@
 				61F9CA8025125C01000A5E61 /* RUMNCSScreen3ViewController.swift in Sources */,
 				6164AE89252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift in Sources */,
 				611EA14225810E1900BC0E56 /* TSHomeViewController.swift in Sources */,
+				612D8F6F25AEE6A7000E2E09 /* RUMScrubbingViewController.swift in Sources */,
 				61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */,
 				61441C952461A649003D8BB8 /* ConsoleOutputInterceptor.swift in Sources */,
 				61D50C5A2580EFF3006038A3 /* URLSessionScenarios.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612983CC2449E62E00D4424B /* LoggingFeature.swift */; };
 		612D8F6925AEE68F000E2E09 /* RUMScrubbingScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 612D8F6825AEE68F000E2E09 /* RUMScrubbingScenario.storyboard */; };
 		612D8F6F25AEE6A7000E2E09 /* RUMScrubbingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612D8F6E25AEE6A7000E2E09 /* RUMScrubbingViewController.swift */; };
+		612D8F8125AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612D8F8025AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift */; };
 		6132BF4224A38D2400D7BD17 /* OTTracer+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6132BF4124A38D2400D7BD17 /* OTTracer+objc.swift */; };
 		6132BF4724A498D800D7BD17 /* DDSpan+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6132BF4624A498D800D7BD17 /* DDSpan+objc.swift */; };
 		6132BF4924A49B6800D7BD17 /* DDSpanContext+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6132BF4824A49B6800D7BD17 /* DDSpanContext+objc.swift */; };
@@ -563,6 +564,7 @@
 		612983CC2449E62E00D4424B /* LoggingFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeature.swift; sourceTree = "<group>"; };
 		612D8F6825AEE68F000E2E09 /* RUMScrubbingScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMScrubbingScenario.storyboard; sourceTree = "<group>"; };
 		612D8F6E25AEE6A7000E2E09 /* RUMScrubbingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMScrubbingViewController.swift; sourceTree = "<group>"; };
+		612D8F8025AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMScrubbingScenarioTests.swift; sourceTree = "<group>"; };
 		6132BF4124A38D2400D7BD17 /* OTTracer+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTTracer+objc.swift"; sourceTree = "<group>"; };
 		6132BF4624A498D800D7BD17 /* DDSpan+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDSpan+objc.swift"; sourceTree = "<group>"; };
 		6132BF4824A49B6800D7BD17 /* DDSpanContext+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDSpanContext+objc.swift"; sourceTree = "<group>"; };
@@ -2351,6 +2353,7 @@
 				615AAC06251E217B00C89EE9 /* RUMTapActionScenarioTests.swift */,
 				61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */,
 				6164AF2D252C9C51000D78C4 /* RUMResourcesScenarioTests.swift */,
+				612D8F8025AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -3132,6 +3135,7 @@
 				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,
 				61441C4124617013003D8BB8 /* LoggingScenarioTests.swift in Sources */,
+				612D8F8125AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift in Sources */,
 				613B77382521E80800155458 /* RUMTabBarControllerScenarioTests.swift in Sources */,
 				61441C4B24618052003D8BB8 /* SpanMatcher.swift in Sources */,
 				6167ACFD251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -111,6 +111,11 @@
             value = "TrackingConsentStartGrantedScenario"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_TEST_SCENARIO_IDENTIFIER"
+            value = "RUMScrubbingScenario"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/Datadog/Example/Scenarios/RUM/Scrubbing/RUMScrubbingScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/Scrubbing/RUMScrubbingScenario.storyboard
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="usR-Xp-6Hm">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Scrubbing View Controller-->
+        <scene sceneID="dBk-wE-grE">
+            <objects>
+                <viewController id="usR-Xp-6Hm" customClass="RUMScrubbingViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="RNQ-cy-Y97">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending and scrubbing  RUM Events... " textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OM6-3c-Pub">
+                                <rect key="frame" x="117" y="445.5" width="180.5" height="41"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="ENc-rI-vn9"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="OM6-3c-Pub" firstAttribute="centerX" secondItem="RNQ-cy-Y97" secondAttribute="centerX" id="0UZ-gh-E2H"/>
+                            <constraint firstItem="OM6-3c-Pub" firstAttribute="centerY" secondItem="RNQ-cy-Y97" secondAttribute="centerY" constant="18" id="xWZ-yW-twP"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="wMY-68-Wjz"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="b6C-xF-arU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1386.9565217391305" y="1232.8125"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Datadog/Example/Scenarios/RUM/Scrubbing/RUMScrubbingViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/Scrubbing/RUMScrubbingViewController.swift
@@ -5,6 +5,77 @@
  */
 
 import UIKit
+import Datadog
 
 internal class RUMScrubbingViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        simulateRUMView()
+    }
+
+    private func simulateRUMView() {
+        Global.rum.startView(viewController: self, path: "ViewName (sensitive detail)")
+
+        simulateRUMUserAction()
+        simulateRUMError()
+        simulateRUMResources {
+            Global.rum.stopView(viewController: self)
+        }
+    }
+
+    private func simulateRUMUserAction() {
+        Global.rum.addUserAction(type: .tap, name: "Purchase (sensitive detail)")
+    }
+
+    private func simulateRUMError() {
+        Global.rum.addError(message: "Error message (sensitive detail).", source: .source)
+    }
+
+    private func simulateRUMResources(completion: @escaping () -> Void) {
+        let simulatedResourceKey1 = "/resource/1"
+        let simulatedResourceRequest1 = URLRequest(url: URL(string: "https://foo.com/resource/1?q=sensitive-detail")!)
+        let simulatedResourceKey2 = "/resource/2"
+        let simulatedResourceRequest2 = URLRequest(url: URL(string: "https://foo.com/resource/2?q=sensitive-detail")!)
+        let simulatedResourceLoadingTime: TimeInterval = 0.1
+
+        Global.rum.startResourceLoading(
+            resourceKey: simulatedResourceKey1,
+            request: simulatedResourceRequest1
+        )
+
+        Global.rum.startResourceLoading(
+            resourceKey: simulatedResourceKey2,
+            request: simulatedResourceRequest2
+        )
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + simulatedResourceLoadingTime) {
+            Global.rum.stopResourceLoading(
+                resourceKey: simulatedResourceKey1,
+                response: HTTPURLResponse(
+                    url: simulatedResourceRequest1.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "image/png"]
+                )!
+            )
+
+            Global.rum.stopResourceLoadingWithError(
+                resourceKey: simulatedResourceKey2,
+                error: NSError(
+                    domain: NSURLErrorDomain,
+                    code: NSURLErrorBadServerResponse,
+                    userInfo: [NSLocalizedDescriptionKey: "Bad response (sensitive detail)."]
+                ),
+                response: HTTPURLResponse(
+                    url: simulatedResourceRequest2.url!,
+                    statusCode: 400,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+            )
+
+            completion()
+        }
+    }
 }

--- a/Datadog/Example/Scenarios/RUM/Scrubbing/RUMScrubbingViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/Scrubbing/RUMScrubbingViewController.swift
@@ -1,0 +1,10 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal class RUMScrubbingViewController: UIViewController {
+}

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
@@ -1,0 +1,64 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import HTTPServerMock
+import XCTest
+
+class RUMScrubbingScenarioTests: IntegrationTests, RUMCommonAsserts {
+    func testRUMScrubbingScenario() throws {
+        let rumServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenario: RUMScrubbingScenario.self,
+            serverConfiguration: HTTPServerMockConfiguration(
+                rumEndpoint: rumServerSession.recordingURL
+            )
+        )
+
+        // Get RUM Session with expected number of RUM Errors
+        let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            try RUMSessionMatcher.from(requests: requests)?.viewVisits.last?.errorEvents.count == 2
+        }
+
+        assertRUM(requests: recordedRUMRequests)
+
+        let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
+
+        XCTAssertEqual(session.viewVisits.count, 1)
+        let viewVisit = session.viewVisits[0]
+
+        XCTAssertGreaterThan(viewVisit.viewEvents.count, 0)
+        viewVisit.viewEvents.forEach { event in
+            XCTAssertTrue(event.view.url.isRedacted)
+        }
+
+        XCTAssertGreaterThan(viewVisit.errorEvents.count, 0)
+        viewVisit.errorEvents.forEach { event in
+            XCTAssertTrue(event.error.message.isRedacted)
+            XCTAssertTrue(event.view.url.isRedacted)
+            XCTAssertTrue(event.error.resource?.url.isRedacted ?? true)
+            XCTAssertTrue(event.error.stack?.isRedacted ?? true)
+        }
+
+        XCTAssertGreaterThan(viewVisit.resourceEvents.count, 0)
+        viewVisit.resourceEvents.forEach { event in
+            XCTAssertTrue(event.resource.url.isRedacted)
+        }
+
+        XCTAssertGreaterThan(viewVisit.actionEvents.count, 0)
+        viewVisit.actionEvents.forEach { event in
+            XCTAssertTrue(event.action.target?.name.isRedacted ?? true)
+        }
+    }
+}
+
+private extension String {
+    var isRedacted: Bool {
+        let sensitivePart = "sensitive"
+        return !contains(sensitivePart)
+    }
+}


### PR DESCRIPTION
### What and why?

🧪 This PR adds `RUMScrubbingScenario` integration test for data scrubbing.

### How?

The `RUMScrubbingScenario` consists of a single view controller:

<img width="261" alt="Screenshot 2021-01-13 at 13 49 02" src="https://user-images.githubusercontent.com/2358722/104454418-1d556580-55a6-11eb-8702-9ffc3348743a.png">

sending bunch of RUM events. Each event contains "sensitive" information in form of `"sensitive"` text, e.g.:

```swift
Global.rum.addError(message: "Error message (sensitive detail).", source: .source)
```

This information is later redacted using data scrubbing API, e.g:
```swift
configurationBuilder
   .setRUMErrorEventMapper { errorEvent in
      var errorEvent = errorEvent
      errorEvent.error.message = redacted(errorEvent.error.message)
      // ...
      return errorEvent
   }

func redacted(_ string: String) -> String {
    return string.replacingOccurrences(of: "sensitive", with: "REDACTED")
}
```

The integration test retrieves events from Python server and asserts that `"sensitive"` text does not appear in any event.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
