### PR TITLE
RUMM-954 trackURLSession(:) is introduced in ObjC API

### DIFF
--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -186,14 +186,20 @@ public class DDConfigurationBuilder: NSObject {
         _ = sdkBuilder.set(tracesEndpoint: tracesEndpoint.sdkEndpoint)
     }
 
-    @available(*, deprecated, message: "This option is replaced by `track(firstPartyHosts:)`. Refer to the new API comment for important details.")
+    @available(*, deprecated, message: "This option is replaced by `trackURLSession(firstPartyHosts:)`. Refer to the new API comment for important details.")
     @objc
     public func set(tracedHosts: Set<String>) {
         track(firstPartyHosts: tracedHosts)
     }
 
+    @available(*, deprecated, message: "This option is replaced by `trackURLSession(firstPartyHosts:)`. Refer to the new API comment for important details.")
     @objc
     public func track(firstPartyHosts: Set<String>) {
+        trackURLSession(firstPartyHosts: firstPartyHosts)
+    }
+
+    @objc
+    public func trackURLSession(firstPartyHosts: Set<String>) {
         _ = sdkBuilder.trackURLSession(firstPartyHosts: firstPartyHosts)
     }
 

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -100,7 +100,7 @@ class DDConfigurationTests: XCTestCase {
         objcBuilder.set(serviceName: "service-name")
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.serviceName, "service-name")
 
-        objcBuilder.track(firstPartyHosts: ["example.com"])
+        objcBuilder.trackURLSession(firstPartyHosts: ["example.com"])
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.firstPartyHosts, ["example.com"])
 
         objcBuilder.trackUIKitActions()

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -28,7 +28,7 @@ class DDDatadogTests: XCTestCase {
 
     func testItFowardsInitializationToSwift() throws {
         let configBuilder = DDConfiguration.builder(clientToken: "abcefghi", environment: "tests")
-        configBuilder.track(firstPartyHosts: ["example.com"])
+        configBuilder.trackURLSession(firstPartyHosts: ["example.com"])
 
         DDDatadog.initialize(
             appContext: DDAppContext(mainBundle: BundleMock.mockWith(CFBundleExecutable: "app-name")),


### PR DESCRIPTION
### What and why?

`track(firstPartyHosts:)` is deprecated in favor of `trackURLSession(firstPartyHosts:)` in Swift API

### How?

The same API is used in ObjC now

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
