### PR TITLE
RUMM-987 Add scrubbing API to `DatadogObjc`

### DIFF
--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -225,6 +225,38 @@ public class DDConfigurationBuilder: NSObject {
     }
 
     @objc
+    public func setRUMViewEventMapper(_ mapper: @escaping (DDRUMViewEvent) -> DDRUMViewEvent?) {
+        _ = sdkBuilder.setRUMViewEventMapper { swiftEvent in
+            let objcEvent = DDRUMViewEvent(swiftModel: swiftEvent)
+            return mapper(objcEvent)?.swiftModel
+        }
+    }
+
+    @objc
+    public func setRUMResourceEventMapper(_ mapper: @escaping (DDRUMResourceEvent) -> DDRUMResourceEvent?) {
+        _ = sdkBuilder.setRUMResourceEventMapper { swiftEvent in
+            let objcEvent = DDRUMResourceEvent(swiftModel: swiftEvent)
+            return mapper(objcEvent)?.swiftModel
+        }
+    }
+
+    @objc
+    public func setRUMActionEventMapper(_ mapper: @escaping (DDRUMActionEvent) -> DDRUMActionEvent?) {
+        _ = sdkBuilder.setRUMActionEventMapper { swiftEvent in
+            let objcEvent = DDRUMActionEvent(swiftModel: swiftEvent)
+            return mapper(objcEvent)?.swiftModel
+        }
+    }
+
+    @objc
+    public func setRUMErrorEventMapper(_ mapper: @escaping (DDRUMErrorEvent) -> DDRUMErrorEvent?) {
+        _ = sdkBuilder.setRUMErrorEventMapper { swiftEvent in
+            let objcEvent = DDRUMErrorEvent(swiftModel: swiftEvent)
+            return mapper(objcEvent)?.swiftModel
+        }
+    }
+
+    @objc
     public func set(batchSize: DDBatchSize) {
         _ = sdkBuilder.set(batchSize: batchSize.swiftType)
     }


### PR DESCRIPTION
### What and why?

📦 Based on RUM `@objc` models generated in #382, this PR adds Scrubbing APIs to `DatadogObjc`:
```swift
// in DDConfigurationBuilder:

@objc
public func setRUMViewEventMapper(_ mapper: @escaping (DDRUMViewEvent) -> DDRUMViewEvent?)

@objc
public func setRUMResourceEventMapper(_ mapper: @escaping (DDRUMResourceEvent) -> DDRUMResourceEvent?)

@objc
public func setRUMActionEventMapper(_ mapper: @escaping (DDRUMActionEvent) -> DDRUMActionEvent?)

@objc
public func setRUMErrorEventMapper(_ mapper: @escaping (DDRUMErrorEvent) -> DDRUMErrorEvent?)
```

### How?

As usual, `DatadogObjc` APIs bridge their calls to `Datadog` (Swift).

I also made sure those APIs are properly exposed, compile and look "nice" in Objective-c. Here, an example of redacting the `resource.url` for `POST` resources and dropping all other resources: 
```objc
[builder setRUMResourceEventMapper:^DDRUMResourceEvent * _Nullable(DDRUMResourceEvent * _Nonnull event) {
    if (event.resource.method == DDRUMResourceEventResourceRUMMethodPost) {
        event.resource.url = @"redacted";
        return event;
    } else {
        return nil;
    }
}];
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
