### PR TITLE
RUMM-908 Sanitize Span and RUM Event attributes

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		61122ECE25B1B74500F9C7F5 /* SpanSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */; };
 		61122ED425B1B84D00F9C7F5 /* RUMEventSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */; };
 		61122EDA25B1BA9700F9C7F5 /* AttributesSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED925B1BA9700F9C7F5 /* AttributesSanitizer.swift */; };
+		61122EE825B1C92500F9C7F5 /* SpanSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122EE725B1C92500F9C7F5 /* SpanSanitizerTests.swift */; };
 		61133B8C242393DE00786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61133B93242393DE00786299 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		61133BCA2423979B00786299 /* EncodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* EncodableValue.swift */; };
@@ -468,6 +469,7 @@
 		61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSanitizer.swift; sourceTree = "<group>"; };
 		61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventSanitizer.swift; sourceTree = "<group>"; };
 		61122ED925B1BA9700F9C7F5 /* AttributesSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesSanitizer.swift; sourceTree = "<group>"; };
+		61122EE725B1C92500F9C7F5 /* SpanSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSanitizerTests.swift; sourceTree = "<group>"; };
 		61133B82242393DE00786299 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61133B85242393DE00786299 /* Datadog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Datadog.h; sourceTree = "<group>"; };
 		61133B86242393DE00786299 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2190,6 +2192,7 @@
 			isa = PBXGroup;
 			children = (
 				61E45BD12450F65B00F2C652 /* SpanBuilderTests.swift */,
+				61122EE725B1C92500F9C7F5 /* SpanSanitizerTests.swift */,
 			);
 			path = Span;
 			sourceTree = "<group>";
@@ -2946,6 +2949,7 @@
 				61B038BA2527257B00518F3C /* URLSessionAutoInstrumentationMocks.swift in Sources */,
 				61133C672423990D00786299 /* LogConsoleOutputTests.swift in Sources */,
 				6114FDEC257659E90084E372 /* FeatureDirectoriesMock.swift in Sources */,
+				61122EE825B1C92500F9C7F5 /* SpanSanitizerTests.swift in Sources */,
 				61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */,
 				617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */,
 				61F9CABA2513A7F5000A5E61 /* RUMSessionMatcher.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */; };
+		61122ECE25B1B74500F9C7F5 /* SpanSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */; };
+		61122ED425B1B84D00F9C7F5 /* RUMEventSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */; };
 		61133B8C242393DE00786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61133B93242393DE00786299 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		61133BCA2423979B00786299 /* EncodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* EncodableValue.swift */; };
@@ -462,6 +464,8 @@
 
 /* Begin PBXFileReference section */
 		6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingWithActiveSpanIntegration.swift; sourceTree = "<group>"; };
+		61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSanitizer.swift; sourceTree = "<group>"; };
+		61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventSanitizer.swift; sourceTree = "<group>"; };
 		61133B82242393DE00786299 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61133B85242393DE00786299 /* Datadog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Datadog.h; sourceTree = "<group>"; };
 		61133B86242393DE00786299 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2164,6 +2168,7 @@
 			children = (
 				61C5A8A424509FAA00DA608C /* SpanEncoder.swift */,
 				61C5A8A524509FAA00DA608C /* SpanBuilder.swift */,
+				61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */,
 				614872762485067300E3EBDB /* SpanTagsReducer.swift */,
 			);
 			path = Span;
@@ -2243,6 +2248,7 @@
 				614B0A4A24EBC43D00A2A780 /* RUMUserInfoProvider.swift */,
 				61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */,
 				61E5333C24B8791A003D6C4E /* RUMEventEncoder.swift */,
+				61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */,
 				614B0A4E24EBDC6B00A2A780 /* RUMConnectivityInfoProvider.swift */,
 			);
 			path = RUMEvent;
@@ -2816,6 +2822,7 @@
 				9EFD112C24B32D29003A1A2B /* FirstPartyURLsFilter.swift in Sources */,
 				61B0386C2527247B00518F3C /* TaskInterception.swift in Sources */,
 				61B03892252724D900518F3C /* HTTPHeadersReader.swift in Sources */,
+				61122ECE25B1B74500F9C7F5 /* SpanSanitizer.swift in Sources */,
 				613E79282577B0EE00DFCC17 /* Writer.swift in Sources */,
 				61B0384E2527246900518F3C /* URLSessionAutoInstrumentation.swift in Sources */,
 				61C5A88924509A0C00DA608C /* DDSpanContext.swift in Sources */,
@@ -2882,6 +2889,7 @@
 				61133BCE2423979B00786299 /* BatteryStatusProvider.swift in Sources */,
 				E13A880C257922EC004FB174 /* EnvironmentSpanIntegration.swift in Sources */,
 				61B038602527247200518F3C /* URLSessionTracingHandler.swift in Sources */,
+				61122ED425B1B84D00F9C7F5 /* RUMEventSanitizer.swift in Sources */,
 				61363D9D24D999F70084CD6F /* DDError.swift in Sources */,
 				61133BD52423979B00786299 /* DataUploadConditions.swift in Sources */,
 				612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		61122ED425B1B84D00F9C7F5 /* RUMEventSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */; };
 		61122EDA25B1BA9700F9C7F5 /* AttributesSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED925B1BA9700F9C7F5 /* AttributesSanitizer.swift */; };
 		61122EE825B1C92500F9C7F5 /* SpanSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122EE725B1C92500F9C7F5 /* SpanSanitizerTests.swift */; };
+		61122EEE25B1D75B00F9C7F5 /* RUMEventSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122EED25B1D75B00F9C7F5 /* RUMEventSanitizerTests.swift */; };
 		61133B8C242393DE00786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61133B93242393DE00786299 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		61133BCA2423979B00786299 /* EncodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* EncodableValue.swift */; };
@@ -470,6 +471,7 @@
 		61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventSanitizer.swift; sourceTree = "<group>"; };
 		61122ED925B1BA9700F9C7F5 /* AttributesSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesSanitizer.swift; sourceTree = "<group>"; };
 		61122EE725B1C92500F9C7F5 /* SpanSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSanitizerTests.swift; sourceTree = "<group>"; };
+		61122EED25B1D75B00F9C7F5 /* RUMEventSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventSanitizerTests.swift; sourceTree = "<group>"; };
 		61133B82242393DE00786299 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61133B85242393DE00786299 /* Datadog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Datadog.h; sourceTree = "<group>"; };
 		61133B86242393DE00786299 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2400,6 +2402,7 @@
 			children = (
 				614B0A4C24EBD71500A2A780 /* RUMUserInfoProviderTests.swift */,
 				61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */,
+				61122EED25B1D75B00F9C7F5 /* RUMEventSanitizerTests.swift */,
 				614B0A5024EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift */,
 			);
 			path = RUMEvent;
@@ -3025,6 +3028,7 @@
 				618DCFDF24C75FD300589570 /* RUMScopeTests.swift in Sources */,
 				61C5A89E24509C1100DA608C /* WarningsTests.swift in Sources */,
 				9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */,
+				61122EEE25B1D75B00F9C7F5 /* RUMEventSanitizerTests.swift in Sources */,
 				614B0A5124EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift in Sources */,
 				611F82032563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift in Sources */,
 				61133C652423990D00786299 /* LogBuilderTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -958,7 +958,6 @@
 				9E9EB37624468CE90002C80B /* Datadog.modulemap */,
 				61133BBB2423979B00786299 /* Datadog.swift */,
 				61133BB52423979B00786299 /* DatadogConfiguration.swift */,
-				61C3E63424BF1794008053F2 /* Attributes.swift */,
 				61133BB62423979B00786299 /* Logger.swift */,
 				61E909E824A24DD3005EA2DE /* Global.swift */,
 				61C5A88D24509A1F00DA608C /* Tracer.swift */,
@@ -1081,6 +1080,7 @@
 		61133BBF2423979B00786299 /* Attributes */ = {
 			isa = PBXGroup;
 			children = (
+				61C3E63424BF1794008053F2 /* Attributes.swift */,
 				61133BC02423979B00786299 /* UserInfoProvider.swift */,
 			);
 			path = Attributes;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */; };
 		61122ECE25B1B74500F9C7F5 /* SpanSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */; };
 		61122ED425B1B84D00F9C7F5 /* RUMEventSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */; };
+		61122EDA25B1BA9700F9C7F5 /* AttributesSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED925B1BA9700F9C7F5 /* AttributesSanitizer.swift */; };
 		61133B8C242393DE00786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61133B93242393DE00786299 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		61133BCA2423979B00786299 /* EncodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* EncodableValue.swift */; };
@@ -466,6 +467,7 @@
 		6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingWithActiveSpanIntegration.swift; sourceTree = "<group>"; };
 		61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSanitizer.swift; sourceTree = "<group>"; };
 		61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventSanitizer.swift; sourceTree = "<group>"; };
+		61122ED925B1BA9700F9C7F5 /* AttributesSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesSanitizer.swift; sourceTree = "<group>"; };
 		61133B82242393DE00786299 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61133B85242393DE00786299 /* Datadog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Datadog.h; sourceTree = "<group>"; };
 		61133B86242393DE00786299 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1085,6 +1087,7 @@
 			isa = PBXGroup;
 			children = (
 				61C3E63424BF1794008053F2 /* Attributes.swift */,
+				61122ED925B1BA9700F9C7F5 /* AttributesSanitizer.swift */,
 				61133BC02423979B00786299 /* UserInfoProvider.swift */,
 			);
 			path = Attributes;
@@ -2810,6 +2813,7 @@
 				61C2C20724C098FC00C0321C /* RUMSessionScope.swift in Sources */,
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
 				61BCB81F256EB77F0039887B /* ServerDateProvider.swift in Sources */,
+				61122EDA25B1BA9700F9C7F5 /* AttributesSanitizer.swift in Sources */,
 				61FF282624B8A248000B3D9B /* RUMEventOutput.swift in Sources */,
 				618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,

--- a/Sources/Datadog/Core/Attributes/Attributes.swift
+++ b/Sources/Datadog/Core/Attributes/Attributes.swift
@@ -22,7 +22,7 @@ import Foundation
 ///     }
 ///
 /// - Important
-/// Values can be nested up to 10 levels deep. Keys using more than 10 levels will be sanitized by SDK.
+/// Values can be nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by the SDK.
 ///
 public typealias AttributeKey = String
 

--- a/Sources/Datadog/Core/Attributes/AttributesSanitizer.swift
+++ b/Sources/Datadog/Core/Attributes/AttributesSanitizer.swift
@@ -17,6 +17,8 @@ internal struct AttributesSanitizer {
         static let maxNumberOfAttributes: Int = 128
     }
 
+    let featureName: String
+
     // MARK: - Attribute keys sanitization
 
     /// Attribute keys can only have `Constants.maxNestedLevelsInAttributeName` levels.
@@ -34,7 +36,7 @@ internal struct AttributesSanitizer {
             if sanitizedName != key {
                 userLogger.warn(
                     """
-                    Attribute '\(key)' was modified to '\(sanitizedName)' to match Datadog constraints.
+                    \(featureName) attribute '\(key)' was modified to '\(sanitizedName)' to match Datadog constraints.
                     """
                 )
                 return (sanitizedName, value)
@@ -67,7 +69,7 @@ internal struct AttributesSanitizer {
             let extraAttributesCount = attributes.count - count
             userLogger.warn(
                 """
-                Number of attributes exceeds the limit of \(Constraints.maxNumberOfAttributes).
+                Number of \(featureName) attributes exceeds the limit of \(Constraints.maxNumberOfAttributes).
                 \(extraAttributesCount) attribute(s) will be ignored.
                 """
             )

--- a/Sources/Datadog/Core/Attributes/AttributesSanitizer.swift
+++ b/Sources/Datadog/Core/Attributes/AttributesSanitizer.swift
@@ -1,0 +1,79 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Common attributes sanitizer for all features.
+internal struct AttributesSanitizer {
+    struct Constraints {
+        /// Maximum number of nested levels in attribute name. E.g. `person.address.street` has 3 levels.
+        /// If attribute name exceeds this number, extra levels are escaped by using `_` character (`one.two.(...).nine.ten_eleven_twelve`).
+        static let maxNestedLevelsInAttributeName: Int = 8
+        /// Maximum number of attributes in log.
+        /// If this number is exceeded, extra attributes will be ignored.
+        static let maxNumberOfAttributes: Int = 128
+    }
+
+    // MARK: - Attribute keys sanitization
+
+    /// Attribute keys can only have `Constants.maxNestedLevelsInAttributeName` levels.
+    /// Extra levels are escaped with "_", e.g.:
+    ///
+    ///     one.two.three.four.five.six.seven.eight.nine.ten.eleven
+    ///
+    /// becomes:
+    ///
+    ///     one.two.three.four.five.six.seven.eight_nine_ten_eleven
+    ///
+    func sanitizeKeys<Value>(for attributes: [String: Value]) -> [String: Value] {
+        let sanitizedAttributes: [(String, Value)] = attributes.map { key, value in
+            let sanitizedName = sanitize(attributeKey: key)
+            if sanitizedName != key {
+                userLogger.warn(
+                    """
+                    Attribute '\(key)' was modified to '\(sanitizedName)' to match Datadog constraints.
+                    """
+                )
+                return (sanitizedName, value)
+            } else {
+                return (key, value)
+            }
+        }
+        return Dictionary(uniqueKeysWithValues: sanitizedAttributes)
+    }
+
+    private func sanitize(attributeKey: String) -> String {
+        var dotsCount = 0
+        var sanitized = ""
+        for char in attributeKey {
+            if char == "." {
+                dotsCount += 1
+                sanitized.append(dotsCount >= Constraints.maxNestedLevelsInAttributeName ? "_" : char)
+            } else {
+                sanitized.append(char)
+            }
+        }
+        return sanitized
+    }
+
+    // MARK: - Attributes count limitting
+
+    /// Removes attributes exceeding the `count` limit.
+    func limitNumberOf<Value>(attributes: [String: Value], to count: Int) -> [String: Value] {
+        if attributes.count > count {
+            let extraAttributesCount = attributes.count - count
+            userLogger.warn(
+                """
+                Number of attributes exceeds the limit of \(Constraints.maxNumberOfAttributes).
+                \(extraAttributesCount) attribute(s) will be ignored.
+                """
+            )
+            return Dictionary(uniqueKeysWithValues: attributes.dropLast(extraAttributesCount))
+        } else {
+            return attributes
+        }
+    }
+}

--- a/Sources/Datadog/Logging/Log/LogEncoder.swift
+++ b/Sources/Datadog/Logging/Log/LogEncoder.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 /// `Encodable` representation of log. It gets sanitized before encoding.
+/// All mutable properties are subject of sanitization.
 internal struct Log: Encodable {
     enum Status: String, Encodable {
         case debug
@@ -29,8 +30,8 @@ internal struct Log: Encodable {
     let userInfo: UserInfo
     let networkConnectionInfo: NetworkConnectionInfo?
     let mobileCarrierInfo: CarrierInfo?
-    let attributes: LogAttributes
-    let tags: [String]?
+    var attributes: LogAttributes
+    var tags: [String]?
 
     func encode(to encoder: Encoder) throws {
         let sanitizedLog = LogSanitizer().sanitize(log: self)

--- a/Sources/Datadog/Logging/Log/LogSanitizer.swift
+++ b/Sources/Datadog/Logging/Log/LogSanitizer.swift
@@ -37,7 +37,7 @@ internal struct LogSanitizer {
         static let maxNumberOfTags: Int = 100
     }
 
-    private let attributesSanitizer = AttributesSanitizer()
+    private let attributesSanitizer = AttributesSanitizer(featureName: "Log")
 
     func sanitize(log: Log) -> Log {
         return Log(

--- a/Sources/Datadog/Logging/Log/LogSanitizer.swift
+++ b/Sources/Datadog/Logging/Log/LogSanitizer.swift
@@ -40,22 +40,13 @@ internal struct LogSanitizer {
     private let attributesSanitizer = AttributesSanitizer(featureName: "Log")
 
     func sanitize(log: Log) -> Log {
-        return Log(
-            date: log.date,
-            status: log.status,
-            message: log.message,
-            serviceName: log.serviceName,
-            environment: log.environment,
-            loggerName: log.loggerName,
-            loggerVersion: log.loggerVersion,
-            threadName: log.threadName,
-            applicationVersion: log.applicationVersion,
-            userInfo: log.userInfo,
-            networkConnectionInfo: log.networkConnectionInfo,
-            mobileCarrierInfo: log.mobileCarrierInfo,
-            attributes: sanitize(attributes: log.attributes),
-            tags: sanitize(tags: log.tags)
-        )
+        let sanitizedAttributes = sanitize(attributes: log.attributes)
+        let sanitizedTags = sanitize(tags: log.tags)
+
+        var sanitizedLog = log
+        sanitizedLog.attributes = sanitizedAttributes
+        sanitizedLog.tags = sanitizedTags
+        return sanitizedLog
     }
 
     // MARK: - Attributes sanitization

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -20,7 +20,8 @@ internal struct RUMEvent<DM: RUMDataModel>: Encodable {
     let customViewTimings: [String: Int64]?
 
     func encode(to encoder: Encoder) throws {
-        try RUMEventEncoder().encode(self, to: encoder)
+        let sanitizedEvent = RUMEventSanitizer().sanitize(event: self)
+        try RUMEventEncoder().encode(sanitizedEvent, to: encoder)
     }
 }
 

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -7,17 +7,17 @@
 import Foundation
 
 /// `Encodable` representation of RUM event.
+/// Mutable properties are subject of sanitization or data scrubbing.
 internal struct RUMEvent<DM: RUMDataModel>: Encodable {
     /// The actual RUM event model created by `RUMMonitor`
-    /// It's mutable as it may be redacted by the user through data scrubbing API.
     var model: DM
 
     /// Custom attributes set by the user
-    let attributes: [String: Encodable]
-    let userInfoAttributes: [String: Encodable]
+    var attributes: [String: Encodable]
+    var userInfoAttributes: [String: Encodable]
 
     /// Custom View timings (only available if `DM` is a RUM View model)
-    let customViewTimings: [String: Int64]?
+    var customViewTimings: [String: Int64]?
 
     func encode(to encoder: Encoder) throws {
         let sanitizedEvent = RUMEventSanitizer().sanitize(event: self)

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventSanitizer.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventSanitizer.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// Sanitizes `RUMEvent` representation received from the user, so it can match Datadog RUM Events constraints.
 internal struct RUMEventSanitizer {
-    private let attributesSanitizer = AttributesSanitizer()
+    private let attributesSanitizer = AttributesSanitizer(featureName: "RUM Event")
 
     func sanitize<DM: RUMDataModel>(event: RUMEvent<DM>) -> RUMEvent<DM> {
         // Sanitize attribute names

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventSanitizer.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventSanitizer.swift
@@ -34,11 +34,10 @@ internal struct RUMEventSanitizer {
             to: AttributesSanitizer.Constraints.maxNumberOfAttributes - (sanitizedTimings?.count ?? 0) - sanitizedUserExtraInfo.count
         )
 
-        return RUMEvent(
-            model: event.model,
-            attributes: sanitizedAttributes,
-            userInfoAttributes: sanitizedUserExtraInfo,
-            customViewTimings: sanitizedTimings
-        )
+        var sanitizedEvent = event
+        sanitizedEvent.attributes = sanitizedAttributes
+        sanitizedEvent.userInfoAttributes = sanitizedUserExtraInfo
+        sanitizedEvent.customViewTimings = sanitizedTimings
+        return sanitizedEvent
     }
 }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventSanitizer.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventSanitizer.swift
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Sanitizes `RUMEvent` representation received from the user, so it can match Datadog RUM Events constraints.
+internal struct RUMEventSanitizer {
+    func sanitize<DM: RUMDataModel>(event: RUMEvent<DM>) -> RUMEvent<DM> {
+        return event
+    }
+}

--- a/Sources/Datadog/Tracing/Span/SpanEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEncoder.swift
@@ -30,6 +30,7 @@ internal struct SpanEnvelope: Encodable {
 }
 
 /// `Encodable` representation of span.
+/// All mutable properties are subject of sanitization.
 internal struct Span: Encodable {
     let traceID: TracingUUID
     let spanID: TracingUUID
@@ -52,13 +53,13 @@ internal struct Span: Encodable {
         let id: String?
         let name: String?
         let email: String?
-        let extraInfo: [AttributeKey: JSONStringEncodableValue]
+        var extraInfo: [AttributeKey: JSONStringEncodableValue]
     }
 
-    let userInfo: UserInfo
+    var userInfo: UserInfo
 
-    /// Custom tags, received from user
-    let tags: [String: JSONStringEncodableValue]
+    /// Custom tags, received from the user.
+    var tags: [String: JSONStringEncodableValue]
 
     func encode(to encoder: Encoder) throws {
         let sanitizedSpan = SpanSanitizer().sanitize(span: self)

--- a/Sources/Datadog/Tracing/Span/SpanEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEncoder.swift
@@ -47,6 +47,14 @@ internal struct Span: Encodable {
     let applicationVersion: String
     let networkConnectionInfo: NetworkConnectionInfo?
     let mobileCarrierInfo: CarrierInfo?
+
+    struct UserInfo {
+        let id: String?
+        let name: String?
+        let email: String?
+        let extraInfo: [AttributeKey: JSONStringEncodableValue]
+    }
+
     let userInfo: UserInfo
 
     /// Custom tags, received from user
@@ -194,6 +202,11 @@ internal struct SpanEncoder {
     /// Encodes `meta.*` attributes coming from user
     private func encodeCustomMeta(_ span: Span, to container: inout KeyedEncodingContainer<DynamicCodingKey>) throws {
         // NOTE: RUMM-299 only string values are supported for `meta.*` attributes
+        try span.userInfo.extraInfo.forEach {
+            let metaKey = "meta.usr.\($0.key)"
+            try container.encode($0.value, forKey: DynamicCodingKey(metaKey))
+        }
+
         try span.tags.forEach {
             let metaKey = "meta.\($0.key)"
             try container.encode($0.value, forKey: DynamicCodingKey(metaKey))

--- a/Sources/Datadog/Tracing/Span/SpanEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEncoder.swift
@@ -61,7 +61,8 @@ internal struct Span: Encodable {
     let tags: [String: JSONStringEncodableValue]
 
     func encode(to encoder: Encoder) throws {
-        try SpanEncoder().encode(self, to: encoder)
+        let sanitizedSpan = SpanSanitizer().sanitize(span: self)
+        try SpanEncoder().encode(sanitizedSpan, to: encoder)
     }
 }
 

--- a/Sources/Datadog/Tracing/Span/SpanSanitizer.swift
+++ b/Sources/Datadog/Tracing/Span/SpanSanitizer.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// Sanitizes `Span` representation received from the user, so it can match Datadog APM constraints.
 internal struct SpanSanitizer {
-    private let attributesSanitizer = AttributesSanitizer()
+    private let attributesSanitizer = AttributesSanitizer(featureName: "Span")
 
     func sanitize(span: Span) -> Span {
         // Sanitize attribute names

--- a/Sources/Datadog/Tracing/Span/SpanSanitizer.swift
+++ b/Sources/Datadog/Tracing/Span/SpanSanitizer.swift
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Sanitizes `Span` representation received from the user, so it can match Datadog APM constraints.
+internal struct SpanSanitizer {
+    func sanitize(span: Span) -> Span {
+        return span
+    }
+}

--- a/Sources/Datadog/Tracing/Span/SpanSanitizer.swift
+++ b/Sources/Datadog/Tracing/Span/SpanSanitizer.swift
@@ -27,27 +27,9 @@ internal struct SpanSanitizer {
             to: AttributesSanitizer.Constraints.maxNumberOfAttributes - sanitizedUserExtraInfo.count
         )
 
-        return Span(
-            traceID: span.traceID,
-            spanID: span.spanID,
-            parentID: span.parentID,
-            operationName: span.operationName,
-            serviceName: span.serviceName,
-            resource: span.resource,
-            startTime: span.startTime,
-            duration: span.duration,
-            isError: span.isError,
-            tracerVersion: span.tracerVersion,
-            applicationVersion: span.applicationVersion,
-            networkConnectionInfo: span.networkConnectionInfo,
-            mobileCarrierInfo: span.mobileCarrierInfo,
-            userInfo: .init(
-                id: span.userInfo.id,
-                name: span.userInfo.name,
-                email: span.userInfo.email,
-                extraInfo: sanitizedUserExtraInfo
-            ),
-            tags: sanitizedTags
-        )
+        var sanitizedSpan = span
+        sanitizedSpan.userInfo.extraInfo = sanitizedUserExtraInfo
+        sanitizedSpan.tags = sanitizedTags
+        return sanitizedSpan
     }
 }

--- a/Sources/Datadog/Tracing/Span/SpanSanitizer.swift
+++ b/Sources/Datadog/Tracing/Span/SpanSanitizer.swift
@@ -8,7 +8,46 @@ import Foundation
 
 /// Sanitizes `Span` representation received from the user, so it can match Datadog APM constraints.
 internal struct SpanSanitizer {
+    private let attributesSanitizer = AttributesSanitizer()
+
     func sanitize(span: Span) -> Span {
-        return span
+        // Sanitize attribute names
+        var sanitizedUserExtraInfo = attributesSanitizer.sanitizeKeys(for: span.userInfo.extraInfo)
+        var sanitizedTags = attributesSanitizer.sanitizeKeys(for: span.tags)
+
+        // Limit to max number of attributes
+        // If any attributes need to be removed, we first reduce number of
+        // span tags, then user info extra attributes.
+        sanitizedUserExtraInfo = attributesSanitizer.limitNumberOf(
+            attributes: sanitizedUserExtraInfo,
+            to: AttributesSanitizer.Constraints.maxNumberOfAttributes
+        )
+        sanitizedTags = attributesSanitizer.limitNumberOf(
+            attributes: sanitizedTags,
+            to: AttributesSanitizer.Constraints.maxNumberOfAttributes - sanitizedUserExtraInfo.count
+        )
+
+        return Span(
+            traceID: span.traceID,
+            spanID: span.spanID,
+            parentID: span.parentID,
+            operationName: span.operationName,
+            serviceName: span.serviceName,
+            resource: span.resource,
+            startTime: span.startTime,
+            duration: span.duration,
+            isError: span.isError,
+            tracerVersion: span.tracerVersion,
+            applicationVersion: span.applicationVersion,
+            networkConnectionInfo: span.networkConnectionInfo,
+            mobileCarrierInfo: span.mobileCarrierInfo,
+            userInfo: .init(
+                id: span.userInfo.id,
+                name: span.userInfo.name,
+                email: span.userInfo.email,
+                extraInfo: sanitizedUserExtraInfo
+            ),
+            tags: sanitizedTags
+        )
     }
 }

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -98,7 +98,16 @@ class TracingStorageBenchmarkTests: XCTestCase {
                 isConstrained: false
             ),
             mobileCarrierInfo: nil,
-            userInfo: .init(id: "abc-123", name: "foo", email: "foo@bar.com", extraInfo: ["str": "value", "int": 11_235, "bool": true]),
+            userInfo: .init(
+                id: "abc-123",
+                name: "foo",
+                email: "foo@bar.com",
+                extraInfo: [
+                    "str": JSONStringEncodableValue("value", encodedUsing: JSONEncoder()),
+                    "int": JSONStringEncodableValue(11_235, encodedUsing: JSONEncoder()),
+                    "bool": JSONStringEncodableValue(true, encodedUsing: JSONEncoder())
+                ]
+            ),
             tags: [
                 "tag": JSONStringEncodableValue("value", encodedUsing: JSONEncoder())
             ]

--- a/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
@@ -72,9 +72,9 @@ class LogSanitizerTests: XCTestCase {
         XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six"])
         XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven"])
         XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight"])
-        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine.ten"])
-        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine.ten_eleven"])
-        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine.ten_eleven_twelve"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight_nine_ten"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
     }
 
     func testWhenUserAttributeNameIsInvalid_itIsIgnored() {
@@ -103,7 +103,7 @@ class LogSanitizerTests: XCTestCase {
 
         let sanitized = LogSanitizer().sanitize(log: log)
 
-        XCTAssertEqual(sanitized.attributes.userAttributes.count, LogSanitizer.Constraints.maxNumberOfAttributes)
+        XCTAssertEqual(sanitized.attributes.userAttributes.count, AttributesSanitizer.Constraints.maxNumberOfAttributes)
     }
 
     func testInternalAttributesAreNotSanitized() {

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -162,6 +162,62 @@ class RelativeTracingUUIDGenerator: TracingUUIDGenerator {
     }
 }
 
+extension Span {
+    static func mockWith(
+        traceID: TracingUUID = .mockAny(),
+        spanID: TracingUUID = .mockAny(),
+        parentID: TracingUUID? = .mockAny(),
+        operationName: String = .mockAny(),
+        serviceName: String = .mockAny(),
+        resource: String = .mockAny(),
+        startTime: Date = .mockAny(),
+        duration: TimeInterval = .mockAny(),
+        isError: Bool = .mockAny(),
+        tracerVersion: String = .mockAny(),
+        applicationVersion: String = .mockAny(),
+        networkConnectionInfo: NetworkConnectionInfo? = .mockAny(),
+        mobileCarrierInfo: CarrierInfo? = .mockAny(),
+        userInfo: Span.UserInfo = .mockAny(),
+        tags: [String: JSONStringEncodableValue] = [:]
+    ) -> Span {
+        return Span(
+            traceID: traceID,
+            spanID: spanID,
+            parentID: parentID,
+            operationName: operationName,
+            serviceName: serviceName,
+            resource: resource,
+            startTime: startTime,
+            duration: duration,
+            isError: isError,
+            tracerVersion: tracerVersion,
+            applicationVersion: applicationVersion,
+            networkConnectionInfo: networkConnectionInfo,
+            mobileCarrierInfo: mobileCarrierInfo,
+            userInfo: userInfo,
+            tags: tags
+        )
+    }
+}
+
+extension Span.UserInfo {
+    static func mockWith(
+        id: String? = .mockAny(),
+        name: String? = .mockAny(),
+        email: String? = .mockAny(),
+        extraInfo: [AttributeKey: JSONStringEncodableValue] = [:]
+    ) -> Span.UserInfo {
+        return Span.UserInfo(
+            id: id,
+            name: name,
+            email: email,
+            extraInfo: extraInfo
+        )
+    }
+
+    static func mockAny() -> Span.UserInfo { .mockWith() }
+}
+
 // MARK: - Component Mocks
 
 extension Tracer {

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
@@ -1,0 +1,169 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMEventSanitizerTests: XCTestCase {
+    private let viewEvent: RUMViewEvent = .mockRandom()
+    private let resourceEvent: RUMResourceEvent = .mockRandom()
+    private let actionEvent: RUMActionEvent = .mockRandom()
+    private let errorEvent: RUMErrorEvent = .mockRandom()
+
+    func testWhenAttributeNameExceeds10NestedLevels_itIsEscapedByUnderscore() {
+        func test<DM: RUMDataModel>(model: DM) {
+            let event = RUMEvent<DM>(
+                model: model,
+                attributes: [
+                    "attribute-one": mockValue(),
+                    "attribute-one.two": mockValue(),
+                    "attribute-one.two.three": mockValue(),
+                    "attribute-one.two.three.four": mockValue(),
+                    "attribute-one.two.three.four.five": mockValue(),
+                    "attribute-one.two.three.four.five.six": mockValue(),
+                    "attribute-one.two.three.four.five.six.seven": mockValue(),
+                    "attribute-one.two.three.four.five.six.seven.eight": mockValue(),
+                    "attribute-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+                    "attribute-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+                    "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+                    "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+                ],
+                userInfoAttributes: [
+                    "user-info-one": mockValue(),
+                    "user-info-one.two": mockValue(),
+                    "user-info-one.two.three": mockValue(),
+                    "user-info-one.two.three.four": mockValue(),
+                    "user-info-one.two.three.four.five": mockValue(),
+                    "user-info-one.two.three.four.five.six": mockValue(),
+                    "user-info-one.two.three.four.five.six.seven": mockValue(),
+                    "user-info-one.two.three.four.five.six.seven.eight": mockValue(),
+                    "user-info-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+                    "user-info-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+                    "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+                    "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+                ],
+                customViewTimings: [
+                    "timing-one": .mockRandom(),
+                    "timing-one.two": .mockRandom(),
+                    "timing-one.two.three": .mockRandom(),
+                    "timing-one.two.three.four": .mockRandom(),
+                    "timing-one.two.three.four.five": .mockRandom(),
+                    "timing-one.two.three.four.five.six": .mockRandom(),
+                    "timing-one.two.three.four.five.six.seven": .mockRandom(),
+                    "timing-one.two.three.four.five.six.seven.eight": .mockRandom(),
+                    "timing-one.two.three.four.five.six.seven.eight.nine": .mockRandom(),
+                    "timing-one.two.three.four.five.six.seven.eight.nine.ten": .mockRandom(),
+                    "timing-one.two.three.four.five.six.seven.eight.nine.ten.eleven": .mockRandom(),
+                    "timing-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": .mockRandom(),
+                ]
+            )
+
+            // When
+            let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+            // Then
+            XCTAssertEqual(sanitized.attributes.count, 12)
+            XCTAssertNotNil(sanitized.attributes["attribute-one"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight_nine_ten"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+
+            XCTAssertEqual(sanitized.userInfoAttributes.count, 12)
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight_nine_ten"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+
+            XCTAssertEqual(sanitized.customViewTimings?.count, 12)
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two.three"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two.three.four"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two.three.four.five"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two.three.four.five.six"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two.three.four.five.six.seven"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two.three.four.five.six.seven.eight"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two.three.four.five.six.seven.eight_nine_ten"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
+            XCTAssertNotNil(sanitized.customViewTimings?["timing-one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+        }
+
+        test(model: viewEvent)
+        test(model: resourceEvent)
+        test(model: actionEvent)
+        test(model: errorEvent)
+    }
+
+    func testWhenNumberOfAttributesExceedsLimit_itDropsExtraOnes() {
+        func test<DM: RUMDataModel>(model: DM) {
+            let oneThirdOfTheLimit = Int(Double(AttributesSanitizer.Constraints.maxNumberOfAttributes) * 0.34)
+            let tripleTheLimit = AttributesSanitizer.Constraints.maxNumberOfAttributes * 3
+
+            let numberOfAttributes: Int = .random(in: oneThirdOfTheLimit...tripleTheLimit)
+            let numberOfUserInfoAttributes: Int = .random(in: oneThirdOfTheLimit...tripleTheLimit)
+            let numberOfTimings: Int = .random(in: oneThirdOfTheLimit...tripleTheLimit)
+
+            let mockAttributes = (0..<numberOfAttributes).map { index in
+                ("attribute-\(index)", mockValue())
+            }
+            let mockUserInfoAttributes = (0..<numberOfUserInfoAttributes).map { index in
+                ("user-info-\(index)", mockValue())
+            }
+            let mockTimings = (0..<numberOfTimings).map { index in
+                ("timing-\(index)", Int64.mockAny())
+            }
+
+            let event = RUMEvent<DM>(
+                model: model,
+                attributes: Dictionary(uniqueKeysWithValues: mockAttributes),
+                userInfoAttributes: Dictionary(uniqueKeysWithValues: mockUserInfoAttributes),
+                customViewTimings: Dictionary(uniqueKeysWithValues: mockTimings)
+            )
+
+            // When
+            let sanitized = RUMEventSanitizer().sanitize(event: event)
+
+            // Then
+            XCTAssertEqual(
+                sanitized.attributes.count + sanitized.userInfoAttributes.count + (sanitized.customViewTimings?.count ?? 0),
+                AttributesSanitizer.Constraints.maxNumberOfAttributes
+            )
+            XCTAssertTrue(
+                (sanitized.customViewTimings?.count ?? 0) >= sanitized.userInfoAttributes.count,
+                "If number of attributes needs to be limited, `userInfoAttributes` are removed prior to `customViewTimings`."
+            )
+            XCTAssertTrue(
+                sanitized.userInfoAttributes.count >= sanitized.attributes.count,
+                "If number of attributes needs to be limited, `attributes` are removed prior to `userInfoAttributes`."
+            )
+        }
+
+        test(model: viewEvent)
+        test(model: resourceEvent)
+        test(model: actionEvent)
+        test(model: errorEvent)
+    }
+
+    // MARK: - Private
+
+    private func mockValue() -> String {
+        return .mockAny()
+    }
+}

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanSanitizerTests.swift
@@ -1,0 +1,116 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class SpanSanitizerTests: XCTestCase {
+    func testWhenAttributeNameExceeds10NestedLevels_itIsEscapedByUnderscore() {
+        let span = Span.mockWith(
+            userInfo: .mockWith(
+                extraInfo: [
+                    "extra-info-one": mockValue(),
+                    "extra-info-one.two": mockValue(),
+                    "extra-info-one.two.three": mockValue(),
+                    "extra-info-one.two.three.four": mockValue(),
+                    "extra-info-one.two.three.four.five": mockValue(),
+                    "extra-info-one.two.three.four.five.six": mockValue(),
+                    "extra-info-one.two.three.four.five.six.seven": mockValue(),
+                    "extra-info-one.two.three.four.five.six.seven.eight": mockValue(),
+                    "extra-info-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+                    "extra-info-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+                    "extra-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+                    "extra-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+                ]
+            ),
+            tags: [
+                "tag-one": mockValue(),
+                "tag-one.two": mockValue(),
+                "tag-one.two.three": mockValue(),
+                "tag-one.two.three.four": mockValue(),
+                "tag-one.two.three.four.five": mockValue(),
+                "tag-one.two.three.four.five.six": mockValue(),
+                "tag-one.two.three.four.five.six.seven": mockValue(),
+                "tag-one.two.three.four.five.six.seven.eight": mockValue(),
+                "tag-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+                "tag-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+                "tag-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+                "tag-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+            ]
+        )
+
+        // When
+        let sanitized = SpanSanitizer().sanitize(span: span)
+
+        // Then
+        XCTAssertEqual(sanitized.userInfo.extraInfo.count, 12)
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight_nine_ten"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+
+        XCTAssertEqual(sanitized.tags.count, 12)
+        XCTAssertNotNil(sanitized.tags["tag-one"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight_nine_ten"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+    }
+
+    func testWhenNumberOfAttributesExceedsLimit_itDropsExtraOnes() {
+        let halfTheLimit = Int(Double(AttributesSanitizer.Constraints.maxNumberOfAttributes) * 0.5)
+        let twiceTheLimit = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
+
+        let numberOfUserExtraAttributes: Int = .random(in: halfTheLimit...twiceTheLimit)
+        let numberOfTags: Int = .random(in: halfTheLimit...twiceTheLimit)
+
+        let mockUserExtraAttributes = (0..<numberOfUserExtraAttributes).map { index in
+            ("extra-info-\(index)", mockValue())
+        }
+        let mockTags = (0..<numberOfTags).map { index in
+            ("tag-\(index)", mockValue())
+        }
+
+        let span = Span.mockWith(
+            userInfo: .mockWith(
+                extraInfo: Dictionary(uniqueKeysWithValues: mockUserExtraAttributes)
+            ),
+            tags: Dictionary(uniqueKeysWithValues: mockTags)
+        )
+
+        // When
+        let sanitized = SpanSanitizer().sanitize(span: span)
+
+        // Then
+        XCTAssertEqual(
+            sanitized.userInfo.extraInfo.count + sanitized.tags.count,
+            AttributesSanitizer.Constraints.maxNumberOfAttributes
+        )
+        XCTAssertTrue(
+            sanitized.userInfo.extraInfo.count >= sanitized.tags.count,
+            "If number of attributes needs to be limited, `tags` are removed prior to `extraInfo` attributes."
+        )
+    }
+
+    // MARK: - Private
+
+    private func mockValue() -> JSONStringEncodableValue {
+        return JSONStringEncodableValue(String.mockAny(), encodedUsing: JSONEncoder())
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR adds `Span` and `RUMEvent` attributes sanitization as it exists for `Logs`. The same rules were applied, unified with `dd-sdk-android` (https://github.com/DataDog/dd-sdk-android/pull/427).

### How?

Similar to `LogSanitizer`, two new sanitizers are introduced:
* `SpanSanitizer`,
* `RUMEventSanitizer`.

All three share common `AttributesSanitizer` which applies equal rules to all attributes with dynamic count:
* `Span` tags,
* `Span` meta information coming from `UserInfo.extraInfo`,
* `RUMEvent<DM>` attributes,
* `RUMEvent<DM>` attributes coming from `UserInfo.extraInfo`,
* `RUMEvent<DM>` custom view timings.

Only two rules are shared:
* attribute key may contain up to 8 nested levels (`"one.two.(...).eight"`),
* there can be up to `128` attributes in total.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
