### PR TITLE
RUMM-908 Fix: Unit test

### DIFF
--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
@@ -141,18 +141,18 @@ class RUMEventSanitizerTests: XCTestCase {
             let sanitized = RUMEventSanitizer().sanitize(event: event)
 
             // Then
-            XCTAssertEqual(
-                sanitized.attributes.count + sanitized.userInfoAttributes.count + (sanitized.customViewTimings?.count ?? 0),
-                AttributesSanitizer.Constraints.maxNumberOfAttributes
-            )
-            XCTAssertTrue(
-                (sanitized.customViewTimings?.count ?? 0) >= sanitized.userInfoAttributes.count,
-                "If number of attributes needs to be limited, `userInfoAttributes` are removed prior to `customViewTimings`."
-            )
-            XCTAssertTrue(
-                sanitized.userInfoAttributes.count >= sanitized.attributes.count,
-                "If number of attributes needs to be limited, `attributes` are removed prior to `userInfoAttributes`."
-            )
+            var remaining = AttributesSanitizer.Constraints.maxNumberOfAttributes
+            let expectedSanitizedCustomTimings = min(sanitized.customViewTimings!.count, remaining)
+            remaining -= expectedSanitizedCustomTimings
+            let expectedSanitizedUserInfo = min(sanitized.userInfoAttributes.count, remaining)
+            remaining -= expectedSanitizedUserInfo
+            let expectedSanitizedAttrs = min(sanitized.attributes.count, remaining)
+            remaining -= expectedSanitizedAttrs
+
+            XCTAssertGreaterThanOrEqual(remaining, 0)
+            XCTAssertEqual(sanitized.customViewTimings!.count, expectedSanitizedCustomTimings, "If number of attributes needs to be limited, `customViewTimings` are removed last")
+            XCTAssertEqual(sanitized.userInfoAttributes.count, expectedSanitizedUserInfo, "If number of attributes needs to be limited, `userInfoAttributes` are removed second")
+            XCTAssertEqual(sanitized.attributes.count, expectedSanitizedAttrs, "If number of attributes needs to be limited, `attributes` are removed first.")
         }
 
         test(model: viewEvent)


### PR DESCRIPTION
### What and why?

`testWhenNumberOfAttributesExceedsLimit_itDropsExtraOnes` unit test case sometimes gives false negatives

False negative case example:
`sanitized.customViewTimings.count == 49`
`sanitized.userInfoAttributes.count == 58`

### How?

We want to make sure if removals are done in the right order, this is unrelated to `count` comparisons.
Now we compute the expected item counts and `assertEqual` with them.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
