### PR TITLE
RUMM-647 Add a Span.setError convenience API for Swift on top of Tracing

### DIFF
--- a/Sources/Datadog/OpenTracing/OTSpan.swift
+++ b/Sources/Datadog/OpenTracing/OTSpan.swift
@@ -74,3 +74,52 @@ public extension OTSpan {
         self.finish(at: Date())
     }
 }
+
+/// Error conveniences
+public extension OTSpan {
+    /// Set or replace the error for the given span.
+    /// This is a convenience to set the proper tags with error details. Consider the `setError(message:stacktrace:file:line:)` variant for a better control over the error details.
+    ///
+    /// - parameter error: An object conforming to the `Error` protocol.
+    /// - parameter file: A string identifying the file where the `Error` was caught. The default is `#fileID` which means `ModuleName/Filename.extension`, consider an helpful yet concise identifier when overriding the default.
+    /// - parameter line: The line number in the file where the `Error` was caught.
+    func setError(
+        _ error: Error,
+        file: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        let dderror = DDError(error: error)
+        setError(
+            kind: dderror.title,
+            message: dderror.message,
+            stacktrace: dderror.details,
+            file: file,
+            line: line
+        )
+    }
+
+    /// Set or replace the error for the given span.
+    /// This is a convenience to set the proper tags with error details.
+    ///
+    /// - parameter kind: The type of error to be logged.
+    /// - parameter message: An error message to be logged.
+    /// - parameter stacktrace: A string detailing the state of the stack when the error was caught. Note that it can also be any details that could help further triaging and investigation of the error downstream, it doesn't have to be an actual stack trace.
+    /// - parameter file: A string identifying the file where the error was caught. The default is `#fileID` which means `ModuleName/Filename.extension`, consider an helpful yet concise identifier when overriding the default.
+    /// - parameter line: The line number in the file where the error was caught.
+    func setError(
+        kind: String,
+        message: String,
+        stacktrace: String = "",
+        file: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        log(
+            fields: [
+                OTLogFields.event: "error",
+                OTLogFields.errorKind: kind,
+                OTLogFields.message: message,
+                OTLogFields.stack: stacktrace + " \(file):\(line)"
+            ]
+        )
+    }
+}

--- a/Sources/Datadog/OpenTracing/OTSpan.swift
+++ b/Sources/Datadog/OpenTracing/OTSpan.swift
@@ -92,7 +92,7 @@ public extension OTSpan {
         setError(
             kind: dderror.title,
             message: dderror.message,
-            stacktrace: dderror.details,
+            stack: dderror.details,
             file: file,
             line: line
         )
@@ -103,13 +103,13 @@ public extension OTSpan {
     ///
     /// - parameter kind: The type of error to be logged.
     /// - parameter message: An error message to be logged.
-    /// - parameter stacktrace: A string detailing the state of the stack when the error was caught. Note that it can also be any details that could help further triaging and investigation of the error downstream, it doesn't have to be an actual stack trace.
+    /// - parameter stack: A string detailing the state of the stack when the error was caught. Note that it can also be any details that could help further triaging and investigation of the error downstream, it doesn't have to be an actual stack trace.
     /// - parameter file: A string identifying the file where the error was caught. The default is `#fileID` which means `ModuleName/Filename.extension`, consider an helpful yet concise identifier when overriding the default.
     /// - parameter line: The line number in the file where the error was caught.
     func setError(
         kind: String,
         message: String,
-        stacktrace: String = "",
+        stack: String = "",
         file: StaticString = #fileID,
         line: UInt = #line
     ) {
@@ -118,7 +118,7 @@ public extension OTSpan {
                 OTLogFields.event: "error",
                 OTLogFields.errorKind: kind,
                 OTLogFields.message: message,
-                OTLogFields.stack: stacktrace + " \(file):\(line)"
+                OTLogFields.stack: stack + " \(file):\(line)"
             ]
         )
     }

--- a/Sources/Datadog/OpenTracing/OTSpan.swift
+++ b/Sources/Datadog/OpenTracing/OTSpan.swift
@@ -80,6 +80,14 @@ public extension OTSpan {
     /// Set or replace the error for the given span.
     /// This is a convenience to set the proper tags with error details. Consider the `setError(message:stacktrace:file:line:)` variant for a better control over the error details.
     ///
+    /// Using this API requires to enable logging on `Datadog.Configuration` using its builder:
+    ///
+    ///       builder
+    ///         // ...
+    ///         .enableLogging(true)
+    ///         // ...
+    ///         .build()
+    ///
     /// - parameter error: An object conforming to the `Error` protocol.
     /// - parameter file: A string identifying the file where the `Error` was caught. The default is `#fileID` which means `ModuleName/Filename.extension`, consider an helpful yet concise identifier when overriding the default.
     /// - parameter line: The line number in the file where the `Error` was caught.
@@ -100,6 +108,14 @@ public extension OTSpan {
 
     /// Set or replace the error for the given span.
     /// This is a convenience to set the proper tags with error details.
+    ///
+    ///  Using this API requires to enable logging on `Datadog.Configuration` using its builder:
+    ///
+    ///       builder
+    ///         // ...
+    ///         .enableLogging(true)
+    ///         // ...
+    ///         .build()
     ///
     /// - parameter kind: The type of error to be logged.
     /// - parameter message: An error message to be logged.

--- a/Sources/Datadog/OpenTracing/OTSpan.swift
+++ b/Sources/Datadog/OpenTracing/OTSpan.swift
@@ -113,12 +113,16 @@ public extension OTSpan {
         file: StaticString = #fileID,
         line: UInt = #line
     ) {
+        var stackWithFile = "\(file):\(line)"
+        if stack.count > 0 {
+            stackWithFile += "\n" + stack
+        }
         log(
             fields: [
                 OTLogFields.event: "error",
                 OTLogFields.errorKind: kind,
                 OTLogFields.message: message,
-                OTLogFields.stack: stack + " \(file):\(line)"
+                OTLogFields.stack: stackWithFile
             ]
         )
     }

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -5,7 +5,6 @@
  */
 
 import Foundation
-import os.activity
 import _Datadog_Private
 
 internal class DDSpan: OTSpan {

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
@@ -138,7 +138,7 @@ class DDSpanTests: XCTestCase {
         0   app                                 0x0000000102bc0d8c 0x102bb8000 + 36236
         1   UIKitCore                           0x00000001b513d9ac 0x1b4739000 + 10504620
         """
-        span.setError(kind: .mockAny(), message: .mockAny(), stacktrace: stack)
+        span.setError(kind: .mockAny(), message: .mockAny(), stack: stack)
 
         XCTAssertEqual(span.logFields.count, 1)
         let spanErrorStack = try span.logFields.first!.otStack()

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
@@ -66,15 +66,17 @@ class DDSpanTests: XCTestCase {
         let span: DDSpan = .mockWith(operationName: "operation")
         XCTAssertEqual(span.logFields.count, 0)
 
+        #sourceLocation(file: "File.swift", line: 42)
         span.setError(ErrorMock())
+        #sourceLocation()
 
         XCTAssertEqual(span.logFields.count, 1)
         let logFields = span.logFields.first!
         XCTAssertNotEqual(logFields.count, 0)
         try XCTAssertEqual(logFields.otEvent(), "error")
         let spanErrorStack = try logFields.otStack()
-        let fileName = #fileID.components(separatedBy: "/").last!
-        XCTAssertTrue(spanErrorStack.contains(fileName))
+        XCTAssertTrue(spanErrorStack.contains("File.swift"))
+        XCTAssertTrue(spanErrorStack.contains("42"))
     }
 
     func testSettingErrorFromSwiftErrorWithFileAndLine() throws {
@@ -93,6 +95,7 @@ class DDSpanTests: XCTestCase {
         let span: DDSpan = .mockWith(operationName: "operation")
         XCTAssertEqual(span.logFields.count, 0)
 
+        #sourceLocation(file: "File.swift", line: 42)
         span.setError(
             NSError(
                 domain: "DDSpan",
@@ -100,6 +103,7 @@ class DDSpanTests: XCTestCase {
                 userInfo: [NSLocalizedDescriptionKey: "some error description"]
             )
         )
+        #sourceLocation()
 
         XCTAssertEqual(span.logFields.count, 1)
         let logFields = span.logFields.first!
@@ -109,15 +113,17 @@ class DDSpanTests: XCTestCase {
         let spanErrorStack = try logFields.otStack()
         XCTAssertTrue(spanErrorMessage.contains("some error description"))
         XCTAssertTrue(spanErrorStack.contains("DDSpan"))
-        let fileName = #fileID.components(separatedBy: "/").last!
-        XCTAssertTrue(spanErrorStack.contains(fileName))
+        XCTAssertTrue(spanErrorStack.contains("File.swift"))
+        XCTAssertTrue(spanErrorStack.contains("42"))
     }
 
     func testSettingErrorFromArguments() throws {
         let span: DDSpan = .mockWith(operationName: "operation")
         XCTAssertEqual(span.logFields.count, 0)
 
+        #sourceLocation(file: "File.swift", line: 42)
         span.setError(kind: .mockAny(), message: "DDSpan Error")
+        #sourceLocation()
 
         XCTAssertEqual(span.logFields.count, 1)
         let logFields = span.logFields.first!
@@ -126,8 +132,8 @@ class DDSpanTests: XCTestCase {
         let spanErrorMessage = try logFields.otMessage()
         let spanErrorStack = try logFields.otStack()
         XCTAssertTrue(spanErrorMessage.contains("DDSpan Error"))
-        let fileName = #fileID.components(separatedBy: "/").last!
-        XCTAssertTrue(spanErrorStack.contains(fileName))
+        XCTAssertTrue(spanErrorStack.contains("File.swift"))
+        XCTAssertTrue(spanErrorStack.contains("42"))
     }
 
     func testSettingErrorFromArgumentsWithStack() throws {

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -75,6 +75,7 @@ public class Datadog
    public func set(tracesEndpoint: TracesEndpoint) -> Builder
    public func set(tracedHosts: Set<String>) -> Builder
    public func track(firstPartyHosts: Set<String>) -> Builder
+   public func trackURLSession(firstPartyHosts: Set<String> = []) -> Builder
    public func enableRUM(_ enabled: Bool) -> Builder
    public func set(rumEndpoint: RUMEndpoint) -> Builder
    public func set(rumSessionsSamplingRate: Float) -> Builder
@@ -183,6 +184,9 @@ public protocol OTSpan
 public extension OTSpan
  func log(fields: [String: Encodable])
  func finish()
+public extension OTSpan
+ func setError(_ error: Error,file: StaticString = #fileID,line: UInt = #line)
+ func setError(kind: String,message: String,stack: String = "",file: StaticString = #fileID,line: UInt = #line)
 public protocol OTSpanContext
  func forEachBaggageItem(callback: (_ key: String, _ value: String) -> Bool)
 public protocol OTTracer
@@ -561,7 +565,7 @@ public class HTTPHeadersWriter: OTHTTPHeadersWriter
  public private(set) var tracePropagationHTTPHeaders: [String: String] = [:]
  public func inject(spanContext: OTSpanContext)
  override public init()
- public init(firstPartyHosts: Set<String>)
+ public init(additionalFirstPartyHosts: Set<String>)
 public class URLSessionInterceptor: URLSessionInterceptorType
  public static var shared: URLSessionInterceptor?
  public func modify(request: URLRequest, session: URLSession? = nil) -> URLRequest


### PR DESCRIPTION
### What and why?

Currently as part of our OpenTracing integration, we provide log fields that can be set on a Span to attach an error to that Span. It's usable but we seek to provide a more convenient way to allow passing some an `Error` conforming type, an `NSError` object or some message and details to log an error using the proper log fields as described by OpenTracing.

In this PR, we add 2 convenience APIs on `OTSpan` (in Swift) to facilitate attaching an error onto the given `OTSpan` using the right field keys.

### How?

This PR introduces an extension on `OTSpan` and piggyback on the existing `log()` as well as `OTLogFields` to properly attach the provided information. It uses `DDError` to extract information out of `NSError` or any object conforming to the `Error` protocol.
It populates the `OTLogFields.stack` field with at least a `#fileId` and `#line`, and the provided stack if any.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Run `make api-surface`

### Next

- Add the Objc counterpart API
- Use the API in AutoInstrumentation (e.g. URLSession)
- Use the API in the mobile app 
