### PR TITLE
RUMM-954 DDURLSessionDelegate takes firstPartyHosts in init

### DIFF
--- a/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
+++ b/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
@@ -141,7 +141,7 @@ final class RUMResourcesScenario: URLSessionBaseScenario, TestScenario {
         _ = builder
             .trackUIKitRUMViews(using: DefaultUIKitRUMViewsPredicate())
 
-        super.configureSDK(builder: builder) // applies the `track(firstPartyHosts:)`
+        super.configureSDK(builder: builder) // applies the `trackURLSession(firstPartyHosts:)`
     }
 }
 

--- a/Datadog/Example/Scenarios/TrackingConsent/TrackingConsentScenarios.swift
+++ b/Datadog/Example/Scenarios/TrackingConsent/TrackingConsentScenarios.swift
@@ -17,7 +17,7 @@ internal class TrackingConsentBaseScenario {
         _ = builder
             .trackUIKitRUMViews(using: DefaultUIKitRUMViewsPredicate())
             .trackUIKitActions(true)
-            .track(firstPartyHosts: ["datadoghq.com"])
+            .trackURLSession(firstPartyHosts: ["datadoghq.com"])
     }
 }
 

--- a/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/ObjcSendFirstPartyRequestsViewController.m
+++ b/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/ObjcSendFirstPartyRequestsViewController.m
@@ -19,9 +19,8 @@
     [super viewDidLoad];
 
     self.testScenario = SwiftGlobals.currentTestScenario;
-    self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
-                                                 delegate:[DDNSURLSessionDelegate new]
-                                            delegateQueue:nil];
+
+    self.session = [self.testScenario buildURLSession];
     assert(self.testScenario != nil);
 }
 

--- a/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/ObjcSendThirdPartyRequestsViewController.m
+++ b/Datadog/Example/Scenarios/URLSession/NSURLSessionAutoInstrumentation/ObjcSendThirdPartyRequestsViewController.m
@@ -18,9 +18,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.testScenario = SwiftGlobals.currentTestScenario;
-    self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
-                                                 delegate:[DDNSURLSessionDelegate new]
-                                            delegateQueue:nil];
+    self.session = [self.testScenario buildURLSession];
     assert(self.testScenario != nil);
 }
 

--- a/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/SendFirstPartyRequestsViewController.swift
+++ b/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/SendFirstPartyRequestsViewController.swift
@@ -10,11 +10,7 @@ import Datadog
 
 internal class SendFirstPartyRequestsViewController: UIViewController {
     private var testScenario: URLSessionBaseScenario!
-    private lazy var session = URLSession(
-        configuration: .default,
-        delegate: DDURLSessionDelegate(),
-        delegateQueue: nil
-    )
+    private lazy var session = testScenario.buildURLSession()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/SendThirdPartyRequestsViewController.swift
+++ b/Datadog/Example/Scenarios/URLSession/URLSessionAutoInstrumentation/SendThirdPartyRequestsViewController.swift
@@ -10,11 +10,7 @@ import Datadog
 
 internal class SendThirdPartyRequestsViewController: UIViewController {
     private var testScenario: URLSessionBaseScenario!
-    private lazy var session = URLSession(
-        configuration: .default,
-        delegate: DDURLSessionDelegate(),
-        delegateQueue: nil
-    )
+    private lazy var session = testScenario.buildURLSession()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Datadog/Example/Scenarios/URLSession/URLSessionScenarios.swift
+++ b/Datadog/Example/Scenarios/URLSession/URLSessionScenarios.swift
@@ -69,7 +69,8 @@ class URLSessionBaseScenario: NSObject {
     }
 
     func configureSDK(builder: Datadog.Configuration.Builder) {
-        _ = builder
-            .track(firstPartyHosts: [customGETResourceURL.host!, customPOSTRequest.url!.host!, badResourceURL.host!])
+        _ = builder.trackURLSession(
+            firstPartyHosts: [customGETResourceURL.host!, customPOSTRequest.url!.host!, badResourceURL.host!]
+        )
     }
 }

--- a/Datadog/Example/Scenarios/URLSession/URLSessionScenarios.swift
+++ b/Datadog/Example/Scenarios/URLSession/URLSessionScenarios.swift
@@ -14,6 +14,10 @@ import Datadog
 /// calls third party endpoints.
 @objc
 class URLSessionBaseScenario: NSObject {
+    /// If yes, instrumented endpoints are passed to `DDURLSessionDelegate`; otherwise, they are passed to `DatadogConfiguration.trackURLSession` method
+    @objc
+    let feedAdditionalFirstyPartyHosts: Bool
+
     /// The URL to custom GET resource, observed by Tracing auto instrumentation.
     @objc
     let customGETResourceURL: URL
@@ -35,6 +39,7 @@ class URLSessionBaseScenario: NSObject {
     let thirdPartyURL: URL
 
     override init() {
+        feedAdditionalFirstyPartyHosts = Bool.random()
         if ProcessInfo.processInfo.arguments.contains("IS_RUNNING_UI_TESTS") {
             let serverMockConfiguration = Environment.serverMockConfiguration()!
             customGETResourceURL = serverMockConfiguration.instrumentedEndpoints[0]
@@ -69,8 +74,33 @@ class URLSessionBaseScenario: NSObject {
     }
 
     func configureSDK(builder: Datadog.Configuration.Builder) {
-        _ = builder.trackURLSession(
-            firstPartyHosts: [customGETResourceURL.host!, customPOSTRequest.url!.host!, badResourceURL.host!]
+        if feedAdditionalFirstyPartyHosts {
+            _ = builder.trackURLSession()
+        } else {
+            _ = builder.trackURLSession(
+                firstPartyHosts: [customGETResourceURL.host!, customPOSTRequest.url!.host!, badResourceURL.host!]
+            )
+        }
+    }
+
+    @objc
+    func buildURLSession() -> URLSession {
+        let delegate: DDURLSessionDelegate
+        if feedAdditionalFirstyPartyHosts {
+            delegate = DDURLSessionDelegate(
+                additionalFirstPartyHosts: [
+                    customGETResourceURL.host!,
+                    customPOSTRequest.url!.host!,
+                    badResourceURL.host!
+                ]
+            )
+        } else {
+            delegate = DDURLSessionDelegate()
+        }
+        return URLSession(
+            configuration: .default,
+            delegate: delegate,
+            delegateQueue: nil
         )
     }
 }

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -181,7 +181,7 @@ extension FeaturesConfiguration {
             }
         }
 
-        if let firstPartyHosts = configuration.firstPartyHosts, !firstPartyHosts.isEmpty {
+        if let firstPartyHosts = configuration.firstPartyHosts {
             if configuration.tracingEnabled || configuration.rumEnabled {
                 urlSessionAutoInstrumentation = URLSessionAutoInstrumentation(
                     userDefinedFirstPartyHosts: sanitized(firstPartyHosts: firstPartyHosts),

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -196,7 +196,7 @@ extension FeaturesConfiguration {
             } else {
                 let error = ProgrammerError(
                     description: """
-                    To use `.track(firstPartyHosts:)` either RUM or Tracing should be enabled.
+                    To use `.trackURLSession(firstPartyHosts:)` either RUM or Tracing should be enabled.
                     """
                 )
                 consolePrint("\(error)")

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -366,12 +366,12 @@ extension Datadog {
             ///
             /// If both RUM and Tracing features are enabled, the SDK will be sending RUM Resources for 1st- and 3rd-party requests and tracing Spans for 1st-parties.
             ///
-            /// Until `firstPartyHosts` is set, network requests monitoring is disabled.
+            /// Until `trackURLSession()` is called, network requests monitoring is disabled.
             ///
-            /// **NOTE 1:** Setting `firstPartyHosts` will install swizzlings on some methods of the `URLSession`. Refer to `URLSessionSwizzler.swift`
+            /// **NOTE 1:** Enabling this option will install swizzlings on some methods of the `URLSession`. Refer to `URLSessionSwizzler.swift`
             /// for implementation details.
             ///
-            /// **NOTE 2:** The `firstPartyHosts` instrumentation will NOT work without using `DDURLSessionDelegate`.
+            /// **NOTE 2:** The `URLSession` instrumentation will NOT work without using `DDURLSessionDelegate`.
             ///
             /// - Parameter firstPartyHosts: empty set by default
             public func trackURLSession(firstPartyHosts: Set<String> = []) -> Builder {

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -337,9 +337,14 @@ extension Datadog {
             }
 
             /// Configures network requests monitoring for Tracing and RUM features. **Must be used together with** `DDURLSessionDelegate` set as the `URLSession` delegate.
-            @available(*, deprecated, message: "This option is replaced by `track(firstPartyHosts:)`. Refer to the new API comment for important details.")
+            @available(*, deprecated, message: "This option is replaced by `trackURLSession(firstPartyHosts:)`. Refer to the new API comment for important details.")
             public func set(tracedHosts: Set<String>) -> Builder {
                 return track(firstPartyHosts: tracedHosts)
+            }
+
+            @available(*, deprecated, message: "This option is replaced by `trackURLSession(firstPartyHosts:)`. Refer to the new API comment for important details.")
+            public func track(firstPartyHosts: Set<String>) -> Builder {
+                return trackURLSession(firstPartyHosts: firstPartyHosts)
             }
 
             /// Configures network requests monitoring for Tracing and RUM features. **It must be used together with** `DDURLSessionDelegate` set as the `URLSession` delegate.
@@ -368,8 +373,8 @@ extension Datadog {
             ///
             /// **NOTE 2:** The `firstPartyHosts` instrumentation will NOT work without using `DDURLSessionDelegate`.
             ///
-            /// - Parameter firstPartyHosts: not set by default
-            public func track(firstPartyHosts: Set<String>) -> Builder {
+            /// - Parameter firstPartyHosts: empty set by default
+            public func trackURLSession(firstPartyHosts: Set<String> = []) -> Builder {
                 configuration.firstPartyHosts = firstPartyHosts
                 return self
             }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -35,7 +35,7 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate {
         // host projects would need to change their `init()`s in subclasses.
         // we can fix this in v2.0
         Self.datadogInitializationCheck()
-        firstPartyURLsFilter = FirstPartyURLsFilter(firstPartyHosts: additionalFirstPartyHosts)
+        firstPartyURLsFilter = FirstPartyURLsFilter(hosts: additionalFirstPartyHosts)
         interceptor = URLSessionAutoInstrumentation.instance?.interceptor
     }
 

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -26,6 +26,7 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate {
     /// - Parameter additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
     /// passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
     /// **NOTE:** If `trackURLSession(firstPartyHosts:)` is never called, automatic tracking will **not** take place
+    @objc
     public init(additionalFirstPartyHosts: Set<String>) {
         // NOTE: RUMM-954 copy&pasting `init()` is a conscious decision.
         // otherwise `DDURLSessionDelegateAsSuperclassTests` fails.

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -7,8 +7,8 @@
 import Foundation
 
 internal protocol URLSessionInterceptorType: class {
-    func modify(request: URLRequest) -> URLRequest
-    func taskCreated(task: URLSessionTask)
+    func modify(request: URLRequest, session: URLSession?) -> URLRequest
+    func taskCreated(task: URLSessionTask, session: URLSession?)
     func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics)
     func taskCompleted(task: URLSessionTask, error: Error?)
 }
@@ -20,7 +20,9 @@ public class URLSessionInterceptor: URLSessionInterceptorType {
     }
 
     /// Filters first party `URLs` defined by the user.
-    private let firstPartyURLsFilter: FirstPartyURLsFilter
+    /// **NOTE:** If `session.delegate` is a `DDURLSessionDelegate` initialized with its own
+    /// set of `firstPartyHosts`, then `defaultFirstPartyURLsFilter` is not used
+    private let defaultFirstPartyURLsFilter: FirstPartyURLsFilter
     /// Filters internal `URLs` used by the SDK.
     private let internalURLsFilter: InternalURLsFilter
     /// Handles resources interception.
@@ -54,7 +56,7 @@ public class URLSessionInterceptor: URLSessionInterceptorType {
         configuration: FeaturesConfiguration.URLSessionAutoInstrumentation,
         handler: URLSessionInterceptionHandler
     ) {
-        self.firstPartyURLsFilter = FirstPartyURLsFilter(hosts: configuration.userDefinedFirstPartyHosts)
+        self.defaultFirstPartyURLsFilter = FirstPartyURLsFilter(hosts: configuration.userDefinedFirstPartyHosts)
         self.internalURLsFilter = InternalURLsFilter(urls: configuration.sdkInternalURLs)
         self.handler = handler
 
@@ -89,10 +91,12 @@ public class URLSessionInterceptor: URLSessionInterceptorType {
     /// from the client application to backend services instrumented with Datadog agents.
     /// - Parameter request: input request.
     /// - Returns: modified input requests. The modified request may contain additional Datadog headers.
-    public func modify(request: URLRequest) -> URLRequest {
+    public func modify(request: URLRequest, session: URLSession? = nil) -> URLRequest {
         guard !internalURLsFilter.isInternal(url: request.url) else {
             return request
         }
+        let ddDelegate = session?.delegate as? DDURLSessionDelegate
+        let firstPartyURLsFilter = ddDelegate?.firstPartyURLsFilter ?? defaultFirstPartyURLsFilter
         if injectTracingHeadersToFirstPartyRequests,
            firstPartyURLsFilter.isFirstParty(url: request.url) {
             return injectSpanContext(into: request)
@@ -103,16 +107,18 @@ public class URLSessionInterceptor: URLSessionInterceptorType {
     /// Notifies the `URLSessionTask` creation.
     /// This method should be called as soon as the task was created.
     /// - Parameter task: the task object obtained from `URLSession`.
-    public func taskCreated(task: URLSessionTask) {
+    public func taskCreated(task: URLSessionTask, session: URLSession? = nil) {
         guard let request = task.originalRequest,
               !internalURLsFilter.isInternal(url: request.url) else {
             return
         }
+        let ddDelegate = session?.delegate as? DDURLSessionDelegate
+        let firstPartyURLsFilter = ddDelegate?.firstPartyURLsFilter ?? defaultFirstPartyURLsFilter
 
         queue.async {
             let interception = TaskInterception(
                 request: request,
-                isFirstParty: self.firstPartyURLsFilter.isFirstParty(url: request.url)
+                isFirstParty: firstPartyURLsFilter.isFirstParty(url: request.url)
             )
             self.interceptionByTask[task] = interception
 

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
@@ -83,7 +83,7 @@ internal class URLSessionSwizzler {
                             completionHandler?(data, response, error)
                         }
 
-                        let newRequest = interceptor.modify(request: urlRequest)
+                        let newRequest = interceptor.modify(request: urlRequest, session: session)
 
                         task = previousImplementation(session, Self.selector, newRequest, newCompletionHandler)
                         taskReference = task
@@ -95,7 +95,7 @@ internal class URLSessionSwizzler {
                         //   `nil` as the `completionHandler` (it produces a warning, but compiles).
                         task = previousImplementation(session, Self.selector, urlRequest, completionHandler)
                     }
-                    interceptor.taskCreated(task: task)
+                    interceptor.taskCreated(task: task, session: session)
                     return task
                 }
             }
@@ -149,7 +149,7 @@ internal class URLSessionSwizzler {
                         //   `nil` as the `completionHandler` (it produces a warning, but compiles).
                         task = previousImplementation(session, Self.selector, url, completionHandler)
                     }
-                    interceptor.taskCreated(task: task)
+                    interceptor.taskCreated(task: task, session: session)
                     return task
                 }
             }
@@ -186,13 +186,13 @@ internal class URLSessionSwizzler {
                     guard let interceptor = (session.delegate as? DDURLSessionDelegate)?.interceptor else {
                         return previousImplementation(session, Self.selector, urlRequest)
                     }
-                    let newRequest = interceptor.modify(request: urlRequest)
+                    let newRequest = interceptor.modify(request: urlRequest, session: session)
                     let task = previousImplementation(session, Self.selector, newRequest)
                     if #available(iOS 13.0, *) {
                         // Prior to iOS 13.0, `dataTask(with:)` (for `URLRequest`) calls the
                         // the `dataTask(with:completionHandler:)` (for `URLRequest`) internally,
                         // so the task creation will be notified from `dataTaskWithURLRequestAndCompletion` swizzling.
-                        interceptor.taskCreated(task: task)
+                        interceptor.taskCreated(task: task, session: session)
                     }
                     return task
                 }
@@ -231,7 +231,7 @@ internal class URLSessionSwizzler {
                         return previousImplementation(session, Self.selector, url)
                     }
                     let task = previousImplementation(session, Self.selector, url)
-                    interceptor.taskCreated(task: task)
+                    interceptor.taskCreated(task: task, session: session)
                     return task
                 }
             }

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -194,7 +194,7 @@ public class DDConfigurationBuilder: NSObject {
 
     @objc
     public func track(firstPartyHosts: Set<String>) {
-        _ = sdkBuilder.track(firstPartyHosts: firstPartyHosts)
+        _ = sdkBuilder.trackURLSession(firstPartyHosts: firstPartyHosts)
     }
 
     @objc

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -476,7 +476,7 @@ class FeaturesConfigurationTests: XCTestCase {
         XCTAssertEqual(
             printFunction.printedMessage,
             """
-            🔥 Datadog SDK usage error: To use `.track(firstPartyHosts:)` either RUM or Tracing should be enabled.
+            🔥 Datadog SDK usage error: To use `.trackURLSession(firstPartyHosts:)` either RUM or Tracing should be enabled.
             """
         )
     }

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -408,9 +408,9 @@ class FeaturesConfigurationTests: XCTestCase {
             rumEnabled: true,
             firstPartyHosts: []
         )
-        XCTAssertNil(
+        XCTAssertNotNil(
             configuration.urlSessionAutoInstrumentation,
-            "When `firstPartyHosts` are set empty, the URLSession auto instrumentation config shuld be `nil`"
+            "When `firstPartyHosts` are set empty and non-nil, the URLSession auto instrumentation config should NOT be nil."
         )
     }
 

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -71,7 +71,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .set(customTracesEndpoint: URL(string: "https://api.custom.traces/")!)
                 .set(customRUMEndpoint: URL(string: "https://api.custom.rum/")!)
                 .set(rumSessionsSamplingRate: 42.5)
-                .track(firstPartyHosts: ["example.com"])
+                .trackURLSession(firstPartyHosts: ["example.com"])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock())
                 .trackUIKitActions(false)
                 .setRUMViewEventMapper { _ in mockRUMViewEvent }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -217,10 +217,10 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(RUMAutoInstrumentation.instance?.userActions)
         }
 
-        try verify(configuration: defaultBuilder.track(firstPartyHosts: ["example.com"]).build()) {
+        try verify(configuration: defaultBuilder.trackURLSession(firstPartyHosts: ["example.com"]).build()) {
             XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
         }
-        try verify(configuration: defaultBuilder.track(firstPartyHosts: []).build()) {
+        try verify(configuration: defaultBuilder.trackURLSession().build()) {
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
         }
     }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -221,7 +221,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
         }
         try verify(configuration: defaultBuilder.trackURLSession().build()) {
-            XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
         }
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
@@ -7,6 +7,12 @@
 import Foundation
 @testable import Datadog
 
+extension URLSession {
+    static func mockWith(_ delegate: URLSessionDelegate) -> URLSession {
+        return URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+    }
+}
+
 class URLSessionInterceptorMock: URLSessionInterceptorType {
     var modifiedRequest: URLRequest?
 

--- a/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
@@ -10,8 +10,8 @@ import Foundation
 class URLSessionInterceptorMock: URLSessionInterceptorType {
     var modifiedRequest: URLRequest?
 
-    var onRequestModified: ((URLRequest) -> Void)?
-    var onTaskCreated: ((URLSessionTask) -> Void)?
+    var onRequestModified: ((URLRequest, URLSession?) -> Void)?
+    var onTaskCreated: ((URLSessionTask, URLSession?) -> Void)?
     var onTaskCompleted: ((URLSessionTask, Error?) -> Void)?
     var onTaskMetricsCollected: ((URLSessionTask, URLSessionTaskMetrics) -> Void)?
 
@@ -19,14 +19,14 @@ class URLSessionInterceptorMock: URLSessionInterceptorType {
     var tasksCompleted: [(task: URLSessionTask, error: Error?)] = []
     var taskMetrics: [(task: URLSessionTask, metrics: URLSessionTaskMetrics)] = []
 
-    func modify(request: URLRequest) -> URLRequest {
-        onRequestModified?(request)
+    func modify(request: URLRequest, session: URLSession?) -> URLRequest {
+        onRequestModified?(request, session)
         return modifiedRequest ?? request
     }
 
-    func taskCreated(task: URLSessionTask) {
+    func taskCreated(task: URLSessionTask, session: URLSession?) {
         tasksCreated.append(task)
-        onTaskCreated?(task)
+        onTaskCreated?(task, session)
     }
 
     func taskCompleted(task: URLSessionTask, error: Error?) {

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1016,7 +1016,7 @@ class RUMMonitorTests: XCTestCase {
             trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration
                 .builderUsing(rumApplicationID: .mockAny(), clientToken: .mockAny(), environment: .mockAny())
-                .track(firstPartyHosts: [.mockAny()])
+                .trackURLSession(firstPartyHosts: [.mockAny()])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock(result: .init(path: .mockAny())))
                 .trackUIKitActions(true)
                 .build()

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -1035,7 +1035,7 @@ class TracerTests: XCTestCase {
             trackingConsent: .mockRandom(),
             configuration: Datadog.Configuration
                 .builderUsing(clientToken: .mockAny(), environment: .mockAny())
-                .track(firstPartyHosts: [.mockAny()])
+                .trackURLSession(firstPartyHosts: [.mockAny()])
                 .build()
         )
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
@@ -161,7 +161,7 @@ class DDURLSessionDelegateTests: XCTestCase {
             printFunction.printedMessage,
             """
             🔥 Datadog SDK usage error: `Datadog.initialize()` must be called before initializing the `DDURLSessionDelegate` and
-            first party hosts must be specified in `Datadog.Configuration`: `track(firstPartyHosts:)`
+            first party hosts must be specified in `Datadog.Configuration`: `trackURLSession(firstPartyHosts:)`
             to enable network requests tracking.
             """
         )
@@ -177,14 +177,14 @@ class DDURLSessionDelegateTests: XCTestCase {
         URLSessionAutoInstrumentation.instance = nil
 
         // when
-        _ = DDURLSessionDelegate(firstPartyHosts: ["foo.com"])
+        _ = DDURLSessionDelegate(additionalFirstPartyHosts: ["foo.com"])
 
         // then
         XCTAssertEqual(
             printFunction.printedMessage,
             """
             🔥 Datadog SDK usage error: `Datadog.initialize()` must be called before initializing the `DDURLSessionDelegate` and
-            first party hosts must be specified in `Datadog.Configuration`: `track(firstPartyHosts:)`
+            first party hosts must be specified in `Datadog.Configuration`: `trackURLSession(firstPartyHosts:)`
             to enable network requests tracking.
             """
         )
@@ -217,7 +217,7 @@ class DDURLSessionDelegateTests: XCTestCase {
         defer { URLSessionAutoInstrumentation.instance = nil }
 
         // when
-        let testDelegate = DDURLSessionDelegate(firstPartyHosts: ["foo.com"])
+        let testDelegate = DDURLSessionDelegate(additionalFirstPartyHosts: ["foo.com"])
 
         // then
         XCTAssert(

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
@@ -29,6 +29,8 @@ class URLSessionInterceptorTests: XCTestCase {
     private let handler = URLSessionInterceptionHandlerMock()
     /// Mock request made to a first party URL.
     private let firstPartyRequest = URLRequest(url: URL(string: "https://api.first-party.com/v1/endpoint")!)
+    /// Alternative mock request made to a first party URL.
+    private let alternativeFirstPartyRequest = URLRequest(url: URL(string: "https://api.another-first-party.com/v1/endpoint")!)
     /// Mock request made to a third party URL.
     private let thirdPartyRequest = URLRequest(url: URL(string: "https://api.third-party.com/v1/endpoint")!)
     /// Mock request made internally by the SDK (used to test that SDK internal calls to Intake servers are not intercepted).
@@ -128,11 +130,22 @@ class URLSessionInterceptorTests: XCTestCase {
         )
         Global.sharedTracer = Tracer.mockAny()
         defer { Global.sharedTracer = DDNoopGlobals.tracer }
+        let sessionWithCustomFirstPartyHosts = URLSession(
+            configuration: .default,
+            delegate: DDURLSessionDelegate(
+                firstPartyHosts: [alternativeFirstPartyRequest.url!.host!]
+            ),
+            delegateQueue: nil
+        )
 
         // When
         let interceptedFirstPartyRequest = interceptor.modify(request: firstPartyRequest)
         let interceptedThirdPartyRequest = interceptor.modify(request: thirdPartyRequest)
         let interceptedInternalRequest = interceptor.modify(request: internalRequest)
+        let interceptedCustomFirstPartyRequest = interceptor.modify(
+            request: alternativeFirstPartyRequest,
+            session: sessionWithCustomFirstPartyHosts
+        )
 
         // Then
         XCTAssertNotNil(interceptedFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
@@ -146,6 +159,19 @@ class URLSessionInterceptorTests: XCTestCase {
             firstPartyRequest,
             "The only modification of the original requests should be the addition of 3 tracing headers."
         )
+
+        XCTAssertNotNil(interceptedCustomFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.traceIDField])
+        XCTAssertNotNil(interceptedCustomFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.parentSpanIDField])
+        XCTAssertEqual(interceptedCustomFirstPartyRequest.allHTTPHeaderFields?[TracingHTTPHeaders.originField], TracingHTTPHeaders.rumOriginValue)
+        assertRequestsEqual(
+            interceptedCustomFirstPartyRequest
+                .removing(httpHeaderField: TracingHTTPHeaders.traceIDField)
+                .removing(httpHeaderField: TracingHTTPHeaders.parentSpanIDField)
+                .removing(httpHeaderField: TracingHTTPHeaders.originField),
+            alternativeFirstPartyRequest,
+            "The only modification of the original requests should be the addition of 3 tracing headers."
+        )
+
         assertRequestsEqual(thirdPartyRequest, interceptedThirdPartyRequest, "Intercepted 3rd party request should not be modified.")
         assertRequestsEqual(internalRequest, interceptedInternalRequest, "Intercepted internal request should not be modified.")
     }
@@ -222,14 +248,14 @@ class URLSessionInterceptorTests: XCTestCase {
 
     func testGivenTracingInstrumentationEnabled_whenInterceptingURLSessionTasks_itNotifiesStartAndCompletion() throws {
         let interceptionStartedExpectation = expectation(description: "Start task interception")
-        interceptionStartedExpectation.expectedFulfillmentCount = 2
+        interceptionStartedExpectation.expectedFulfillmentCount = 3
         handler.didNotifyInterceptionStart = { interception in
             XCTAssertFalse(interception.isDone)
             interceptionStartedExpectation.fulfill()
         }
 
         let interceptionCompletedExpectation = expectation(description: "Complete task interception")
-        interceptionCompletedExpectation.expectedFulfillmentCount = 2
+        interceptionCompletedExpectation.expectedFulfillmentCount = 3
         handler.didNotifyInterceptionCompletion = { interception in
             XCTAssertTrue(interception.isDone)
             interceptionCompletedExpectation.fulfill()
@@ -242,29 +268,47 @@ class URLSessionInterceptorTests: XCTestCase {
         )
         Global.sharedTracer = Tracer.mockAny()
         defer { Global.sharedTracer = DDNoopGlobals.tracer }
+        let sessionWithCustomFirstPartyHosts = URLSession(
+            configuration: .default,
+            delegate: DDURLSessionDelegate(
+                firstPartyHosts: [alternativeFirstPartyRequest.url!.host!]
+            ),
+            delegateQueue: nil
+        )
 
         let interceptedFirstPartyRequest = interceptor.modify(request: firstPartyRequest)
         let interceptedThirdPartyRequest = interceptor.modify(request: thirdPartyRequest)
         let interceptedInternalRequest = interceptor.modify(request: internalRequest)
+        let interceptedCustomFirstPartyRequest = interceptor.modify(
+            request: alternativeFirstPartyRequest,
+            session: sessionWithCustomFirstPartyHosts
+        )
 
         // When
         let firstPartyTask: URLSessionTask = .mockWith(request: interceptedFirstPartyRequest, response: .mockAny())
         let thirdPartyTask: URLSessionTask = .mockWith(request: interceptedThirdPartyRequest, response: .mockAny())
         let internalTask: URLSessionTask = .mockWith(request: interceptedInternalRequest, response: .mockAny())
+        let alternativeFirstPartyTask: URLSessionTask = .mockWith(request: interceptedCustomFirstPartyRequest, response: .mockAny())
 
         // swiftlint:disable opening_brace
         callConcurrently(
             { interceptor.taskCreated(task: firstPartyTask) },
             { interceptor.taskCreated(task: thirdPartyTask) },
-            { interceptor.taskCreated(task: internalTask) }
+            { interceptor.taskCreated(task: internalTask) },
+            { interceptor.taskCreated(task: alternativeFirstPartyTask, session: sessionWithCustomFirstPartyHosts) }
         )
         callConcurrently(
-            { interceptor.taskCompleted(task: firstPartyTask, error: nil) },
-            { interceptor.taskCompleted(task: thirdPartyTask, error: nil) },
-            { interceptor.taskCompleted(task: internalTask, error: nil) },
-            { interceptor.taskMetricsCollected(task: firstPartyTask, metrics: .mockAny()) },
-            { interceptor.taskMetricsCollected(task: thirdPartyTask, metrics: .mockAny()) },
-            { interceptor.taskMetricsCollected(task: internalTask, metrics: .mockAny()) }
+            closures: [
+                { interceptor.taskCompleted(task: firstPartyTask, error: nil) },
+                { interceptor.taskCompleted(task: thirdPartyTask, error: nil) },
+                { interceptor.taskCompleted(task: internalTask, error: nil) },
+                { interceptor.taskCompleted(task: alternativeFirstPartyTask, error: nil) },
+                { interceptor.taskMetricsCollected(task: firstPartyTask, metrics: .mockAny()) },
+                { interceptor.taskMetricsCollected(task: thirdPartyTask, metrics: .mockAny()) },
+                { interceptor.taskMetricsCollected(task: internalTask, metrics: .mockAny()) },
+                { interceptor.taskMetricsCollected(task: alternativeFirstPartyTask, metrics: .mockAny()) }
+            ],
+            iterations: 1
         )
         // swiftlint:enable opening_brace
 
@@ -275,7 +319,7 @@ class URLSessionInterceptorTests: XCTestCase {
         // due to https://openradar.appspot.com/radar?id=4988276943355904
 
         let startedInterceptions = handler.startedInterceptions
-        XCTAssertEqual(startedInterceptions.count, 2)
+        XCTAssertEqual(startedInterceptions.count, 3)
         XCTAssertTrue(
             startedInterceptions.contains { $0.request.url == firstPartyRequest.url && $0.spanContext != nil },
             "Interception should be started and span context should be set for 1st party request."
@@ -284,9 +328,13 @@ class URLSessionInterceptorTests: XCTestCase {
             startedInterceptions.contains { $0.request.url == thirdPartyRequest.url && $0.spanContext == nil },
             "Interception should be started but span context should NOT be set for 3rd party request."
         )
+        XCTAssertTrue(
+            startedInterceptions.contains { $0.request.url == alternativeFirstPartyRequest.url && $0.spanContext != nil },
+            "Interception should be started and span context should be set for custom 1st party request."
+        )
 
         let completedInterceptions = handler.completedInterceptions
-        XCTAssertEqual(completedInterceptions.count, 2)
+        XCTAssertEqual(completedInterceptions.count, 3)
         XCTAssertTrue(
             completedInterceptions.contains { $0.request.url == firstPartyRequest.url && $0.spanContext != nil },
             "Interception should be completed and span context be set for 1st party request."
@@ -294,6 +342,10 @@ class URLSessionInterceptorTests: XCTestCase {
         XCTAssertTrue(
             completedInterceptions.contains { $0.request.url == thirdPartyRequest.url && $0.spanContext == nil },
             "Interception should be completed but span context should NOT be set for 3rd party request."
+        )
+        XCTAssertTrue(
+            completedInterceptions.contains { $0.request.url == alternativeFirstPartyRequest.url && $0.spanContext != nil },
+            "Interception should be completed and span context be set for custom 1st party request."
         )
     }
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
@@ -130,12 +130,8 @@ class URLSessionInterceptorTests: XCTestCase {
         )
         Global.sharedTracer = Tracer.mockAny()
         defer { Global.sharedTracer = DDNoopGlobals.tracer }
-        let sessionWithCustomFirstPartyHosts = URLSession(
-            configuration: .default,
-            delegate: DDURLSessionDelegate(
-                firstPartyHosts: [alternativeFirstPartyRequest.url!.host!]
-            ),
-            delegateQueue: nil
+        let sessionWithCustomFirstPartyHosts = URLSession.mockWith(
+            DDURLSessionDelegate(additionalFirstPartyHosts: [alternativeFirstPartyRequest.url!.host!])
         )
 
         // When
@@ -268,12 +264,8 @@ class URLSessionInterceptorTests: XCTestCase {
         )
         Global.sharedTracer = Tracer.mockAny()
         defer { Global.sharedTracer = DDNoopGlobals.tracer }
-        let sessionWithCustomFirstPartyHosts = URLSession(
-            configuration: .default,
-            delegate: DDURLSessionDelegate(
-                firstPartyHosts: [alternativeFirstPartyRequest.url!.host!]
-            ),
-            delegateQueue: nil
+        let sessionWithCustomFirstPartyHosts = URLSession.mockWith(
+            DDURLSessionDelegate(additionalFirstPartyHosts: [alternativeFirstPartyRequest.url!.host!])
         )
 
         let interceptedFirstPartyRequest = interceptor.modify(request: firstPartyRequest)

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -47,8 +47,14 @@ class URLSessionSwizzlerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
-        interceptor.onRequestModified = { _ in requestModified.fulfill() }
-        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onRequestModified = { _, session in
+            XCTAssertNotNil(session)
+            requestModified.fulfill()
+        }
+        interceptor.onTaskCreated = { _, session in
+            XCTAssertNotNil(session)
+            notifyTaskCreated.fulfill()
+        }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
@@ -78,8 +84,14 @@ class URLSessionSwizzlerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
-        interceptor.onRequestModified = { _ in requestModified.fulfill() }
-        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onRequestModified = { _, session in
+            XCTAssertNotNil(session)
+            requestModified.fulfill()
+        }
+        interceptor.onTaskCreated = { _, session in
+            XCTAssertNotNil(session)
+            notifyTaskCreated.fulfill()
+        }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
@@ -109,8 +121,14 @@ class URLSessionSwizzlerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
-        interceptor.onRequestModified = { _ in requestModified.fulfill() }
-        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onRequestModified = { _, session in
+            XCTAssertNotNil(session)
+            requestModified.fulfill()
+        }
+        interceptor.onTaskCreated = { _, session in
+            XCTAssertNotNil(session)
+            notifyTaskCreated.fulfill()
+        }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
@@ -135,8 +153,11 @@ class URLSessionSwizzlerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
-        interceptor.onRequestModified = { _ in requestNotModified.fulfill() }
-        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onRequestModified = { _, _ in requestNotModified.fulfill() }
+        interceptor.onTaskCreated = { _, session in
+            XCTAssertNotNil(session)
+            notifyTaskCreated.fulfill()
+        }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
@@ -161,7 +182,10 @@ class URLSessionSwizzlerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
         interceptor.modifiedRequest = URLRequest(url: .mockRandom())
-        interceptor.onTaskCreated = { _ in notifyTaskCreated.fulfill() }
+        interceptor.onTaskCreated = { _, session in
+            XCTAssertNotNil(session)
+            notifyTaskCreated.fulfill()
+        }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
@@ -183,10 +207,10 @@ class URLSessionSwizzlerTests: XCTestCase {
     func testGivenNonInterceptedSession_itDoesntCallInterceptor() throws {
         let doNotModifyRequest = expectation(description: "Notify request modification")
         doNotModifyRequest.isInverted = true
-        interceptor.onRequestModified = { _ in doNotModifyRequest.fulfill() }
+        interceptor.onRequestModified = { _, _ in doNotModifyRequest.fulfill() }
         let doNotNotifyTaskCreated = expectation(description: "Notify task creation")
         doNotNotifyTaskCreated.isInverted = true
-        interceptor.onTaskCreated = { _ in doNotNotifyTaskCreated.fulfill() }
+        interceptor.onTaskCreated = { _, _ in doNotNotifyTaskCreated.fulfill() }
 
         // Given
         let session = URLSession(configuration: .default)

--- a/Tests/DatadogTests/Helpers/XCTestCase.swift
+++ b/Tests/DatadogTests/Helpers/XCTestCase.swift
@@ -26,7 +26,7 @@ extension XCTestCase {
 
     /// Calls given closures concurrently from multiple threads.
     /// Each closure will be called the number of times given by `iterations` count.
-    func callConcurrently(closures: [() -> Void], iterations: Int) {
+    func callConcurrently(closures: [() -> Void], iterations: Int = 1) {
         var moreClosures: [() -> Void] = []
         (0..<iterations).forEach { _ in moreClosures.append(contentsOf: closures) }
         let randomizedClosures = moreClosures.shuffled()

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -144,7 +144,7 @@ public enum DDRUMUserActionType: Int
  case scroll
  case swipe
  case custom
-public enum DDRUMResourceKind: Int
+public enum DDRUMResourceType: Int
  case image
  case xhr
  case beacon
@@ -155,6 +155,13 @@ public enum DDRUMResourceKind: Int
  case js
  case media
  case other
+public enum DDRUMMethod: Int
+ case post
+ case get
+ case head
+ case put
+ case delete
+ case patch
 public class DDRUMMonitor: NSObject
  override public convenience init()
  public func startView(viewController: UIViewController,path: String?,attributes: [String: Any])
@@ -166,10 +173,10 @@ public class DDRUMMonitor: NSObject
  public func addError(error: Error,source: DDRUMErrorSource,attributes: [String: Any])
  public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [String: Any])
  public func startResourceLoading(resourceKey: String,url: URL,attributes: [String: Any])
- public func startResourceLoading(resourceKey: String,httpMethod: String,urlString: String,attributes: [String: Any])
+ public func startResourceLoading(resourceKey: String,httpMethod: DDRUMMethod,urlString: String,attributes: [String: Any])
  public func addResourceMetrics(resourceKey: String,metrics: URLSessionTaskMetrics,attributes: [String: Any])
  public func stopResourceLoading(resourceKey: String,response: URLResponse,attributes: [String: Any])
- public func stopResourceLoading(resourceKey: String,statusCode: Int,kind: DDRUMResourceKind,attributes: [String: Any])
+ public func stopResourceLoading(resourceKey: String,statusCode: Int,kind: DDRUMResourceType,attributes: [String: Any])
  public func stopResourceLoadingWithError(resourceKey: String,error: Error,response: URLResponse?,attributes: [String: Any])
  public func stopResourceLoadingWithError(resourceKey: String,errorMessage: String,response: URLResponse?,attributes: [String: Any])
  public func startUserAction(type: DDRUMUserActionType,name: String,attributes: [String: Any])

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -14,10 +14,10 @@ public class DDRUMMonitor
  public func addError(error: Error,source: RUMErrorSource = .custom,attributes: [AttributeKey: AttributeValue] = [:])
  public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [AttributeKey: AttributeValue] = [:])
  public func startResourceLoading(resourceKey: String,url: URL,attributes: [AttributeKey: AttributeValue] = [:])
- public func startResourceLoading(resourceKey: String,httpMethod: String,urlString: String,attributes: [AttributeKey: AttributeValue] = [:])
+ public func startResourceLoading(resourceKey: String,httpMethod: RUMMethod,urlString: String,attributes: [AttributeKey: AttributeValue] = [:])
  public func addResourceMetrics(resourceKey: String,metrics: URLSessionTaskMetrics,attributes: [AttributeKey: AttributeValue] = [:])
  public func stopResourceLoading(resourceKey: String,response: URLResponse,size: Int64? = nil,attributes: [AttributeKey: AttributeValue] = [:])
- public func stopResourceLoading(resourceKey: String,statusCode: Int?,kind: RUMResourceKind,size: Int64? = nil,attributes: [AttributeKey: AttributeValue] = [:])
+ public func stopResourceLoading(resourceKey: String,statusCode: Int?,kind: RUMResourceType,size: Int64? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  public func stopResourceLoadingWithError(resourceKey: String,error: Error,response: URLResponse? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  public func stopResourceLoadingWithError(resourceKey: String,errorMessage: String,response: URLResponse? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  public func startUserAction(type: RUMUserActionType,name: String,attributes: [AttributeKey: AttributeValue] = [:])
@@ -80,6 +80,10 @@ public class Datadog
    public func set(rumSessionsSamplingRate: Float) -> Builder
    public func trackUIKitRUMViews(using predicate: UIKitRUMViewsPredicate = DefaultUIKitRUMViewsPredicate()) -> Builder
    public func trackUIKitActions(_ enabled: Bool = true) -> Builder
+   public func setRUMViewEventMapper(_ mapper: @escaping (RUMViewEvent) -> RUMViewEvent?) -> Builder
+   public func setRUMResourceEventMapper(_ mapper: @escaping (RUMResourceEvent) -> RUMResourceEvent?) -> Builder
+   public func setRUMActionEventMapper(_ mapper: @escaping (RUMActionEvent) -> RUMActionEvent?) -> Builder
+   public func setRUMErrorEventMapper(_ mapper: @escaping (RUMErrorEvent) -> RUMErrorEvent?) -> Builder
    public func set(serviceName: String) -> Builder
    public func set(batchSize: BatchSize) -> Builder
    public func set(uploadFrequency: UploadFrequency) -> Builder
@@ -503,17 +507,7 @@ public enum RUMMethod: String, Codable
  case put = "PUT"
  case delete = "DELETE"
  case patch = "PATCH"
-public enum RUMResourceKind
- case image
- case xhr
- case beacon
- case css
- case document
- case fetch
- case font
- case js
- case media
- case other
+public typealias RUMResourceType = RUMResourceEvent.Resource.ResourceType
 public enum RUMUserActionType
  case tap
  case scroll
@@ -535,10 +529,10 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber
  override public func addError(error: Error,source: RUMErrorSource,attributes: [AttributeKey: AttributeValue])
  override public func startResourceLoading(resourceKey: String,request: URLRequest,attributes: [AttributeKey: AttributeValue])
  override public func startResourceLoading(resourceKey: String,url: URL,attributes: [AttributeKey: AttributeValue])
- override public func startResourceLoading(resourceKey: String,httpMethod: String,urlString: String,attributes: [AttributeKey: AttributeValue] = [:])
+ override public func startResourceLoading(resourceKey: String,httpMethod: RUMMethod,urlString: String,attributes: [AttributeKey: AttributeValue] = [:])
  override public func addResourceMetrics(resourceKey: String,metrics: URLSessionTaskMetrics,attributes: [AttributeKey: AttributeValue])
  override public func stopResourceLoading(resourceKey: String,response: URLResponse,size: Int64?,attributes: [AttributeKey: AttributeValue])
- override public func stopResourceLoading(resourceKey: String,statusCode: Int?,kind: RUMResourceKind,size: Int64? = nil,attributes: [AttributeKey: AttributeValue] = [:])
+ override public func stopResourceLoading(resourceKey: String,statusCode: Int?,kind: RUMResourceType,size: Int64? = nil,attributes: [AttributeKey: AttributeValue] = [:])
  override public func stopResourceLoadingWithError(resourceKey: String,error: Error,response: URLResponse?,attributes: [AttributeKey: AttributeValue])
  override public func stopResourceLoadingWithError(resourceKey: String,errorMessage: String,response: URLResponse?,attributes: [AttributeKey: AttributeValue])
  override public func startUserAction(type: RUMUserActionType, name: String, attributes: [AttributeKey: AttributeValue])
@@ -567,9 +561,10 @@ public class HTTPHeadersWriter: OTHTTPHeadersWriter
  public private(set) var tracePropagationHTTPHeaders: [String: String] = [:]
  public func inject(spanContext: OTSpanContext)
  override public init()
+ public init(firstPartyHosts: Set<String>)
 public class URLSessionInterceptor: URLSessionInterceptorType
  public static var shared: URLSessionInterceptor?
- public func modify(request: URLRequest) -> URLRequest
- public func taskCreated(task: URLSessionTask)
+ public func modify(request: URLRequest, session: URLSession? = nil) -> URLRequest
+ public func taskCreated(task: URLSessionTask, session: URLSession? = nil)
  public func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics)
  public func taskCompleted(task: URLSessionTask, error: Error?)


### PR DESCRIPTION
### What and why?

Auto-instrumented `firstPartyHosts` were set at global level via `DatadogConfiguration`
Every `URLSession` instance had the same set of `firstPartyHosts`

Now this set can be customized per instance via `DDURLSessionDelegate`
```swift
let delegateWithCustomHosts = DDURLSessionDelegate(firstPartyHosts: ["foo.com"])
let session = URLSession(delegate: delegateWithCustomHosts)
```
`session` tracks requests made to host `foo.com` regardless of `DatadogConfiguration`

### How?

`URLSessionInterceptor` checks if `session.delegate` has its own URL filter;
1. if so, this filter is used
2. otherwise, default URL filter of `URLSessionInterceptor` is used

### Note on Objc

Next PR will bring its Objc counterpart once Swift one is approved

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
