### PR TITLE
RUMM-990 Special InternalTimestamp attribute is handled

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Command processed through the tree of `RUMScopes`.
 internal protocol RUMCommand {
     /// The time of command issue.
-    var time: Date { get }
+    var time: Date { set get }
     /// Attributes associated with the command.
     var attributes: [AttributeKey: AttributeValue] { set get }
 }
@@ -17,7 +17,7 @@ internal protocol RUMCommand {
 // MARK: - RUM View related commands
 
 internal struct RUMStartViewCommand: RUMCommand {
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     /// The value holding stable identity of the RUM View.
@@ -40,7 +40,7 @@ internal struct RUMStartViewCommand: RUMCommand {
 }
 
 internal struct RUMStopViewCommand: RUMCommand {
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     /// The value holding stable identity of the RUM View.
@@ -48,7 +48,7 @@ internal struct RUMStopViewCommand: RUMCommand {
 }
 
 internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     /// The error message.
@@ -89,7 +89,7 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
 }
 
 internal struct RUMAddViewTimingCommand: RUMCommand {
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     /// The name of the timing. It will be used as a JSON key, whereas the value will be the timing duration,
@@ -113,7 +113,7 @@ internal struct RUMSpanContext {
 
 internal struct RUMStartResourceCommand: RUMResourceCommand {
     let resourceKey: String
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     /// Resource url
@@ -128,7 +128,7 @@ internal struct RUMStartResourceCommand: RUMResourceCommand {
 
 internal struct RUMAddResourceMetricsCommand: RUMResourceCommand {
     let resourceKey: String
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     /// Resource metrics.
@@ -137,7 +137,7 @@ internal struct RUMAddResourceMetricsCommand: RUMResourceCommand {
 
 internal struct RUMStopResourceCommand: RUMResourceCommand {
     let resourceKey: String
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     /// A type of the Resource
@@ -150,7 +150,7 @@ internal struct RUMStopResourceCommand: RUMResourceCommand {
 
 internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
     let resourceKey: String
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     /// The error message.
@@ -210,7 +210,7 @@ internal protocol RUMUserActionCommand: RUMCommand {
 
 /// Starts continuous User Action.
 internal struct RUMStartUserActionCommand: RUMUserActionCommand {
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     let actionType: RUMUserActionType
@@ -219,7 +219,7 @@ internal struct RUMStartUserActionCommand: RUMUserActionCommand {
 
 /// Stops continuous User Action.
 internal struct RUMStopUserActionCommand: RUMUserActionCommand {
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     let actionType: RUMUserActionType
@@ -228,7 +228,7 @@ internal struct RUMStopUserActionCommand: RUMUserActionCommand {
 
 /// Adds discrete (discontinuous) User Action.
 internal struct RUMAddUserActionCommand: RUMUserActionCommand {
-    let time: Date
+    var time: Date
     var attributes: [AttributeKey: AttributeValue]
 
     let actionType: RUMUserActionType

--- a/Sources/Datadog/Utils/SwiftExtensions.swift
+++ b/Sources/Datadog/Utils/SwiftExtensions.swift
@@ -19,6 +19,10 @@ extension Optional {
 // MARK: - TimeInterval
 
 extension TimeInterval {
+    init(fromMiliseconds miliseconds: Int64) {
+        self = Double(miliseconds) / 1_000
+    }
+
     /// `TimeInterval` represented in milliseconds (capped to `UInt64.max`).
     var toMilliseconds: UInt64 {
         let miliseconds = self * 1_000

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1077,6 +1077,25 @@ class RUMMonitorTests: XCTestCase {
         try Datadog.deinitializeOrThrow()
     }
 
+    // MARK: - Internal attributes
+
+    func testHandlingInternalTimestampAttribute() throws {
+        RUMFeature.instance = .mockNoOp()
+        defer { RUMFeature.instance = nil }
+
+        var mockCommand = RUMCommandMock()
+        mockCommand.attributes = [
+            RUMAttribute.internalTimestamp: Int64(1_000) // 1000 in miliseconds
+        ]
+
+        let monitor = try XCTUnwrap(RUMMonitor.initialize() as? RUMMonitor)
+
+        let transformedCommand = monitor.transform(command: mockCommand)
+        XCTAssertTrue(transformedCommand.attributes.isEmpty)
+        XCTAssertNotEqual(transformedCommand.time, mockCommand.time)
+        XCTAssertEqual(transformedCommand.time, Date(timeIntervalSince1970: 1)) // 1 in seconds
+    }
+
     // MARK: - Private helpers
 
     private var expectedAttributes = [String: String]()

--- a/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
@@ -8,6 +8,14 @@ import XCTest
 @testable import Datadog
 
 class TimeIntervalExtensionTests: XCTestCase {
+    func testTimeIntervalFromMiliseconds() {
+        let miliseconds: Int64 = 1_576_404_000_000
+
+        let timeInterval = TimeInterval(fromMiliseconds: miliseconds)
+        let date = Date(timeIntervalSince1970: timeInterval)
+        XCTAssertEqual(date, Date.mockDecember15th2019At10AMUTC())
+    }
+
     func testTimeIntervalSince1970InMilliseconds() {
         let date15Dec2019 = Date.mockDecember15th2019At10AMUTC()
         XCTAssertEqual(date15Dec2019.timeIntervalSince1970.toMilliseconds, 1_576_404_000_000)


### PR DESCRIPTION
### What and why?

In some special cases, `RUMMonitor` should let the caller feed event time explicitly

### How?

We use `_dd.timestamp` special attribute for such cases.
`RUMMonitor` extracts and removes it from `attributes` and use it as `command.time`.
This attribute overwrites default `command.time: Date()` behavior.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
