### PR TITLE
RUMM-956 Create `DatadogCrashReporting` module

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "lyft/Kronos" ~> 4.1
+github "microsoft/plcrashreporter" ~> 1.8.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
 github "lyft/Kronos" "4.1.1"
+github "microsoft/plcrashreporter" "1.8.1"

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 		616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */; };
 		616CCE13250A1868009FED46 /* RUMCommandSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CCE12250A1868009FED46 /* RUMCommandSubscriber.swift */; };
 		616CCE16250A467E009FED46 /* RUMAutoInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CCE15250A467E009FED46 /* RUMAutoInstrumentation.swift */; };
+		6170DC1C25C18729003AED5C /* DDCrashReportingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */; };
+		6170DC5125C18E57003AED5C /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */; };
 		6179FFD3254ADB1700556A0B /* ObjcAppLaunchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */; };
 		6179FFDE254ADBEF00556A0B /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -268,6 +270,9 @@
 		61B22E5A24F3E6B700DC26D2 /* RUMDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */; };
 		61B558CF2469561C001460D3 /* LoggerBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */; };
 		61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */; };
+		61B7885D25C180CB002675B5 /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; };
+		61B7886225C180CB002675B5 /* DatadogCrashReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B7886125C180CB002675B5 /* DatadogCrashReportingTests.swift */; };
+		61B7886425C180CB002675B5 /* DatadogCrashReporting.h in Headers */ = {isa = PBXBuildFile; fileRef = 61B7885625C180CB002675B5 /* DatadogCrashReporting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */; };
 		61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */; };
 		61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */; };
@@ -434,6 +439,27 @@
 			remoteGlobalIDString = 61441C0124616DE9003D8BB8;
 			remoteInfo = Example;
 		};
+		6170DC5225C18E57003AED5C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 61B7885325C180CB002675B5;
+			remoteInfo = DatadogCrashReporting;
+		};
+		61B7885E25C180CB002675B5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 61B7885325C180CB002675B5;
+			remoteInfo = DatadogCrashReporting;
+		};
+		61B7887F25C18147002675B5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 61441C0124616DE9003D8BB8;
+			remoteInfo = Example;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -445,6 +471,7 @@
 			files = (
 				61441C4E24619498003D8BB8 /* Datadog.framework in ⚙️ Embed Framework Dependencies */,
 				61570006246AAE5E00E96950 /* DatadogObjc.framework in ⚙️ Embed Framework Dependencies */,
+				6170DC5125C18E57003AED5C /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */,
 				615697E4256CFB4700C6AADA /* Kronos.framework in ⚙️ Embed Framework Dependencies */,
 			);
 			name = "⚙️ Embed Framework Dependencies";
@@ -671,6 +698,8 @@
 		616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMMonitorTests.swift; sourceTree = "<group>"; };
 		616CCE12250A1868009FED46 /* RUMCommandSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommandSubscriber.swift; sourceTree = "<group>"; };
 		616CCE15250A467E009FED46 /* RUMAutoInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAutoInstrumentation.swift; sourceTree = "<group>"; };
+		6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportingPlugin.swift; sourceTree = "<group>"; };
+		6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogCrashReportingTests.xcconfig; sourceTree = "<group>"; };
 		61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebuggingTests.swift; sourceTree = "<group>"; };
 		6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcAppLaunchHandler.h; sourceTree = "<group>"; };
 		6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcAppLaunchHandler.m; sourceTree = "<group>"; };
@@ -721,6 +750,12 @@
 		61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebugging.swift; sourceTree = "<group>"; };
 		61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerBuilderTests.swift; sourceTree = "<group>"; };
 		61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDGeneratorTests.swift; sourceTree = "<group>"; };
+		61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCrashReporting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		61B7885625C180CB002675B5 /* DatadogCrashReporting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DatadogCrashReporting.h; sourceTree = "<group>"; };
+		61B7885725C180CB002675B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogCrashReportingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		61B7886125C180CB002675B5 /* DatadogCrashReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCrashReportingTests.swift; sourceTree = "<group>"; };
+		61B7886325C180CB002675B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61B9ED1A2461E12000C0DCFF /* SendLogsFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendLogsFixtureViewController.swift; sourceTree = "<group>"; };
 		61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendTracesFixtureViewController.swift; sourceTree = "<group>"; };
 		61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsHelpers.swift; sourceTree = "<group>"; };
@@ -903,6 +938,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		61B7885125C180CB002675B5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61B7885925C180CB002675B5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61B7885D25C180CB002675B5 /* DatadogCrashReporting.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -919,8 +969,10 @@
 			children = (
 				61133B9C2423979B00786299 /* Datadog */,
 				61133C082423983800786299 /* DatadogObjc */,
+				6170DC1325C1864B003AED5C /* DatadogCrashReporting */,
 				9E68FB52244707FD0013A8AA /* _Datadog_Private */,
 				61133C122423990D00786299 /* DatadogTests */,
+				6170DC1425C18663003AED5C /* DatadogCrashReportingTests */,
 				61441C772461A204003D8BB8 /* DatadogBenchmarkTests */,
 				61441C3524617013003D8BB8 /* DatadogIntegrationTests */,
 				61133C07242397F200786299 /* TargetSupport */,
@@ -939,6 +991,8 @@
 				61441C0224616DE9003D8BB8 /* Example.app */,
 				61441C2A24616F1D003D8BB8 /* DatadogIntegrationTests.xctest */,
 				61441C6824619FE4003D8BB8 /* DatadogBenchmarkTests.xctest */,
+				61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */,
+				61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1134,7 +1188,9 @@
 				615519242461BCE7002A85CF /* xcconfigs */,
 				61133B84242393DE00786299 /* Datadog */,
 				61133BF1242397DA00786299 /* DatadogObjc */,
+				6170DC0525C184FA003AED5C /* DatadogCrashReporting */,
 				61133B8F242393DE00786299 /* DatadogTests */,
+				6170DC0625C184FA003AED5C /* DatadogCrashReportingTests */,
 				61441C762461A01D003D8BB8 /* DatadogBenchmarkTests */,
 				9EF49F1524476FBD004F2CA0 /* DatadogIntegrationTests */,
 				61441C9E2461AF4D003D8BB8 /* Example */,
@@ -1888,6 +1944,42 @@
 			path = AutoInstrumentation;
 			sourceTree = "<group>";
 		};
+		6170DC0525C184FA003AED5C /* DatadogCrashReporting */ = {
+			isa = PBXGroup;
+			children = (
+				61B7885625C180CB002675B5 /* DatadogCrashReporting.h */,
+				61B7885725C180CB002675B5 /* Info.plist */,
+			);
+			path = DatadogCrashReporting;
+			sourceTree = "<group>";
+		};
+		6170DC0625C184FA003AED5C /* DatadogCrashReportingTests */ = {
+			isa = PBXGroup;
+			children = (
+				6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */,
+				61B7886325C180CB002675B5 /* Info.plist */,
+			);
+			path = DatadogCrashReportingTests;
+			sourceTree = "<group>";
+		};
+		6170DC1325C1864B003AED5C /* DatadogCrashReporting */ = {
+			isa = PBXGroup;
+			children = (
+				6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */,
+			);
+			name = DatadogCrashReporting;
+			path = ../Sources/DatadogCrashReporting;
+			sourceTree = "<group>";
+		};
+		6170DC1425C18663003AED5C /* DatadogCrashReportingTests */ = {
+			isa = PBXGroup;
+			children = (
+				61B7886125C180CB002675B5 /* DatadogCrashReportingTests.swift */,
+			);
+			name = DatadogCrashReportingTests;
+			path = ../Tests/DatadogCrashReportingTests;
+			sourceTree = "<group>";
+		};
 		61786F7524FCDDE2009E6BAB /* Debugging */ = {
 			isa = PBXGroup;
 			children = (
@@ -2504,6 +2596,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		61B7884F25C180CB002675B5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61B7886425C180CB002675B5 /* DatadogCrashReporting.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -2577,6 +2677,7 @@
 			);
 			dependencies = (
 				61441C5024619499003D8BB8 /* PBXTargetDependency */,
+				6170DC5325C18E57003AED5C /* PBXTargetDependency */,
 			);
 			name = Example;
 			packageProductDependencies = (
@@ -2627,13 +2728,52 @@
 			productReference = 61441C6824619FE4003D8BB8 /* DatadogBenchmarkTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		61B7885325C180CB002675B5 /* DatadogCrashReporting */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 61B7886B25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReporting" */;
+			buildPhases = (
+				61B7884F25C180CB002675B5 /* Headers */,
+				61B7885025C180CB002675B5 /* Sources */,
+				61B7885125C180CB002675B5 /* Frameworks */,
+				61B7885225C180CB002675B5 /* Resources */,
+				6170DC2325C18762003AED5C /* ⚙️ Run linter */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DatadogCrashReporting;
+			productName = DatadogCrashReporting;
+			productReference = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		61B7885B25C180CB002675B5 /* DatadogCrashReportingTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 61B7886C25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReportingTests" */;
+			buildPhases = (
+				61B7885825C180CB002675B5 /* Sources */,
+				61B7885925C180CB002675B5 /* Frameworks */,
+				61B7885A25C180CB002675B5 /* Resources */,
+				6170DC2425C18784003AED5C /* ⚙️ Run linter */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				61B7885F25C180CB002675B5 /* PBXTargetDependency */,
+				61B7888025C18147002675B5 /* PBXTargetDependency */,
+			);
+			name = DatadogCrashReportingTests;
+			productName = DatadogCrashReportingTests;
+			productReference = 61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		61133B79242393DE00786299 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1140;
+				LastSwiftUpdateCheck = 1230;
 				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = Datadog;
 				TargetAttributes = {
@@ -2660,6 +2800,14 @@
 						CreatedOnToolsVersion = 11.4;
 						TestTargetID = 61441C0124616DE9003D8BB8;
 					};
+					61B7885325C180CB002675B5 = {
+						CreatedOnToolsVersion = 12.3;
+						LastSwiftMigration = 1230;
+					};
+					61B7885B25C180CB002675B5 = {
+						CreatedOnToolsVersion = 12.3;
+						TestTargetID = 61441C0124616DE9003D8BB8;
+					};
 				};
 			};
 			buildConfigurationList = 61133B7C242393DE00786299 /* Build configuration list for PBXProject "Datadog" */;
@@ -2677,7 +2825,9 @@
 			targets = (
 				61133B81242393DE00786299 /* Datadog */,
 				61133BEF242397DA00786299 /* DatadogObjc */,
+				61B7885325C180CB002675B5 /* DatadogCrashReporting */,
 				61133B8A242393DE00786299 /* DatadogTests */,
+				61B7885B25C180CB002675B5 /* DatadogCrashReportingTests */,
 				61441C6724619FE4003D8BB8 /* DatadogBenchmarkTests */,
 				61441C2924616F1D003D8BB8 /* DatadogIntegrationTests */,
 				61441C0124616DE9003D8BB8 /* Example */,
@@ -2742,10 +2892,62 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		61B7885225C180CB002675B5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61B7885A25C180CB002675B5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		61133C772423A4C300786299 /* ⚙️ Run linter */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "⚙️ Run linter";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		6170DC2325C18762003AED5C /* ⚙️ Run linter */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "⚙️ Run linter";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		6170DC2425C18784003AED5C /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3187,6 +3389,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		61B7885025C180CB002675B5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6170DC1C25C18729003AED5C /* DDCrashReportingPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61B7885825C180CB002675B5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61B7886225C180CB002675B5 /* DatadogCrashReportingTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -3214,6 +3432,21 @@
 			isa = PBXTargetDependency;
 			target = 61441C0124616DE9003D8BB8 /* Example */;
 			targetProxy = 61441C7424619FED003D8BB8 /* PBXContainerItemProxy */;
+		};
+		6170DC5325C18E57003AED5C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
+			targetProxy = 6170DC5225C18E57003AED5C /* PBXContainerItemProxy */;
+		};
+		61B7885F25C180CB002675B5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
+			targetProxy = 61B7885E25C180CB002675B5 /* PBXContainerItemProxy */;
+		};
+		61B7888025C18147002675B5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 61441C0124616DE9003D8BB8 /* Example */;
+			targetProxy = 61B7887F25C18147002675B5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -3440,7 +3673,6 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
 			name = Debug;
@@ -3463,7 +3695,6 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
 			name = Release;
@@ -3707,6 +3938,141 @@
 			};
 			name = Integration;
 		};
+		61B7886525C180CB002675B5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = TargetSupport/DatadogCrashReporting/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReporting;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		61B7886625C180CB002675B5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = TargetSupport/DatadogCrashReporting/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReporting;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		61B7886725C180CB002675B5 /* Integration */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = TargetSupport/DatadogCrashReporting/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReporting;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Integration;
+		};
+		61B7886825C180CB002675B5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/DatadogCrashReportingTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
+			};
+			name = Debug;
+		};
+		61B7886925C180CB002675B5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/DatadogCrashReportingTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
+			};
+			name = Release;
+		};
+		61B7886A25C180CB002675B5 /* Integration */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/DatadogCrashReportingTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
+			};
+			name = Integration;
+		};
 		9E2FB28224476765001C9B7B /* Integration */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3840,7 +4206,6 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
 			name = Integration;
@@ -3914,6 +4279,26 @@
 				61441C7124619FE4003D8BB8 /* Debug */,
 				61441C7224619FE4003D8BB8 /* Release */,
 				61441C7324619FE4003D8BB8 /* Integration */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		61B7886B25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReporting" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				61B7886525C180CB002675B5 /* Debug */,
+				61B7886625C180CB002675B5 /* Release */,
+				61B7886725C180CB002675B5 /* Integration */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		61B7886C25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReportingTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				61B7886825C180CB002675B5 /* Debug */,
+				61B7886925C180CB002675B5 /* Release */,
+				61B7886A25C180CB002675B5 /* Integration */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 		61C3E63924BF19B4008053F2 /* RUMContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63824BF19B4008053F2 /* RUMContext.swift */; };
 		61C3E63B24BF1A4B008053F2 /* RUMCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63A24BF1A4B008053F2 /* RUMCommand.swift */; };
 		61C3E63E24BF1B91008053F2 /* RUMApplicationScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */; };
+		61C4DBAD25C2E6570058DED4 /* CrashReporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61C4DBAC25C2E6570058DED4 /* CrashReporter.framework */; };
 		61C576C6256E65BD00295F7C /* DateCorrector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C576C5256E65BD00295F7C /* DateCorrector.swift */; };
 		61C5A88424509A0C00DA608C /* DDSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87824509A0C00DA608C /* DDSpan.swift */; };
 		61C5A88524509A0C00DA608C /* DDNoOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87924509A0C00DA608C /* DDNoOps.swift */; };
@@ -780,6 +781,7 @@
 		61C3E63824BF19B4008053F2 /* RUMContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMContext.swift; sourceTree = "<group>"; };
 		61C3E63A24BF1A4B008053F2 /* RUMCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommand.swift; sourceTree = "<group>"; };
 		61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMApplicationScope.swift; sourceTree = "<group>"; };
+		61C4DBAC25C2E6570058DED4 /* CrashReporter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CrashReporter.framework; path = ../Carthage/Build/iOS/Static/CrashReporter.framework; sourceTree = "<group>"; };
 		61C576C5256E65BD00295F7C /* DateCorrector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCorrector.swift; sourceTree = "<group>"; };
 		61C5A87824509A0C00DA608C /* DDSpan.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDSpan.swift; sourceTree = "<group>"; };
 		61C5A87924509A0C00DA608C /* DDNoOps.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDNoOps.swift; sourceTree = "<group>"; };
@@ -942,6 +944,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61C4DBAD25C2E6570058DED4 /* CrashReporter.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1427,6 +1430,7 @@
 		61133C6F2423993200786299 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				61C4DBAC25C2E6570058DED4 /* CrashReporter.framework */,
 				61569794256CF6D400C6AADA /* Kronos.framework */,
 			);
 			name = Frameworks;
@@ -2734,9 +2738,9 @@
 			buildPhases = (
 				61B7884F25C180CB002675B5 /* Headers */,
 				61B7885025C180CB002675B5 /* Sources */,
-				61B7885125C180CB002675B5 /* Frameworks */,
 				61B7885225C180CB002675B5 /* Resources */,
 				6170DC2325C18762003AED5C /* ⚙️ Run linter */,
+				61B7885125C180CB002675B5 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3947,6 +3951,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../Carthage/Build/iOS/**",
+				);
 				INFOPLIST_FILE = TargetSupport/DatadogCrashReporting/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3974,6 +3982,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../Carthage/Build/iOS/**",
+				);
 				INFOPLIST_FILE = TargetSupport/DatadogCrashReporting/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3999,6 +4011,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../Carthage/Build/iOS/**",
+				);
 				INFOPLIST_FILE = TargetSupport/DatadogCrashReporting/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -298,6 +298,8 @@
 		61C3E63B24BF1A4B008053F2 /* RUMCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63A24BF1A4B008053F2 /* RUMCommand.swift */; };
 		61C3E63E24BF1B91008053F2 /* RUMApplicationScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */; };
 		61C4DBAD25C2E6570058DED4 /* CrashReporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61C4DBAC25C2E6570058DED4 /* CrashReporter.framework */; };
+		61C4DC5925C41D130058DED4 /* CrashReporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61C4DBAC25C2E6570058DED4 /* CrashReporter.framework */; };
+		61C4DC5A25C41D130058DED4 /* CrashReporter.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61C4DBAC25C2E6570058DED4 /* CrashReporter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61C576C6256E65BD00295F7C /* DateCorrector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C576C5256E65BD00295F7C /* DateCorrector.swift */; };
 		61C5A88424509A0C00DA608C /* DDSpan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87824509A0C00DA608C /* DDSpan.swift */; };
 		61C5A88524509A0C00DA608C /* DDNoOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A87924509A0C00DA608C /* DDNoOps.swift */; };
@@ -470,6 +472,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				61C4DC5A25C41D130058DED4 /* CrashReporter.framework in ⚙️ Embed Framework Dependencies */,
 				61441C4E24619498003D8BB8 /* Datadog.framework in ⚙️ Embed Framework Dependencies */,
 				61570006246AAE5E00E96950 /* DatadogObjc.framework in ⚙️ Embed Framework Dependencies */,
 				6170DC5125C18E57003AED5C /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */,
@@ -911,6 +914,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				615697E3256CFB4700C6AADA /* Kronos.framework in Frameworks */,
+				61C4DC5925C41D130058DED4 /* CrashReporter.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3762,7 +3766,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../Carthage/Build/iOS",
+					"$(SRCROOT)/../Carthage/Build/iOS/**",
 				);
 				INFOPLIST_FILE = TargetSupport/Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3788,7 +3792,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../Carthage/Build/iOS",
+					"$(SRCROOT)/../Carthage/Build/iOS/**",
 				);
 				INFOPLIST_FILE = TargetSupport/Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3812,7 +3816,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../Carthage/Build/iOS",
+					"$(SRCROOT)/../Carthage/Build/iOS/**",
 				);
 				INFOPLIST_FILE = TargetSupport/Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3944,6 +3948,7 @@
 		};
 		61B7886525C180CB002675B5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -3975,6 +3980,7 @@
 		};
 		61B7886625C180CB002675B5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -4004,6 +4010,7 @@
 		};
 		61B7886725C180CB002675B5 /* Integration */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting.xcscheme
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1230"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "61B7885325C180CB002675B5"
+               BuildableName = "DatadogCrashReporting.framework"
+               BlueprintName = "DatadogCrashReporting"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61B7885B25C180CB002675B5"
+            BuildableName = "DatadogCrashReportingTests.xctest"
+            BlueprintName = "DatadogCrashReportingTests"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "IS_RUNNING_UNIT_TESTS"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "DD_TEST_RUNNER"
+            value = "$(DD_TEST_RUNNER)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DATADOG_CLIENT_TOKEN"
+            value = "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENV"
+            value = "$(DD_SDK_SWIFT_TESTING_ENV)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_SERVICE"
+            value = "$(DD_SDK_SWIFT_TESTING_SERVICE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_DISABLE_SDKIOS_INTEGRATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_DISABLE_HEADERS_INJECTION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GIT_REPOSITORY_URL"
+            value = "$(GIT_REPOSITORY_URL)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_GIT_COMMIT"
+            value = "$(BITRISE_GIT_COMMIT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_SOURCE_DIR"
+            value = "$(BITRISE_SOURCE_DIR)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_NUMBER"
+            value = "$(BITRISE_BUILD_NUMBER)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_URL"
+            value = "$(BITRISE_BUILD_URL)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_GIT_BRANCH"
+            value = "$(BITRISE_GIT_BRANCH)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISEIO_GIT_BRANCH_DEST"
+            value = "$(BITRISEIO_GIT_BRANCH_DEST)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_GIT_TAG"
+            value = "$(BITRISE_GIT_TAG)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GIT_CLONE_COMMIT_HASH"
+            value = "$(GIT_CLONE_COMMIT_HASH)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_APP_TITLE"
+            value = "$(BITRISE_APP_TITLE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_BUILD_SLUG"
+            value = "$(BITRISE_BUILD_SLUG)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BITRISE_GIT_MESSAGE"
+            value = "$(BITRISE_GIT_MESSAGE)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GIT_CLONE_COMMIT_MESSAGE_SUBJECT"
+            value = "$(GIT_CLONE_COMMIT_MESSAGE_SUBJECT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GIT_CLONE_COMMIT_MESSAGE_BODY"
+            value = "$(GIT_CLONE_COMMIT_MESSAGE_BODY)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GIT_CLONE_COMMIT_AUTHOR_NAME"
+            value = "$(GIT_CLONE_COMMIT_AUTHOR_NAME)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GIT_CLONE_COMMIT_AUTHOR_EMAIL"
+            value = "$(GIT_CLONE_COMMIT_AUTHOR_EMAIL)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GIT_CLONE_COMMIT_COMMITER_NAME"
+            value = "$(GIT_CLONE_COMMIT_COMMITER_NAME)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GIT_CLONE_COMMIT_COMMITER_EMAIL"
+            value = "$(GIT_CLONE_COMMIT_COMMITER_EMAIL)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61B7885325C180CB002675B5"
+            BuildableName = "DatadogCrashReporting.framework"
+            BlueprintName = "DatadogCrashReporting"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "61B7885B25C180CB002675B5"
+               BuildableName = "DatadogCrashReportingTests.xctest"
+               BlueprintName = "DatadogCrashReportingTests"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61B7885325C180CB002675B5"
+            BuildableName = "DatadogCrashReporting.framework"
+            BlueprintName = "DatadogCrashReporting"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 import Datadog
+import DatadogCrashReporting
 
 var logger: Logger!
 var tracer: OTTracer { Global.sharedTracer }
@@ -32,6 +33,9 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
             trackingConsent: appConfiguration.initialTrackingConsent,
             configuration: appConfiguration.sdkConfiguration()
         )
+
+        let plugin = DDCrashReportingPlugin()
+        plugin?.testIfItWorks()
 
         // Set user information
         Datadog.setUserInfo(id: "abcd-1234", name: "foo", email: "foo@example.com", extraInfo: ["key-extraUserInfo": "value-extraUserInfo"])

--- a/Datadog/TargetSupport/DatadogCrashReporting/DatadogCrashReporting.h
+++ b/Datadog/TargetSupport/DatadogCrashReporting/DatadogCrashReporting.h
@@ -1,0 +1,17 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for DatadogCrashReporting.
+FOUNDATION_EXPORT double DatadogCrashReportingVersionNumber;
+
+//! Project version string for DatadogCrashReporting.
+FOUNDATION_EXPORT const unsigned char DatadogCrashReportingVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <DatadogCrashReporting/PublicHeader.h>
+
+

--- a/Datadog/TargetSupport/DatadogCrashReporting/Info.plist
+++ b/Datadog/TargetSupport/DatadogCrashReporting/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Datadog/TargetSupport/DatadogCrashReportingTests/DatadogCrashReportingTests.xcconfig
+++ b/Datadog/TargetSupport/DatadogCrashReportingTests/DatadogCrashReportingTests.xcconfig
@@ -1,0 +1,5 @@
+// Add common settings from Datadog.xcconfig
+#include "../xcconfigs/Datadog.xcconfig"
+
+// Add DatadogSDKTesting instrumentation (if available in current environment)
+#include "../xcconfigs/DatadogSDKTesting.local.xcconfig"

--- a/Datadog/TargetSupport/DatadogCrashReportingTests/Info.plist
+++ b/Datadog/TargetSupport/DatadogCrashReportingTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,6 +1,7 @@
 Component,Origin,License,Copyright
 import,io.opentracing,MIT,Copyright 2018 LightStep
 import,com.Lyft.Kronos,Apache-2.0,Copyright (C) 2016 Lyft Inc.
+import,PLCrashReporter,MIT,Copyright Microsoft Corporation
 import (tools),https://github.com/jpsim/SourceKitten,MIT,Copyright (c) 2014 JP Simard
 import (tools),https://github.com/apple/swift-argument-parser,Apache-2.0,(c) 2020 Apple Inc. and the Swift project authors
 import (tools),https://github.com/krzysztofzablocki/Difference.git,MIT,Copyright (c) 2017 Krzysztof Zablocki

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 
 import PackageDescription
 
@@ -11,27 +11,45 @@ let package = Package(
         .library(
             name: "Datadog",
             type: .dynamic,
-            targets: ["Datadog"]),
+            targets: ["Datadog"]
+        ),
         .library(
             name: "DatadogObjc",
             type: .dynamic,
-            targets: ["DatadogObjc"]),
+            targets: ["DatadogObjc"]
+        ),
+        .library(
+            name: "DatadogCrashReporting",
+            type: .dynamic,
+            targets: ["DatadogCrashReporting"]
+        ),
     ],
     dependencies: [
-        .package(url: "https://github.com/lyft/Kronos.git", .upToNextMinor(from: "4.1.0"))
+        .package(url: "https://github.com/lyft/Kronos.git", .upToNextMinor(from: "4.1.0")),
+        .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.8.1"),
     ],
     targets: [
         .target(
             name: "Datadog",
-            dependencies: ["_Datadog_Private", "Kronos"]),
+            dependencies: [
+                "_Datadog_Private", 
+                "Kronos"
+            ]
+        ),
         .target(
             name: "DatadogObjc",
-            dependencies: ["Datadog"]),
+            dependencies: [
+                "Datadog"
+            ]
+        ),
         .target(
             name: "_Datadog_Private"
         ),
-        .testTarget(
-            name: "DatadogTests",
-            dependencies: ["Datadog", "DatadogObjc"]),
+        .target(
+            name: "DatadogCrashReporting",
+            dependencies: [
+                .product(name: "CrashReporter", package: "PLCrashReporter"),
+            ]
+        )
     ]
 )

--- a/Sources/DatadogCrashReporting/DDCrashReportingPlugin.swift
+++ b/Sources/DatadogCrashReporting/DDCrashReportingPlugin.swift
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+public class DDCrashReportingPlugin {
+    public init() {}
+}

--- a/Sources/DatadogCrashReporting/DDCrashReportingPlugin.swift
+++ b/Sources/DatadogCrashReporting/DDCrashReportingPlugin.swift
@@ -5,7 +5,31 @@
  */
 
 import Foundation
+import CrashReporter
 
 public class DDCrashReportingPlugin {
-    public init() {}
+    private static var sharedPLCrashReporter: PLCrashReporter?
+
+    public init?() {
+        DDCrashReportingPlugin.sharedPLCrashReporter = PLCrashReporter(
+            configuration: PLCrashReporterConfig(
+                signalHandlerType: .BSD,
+                symbolicationStrategy: .all
+            )
+        )
+    }
+
+    // TODO: RUMM-956 Revamp this by shaping the final API
+    public func testIfItWorks() {
+        do {
+            guard let plCrashReporter = DDCrashReportingPlugin.sharedPLCrashReporter else {
+                print("🔥 Failed to instantiate `PLCrashReporter`")
+                return
+            }
+            try plCrashReporter.enableAndReturnError()
+            print("✅ Succeded with enabling `PLCrashReporter`")
+        } catch {
+            print("🔥 Failed to enable `PLCrashReporter`: \(error)")
+        }
+    }
 }

--- a/Tests/DatadogCrashReportingTests/DatadogCrashReportingTests.swift
+++ b/Tests/DatadogCrashReportingTests/DatadogCrashReportingTests.swift
@@ -8,7 +8,8 @@ import XCTest
 @testable import DatadogCrashReporting
 
 class DatadogCrashReportingTests: XCTestCase {
-    func testDDCrashReportingPluginInitialization() {
-        _ = DDCrashReportingPlugin()
+    func testDDCrashReportingPluginInitialization() throws {
+        let plugin = try XCTUnwrap(DDCrashReportingPlugin())
+        plugin.testIfItWorks()
     }
 }

--- a/Tests/DatadogCrashReportingTests/DatadogCrashReportingTests.swift
+++ b/Tests/DatadogCrashReportingTests/DatadogCrashReportingTests.swift
@@ -1,0 +1,14 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import XCTest
+@testable import DatadogCrashReporting
+
+class DatadogCrashReportingTests: XCTestCase {
+    func testDDCrashReportingPluginInitialization() {
+        _ = DDCrashReportingPlugin()
+    }
+}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -85,7 +85,15 @@ workflows:
         - should_retry_test_on_fail: 'yes' # temporarily mutes flakiness until we collect more info (in RUMM-839) then fix it
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
-        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests.html"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Datadog-unit-tests.html"
+    - xcode-test:
+        title: Run unit tests for DatadogCrashReporting - iOS Simulator
+        inputs:
+        - scheme: DatadogCrashReporting
+        - simulator_device: iPhone 11
+        - generate_code_coverage_files: 'yes'
+        - project_path: Datadog.xcworkspace
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogCrashReporting-unit-tests.html"
     - xcode-test:
         title: Run benchmarks - DatadogBenchmarkTests on iOS Simulator
         inputs:

--- a/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		61C36430243752A600C4D4E6 /* CTProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3642F243752A600C4D4E6 /* CTProjectTests.swift */; };
 		61C3643B243752A600C4D4E6 /* CTProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3643A243752A600C4D4E6 /* CTProjectUITests.swift */; };
 		61C3644B2437547A00C4D4E6 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61C3644A2437547A00C4D4E6 /* Datadog.framework */; };
+		61C4DBE825C2FFCD0058DED4 /* CrashReporter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61C4DBE725C2FFCD0058DED4 /* CrashReporter.framework */; };
+		61C4DBE925C2FFCD0058DED4 /* CrashReporter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61C4DBE725C2FFCD0058DED4 /* CrashReporter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +36,20 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		61C4DBEA25C2FFCD0058DED4 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				61C4DBE925C2FFCD0058DED4 /* CrashReporter.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		615519322461CDB4002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519332461CDB4002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
@@ -52,6 +68,7 @@
 		61C3643A243752A600C4D4E6 /* CTProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CTProjectUITests.swift; sourceTree = "<group>"; };
 		61C3643C243752A600C4D4E6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61C3644A2437547A00C4D4E6 /* Datadog.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Datadog.framework; path = Carthage/Build/iOS/Datadog.framework; sourceTree = "<group>"; };
+		61C4DBE725C2FFCD0058DED4 /* CrashReporter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CrashReporter.framework; path = Carthage/Build/iOS/Static/CrashReporter.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,6 +77,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61C3644B2437547A00C4D4E6 /* Datadog.framework in Frameworks */,
+				61C4DBE825C2FFCD0058DED4 /* CrashReporter.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,6 +164,7 @@
 		61C364492437547A00C4D4E6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				61C4DBE725C2FFCD0058DED4 /* CrashReporter.framework */,
 				615519342461D121002A85CF /* OpenTracing.framework */,
 				61C3644A2437547A00C4D4E6 /* Datadog.framework */,
 			);
@@ -164,6 +183,7 @@
 				61C36413243752A500C4D4E6 /* Resources */,
 				61C364482437544F00C4D4E6 /* ⚙️ Carthage */,
 				61C3645C243768FC00C4D4E6 /* ⚙️ Run linter */,
+				61C4DBEA25C2FFCD0058DED4 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -290,6 +310,7 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Datadog.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Kronos.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/Static/CrashReporter.framework",
 			);
 			name = "⚙️ Carthage";
 			outputFileListPaths = (
@@ -442,6 +463,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Debug;
 		};
@@ -497,6 +519,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
+				VALIDATE_WORKSPACE = YES;
 			};
 			name = Release;
 		};
@@ -508,6 +531,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
 				);
 				INFOPLIST_FILE = CTProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -529,6 +553,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
 				);
 				INFOPLIST_FILE = CTProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/dependency-manager-tests/carthage/CTProject/ViewController.swift
+++ b/dependency-manager-tests/carthage/CTProject/ViewController.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 import Datadog
+import DatadogCrashReporting
 
 internal class ViewController: UIViewController {
     private var logger: Logger! // swiftlint:disable:this implicitly_unwrapped_optional
@@ -15,6 +16,7 @@ internal class ViewController: UIViewController {
 
         Datadog.initialize(
             appContext: .init(),
+            trackingConsent: .granted,
             configuration: Datadog.Configuration
                 .builderUsing(clientToken: "abc", environment: "tests")
                 .build()

--- a/dependency-manager-tests/carthage/Makefile
+++ b/dependency-manager-tests/carthage/Makefile
@@ -19,4 +19,5 @@ test:
 		@[ -e "Carthage/Build/iOS/Datadog.framework" ] && echo "Datadog.framework - OK" || { echo "Datadog.framework - missing"; false; }
 		@[ -e "Carthage/Build/iOS/DatadogObjc.framework" ] && echo "DatadogObjc.framework - OK" || { echo "DatadogObjc.framework - missing"; false; }
 		@[ -e "Carthage/Build/iOS/Kronos.framework" ] && echo "Kronos.framework - OK" || { echo "Kronos.framework - missing"; false; }
+		@[ -e "Carthage/Build/iOS/Static/CrashReporter.framework" ] && echo "CrashReporter.framework - OK" || { echo "CrashReporter.framework - missing"; false; }
 		@echo "🧪 SUCCEEDED"

--- a/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
+++ b/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
@@ -14,6 +14,8 @@
 		61C363E624374D6000C4D4E6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61C363E424374D6000C4D4E6 /* LaunchScreen.storyboard */; };
 		61C363F124374D6100C4D4E6 /* SPMProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363F024374D6100C4D4E6 /* SPMProjectTests.swift */; };
 		61C363FC24374D6100C4D4E6 /* SPMProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363FB24374D6100C4D4E6 /* SPMProjectUITests.swift */; };
+		61C4DBDE25C2FB0B0058DED4 /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 61C4DBDD25C2FB0B0058DED4 /* DatadogCrashReporting */; };
+		61C4DBDF25C2FB0B0058DED4 /* DatadogCrashReporting in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 61C4DBDD25C2FB0B0058DED4 /* DatadogCrashReporting */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		9EC32C6224E596C20063BCCE /* DatadogObjc in Frameworks */ = {isa = PBXBuildFile; productRef = 9EC32C6124E596C20063BCCE /* DatadogObjc */; };
 		9EC32C6324E596C20063BCCE /* DatadogObjc in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 9EC32C6124E596C20063BCCE /* DatadogObjc */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -42,6 +44,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				61C4DBDF25C2FB0B0058DED4 /* DatadogCrashReporting in Embed Frameworks */,
 				9EC32C6324E596C20063BCCE /* DatadogObjc in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -72,6 +75,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61C4DBDE25C2FB0B0058DED4 /* DatadogCrashReporting in Frameworks */,
 				9EC32C6224E596C20063BCCE /* DatadogObjc in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -183,6 +187,7 @@
 			name = SPMProject;
 			packageProductDependencies = (
 				9EC32C6124E596C20063BCCE /* DatadogObjc */,
+				61C4DBDD25C2FB0B0058DED4 /* DatadogCrashReporting */,
 			);
 			productName = SPMProject;
 			productReference = 61C363D624374D5F00C4D4E6 /* SPMProject.app */;
@@ -689,6 +694,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		61C4DBDD25C2FB0B0058DED4 /* DatadogCrashReporting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 61C3640924374DF200C4D4E6 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
+			productName = DatadogCrashReporting;
+		};
 		9EC32C6124E596C20063BCCE /* DatadogObjc */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 61C3640924374DF200C4D4E6 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;

--- a/dependency-manager-tests/spm/SPMProject/ViewController.swift
+++ b/dependency-manager-tests/spm/SPMProject/ViewController.swift
@@ -7,6 +7,7 @@
 import UIKit
 import Datadog
 import DatadogObjc
+import DatadogCrashReporting
 
 internal class ViewController: UIViewController {
     private var logger: Logger! // swiftlint:disable:this implicitly_unwrapped_optional
@@ -16,6 +17,7 @@ internal class ViewController: UIViewController {
 
         Datadog.initialize(
             appContext: .init(),
+            trackingConsent: .granted,
             configuration: Datadog.Configuration
                 .builderUsing(clientToken: "abc", environment: "tests")
                 .build()


### PR DESCRIPTION
### What and why?

📦 This PR starts the work no crash reporting feature by introducing `DatadogCrashReporting` module. Both SPM and Carthage support is added.

Beside the setup, I also added basic invocation of `PLCrashReporter's` code to make sure everything runs everywhere with no runtime linkage issue.

### How?

Many configuration changes of different size:
* added `DatadogCrashReporting` and `DatadogCrashReportingTests` targets,
* linked `PLCrashReporter` through `Cartfile` and `Package.swift`,
* updated `LICENSE-3rdparty.csv`,
* configured folders structure to be compatible with linter setup,
* configured `.xcconfig` for `DatadogCrashReporting` processing,
* configured `.xcconfig` for `dd-swift-testing` instrumentation and code signing,
* configured tests schema with our standard setup (TSAN, code coverage, etc.),
* included `DatadogCrashReporting` in `bitrise.yml` so that we run its unit tests on CI.

I also updated `SPMProject` and `CTProject` under `dependency-manager-tests/` so that the configuration is tested on CI.

### Next PR

Next PR will deliver necessary public API changes in both `DatadogCrashReporting` and `Datadog` so that we can obtain the crash report written by `PLCrashReporter`.

This PR targets `crash-reporting` branch.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
