### PR TITLE
RUMM-952 Missing RUM API added

### DIFF
--- a/Sources/Datadog/DDRUMMonitor.swift
+++ b/Sources/Datadog/DDRUMMonitor.swift
@@ -65,7 +65,7 @@ public class DDRUMMonitor {
     /// - Parameters:
     ///   - message: a message explaining the Error.
     ///   - source: the origin of the error.
-    ///   - stack: stack trace of the error. no specific format needed. overwrites `file` and `line` parameters below.
+    ///   - stack: stack trace of the error. No specific format needed. Overwrites `file` and `line` parameters below.
     ///   - attributes: custom attributes to attach to the Error
     ///   - file: the file in which the Error occurred (the default is the file name in which this method was called).
     ///   - line: the line number on which the Error occurred (the default is the line number on which this method was called).
@@ -111,7 +111,7 @@ public class DDRUMMonitor {
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {}
 
-    /// Notifies that the Resource starts being loaded using GET request to given `url`.
+    /// Notifies that the Resource starts being loaded from given `urlString`.
     /// - Parameters:
     ///   - resourceKey: the key representing the Resource - must be unique among all Resources being currently loaded.
     ///   - httpMethod: HTTP method used to fetch resource
@@ -119,7 +119,7 @@ public class DDRUMMonitor {
     ///   - attributes: custom attributes to attach to the Resource.
     public func startResourceLoading(
         resourceKey: String,
-        httpMethod: String,
+        httpMethod: RUMMethod,
         urlString: String,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {}

--- a/Sources/Datadog/DDRUMMonitor.swift
+++ b/Sources/Datadog/DDRUMMonitor.swift
@@ -152,13 +152,13 @@ public class DDRUMMonitor {
     /// - Parameters:
     ///   - resourceKey: the key representing the Resource - must match the one used in `startResourceLoading(...)`.
     ///   - statusCode: HTTP status code of response. e.g: `response.statusCode`
-    ///   - kind: corresponding `RUMResourceKind` of the resource.
+    ///   - kind: corresponding `RUMResourceType` of the resource.
     ///   - size: an optional size of the data received for the Resource (in bytes). If not provided, the SDK will try to infer it from the "Content-Length" header of the `response`.
     ///   - attributes: custom attributes to attach to the Resource.
     public func stopResourceLoading(
         resourceKey: String,
         statusCode: Int?,
-        kind: RUMResourceKind,
+        kind: RUMResourceType,
         size: Int64? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {}

--- a/Sources/Datadog/DDRUMMonitor.swift
+++ b/Sources/Datadog/DDRUMMonitor.swift
@@ -65,12 +65,14 @@ public class DDRUMMonitor {
     /// - Parameters:
     ///   - message: a message explaining the Error.
     ///   - source: the origin of the error.
+    ///   - stack: stack trace of the error. no specific format needed. overwrites `file` and `line` parameters below.
     ///   - attributes: custom attributes to attach to the Error
     ///   - file: the file in which the Error occurred (the default is the file name in which this method was called).
     ///   - line: the line number on which the Error occurred (the default is the line number on which this method was called).
     public func addError(
         message: String,
         source: RUMErrorSource = .custom,
+        stack: String? = nil,
         attributes: [AttributeKey: AttributeValue] = [:],
         file: StaticString? = #file,
         line: UInt? = #line
@@ -109,6 +111,19 @@ public class DDRUMMonitor {
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {}
 
+    /// Notifies that the Resource starts being loaded using GET request to given `url`.
+    /// - Parameters:
+    ///   - resourceKey: the key representing the Resource - must be unique among all Resources being currently loaded.
+    ///   - httpMethod: HTTP method used to fetch resource
+    ///   - urlString: the `URL` for the Resource in `String` form.
+    ///   - attributes: custom attributes to attach to the Resource.
+    public func startResourceLoading(
+        resourceKey: String,
+        httpMethod: String,
+        urlString: String,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {}
+
     /// Adds temporal metrics to given Resource. This method must be called before the Resource is stopped.
     /// - Parameters:
     ///   - resourceKey: the key representing the Resource - must match the one used in `startResourceLoading(...)`.
@@ -129,6 +144,21 @@ public class DDRUMMonitor {
     public func stopResourceLoading(
         resourceKey: String,
         response: URLResponse,
+        size: Int64? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {}
+
+    /// Notifies that the Resource stops being loaded succesfully.
+    /// - Parameters:
+    ///   - resourceKey: the key representing the Resource - must match the one used in `startResourceLoading(...)`.
+    ///   - statusCode: HTTP status code of response. e.g: `response.statusCode`
+    ///   - kind: corresponding `RUMResourceKind` of the resource.
+    ///   - size: an optional size of the data received for the Resource (in bytes). If not provided, the SDK will try to infer it from the "Content-Length" header of the `response`.
+    ///   - attributes: custom attributes to attach to the Resource.
+    public func stopResourceLoading(
+        resourceKey: String,
+        statusCode: Int?,
+        kind: RUMResourceKind,
         size: Int64? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {}

--- a/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -35,7 +35,7 @@ internal class URLSessionRUMResourcesHandler: URLSessionInterceptionHandler {
                 attributes: [:],
                 url: url,
                 httpMethod: RUMMethod(httpMethod: interception.request.httpMethod),
-                kind: RUMResourceKind(request: interception.request),
+                kind: RUMResourceType(request: interception.request),
                 spanContext: interception.spanContext.flatMap { spanContext in
                     .init(
                         traceID: String(spanContext.traceID.rawValue),
@@ -73,7 +73,7 @@ internal class URLSessionRUMResourcesHandler: URLSessionInterceptionHandler {
                     resourceKey: interception.identifier.uuidString,
                     time: dateProvider.currentDate(),
                     attributes: [:],
-                    kind: RUMResourceKind(response: httpResponse),
+                    kind: RUMResourceType(response: httpResponse),
                     httpStatusCode: httpResponse.statusCode,
                     size: interception.metrics?.responseSize
                 )

--- a/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -34,7 +34,7 @@ internal class URLSessionRUMResourcesHandler: URLSessionInterceptionHandler {
                 time: dateProvider.currentDate(),
                 attributes: [:],
                 url: url,
-                httpMethod: RUMHTTPMethod(request: interception.request),
+                httpMethod: RUMMethod(httpMethod: interception.request.httpMethod),
                 kind: RUMResourceKind(request: interception.request),
                 spanContext: interception.spanContext.flatMap { spanContext in
                     .init(

--- a/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
@@ -20,19 +20,6 @@ internal extension RUMUUID {
     }
 }
 
-internal extension RUMHTTPMethod {
-    var toRUMDataFormat: RUMMethod {
-        switch self {
-        case .GET: return .get
-        case .POST: return .post
-        case .PUT: return .put
-        case .DELETE: return .delete
-        case .HEAD: return .head
-        case .PATCH: return .patch
-        }
-    }
-}
-
 internal extension RUMResourceKind {
     var toRUMDataFormat: RUMResourceEvent.Resource.ResourceType {
         switch self {

--- a/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
@@ -20,23 +20,6 @@ internal extension RUMUUID {
     }
 }
 
-internal extension RUMResourceKind {
-    var toRUMDataFormat: RUMResourceEvent.Resource.ResourceType {
-        switch self {
-        case .image: return .image
-        case .xhr: return .xhr
-        case .beacon: return .beacon
-        case .css: return .css
-        case .document: return .document
-        case .fetch: return .fetch
-        case .font: return .font
-        case .js: return .js
-        case .media: return .media
-        case .other: return .other
-        }
-    }
-}
-
 internal extension RUMInternalErrorSource {
     var toRUMDataFormat: RUMErrorEvent.Error.Source {
         switch self {

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -119,7 +119,7 @@ internal struct RUMStartResourceCommand: RUMResourceCommand {
     /// Resource url
     let url: String
     /// HTTP method used to load the Resource
-    let httpMethod: RUMHTTPMethod
+    let httpMethod: RUMMethod
     /// A type of the Resource if it's possible to determine on start (when the response MIME is not yet known).
     let kind: RUMResourceKind?
     /// Span context passed to the RUM backend in order to generate the APM span for underlying resource.

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -121,7 +121,7 @@ internal struct RUMStartResourceCommand: RUMResourceCommand {
     /// HTTP method used to load the Resource
     let httpMethod: RUMMethod
     /// A type of the Resource if it's possible to determine on start (when the response MIME is not yet known).
-    let kind: RUMResourceKind?
+    let kind: RUMResourceType?
     /// Span context passed to the RUM backend in order to generate the APM span for underlying resource.
     let spanContext: RUMSpanContext?
 }
@@ -141,7 +141,7 @@ internal struct RUMStopResourceCommand: RUMResourceCommand {
     var attributes: [AttributeKey: AttributeValue]
 
     /// A type of the Resource
-    let kind: RUMResourceKind
+    let kind: RUMResourceType
     /// HTTP status code of loading the Ressource
     let httpStatusCode: Int?
     /// The size of loaded Resource

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -26,7 +26,7 @@ internal class RUMResourceScope: RUMScope {
     /// Date correction to server time.
     private let dateCorrection: DateCorrection
     /// The HTTP method used to load this Resource.
-    private var resourceHTTPMethod: RUMHTTPMethod
+    private var resourceHTTPMethod: RUMMethod
     /// The Resource kind captured when starting the `URLRequest`.
     /// It may be `nil` if it's not possible to predict the kind from resource and the response MIME type is needed.
     private var resourceKindBasedOnRequest: RUMResourceKind?
@@ -46,7 +46,7 @@ internal class RUMResourceScope: RUMScope {
         startTime: Date,
         dateCorrection: DateCorrection,
         url: String,
-        httpMethod: RUMHTTPMethod,
+        httpMethod: RUMMethod,
         resourceKindBasedOnRequest: RUMResourceKind?,
         spanContext: RUMSpanContext?
     ) {
@@ -144,7 +144,7 @@ internal class RUMResourceScope: RUMScope {
                     )
                 },
                 id: resourceUUID.toRUMDataFormat,
-                method: resourceHTTPMethod.toRUMDataFormat,
+                method: resourceHTTPMethod,
                 provider: nil,
                 redirect: resourceMetrics?.redirection.flatMap { metric in
                     .init(
@@ -192,7 +192,7 @@ internal class RUMResourceScope: RUMScope {
                 isCrash: false,
                 message: command.errorMessage,
                 resource: .init(
-                    method: resourceHTTPMethod.toRUMDataFormat,
+                    method: resourceHTTPMethod,
                     provider: nil,
                     statusCode: command.httpStatusCode?.toInt64 ?? 0,
                     url: resourceURL

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -29,7 +29,7 @@ internal class RUMResourceScope: RUMScope {
     private var resourceHTTPMethod: RUMMethod
     /// The Resource kind captured when starting the `URLRequest`.
     /// It may be `nil` if it's not possible to predict the kind from resource and the response MIME type is needed.
-    private var resourceKindBasedOnRequest: RUMResourceKind?
+    private var resourceKindBasedOnRequest: RUMResourceType?
 
     /// The Resource metrics, if received. When sending RUM Resource event, `resourceMetrics` values
     /// take precedence over other values collected for this Resource.
@@ -47,7 +47,7 @@ internal class RUMResourceScope: RUMScope {
         dateCorrection: DateCorrection,
         url: String,
         httpMethod: RUMMethod,
-        resourceKindBasedOnRequest: RUMResourceKind?,
+        resourceKindBasedOnRequest: RUMResourceType?,
         spanContext: RUMSpanContext?
     ) {
         self.context = context
@@ -105,6 +105,7 @@ internal class RUMResourceScope: RUMScope {
             resourceDuration = command.time.timeIntervalSince(resourceLoadingStartTime)
             size = command.size
         }
+        let resourceType: RUMResourceType = resourceKindBasedOnRequest ?? command.kind
 
         let eventData = RUMResourceEvent(
             dd: .init(
@@ -160,7 +161,7 @@ internal class RUMResourceScope: RUMScope {
                     )
                 },
                 statusCode: command.httpStatusCode?.toInt64,
-                type: (resourceKindBasedOnRequest ?? command.kind).toRUMDataFormat,
+                type: resourceType,
                 url: resourceURL
             ),
             service: nil,

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -19,6 +19,7 @@ internal extension RUMMethod {
 }
 
 public typealias RUMResourceType = RUMResourceEvent.Resource.ResourceType
+
 internal extension RUMResourceType {
     /// Determines the `RUMResourceType` based on a given `URLRequest`.
     /// Returns `nil` if the kind cannot be determined with only `URLRequest` and `HTTPURLRespones` is needed.

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -7,19 +7,14 @@
 import UIKit
 import Foundation
 
-internal enum RUMHTTPMethod: String {
-    case GET
-    case POST
-    case PUT
-    case DELETE
-    case HEAD
-    case PATCH
-
-    /// Determines the `RUMHTTPMethod` based on a given `URLRequest`. Defaults to `.GET`.
-    /// - Parameter request: the `URLRequest` for the resource.
-    init(request: URLRequest) {
-        let requestMethod = request.httpMethod ?? "GET"
-        self = RUMHTTPMethod(rawValue: requestMethod.uppercased()) ?? .GET
+internal extension RUMMethod {
+    init(httpMethod: String?) {
+        if let someMethod = httpMethod,
+           let someCase = RUMMethod(rawValue: someMethod.uppercased()) {
+            self = someCase
+        } else {
+            self = .get
+        }
     }
 }
 
@@ -342,7 +337,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 time: dateProvider.currentDate(),
                 attributes: attributes,
                 url: request.url?.absoluteString ?? "unknown_url",
-                httpMethod: RUMHTTPMethod(request: request),
+                httpMethod: RUMMethod(httpMethod: request.httpMethod),
                 kind: RUMResourceKind(request: request),
                 spanContext: nil
             )
@@ -360,7 +355,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 time: dateProvider.currentDate(),
                 attributes: attributes,
                 url: url.absoluteString,
-                httpMethod: .GET,
+                httpMethod: .get,
                 kind: nil,
                 spanContext: nil
             )
@@ -369,7 +364,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
 
     override public func startResourceLoading(
         resourceKey: String,
-        httpMethod: String,
+        httpMethod: RUMMethod,
         urlString: String,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
@@ -379,7 +374,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 time: dateProvider.currentDate(),
                 attributes: attributes,
                 url: urlString,
-                httpMethod: RUMHTTPMethod(rawValue: httpMethod.uppercased()) ?? .GET,
+                httpMethod: httpMethod,
                 kind: nil,
                 spanContext: nil
             )

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -18,34 +18,25 @@ internal extension RUMMethod {
     }
 }
 
-public enum RUMResourceKind {
-    case image
-    case xhr
-    case beacon
-    case css
-    case document
-    case fetch
-    case font
-    case js
-    case media
-    case other
-
-    private static let xhrHTTPMethods: Set<String> = ["POST", "PUT", "DELETE"]
-
-    /// Determines the `RUMResourceKind` based on a given `URLRequest`.
+public typealias RUMResourceType = RUMResourceEvent.Resource.ResourceType
+internal extension RUMResourceType {
+    /// Determines the `RUMResourceType` based on a given `URLRequest`.
     /// Returns `nil` if the kind cannot be determined with only `URLRequest` and `HTTPURLRespones` is needed.
     ///
     /// - Parameters:
     ///   - request: the `URLRequest` for the resource.
     init?(request: URLRequest) {
-        if let requestMethod = request.httpMethod?.uppercased(), RUMResourceKind.xhrHTTPMethods.contains(requestMethod) {
+        let xhrHTTPMethods: Set<String> = ["POST", "PUT", "DELETE"]
+
+        if let requestMethod = request.httpMethod?.uppercased(),
+           xhrHTTPMethods.contains(requestMethod) {
             self = .xhr
         } else {
             return nil
         }
     }
 
-    /// Determines the `RUMResourceKind` based on the MIME type of given `HTTPURLResponse`.
+    /// Determines the `RUMResourceType` based on the MIME type of given `HTTPURLResponse`.
     /// Defaults to `.other`.
     ///
     /// - Parameters:
@@ -338,7 +329,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 attributes: attributes,
                 url: request.url?.absoluteString ?? "unknown_url",
                 httpMethod: RUMMethod(httpMethod: request.httpMethod),
-                kind: RUMResourceKind(request: request),
+                kind: RUMResourceType(request: request),
                 spanContext: nil
             )
         )
@@ -402,11 +393,11 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         size: Int64?,
         attributes: [AttributeKey: AttributeValue]
     ) {
-        let resourceKind: RUMResourceKind
+        let resourceKind: RUMResourceType
         var statusCode: Int?
 
         if let response = response as? HTTPURLResponse {
-            resourceKind = RUMResourceKind(response: response)
+            resourceKind = RUMResourceType(response: response)
             statusCode = response.statusCode
         } else {
             resourceKind = .other
@@ -427,7 +418,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
     override public func stopResourceLoading(
         resourceKey: String,
         statusCode: Int?,
-        kind: RUMResourceKind,
+        kind: RUMResourceType,
         size: Int64? = nil,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {

--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -10,6 +10,7 @@ import class Datadog.DDRUMMonitor
 import class Datadog.RUMMonitor
 import enum Datadog.RUMErrorSource
 import enum Datadog.RUMUserActionType
+import enum Datadog.RUMResourceKind
 import struct Datadog.RUMView
 import protocol Datadog.UIKitRUMViewsPredicate
 
@@ -90,6 +91,35 @@ public enum DDRUMUserActionType: Int {
 }
 
 @objc
+public enum DDRUMResourceKind: Int {
+    case image
+    case xhr
+    case beacon
+    case css
+    case document
+    case fetch
+    case font
+    case js
+    case media
+    case other
+
+    internal var swiftType: RUMResourceKind {
+        switch self {
+        case .image: return .image
+        case .xhr: return .xhr
+        case .beacon: return .beacon
+        case .css: return .css
+        case .document: return .document
+        case .fetch: return .fetch
+        case .font: return .font
+        case .js: return .js
+        case .media: return .media
+        default: return .other
+        }
+    }
+}
+
+@objc
 public class DDRUMMonitor: NSObject {
     // MARK: - Internal
 
@@ -147,6 +177,16 @@ public class DDRUMMonitor: NSObject {
 
     @objc
     public func addError(
+        message: String,
+        source: DDRUMErrorSource,
+        stack: String?,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.addError(message: message, source: source.swiftType, stack: stack, attributes: castAttributesToSwift(attributes))
+    }
+
+    @objc
+    public func addError(
         error: Error,
         source: DDRUMErrorSource,
         attributes: [String: Any]
@@ -173,6 +213,16 @@ public class DDRUMMonitor: NSObject {
     }
 
     @objc
+    public func startResourceLoading(
+        resourceKey: String,
+        httpMethod: String,
+        urlString: String,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.startResourceLoading(resourceKey: resourceKey, httpMethod: httpMethod, urlString: urlString, attributes: castAttributesToSwift(attributes))
+    }
+
+    @objc
     public func addResourceMetrics(
         resourceKey: String,
         metrics: URLSessionTaskMetrics,
@@ -188,6 +238,16 @@ public class DDRUMMonitor: NSObject {
         attributes: [String: Any]
     ) {
         swiftRUMMonitor.stopResourceLoading(resourceKey: resourceKey, response: response, attributes: castAttributesToSwift(attributes))
+    }
+
+    @objc
+    public func stopResourceLoading(
+        resourceKey: String,
+        statusCode: Int,
+        kind: DDRUMResourceKind,
+        attributes: [String: Any]
+    ) {
+        swiftRUMMonitor.stopResourceLoading(resourceKey: resourceKey, statusCode: statusCode, kind: kind.swiftType, attributes: castAttributesToSwift(attributes))
     }
 
     @objc

--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -10,7 +10,6 @@ import class Datadog.DDRUMMonitor
 import class Datadog.RUMMonitor
 import enum Datadog.RUMErrorSource
 import enum Datadog.RUMUserActionType
-//import enum Datadog.RUM
 import typealias Datadog.RUMResourceType
 import enum Datadog.RUMMethod
 import struct Datadog.RUMView

--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -11,6 +11,7 @@ import class Datadog.RUMMonitor
 import enum Datadog.RUMErrorSource
 import enum Datadog.RUMUserActionType
 import enum Datadog.RUMResourceKind
+import enum Datadog.RUMMethod
 import struct Datadog.RUMView
 import protocol Datadog.UIKitRUMViewsPredicate
 
@@ -120,6 +121,28 @@ public enum DDRUMResourceKind: Int {
 }
 
 @objc
+public enum DDRUMMethod: Int {
+    case post
+    case get
+    case head
+    case put
+    case delete
+    case patch
+
+    internal var swiftType: RUMMethod {
+        switch self {
+        case .post: return .post
+        case .get: return .get
+        case .head: return .head
+        case .put: return .put
+        case .delete: return .delete
+        case .patch: return .patch
+        default: return .get
+        }
+    }
+}
+
+@objc
 public class DDRUMMonitor: NSObject {
     // MARK: - Internal
 
@@ -215,11 +238,11 @@ public class DDRUMMonitor: NSObject {
     @objc
     public func startResourceLoading(
         resourceKey: String,
-        httpMethod: String,
+        httpMethod: DDRUMMethod,
         urlString: String,
         attributes: [String: Any]
     ) {
-        swiftRUMMonitor.startResourceLoading(resourceKey: resourceKey, httpMethod: httpMethod, urlString: urlString, attributes: castAttributesToSwift(attributes))
+        swiftRUMMonitor.startResourceLoading(resourceKey: resourceKey, httpMethod: httpMethod.swiftType, urlString: urlString, attributes: castAttributesToSwift(attributes))
     }
 
     @objc

--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -10,7 +10,8 @@ import class Datadog.DDRUMMonitor
 import class Datadog.RUMMonitor
 import enum Datadog.RUMErrorSource
 import enum Datadog.RUMUserActionType
-import enum Datadog.RUMResourceKind
+//import enum Datadog.RUM
+import typealias Datadog.RUMResourceType
 import enum Datadog.RUMMethod
 import struct Datadog.RUMView
 import protocol Datadog.UIKitRUMViewsPredicate
@@ -92,7 +93,7 @@ public enum DDRUMUserActionType: Int {
 }
 
 @objc
-public enum DDRUMResourceKind: Int {
+public enum DDRUMResourceType: Int {
     case image
     case xhr
     case beacon
@@ -104,7 +105,7 @@ public enum DDRUMResourceKind: Int {
     case media
     case other
 
-    internal var swiftType: RUMResourceKind {
+    internal var swiftType: RUMResourceType {
         switch self {
         case .image: return .image
         case .xhr: return .xhr
@@ -267,7 +268,7 @@ public class DDRUMMonitor: NSObject {
     public func stopResourceLoading(
         resourceKey: String,
         statusCode: Int,
-        kind: DDRUMResourceKind,
+        kind: DDRUMResourceType,
         attributes: [String: Any]
     ) {
         swiftRUMMonitor.stopResourceLoading(resourceKey: resourceKey, statusCode: statusCode, kind: kind.swiftType, attributes: castAttributesToSwift(attributes))

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -67,8 +67,8 @@ extension RUMFeature {
 
 // MARK: - Public API Mocks
 
-extension RUMHTTPMethod {
-    static func mockAny() -> RUMHTTPMethod { .GET }
+extension RUMMethod {
+    static func mockAny() -> RUMMethod { .get }
 }
 
 extension RUMResourceKind {
@@ -190,7 +190,7 @@ extension RUMStartResourceCommand {
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
         url: String = .mockAny(),
-        httpMethod: RUMHTTPMethod = .mockAny(),
+        httpMethod: RUMMethod = .mockAny(),
         kind: RUMResourceKind = .mockAny(),
         spanContext: RUMSpanContext? = nil
     ) -> RUMStartResourceCommand {

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -71,8 +71,8 @@ extension RUMMethod {
     static func mockAny() -> RUMMethod { .get }
 }
 
-extension RUMResourceKind {
-    static func mockAny() -> RUMResourceKind { .image }
+extension RUMResourceType {
+    static func mockAny() -> RUMResourceType { .image }
 }
 
 // MARK: - RUMDataModel Mocks
@@ -191,7 +191,7 @@ extension RUMStartResourceCommand {
         attributes: [AttributeKey: AttributeValue] = [:],
         url: String = .mockAny(),
         httpMethod: RUMMethod = .mockAny(),
-        kind: RUMResourceKind = .mockAny(),
+        kind: RUMResourceType = .mockAny(),
         spanContext: RUMSpanContext? = nil
     ) -> RUMStartResourceCommand {
         return RUMStartResourceCommand(
@@ -213,7 +213,7 @@ extension RUMStopResourceCommand {
         resourceKey: String = .mockAny(),
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
-        kind: RUMResourceKind = .mockAny(),
+        kind: RUMResourceType = .mockAny(),
         httpStatusCode: Int? = .mockAny(),
         size: Int64? = .mockAny()
     ) -> RUMStopResourceCommand {

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -96,7 +96,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(resourceStopCommand.resourceKey, taskInterception.identifier.uuidString)
         XCTAssertEqual(resourceStopCommand.time, .mockDecember15th2019At10AMUTC())
         XCTAssertEqual(resourceStopCommand.attributes.count, 0)
-        XCTAssertEqual(resourceStopCommand.kind, RUMResourceKind(response: resourceCompletion.httpResponse!))
+        XCTAssertEqual(resourceStopCommand.kind, RUMResourceType(response: resourceCompletion.httpResponse!))
         XCTAssertEqual(resourceStopCommand.httpStatusCode, 200)
         XCTAssertEqual(resourceStopCommand.size, taskInterception.metrics?.responseSize)
     }

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -40,7 +40,7 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(resourceStartCommand.time, .mockDecember15th2019At10AMUTC())
         XCTAssertEqual(resourceStartCommand.attributes.count, 0)
         XCTAssertEqual(resourceStartCommand.url, taskInterception.request.url?.absoluteString)
-        XCTAssertEqual(resourceStartCommand.httpMethod, RUMHTTPMethod(request: request))
+        XCTAssertEqual(resourceStartCommand.httpMethod, RUMMethod(httpMethod: request.httpMethod))
         XCTAssertNil(resourceStartCommand.spanContext)
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/DataModels/RUMDataModelsMappingTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/DataModels/RUMDataModelsMappingTests.swift
@@ -12,7 +12,6 @@ private protocol RUMDataFormatConvertible {
     var toRUMDataFormat: DTOValue { get }
 }
 
-extension RUMResourceKind: RUMDataFormatConvertible {}
 extension RUMInternalErrorSource: RUMDataFormatConvertible {}
 extension RUMUserActionType: RUMDataFormatConvertible {}
 
@@ -41,19 +40,6 @@ class RUMDataModelsMappingTests: XCTestCase {
         (0...50).forEach { _ in
             XCTAssertValidRumUUID(generator.generateUnique().toRUMDataFormat)
         }
-    }
-
-    func testRUMResourceKind() {
-        verify(value: RUMResourceKind.image, matches: .image)
-        verify(value: RUMResourceKind.xhr, matches: .xhr)
-        verify(value: RUMResourceKind.beacon, matches: .beacon)
-        verify(value: RUMResourceKind.css, matches: .css)
-        verify(value: RUMResourceKind.document, matches: .document)
-        verify(value: RUMResourceKind.fetch, matches: .fetch)
-        verify(value: RUMResourceKind.font, matches: .font)
-        verify(value: RUMResourceKind.js, matches: .js)
-        verify(value: RUMResourceKind.media, matches: .media)
-        verify(value: RUMResourceKind.other, matches: .other)
     }
 
     func testRUMInternalErrorSource() {

--- a/Tests/DatadogTests/Datadog/RUM/DataModels/RUMDataModelsMappingTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/DataModels/RUMDataModelsMappingTests.swift
@@ -12,7 +12,6 @@ private protocol RUMDataFormatConvertible {
     var toRUMDataFormat: DTOValue { get }
 }
 
-extension RUMHTTPMethod: RUMDataFormatConvertible {}
 extension RUMResourceKind: RUMDataFormatConvertible {}
 extension RUMInternalErrorSource: RUMDataFormatConvertible {}
 extension RUMUserActionType: RUMDataFormatConvertible {}
@@ -42,15 +41,6 @@ class RUMDataModelsMappingTests: XCTestCase {
         (0...50).forEach { _ in
             XCTAssertValidRumUUID(generator.generateUnique().toRUMDataFormat)
         }
-    }
-
-    func testRUMHTTPMethod() {
-        verify(value: RUMHTTPMethod.GET, matches: .get)
-        verify(value: RUMHTTPMethod.POST, matches: .post)
-        verify(value: RUMHTTPMethod.PUT, matches: .put)
-        verify(value: RUMHTTPMethod.DELETE, matches: .delete)
-        verify(value: RUMHTTPMethod.HEAD, matches: .head)
-        verify(value: RUMHTTPMethod.PATCH, matches: .patch)
     }
 
     func testRUMResourceKind() {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -293,7 +293,7 @@ class RUMResourceScopeTests: XCTestCase {
     }
 
     func testGivenResourceStartedWithKindBasedOnRequest_whenLoadingEndsWithDifferentKind_itSendsTheKindBasedOnRequest() throws {
-        let kinds: [RUMResourceKind] = [.image, .xhr, .beacon, .css, .document, .fetch, .font, .js, .media, .other]
+        let kinds: [RUMResourceType] = [.image, .xhr, .beacon, .css, .document, .fetch, .font, .js, .media, .other]
         let kindBasedOnRequest = kinds.randomElement()!
         let kindBasedOnResponse = kinds.randomElement()!
 
@@ -323,6 +323,6 @@ class RUMResourceScopeTests: XCTestCase {
 
         // Then
         let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMResourceEvent>.self).first)
-        XCTAssertEqual(event.model.resource.type, kindBasedOnRequest.toRUMDataFormat)
+        XCTAssertEqual(event.model.resource.type, kindBasedOnRequest)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -51,7 +51,7 @@ class RUMResourceScopeTests: XCTestCase {
             startTime: currentTime,
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
-            httpMethod: .POST,
+            httpMethod: .post,
             resourceKindBasedOnRequest: nil,
             spanContext: .init(traceID: "100", spanID: "200")
         )
@@ -111,7 +111,7 @@ class RUMResourceScopeTests: XCTestCase {
             startTime: currentTime,
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
-            httpMethod: .POST,
+            httpMethod: .post,
             resourceKindBasedOnRequest: nil,
             spanContext: nil
         )
@@ -162,7 +162,7 @@ class RUMResourceScopeTests: XCTestCase {
             startTime: currentTime,
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
-            httpMethod: .POST,
+            httpMethod: .post,
             resourceKindBasedOnRequest: nil,
             spanContext: nil
         )
@@ -306,7 +306,7 @@ class RUMResourceScopeTests: XCTestCase {
             startTime: Date(),
             dateCorrection: .zero,
             url: .mockAny(),
-            httpMethod: .POST,
+            httpMethod: .post,
             resourceKindBasedOnRequest: kindBasedOnRequest,
             spanContext: nil
         )

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -183,7 +183,7 @@ class RUMMonitorTests: XCTestCase {
         setGlobalAttributes(of: monitor)
 
         monitor.startView(viewController: mockView)
-        monitor.startResourceLoading(resourceKey: "/resource/1", httpMethod: "post", urlString: "/some/url/string", attributes: [:])
+        monitor.startResourceLoading(resourceKey: "/resource/1", httpMethod: .post, urlString: "/some/url/string", attributes: [:])
         monitor.stopResourceLoading(resourceKey: "/resource/1", statusCode: 333, kind: .beacon)
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
@@ -1035,28 +1035,28 @@ class RUMMonitorTests: XCTestCase {
 class RUMHTTPMethodTests: XCTestCase {
     func testItCanBeInitializedFromURLRequest() {
         XCTAssertEqual(
-            RUMHTTPMethod(request: .mockWith(httpMethod: "get".randomcased())), .GET
+            RUMMethod(httpMethod: "get".randomcased()), .get
         )
         XCTAssertEqual(
-            RUMHTTPMethod(request: .mockWith(httpMethod: "post".randomcased())), .POST
+            RUMMethod(httpMethod: "post".randomcased()), .post
         )
         XCTAssertEqual(
-            RUMHTTPMethod(request: .mockWith(httpMethod: "put".randomcased())), .PUT
+            RUMMethod(httpMethod: "put".randomcased()), .put
         )
         XCTAssertEqual(
-            RUMHTTPMethod(request: .mockWith(httpMethod: "delete".randomcased())), .DELETE
+            RUMMethod(httpMethod: "delete".randomcased()), .delete
         )
         XCTAssertEqual(
-            RUMHTTPMethod(request: .mockWith(httpMethod: "head".randomcased())), .HEAD
+            RUMMethod(httpMethod: "head".randomcased()), .head
         )
         XCTAssertEqual(
-            RUMHTTPMethod(request: .mockWith(httpMethod: "patch".randomcased())), .PATCH
+            RUMMethod(httpMethod: "patch".randomcased()), .patch
         )
     }
 
     func testWhenInitializingFromURLRequest_itDefaultsToGET() {
         XCTAssertEqual(
-            RUMHTTPMethod(request: .mockWith(httpMethod: "unknown_method")), .GET
+            RUMMethod(httpMethod: "unknown_method".randomcased()), .get
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1063,7 +1063,7 @@ class RUMHTTPMethodTests: XCTestCase {
 
 class RUMResourceKindTests: XCTestCase {
     func testWhenInitializedWithResponse_itReturnsKindBasedOnMIMEType() {
-        let fixtures: [(mime: String, kind: RUMResourceKind)] = [
+        let fixtures: [(mime: String, kind: RUMResourceType)] = [
             (mime: "image/png", kind: .image),
             (mime: "video/mpeg", kind: .media),
             (mime: "audio/ogg", kind: .media),
@@ -1076,7 +1076,7 @@ class RUMResourceKindTests: XCTestCase {
 
         fixtures.forEach { mime, expectedKind in
             XCTAssertEqual(
-                RUMResourceKind(response: .mockWith(mimeType: mime.randomcased())),
+                RUMResourceType(response: .mockWith(mimeType: mime.randomcased())),
                 expectedKind
             )
         }
@@ -1084,31 +1084,31 @@ class RUMResourceKindTests: XCTestCase {
 
     func testWhenInitializedWithPOSTorPUTorDELETErequest_itReturnsXHR() {
         XCTAssertEqual(
-            RUMResourceKind(request: .mockWith(httpMethod: "POST".randomcased())), .xhr
+            RUMResourceType(request: .mockWith(httpMethod: "POST".randomcased())), .xhr
         )
         XCTAssertEqual(
-            RUMResourceKind(request: .mockWith(httpMethod: "PUT".randomcased())), .xhr
+            RUMResourceType(request: .mockWith(httpMethod: "PUT".randomcased())), .xhr
         )
         XCTAssertEqual(
-            RUMResourceKind(request: .mockWith(httpMethod: "DELETE".randomcased())), .xhr
+            RUMResourceType(request: .mockWith(httpMethod: "DELETE".randomcased())), .xhr
         )
     }
 
     func testWhenInitializedWithGETorHEADorPATCHrequest_itReturnsNil() {
         XCTAssertNil(
-            RUMResourceKind(request: .mockWith(httpMethod: "GET".randomcased()))
+            RUMResourceType(request: .mockWith(httpMethod: "GET".randomcased()))
         )
         XCTAssertNil(
-            RUMResourceKind(request: .mockWith(httpMethod: "HEAD".randomcased()))
+            RUMResourceType(request: .mockWith(httpMethod: "HEAD".randomcased()))
         )
         XCTAssertNil(
-            RUMResourceKind(request: .mockWith(httpMethod: "PATCH".randomcased()))
+            RUMResourceType(request: .mockWith(httpMethod: "PATCH".randomcased()))
         )
     }
 
     func testWhenInitializingFromHTTPURLResponse_itDefaultsToOther() {
         XCTAssertEqual(
-            RUMResourceKind(response: .mockWith(mimeType: "unknown/type")), .other
+            RUMResourceType(response: .mockWith(mimeType: "unknown/type")), .other
         )
     }
 }

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -57,16 +57,16 @@ class DDRUMErrorSourceTests: XCTestCase {
 
 class DDRUMResourceKindTests: XCTestCase {
     func testMappingToSwiftRUMResourceKind() {
-        XCTAssertEqual(DDRUMResourceKind.image.swiftType, .image)
-        XCTAssertEqual(DDRUMResourceKind.xhr.swiftType, .xhr)
-        XCTAssertEqual(DDRUMResourceKind.beacon.swiftType, .beacon)
-        XCTAssertEqual(DDRUMResourceKind.css.swiftType, .css)
-        XCTAssertEqual(DDRUMResourceKind.document.swiftType, .document)
-        XCTAssertEqual(DDRUMResourceKind.fetch.swiftType, .fetch)
-        XCTAssertEqual(DDRUMResourceKind.font.swiftType, .font)
-        XCTAssertEqual(DDRUMResourceKind.js.swiftType, .js)
-        XCTAssertEqual(DDRUMResourceKind.media.swiftType, .media)
-        XCTAssertEqual(DDRUMResourceKind.other.swiftType, .other)
+        XCTAssertEqual(DDRUMResourceType.image.swiftType, .image)
+        XCTAssertEqual(DDRUMResourceType.xhr.swiftType, .xhr)
+        XCTAssertEqual(DDRUMResourceType.beacon.swiftType, .beacon)
+        XCTAssertEqual(DDRUMResourceType.css.swiftType, .css)
+        XCTAssertEqual(DDRUMResourceType.document.swiftType, .document)
+        XCTAssertEqual(DDRUMResourceType.fetch.swiftType, .fetch)
+        XCTAssertEqual(DDRUMResourceType.font.swiftType, .font)
+        XCTAssertEqual(DDRUMResourceType.js.swiftType, .js)
+        XCTAssertEqual(DDRUMResourceType.media.swiftType, .media)
+        XCTAssertEqual(DDRUMResourceType.other.swiftType, .other)
     }
 }
 

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -70,6 +70,17 @@ class DDRUMResourceKindTests: XCTestCase {
     }
 }
 
+class DDRUMMethodTests: XCTestCase {
+    func testMappingToSwiftRUMMethod() {
+        XCTAssertEqual(DDRUMMethod.post.swiftType, .post)
+        XCTAssertEqual(DDRUMMethod.get.swiftType, .get)
+        XCTAssertEqual(DDRUMMethod.head.swiftType, .head)
+        XCTAssertEqual(DDRUMMethod.put.swiftType, .put)
+        XCTAssertEqual(DDRUMMethod.delete.swiftType, .delete)
+        XCTAssertEqual(DDRUMMethod.patch.swiftType, .patch)
+    }
+}
+
 class DDRUMMonitorTests: XCTestCase {
     override func setUp() {
         super.setUp()
@@ -163,7 +174,7 @@ class DDRUMMonitorTests: XCTestCase {
         )
         objcRUMMonitor.stopResourceLoading(resourceKey: "/resource1", response: .mockAny(), attributes: ["event-attribute3": "foo3"])
 
-        objcRUMMonitor.startResourceLoading(resourceKey: "/resource2", httpMethod: "GET", urlString: "/some/url/string", attributes: [:])
+        objcRUMMonitor.startResourceLoading(resourceKey: "/resource2", httpMethod: .get, urlString: "/some/url/string", attributes: [:])
         objcRUMMonitor.stopResourceLoading(resourceKey: "/resource2", statusCode: 333, kind: .beacon, attributes: [:])
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 6)

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -144,6 +144,17 @@ public enum DDRUMUserActionType: Int
  case scroll
  case swipe
  case custom
+public enum DDRUMResourceKind: Int
+ case image
+ case xhr
+ case beacon
+ case css
+ case document
+ case fetch
+ case font
+ case js
+ case media
+ case other
 public class DDRUMMonitor: NSObject
  override public convenience init()
  public func startView(viewController: UIViewController,path: String?,attributes: [String: Any])
@@ -151,11 +162,14 @@ public class DDRUMMonitor: NSObject
  public func startView(key: String,path: String?,attributes: [String: Any])
  public func stopView(key: String,attributes: [String: Any])
  public func addTiming(name: String)
+ public func addError(message: String,source: DDRUMErrorSource,stack: String?,attributes: [String: Any])
  public func addError(error: Error,source: DDRUMErrorSource,attributes: [String: Any])
  public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [String: Any])
  public func startResourceLoading(resourceKey: String,url: URL,attributes: [String: Any])
+ public func startResourceLoading(resourceKey: String,httpMethod: String,urlString: String,attributes: [String: Any])
  public func addResourceMetrics(resourceKey: String,metrics: URLSessionTaskMetrics,attributes: [String: Any])
  public func stopResourceLoading(resourceKey: String,response: URLResponse,attributes: [String: Any])
+ public func stopResourceLoading(resourceKey: String,statusCode: Int,kind: DDRUMResourceKind,attributes: [String: Any])
  public func stopResourceLoadingWithError(resourceKey: String,error: Error,response: URLResponse?,attributes: [String: Any])
  public func stopResourceLoadingWithError(resourceKey: String,errorMessage: String,response: URLResponse?,attributes: [String: Any])
  public func startUserAction(type: DDRUMUserActionType,name: String,attributes: [String: Any])

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -10,12 +10,14 @@ public class DDRUMMonitor
  public func startView(key: String,path: String? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  public func stopView(key: String,attributes: [AttributeKey: AttributeValue] = [:])
  public func addTiming(name: String)
- public func addError(message: String,source: RUMErrorSource = .custom,attributes: [AttributeKey: AttributeValue] = [:],file: StaticString? = #file,line: UInt? = #line)
+ public func addError(message: String,source: RUMErrorSource = .custom,stack: String? = nil,attributes: [AttributeKey: AttributeValue] = [:],file: StaticString? = #file,line: UInt? = #line)
  public func addError(error: Error,source: RUMErrorSource = .custom,attributes: [AttributeKey: AttributeValue] = [:])
  public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [AttributeKey: AttributeValue] = [:])
  public func startResourceLoading(resourceKey: String,url: URL,attributes: [AttributeKey: AttributeValue] = [:])
+ public func startResourceLoading(resourceKey: String,httpMethod: String,urlString: String,attributes: [AttributeKey: AttributeValue] = [:])
  public func addResourceMetrics(resourceKey: String,metrics: URLSessionTaskMetrics,attributes: [AttributeKey: AttributeValue] = [:])
  public func stopResourceLoading(resourceKey: String,response: URLResponse,size: Int64? = nil,attributes: [AttributeKey: AttributeValue] = [:])
+ public func stopResourceLoading(resourceKey: String,statusCode: Int?,kind: RUMResourceKind,size: Int64? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  public func stopResourceLoadingWithError(resourceKey: String,error: Error,response: URLResponse? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  public func stopResourceLoadingWithError(resourceKey: String,errorMessage: String,response: URLResponse? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  public func startUserAction(type: RUMUserActionType,name: String,attributes: [AttributeKey: AttributeValue] = [:])
@@ -501,6 +503,17 @@ public enum RUMMethod: String, Codable
  case put = "PUT"
  case delete = "DELETE"
  case patch = "PATCH"
+public enum RUMResourceKind
+ case image
+ case xhr
+ case beacon
+ case css
+ case document
+ case fetch
+ case font
+ case js
+ case media
+ case other
 public enum RUMUserActionType
  case tap
  case scroll
@@ -518,12 +531,14 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber
  override public func startView(key: String,path: String?,attributes: [AttributeKey: AttributeValue])
  override public func stopView(key: String,attributes: [AttributeKey: AttributeValue])
  override public func addTiming(name: String)
- override public func addError(message: String,source: RUMErrorSource,attributes: [AttributeKey: AttributeValue],file: StaticString?,line: UInt?)
+ override public func addError(message: String,source: RUMErrorSource,stack: String?,attributes: [AttributeKey: AttributeValue],file: StaticString?,line: UInt?)
  override public func addError(error: Error,source: RUMErrorSource,attributes: [AttributeKey: AttributeValue])
  override public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [AttributeKey: AttributeValue])
  override public func startResourceLoading(resourceKey: String,url: URL,attributes: [AttributeKey: AttributeValue])
+ override public func startResourceLoading(resourceKey: String,httpMethod: String,urlString: String,attributes: [AttributeKey: AttributeValue] = [:])
  override public func addResourceMetrics(resourceKey: String,metrics: URLSessionTaskMetrics,attributes: [AttributeKey: AttributeValue])
  override public func stopResourceLoading(resourceKey: String,response: URLResponse,size: Int64?,attributes: [AttributeKey: AttributeValue])
+ override public func stopResourceLoading(resourceKey: String,statusCode: Int?,kind: RUMResourceKind,size: Int64? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  override public func stopResourceLoadingWithError(resourceKey: String,error: Error,response: URLResponse?,attributes: [AttributeKey: AttributeValue])
  override public func stopResourceLoadingWithError(resourceKey: String,errorMessage: String,response: URLResponse?,attributes: [AttributeKey: AttributeValue])
  override public func startUserAction(type: RUMUserActionType, name: String, attributes: [AttributeKey: AttributeValue])


### PR DESCRIPTION
### What and why?

Those methods are needed for internal usage

#### Swift API

```swift
func addError(message: String,source: RUMErrorSource = .custom,stack: String? = nil,attributes: [AttributeKey: AttributeValue] = [:],file: StaticString? = #file,line: UInt? = #line)

func startResourceLoading(resourceKey: String,httpMethod: String,urlString: String,kind: RUMResourceKind,attributes: [AttributeKey: AttributeValue] = [:])

func stopResourceLoading(resourceKey: String,statusCode: Int?,kind: RUMResourceKind = .other,size: Int64? = nil,attributes: [AttributeKey: AttributeValue] = [:])

enum RUMResourceKind
```

#### Obj-C API
```swift
func addError(message: String,source: DDRUMErrorSource,stack: String?,attributes: [String: Any])

func startResourceLoading(resourceKey: String,httpMethod: String,urlString: String,kind: DDRUMResourceKind,attributes: [String: Any])

func stopResourceLoading(resourceKey: String,statusCode: Int,kind: DDRUMResourceKind,attributes: [String: Any])

enum DDRUMResourceKind
```
### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
