### PR TITLE
RUMM-1020 Govcloud endpoints changed

### DIFF
--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -89,7 +89,7 @@ extension Datadog {
                 switch self {
                 case .us: return "https://mobile-http-intake.logs.datadoghq.com/v1/input/"
                 case .eu: return "https://mobile-http-intake.logs.datadoghq.eu/v1/input/"
-                case .gov: return "https://mobile-http-intake.logs.ddog-gov.com/v1/input/"
+                case .gov: return "https://logs.browser-intake-ddog-gov.com/v1/input/"
                 case let .custom(url: url): return url
                 }
             }
@@ -113,7 +113,7 @@ extension Datadog {
                 switch self {
                 case .us: return "https://public-trace-http-intake.logs.datadoghq.com/v1/input/"
                 case .eu: return "https://public-trace-http-intake.logs.datadoghq.eu/v1/input/"
-                case .gov: return "https://public-trace-http-intake.logs.ddog-gov.com/v1/input/"
+                case .gov: return "https://trace.browser-intake-ddog-gov.com/v1/input/"
                 case let .custom(url: url): return url
                 }
             }
@@ -137,7 +137,7 @@ extension Datadog {
                 switch self {
                 case .us: return "https://rum-http-intake.logs.datadoghq.com/v1/input/"
                 case .eu: return "https://rum-http-intake.logs.datadoghq.eu/v1/input/"
-                case .gov: return "https://rum-http-intake.logs.ddog-gov.com/v1/input/"
+                case .gov: return "https://rum.browser-intake-ddog-gov.com/v1/input/"
                 case let .custom(url: url): return url
                 }
             }

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -147,7 +147,7 @@ class FeaturesConfigurationTests: XCTestCase {
         )
         XCTAssertEqual(
             try configuration(datadogEndpoint: .gov).logging?.uploadURLWithClientToken.absoluteString,
-            "https://mobile-http-intake.logs.ddog-gov.com/v1/input/" + clientToken
+            "https://logs.browser-intake-ddog-gov.com/v1/input/" + clientToken
         )
 
         XCTAssertEqual(
@@ -160,7 +160,7 @@ class FeaturesConfigurationTests: XCTestCase {
         )
         XCTAssertEqual(
             try configuration(datadogEndpoint: .gov).tracing?.uploadURLWithClientToken.absoluteString,
-            "https://public-trace-http-intake.logs.ddog-gov.com/v1/input/" + clientToken
+            "https://trace.browser-intake-ddog-gov.com/v1/input/" + clientToken
         )
 
         XCTAssertEqual(
@@ -173,7 +173,7 @@ class FeaturesConfigurationTests: XCTestCase {
         )
         XCTAssertEqual(
             try configuration(datadogEndpoint: .gov).rum?.uploadURLWithClientToken.absoluteString,
-            "https://rum-http-intake.logs.ddog-gov.com/v1/input/" + clientToken
+            "https://rum.browser-intake-ddog-gov.com/v1/input/" + clientToken
         )
 
         XCTAssertEqual(


### PR DESCRIPTION
### What and why?

GovCloud endpoints are moved 
* to `{feature_name}.browser-intake-ddog-gov.com`
* from `mobile-http-intake.{feature_name}.ddog-gov.com`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Make sure by going to GovCloud website and looking at data
