### PR TITLE
RUMM-989 Fix compiler error in Notification Service Extension

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		615AAC36251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 615AAC35251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard */; };
 		615C3155251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3154251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift */; };
 		615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */; };
+		615F197C25B5A64B00BE14B5 /* UIKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */; };
 		6164AE89252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6164AE88252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift */; };
 		6164AF06252C9004000D78C4 /* ObjcSendFirstPartyRequestsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6164AF05252C9004000D78C4 /* ObjcSendFirstPartyRequestsViewController.m */; };
 		6164AF0E252C9016000D78C4 /* ObjcSendThirdPartyRequestsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6164AF0D252C9016000D78C4 /* ObjcSendThirdPartyRequestsViewController.m */; };
@@ -571,6 +572,7 @@
 		615AAC35251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMTabBarAutoInstrumentationScenario.storyboard; sourceTree = "<group>"; };
 		615C3154251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASVariousUIControllsViewController.swift; sourceTree = "<group>"; };
 		615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandlerTests.swift; sourceTree = "<group>"; };
+		615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensions.swift; sourceTree = "<group>"; };
 		6164AE88252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendThirdPartyRequestsViewController.swift; sourceTree = "<group>"; };
 		6164AF04252C9004000D78C4 /* ObjcSendFirstPartyRequestsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcSendFirstPartyRequestsViewController.h; sourceTree = "<group>"; };
 		6164AF05252C9004000D78C4 /* ObjcSendFirstPartyRequestsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcSendFirstPartyRequestsViewController.m; sourceTree = "<group>"; };
@@ -947,6 +949,7 @@
 				61133BB82423979B00786299 /* InternalLoggers.swift */,
 				61133BB92423979B00786299 /* CompilationConditions.swift */,
 				61133BBA2423979B00786299 /* SwiftExtensions.swift */,
+				615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2511,6 +2514,7 @@
 				6157FA5E252767CB009A8A3B /* URLSessionRUMResourcesHandler.swift in Sources */,
 				616CCE13250A1868009FED46 /* RUMCommandSubscriber.swift in Sources */,
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
+				615F197C25B5A64B00BE14B5 /* UIKitExtensions.swift in Sources */,
 				614D812C24E3EA15004C9C5D /* Feature.swift in Sources */,
 				61B0385A2527247000518F3C /* DDURLSessionDelegate.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspector.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitHierarchyInspection/UIKitHierarchyInspector.swift
@@ -18,7 +18,7 @@ internal struct UIKitHierarchyInspector: UIKitHierarchyInspectorType {
 
     init(
         rootViewControllerProvider: @escaping () -> UIViewController? = {
-            let keyWindow = UIApplication.shared.windows.first { $0.isKeyWindow }
+            let keyWindow = UIApplication.managedShared?.windows.first { $0.isKeyWindow }
             return keyWindow?.rootViewController
         }
     ) {

--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -96,7 +96,7 @@ internal class RUMDebugging {
             canvas.addSubview(view)
         }
         if canvas.superview == nil,
-            let someWindow = UIApplication.shared.keyWindow {
+            let someWindow = UIApplication.managedShared?.keyWindow {
             canvas.frame.size = someWindow.bounds.size
             someWindow.addSubview(canvas)
         }

--- a/Sources/Datadog/Utils/UIKitExtensions.swift
+++ b/Sources/Datadog/Utils/UIKitExtensions.swift
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal extension UIApplication {
+    /// `UIApplication.shared` does not compile in some environments (e.g. notification service app extension), resulting with:
+    /// _"shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead"_.
+    ///
+    /// As a workaround, this `managedShared` utility provides a key-path access to the `UIApplication.shared` to make the compiler pass.
+    static var managedShared: UIApplication? {
+        return UIApplication
+            .value(forKeyPath: #keyPath(UIApplication.shared)) as? UIApplication // swiftlint:disable:this unsafe_uiapplication_shared
+    }
+}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -47,14 +47,14 @@ workflows:
     description: |-
         Runs swiftlint and license check for all source and test files.
     steps:
-    - swiftlint@0.7.0:
+    - swiftlint@0.8.0:
         title: Lint Sources/*
         inputs:
         - strict: 'yes'
         - lint_config_file: "$BITRISE_SOURCE_DIR/tools/lint/sources.swiftlint.yml"
         - linting_path: "$BITRISE_SOURCE_DIR"
         - reporter: emoji
-    - swiftlint@0.7.0:
+    - swiftlint@0.8.0:
         title: Lint Tests/*
         is_always_run: true
         inputs:

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -79,6 +79,15 @@ custom_rules:
       - comment
     message: "All TODOs must be followed by JIRA reference, for example: \"TODO: RUMM-123\""
     severity: error
+  unsafe_uiapplication_shared: # prevents from using `UIApplication.shared` API
+    included: Sources
+    name: "Unsafe API: `UIApplication.shared`"
+    regex: '(UIApplication.shared)|(UIApplication = .shared)'
+    excluded_match_kinds: 
+      - comment
+      - doccomment
+    message: "`UIApplication.shared` is unavailable in some environments. Check `UIApplication.managedShared`."
+    severity: error
 
 included:
   - Sources


### PR DESCRIPTION
### What and why?

🔧 When compiling the SDK for some app extension types (e.g. Notification Service Extension), compiler error is issued:
> `'shared'` is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead

Solves #370, qualifies for `1.4.1` hotfix.

### How?

There is no [compiler control statement](https://docs.swift.org/swift-book/ReferenceManual/Statements.html#ID538) to exclude [`UIApplication.shared`](https://developer.apple.com/documentation/uikit/uiapplication/1622975-shared) usage in iOS app extension, so I used a known workaround (https://github.com/slackhq/PanModal/pull/81) of referencing it using key-path.

Convenient extension of `UIApplication.managedShared: UIApplication?` is created and swift-lint rule is added to enforce its usage. This required bumping the swift-lint version in `bitrise.yml` to leverage its new `excluded_match_kinds` syntax.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
