### PR TITLE
RUMM-987 Prepare code generation for RUM @objc models

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */; };
+		6111C58225C0081F00F5C4A2 /* RUMDataModels+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */; };
 		61122ECE25B1B74500F9C7F5 /* SpanSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */; };
 		61122ED425B1B84D00F9C7F5 /* RUMEventSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */; };
 		61122EDA25B1BA9700F9C7F5 /* AttributesSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED925B1BA9700F9C7F5 /* AttributesSanitizer.swift */; };
@@ -471,6 +472,7 @@
 
 /* Begin PBXFileReference section */
 		6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingWithActiveSpanIntegration.swift; sourceTree = "<group>"; };
+		6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMDataModels+objc.swift"; sourceTree = "<group>"; };
 		61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSanitizer.swift; sourceTree = "<group>"; };
 		61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventSanitizer.swift; sourceTree = "<group>"; };
 		61122ED925B1BA9700F9C7F5 /* AttributesSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesSanitizer.swift; sourceTree = "<group>"; };
@@ -922,6 +924,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6111C58025C0080C00F5C4A2 /* RUM */ = {
+			isa = PBXGroup;
+			children = (
+				6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */,
+			);
+			path = RUM;
+			sourceTree = "<group>";
+		};
 		61133B78242393DE00786299 = {
 			isa = PBXGroup;
 			children = (
@@ -1162,6 +1172,7 @@
 				9E55407B25812D1C00F6E3AD /* RUMMonitor+objc.swift */,
 				9EEA4870258B76A100EBDA9D /* Global+objc.swift */,
 				6132BF4524A498B400D7BD17 /* Tracing */,
+				6111C58025C0080C00F5C4A2 /* RUM */,
 				6132BF4024A38D0600D7BD17 /* OpenTracing */,
 				61133C0A2423983800786299 /* ObjcIntercompatibility */,
 			);
@@ -3086,6 +3097,7 @@
 			files = (
 				61133C0F2423983800786299 /* AnyEncodable.swift in Sources */,
 				6132BF5124A49F7400D7BD17 /* Casting.swift in Sources */,
+				6111C58225C0081F00F5C4A2 /* RUMDataModels+objc.swift in Sources */,
 				6132BF4924A49B6800D7BD17 /* DDSpanContext+objc.swift in Sources */,
 				6132BF4224A38D2400D7BD17 /* OTTracer+objc.swift in Sources */,
 				615A4A8524A3445700233986 /* TracerConfiguration+objc.swift in Sources */,

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -5,6 +5,7 @@
  */
 
 import Datadog
+import Foundation
 
 // This file was generated from JSON Schema. Do not modify it directly.
 

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -1,0 +1,1938 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+// This file was generated from JSON Schema. Do not modify it directly.
+
+// swiftlint:disable force_unwrapping
+
+@objc
+public class DDRUMViewEvent: NSObject {
+    internal var swiftModel: RUMViewEvent
+    internal var root: DDRUMViewEvent { self }
+
+    internal init(swiftModel: RUMViewEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var dd: DDRUMViewEventDD {
+        DDRUMViewEventDD(root: root)
+    }
+
+    @objc public var application: DDRUMViewEventApplication {
+        DDRUMViewEventApplication(root: root)
+    }
+
+    @objc public var connectivity: DDRUMViewEventRUMConnectivity? {
+        root.swiftModel.connectivity != nil ? DDRUMViewEventRUMConnectivity(root: root) : nil
+    }
+
+    @objc public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    @objc public var service: String? {
+        root.swiftModel.service
+    }
+
+    @objc public var session: DDRUMViewEventSession {
+        DDRUMViewEventSession(root: root)
+    }
+
+    @objc public var type: String {
+        root.swiftModel.type
+    }
+
+    @objc public var usr: DDRUMViewEventRUMUser? {
+        root.swiftModel.usr != nil ? DDRUMViewEventRUMUser(root: root) : nil
+    }
+
+    @objc public var view: DDRUMViewEventView {
+        DDRUMViewEventView(root: root)
+    }
+}
+
+@objc
+public class DDRUMViewEventDD: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var documentVersion: NSNumber {
+        root.swiftModel.dd.documentVersion as NSNumber
+    }
+
+    @objc public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventApplication: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMViewEventRUMConnectivity: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var cellular: DDRUMViewEventRUMConnectivityCellular? {
+        root.swiftModel.connectivity!.cellular != nil ? DDRUMViewEventRUMConnectivityCellular(root: root) : nil
+    }
+
+    @objc public var interfaces: [Int] {
+        root.swiftModel.connectivity!.interfaces.map { DDRUMViewEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    }
+
+    @objc public var status: DDRUMViewEventRUMConnectivityStatus {
+        .init(swift: root.swiftModel.connectivity!.status)
+    }
+}
+
+@objc
+public class DDRUMViewEventRUMConnectivityCellular: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var carrierName: String? {
+        root.swiftModel.connectivity!.cellular!.carrierName
+    }
+
+    @objc public var technology: String? {
+        root.swiftModel.connectivity!.cellular!.technology
+    }
+}
+
+@objc
+public enum DDRUMViewEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces) {
+        switch swift {
+        case .bluetooth: self = .bluetooth
+        case .cellular: self = .cellular
+        case .ethernet: self = .ethernet
+        case .wifi: self = .wifi
+        case .wimax: self = .wimax
+        case .mixed: self = .mixed
+        case .other: self = .other
+        case .unknown: self = .unknown
+        case .none: self = .none
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces {
+        switch self {
+        case .bluetooth: return .bluetooth
+        case .cellular: return .cellular
+        case .ethernet: return .ethernet
+        case .wifi: return .wifi
+        case .wimax: return .wimax
+        case .mixed: return .mixed
+        case .other: return .other
+        case .unknown: return .unknown
+        case .none: return .none
+        }
+    }
+
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case none
+}
+
+@objc
+public enum DDRUMViewEventRUMConnectivityStatus: Int {
+    internal init(swift: RUMConnectivity.Status) {
+        switch swift {
+        case .connected: self = .connected
+        case .notConnected: self = .notConnected
+        case .maybe: self = .maybe
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Status {
+        switch self {
+        case .connected: return .connected
+        case .notConnected: return .notConnected
+        case .maybe: return .maybe
+        }
+    }
+
+    case connected
+    case notConnected
+    case maybe
+}
+
+@objc
+public class DDRUMViewEventSession: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.session.id
+    }
+
+    @objc public var type: DDRUMViewEventSessionSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc
+public enum DDRUMViewEventSessionSessionType: Int {
+    internal init(swift: RUMViewEvent.Session.SessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        }
+    }
+
+    internal var toSwift: RUMViewEvent.Session.SessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        }
+    }
+
+    case user
+    case synthetics
+}
+
+@objc
+public class DDRUMViewEventRUMUser: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var email: String? {
+        root.swiftModel.usr!.email
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.usr!.id
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.usr!.name
+    }
+}
+
+@objc
+public class DDRUMViewEventView: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var action: DDRUMViewEventViewAction {
+        DDRUMViewEventViewAction(root: root)
+    }
+
+    @objc public var crash: DDRUMViewEventViewCrash? {
+        root.swiftModel.view.crash != nil ? DDRUMViewEventViewCrash(root: root) : nil
+    }
+
+    @objc public var cumulativeLayoutShift: NSNumber? {
+        root.swiftModel.view.cumulativeLayoutShift as NSNumber?
+    }
+
+    @objc public var domComplete: NSNumber? {
+        root.swiftModel.view.domComplete as NSNumber?
+    }
+
+    @objc public var domContentLoaded: NSNumber? {
+        root.swiftModel.view.domContentLoaded as NSNumber?
+    }
+
+    @objc public var domInteractive: NSNumber? {
+        root.swiftModel.view.domInteractive as NSNumber?
+    }
+
+    @objc public var error: DDRUMViewEventViewError {
+        DDRUMViewEventViewError(root: root)
+    }
+
+    @objc public var firstContentfulPaint: NSNumber? {
+        root.swiftModel.view.firstContentfulPaint as NSNumber?
+    }
+
+    @objc public var firstInputDelay: NSNumber? {
+        root.swiftModel.view.firstInputDelay as NSNumber?
+    }
+
+    @objc public var id: String {
+        root.swiftModel.view.id
+    }
+
+    @objc public var isActive: NSNumber? {
+        root.swiftModel.view.isActive as NSNumber?
+    }
+
+    @objc public var largestContentfulPaint: NSNumber? {
+        root.swiftModel.view.largestContentfulPaint as NSNumber?
+    }
+
+    @objc public var loadEvent: NSNumber? {
+        root.swiftModel.view.loadEvent as NSNumber?
+    }
+
+    @objc public var loadingTime: NSNumber? {
+        root.swiftModel.view.loadingTime as NSNumber?
+    }
+
+    @objc public var loadingType: DDRUMViewEventViewLoadingType {
+        .init(swift: root.swiftModel.view.loadingType)
+    }
+
+    @objc public var longTask: DDRUMViewEventViewLongTask? {
+        root.swiftModel.view.longTask != nil ? DDRUMViewEventViewLongTask(root: root) : nil
+    }
+
+    @objc public var referrer: String? {
+        set { root.swiftModel.view.referrer = newValue }
+        get { root.swiftModel.view.referrer }
+    }
+
+    @objc public var resource: DDRUMViewEventViewResource {
+        DDRUMViewEventViewResource(root: root)
+    }
+
+    @objc public var timeSpent: NSNumber {
+        root.swiftModel.view.timeSpent as NSNumber
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.view.url = newValue }
+        get { root.swiftModel.view.url }
+    }
+}
+
+@objc
+public class DDRUMViewEventViewAction: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.action.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewCrash: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.crash!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewError: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.error.count as NSNumber
+    }
+}
+
+@objc
+public enum DDRUMViewEventViewLoadingType: Int {
+    internal init(swift: RUMViewEvent.View.LoadingType?) {
+        switch swift {
+        case nil: self = .none
+        case .initialLoad?: self = .initialLoad
+        case .routeChange?: self = .routeChange
+        case .activityDisplay?: self = .activityDisplay
+        case .activityRedisplay?: self = .activityRedisplay
+        case .fragmentDisplay?: self = .fragmentDisplay
+        case .fragmentRedisplay?: self = .fragmentRedisplay
+        case .viewControllerDisplay?: self = .viewControllerDisplay
+        case .viewControllerRedisplay?: self = .viewControllerRedisplay
+        }
+    }
+
+    internal var toSwift: RUMViewEvent.View.LoadingType? {
+        switch self {
+        case .none: return nil
+        case .initialLoad: return .initialLoad
+        case .routeChange: return .routeChange
+        case .activityDisplay: return .activityDisplay
+        case .activityRedisplay: return .activityRedisplay
+        case .fragmentDisplay: return .fragmentDisplay
+        case .fragmentRedisplay: return .fragmentRedisplay
+        case .viewControllerDisplay: return .viewControllerDisplay
+        case .viewControllerRedisplay: return .viewControllerRedisplay
+        }
+    }
+
+    case none
+    case initialLoad
+    case routeChange
+    case activityDisplay
+    case activityRedisplay
+    case fragmentDisplay
+    case fragmentRedisplay
+    case viewControllerDisplay
+    case viewControllerRedisplay
+}
+
+@objc
+public class DDRUMViewEventViewLongTask: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.longTask!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewResource: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.resource.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMResourceEvent: NSObject {
+    internal var swiftModel: RUMResourceEvent
+    internal var root: DDRUMResourceEvent { self }
+
+    internal init(swiftModel: RUMResourceEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var dd: DDRUMResourceEventDD {
+        DDRUMResourceEventDD(root: root)
+    }
+
+    @objc public var action: DDRUMResourceEventAction? {
+        root.swiftModel.action != nil ? DDRUMResourceEventAction(root: root) : nil
+    }
+
+    @objc public var application: DDRUMResourceEventApplication {
+        DDRUMResourceEventApplication(root: root)
+    }
+
+    @objc public var connectivity: DDRUMResourceEventRUMConnectivity? {
+        root.swiftModel.connectivity != nil ? DDRUMResourceEventRUMConnectivity(root: root) : nil
+    }
+
+    @objc public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    @objc public var resource: DDRUMResourceEventResource {
+        DDRUMResourceEventResource(root: root)
+    }
+
+    @objc public var service: String? {
+        root.swiftModel.service
+    }
+
+    @objc public var session: DDRUMResourceEventSession {
+        DDRUMResourceEventSession(root: root)
+    }
+
+    @objc public var type: String {
+        root.swiftModel.type
+    }
+
+    @objc public var usr: DDRUMResourceEventRUMUser? {
+        root.swiftModel.usr != nil ? DDRUMResourceEventRUMUser(root: root) : nil
+    }
+
+    @objc public var view: DDRUMResourceEventView {
+        DDRUMResourceEventView(root: root)
+    }
+}
+
+@objc
+public class DDRUMResourceEventDD: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+
+    @objc public var spanId: String? {
+        root.swiftModel.dd.spanId
+    }
+
+    @objc public var traceId: String? {
+        root.swiftModel.dd.traceId
+    }
+}
+
+@objc
+public class DDRUMResourceEventAction: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.action!.id
+    }
+}
+
+@objc
+public class DDRUMResourceEventApplication: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMResourceEventRUMConnectivity: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var cellular: DDRUMResourceEventRUMConnectivityCellular? {
+        root.swiftModel.connectivity!.cellular != nil ? DDRUMResourceEventRUMConnectivityCellular(root: root) : nil
+    }
+
+    @objc public var interfaces: [Int] {
+        root.swiftModel.connectivity!.interfaces.map { DDRUMResourceEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    }
+
+    @objc public var status: DDRUMResourceEventRUMConnectivityStatus {
+        .init(swift: root.swiftModel.connectivity!.status)
+    }
+}
+
+@objc
+public class DDRUMResourceEventRUMConnectivityCellular: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var carrierName: String? {
+        root.swiftModel.connectivity!.cellular!.carrierName
+    }
+
+    @objc public var technology: String? {
+        root.swiftModel.connectivity!.cellular!.technology
+    }
+}
+
+@objc
+public enum DDRUMResourceEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces) {
+        switch swift {
+        case .bluetooth: self = .bluetooth
+        case .cellular: self = .cellular
+        case .ethernet: self = .ethernet
+        case .wifi: self = .wifi
+        case .wimax: self = .wimax
+        case .mixed: self = .mixed
+        case .other: self = .other
+        case .unknown: self = .unknown
+        case .none: self = .none
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces {
+        switch self {
+        case .bluetooth: return .bluetooth
+        case .cellular: return .cellular
+        case .ethernet: return .ethernet
+        case .wifi: return .wifi
+        case .wimax: return .wimax
+        case .mixed: return .mixed
+        case .other: return .other
+        case .unknown: return .unknown
+        case .none: return .none
+        }
+    }
+
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case none
+}
+
+@objc
+public enum DDRUMResourceEventRUMConnectivityStatus: Int {
+    internal init(swift: RUMConnectivity.Status) {
+        switch swift {
+        case .connected: self = .connected
+        case .notConnected: self = .notConnected
+        case .maybe: self = .maybe
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Status {
+        switch self {
+        case .connected: return .connected
+        case .notConnected: return .notConnected
+        case .maybe: return .maybe
+        }
+    }
+
+    case connected
+    case notConnected
+    case maybe
+}
+
+@objc
+public class DDRUMResourceEventResource: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var connect: DDRUMResourceEventResourceConnect? {
+        root.swiftModel.resource.connect != nil ? DDRUMResourceEventResourceConnect(root: root) : nil
+    }
+
+    @objc public var dns: DDRUMResourceEventResourceDNS? {
+        root.swiftModel.resource.dns != nil ? DDRUMResourceEventResourceDNS(root: root) : nil
+    }
+
+    @objc public var download: DDRUMResourceEventResourceDownload? {
+        root.swiftModel.resource.download != nil ? DDRUMResourceEventResourceDownload(root: root) : nil
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.duration as NSNumber
+    }
+
+    @objc public var firstByte: DDRUMResourceEventResourceFirstByte? {
+        root.swiftModel.resource.firstByte != nil ? DDRUMResourceEventResourceFirstByte(root: root) : nil
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.resource.id
+    }
+
+    @objc public var method: DDRUMResourceEventResourceRUMMethod {
+        .init(swift: root.swiftModel.resource.method)
+    }
+
+    @objc public var provider: DDRUMResourceEventResourceProvider? {
+        root.swiftModel.resource.provider != nil ? DDRUMResourceEventResourceProvider(root: root) : nil
+    }
+
+    @objc public var redirect: DDRUMResourceEventResourceRedirect? {
+        root.swiftModel.resource.redirect != nil ? DDRUMResourceEventResourceRedirect(root: root) : nil
+    }
+
+    @objc public var size: NSNumber? {
+        root.swiftModel.resource.size as NSNumber?
+    }
+
+    @objc public var ssl: DDRUMResourceEventResourceSSL? {
+        root.swiftModel.resource.ssl != nil ? DDRUMResourceEventResourceSSL(root: root) : nil
+    }
+
+    @objc public var statusCode: NSNumber? {
+        root.swiftModel.resource.statusCode as NSNumber?
+    }
+
+    @objc public var type: DDRUMResourceEventResourceResourceType {
+        .init(swift: root.swiftModel.resource.type)
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.resource.url = newValue }
+        get { root.swiftModel.resource.url }
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceConnect: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.connect!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.connect!.start as NSNumber
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceDNS: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.dns!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.dns!.start as NSNumber
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceDownload: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.download!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.download!.start as NSNumber
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceFirstByte: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.firstByte!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.firstByte!.start as NSNumber
+    }
+}
+
+@objc
+public enum DDRUMResourceEventResourceRUMMethod: Int {
+    internal init(swift: RUMMethod?) {
+        switch swift {
+        case nil: self = .none
+        case .post?: self = .post
+        case .get?: self = .get
+        case .head?: self = .head
+        case .put?: self = .put
+        case .delete?: self = .delete
+        case .patch?: self = .patch
+        }
+    }
+
+    internal var toSwift: RUMMethod? {
+        switch self {
+        case .none: return nil
+        case .post: return .post
+        case .get: return .get
+        case .head: return .head
+        case .put: return .put
+        case .delete: return .delete
+        case .patch: return .patch
+        }
+    }
+
+    case none
+    case post
+    case get
+    case head
+    case put
+    case delete
+    case patch
+}
+
+@objc
+public class DDRUMResourceEventResourceProvider: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var domain: String? {
+        root.swiftModel.resource.provider!.domain
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.resource.provider!.name
+    }
+
+    @objc public var type: DDRUMResourceEventResourceProviderProviderType {
+        .init(swift: root.swiftModel.resource.provider!.type)
+    }
+}
+
+@objc
+public enum DDRUMResourceEventResourceProviderProviderType: Int {
+    internal init(swift: RUMResourceEvent.Resource.Provider.ProviderType?) {
+        switch swift {
+        case nil: self = .none
+        case .ad?: self = .ad
+        case .advertising?: self = .advertising
+        case .analytics?: self = .analytics
+        case .cdn?: self = .cdn
+        case .content?: self = .content
+        case .customerSuccess?: self = .customerSuccess
+        case .firstParty?: self = .firstParty
+        case .hosting?: self = .hosting
+        case .marketing?: self = .marketing
+        case .other?: self = .other
+        case .social?: self = .social
+        case .tagManager?: self = .tagManager
+        case .utility?: self = .utility
+        case .video?: self = .video
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.Resource.Provider.ProviderType? {
+        switch self {
+        case .none: return nil
+        case .ad: return .ad
+        case .advertising: return .advertising
+        case .analytics: return .analytics
+        case .cdn: return .cdn
+        case .content: return .content
+        case .customerSuccess: return .customerSuccess
+        case .firstParty: return .firstParty
+        case .hosting: return .hosting
+        case .marketing: return .marketing
+        case .other: return .other
+        case .social: return .social
+        case .tagManager: return .tagManager
+        case .utility: return .utility
+        case .video: return .video
+        }
+    }
+
+    case none
+    case ad
+    case advertising
+    case analytics
+    case cdn
+    case content
+    case customerSuccess
+    case firstParty
+    case hosting
+    case marketing
+    case other
+    case social
+    case tagManager
+    case utility
+    case video
+}
+
+@objc
+public class DDRUMResourceEventResourceRedirect: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.redirect!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.redirect!.start as NSNumber
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceSSL: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.ssl!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.ssl!.start as NSNumber
+    }
+}
+
+@objc
+public enum DDRUMResourceEventResourceResourceType: Int {
+    internal init(swift: RUMResourceEvent.Resource.ResourceType) {
+        switch swift {
+        case .document: self = .document
+        case .xhr: self = .xhr
+        case .beacon: self = .beacon
+        case .fetch: self = .fetch
+        case .css: self = .css
+        case .js: self = .js
+        case .image: self = .image
+        case .font: self = .font
+        case .media: self = .media
+        case .other: self = .other
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.Resource.ResourceType {
+        switch self {
+        case .document: return .document
+        case .xhr: return .xhr
+        case .beacon: return .beacon
+        case .fetch: return .fetch
+        case .css: return .css
+        case .js: return .js
+        case .image: return .image
+        case .font: return .font
+        case .media: return .media
+        case .other: return .other
+        }
+    }
+
+    case document
+    case xhr
+    case beacon
+    case fetch
+    case css
+    case js
+    case image
+    case font
+    case media
+    case other
+}
+
+@objc
+public class DDRUMResourceEventSession: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.session.id
+    }
+
+    @objc public var type: DDRUMResourceEventSessionSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc
+public enum DDRUMResourceEventSessionSessionType: Int {
+    internal init(swift: RUMResourceEvent.Session.SessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.Session.SessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        }
+    }
+
+    case user
+    case synthetics
+}
+
+@objc
+public class DDRUMResourceEventRUMUser: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var email: String? {
+        root.swiftModel.usr!.email
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.usr!.id
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.usr!.name
+    }
+}
+
+@objc
+public class DDRUMResourceEventView: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.view.id
+    }
+
+    @objc public var referrer: String? {
+        set { root.swiftModel.view.referrer = newValue }
+        get { root.swiftModel.view.referrer }
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.view.url = newValue }
+        get { root.swiftModel.view.url }
+    }
+}
+
+@objc
+public class DDRUMActionEvent: NSObject {
+    internal var swiftModel: RUMActionEvent
+    internal var root: DDRUMActionEvent { self }
+
+    internal init(swiftModel: RUMActionEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var dd: DDRUMActionEventDD {
+        DDRUMActionEventDD(root: root)
+    }
+
+    @objc public var action: DDRUMActionEventAction {
+        DDRUMActionEventAction(root: root)
+    }
+
+    @objc public var application: DDRUMActionEventApplication {
+        DDRUMActionEventApplication(root: root)
+    }
+
+    @objc public var connectivity: DDRUMActionEventRUMConnectivity? {
+        root.swiftModel.connectivity != nil ? DDRUMActionEventRUMConnectivity(root: root) : nil
+    }
+
+    @objc public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    @objc public var service: String? {
+        root.swiftModel.service
+    }
+
+    @objc public var session: DDRUMActionEventSession {
+        DDRUMActionEventSession(root: root)
+    }
+
+    @objc public var type: String {
+        root.swiftModel.type
+    }
+
+    @objc public var usr: DDRUMActionEventRUMUser? {
+        root.swiftModel.usr != nil ? DDRUMActionEventRUMUser(root: root) : nil
+    }
+
+    @objc public var view: DDRUMActionEventView {
+        DDRUMActionEventView(root: root)
+    }
+}
+
+@objc
+public class DDRUMActionEventDD: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+}
+
+@objc
+public class DDRUMActionEventAction: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var crash: DDRUMActionEventActionCrash? {
+        root.swiftModel.action.crash != nil ? DDRUMActionEventActionCrash(root: root) : nil
+    }
+
+    @objc public var error: DDRUMActionEventActionError? {
+        root.swiftModel.action.error != nil ? DDRUMActionEventActionError(root: root) : nil
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.action.id
+    }
+
+    @objc public var loadingTime: NSNumber? {
+        root.swiftModel.action.loadingTime as NSNumber?
+    }
+
+    @objc public var longTask: DDRUMActionEventActionLongTask? {
+        root.swiftModel.action.longTask != nil ? DDRUMActionEventActionLongTask(root: root) : nil
+    }
+
+    @objc public var resource: DDRUMActionEventActionResource? {
+        root.swiftModel.action.resource != nil ? DDRUMActionEventActionResource(root: root) : nil
+    }
+
+    @objc public var target: DDRUMActionEventActionTarget? {
+        root.swiftModel.action.target != nil ? DDRUMActionEventActionTarget(root: root) : nil
+    }
+
+    @objc public var type: DDRUMActionEventActionActionType {
+        .init(swift: root.swiftModel.action.type)
+    }
+}
+
+@objc
+public class DDRUMActionEventActionCrash: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.action.crash!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMActionEventActionError: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.action.error!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMActionEventActionLongTask: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.action.longTask!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMActionEventActionResource: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.action.resource!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMActionEventActionTarget: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var name: String {
+        set { root.swiftModel.action.target!.name = newValue }
+        get { root.swiftModel.action.target!.name }
+    }
+}
+
+@objc
+public enum DDRUMActionEventActionActionType: Int {
+    internal init(swift: RUMActionEvent.Action.ActionType) {
+        switch swift {
+        case .custom: self = .custom
+        case .click: self = .click
+        case .tap: self = .tap
+        case .scroll: self = .scroll
+        case .swipe: self = .swipe
+        case .applicationStart: self = .applicationStart
+        case .back: self = .back
+        }
+    }
+
+    internal var toSwift: RUMActionEvent.Action.ActionType {
+        switch self {
+        case .custom: return .custom
+        case .click: return .click
+        case .tap: return .tap
+        case .scroll: return .scroll
+        case .swipe: return .swipe
+        case .applicationStart: return .applicationStart
+        case .back: return .back
+        }
+    }
+
+    case custom
+    case click
+    case tap
+    case scroll
+    case swipe
+    case applicationStart
+    case back
+}
+
+@objc
+public class DDRUMActionEventApplication: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMActionEventRUMConnectivity: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var cellular: DDRUMActionEventRUMConnectivityCellular? {
+        root.swiftModel.connectivity!.cellular != nil ? DDRUMActionEventRUMConnectivityCellular(root: root) : nil
+    }
+
+    @objc public var interfaces: [Int] {
+        root.swiftModel.connectivity!.interfaces.map { DDRUMActionEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    }
+
+    @objc public var status: DDRUMActionEventRUMConnectivityStatus {
+        .init(swift: root.swiftModel.connectivity!.status)
+    }
+}
+
+@objc
+public class DDRUMActionEventRUMConnectivityCellular: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var carrierName: String? {
+        root.swiftModel.connectivity!.cellular!.carrierName
+    }
+
+    @objc public var technology: String? {
+        root.swiftModel.connectivity!.cellular!.technology
+    }
+}
+
+@objc
+public enum DDRUMActionEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces) {
+        switch swift {
+        case .bluetooth: self = .bluetooth
+        case .cellular: self = .cellular
+        case .ethernet: self = .ethernet
+        case .wifi: self = .wifi
+        case .wimax: self = .wimax
+        case .mixed: self = .mixed
+        case .other: self = .other
+        case .unknown: self = .unknown
+        case .none: self = .none
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces {
+        switch self {
+        case .bluetooth: return .bluetooth
+        case .cellular: return .cellular
+        case .ethernet: return .ethernet
+        case .wifi: return .wifi
+        case .wimax: return .wimax
+        case .mixed: return .mixed
+        case .other: return .other
+        case .unknown: return .unknown
+        case .none: return .none
+        }
+    }
+
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case none
+}
+
+@objc
+public enum DDRUMActionEventRUMConnectivityStatus: Int {
+    internal init(swift: RUMConnectivity.Status) {
+        switch swift {
+        case .connected: self = .connected
+        case .notConnected: self = .notConnected
+        case .maybe: self = .maybe
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Status {
+        switch self {
+        case .connected: return .connected
+        case .notConnected: return .notConnected
+        case .maybe: return .maybe
+        }
+    }
+
+    case connected
+    case notConnected
+    case maybe
+}
+
+@objc
+public class DDRUMActionEventSession: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.session.id
+    }
+
+    @objc public var type: DDRUMActionEventSessionSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc
+public enum DDRUMActionEventSessionSessionType: Int {
+    internal init(swift: RUMActionEvent.Session.SessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        }
+    }
+
+    internal var toSwift: RUMActionEvent.Session.SessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        }
+    }
+
+    case user
+    case synthetics
+}
+
+@objc
+public class DDRUMActionEventRUMUser: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var email: String? {
+        root.swiftModel.usr!.email
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.usr!.id
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.usr!.name
+    }
+}
+
+@objc
+public class DDRUMActionEventView: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.view.id
+    }
+
+    @objc public var referrer: String? {
+        set { root.swiftModel.view.referrer = newValue }
+        get { root.swiftModel.view.referrer }
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.view.url = newValue }
+        get { root.swiftModel.view.url }
+    }
+}
+
+@objc
+public class DDRUMErrorEvent: NSObject {
+    internal var swiftModel: RUMErrorEvent
+    internal var root: DDRUMErrorEvent { self }
+
+    internal init(swiftModel: RUMErrorEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var dd: DDRUMErrorEventDD {
+        DDRUMErrorEventDD(root: root)
+    }
+
+    @objc public var action: DDRUMErrorEventAction? {
+        root.swiftModel.action != nil ? DDRUMErrorEventAction(root: root) : nil
+    }
+
+    @objc public var application: DDRUMErrorEventApplication {
+        DDRUMErrorEventApplication(root: root)
+    }
+
+    @objc public var connectivity: DDRUMErrorEventRUMConnectivity? {
+        root.swiftModel.connectivity != nil ? DDRUMErrorEventRUMConnectivity(root: root) : nil
+    }
+
+    @objc public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    @objc public var error: DDRUMErrorEventError {
+        DDRUMErrorEventError(root: root)
+    }
+
+    @objc public var service: String? {
+        root.swiftModel.service
+    }
+
+    @objc public var session: DDRUMErrorEventSession {
+        DDRUMErrorEventSession(root: root)
+    }
+
+    @objc public var type: String {
+        root.swiftModel.type
+    }
+
+    @objc public var usr: DDRUMErrorEventRUMUser? {
+        root.swiftModel.usr != nil ? DDRUMErrorEventRUMUser(root: root) : nil
+    }
+
+    @objc public var view: DDRUMErrorEventView {
+        DDRUMErrorEventView(root: root)
+    }
+}
+
+@objc
+public class DDRUMErrorEventDD: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+}
+
+@objc
+public class DDRUMErrorEventAction: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.action!.id
+    }
+}
+
+@objc
+public class DDRUMErrorEventApplication: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMErrorEventRUMConnectivity: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var cellular: DDRUMErrorEventRUMConnectivityCellular? {
+        root.swiftModel.connectivity!.cellular != nil ? DDRUMErrorEventRUMConnectivityCellular(root: root) : nil
+    }
+
+    @objc public var interfaces: [Int] {
+        root.swiftModel.connectivity!.interfaces.map { DDRUMErrorEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    }
+
+    @objc public var status: DDRUMErrorEventRUMConnectivityStatus {
+        .init(swift: root.swiftModel.connectivity!.status)
+    }
+}
+
+@objc
+public class DDRUMErrorEventRUMConnectivityCellular: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var carrierName: String? {
+        root.swiftModel.connectivity!.cellular!.carrierName
+    }
+
+    @objc public var technology: String? {
+        root.swiftModel.connectivity!.cellular!.technology
+    }
+}
+
+@objc
+public enum DDRUMErrorEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces) {
+        switch swift {
+        case .bluetooth: self = .bluetooth
+        case .cellular: self = .cellular
+        case .ethernet: self = .ethernet
+        case .wifi: self = .wifi
+        case .wimax: self = .wimax
+        case .mixed: self = .mixed
+        case .other: self = .other
+        case .unknown: self = .unknown
+        case .none: self = .none
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces {
+        switch self {
+        case .bluetooth: return .bluetooth
+        case .cellular: return .cellular
+        case .ethernet: return .ethernet
+        case .wifi: return .wifi
+        case .wimax: return .wimax
+        case .mixed: return .mixed
+        case .other: return .other
+        case .unknown: return .unknown
+        case .none: return .none
+        }
+    }
+
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case none
+}
+
+@objc
+public enum DDRUMErrorEventRUMConnectivityStatus: Int {
+    internal init(swift: RUMConnectivity.Status) {
+        switch swift {
+        case .connected: self = .connected
+        case .notConnected: self = .notConnected
+        case .maybe: self = .maybe
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Status {
+        switch self {
+        case .connected: return .connected
+        case .notConnected: return .notConnected
+        case .maybe: return .maybe
+        }
+    }
+
+    case connected
+    case notConnected
+    case maybe
+}
+
+@objc
+public class DDRUMErrorEventError: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var isCrash: NSNumber? {
+        root.swiftModel.error.isCrash as NSNumber?
+    }
+
+    @objc public var message: String {
+        set { root.swiftModel.error.message = newValue }
+        get { root.swiftModel.error.message }
+    }
+
+    @objc public var resource: DDRUMErrorEventErrorResource? {
+        root.swiftModel.error.resource != nil ? DDRUMErrorEventErrorResource(root: root) : nil
+    }
+
+    @objc public var source: DDRUMErrorEventErrorSource {
+        .init(swift: root.swiftModel.error.source)
+    }
+
+    @objc public var stack: String? {
+        set { root.swiftModel.error.stack = newValue }
+        get { root.swiftModel.error.stack }
+    }
+}
+
+@objc
+public class DDRUMErrorEventErrorResource: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var method: DDRUMErrorEventErrorResourceRUMMethod {
+        .init(swift: root.swiftModel.error.resource!.method)
+    }
+
+    @objc public var provider: DDRUMErrorEventErrorResourceProvider? {
+        root.swiftModel.error.resource!.provider != nil ? DDRUMErrorEventErrorResourceProvider(root: root) : nil
+    }
+
+    @objc public var statusCode: NSNumber {
+        root.swiftModel.error.resource!.statusCode as NSNumber
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.error.resource!.url = newValue }
+        get { root.swiftModel.error.resource!.url }
+    }
+}
+
+@objc
+public enum DDRUMErrorEventErrorResourceRUMMethod: Int {
+    internal init(swift: RUMMethod) {
+        switch swift {
+        case .post: self = .post
+        case .get: self = .get
+        case .head: self = .head
+        case .put: self = .put
+        case .delete: self = .delete
+        case .patch: self = .patch
+        }
+    }
+
+    internal var toSwift: RUMMethod {
+        switch self {
+        case .post: return .post
+        case .get: return .get
+        case .head: return .head
+        case .put: return .put
+        case .delete: return .delete
+        case .patch: return .patch
+        }
+    }
+
+    case post
+    case get
+    case head
+    case put
+    case delete
+    case patch
+}
+
+@objc
+public class DDRUMErrorEventErrorResourceProvider: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var domain: String? {
+        root.swiftModel.error.resource!.provider!.domain
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.error.resource!.provider!.name
+    }
+
+    @objc public var type: DDRUMErrorEventErrorResourceProviderProviderType {
+        .init(swift: root.swiftModel.error.resource!.provider!.type)
+    }
+}
+
+@objc
+public enum DDRUMErrorEventErrorResourceProviderProviderType: Int {
+    internal init(swift: RUMErrorEvent.Error.Resource.Provider.ProviderType?) {
+        switch swift {
+        case nil: self = .none
+        case .ad?: self = .ad
+        case .advertising?: self = .advertising
+        case .analytics?: self = .analytics
+        case .cdn?: self = .cdn
+        case .content?: self = .content
+        case .customerSuccess?: self = .customerSuccess
+        case .firstParty?: self = .firstParty
+        case .hosting?: self = .hosting
+        case .marketing?: self = .marketing
+        case .other?: self = .other
+        case .social?: self = .social
+        case .tagManager?: self = .tagManager
+        case .utility?: self = .utility
+        case .video?: self = .video
+        }
+    }
+
+    internal var toSwift: RUMErrorEvent.Error.Resource.Provider.ProviderType? {
+        switch self {
+        case .none: return nil
+        case .ad: return .ad
+        case .advertising: return .advertising
+        case .analytics: return .analytics
+        case .cdn: return .cdn
+        case .content: return .content
+        case .customerSuccess: return .customerSuccess
+        case .firstParty: return .firstParty
+        case .hosting: return .hosting
+        case .marketing: return .marketing
+        case .other: return .other
+        case .social: return .social
+        case .tagManager: return .tagManager
+        case .utility: return .utility
+        case .video: return .video
+        }
+    }
+
+    case none
+    case ad
+    case advertising
+    case analytics
+    case cdn
+    case content
+    case customerSuccess
+    case firstParty
+    case hosting
+    case marketing
+    case other
+    case social
+    case tagManager
+    case utility
+    case video
+}
+
+@objc
+public enum DDRUMErrorEventErrorSource: Int {
+    internal init(swift: RUMErrorEvent.Error.Source) {
+        switch swift {
+        case .network: self = .network
+        case .source: self = .source
+        case .console: self = .console
+        case .logger: self = .logger
+        case .agent: self = .agent
+        case .webview: self = .webview
+        case .custom: self = .custom
+        }
+    }
+
+    internal var toSwift: RUMErrorEvent.Error.Source {
+        switch self {
+        case .network: return .network
+        case .source: return .source
+        case .console: return .console
+        case .logger: return .logger
+        case .agent: return .agent
+        case .webview: return .webview
+        case .custom: return .custom
+        }
+    }
+
+    case network
+    case source
+    case console
+    case logger
+    case agent
+    case webview
+    case custom
+}
+
+@objc
+public class DDRUMErrorEventSession: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.session.id
+    }
+
+    @objc public var type: DDRUMErrorEventSessionSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc
+public enum DDRUMErrorEventSessionSessionType: Int {
+    internal init(swift: RUMErrorEvent.Session.SessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        }
+    }
+
+    internal var toSwift: RUMErrorEvent.Session.SessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        }
+    }
+
+    case user
+    case synthetics
+}
+
+@objc
+public class DDRUMErrorEventRUMUser: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var email: String? {
+        root.swiftModel.usr!.email
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.usr!.id
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.usr!.name
+    }
+}
+
+@objc
+public class DDRUMErrorEventView: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.view.id
+    }
+
+    @objc public var referrer: String? {
+        set { root.swiftModel.view.referrer = newValue }
+        get { root.swiftModel.view.referrer }
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.view.url = newValue }
+        get { root.swiftModel.view.url }
+    }
+}
+
+// swiftlint:enable force_unwrapping

--- a/tools/rum-models-generator/Package.swift
+++ b/tools/rum-models-generator/Package.swift
@@ -6,11 +6,6 @@ import PackageDescription
 let package = Package(
     name: "rum-models-generator",
     platforms: [.macOS(.v10_15)],
-    products: [
-        .library(
-            name: "rum-models-generator",
-            targets: ["rum-models-generator"]),
-    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.2.0"),
         .package(name: "Difference", url: "https://github.com/krzysztofzablocki/Difference.git", from: "0.5.0"),

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
@@ -30,7 +30,7 @@ internal class ObjcInteropRootClass: ObjcInteropClass {
 /// Schema of an `@objc class` managing the access to a nested `SwiftStruct`.
 internal class ObjcInteropTransitiveClass: ObjcInteropClass {
     /// Property wrapper in the parent class, which stores the definition of this transitive class.
-    unowned private(set) var parentProperty: ObjcInteropPropertyWrapper
+    private(set) unowned var parentProperty: ObjcInteropPropertyWrapper
 
     /// The nested `SwiftStruct` managed by this `@objc class`.
     let managedSwiftStruct: SwiftStruct
@@ -49,7 +49,7 @@ internal class ObjcInteropReferencedTransitiveClass: ObjcInteropTransitiveClass 
 /// Schema of an `@objc enum` exposing values of a `SwiftEnum`.
 internal class ObjcInteropEnum: ObjcInteropType {
     /// Property wrapper in the parent class, which stores the definition of this `ObjcInteropEnum`.
-    unowned private(set) var parentProperty: ObjcInteropPropertyWrapper
+    private(set) unowned var parentProperty: ObjcInteropPropertyWrapper
     /// The `SwiftEnum` wrapped by this Obj-c enum.
     let managedSwiftEnum: SwiftEnum
 
@@ -70,7 +70,7 @@ internal class ObjcInteropEnumArray: ObjcInteropEnum {}
 /// Schema fo an `@objc` property which manages the access to a `SwiftStruct` property.
 internal class ObjcInteropPropertyWrapper: ObjcInteropType {
     /// The class owning this property.
-    unowned private(set) var owner: ObjcInteropClass
+    private(set) unowned var owner: ObjcInteropClass
     /// Corresponding Swift property in `SwiftStruct`.
     let swiftProperty: SwiftStruct.Property
 
@@ -86,32 +86,26 @@ internal protocol ObjcInteropPropertyWrapperForTransitiveType {
 }
 
 /// Schema for an `@objc` property managing the access to nested `SwiftStruct`.
-internal class ObjcInteropPropertyWrapperAccessingNestedStruct:
-    ObjcInteropPropertyWrapper,
-    ObjcInteropPropertyWrapperForTransitiveType {
-    var objcNestedClass: ObjcInteropTransitiveClass!
+internal class ObjcInteropPropertyWrapperAccessingNestedStruct: ObjcInteropPropertyWrapper, ObjcInteropPropertyWrapperForTransitiveType {
+    var objcNestedClass: ObjcInteropTransitiveClass! // swiftlint:disable:this implicitly_unwrapped_optional
     var objcTransitiveType: ObjcInteropType { objcNestedClass }
 }
 
 /// Schema for an `@objc` property managing the access to nested `SwiftEnum`.
-internal class ObjcInteropPropertyWrapperAccessingNestedEnum:
-    ObjcInteropPropertyWrapper,
-    ObjcInteropPropertyWrapperForTransitiveType {
-    var objcNestedEnum: ObjcInteropEnum!
+internal class ObjcInteropPropertyWrapperAccessingNestedEnum: ObjcInteropPropertyWrapper, ObjcInteropPropertyWrapperForTransitiveType {
+    var objcNestedEnum: ObjcInteropEnum! // swiftlint:disable:this implicitly_unwrapped_optional
     var objcTransitiveType: ObjcInteropType { objcNestedEnum }
 }
 
 /// Schema for an `@objc` property managing the access array of `SwiftEnums`.
-internal class ObjcInteropPropertyWrapperAccessingNestedEnumsArray:
-    ObjcInteropPropertyWrapper,
-    ObjcInteropPropertyWrapperForTransitiveType {
-    var objcNestedEnumsArray: ObjcInteropEnumArray!
+internal class ObjcInteropPropertyWrapperAccessingNestedEnumsArray: ObjcInteropPropertyWrapper, ObjcInteropPropertyWrapperForTransitiveType {
+    var objcNestedEnumsArray: ObjcInteropEnumArray! // swiftlint:disable:this implicitly_unwrapped_optional
     var objcTransitiveType: ObjcInteropType { objcNestedEnumsArray }
 }
 
 /// Schema for an `@objc` property managing the access to `SwiftStruct` property.
 internal class ObjcInteropPropertyWrapperManagingSwiftStructProperty: ObjcInteropPropertyWrapper {
-    var objcInteropType: ObjcInteropType!
+    var objcInteropType: ObjcInteropType! // swiftlint:disable:this implicitly_unwrapped_optional
 }
 
 // MARK: - Plaing type schemas

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
@@ -9,13 +9,13 @@ import Foundation
 /// Type-safe Swift ↔ Objc interopability schema.
 internal protocol ObjcInteropType: AnyObject {}
 
-/// An interop class which manages Swift `struct`.
+/// Any `@objc class` which manages Swift `struct`.
 internal protocol ObjcInteropClass: ObjcInteropType {
     var managedSwiftStruct: SwiftStruct { get }
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] { set get }
 }
 
-/// Schema a root `@objc class` storing the mutable value of a `SwiftStruct`.
+/// Schema of a root `@objc class` storing the mutable value of a `SwiftStruct`.
 internal class ObjcInteropRootClass: ObjcInteropClass {
     /// The `SwiftStruct` managed by this `@objc class`.
     let managedSwiftStruct: SwiftStruct
@@ -27,7 +27,7 @@ internal class ObjcInteropRootClass: ObjcInteropClass {
     }
 }
 
-/// Schema of an `@objc class` managing the access to a nested `SwiftStruct`.
+/// Schema of a transitive `@objc class` managing the access to the nested `SwiftStruct`.
 internal class ObjcInteropTransitiveClass: ObjcInteropClass {
     /// Property wrapper in the parent class, which stores the definition of this transitive class.
     private(set) unowned var parentProperty: ObjcInteropPropertyWrapper
@@ -43,14 +43,14 @@ internal class ObjcInteropTransitiveClass: ObjcInteropClass {
     }
 }
 
-/// Schema of an `@objc class` managing the access to a nested `SwiftStruct` referenced using `SwiftTypeReference`.
+/// Schema of a transitive `@objc class` managing the access to a nested `SwiftStruct` referenced using `SwiftTypeReference`.
 internal class ObjcInteropReferencedTransitiveClass: ObjcInteropTransitiveClass {}
 
-/// Schema of an `@objc enum` exposing values of a `SwiftEnum`.
+/// Schema of an `@objc enum` exposing values for the `SwiftEnum`.
 internal class ObjcInteropEnum: ObjcInteropType {
-    /// Property wrapper in the parent class, which stores the definition of this `ObjcInteropEnum`.
+    /// Property wrapper in the parent class, which stores the definition of this enum.
     private(set) unowned var parentProperty: ObjcInteropPropertyWrapper
-    /// The `SwiftEnum` wrapped by this Obj-c enum.
+    /// The `SwiftEnum` exposed by this Obj-c enum.
     let managedSwiftEnum: SwiftEnum
 
     init(owner: ObjcInteropPropertyWrapper, managedSwiftEnum: SwiftEnum) {
@@ -59,17 +59,17 @@ internal class ObjcInteropEnum: ObjcInteropType {
     }
 }
 
-/// Schema of an `@objc enum` exposing values a `SwiftEnum` referenced using `SwiftTypeReference`.
+/// Schema of an `@objc enum` exposing values of the `SwiftEnum` referenced using `SwiftTypeReference`.
 internal class ObjcInteropReferencedEnum: ObjcInteropEnum {}
 
-/// Schema of an `@objc enum` exposing values from an array of `SwiftEnums`.
+/// Schema of an `@objc enum` exposing values of an array of `SwiftEnums`.
 internal class ObjcInteropEnumArray: ObjcInteropEnum {}
 
 // MARK: - Property wrapper schemas
 
-/// Schema fo an `@objc` property which manages the access to a `SwiftStruct` property.
+/// Schema fo an `@objc` property which manages the access to the `SwiftStruct's` property.
 internal class ObjcInteropPropertyWrapper: ObjcInteropType {
-    /// The class owning this property.
+    /// The `@objc class` owning this property.
     private(set) unowned var owner: ObjcInteropClass
     /// Corresponding Swift property in `SwiftStruct`.
     let swiftProperty: SwiftStruct.Property
@@ -80,30 +80,30 @@ internal class ObjcInteropPropertyWrapper: ObjcInteropType {
     }
 }
 
-/// A property wrapper which uses another `ObjcInteropType` for managing the acces to nested `SwiftStruct` property.
+/// A property wrapper which uses another `ObjcInteropType` for managing acces to a property in nested `SwiftStruct`.
 internal protocol ObjcInteropPropertyWrapperForTransitiveType {
     var objcTransitiveType: ObjcInteropType { get }
 }
 
-/// Schema for an `@objc` property managing the access to nested `SwiftStruct`.
+/// Schema of an `@objc` property managing access to the nested `SwiftStruct`.
 internal class ObjcInteropPropertyWrapperAccessingNestedStruct: ObjcInteropPropertyWrapper, ObjcInteropPropertyWrapperForTransitiveType {
     var objcNestedClass: ObjcInteropTransitiveClass! // swiftlint:disable:this implicitly_unwrapped_optional
     var objcTransitiveType: ObjcInteropType { objcNestedClass }
 }
 
-/// Schema for an `@objc` property managing the access to nested `SwiftEnum`.
+/// Schema of an `@objc` property managing access to the nested `SwiftEnum`.
 internal class ObjcInteropPropertyWrapperAccessingNestedEnum: ObjcInteropPropertyWrapper, ObjcInteropPropertyWrapperForTransitiveType {
     var objcNestedEnum: ObjcInteropEnum! // swiftlint:disable:this implicitly_unwrapped_optional
     var objcTransitiveType: ObjcInteropType { objcNestedEnum }
 }
 
-/// Schema for an `@objc` property managing the access array of `SwiftEnums`.
+/// Schema of an `@objc` property managing access to the array of `SwiftEnums`.
 internal class ObjcInteropPropertyWrapperAccessingNestedEnumsArray: ObjcInteropPropertyWrapper, ObjcInteropPropertyWrapperForTransitiveType {
     var objcNestedEnumsArray: ObjcInteropEnumArray! // swiftlint:disable:this implicitly_unwrapped_optional
     var objcTransitiveType: ObjcInteropType { objcNestedEnumsArray }
 }
 
-/// Schema for an `@objc` property managing the access to `SwiftStruct` property.
+/// Schema of an `@objc` property managing access to a property of the `SwiftStruct`.
 internal class ObjcInteropPropertyWrapperManagingSwiftStructProperty: ObjcInteropPropertyWrapper {
     var objcInteropType: ObjcInteropType! // swiftlint:disable:this implicitly_unwrapped_optional
 }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
@@ -11,19 +11,19 @@ internal protocol ObjcInteropType: AnyObject {}
 
 /// Any `@objc class` which manages Swift `struct`.
 internal protocol ObjcInteropClass: ObjcInteropType {
-    var managedSwiftStruct: SwiftStruct { get }
+    var bridgedSwiftStruct: SwiftStruct { get }
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] { set get }
 }
 
 /// Schema of a root `@objc class` storing the mutable value of a `SwiftStruct`.
 internal class ObjcInteropRootClass: ObjcInteropClass {
     /// The `SwiftStruct` managed by this `@objc class`.
-    let managedSwiftStruct: SwiftStruct
+    let bridgedSwiftStruct: SwiftStruct
     /// `managedSwiftStruct's` property wrappers exposed to Objc.
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
 
     init(managedSwiftStruct: SwiftStruct) {
-        self.managedSwiftStruct = managedSwiftStruct
+        self.bridgedSwiftStruct = managedSwiftStruct
     }
 }
 
@@ -33,13 +33,13 @@ internal class ObjcInteropTransitiveClass: ObjcInteropClass {
     private(set) unowned var parentProperty: ObjcInteropPropertyWrapper
 
     /// The nested `SwiftStruct` managed by this `@objc class`.
-    let managedSwiftStruct: SwiftStruct
+    let bridgedSwiftStruct: SwiftStruct
     /// `managedSwiftStruct's` property wrappers exposed to Objc.
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
 
     init(owner: ObjcInteropPropertyWrapper, managedSwiftStruct: SwiftStruct) {
         self.parentProperty = owner
-        self.managedSwiftStruct = managedSwiftStruct
+        self.bridgedSwiftStruct = managedSwiftStruct
     }
 }
 
@@ -51,11 +51,11 @@ internal class ObjcInteropEnum: ObjcInteropType {
     /// Property wrapper in the parent class, which stores the definition of this enum.
     private(set) unowned var parentProperty: ObjcInteropPropertyWrapper
     /// The `SwiftEnum` exposed by this Obj-c enum.
-    let managedSwiftEnum: SwiftEnum
+    let bridgedSwiftEnum: SwiftEnum
 
     init(owner: ObjcInteropPropertyWrapper, managedSwiftEnum: SwiftEnum) {
         self.parentProperty = owner
-        self.managedSwiftEnum = managedSwiftEnum
+        self.bridgedSwiftEnum = managedSwiftEnum
     }
 }
 
@@ -72,11 +72,11 @@ internal class ObjcInteropPropertyWrapper: ObjcInteropType {
     /// The `@objc class` owning this property.
     private(set) unowned var owner: ObjcInteropClass
     /// Corresponding Swift property in `SwiftStruct`.
-    let swiftProperty: SwiftStruct.Property
+    let bridgedSwiftProperty: SwiftStruct.Property
 
     init(owner: ObjcInteropClass, swiftProperty: SwiftStruct.Property) {
         self.owner = owner
-        self.swiftProperty = swiftProperty
+        self.bridgedSwiftProperty = swiftProperty
     }
 }
 
@@ -108,7 +108,7 @@ internal class ObjcInteropPropertyWrapperManagingSwiftStructProperty: ObjcIntero
     var objcInteropType: ObjcInteropType! // swiftlint:disable:this implicitly_unwrapped_optional
 }
 
-// MARK: - Plaing type schemas
+// MARK: - Plain type schemas
 
 internal class ObjcInteropNSNumber: ObjcInteropType {
     let swiftType: SwiftType

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
@@ -1,0 +1,141 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import Foundation
+
+/// Type-safe Swift ↔ Objc interopability schema.
+internal protocol ObjcInteropType: AnyObject {}
+
+/// An interop class which manages Swift `struct`.
+internal protocol ObjcInteropClass: ObjcInteropType {
+    var managedSwiftStruct: SwiftStruct { get }
+    var objcPropertyWrappers: [ObjcInteropPropertyWrapper] { set get }
+}
+
+/// Schema a root `@objc class` storing the mutable value of a `SwiftStruct`.
+internal class ObjcInteropRootClass: ObjcInteropClass {
+    /// The `SwiftStruct` managed by this `@objc class`.
+    let managedSwiftStruct: SwiftStruct
+    /// `managedSwiftStruct's` property wrappers exposed to Objc.
+    var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
+
+    init(managedSwiftStruct: SwiftStruct) {
+        self.managedSwiftStruct = managedSwiftStruct
+    }
+}
+
+/// Schema of an `@objc class` managing the access to a nested `SwiftStruct`.
+internal class ObjcInteropTransitiveClass: ObjcInteropClass {
+    /// Property wrapper in the parent class, which stores the definition of this transitive class.
+    unowned private(set) var parentProperty: ObjcInteropPropertyWrapper
+
+    /// The nested `SwiftStruct` managed by this `@objc class`.
+    let managedSwiftStruct: SwiftStruct
+    /// `managedSwiftStruct's` property wrappers exposed to Objc.
+    var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
+
+    init(owner: ObjcInteropPropertyWrapper, managedSwiftStruct: SwiftStruct) {
+        self.parentProperty = owner
+        self.managedSwiftStruct = managedSwiftStruct
+    }
+}
+
+/// Schema of an `@objc class` managing the access to a nested `SwiftStruct` referenced using `SwiftTypeReference`.
+internal class ObjcInteropReferencedTransitiveClass: ObjcInteropTransitiveClass {}
+
+/// Schema of an `@objc enum` exposing values of a `SwiftEnum`.
+internal class ObjcInteropEnum: ObjcInteropType {
+    /// Property wrapper in the parent class, which stores the definition of this `ObjcInteropEnum`.
+    unowned private(set) var parentProperty: ObjcInteropPropertyWrapper
+    /// The `SwiftEnum` wrapped by this Obj-c enum.
+    let managedSwiftEnum: SwiftEnum
+
+    init(owner: ObjcInteropPropertyWrapper, managedSwiftEnum: SwiftEnum) {
+        self.parentProperty = owner
+        self.managedSwiftEnum = managedSwiftEnum
+    }
+}
+
+/// Schema of an `@objc enum` exposing values a `SwiftEnum` referenced using `SwiftTypeReference`.
+internal class ObjcInteropReferencedEnum: ObjcInteropEnum {}
+
+/// Schema of an `@objc enum` exposing values from an array of `SwiftEnums`.
+internal class ObjcInteropEnumArray: ObjcInteropEnum {}
+
+// MARK: - Property wrapper schemas
+
+/// Schema fo an `@objc` property which manages the access to a `SwiftStruct` property.
+internal class ObjcInteropPropertyWrapper: ObjcInteropType {
+    /// The class owning this property.
+    unowned private(set) var owner: ObjcInteropClass
+    /// Corresponding Swift property in `SwiftStruct`.
+    let swiftProperty: SwiftStruct.Property
+
+    init(owner: ObjcInteropClass, swiftProperty: SwiftStruct.Property) {
+        self.owner = owner
+        self.swiftProperty = swiftProperty
+    }
+}
+
+/// A property wrapper which uses another `ObjcInteropType` for managing the acces to nested `SwiftStruct` property.
+internal protocol ObjcInteropPropertyWrapperForTransitiveType {
+    var objcTransitiveType: ObjcInteropType { get }
+}
+
+/// Schema for an `@objc` property managing the access to nested `SwiftStruct`.
+internal class ObjcInteropPropertyWrapperAccessingNestedStruct:
+    ObjcInteropPropertyWrapper,
+    ObjcInteropPropertyWrapperForTransitiveType {
+    var objcNestedClass: ObjcInteropTransitiveClass!
+    var objcTransitiveType: ObjcInteropType { objcNestedClass }
+}
+
+/// Schema for an `@objc` property managing the access to nested `SwiftEnum`.
+internal class ObjcInteropPropertyWrapperAccessingNestedEnum:
+    ObjcInteropPropertyWrapper,
+    ObjcInteropPropertyWrapperForTransitiveType {
+    var objcNestedEnum: ObjcInteropEnum!
+    var objcTransitiveType: ObjcInteropType { objcNestedEnum }
+}
+
+/// Schema for an `@objc` property managing the access array of `SwiftEnums`.
+internal class ObjcInteropPropertyWrapperAccessingNestedEnumsArray:
+    ObjcInteropPropertyWrapper,
+    ObjcInteropPropertyWrapperForTransitiveType {
+    var objcNestedEnumsArray: ObjcInteropEnumArray!
+    var objcTransitiveType: ObjcInteropType { objcNestedEnumsArray }
+}
+
+/// Schema for an `@objc` property managing the access to `SwiftStruct` property.
+internal class ObjcInteropPropertyWrapperManagingSwiftStructProperty: ObjcInteropPropertyWrapper {
+    var objcInteropType: ObjcInteropType!
+}
+
+// MARK: - Plaing type schemas
+
+internal class ObjcInteropNSNumber: ObjcInteropType {
+    let swiftType: SwiftType
+
+    init(swiftType: SwiftType) {
+        self.swiftType = swiftType
+    }
+}
+
+internal class ObjcInteropNSString: ObjcInteropType {
+    let swiftString: SwiftPrimitive<String>
+
+    init(swiftString: SwiftPrimitive<String>) {
+        self.swiftString = swiftString
+    }
+}
+
+internal class ObjcInteropNSArray: ObjcInteropType {
+    let element: ObjcInteropType
+
+    init(element: ObjcInteropType) {
+        self.element = element
+    }
+}

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropTypeReader.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropTypeReader.swift
@@ -31,7 +31,7 @@ internal class ObjcInteropTypeReader {
 
     private func generateTransitiveObjcInteropTypes(in objcClass: ObjcInteropClass) throws {
         // Generate property wrappers
-        objcClass.objcPropertyWrappers = try objcClass.managedSwiftStruct.properties
+        objcClass.objcPropertyWrappers = try objcClass.bridgedSwiftStruct.properties
             .map { swiftProperty in
                 switch swiftProperty.type {
                 case let swiftPrimitive as SwiftPrimitiveType:

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropTypeReader.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropTypeReader.swift
@@ -23,7 +23,7 @@ internal class ObjcInteropTypeReader {
 
         let rootSwiftStructs = swiftTypes
             .compactMap { $0 as? SwiftStruct }
-            .filter { !referencedTypeNames.contains($0.typeName!) }
+            .filter { !referencedTypeNames.contains($0.typeName!) } // swiftlint:disable:this force_unwrapping
 
         try rootSwiftStructs.forEach { swiftStruct in
             let rootClass = ObjcInteropRootClass(managedSwiftStruct: swiftStruct)
@@ -75,7 +75,7 @@ internal class ObjcInteropTypeReader {
                     )
                     propertyWrapper.objcNestedEnumsArray = ObjcInteropEnumArray(
                         owner: propertyWrapper,
-                        managedSwiftEnum: swiftArray.element as! SwiftEnum
+                        managedSwiftEnum: swiftArray.element as! SwiftEnum // swiftlint:disable:this force_cast
                     )
                     return propertyWrapper
                 case let swiftArray as SwiftArray where swiftArray.element is SwiftPrimitiveType:
@@ -154,7 +154,7 @@ internal class ObjcInteropTypeReader {
     /// Searches `SwiftTypes` passed on input and returns the one described by given `SwiftTypeReference`.
     private func resolve(swiftTypeReference: SwiftTypeReference) throws -> SwiftType {
         return try inputSwiftTypes
-            .first(where: { $0.typeName == swiftTypeReference.referencedTypeName })
+            .first { $0.typeName == swiftTypeReference.referencedTypeName }
             .unwrapOrThrow(.inconsistency("Cannot find referenced type \(swiftTypeReference.referencedTypeName)"))
     }
 }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropTypeReader.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropTypeReader.swift
@@ -1,0 +1,174 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import Foundation
+
+/// Reads `ObjcInteropType` definitions from `SwiftType` definitions.
+internal class ObjcInteropTypeReader {
+    private var inputSwiftTypes: [SwiftType] = []
+    private var outputObjcInteropTypes: [ObjcInteropType] = []
+
+    func readObjcInteropTypes(from swiftTypes: [SwiftType]) throws -> [ObjcInteropType] {
+        self.inputSwiftTypes = swiftTypes
+        self.outputObjcInteropTypes = []
+
+        let referencedTypeNames = swiftTypes
+            .compactMap { $0 as? SwiftStruct }
+            .flatMap { $0.recursiveSwiftTypeReferences }
+            .map { $0.referencedTypeName }
+            .asSet()
+
+        let rootSwiftStructs = swiftTypes
+            .compactMap { $0 as? SwiftStruct }
+            .filter { !referencedTypeNames.contains($0.typeName!) }
+
+        try rootSwiftStructs.forEach { swiftStruct in
+            let rootClass = ObjcInteropRootClass(managedSwiftStruct: swiftStruct)
+            outputObjcInteropTypes.append(rootClass)
+            try generateTransitiveObjcInteropTypes(in: rootClass)
+        }
+
+        return outputObjcInteropTypes
+    }
+
+    // MARK: - Private
+
+    private func generateTransitiveObjcInteropTypes(in objcClass: ObjcInteropClass) throws {
+        // Generate property wrappers
+        objcClass.objcPropertyWrappers = try objcClass.managedSwiftStruct.properties
+            .map { swiftProperty in
+                switch swiftProperty.type {
+                case let swiftPrimitive as SwiftPrimitiveType:
+                    let propertyWrapper = ObjcInteropPropertyWrapperManagingSwiftStructProperty(
+                        owner: objcClass,
+                        swiftProperty: swiftProperty
+                    )
+                    propertyWrapper.objcInteropType = try objcInteropType(for: swiftPrimitive)
+                    return propertyWrapper
+                case let swiftStruct as SwiftStruct:
+                    let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedStruct(
+                        owner: objcClass,
+                        swiftProperty: swiftProperty
+                    )
+                    propertyWrapper.objcNestedClass = ObjcInteropTransitiveClass(
+                        owner: propertyWrapper,
+                        managedSwiftStruct: swiftStruct
+                    )
+                    return propertyWrapper
+                case let swiftEnum as SwiftEnum:
+                    let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedEnum(
+                        owner: objcClass,
+                        swiftProperty: swiftProperty
+                    )
+                    propertyWrapper.objcNestedEnum = ObjcInteropEnum(
+                        owner: propertyWrapper,
+                        managedSwiftEnum: swiftEnum
+                    )
+                    return propertyWrapper
+                case let swiftArray as SwiftArray where swiftArray.element is SwiftEnum:
+                    let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedEnumsArray(
+                        owner: objcClass,
+                        swiftProperty: swiftProperty
+                    )
+                    propertyWrapper.objcNestedEnumsArray = ObjcInteropEnumArray(
+                        owner: propertyWrapper,
+                        managedSwiftEnum: swiftArray.element as! SwiftEnum
+                    )
+                    return propertyWrapper
+                case let swiftArray as SwiftArray where swiftArray.element is SwiftPrimitiveType:
+                    let propertyWrapper = ObjcInteropPropertyWrapperManagingSwiftStructProperty(
+                        owner: objcClass,
+                        swiftProperty: swiftProperty
+                    )
+                    propertyWrapper.objcInteropType = try objcInteropType(for: swiftArray)
+                    return propertyWrapper
+                case let swifTypeReference as SwiftTypeReference:
+                    let referencedType = try resolve(swiftTypeReference: swifTypeReference)
+
+                    switch referencedType {
+                    case let swiftStruct as SwiftStruct:
+                        let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedStruct(
+                            owner: objcClass,
+                            swiftProperty: swiftProperty
+                        )
+                        propertyWrapper.objcNestedClass = ObjcInteropReferencedTransitiveClass(
+                            owner: propertyWrapper,
+                            managedSwiftStruct: swiftStruct
+                        )
+                        return propertyWrapper
+                    case let swiftEnum as SwiftEnum:
+                        let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedEnum(
+                            owner: objcClass,
+                            swiftProperty: swiftProperty
+                        )
+                        propertyWrapper.objcNestedEnum = ObjcInteropReferencedEnum(
+                            owner: propertyWrapper,
+                            managedSwiftEnum: swiftEnum
+                        )
+                        return propertyWrapper
+                    default:
+                        throw Exception.illegal("Illegal reference type: \(swifTypeReference)")
+                    }
+                default:
+                    throw Exception.unimplemented(
+                        "Cannot generate @objc property wrapper for: \(type(of: swiftProperty.type))"
+                    )
+                }
+            }
+
+        try objcClass.objcPropertyWrappers
+            .compactMap { $0 as? ObjcInteropPropertyWrapperForTransitiveType }
+            .forEach { propertyWrapper in
+                // Store `ObjcInteropTypes` created for property wrappers
+                outputObjcInteropTypes.append(propertyWrapper.objcTransitiveType)
+                if let transitiveClass = propertyWrapper.objcTransitiveType as? ObjcInteropClass {
+                    // Recursively generate property wrappers for each transitive `ObjcInteropClass`
+                    try generateTransitiveObjcInteropTypes(in: transitiveClass)
+                }
+            }
+    }
+
+    private func objcInteropType(for swiftType: SwiftType) throws -> ObjcInteropType {
+        switch swiftType {
+        case _ as SwiftPrimitive<Bool>,
+             _ as SwiftPrimitive<Double>,
+             _ as SwiftPrimitive<Int>,
+             _ as SwiftPrimitive<Int64>:
+            return ObjcInteropNSNumber(swiftType: swiftType)
+        case let swiftString as SwiftPrimitive<String>:
+            return ObjcInteropNSString(swiftString: swiftString)
+        case let swiftArray as SwiftArray:
+            return ObjcInteropNSArray(element: try objcInteropType(for: swiftArray.element))
+        default:
+            throw Exception.unimplemented(
+                "Cannot create `ObjcInteropType` type for \(type(of: swiftType))."
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Searches `SwiftTypes` passed on input and returns the one described by given `SwiftTypeReference`.
+    private func resolve(swiftTypeReference: SwiftTypeReference) throws -> SwiftType {
+        return try inputSwiftTypes
+            .first(where: { $0.typeName == swiftTypeReference.referencedTypeName })
+            .unwrapOrThrow(.inconsistency("Cannot find referenced type \(swiftTypeReference.referencedTypeName)"))
+    }
+}
+
+// MARK: - Reflection Helpers
+
+private extension SwiftStruct {
+    /// Returns `SwiftTypeReferences` used by this or nested structs.
+    var recursiveSwiftTypeReferences: [SwiftTypeReference] {
+        let referencesInThisStruct = properties
+            .compactMap { $0.type as? SwiftTypeReference }
+        let referencesInNestedStructs = properties
+            .compactMap { $0.type as? SwiftStruct }
+            .flatMap { $0.recursiveSwiftTypeReferences }
+        return referencesInThisStruct + referencesInNestedStructs
+    }
+}

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Type-safe Swift schema.
-internal protocol SwiftType {}
+public protocol SwiftType {}
 
 /// Swift primitive type.
 internal protocol SwiftPrimitiveType: SwiftType {}

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -171,7 +171,7 @@ internal class ObjcInteropPrinter: Printer {
     }
 
     private func printPropertyAccessingNestedClass(_ propertyWrapper: ObjcInteropPropertyWrapperAccessingNestedStruct) throws {
-        let nestedObjcClass = propertyWrapper.objcNestedClass!
+        let nestedObjcClass = propertyWrapper.objcNestedClass! // swiftlint:disable:this force_unwrapping
 
         // Generate accessor to the referenced wrapper, e.g.:
         // ```
@@ -203,7 +203,7 @@ internal class ObjcInteropPrinter: Printer {
     }
 
     private func printPropertyAccessingNestedEnum(_ propertyWrapper: ObjcInteropPropertyWrapperAccessingNestedEnum) throws {
-        let nestedObjcEnum = propertyWrapper.objcNestedEnum!
+        let nestedObjcEnum = propertyWrapper.objcNestedEnum! // swiftlint:disable:this force_unwrapping
 
         // Generate getter and setter for managed enum, e.g.:
         // ```
@@ -233,7 +233,7 @@ internal class ObjcInteropPrinter: Printer {
     }
 
     private func printPropertyAccessingNestedEnumArray(_ propertyWrapper: ObjcInteropPropertyWrapperAccessingNestedEnumsArray) throws {
-        let nestedObjcEnumArray = propertyWrapper.objcNestedEnumsArray!
+        let nestedObjcEnumArray = propertyWrapper.objcNestedEnumsArray! // swiftlint:disable:this force_unwrapping
 
         // Generate getter for managed enum array.
         // Because `[Enum]` cannot be exposed to Objc directly, we map each value to its `.rawValue`
@@ -358,6 +358,8 @@ internal class ObjcInteropPrinter: Printer {
 
 // MARK: - Reflection Helpers
 
+// swiftlint:disable force_cast
+
 private protocol ObjcInteropReflectable {
     var objcRootClass: ObjcInteropRootClass { get }
     var objcTypeName: String { get }
@@ -427,3 +429,5 @@ private extension ObjcInteropPropertyWrapper {
         }
     }
 }
+
+// swiftlint:enable force_cast

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Generates Swift code for Obj-c interoperability from `SwiftStructs`.
+/// Generates Swift code for Obj-c interoperability for given `SwiftStructs`.
 ///
 /// E.g. given `SwiftStruct` describing:
 ///
@@ -416,7 +416,7 @@ extension ObjcInteropEnum: ObjcInteropReflectable {
 
 private extension ObjcInteropPropertyWrapper {
     /// A key-path referencing this property, e.g. if this property is called `property` and belongs to class `Bar`,
-    /// stored on `bar` property in `Foo` class, then the `keyPath` is `bar.property`.
+    /// stored on property named `bar` in class `Foo`, then the `keyPath` is `bar.property`.
     var keyPath: String {
         let swiftPropertyName = swiftProperty.name
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -108,8 +108,8 @@ internal class ObjcInteropPrinter: Printer, SwiftCodePrinter {
 
     private func print(objcInteropEnum: ObjcInteropEnum) throws {
         let enumName = objcTypeNamesPrefix + objcInteropEnum.objcTypeName
-        let swiftEnum = objcInteropEnum.managedSwiftEnum
-        let managesOptionalEnum = objcInteropEnum.parentProperty.swiftProperty.isOptional
+        let swiftEnum = objcInteropEnum.bridgedSwiftEnum
+        let managesOptionalEnum = objcInteropEnum.parentProperty.bridgedSwiftProperty.isOptional
         let objcEnumOptionality = managesOptionalEnum ? "?" : ""
         writeEmptyLine()
         writeLine("@objc")
@@ -179,7 +179,7 @@ internal class ObjcInteropPrinter: Printer, SwiftCodePrinter {
         //     root.swiftModel.bar != nil ? DDFooBar(root: root) : nil
         // }
         // ```
-        let swiftProperty = propertyWrapper.swiftProperty
+        let swiftProperty = propertyWrapper.bridgedSwiftProperty
         let objcPropertyName = swiftProperty.name
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcClassName = objcTypeNamesPrefix + nestedObjcClass.objcTypeName
@@ -212,7 +212,7 @@ internal class ObjcInteropPrinter: Printer, SwiftCodePrinter {
         //    get { .init(swift: root.swiftModel.enumeration) }
         // }
         // ```
-        let swiftProperty = propertyWrapper.swiftProperty
+        let swiftProperty = propertyWrapper.bridgedSwiftProperty
         let objcPropertyName = swiftProperty.name
         let objcEnumName = objcTypeNamesPrefix + nestedObjcEnum.objcTypeName
 
@@ -243,7 +243,7 @@ internal class ObjcInteropPrinter: Printer, SwiftCodePrinter {
         //     root.swiftModel.bar.options.map { DDFooOptions(swift: $0).rawValue }
         // }
         // ```
-        let swiftProperty = propertyWrapper.swiftProperty
+        let swiftProperty = propertyWrapper.bridgedSwiftProperty
         let objcPropertyName = swiftProperty.name
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcEnumName = objcTypeNamesPrefix + nestedObjcEnumArray.objcTypeName
@@ -260,7 +260,7 @@ internal class ObjcInteropPrinter: Printer, SwiftCodePrinter {
     }
 
     private func printPrimitivePropertyWrapper(_ propertyWrapper: ObjcInteropPropertyWrapperManagingSwiftStructProperty) throws {
-        let swiftProperty = propertyWrapper.swiftProperty
+        let swiftProperty = propertyWrapper.bridgedSwiftProperty
         let objcPropertyName = swiftProperty.name
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcTypeName = try objcInteropTypeName(for: propertyWrapper.objcInteropType)
@@ -368,8 +368,8 @@ private protocol ObjcInteropReflectable {
 
 extension ObjcInteropRootClass: ObjcInteropReflectable {
     var objcRootClass: ObjcInteropRootClass { self }
-    var objcTypeName: String { managedSwiftStruct.name }
-    var swiftTypeName: String { managedSwiftStruct.name }
+    var objcTypeName: String { bridgedSwiftStruct.name }
+    var swiftTypeName: String { bridgedSwiftStruct.name }
 }
 
 extension ObjcInteropTransitiveClass: ObjcInteropReflectable {
@@ -382,14 +382,14 @@ extension ObjcInteropTransitiveClass: ObjcInteropReflectable {
     }
 
     var objcTypeName: String {
-        return (parentClass as! ObjcInteropReflectable).objcTypeName + managedSwiftStruct.name
+        return (parentClass as! ObjcInteropReflectable).objcTypeName + bridgedSwiftStruct.name
     }
 
     var swiftTypeName: String {
         if self is ObjcInteropReferencedTransitiveClass {
-            return managedSwiftStruct.name
+            return bridgedSwiftStruct.name
         }
-        return (parentClass as! ObjcInteropReflectable).swiftTypeName + "." + managedSwiftStruct.name
+        return (parentClass as! ObjcInteropReflectable).swiftTypeName + "." + bridgedSwiftStruct.name
     }
 }
 
@@ -403,14 +403,14 @@ extension ObjcInteropEnum: ObjcInteropReflectable {
     }
 
     var objcTypeName: String {
-        return (parentClass as! ObjcInteropReflectable).objcTypeName + managedSwiftEnum.name
+        return (parentClass as! ObjcInteropReflectable).objcTypeName + bridgedSwiftEnum.name
     }
 
     var swiftTypeName: String {
         if self is ObjcInteropReferencedEnum {
-            return managedSwiftEnum.name
+            return bridgedSwiftEnum.name
         }
-        return (parentClass as! ObjcInteropReflectable).swiftTypeName + "." + managedSwiftEnum.name
+        return (parentClass as! ObjcInteropReflectable).swiftTypeName + "." + bridgedSwiftEnum.name
     }
 }
 
@@ -418,11 +418,11 @@ private extension ObjcInteropPropertyWrapper {
     /// A key-path referencing this property, e.g. if this property is called `property` and belongs to class `Bar`,
     /// stored on property named `bar` in class `Foo`, then the `keyPath` is `bar.property`.
     var keyPath: String {
-        let swiftPropertyName = swiftProperty.name
+        let swiftPropertyName = bridgedSwiftProperty.name
 
         if let parentNestedClass = owner as? ObjcInteropTransitiveClass {
             let parentProperty = parentNestedClass.parentProperty
-            let forceUnwrapping = parentProperty.swiftProperty.isOptional ? "!" : ""
+            let forceUnwrapping = parentProperty.bridgedSwiftProperty.isOptional ? "!" : ""
             return parentProperty.keyPath + forceUnwrapping + "." + swiftPropertyName
         } else {
             return swiftPropertyName

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -35,11 +35,11 @@ import Foundation
 ///         public var integer: NSNumber { foo.integer as NSNumber }
 ///     }
 ///
-internal class ObjcInteropPrinter: Printer {
+internal class ObjcInteropPrinter: Printer, SwiftCodePrinter {
     /// The prefix used for types exposed to Obj-c.
     private let objcTypeNamesPrefix: String = "DD"
 
-    func printObjcInterop(for swiftTypes: [SwiftType]) throws -> String {
+    func print(swiftTypes: [SwiftType]) throws -> String {
         reset()
 
         try ObjcInteropTypeReader()

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -1,0 +1,429 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import Foundation
+
+/// Generates Swift code for Obj-c interoperability from `SwiftStructs`.
+///
+/// E.g. given `SwiftStruct` describing:
+///
+///     public struct Foo {
+///         public var string = "foo"
+///         public let integer = 123
+///     }
+///
+/// it prints it's Obj-c interoperability wrapper:
+///
+///     @objc
+///     public class DDFoo: NSObject {
+///         internal var foo: Foo
+///
+///         internal init(foo: Foo) {
+///             self.foo = foo
+///         }
+///
+///         @objc
+///         public var string: String {
+///             set { foo.string = newValue }
+///             get { foo.string }
+///         }
+///
+///         @objc
+///         public var integer: NSNumber { foo.integer as NSNumber }
+///     }
+///
+internal class ObjcInteropPrinter: Printer {
+    /// The prefix used for types exposed to Obj-c.
+    private let objcTypeNamesPrefix: String = "DD"
+
+    func printObjcInterop(for swiftTypes: [SwiftType]) throws -> String {
+        reset()
+
+        try ObjcInteropTypeReader()
+            .readObjcInteropTypes(from: swiftTypes)
+            .forEach { try print(objcInteropType: $0) }
+
+        return output
+    }
+
+    // MARK: - Printing Objc Classes and Enums
+
+    private func print(objcInteropType: ObjcInteropType) throws {
+        switch objcInteropType {
+        case let rootClass as ObjcInteropRootClass:
+            try print(objcInteropRootClass: rootClass)
+        case let nestedClass as ObjcInteropTransitiveClass:
+            try print(objcInteropNestedClass: nestedClass)
+        case let enumeration as ObjcInteropEnum:
+            try print(objcInteropEnum: enumeration)
+        default:
+            throw Exception.unimplemented("Cannot print `ObjcInteropType`: \(type(of: objcInteropType))")
+        }
+    }
+
+    private func print(objcInteropRootClass: ObjcInteropRootClass) throws {
+        let className = objcTypeNamesPrefix + objcInteropRootClass.objcTypeName
+        writeEmptyLine()
+        writeLine("@objc")
+        writeLine("public class \(className): NSObject {")
+        indentRight()
+            writeLine("internal var swiftModel: \(objcInteropRootClass.swiftTypeName)")
+            writeLine("internal var root: \(className) { self }")
+            writeEmptyLine()
+            writeLine("internal init(swiftModel: \(objcInteropRootClass.swiftTypeName)) {")
+            indentRight()
+                writeLine("self.swiftModel = swiftModel")
+            indentLeft()
+            writeLine("}")
+            try objcInteropRootClass.objcPropertyWrappers.forEach { propertyWrapper in
+                try print(objcInteropPropertyWrapper: propertyWrapper)
+            }
+        indentLeft()
+        writeLine("}")
+    }
+
+    private func print(objcInteropNestedClass: ObjcInteropTransitiveClass) throws {
+        let className = objcTypeNamesPrefix + objcInteropNestedClass.objcTypeName
+        let rootClassName = objcTypeNamesPrefix + objcInteropNestedClass.objcRootClass.objcTypeName
+        writeEmptyLine()
+        writeLine("@objc")
+        writeLine("public class \(className): NSObject {")
+        indentRight()
+            writeLine("internal let root: \(rootClassName)")
+            writeEmptyLine()
+            writeLine("internal init(root: \(rootClassName)) {")
+            indentRight()
+                writeLine("self.root = root")
+            indentLeft()
+            writeLine("}")
+            try objcInteropNestedClass.objcPropertyWrappers.forEach { propertyWrapper in
+                try print(objcInteropPropertyWrapper: propertyWrapper)
+            }
+        indentLeft()
+        writeLine("}")
+    }
+
+    private func print(objcInteropEnum: ObjcInteropEnum) throws {
+        let enumName = objcTypeNamesPrefix + objcInteropEnum.objcTypeName
+        let swiftEnum = objcInteropEnum.managedSwiftEnum
+        let managesOptionalEnum = objcInteropEnum.parentProperty.swiftProperty.isOptional
+        let objcEnumOptionality = managesOptionalEnum ? "?" : ""
+        writeEmptyLine()
+        writeLine("@objc")
+        writeLine("public enum \(enumName): Int {")
+        indentRight()
+            writeLine("internal init(swift: \(objcInteropEnum.swiftTypeName)\(objcEnumOptionality)) {")
+            indentRight()
+                writeLine("switch swift {")
+                if managesOptionalEnum {
+                    writeLine("case nil: self = .none")
+                }
+                swiftEnum.cases.forEach { enumCase in
+                    writeLine("case .\(enumCase.label)\(objcEnumOptionality): self = .\(enumCase.label)")
+                }
+                writeLine("}")
+            indentLeft()
+            writeLine("}")
+            writeEmptyLine()
+            writeLine("internal var toSwift: \(objcInteropEnum.swiftTypeName)\(objcEnumOptionality) {")
+            indentRight()
+                writeLine("switch self {")
+                if managesOptionalEnum {
+                    writeLine("case .none: return nil")
+                }
+                swiftEnum.cases.forEach { enumCase in
+                    writeLine("case .\(enumCase.label): return .\(enumCase.label)")
+                }
+                writeLine("}")
+            indentLeft()
+            writeLine("}")
+            writeEmptyLine()
+            if managesOptionalEnum {
+                writeLine("case none")
+            }
+            swiftEnum.cases.forEach { enumCase in
+                writeLine("case \(enumCase.label)")
+            }
+        indentLeft()
+        writeLine("}")
+    }
+
+    // MARK: - Printing Property Wrappers
+
+    private func print(objcInteropPropertyWrapper: ObjcInteropPropertyWrapper) throws {
+        writeEmptyLine()
+
+        switch objcInteropPropertyWrapper {
+        case let wrapper as ObjcInteropPropertyWrapperAccessingNestedStruct:
+            try printPropertyAccessingNestedClass(wrapper)
+        case let wrapper as ObjcInteropPropertyWrapperAccessingNestedEnum:
+            try printPropertyAccessingNestedEnum(wrapper)
+        case let wrapper as ObjcInteropPropertyWrapperAccessingNestedEnumsArray:
+            try printPropertyAccessingNestedEnumArray(wrapper)
+        case let wrapper as ObjcInteropPropertyWrapperManagingSwiftStructProperty:
+            try printPrimitivePropertyWrapper(wrapper)
+        default:
+            throw Exception.illegal("Unrecognized property wrapper: \(type(of: objcInteropPropertyWrapper))")
+        }
+    }
+
+    private func printPropertyAccessingNestedClass(_ propertyWrapper: ObjcInteropPropertyWrapperAccessingNestedStruct) throws {
+        let nestedObjcClass = propertyWrapper.objcNestedClass!
+
+        // Generate accessor to the referenced wrapper, e.g.:
+        // ```
+        // @objc public var bar: DDFooBar? {
+        //     root.swiftModel.bar != nil ? DDFooBar(root: root) : nil
+        // }
+        // ```
+        let swiftProperty = propertyWrapper.swiftProperty
+        let objcPropertyName = swiftProperty.name
+        let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
+        let objcClassName = objcTypeNamesPrefix + nestedObjcClass.objcTypeName
+        writeLine("@objc public var \(objcPropertyName): \(objcClassName)\(objcPropertyOptionality) {")
+        indentRight()
+            if swiftProperty.isOptional {
+                // The property is optional, so the accessor must be returned only if the wrapped value is `!= nil`, e.g.:
+                // ```
+                // root.swiftModel.bar != nil ? DDFooBar(root: root) : nil
+                // ```
+                writeLine("root.swiftModel.\(propertyWrapper.keyPath) != nil ? \(objcClassName)(root: root) : nil")
+            } else {
+                // The property is non-optional, so accessor can be provided without considering `nil` value:
+                // ```
+                // DDFooBar(root: root)
+                // ```
+                writeLine("\(objcClassName)(root: root)")
+            }
+        indentLeft()
+        writeLine("}")
+    }
+
+    private func printPropertyAccessingNestedEnum(_ propertyWrapper: ObjcInteropPropertyWrapperAccessingNestedEnum) throws {
+        let nestedObjcEnum = propertyWrapper.objcNestedEnum!
+
+        // Generate getter and setter for managed enum, e.g.:
+        // ```
+        // @objc public var enumeration: DDFooEnumeration {
+        //    set { root.swiftModel.enumeration = newValue.toSwift }
+        //    get { .init(swift: root.swiftModel.enumeration) }
+        // }
+        // ```
+        let swiftProperty = propertyWrapper.swiftProperty
+        let objcPropertyName = swiftProperty.name
+        let objcEnumName = objcTypeNamesPrefix + nestedObjcEnum.objcTypeName
+
+        if swiftProperty.isMutable {
+            writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
+            indentRight()
+                writeLine("set { root.swiftModel.\(propertyWrapper.keyPath) = newValue.toSwift }")
+                writeLine("get { .init(swift: root.swiftModel.\(propertyWrapper.keyPath)) }")
+            indentLeft()
+            writeLine("}")
+        } else {
+            writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
+            indentRight()
+                writeLine(".init(swift: root.swiftModel.\(propertyWrapper.keyPath))")
+            indentLeft()
+            writeLine("}")
+        }
+    }
+
+    private func printPropertyAccessingNestedEnumArray(_ propertyWrapper: ObjcInteropPropertyWrapperAccessingNestedEnumsArray) throws {
+        let nestedObjcEnumArray = propertyWrapper.objcNestedEnumsArray!
+
+        // Generate getter for managed enum array.
+        // Because `[Enum]` cannot be exposed to Objc directly, we map each value to its `.rawValue`
+        // representation (which is `Int` for all `@objc` enums), e.g.:
+        // ```
+        // @objc public var options: [Int] {
+        //     root.swiftModel.bar.options.map { DDFooOptions(swift: $0).rawValue }
+        // }
+        // ```
+        let swiftProperty = propertyWrapper.swiftProperty
+        let objcPropertyName = swiftProperty.name
+        let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
+        let objcEnumName = objcTypeNamesPrefix + nestedObjcEnumArray.objcTypeName
+
+        guard swiftProperty.isMutable == false else {
+            throw Exception.unimplemented("Cannot print setter for `ObjcInteropEnumArray`: \(swiftProperty.type).")
+        }
+
+        writeLine("@objc public var \(objcPropertyName): [Int]\(objcPropertyOptionality) {")
+        indentRight()
+            writeLine("root.swiftModel.\(propertyWrapper.keyPath)\(objcPropertyOptionality).map { \(objcEnumName)(swift: $0).rawValue }")
+        indentLeft()
+        writeLine("}")
+    }
+
+    private func printPrimitivePropertyWrapper(_ propertyWrapper: ObjcInteropPropertyWrapperManagingSwiftStructProperty) throws {
+        let swiftProperty = propertyWrapper.swiftProperty
+        let objcPropertyName = swiftProperty.name
+        let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
+        let objcTypeName = try objcInteropTypeName(for: propertyWrapper.objcInteropType)
+        let asObjcCast = try swiftToObjcCast(for: propertyWrapper.objcInteropType).ifNotNil { asObjcCast in
+            asObjcCast + objcPropertyOptionality
+        } ?? ""
+
+        if swiftProperty.isMutable {
+            // Generate getter and setter for the managed value, e.g.:
+            // ```
+            // @objc public var propertyX: String? {
+            //     set { root.swiftModel.bar.propertyX = newValue }
+            //     get { root.swiftModel.bar.propertyX }
+            // }
+            // ```
+            let toSwiftCast = try objcToSwiftCast(for: swiftProperty.type).ifNotNil { toSwiftCast in
+                objcPropertyOptionality + toSwiftCast
+            } ?? ""
+            writeLine("@objc public var \(objcPropertyName): \(objcTypeName)\(objcPropertyOptionality) {")
+            indentRight()
+                writeLine("set { root.swiftModel.\(propertyWrapper.keyPath) = newValue\(toSwiftCast) }")
+                writeLine("get { root.swiftModel.\(propertyWrapper.keyPath)\(asObjcCast) }")
+            indentLeft()
+            writeLine("}")
+        } else {
+            // Generate getter for the managed value, e.g.:
+            // ```
+            // @objc public var propertyX: String? {
+            //     root.swiftModel.bar.propertyX
+            // }
+            // ```
+            writeLine("@objc public var \(objcPropertyName): \(objcTypeName)\(objcPropertyOptionality) {")
+            indentRight()
+                writeLine("root.swiftModel.\(propertyWrapper.keyPath)\(asObjcCast)")
+            indentLeft()
+            writeLine("}")
+        }
+    }
+
+    // MARK: - Generating names
+
+    private func objcInteropTypeName(for objcType: ObjcInteropType) throws -> String {
+        switch objcType {
+        case _ as ObjcInteropNSNumber:
+            return "NSNumber"
+        case _ as ObjcInteropNSString:
+            return "String"
+        case let objcArray as ObjcInteropNSArray:
+            return "[\(try objcInteropTypeName(for: objcArray.element))]"
+        default:
+            throw Exception.unimplemented(
+                "Cannot print `ObjcInteropType` name for \(type(of: objcType))."
+            )
+        }
+    }
+
+    private func swiftToObjcCast(for objcType: ObjcInteropType) throws -> String? {
+        switch objcType {
+        case _ as ObjcInteropNSNumber:
+            return " as NSNumber"
+        case let nsArray as ObjcInteropNSArray where nsArray.element is ObjcInteropNSNumber:
+            return " as [NSNumber]"
+        case _ as ObjcInteropNSString:
+            return nil // `String` <> `NSString` interoperability doesn't require casting
+        case let nsArray as ObjcInteropNSArray where nsArray.element is ObjcInteropNSString:
+            return nil // `[String]` <> `[NSString]` interoperability doesn't require casting
+        default:
+            throw Exception.unimplemented("Cannot print `swiftToObjcCast()` for \(type(of: objcType)).")
+        }
+    }
+
+    private func objcToSwiftCast(for swiftType: SwiftType) throws -> String? {
+        switch swiftType {
+        case _ as SwiftPrimitive<Bool>:
+            return ".boolValue"
+        case _ as SwiftPrimitive<Double>:
+            return ".doubleValue"
+        case _ as SwiftPrimitive<Int>:
+            return ".intValue"
+        case _ as SwiftPrimitive<Int64>:
+            return ".int64Value"
+        case let swiftArray as SwiftArray where swiftArray.element is SwiftPrimitive<String>:
+            return nil // `[String]` <> `[NSString]` interoperability doesn't require casting
+        case let swiftArray as SwiftArray:
+            let elementCast = try objcToSwiftCast(for: swiftArray.element)
+                .unwrapOrThrow(.illegal("Cannot print `objcToSwiftCast()` for `SwiftArray` with elements of type: \(type(of: swiftArray.element))"))
+            return ".map { $0\(elementCast) }"
+        case _ as SwiftPrimitive<String>:
+            return nil // `String` <> `NSString` interoperability doesn't require casting
+        default:
+            throw Exception.unimplemented("Cannot print `objcToSwiftCast()` for \(type(of: swiftType)).")
+        }
+    }
+}
+
+// MARK: - Reflection Helpers
+
+private protocol ObjcInteropReflectable {
+    var objcRootClass: ObjcInteropRootClass { get }
+    var objcTypeName: String { get }
+    var swiftTypeName: String { get }
+}
+
+extension ObjcInteropRootClass: ObjcInteropReflectable {
+    var objcRootClass: ObjcInteropRootClass { self }
+    var objcTypeName: String { managedSwiftStruct.name }
+    var swiftTypeName: String { managedSwiftStruct.name }
+}
+
+extension ObjcInteropTransitiveClass: ObjcInteropReflectable {
+    private var parentClass: ObjcInteropClass {
+        return parentProperty.owner
+    }
+
+    var objcRootClass: ObjcInteropRootClass {
+        return (parentClass as! ObjcInteropReflectable).objcRootClass
+    }
+
+    var objcTypeName: String {
+        return (parentClass as! ObjcInteropReflectable).objcTypeName + managedSwiftStruct.name
+    }
+
+    var swiftTypeName: String {
+        if self is ObjcInteropReferencedTransitiveClass {
+            return managedSwiftStruct.name
+        }
+        return (parentClass as! ObjcInteropReflectable).swiftTypeName + "." + managedSwiftStruct.name
+    }
+}
+
+extension ObjcInteropEnum: ObjcInteropReflectable {
+    private var parentClass: ObjcInteropClass {
+        return parentProperty.owner
+    }
+
+    var objcRootClass: ObjcInteropRootClass {
+        return (parentClass as! ObjcInteropReflectable).objcRootClass
+    }
+
+    var objcTypeName: String {
+        return (parentClass as! ObjcInteropReflectable).objcTypeName + managedSwiftEnum.name
+    }
+
+    var swiftTypeName: String {
+        if self is ObjcInteropReferencedEnum {
+            return managedSwiftEnum.name
+        }
+        return (parentClass as! ObjcInteropReflectable).swiftTypeName + "." + managedSwiftEnum.name
+    }
+}
+
+private extension ObjcInteropPropertyWrapper {
+    /// A key-path referencing this property, e.g. if this property is called `property` and belongs to class `Bar`,
+    /// stored on `bar` property in `Foo` class, then the `keyPath` is `bar.property`.
+    var keyPath: String {
+        let swiftPropertyName = swiftProperty.name
+
+        if let parentNestedClass = owner as? ObjcInteropTransitiveClass {
+            let parentProperty = parentNestedClass.parentProperty
+            let forceUnwrapping = parentProperty.swiftProperty.isOptional ? "!" : ""
+            return parentProperty.keyPath + forceUnwrapping + "." + swiftPropertyName
+        } else {
+            return swiftPropertyName
+        }
+    }
+}

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/Printer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/Printer.swift
@@ -7,8 +7,10 @@
 import Foundation
 
 /// Manages lines indentation for generating code.
-internal class Printer {
+public class Printer {
     var output = ""
+
+    public init() {}
 
     // MARK: - Indentation
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
@@ -39,7 +39,9 @@ internal class SwiftPrinter: Printer {
         writeLine("public struct \(swiftStruct.name)\(conformance) {")
         indentRight()
         try printPropertiesList(swiftStruct.properties)
-        try printCodingKeys(for: swiftStruct.properties)
+        if swiftStruct.conforms(to: codableProtocol) {
+            try printCodingKeys(for: swiftStruct.properties)
+        }
         try printNestedTypes(in: swiftStruct)
         indentLeft()
         writeLine("}")
@@ -146,5 +148,30 @@ internal class SwiftPrinter: Printer {
         default:
             throw Exception.unimplemented("Printing \(type) is not implemented.")
         }
+    }
+}
+
+// MARK: - Reflection Helpers
+
+private protocol SwiftReflectable {
+    func conforms(to swiftProtocol: SwiftProtocol) -> Bool
+}
+
+extension SwiftProtocol: SwiftReflectable {
+    func conforms(to swiftProtocol: SwiftProtocol) -> Bool {
+        return self == swiftProtocol
+            || conformance.contains { $0.conforms(to: swiftProtocol) }
+    }
+}
+
+extension SwiftStruct: SwiftReflectable {
+    func conforms(to swiftProtocol: SwiftProtocol) -> Bool {
+        return conformance.contains { $0.conforms(to: swiftProtocol) }
+    }
+}
+
+extension SwiftEnum: SwiftReflectable {
+    func conforms(to swiftProtocol: SwiftProtocol) -> Bool {
+        return conformance.contains { $0.conforms(to: swiftProtocol) }
     }
 }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
@@ -6,11 +6,16 @@
 
 import Foundation
 
+/// A type which prints Swift code.
+public protocol SwiftCodePrinter {
+    func print(swiftTypes: [SwiftType]) throws -> String
+}
+
 /// Generates Swift code from `SwiftTypes`.
-internal class SwiftPrinter: Printer {
+public class SwiftPrinter: Printer, SwiftCodePrinter {
     // MARK: - Printing
 
-    func print(swiftTypes: [SwiftType]) throws -> String {
+    public func print(swiftTypes: [SwiftType]) throws -> String {
         reset()
 
         try swiftTypes.forEach { type in

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUMModelsGenerator.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUMModelsGenerator.swift
@@ -47,11 +47,13 @@ public class RUMModelsGenerator {
     private let jsonObjectReader = JSONTypeReader()
     private let swiftTypeReader = SwiftTypeReader()
     private let rumSwiftTransformer = RUMSwiftTypeTransformer()
-    private let swiftPrinter = SwiftPrinter()
 
     public init() {}
 
-    public func printRUMModels(for schemaFiles: RUMJSONSchemaFiles) throws -> String {
+    public func printRUMModels(
+        for schemaFiles: RUMJSONSchemaFiles,
+        using swiftCodePrinter: SwiftCodePrinter
+    ) throws -> String {
         var output = """
         /*
          * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
@@ -83,7 +85,7 @@ public class RUMModelsGenerator {
 
         let rumModels = try rumSwiftTransformer.transform(types: swiftModels)
 
-        output += try swiftPrinter.print(swiftTypes: rumModels)
+        output += try swiftCodePrinter.print(swiftTypes: rumModels)
 
         return output
     }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Utilities.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Utilities.swift
@@ -67,3 +67,9 @@ extension String {
     /// "UpperCamelCased" notation.
     var upperCamelCased: String { camelCased.uppercasingFirst }
 }
+
+extension Array where Element: Hashable {
+    func asSet() -> Set<Element> {
+        return Set(self)
+    }
+}

--- a/tools/rum-models-generator/Sources/rum-models-generator/main.swift
+++ b/tools/rum-models-generator/Sources/rum-models-generator/main.swift
@@ -30,7 +30,7 @@ private struct RootCommand: ParsableCommand {
                 let schemasFolderURL = URL(fileURLWithPath: path)
                 let schemas = try RUMJSONSchemaFiles(folder: schemasFolderURL)
                 let generator = RUMModelsGenerator()
-                print(try generator.printRUMModels(for: schemas))
+                print(try generator.printRUMModels(for: schemas, using: SwiftPrinter()))
             } catch {
                 print("Failed to generate Swift models: \(error)")
             }

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
@@ -14,7 +14,7 @@ final class ObjcInteropPrinterTests: XCTestCase {
         // MARK: - Swift
         \(try SwiftPrinter().print(swiftTypes: types))
         // MARK: - ObjcInterop
-        \(try ObjcInteropPrinter().printObjcInterop(for: types))
+        \(try ObjcInteropPrinter().print(swiftTypes: types))
         """
     }
 

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
@@ -1,0 +1,1576 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import XCTest
+@testable import RUMModelsGeneratorCore
+
+final class ObjcInteropPrinterTests: XCTestCase {
+    /// Prints Swift code along with its `@objc` interop code.
+    private func printSwiftWithObjcInterop(for types: [SwiftType]) throws -> String {
+        return """
+        // MARK: - Swift
+        \(try SwiftPrinter().print(swiftTypes: types))
+        // MARK: - ObjcInterop
+        \(try ObjcInteropPrinter().printObjcInterop(for: types))
+        """
+    }
+
+    // MARK: - Property wrappers for plain Swift values
+
+    func testPrintingObjcInteropForSwiftStructWithStringProperties() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "immutableString",
+                    type: SwiftPrimitive<String>(),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalImmutableString",
+                    type: SwiftPrimitive<String>(),
+                    isOptional: true,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "mutableString",
+                    type: SwiftPrimitive<String>(),
+                    isOptional: false,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "optionalMutableString",
+                    type: SwiftPrimitive<String>(),
+                    isOptional: true,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public let immutableString: String
+
+            public let optionalImmutableString: String?
+
+            public var mutableString: String
+
+            public var optionalMutableString: String?
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var immutableString: String {
+                root.swiftModel.immutableString
+            }
+
+            @objc public var optionalImmutableString: String? {
+                root.swiftModel.optionalImmutableString
+            }
+
+            @objc public var mutableString: String {
+                set { root.swiftModel.mutableString = newValue }
+                get { root.swiftModel.mutableString }
+            }
+
+            @objc public var optionalMutableString: String? {
+                set { root.swiftModel.optionalMutableString = newValue }
+                get { root.swiftModel.optionalMutableString }
+            }
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingObjcInteropForSwiftStructWithIntProperties() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "immutableInt",
+                    type: SwiftPrimitive<Int>(),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalImmutableInt",
+                    type: SwiftPrimitive<Int>(),
+                    isOptional: true,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "mutableInt",
+                    type: SwiftPrimitive<Int>(),
+                    isOptional: false,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "optionalMutableInt",
+                    type: SwiftPrimitive<Int>(),
+                    isOptional: true,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public let immutableInt: Int
+
+            public let optionalImmutableInt: Int?
+
+            public var mutableInt: Int
+
+            public var optionalMutableInt: Int?
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var immutableInt: NSNumber {
+                root.swiftModel.immutableInt as NSNumber
+            }
+
+            @objc public var optionalImmutableInt: NSNumber? {
+                root.swiftModel.optionalImmutableInt as NSNumber?
+            }
+
+            @objc public var mutableInt: NSNumber {
+                set { root.swiftModel.mutableInt = newValue.intValue }
+                get { root.swiftModel.mutableInt as NSNumber }
+            }
+
+            @objc public var optionalMutableInt: NSNumber? {
+                set { root.swiftModel.optionalMutableInt = newValue?.intValue }
+                get { root.swiftModel.optionalMutableInt as NSNumber? }
+            }
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingObjcInteropForSwiftStructWithInt64Properties() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "immutableInt64",
+                    type: SwiftPrimitive<Int64>(),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalImmutableInt64",
+                    type: SwiftPrimitive<Int64>(),
+                    isOptional: true,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "mutableInt",
+                    type: SwiftPrimitive<Int64>(),
+                    isOptional: false,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "optionalMutableInt64",
+                    type: SwiftPrimitive<Int64>(),
+                    isOptional: true,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public let immutableInt64: Int64
+
+            public let optionalImmutableInt64: Int64?
+
+            public var mutableInt: Int64
+
+            public var optionalMutableInt64: Int64?
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var immutableInt64: NSNumber {
+                root.swiftModel.immutableInt64 as NSNumber
+            }
+
+            @objc public var optionalImmutableInt64: NSNumber? {
+                root.swiftModel.optionalImmutableInt64 as NSNumber?
+            }
+
+            @objc public var mutableInt: NSNumber {
+                set { root.swiftModel.mutableInt = newValue.int64Value }
+                get { root.swiftModel.mutableInt as NSNumber }
+            }
+
+            @objc public var optionalMutableInt64: NSNumber? {
+                set { root.swiftModel.optionalMutableInt64 = newValue?.int64Value }
+                get { root.swiftModel.optionalMutableInt64 as NSNumber? }
+            }
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingObjcInteropForSwiftStructWithDoubleProperties() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "immutableDouble",
+                    type: SwiftPrimitive<Double>(),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalImmutableDouble",
+                    type: SwiftPrimitive<Double>(),
+                    isOptional: true,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "mutableDouble",
+                    type: SwiftPrimitive<Double>(),
+                    isOptional: false,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "optionalMutableDouble",
+                    type: SwiftPrimitive<Double>(),
+                    isOptional: true,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public let immutableDouble: Double
+
+            public let optionalImmutableDouble: Double?
+
+            public var mutableDouble: Double
+
+            public var optionalMutableDouble: Double?
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var immutableDouble: NSNumber {
+                root.swiftModel.immutableDouble as NSNumber
+            }
+
+            @objc public var optionalImmutableDouble: NSNumber? {
+                root.swiftModel.optionalImmutableDouble as NSNumber?
+            }
+
+            @objc public var mutableDouble: NSNumber {
+                set { root.swiftModel.mutableDouble = newValue.doubleValue }
+                get { root.swiftModel.mutableDouble as NSNumber }
+            }
+
+            @objc public var optionalMutableDouble: NSNumber? {
+                set { root.swiftModel.optionalMutableDouble = newValue?.doubleValue }
+                get { root.swiftModel.optionalMutableDouble as NSNumber? }
+            }
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingObjcInteropForSwiftStructWithBoolProperties() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "immutableBool",
+                    type: SwiftPrimitive<Bool>(),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalImmutableBool",
+                    type: SwiftPrimitive<Bool>(),
+                    isOptional: true,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "mutableBool",
+                    type: SwiftPrimitive<Bool>(),
+                    isOptional: false,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "optionalMutableBool",
+                    type: SwiftPrimitive<Bool>(),
+                    isOptional: true,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public let immutableBool: Bool
+
+            public let optionalImmutableBool: Bool?
+
+            public var mutableBool: Bool
+
+            public var optionalMutableBool: Bool?
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var immutableBool: NSNumber {
+                root.swiftModel.immutableBool as NSNumber
+            }
+
+            @objc public var optionalImmutableBool: NSNumber? {
+                root.swiftModel.optionalImmutableBool as NSNumber?
+            }
+
+            @objc public var mutableBool: NSNumber {
+                set { root.swiftModel.mutableBool = newValue.boolValue }
+                get { root.swiftModel.mutableBool as NSNumber }
+            }
+
+            @objc public var optionalMutableBool: NSNumber? {
+                set { root.swiftModel.optionalMutableBool = newValue?.boolValue }
+                get { root.swiftModel.optionalMutableBool as NSNumber? }
+            }
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingObjcInteropForSwiftStructWithEnumProperties() throws {
+        func mockEnumeration(named name: String) -> SwiftEnum {
+            return SwiftEnum(
+                name: name,
+                comment: nil,
+                cases: [
+                    SwiftEnum.Case(label: "case1", rawValue: "case1"),
+                    SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                    SwiftEnum.Case(label: "case3", rawValue: "case3"),
+                ],
+                conformance: []
+            )
+        }
+
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "immutableEnum",
+                    type: mockEnumeration(named: "Enumeration1"),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalImmutableEnum",
+                    type: mockEnumeration(named: "Enumeration2"),
+                    isOptional: true,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "mutableEnum",
+                    type: mockEnumeration(named: "Enumeration3"),
+                    isOptional: false,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "optionalMutableEnum",
+                    type: mockEnumeration(named: "Enumeration4"),
+                    isOptional: true,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public let immutableEnum: Enumeration1
+
+            public let optionalImmutableEnum: Enumeration2?
+
+            public var mutableEnum: Enumeration3
+
+            public var optionalMutableEnum: Enumeration4?
+
+            public enum Enumeration1: String {
+                case case1 = "case1"
+                case case2 = "case2"
+                case case3 = "case3"
+            }
+
+            public enum Enumeration2: String {
+                case case1 = "case1"
+                case case2 = "case2"
+                case case3 = "case3"
+            }
+
+            public enum Enumeration3: String {
+                case case1 = "case1"
+                case case2 = "case2"
+                case case3 = "case3"
+            }
+
+            public enum Enumeration4: String {
+                case case1 = "case1"
+                case case2 = "case2"
+                case case3 = "case3"
+            }
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var immutableEnum: DDFooEnumeration1 {
+                .init(swift: root.swiftModel.immutableEnum)
+            }
+
+            @objc public var optionalImmutableEnum: DDFooEnumeration2 {
+                .init(swift: root.swiftModel.optionalImmutableEnum)
+            }
+
+            @objc public var mutableEnum: DDFooEnumeration3 {
+                set { root.swiftModel.mutableEnum = newValue.toSwift }
+                get { .init(swift: root.swiftModel.mutableEnum) }
+            }
+
+            @objc public var optionalMutableEnum: DDFooEnumeration4 {
+                set { root.swiftModel.optionalMutableEnum = newValue.toSwift }
+                get { .init(swift: root.swiftModel.optionalMutableEnum) }
+            }
+        }
+
+        @objc
+        public enum DDFooEnumeration1: Int {
+            internal init(swift: Foo.Enumeration1) {
+                switch swift {
+                case .case1: self = .case1
+                case .case2: self = .case2
+                case .case3: self = .case3
+                }
+            }
+
+            internal var toSwift: Foo.Enumeration1 {
+                switch self {
+                case .case1: return .case1
+                case .case2: return .case2
+                case .case3: return .case3
+                }
+            }
+
+            case case1
+            case case2
+            case case3
+        }
+
+        @objc
+        public enum DDFooEnumeration2: Int {
+            internal init(swift: Foo.Enumeration2?) {
+                switch swift {
+                case nil: self = .none
+                case .case1?: self = .case1
+                case .case2?: self = .case2
+                case .case3?: self = .case3
+                }
+            }
+
+            internal var toSwift: Foo.Enumeration2? {
+                switch self {
+                case .none: return nil
+                case .case1: return .case1
+                case .case2: return .case2
+                case .case3: return .case3
+                }
+            }
+
+            case none
+            case case1
+            case case2
+            case case3
+        }
+
+        @objc
+        public enum DDFooEnumeration3: Int {
+            internal init(swift: Foo.Enumeration3) {
+                switch swift {
+                case .case1: self = .case1
+                case .case2: self = .case2
+                case .case3: self = .case3
+                }
+            }
+
+            internal var toSwift: Foo.Enumeration3 {
+                switch self {
+                case .case1: return .case1
+                case .case2: return .case2
+                case .case3: return .case3
+                }
+            }
+
+            case case1
+            case case2
+            case case3
+        }
+
+        @objc
+        public enum DDFooEnumeration4: Int {
+            internal init(swift: Foo.Enumeration4?) {
+                switch swift {
+                case nil: self = .none
+                case .case1?: self = .case1
+                case .case2?: self = .case2
+                case .case3?: self = .case3
+                }
+            }
+
+            internal var toSwift: Foo.Enumeration4? {
+                switch self {
+                case .none: return nil
+                case .case1: return .case1
+                case .case2: return .case2
+                case .case3: return .case3
+                }
+            }
+
+            case none
+            case case1
+            case case2
+            case case3
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    // MARK: - Property wrappers for Swift arrays
+
+    func testPrintingObjcInteropForSwiftStructWithStringArrayProperties() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "immutableStrings",
+                    type: SwiftArray(element: SwiftPrimitive<String>()),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalImmutableStrings",
+                    type: SwiftArray(element: SwiftPrimitive<String>()),
+                    isOptional: true,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "mutableStrings",
+                    type: SwiftArray(element: SwiftPrimitive<String>()),
+                    isOptional: false,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "optionalMutableStrings",
+                    type: SwiftArray(element: SwiftPrimitive<String>()),
+                    isOptional: true,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public let immutableStrings: [String]
+
+            public let optionalImmutableStrings: [String]?
+
+            public var mutableStrings: [String]
+
+            public var optionalMutableStrings: [String]?
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var immutableStrings: [String] {
+                root.swiftModel.immutableStrings
+            }
+
+            @objc public var optionalImmutableStrings: [String]? {
+                root.swiftModel.optionalImmutableStrings
+            }
+
+            @objc public var mutableStrings: [String] {
+                set { root.swiftModel.mutableStrings = newValue }
+                get { root.swiftModel.mutableStrings }
+            }
+
+            @objc public var optionalMutableStrings: [String]? {
+                set { root.swiftModel.optionalMutableStrings = newValue }
+                get { root.swiftModel.optionalMutableStrings }
+            }
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingObjcInteropForSwiftStructWithInt64ArrayProperties() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "immutableInt64s",
+                    type: SwiftArray(element: SwiftPrimitive<Int64>()),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalImmutableInt64s",
+                    type: SwiftArray(element: SwiftPrimitive<Int64>()),
+                    isOptional: true,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "mutableInt64s",
+                    type: SwiftArray(element: SwiftPrimitive<Int64>()),
+                    isOptional: false,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "optionalMutableInt64s",
+                    type: SwiftArray(element: SwiftPrimitive<Int64>()),
+                    isOptional: true,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public let immutableInt64s: [Int64]
+
+            public let optionalImmutableInt64s: [Int64]?
+
+            public var mutableInt64s: [Int64]
+
+            public var optionalMutableInt64s: [Int64]?
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var immutableInt64s: [NSNumber] {
+                root.swiftModel.immutableInt64s as [NSNumber]
+            }
+
+            @objc public var optionalImmutableInt64s: [NSNumber]? {
+                root.swiftModel.optionalImmutableInt64s as [NSNumber]?
+            }
+
+            @objc public var mutableInt64s: [NSNumber] {
+                set { root.swiftModel.mutableInt64s = newValue.map { $0.int64Value } }
+                get { root.swiftModel.mutableInt64s as [NSNumber] }
+            }
+
+            @objc public var optionalMutableInt64s: [NSNumber]? {
+                set { root.swiftModel.optionalMutableInt64s = newValue?.map { $0.int64Value } }
+                get { root.swiftModel.optionalMutableInt64s as [NSNumber]? }
+            }
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingObjcInteropForSwiftStructWithEnumArrayProperties() throws {
+        func mockEnumeration(named name: String) -> SwiftEnum {
+            return SwiftEnum(
+                name: name,
+                comment: nil,
+                cases: [
+                    SwiftEnum.Case(label: "option1", rawValue: "option1"),
+                    SwiftEnum.Case(label: "option2", rawValue: "option2"),
+                    SwiftEnum.Case(label: "option3", rawValue: "option3"),
+                ],
+                conformance: []
+            )
+        }
+
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "immutableEnums",
+                    type: SwiftArray(element: mockEnumeration(named: "Options1")),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalImmutableEnums",
+                    type: SwiftArray(element: mockEnumeration(named: "Options2")),
+                    isOptional: true,
+                    isMutable: false
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public let immutableEnums: [Options1]
+
+            public let optionalImmutableEnums: [Options2]?
+
+            public enum Options1: String {
+                case option1 = "option1"
+                case option2 = "option2"
+                case option3 = "option3"
+            }
+
+            public enum Options2: String {
+                case option1 = "option1"
+                case option2 = "option2"
+                case option3 = "option3"
+            }
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var immutableEnums: [Int] {
+                root.swiftModel.immutableEnums.map { DDFooOptions1(swift: $0).rawValue }
+            }
+
+            @objc public var optionalImmutableEnums: [Int]? {
+                root.swiftModel.optionalImmutableEnums?.map { DDFooOptions2(swift: $0).rawValue }
+            }
+        }
+
+        @objc
+        public enum DDFooOptions1: Int {
+            internal init(swift: Foo.Options1) {
+                switch swift {
+                case .option1: self = .option1
+                case .option2: self = .option2
+                case .option3: self = .option3
+                }
+            }
+
+            internal var toSwift: Foo.Options1 {
+                switch self {
+                case .option1: return .option1
+                case .option2: return .option2
+                case .option3: return .option3
+                }
+            }
+
+            case option1
+            case option2
+            case option3
+        }
+
+        @objc
+        public enum DDFooOptions2: Int {
+            internal init(swift: Foo.Options2?) {
+                switch swift {
+                case nil: self = .none
+                case .option1?: self = .option1
+                case .option2?: self = .option2
+                case .option3?: self = .option3
+                }
+            }
+
+            internal var toSwift: Foo.Options2? {
+                switch self {
+                case .none: return nil
+                case .option1: return .option1
+                case .option2: return .option2
+                case .option3: return .option3
+                }
+            }
+
+            case none
+            case option1
+            case option2
+            case option3
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    // MARK: - Nested Swift Structs and Enums
+
+    func testPrintingObjcInteropForSwiftStructWithNestedStructs() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "mutableBar",
+                    type: SwiftStruct(
+                        name: "MutableBar",
+                        comment: nil,
+                        properties: [
+                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: false),
+                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: false),
+                            .mock(propertyName: "mutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: true),
+                            .mock(propertyName: "optionalMutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: true),
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: false,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "immutableBar",
+                    type: SwiftStruct(
+                        name: "ImmutableBar",
+                        comment: nil,
+                        properties: [
+                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: false),
+                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: false),
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: false,
+                    isMutable: false
+                ),
+                .mock(
+                    propertyName: "optionalMutableBar",
+                    type: SwiftStruct(
+                        name: "OptionalMutableBar",
+                        comment: nil,
+                        properties: [
+                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: false),
+                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: false),
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: true,
+                    isMutable: true
+                ),
+                .mock(
+                    propertyName: "optionalImmutableBar",
+                    type: SwiftStruct(
+                        name: "OptionalImmutableBar",
+                        comment: nil,
+                        properties: [
+                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: false),
+                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: false),
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: true,
+                    isMutable: false
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public var mutableBar: MutableBar
+
+            public let immutableBar: ImmutableBar
+
+            public var optionalMutableBar: OptionalMutableBar?
+
+            public let optionalImmutableBar: OptionalImmutableBar?
+
+            public struct MutableBar {
+                public let immutableString: String
+
+                public let optionalImmutableString: String?
+
+                public var mutableString: String
+
+                public var optionalMutableString: String?
+            }
+
+            public struct ImmutableBar {
+                public let immutableString: String
+
+                public let optionalImmutableString: String?
+            }
+
+            public struct OptionalMutableBar {
+                public let immutableString: String
+
+                public let optionalImmutableString: String?
+            }
+
+            public struct OptionalImmutableBar {
+                public let immutableString: String
+
+                public let optionalImmutableString: String?
+            }
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var mutableBar: DDFooMutableBar {
+                DDFooMutableBar(root: root)
+            }
+
+            @objc public var immutableBar: DDFooImmutableBar {
+                DDFooImmutableBar(root: root)
+            }
+
+            @objc public var optionalMutableBar: DDFooOptionalMutableBar? {
+                root.swiftModel.optionalMutableBar != nil ? DDFooOptionalMutableBar(root: root) : nil
+            }
+
+            @objc public var optionalImmutableBar: DDFooOptionalImmutableBar? {
+                root.swiftModel.optionalImmutableBar != nil ? DDFooOptionalImmutableBar(root: root) : nil
+            }
+        }
+
+        @objc
+        public class DDFooMutableBar: NSObject {
+            internal let root: DDFoo
+
+            internal init(root: DDFoo) {
+                self.root = root
+            }
+
+            @objc public var immutableString: String {
+                root.swiftModel.mutableBar.immutableString
+            }
+
+            @objc public var optionalImmutableString: String? {
+                root.swiftModel.mutableBar.optionalImmutableString
+            }
+
+            @objc public var mutableString: String {
+                set { root.swiftModel.mutableBar.mutableString = newValue }
+                get { root.swiftModel.mutableBar.mutableString }
+            }
+
+            @objc public var optionalMutableString: String? {
+                set { root.swiftModel.mutableBar.optionalMutableString = newValue }
+                get { root.swiftModel.mutableBar.optionalMutableString }
+            }
+        }
+
+        @objc
+        public class DDFooImmutableBar: NSObject {
+            internal let root: DDFoo
+
+            internal init(root: DDFoo) {
+                self.root = root
+            }
+
+            @objc public var immutableString: String {
+                root.swiftModel.immutableBar.immutableString
+            }
+
+            @objc public var optionalImmutableString: String? {
+                root.swiftModel.immutableBar.optionalImmutableString
+            }
+        }
+
+        @objc
+        public class DDFooOptionalMutableBar: NSObject {
+            internal let root: DDFoo
+
+            internal init(root: DDFoo) {
+                self.root = root
+            }
+
+            @objc public var immutableString: String {
+                root.swiftModel.optionalMutableBar!.immutableString
+            }
+
+            @objc public var optionalImmutableString: String? {
+                root.swiftModel.optionalMutableBar!.optionalImmutableString
+            }
+        }
+
+        @objc
+        public class DDFooOptionalImmutableBar: NSObject {
+            internal let root: DDFoo
+
+            internal init(root: DDFoo) {
+                self.root = root
+            }
+
+            @objc public var immutableString: String {
+                root.swiftModel.optionalImmutableBar!.immutableString
+            }
+
+            @objc public var optionalImmutableString: String? {
+                root.swiftModel.optionalImmutableBar!.optionalImmutableString
+            }
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingObjcInteropForSwiftStructWithNestedEnum() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "bar",
+                    type: SwiftStruct(
+                        name: "Bar",
+                        comment: nil,
+                        properties: [
+                            .mock(
+                                propertyName: "enumeration",
+                                type: SwiftEnum(
+                                    name: "Enumeration",
+                                    comment: nil,
+                                    cases: [
+                                        SwiftEnum.Case(label: "case1", rawValue: "case1"),
+                                        SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                                        SwiftEnum.Case(label: "case3", rawValue: "case3"),
+                                    ],
+                                    conformance: []
+                                ),
+                                isOptional: false,
+                                isMutable: true
+                            ),
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: false,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public var bar: Bar
+
+            public struct Bar {
+                public var enumeration: Enumeration
+
+                public enum Enumeration: String {
+                    case case1 = "case1"
+                    case case2 = "case2"
+                    case case3 = "case3"
+                }
+            }
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var bar: DDFooBar {
+                DDFooBar(root: root)
+            }
+        }
+
+        @objc
+        public class DDFooBar: NSObject {
+            internal let root: DDFoo
+
+            internal init(root: DDFoo) {
+                self.root = root
+            }
+
+            @objc public var enumeration: DDFooBarEnumeration {
+                set { root.swiftModel.bar.enumeration = newValue.toSwift }
+                get { .init(swift: root.swiftModel.bar.enumeration) }
+            }
+        }
+
+        @objc
+        public enum DDFooBarEnumeration: Int {
+            internal init(swift: Foo.Bar.Enumeration) {
+                switch swift {
+                case .case1: self = .case1
+                case .case2: self = .case2
+                case .case3: self = .case3
+                }
+            }
+
+            internal var toSwift: Foo.Bar.Enumeration {
+                switch self {
+                case .case1: return .case1
+                case .case2: return .case2
+                case .case3: return .case3
+                }
+            }
+
+            case case1
+            case case2
+            case case3
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct])
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    // MARK: - Referenced Swift Structs and Enums
+
+    func testPrintingObjcInteropForSwiftStructsWithReferencedStructAndEnum() throws {
+        let fooStruct = SwiftStruct(
+            name: "Foo",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "bar",
+                    type: SwiftStruct(
+                        name: "Bar",
+                        comment: nil,
+                        properties: [
+                            .mock(
+                                propertyName: "sharedStruct",
+                                type: SwiftTypeReference(referencedTypeName: "SharedStruct"),
+                                isOptional: false,
+                                isMutable: true
+                            ),
+                            .mock(
+                                propertyName: "sharedEnumeration",
+                                type: SwiftTypeReference(referencedTypeName: "SharedEnum"),
+                                isOptional: false,
+                                isMutable: true
+                            ),
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: false,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let bizzStruct = SwiftStruct(
+            name: "Bizz",
+            comment: nil,
+            properties: [
+                .mock(
+                    propertyName: "buzz",
+                    type: SwiftStruct(
+                        name: "Buzz",
+                        comment: nil,
+                        properties: [
+                            .mock(
+                                propertyName: "sharedStruct",
+                                type: SwiftTypeReference(referencedTypeName: "SharedStruct"),
+                                isOptional: false,
+                                isMutable: true
+                            ),
+                            .mock(
+                                propertyName: "sharedEnumeration",
+                                type: SwiftTypeReference(referencedTypeName: "SharedEnum"),
+                                isOptional: false,
+                                isMutable: true
+                            ),
+                        ],
+                        conformance: []
+                    ),
+                    isOptional: false,
+                    isMutable: true
+                ),
+            ],
+            conformance: []
+        )
+
+        let sharedStruct = SwiftStruct(
+            name: "SharedStruct",
+            comment: nil,
+            properties: [
+                .mock(propertyName: "integer", type: SwiftPrimitive<Int>(), isOptional: true, isMutable: true)
+            ],
+            conformance: []
+        )
+
+        let sharedEnum = SwiftEnum(
+            name: "SharedEnum",
+            comment: nil,
+            cases: [
+                SwiftEnum.Case(label: "case1", rawValue: "case1"),
+                SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                SwiftEnum.Case(label: "case3", rawValue: "case3"),
+            ],
+            conformance: []
+        )
+
+        let expected = """
+        // MARK: - Swift
+
+        public struct Foo {
+            public var bar: Bar
+
+            public struct Bar {
+                public var sharedStruct: SharedStruct
+
+                public var sharedEnumeration: SharedEnum
+            }
+        }
+
+        public struct Bizz {
+            public var buzz: Buzz
+
+            public struct Buzz {
+                public var sharedStruct: SharedStruct
+
+                public var sharedEnumeration: SharedEnum
+            }
+        }
+
+        public struct SharedStruct {
+            public var integer: Int?
+        }
+
+        public enum SharedEnum: String {
+            case case1 = "case1"
+            case case2 = "case2"
+            case case3 = "case3"
+        }
+
+        // MARK: - ObjcInterop
+
+        @objc
+        public class DDFoo: NSObject {
+            internal var swiftModel: Foo
+            internal var root: DDFoo { self }
+
+            internal init(swiftModel: Foo) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var bar: DDFooBar {
+                DDFooBar(root: root)
+            }
+        }
+
+        @objc
+        public class DDFooBar: NSObject {
+            internal let root: DDFoo
+
+            internal init(root: DDFoo) {
+                self.root = root
+            }
+
+            @objc public var sharedStruct: DDFooBarSharedStruct {
+                DDFooBarSharedStruct(root: root)
+            }
+
+            @objc public var sharedEnumeration: DDFooBarSharedEnum {
+                set { root.swiftModel.bar.sharedEnumeration = newValue.toSwift }
+                get { .init(swift: root.swiftModel.bar.sharedEnumeration) }
+            }
+        }
+
+        @objc
+        public class DDFooBarSharedStruct: NSObject {
+            internal let root: DDFoo
+
+            internal init(root: DDFoo) {
+                self.root = root
+            }
+
+            @objc public var integer: NSNumber? {
+                set { root.swiftModel.bar.sharedStruct.integer = newValue?.intValue }
+                get { root.swiftModel.bar.sharedStruct.integer as NSNumber? }
+            }
+        }
+
+        @objc
+        public enum DDFooBarSharedEnum: Int {
+            internal init(swift: SharedEnum) {
+                switch swift {
+                case .case1: self = .case1
+                case .case2: self = .case2
+                case .case3: self = .case3
+                }
+            }
+
+            internal var toSwift: SharedEnum {
+                switch self {
+                case .case1: return .case1
+                case .case2: return .case2
+                case .case3: return .case3
+                }
+            }
+
+            case case1
+            case case2
+            case case3
+        }
+
+        @objc
+        public class DDBizz: NSObject {
+            internal var swiftModel: Bizz
+            internal var root: DDBizz { self }
+
+            internal init(swiftModel: Bizz) {
+                self.swiftModel = swiftModel
+            }
+
+            @objc public var buzz: DDBizzBuzz {
+                DDBizzBuzz(root: root)
+            }
+        }
+
+        @objc
+        public class DDBizzBuzz: NSObject {
+            internal let root: DDBizz
+
+            internal init(root: DDBizz) {
+                self.root = root
+            }
+
+            @objc public var sharedStruct: DDBizzBuzzSharedStruct {
+                DDBizzBuzzSharedStruct(root: root)
+            }
+
+            @objc public var sharedEnumeration: DDBizzBuzzSharedEnum {
+                set { root.swiftModel.buzz.sharedEnumeration = newValue.toSwift }
+                get { .init(swift: root.swiftModel.buzz.sharedEnumeration) }
+            }
+        }
+
+        @objc
+        public class DDBizzBuzzSharedStruct: NSObject {
+            internal let root: DDBizz
+
+            internal init(root: DDBizz) {
+                self.root = root
+            }
+
+            @objc public var integer: NSNumber? {
+                set { root.swiftModel.buzz.sharedStruct.integer = newValue?.intValue }
+                get { root.swiftModel.buzz.sharedStruct.integer as NSNumber? }
+            }
+        }
+
+        @objc
+        public enum DDBizzBuzzSharedEnum: Int {
+            internal init(swift: SharedEnum) {
+                switch swift {
+                case .case1: self = .case1
+                case .case2: self = .case2
+                case .case3: self = .case3
+                }
+            }
+
+            internal var toSwift: SharedEnum {
+                switch self {
+                case .case1: return .case1
+                case .case2: return .case2
+                case .case3: return .case3
+                }
+            }
+
+            case case1
+            case case2
+            case case3
+        }
+
+        """
+
+        let actual = try printSwiftWithObjcInterop(for: [fooStruct, bizzStruct, sharedStruct, sharedEnum])
+
+        XCTAssertEqual(expected, actual)
+    }
+}
+
+extension SwiftStruct.Property {
+    static func mock(
+        propertyName: String,
+        type: SwiftType,
+        isOptional: Bool,
+        isMutable: Bool
+    ) -> SwiftStruct.Property {
+        return SwiftStruct.Property(
+            name: propertyName,
+            comment: nil,
+            type: type,
+            isOptional: isOptional,
+            isMutable: isMutable,
+            defaultVaule: nil,
+            codingKey: propertyName
+        )
+    }
+}

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUMModelsGeneratorTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUMModelsGeneratorTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 final class RUMModelsGeneratorTests: XCTestCase {
     /// Test made for debugging purpose.
-    /// Uncomment it to run with real `rum-events-format/schemas` URL.
+    /// Uncomment it to run code generation for `../../../rum-events-format/schemas`.
 //    func testPrintDebugSchemas() throws {
 //        let rumEventsFormatSchemasFolder = URL(fileURLWithPath: #file)
 //            .deletingLastPathComponent()

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUMModelsGeneratorTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUMModelsGeneratorTests.swift
@@ -9,17 +9,24 @@ import XCTest
 
 final class RUMModelsGeneratorTests: XCTestCase {
     /// Test made for debugging purpose.
-    /// Uncomment it and run it using real `rum-events-format/schemas` URL.
-    func testPrintDebugSchemas() throws {
-//        let schemasFolderURL = URL(
-//            fileURLWithPath: "..."
-//        )
+    /// Uncomment it to run with real `rum-events-format/schemas` URL.
+//    func testPrintDebugSchemas() throws {
+//        let rumEventsFormatSchemasFolder = URL(fileURLWithPath: #file)
+//            .deletingLastPathComponent()
+//            .deletingLastPathComponent()
+//            .deletingLastPathComponent()
+//            .appendingPathComponent("rum-events-format/schemas", isDirectory: true)
+//
+//        let schemasFolderURL = URL(fileURLWithPath: rumEventsFormatSchemasFolder.absoluteString)
 //
 //        let schemas = try RUMJSONSchemaFiles(folder: schemasFolderURL)
 //        let generator = RUMModelsGenerator()
 //
-//        print(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
-//        print(try generator.printRUMModels(for: schemas))
-//        print("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
-    }
+//        print(">>>>>>>>>>>>>>>>>> Swift >>>>>>>>>>>>>>>>>>>>>>")
+//        print(try generator.printRUMModels(for: schemas, using: SwiftPrinter()))
+//        print("<<<<<<<<<<<<<<<<<< Swift <<<<<<<<<<<<<<<<<<<<<<")
+//        print(">>>>>>>>>>>>>>>>>> ObjcInterop >>>>>>>>>>>>>>>>>>>>>>")
+//        print(try generator.printRUMModels(for: schemas, using: ObjcInteropPrinter()))
+//        print(">>>>>>>>>>>>>>>>>> ObjcInterop >>>>>>>>>>>>>>>>>>>>>>")
+//    }
 }

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUMModelsGeneratorTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUMModelsGeneratorTests.swift
@@ -1,0 +1,25 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import XCTest
+@testable import RUMModelsGeneratorCore
+
+final class RUMModelsGeneratorTests: XCTestCase {
+    /// Test made for debugging purpose.
+    /// Uncomment it and run it using real `rum-events-format/schemas` URL.
+    func testPrintDebugSchemas() throws {
+//        let schemasFolderURL = URL(
+//            fileURLWithPath: "..."
+//        )
+//
+//        let schemas = try RUMJSONSchemaFiles(folder: schemasFolderURL)
+//        let generator = RUMModelsGenerator()
+//
+//        print(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
+//        print(try generator.printRUMModels(for: schemas))
+//        print("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR updates the `rum-models-generator` tool to generate `@objc` RUM data models. This is required to further expose scrubbing API in `DatadogObjc` as it was done for Swift (#367). 

### How?

I leveraged the existing architecture of `rum-models-generator`: 
* `read → transform → print`

by implementing another `Printer`:

* `read → transform → SwiftPrinter`
* `read → transform → ObjcInteropPrinter`

The `SwiftType` schema generated and transformed for Swift code generation is now used by `ObjcInteropReader` to generate `ObjcInteropType` schema. The schema is later passed to the `ObjcInteropPrinter` for printing the actual code.

### Swift / Obj-c interoperability for RUM

`@objc` interoperability is done by wrapping Swift `structs` in `@objc` classes and exposing Swift `enums` as `@objc enum` .

Simple example can be illustrated as:
```swift
// MARK: - Swift

public struct Foo {
    public let immutableString: String
    public let optionalImmutableString: String?
    public var mutableString: String
    public var optionalMutableString: String?
}

// MARK: - ObjcInterop

@objc
public class DDFoo: NSObject {
    internal var swiftModel: Foo
    internal var root: DDFoo { self }

    internal init(swiftModel: Foo) {
        self.swiftModel = swiftModel
    }

    @objc public var immutableString: String {
        root.swiftModel.immutableString
    }

    @objc public var optionalImmutableString: String? {
        root.swiftModel.optionalImmutableString
    }

    @objc public var mutableString: String {
        set { root.swiftModel.mutableString = newValue }
        get { root.swiftModel.mutableString }
    }

    @objc public var optionalMutableString: String? {
        set { root.swiftModel.optionalMutableString = newValue }
        get { root.swiftModel.optionalMutableString }
    }
}
```

Nested `structs` are managed by transitive `@objc classes`:
```swift
// MARK: - Swift

public struct Foo {
    public var bar: Bar

    public struct Bar {
        public let property: Int
    }
}

// MARK: - ObjcInterop

@objc
public class DDFoo: NSObject {
    internal var swiftModel: Foo
    internal var root: DDFoo { self }

    internal init(swiftModel: Foo) {
        self.swiftModel = swiftModel
    }

    @objc public var bar: DDFooBar {
        DDFooBar(root: root)
    }
}

@objc
public class DDFooBar: NSObject {
    internal let root: DDFoo

    internal init(root: DDFoo) {
        self.root = root
    }

    @objc public var property: NSNumber {
        root.swiftModel.bar.property as NSNumber
    }
}
```

### Code Reviewing

🙏 Please, carefully follow all the code snippets generated in `ObjcInteropPrinterTests`. They showcase solutions to all edge-cases and Swift <> Obj-c interoperability limitations that I struggled with. Better alternatives are welcome 🙌.

Especially, I want to draw your attention to two things:

#### 1/ Some Swift value types are incompatible with `@objc`
Types like `Int64`, `Bool?` or `Enumeration?` cannot be directly exposed. Numeric types are represented as `NSNumber`. Optional `enums` required adding extra `case none` to represent `nil`.

####  2/ Building key-paths to optional properties requires `!` unwrapping
Some property wrappers in transitive `@objc` classes require force unwrapping of the Swift `struct's` key path, e.g.:
```swift
// Property wrapper defined in transitive @objc class `DDFooBar`:
@objc public var property: String {
    // Because `bar` is an optional property on `Foo`, its key-path requires force unwrapping
    root.swiftModel.bar!.property
}
```
The safety of this construct is guaranteed by the `!= nil` check in the property wrapper providing the access to `DDFooBar`:
```swift
// Property wrapper defined in root @objc class `DDFoo`:
@objc public var bar: DDFooBar? {
    root.swiftModel.bar != nil ? DDFooBar(root: root) : nil
}
```

### Coming in next PRs:

Next PRs will focus on:
* configuring CI job for `@objc` RUM models validation,
* exposing scrubbing API in `DatadogObjc`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
