### PR TITLE
RUMM-786 Support RUM Explorer's indicator for active views

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -70,6 +70,8 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
     // MARK: - RUMContextProvider
 
     var context: RUMContext {
+        // Per `RUMCurrentContext.activeViewContext`, we currently only get the context from the parent scope (`RUMViewScope`) when it's still active (`viewScopes.last`).
+        // This might change at some point and the following context might then hold the wrong active view's properties at that point as this is not checked inside `RUMViewScope.context`.
         return parent.context
     }
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -76,9 +76,11 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
     var context: RUMContext {
         var context = parent.context
-        context.activeViewID = viewUUID
-        context.activeViewURI = viewURI
-        context.activeUserActionID = userActionScope?.actionUUID
+        if isActiveView {
+            context.activeViewID = viewUUID
+            context.activeViewURI = viewURI
+            context.activeUserActionID = userActionScope?.actionUUID
+        }
         return context
     }
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -278,7 +278,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 firstContentfulPaint: nil,
                 firstInputDelay: nil,
                 id: viewUUID.toRUMDataFormat,
-                isActive: nil,
+                isActive: isActiveView,
                 largestContentfulPaint: nil,
                 loadEvent: nil,
                 loadingTime: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -76,11 +76,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
     var context: RUMContext {
         var context = parent.context
-        if isActiveView {
-            context.activeViewID = viewUUID
-            context.activeViewURI = viewURI
-            context.activeUserActionID = userActionScope?.actionUUID
-        }
+        context.activeViewID = viewUUID
+        context.activeViewURI = viewURI
+        context.activeUserActionID = userActionScope?.actionUUID
         return context
     }
 

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
@@ -61,10 +61,6 @@ extension RUMSessionMatcher {
         return sessionMatchers.first
     }
 
-    class func assertViewWasInitiallyActive(_ viewVisit: ViewVisit) {
-        XCTAssertTrue(try XCTUnwrap(viewVisit.viewEvents.first?.view.isActive))
-    }
-
     class func assertViewWasEventuallyInactive(_ viewVisit: ViewVisit) {
         XCTAssertFalse(try XCTUnwrap(viewVisit.viewEvents.last?.view.isActive))
     }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
@@ -60,4 +60,12 @@ extension RUMSessionMatcher {
 
         return sessionMatchers.first
     }
+
+    class func assertViewWasInitiallyActive(_ viewVisit: ViewVisit) {
+        XCTAssertTrue(try XCTUnwrap(viewVisit.viewEvents.first?.view.isActive))
+    }
+
+    class func assertViewWasEventuallyInactive(_ viewVisit: ViewVisit) {
+        XCTAssertFalse(try XCTUnwrap(viewVisit.viewEvents.last?.view.isActive))
+    }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -76,7 +76,6 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view1.errorEvents[0].error.resource?.url, "https://foo.com/resource/2")
         XCTAssertEqual(view1.errorEvents[0].error.resource?.method, .get)
         XCTAssertEqual(view1.errorEvents[0].error.resource?.statusCode, 400)
-        RUMSessionMatcher.assertViewWasInitiallyActive(view1)
         RUMSessionMatcher.assertViewWasEventuallyInactive(view1)
 
         let contentReadyTiming = try XCTUnwrap(view1.viewEventMatchers.last?.timing(named: "content-ready"))
@@ -93,7 +92,6 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view2.viewEvents.last?.view.error.count, 1)
         XCTAssertEqual(view2.errorEvents[0].error.message, "Simulated view error")
         XCTAssertEqual(view2.errorEvents[0].error.source, .source)
-        RUMSessionMatcher.assertViewWasInitiallyActive(view2)
         RUMSessionMatcher.assertViewWasEventuallyInactive(view2)
 
         let view3 = session.viewVisits[2]
@@ -101,6 +99,5 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view3.viewEvents.last?.view.action.count, 0)
         XCTAssertEqual(view3.viewEvents.last?.view.resource.count, 0)
         XCTAssertEqual(view3.viewEvents.last?.view.error.count, 0)
-        RUMSessionMatcher.assertViewWasInitiallyActive(view3)
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -76,6 +76,8 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view1.errorEvents[0].error.resource?.url, "https://foo.com/resource/2")
         XCTAssertEqual(view1.errorEvents[0].error.resource?.method, .get)
         XCTAssertEqual(view1.errorEvents[0].error.resource?.statusCode, 400)
+        RUMSessionMatcher.assertViewWasInitiallyActive(view1)
+        RUMSessionMatcher.assertViewWasEventuallyInactive(view1)
 
         let contentReadyTiming = try XCTUnwrap(view1.viewEventMatchers.last?.timing(named: "content-ready"))
         let firstInteractionTiming = try XCTUnwrap(view1.viewEventMatchers.last?.timing(named: "first-interaction"))
@@ -91,11 +93,14 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view2.viewEvents.last?.view.error.count, 1)
         XCTAssertEqual(view2.errorEvents[0].error.message, "Simulated view error")
         XCTAssertEqual(view2.errorEvents[0].error.source, .source)
+        RUMSessionMatcher.assertViewWasInitiallyActive(view2)
+        RUMSessionMatcher.assertViewWasEventuallyInactive(view2)
 
         let view3 = session.viewVisits[2]
         XCTAssertEqual(view3.path, "SendRUMFixture3ViewController")
         XCTAssertEqual(view3.viewEvents.last?.view.action.count, 0)
         XCTAssertEqual(view3.viewEvents.last?.view.resource.count, 0)
         XCTAssertEqual(view3.viewEvents.last?.view.error.count, 0)
+        RUMSessionMatcher.assertViewWasInitiallyActive(view3)
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
@@ -63,38 +63,29 @@ class RUMModalViewsScenarioTests: IntegrationTests, RUMCommonAsserts {
         XCTAssertEqual(visits[0].path, "Screen")
         XCTAssertEqual(visits[0].actionEvents[0].action.type, .applicationStart)
         XCTAssertGreaterThan(visits[0].actionEvents[0].action.loadingTime!, 0)
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[0]) // start on "Screen"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[0]) // go to modal "Modal"
 
         XCTAssertEqual(visits[1].path, "Modal")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[1]) // go to modal "Modal"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[1]) // dismiss to "Screen"
 
         XCTAssertEqual(visits[2].path, "Screen")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[2]) // dismiss to "Screen"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[2]) // go to modal "Modal"
 
         XCTAssertEqual(visits[3].path, "Modal")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[3]) // go to modal "Modal"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[3]) // interactive dismiss to "Screen"
 
         XCTAssertEqual(visits[4].path, "Screen")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[4]) // interactive dismiss to "Screen"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[4]) // go to modal "Modal"
 
         XCTAssertEqual(visits[5].path, "Modal")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[5]) // go to modal "Modal"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[5]) // interactive and cancelled dismiss, stay on "Modal"
 
         XCTAssertEqual(visits[6].path, "Screen")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[6])  // interactive and cancelled dismiss, stay on "Modal"
-        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[6])
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[6]) // interactive and cancelled dismiss, stay on "Modal"
 
         XCTAssertEqual(visits[7].path, "Modal")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[7]) // interactive and cancelled dismiss, stay on "Modal"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[7]) // dismiss to "Screen"
 
         XCTAssertEqual(visits[8].path, "Screen")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[8]) // dismiss to "Screen"
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
@@ -59,16 +59,42 @@ class RUMModalViewsScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
-        XCTAssertEqual(session.viewVisits[0].path, "Screen")
-        XCTAssertEqual(session.viewVisits[0].actionEvents[0].action.type, .applicationStart)
-        XCTAssertGreaterThan(session.viewVisits[0].actionEvents[0].action.loadingTime!, 0)
-        XCTAssertEqual(session.viewVisits[1].path, "Modal")
-        XCTAssertEqual(session.viewVisits[2].path, "Screen")
-        XCTAssertEqual(session.viewVisits[3].path, "Modal")
-        XCTAssertEqual(session.viewVisits[4].path, "Screen")
-        XCTAssertEqual(session.viewVisits[5].path, "Modal")
-        XCTAssertEqual(session.viewVisits[6].path, "Screen")
-        XCTAssertEqual(session.viewVisits[7].path, "Modal")
-        XCTAssertEqual(session.viewVisits[8].path, "Screen")
+        let visits = session.viewVisits
+        XCTAssertEqual(visits[0].path, "Screen")
+        XCTAssertEqual(visits[0].actionEvents[0].action.type, .applicationStart)
+        XCTAssertGreaterThan(visits[0].actionEvents[0].action.loadingTime!, 0)
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[0]) // start on "Screen"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[0]) // go to modal "Modal"
+
+        XCTAssertEqual(visits[1].path, "Modal")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[1]) // go to modal "Modal"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[1]) // dismiss to "Screen"
+
+        XCTAssertEqual(visits[2].path, "Screen")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[2]) // dismiss to "Screen"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[2]) // go to modal "Modal"
+
+        XCTAssertEqual(visits[3].path, "Modal")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[3]) // go to modal "Modal"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[3]) // interactive dismiss to "Screen"
+
+        XCTAssertEqual(visits[4].path, "Screen")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[4]) // interactive dismiss to "Screen"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[4]) // go to modal "Modal"
+
+        XCTAssertEqual(visits[5].path, "Modal")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[5]) // go to modal "Modal"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[5]) // interactive and cancelled dismiss, stay on "Modal"
+
+        XCTAssertEqual(visits[6].path, "Screen")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[6])  // interactive and cancelled dismiss, stay on "Modal"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[6])
+
+        XCTAssertEqual(visits[7].path, "Modal")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[7]) // interactive and cancelled dismiss, stay on "Modal"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[7]) // dismiss to "Screen"
+
+        XCTAssertEqual(visits[8].path, "Screen")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[8]) // dismiss to "Screen"
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -61,34 +61,26 @@ class RUMNavigationControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         XCTAssertEqual(visits[0].path, "Screen1")
         XCTAssertEqual(visits[0].actionEvents[0].action.type, .applicationStart)
         XCTAssertGreaterThan(visits[0].actionEvents[0].action.loadingTime!, 0)
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[0]) // start on "Screen1"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[0]) // go to "Screen2"
 
         XCTAssertEqual(session.viewVisits[1].path, "Screen2")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[1]) // go to "Screen2"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[1])// go to "Screen3"
 
         XCTAssertEqual(session.viewVisits[2].path, "Screen3")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[2]) // go to "Screen3"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[2])// go to "Screen4"
 
         XCTAssertEqual(session.viewVisits[3].path, "Screen4")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[3]) // go to "Screen4"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[3])// go to "Screen3"
 
         XCTAssertEqual(session.viewVisits[4].path, "Screen3")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[4]) // go to "Screen3"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[4])// go to "Screen1"
 
         XCTAssertEqual(session.viewVisits[5].path, "Screen1")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[5]) // go to "Screen1"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[5])// go to "Screen2"
 
         XCTAssertEqual(session.viewVisits[6].path, "Screen2")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[6]) // go to "Screen2"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[6])// swipe back to "Screen1"
 
         XCTAssertEqual(session.viewVisits[7].path, "Screen1")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[7]) // swipe back to "Screen1"
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -56,15 +56,39 @@ class RUMNavigationControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
-        XCTAssertEqual(session.viewVisits[0].path, "Screen1")
-        XCTAssertEqual(session.viewVisits[0].actionEvents[0].action.type, .applicationStart)
-        XCTAssertGreaterThan(session.viewVisits[0].actionEvents[0].action.loadingTime!, 0)
+        let visits = session.viewVisits
+
+        XCTAssertEqual(visits[0].path, "Screen1")
+        XCTAssertEqual(visits[0].actionEvents[0].action.type, .applicationStart)
+        XCTAssertGreaterThan(visits[0].actionEvents[0].action.loadingTime!, 0)
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[0]) // start on "Screen1"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[0]) // go to "Screen2"
+
         XCTAssertEqual(session.viewVisits[1].path, "Screen2")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[1]) // go to "Screen2"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[1])// go to "Screen3"
+
         XCTAssertEqual(session.viewVisits[2].path, "Screen3")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[2]) // go to "Screen3"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[2])// go to "Screen4"
+
         XCTAssertEqual(session.viewVisits[3].path, "Screen4")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[3]) // go to "Screen4"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[3])// go to "Screen3"
+
         XCTAssertEqual(session.viewVisits[4].path, "Screen3")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[4]) // go to "Screen3"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[4])// go to "Screen1"
+
         XCTAssertEqual(session.viewVisits[5].path, "Screen1")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[5]) // go to "Screen1"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[5])// go to "Screen2"
+
         XCTAssertEqual(session.viewVisits[6].path, "Screen2")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[6]) // go to "Screen2"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[6])// swipe back to "Screen1"
+
         XCTAssertEqual(session.viewVisits[7].path, "Screen1")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[7]) // swipe back to "Screen1"
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
@@ -56,38 +56,29 @@ class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         XCTAssertEqual(session.viewVisits[0].path, "Screen A")
         XCTAssertEqual(session.viewVisits[0].actionEvents[0].action.type, .applicationStart)
         XCTAssertGreaterThan(session.viewVisits[0].actionEvents[0].action.loadingTime!, 0)
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[0]) // start on "Screen A"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[0]) // go to "Screen B1"
 
         XCTAssertEqual(session.viewVisits[1].path, "Screen B1")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[1]) // go to "Screen B1"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[1])// go to "Screen B2"
 
         XCTAssertEqual(session.viewVisits[2].path, "Screen B2")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[2]) // go to "Screen B2"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[2])// go to "Screen B1"
 
         XCTAssertEqual(session.viewVisits[3].path, "Screen B1")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[3]) // go to "Screen B1"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[3])// go to "Screen C1"
 
         XCTAssertEqual(session.viewVisits[4].path, "Screen C1")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[4]) // go to "Screen C1"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[4])// go to "Screen C2"
 
         XCTAssertEqual(session.viewVisits[5].path, "Screen C2")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[5]) // go to "Screen C2"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[5])// go to "Screen A"
 
         XCTAssertEqual(session.viewVisits[6].path, "Screen A")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[6]) // go to "Screen A"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[6])// go to "Screen C2"
 
         XCTAssertEqual(session.viewVisits[7].path, "Screen C2")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[7]) // go to "Screen C2"
         RUMSessionMatcher.assertViewWasEventuallyInactive(visits[7])// go to "Screen C1"
 
         XCTAssertEqual(session.viewVisits[8].path, "Screen C1")
-        RUMSessionMatcher.assertViewWasInitiallyActive(visits[8]) // go to "Screen C1"
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
@@ -51,16 +51,43 @@ class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
+        let visits = session.viewVisits
+
         XCTAssertEqual(session.viewVisits[0].path, "Screen A")
         XCTAssertEqual(session.viewVisits[0].actionEvents[0].action.type, .applicationStart)
         XCTAssertGreaterThan(session.viewVisits[0].actionEvents[0].action.loadingTime!, 0)
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[0]) // start on "Screen A"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[0]) // go to "Screen B1"
+
         XCTAssertEqual(session.viewVisits[1].path, "Screen B1")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[1]) // go to "Screen B1"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[1])// go to "Screen B2"
+
         XCTAssertEqual(session.viewVisits[2].path, "Screen B2")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[2]) // go to "Screen B2"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[2])// go to "Screen B1"
+
         XCTAssertEqual(session.viewVisits[3].path, "Screen B1")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[3]) // go to "Screen B1"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[3])// go to "Screen C1"
+
         XCTAssertEqual(session.viewVisits[4].path, "Screen C1")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[4]) // go to "Screen C1"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[4])// go to "Screen C2"
+
         XCTAssertEqual(session.viewVisits[5].path, "Screen C2")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[5]) // go to "Screen C2"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[5])// go to "Screen A"
+
         XCTAssertEqual(session.viewVisits[6].path, "Screen A")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[6]) // go to "Screen A"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[6])// go to "Screen C2"
+
         XCTAssertEqual(session.viewVisits[7].path, "Screen C2")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[7]) // go to "Screen C2"
+        RUMSessionMatcher.assertViewWasEventuallyInactive(visits[7])// go to "Screen C1"
+
         XCTAssertEqual(session.viewVisits[8].path, "Screen C1")
+        RUMSessionMatcher.assertViewWasInitiallyActive(visits[8]) // go to "Screen C1"
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -232,15 +232,13 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self)
-        XCTAssertTrue(viewEvents.count == 2)
-        if viewEvents.count == 2 {
-            let view1WasActive = try XCTUnwrap(viewEvents[0].model.view.isActive)
-            XCTAssertTrue(view1WasActive)
-            XCTAssertEqual(viewEvents[1].model.view.url, "FirstViewController")
-            let view2IsActive = try XCTUnwrap(viewEvents[1].model.view.isActive)
-            XCTAssertFalse(view2IsActive)
-            XCTAssertEqual(viewEvents[1].model.view.timeSpent, TimeInterval(1).toInt64Nanoseconds, "The View should last for 1 second")
-        }
+        XCTAssertEqual(viewEvents.count, 2)
+        let view1WasActive = try XCTUnwrap(viewEvents[0].model.view.isActive)
+        XCTAssertTrue(view1WasActive)
+        XCTAssertEqual(viewEvents[1].model.view.url, "FirstViewController")
+        let view2IsActive = try XCTUnwrap(viewEvents[1].model.view.isActive)
+        XCTAssertFalse(view2IsActive)
+        XCTAssertEqual(viewEvents[1].model.view.timeSpent, TimeInterval(1).toInt64Nanoseconds, "The View should last for 1 second")
     }
 
     func testWhenTheViewIsStartedAnotherTime_itEndsTheScope() throws {
@@ -267,15 +265,13 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         let viewEvents = try output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self)
-        XCTAssertTrue(viewEvents.count == 2)
-        if viewEvents.count == 2 {
-            let viewWasActive = try XCTUnwrap(viewEvents[0].model.view.isActive)
-            XCTAssertTrue(viewWasActive)
-            XCTAssertEqual(viewEvents[0].model.view.url, "FirstViewController")
-            let viewIsActive = try XCTUnwrap(viewEvents[1].model.view.isActive)
-            XCTAssertFalse(viewIsActive)
-            XCTAssertEqual(viewEvents[0].model.view.timeSpent, TimeInterval(1).toInt64Nanoseconds, "The View should last for 1 second")
-        }
+        XCTAssertEqual(viewEvents.count, 2)
+        let viewWasActive = try XCTUnwrap(viewEvents[0].model.view.isActive)
+        XCTAssertTrue(viewWasActive)
+        XCTAssertEqual(viewEvents[0].model.view.url, "FirstViewController")
+        let viewIsActive = try XCTUnwrap(viewEvents[1].model.view.isActive)
+        XCTAssertFalse(viewIsActive)
+        XCTAssertEqual(viewEvents[0].model.view.timeSpent, TimeInterval(1).toInt64Nanoseconds, "The View should last for 1 second")
     }
 
     func testGivenMultipleViewScopes_whenSendingViewEvent_eachScopeUsesUniqueViewID() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -114,7 +114,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertValidRumUUID(event.model.view.id)
         XCTAssertEqual(event.model.view.url, "UIViewController")
         XCTAssertEqual(event.model.view.timeSpent, 0)
-        XCTAssertEqual(event.model.view.action.count, 1, "The initial view udate must have come with `applicat_start` action sent.")
+        XCTAssertEqual(event.model.view.action.count, 1, "The initial view udate must have come with `application_start` action sent.")
         XCTAssertEqual(event.model.view.error.count, 0)
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -169,6 +169,28 @@ internal class RUMSessionMatcher {
             }
         }
 
+        // Validate ViewVisit's view.isActive for each events
+        try visits.forEach { visit in
+            var viewWasPreviouslyActive = false
+            try visit.viewEvents.enumerated().forEach { index, viewEvent in
+                let viewIsActive = viewEvent.view.isActive!
+                if index == 0 {
+                    if !viewIsActive {
+                        throw RUMSessionConsistencyException(
+                            description: "A `RUMSessionMatcher.ViewVisit` can't have a first event with an inactive `View`."
+                        )
+                    }
+                } else {
+                    if !viewWasPreviouslyActive && viewIsActive {
+                        throw RUMSessionConsistencyException(
+                            description: "A `RUMSessionMatcher.ViewVisit` can't have an event where a `View` is active after the `View` was marked as inactive."
+                        )
+                    }
+                }
+                viewWasPreviouslyActive = viewIsActive
+            }
+        }
+
         self.viewVisits = visitsEventOrderedByTime
     }
 }


### PR DESCRIPTION
### What and why?

This is the iOS counter-part of RUMM-787 / #430.
As a reminder, it sets the `view.is_active` attribute for RUM Views to let the frontend know when a View is still in progress.

### How?

In `dd-sdk-ios`, the `RUMViewScope` was already able to handle `RUMStartViewCommand` and `RUMStopViewCommand` and it was tracking some `isActiveView`. This change makes sure a `RUMViewEvent` gets a `View` with its `isActive` property's value matching `RUMViewScope.isActiveView`'s value.

This PR also changes the behaviour of `RUMViewScope.context` by checking `isActiveView` before setting/overwriting `RUMContext.active*` properties.

Finally, it updates existing unit and integration tests to assert on the `view.isActive` based on a given navigation path.

### Review checklist

- ✅ Feature or bugfix MUST have appropriate tests (unit, integration)
- ✅ Make sure each commit and the PR mention the Issue number or JIRA reference
