### PR TITLE
RUMM-722 Set a Provider for first party Resources

### DIFF
--- a/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandler.swift
@@ -36,6 +36,7 @@ internal class URLSessionRUMResourcesHandler: URLSessionInterceptionHandler {
                 url: url,
                 httpMethod: RUMMethod(httpMethod: interception.request.httpMethod),
                 kind: RUMResourceType(request: interception.request),
+                isFirstPartyRequest: interception.isFirstPartyRequest,
                 spanContext: interception.spanContext.flatMap { spanContext in
                     .init(
                         traceID: String(spanContext.traceID.rawValue),

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -122,6 +122,8 @@ internal struct RUMStartResourceCommand: RUMResourceCommand {
     let httpMethod: RUMMethod
     /// A type of the Resource if it's possible to determine on start (when the response MIME is not yet known).
     let kind: RUMResourceType?
+    /// Whether or not the resource url targets a first party host, if that information is available.
+    let isFirstPartyRequest: Bool?
     /// Span context passed to the RUM backend in order to generate the APM span for underlying resource.
     let spanContext: RUMSpanContext?
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -28,7 +28,7 @@ internal class RUMResourceScope: RUMScope {
     /// The HTTP method used to load this Resource.
     private var resourceHTTPMethod: RUMMethod
     /// Whether or not the Resource is provided by a first party host, if that information is available.
-    private var isFirstPartyResource: Bool?
+    private let isFirstPartyResource: Bool?
     /// The Resource kind captured when starting the `URLRequest`.
     /// It may be `nil` if it's not possible to predict the kind from resource and the response MIME type is needed.
     private var resourceKindBasedOnRequest: RUMResourceType?
@@ -222,27 +222,27 @@ internal class RUMResourceScope: RUMScope {
     // MARK: - Resource provider helpers
 
     private var resourceEventProvider: RUMResourceEvent.Resource.Provider? {
-        // Only handle first party hosts at this point:
-        guard let isFirstPartyResource = isFirstPartyResource, isFirstPartyResource else {
+        if isFirstPartyResource == true {
+            return RUMResourceEvent.Resource.Provider(
+                domain: providerDomain(from: resourceURL),
+                name: nil,
+                type: .firstParty
+            )
+        } else {
             return nil
         }
-        return RUMResourceEvent.Resource.Provider(
-            domain: providerDomain(from: resourceURL),
-            name: nil,
-            type: .firstParty
-        )
     }
 
     private var errorEventProvider: RUMErrorEvent.Error.Resource.Provider? {
-        // Only handle first party hosts at this point:
-        guard let isFirstPartyResource = isFirstPartyResource, isFirstPartyResource else {
+        if isFirstPartyResource == true {
+            return RUMErrorEvent.Error.Resource.Provider(
+                domain: providerDomain(from: resourceURL),
+                name: nil,
+                type: .firstParty
+            )
+        } else {
             return nil
         }
-        return RUMErrorEvent.Error.Resource.Provider(
-            domain: providerDomain(from: resourceURL),
-            name: nil,
-            type: .firstParty
-        )
     }
 
     private func providerDomain(from url: String) -> String? {

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -27,6 +27,8 @@ internal class RUMResourceScope: RUMScope {
     private let dateCorrection: DateCorrection
     /// The HTTP method used to load this Resource.
     private var resourceHTTPMethod: RUMMethod
+    /// Whether or not the Resource is provided by a first party host, if that information is available.
+    private var isFirstPartyResource: Bool?
     /// The Resource kind captured when starting the `URLRequest`.
     /// It may be `nil` if it's not possible to predict the kind from resource and the response MIME type is needed.
     private var resourceKindBasedOnRequest: RUMResourceType?
@@ -47,6 +49,7 @@ internal class RUMResourceScope: RUMScope {
         dateCorrection: DateCorrection,
         url: String,
         httpMethod: RUMMethod,
+        isFirstPartyResource: Bool?,
         resourceKindBasedOnRequest: RUMResourceType?,
         spanContext: RUMSpanContext?
     ) {
@@ -59,6 +62,7 @@ internal class RUMResourceScope: RUMScope {
         self.resourceLoadingStartTime = startTime
         self.dateCorrection = dateCorrection
         self.resourceHTTPMethod = httpMethod
+        self.isFirstPartyResource = isFirstPartyResource
         self.resourceKindBasedOnRequest = resourceKindBasedOnRequest
         self.spanContext = spanContext
     }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -190,6 +190,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dateCorrection: dateCorrection,
             url: command.url,
             httpMethod: command.httpMethod,
+            isFirstPartyResource: command.isFirstPartyRequest,
             resourceKindBasedOnRequest: command.kind,
             spanContext: command.spanContext
         )

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -337,6 +337,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 url: request.url?.absoluteString ?? "unknown_url",
                 httpMethod: RUMMethod(httpMethod: request.httpMethod),
                 kind: RUMResourceType(request: request),
+                isFirstPartyRequest: nil,
                 spanContext: nil
             )
         )
@@ -355,6 +356,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 url: url.absoluteString,
                 httpMethod: .get,
                 kind: nil,
+                isFirstPartyRequest: nil,
                 spanContext: nil
             )
         )
@@ -374,6 +376,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 url: urlString,
                 httpMethod: httpMethod,
                 kind: nil,
+                isFirstPartyRequest: nil,
                 spanContext: nil
             )
         )

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/FirstPartyURLsFilter.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/FirstPartyURLsFilter.swift
@@ -12,9 +12,9 @@ internal struct FirstPartyURLsFilter {
     /// "example.com", "api.example.com", but not "foo.com".
     private let regex: String
 
-    init(configuration: FeaturesConfiguration.URLSessionAutoInstrumentation) {
+    init(hosts: Set<String>) {
         // pattern = "^(.*\\.)*tracedHost1|^(.*\\.)*tracedHost2|..."
-        self.regex = configuration.userDefinedFirstPartyHosts.map { host in
+        self.regex = hosts.map { host in
             let escaped = NSRegularExpression.escapedPattern(for: host)
             return "^(.*\\.)*\(escaped)$"
         }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/FirstPartyURLsFilter.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/FirstPartyURLsFilter.swift
@@ -13,12 +13,9 @@ internal struct FirstPartyURLsFilter {
     private let regex: String
 
     init(hosts: Set<String>) {
-        // pattern = "^(.*\\.)*tracedHost1|^(.*\\.)*tracedHost2|..."
-        self.regex = hosts.map { host in
-            let escaped = NSRegularExpression.escapedPattern(for: host)
-            return "^(.*\\.)*\(escaped)$"
-        }
-        .joined(separator: "|")
+        // pattern = "^(.*\\.)*tracedHost1|tracedHost2|...$"
+        let escapedHosts = hosts.map { NSRegularExpression.escapedPattern(for: $0) }.joined(separator: "|")
+        self.regex = "^(.*\\.)*\(escapedHosts)$"
     }
 
     /// Returns `true` if given `URL` matches the first party hosts defined by the user; `false` otherwise.

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/InternalURLsFilter.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/InternalURLsFilter.swift
@@ -10,8 +10,8 @@ import Foundation
 internal struct InternalURLsFilter {
     private let internalURLPrefixes: Set<String>
 
-    init(internalURLs: Set<String>) {
-        self.internalURLPrefixes = internalURLs
+    init(urls: Set<String>) {
+        self.internalURLPrefixes = urls
     }
 
     /// Returns `true` if given `URL` is an internal `URL` used by the SDK; `false` otherwise.

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/InternalURLsFilter.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/InternalURLsFilter.swift
@@ -10,8 +10,8 @@ import Foundation
 internal struct InternalURLsFilter {
     private let internalURLPrefixes: Set<String>
 
-    init(configuration: FeaturesConfiguration.URLSessionAutoInstrumentation) {
-        self.internalURLPrefixes = configuration.sdkInternalURLs
+    init(internalURLs: Set<String>) {
+        self.internalURLPrefixes = internalURLs
     }
 
     /// Returns `true` if given `URL` is an internal `URL` used by the SDK; `false` otherwise.

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -54,8 +54,8 @@ public class URLSessionInterceptor: URLSessionInterceptorType {
         configuration: FeaturesConfiguration.URLSessionAutoInstrumentation,
         handler: URLSessionInterceptionHandler
     ) {
-        self.firstPartyURLsFilter = FirstPartyURLsFilter(configuration: configuration)
-        self.internalURLsFilter = InternalURLsFilter(configuration: configuration)
+        self.firstPartyURLsFilter = FirstPartyURLsFilter(hosts: configuration.userDefinedFirstPartyHosts)
+        self.internalURLsFilter = InternalURLsFilter(internalURLs: configuration.sdkInternalURLs)
         self.handler = handler
 
         if configuration.instrumentTracing {

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -55,7 +55,7 @@ public class URLSessionInterceptor: URLSessionInterceptorType {
         handler: URLSessionInterceptionHandler
     ) {
         self.firstPartyURLsFilter = FirstPartyURLsFilter(hosts: configuration.userDefinedFirstPartyHosts)
-        self.internalURLsFilter = InternalURLsFilter(internalURLs: configuration.sdkInternalURLs)
+        self.internalURLsFilter = InternalURLsFilter(urls: configuration.sdkInternalURLs)
         self.handler = handler
 
         if configuration.instrumentTracing {

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -241,6 +241,7 @@ extension RUMStartResourceCommand {
         url: String = .mockAny(),
         httpMethod: RUMMethod = .mockAny(),
         kind: RUMResourceType = .mockAny(),
+        isFirstPartyRequest: Bool = .mockAny(),
         spanContext: RUMSpanContext? = nil
     ) -> RUMStartResourceCommand {
         return RUMStartResourceCommand(
@@ -250,6 +251,7 @@ extension RUMStartResourceCommand {
             url: url,
             httpMethod: httpMethod,
             kind: kind,
+            isFirstPartyRequest: isFirstPartyRequest,
             spanContext: spanContext
         )
     }

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Resources/URLSessionRUMResourcesHandlerTests.swift
@@ -41,7 +41,6 @@ class URLSessionRUMResourcesHandlerTests: XCTestCase {
         XCTAssertEqual(resourceStartCommand.attributes.count, 0)
         XCTAssertEqual(resourceStartCommand.url, taskInterception.request.url?.absoluteString)
         XCTAssertEqual(resourceStartCommand.httpMethod, RUMMethod(httpMethod: request.httpMethod))
-        XCTAssertFalse(resourceStartCommand.isFirstPartyRequest!)
         XCTAssertNil(resourceStartCommand.spanContext)
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -424,7 +424,7 @@ class RUMResourceScopeTests: XCTestCase {
         // When
         XCTAssertFalse(
             scope.process(
-                command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1")
+                command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/1")
             )
         )
 
@@ -459,7 +459,7 @@ class RUMResourceScopeTests: XCTestCase {
         // When
         XCTAssertFalse(
             scope.process(
-                command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1")
+                command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/1")
             )
         )
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -28,6 +28,7 @@ class RUMResourceScopeTests: XCTestCase {
             dateCorrection: .zero,
             url: .mockAny(),
             httpMethod: .mockAny(),
+            isFirstPartyResource: nil,
             resourceKindBasedOnRequest: nil,
             spanContext: nil
         )
@@ -52,6 +53,7 @@ class RUMResourceScopeTests: XCTestCase {
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
             httpMethod: .post,
+            isFirstPartyResource: nil,
             resourceKindBasedOnRequest: nil,
             spanContext: .init(traceID: "100", spanID: "200")
         )
@@ -112,6 +114,7 @@ class RUMResourceScopeTests: XCTestCase {
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
             httpMethod: .post,
+            isFirstPartyResource: nil,
             resourceKindBasedOnRequest: nil,
             spanContext: nil
         )
@@ -163,6 +166,7 @@ class RUMResourceScopeTests: XCTestCase {
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
             httpMethod: .post,
+            isFirstPartyResource: nil,
             resourceKindBasedOnRequest: nil,
             spanContext: nil
         )
@@ -271,6 +275,7 @@ class RUMResourceScopeTests: XCTestCase {
                 dateCorrection: .zero,
                 url: url,
                 httpMethod: .mockAny(),
+                isFirstPartyResource: nil,
                 resourceKindBasedOnRequest: nil,
                 spanContext: nil
             )
@@ -307,6 +312,7 @@ class RUMResourceScopeTests: XCTestCase {
             dateCorrection: .zero,
             url: .mockAny(),
             httpMethod: .post,
+            isFirstPartyResource: nil,
             resourceKindBasedOnRequest: kindBasedOnRequest,
             spanContext: nil
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -357,14 +357,7 @@ class RUMResourceScopeTests: XCTestCase {
         // When
         XCTAssertFalse(
             scope.process(
-                command: RUMStopResourceCommand(
-                    resourceKey: "/resource/1",
-                    time: currentTime,
-                    attributes: ["foo": "bar"],
-                    kind: .image,
-                    httpStatusCode: 200,
-                    size: 1_024
-                )
+                command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1")
             )
         )
 
@@ -376,7 +369,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(providerDomain, "foo.com")
     }
 
-    func testGivenStartedNonFirstPartyResource_whenResourceLoadingEnds_itSendsResourceEventWithoutFirstPartyProvider() throws {
+    func testGivenStartedThirdartyResource_whenResourceLoadingEnds_itSendsResourceEventWithoutResourceProvider() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
@@ -399,14 +392,7 @@ class RUMResourceScopeTests: XCTestCase {
         // When
         XCTAssertFalse(
             scope.process(
-                command: RUMStopResourceCommand(
-                    resourceKey: "/resource/1",
-                    time: currentTime,
-                    attributes: ["foo": "bar"],
-                    kind: .image,
-                    httpStatusCode: 200,
-                    size: 1_024
-                )
+                command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1")
             )
         )
 
@@ -438,14 +424,7 @@ class RUMResourceScopeTests: XCTestCase {
         // When
         XCTAssertFalse(
             scope.process(
-                command: RUMStopResourceWithErrorCommand(
-                    resourceKey: "/resource/1",
-                    time: currentTime,
-                    error: ErrorMock("network issue explanation"),
-                    source: .network,
-                    httpStatusCode: 500,
-                    attributes: ["foo": "bar"]
-                )
+                command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1")
             )
         )
 
@@ -457,7 +436,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(providerDomain, "foo.com")
     }
 
-    func testGivenStartedNonFirstPartyResource_whenResourceLoadingEndsWithError_itSendsErrorEventWithoutFirstPartyProvider() throws {
+    func testGivenStartedThirdPartyResource_whenResourceLoadingEndsWithError_itSendsErrorEventWithoutResourceProvider() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
@@ -480,14 +459,7 @@ class RUMResourceScopeTests: XCTestCase {
         // When
         XCTAssertFalse(
             scope.process(
-                command: RUMStopResourceWithErrorCommand(
-                    resourceKey: "/resource/1",
-                    time: currentTime,
-                    error: ErrorMock("network issue explanation"),
-                    source: .network,
-                    httpStatusCode: 500,
-                    attributes: ["foo": "bar"]
-                )
+                command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1")
             )
         )
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/FirstPartyURLsFilterTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/FirstPartyURLsFilterTests.swift
@@ -9,9 +9,7 @@ import XCTest
 
 class FirstPartyURLsFilterTests: XCTestCase {
     private let filter = FirstPartyURLsFilter(
-        configuration: .mockWith(
-            userDefinedFirstPartyHosts: ["first-party.com", "eu"]
-        )
+        hosts: ["first-party.com", "eu"]
     )
 
     func testWhenURLHostEndingMatchesAnyUserDefinedHost_itIsConsideredFirstParty() {

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/InternalURLsFilterTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/InternalURLsFilterTests.swift
@@ -9,13 +9,11 @@ import XCTest
 
 class InternalURLsFilterTests: XCTestCase {
     private let filter = InternalURLsFilter(
-        configuration: .mockWith(
-            sdkInternalURLs: [
-                "https://dd.internal.com/logs",
-                "https://dd.internal.com/traces",
-                "https://dd.internal.com/rum"
-            ]
-        )
+        internalURLs: [
+            "https://dd.internal.com/logs",
+            "https://dd.internal.com/traces",
+            "https://dd.internal.com/rum"
+        ]
     )
 
     func testWhenURLBeginningMatchesAnySDKInternalURL_itIsConsideredInternal() {

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/InternalURLsFilterTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLFiltering/InternalURLsFilterTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 class InternalURLsFilterTests: XCTestCase {
     private let filter = InternalURLsFilter(
-        internalURLs: [
+        urls: [
             "https://dd.internal.com/logs",
             "https://dd.internal.com/traces",
             "https://dd.internal.com/rum"


### PR DESCRIPTION
### What and why?

This is the counter part of [`dd-sdk-android/pull/442`](https://github.com/DataDog/dd-sdk-android/pull/442).

Note that we only set a Provider in the events for first party hosts, any other case will get a `nil` / `unknown`. Also note that the provider name is not set.

### How?

It leverages the existing `URLSessionInterceptor` mechanism and the `URLSessionAutoInstrumentation` configuration. Upstream it relies on a `FirstPartyURLsFilter` to notify interceptions with a flag, the flag will be used downstream to mark commands. The commands will be eventually consumed by a `RUMResourceScope`.
A `RUMResourceScope` will then be able to instantiate a `Provider` for first party resources as part of the Resource/Error events that need to be sent.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Run the Example app with the `RUMResourcesScenario`, send first/third party requests, check `ios-sdk-example-app` on the RUM Explorer 
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
