### PR TITLE
RUMM-1026 Use sysctl to gather a more accurate App Launch Time

### DIFF
--- a/Sources/Datadog/Core/System/LaunchTimeProvider.swift
+++ b/Sources/Datadog/Core/System/LaunchTimeProvider.swift
@@ -16,10 +16,7 @@ internal protocol LaunchTimeProviderType {
 
 internal class LaunchTimeProvider: LaunchTimeProviderType {
     var launchTime: TimeInterval? {
-        // Following dynamic dispatch synchronisation mutes TSAN issues when running tests from CLI.
-        objc_sync_enter(self)
-        let time = ObjcAppLaunchHandler.launchTime()
-        objc_sync_exit(self)
+        let time = AppLaunchTime()
         return time > 0 ? time : nil
     }
 }

--- a/Sources/Datadog/Core/System/LaunchTimeProvider.swift
+++ b/Sources/Datadog/Core/System/LaunchTimeProvider.swift
@@ -16,7 +16,10 @@ internal protocol LaunchTimeProviderType {
 
 internal class LaunchTimeProvider: LaunchTimeProviderType {
     var launchTime: TimeInterval? {
+        // Even if AppLaunchTime() is using a lock behind the scenes, TSAN will report a data race if there are no synchronizations at this level.
+        objc_sync_enter(self)
         let time = AppLaunchTime()
+        objc_sync_exit(self)
         return time > 0 ? time : nil
     }
 }

--- a/Sources/_Datadog_Private/include/ObjcAppLaunchHandler.h
+++ b/Sources/_Datadog_Private/include/ObjcAppLaunchHandler.h
@@ -4,10 +4,6 @@
 * Copyright 2019-2020 Datadog, Inc.
 */
 
-#import <Foundation/Foundation.h>
+#import <CoreFoundation/CFDate.h>
 
-@interface ObjcAppLaunchHandler : NSObject
-
-+ (NSTimeInterval)launchTime;
-
-@end
+CFTimeInterval AppLaunchTime(void);


### PR DESCRIPTION
### What and why?

`ObjcAppLaunchHandler` is the existing mechanism that observes early steps of the [App Launch sequence](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence) to provide a Launch Time for further reporting by `RUMViewScope` into `RUMActionEvent.Action` for the `start_application` event.

This currently relies on Objective-C's runtime initialisation which calls classes' `+(void)load` method as soon as they are loaded into the runtime. This happens before the `UIApplication.sharedInstance` is instantiated, and this provides an early point in time regarding the launch sequence.
The limitations are that the "earliness" is not guaranteed and depends on many factors, so it might lead to not accounting for some launch time.

This is why we aim to use a more accurate and stable source of information for the App Launch time.

Note that in that PR, we don't change the existing definition of App Launch Time as we still include the time to load the main UI, create/setup the app delegate. 

### How?

In that PR, we refactor the pair `ObjcAppLaunchHandler`/`AppLaunchTimer` into a single `AppLaunchHandler` class that becomes an implementation detail for a C function `AppLaunchTime()`.

The `AppLaunchTimer` class still implements and reacts to `+(void)load` to set up some observation on `UIApplication`.
Note the `AppLaunchTimer` is only kept alive by the capturing blocks until it has computed the times.

More specifically, `AppLaunchTimer` calls `sysctl()` to get a `kinfo_proc` for the current process (`getpid()`) and especially looks at `p_starttime`.

### Review checklist

- [x] Run the Example.app target in Simulator/on Device and check that the values are provided and make sense. 
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] ~~Feature or bugfix MUST have appropriate tests (unit, integration)~~
  - This depends on Foundation/UIKit/System APIs that can't be mocked so this wouldn't be straightforward.  

