### PR TITLE
RUMM-892 Provide more details when upload conditions are not met in console logs

### DIFF
--- a/Sources/Datadog/Core/Upload/DataUploadConditions.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadConditions.swift
@@ -23,27 +23,28 @@ internal struct DataUploadConditions {
         }
 
         if let batteryStatus = batteryStatus {
-            return shouldUploadFor(networkConnectionInfo: networkConnectionInfo) && shouldUploadFor(batteryStatus: batteryStatus)
+            return canUploadWith(networkConnectionInfo: networkConnectionInfo) && canUploadWith(batteryStatus: batteryStatus)
         } else {
-            return shouldUploadFor(networkConnectionInfo: networkConnectionInfo)
+            return canUploadWith(networkConnectionInfo: networkConnectionInfo)
         }
     }
 
-    private func shouldUploadFor(batteryStatus: BatteryStatus) -> Bool {
-        if batteryStatus.state == .unknown {
+    private func canUploadWith(batteryStatus: BatteryStatus) -> Bool {
+        let state = batteryStatus.state
+        if state == .unknown {
             // Note: in RUMS-132 we got the report on `.unknown` battery state reporing `-1` battery level on iPad device
             // plugged to Mac through lightning cable. As `.unkown` may lead to other unreliable values,
             // it seems safer to arbitrary allow uploads in such case.
             return true
         }
 
-        let batteryFullOrCharging = batteryStatus.state == .full || batteryStatus.state == .charging
+        let batteryFullOrCharging = state == .full || state == .charging
         let batteryLevelIsEnough = batteryStatus.level > Constants.minBatteryLevel
         let isLowPowerModeEnabled = batteryStatus.isLowPowerModeEnabled
         return (batteryLevelIsEnough || batteryFullOrCharging) && !isLowPowerModeEnabled
     }
 
-    private func shouldUploadFor(networkConnectionInfo: NetworkConnectionInfo) -> Bool {
+    private func canUploadWith(networkConnectionInfo: NetworkConnectionInfo) -> Bool {
         return networkConnectionInfo.reachability == .yes || networkConnectionInfo.reachability == .maybe
     }
 }

--- a/Sources/Datadog/Core/Upload/DataUploadConditions.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadConditions.swift
@@ -8,6 +8,30 @@ import Foundation
 
 /// Tells if data upload can be performed based on given system conditions.
 internal struct DataUploadConditions {
+    enum Blocker {
+        case batteryLevel
+        case lowPowerModeOn
+        case networkCondition
+    }
+
+    enum Report {
+        case go
+        case noGo(blockers: Set<Blocker>)
+
+        static func && (lhs: Report, rhs: Report) -> Report {
+            switch (lhs, rhs) {
+            case (.go, .go):
+                return .go
+            case (.go, .noGo):
+                return rhs
+            case (.noGo, .go):
+                return lhs
+            case (let .noGo(blockers: lbs), let .noGo(blockers: rbs)):
+                return .noGo(blockers: lbs.union(rbs))
+            }
+        }
+    }
+
     struct Constants {
         /// Battery level above which data upload can be performed.
         static let minBatteryLevel: Float = 0.1
@@ -16,35 +40,44 @@ internal struct DataUploadConditions {
     let batteryStatus: BatteryStatusProviderType?
     let networkConnectionInfo: NetworkConnectionInfoProviderType
 
-    func canPerformUpload() -> Bool {
+    func canPerformUpload() -> Report {
         let batteryStatus = self.batteryStatus?.current
         guard let networkConnectionInfo = self.networkConnectionInfo.current else {
-            return false // when `NetworkConnectionInfo` is not yet available
+            return .noGo(blockers: [.networkCondition]) // when `NetworkConnectionInfo` is not yet available
         }
 
         if let batteryStatus = batteryStatus {
-            return canUploadWith(networkConnectionInfo: networkConnectionInfo) && canUploadWith(batteryStatus: batteryStatus)
+            return canUploadWith(networkConnectionInfo) && canUploadWith(batteryStatus)
         } else {
-            return canUploadWith(networkConnectionInfo: networkConnectionInfo)
+            return canUploadWith(networkConnectionInfo)
         }
     }
 
-    private func canUploadWith(batteryStatus: BatteryStatus) -> Bool {
+    private func canUploadWith(_ batteryStatus: BatteryStatus) -> Report {
         let state = batteryStatus.state
         if state == .unknown {
             // Note: in RUMS-132 we got the report on `.unknown` battery state reporing `-1` battery level on iPad device
             // plugged to Mac through lightning cable. As `.unkown` may lead to other unreliable values,
             // it seems safer to arbitrary allow uploads in such case.
-            return true
+            return .go
         }
 
+        var blockers = Set<Blocker>()
         let batteryFullOrCharging = state == .full || state == .charging
         let batteryLevelIsEnough = batteryStatus.level > Constants.minBatteryLevel
-        let isLowPowerModeEnabled = batteryStatus.isLowPowerModeEnabled
-        return (batteryLevelIsEnough || batteryFullOrCharging) && !isLowPowerModeEnabled
+        if !(batteryFullOrCharging || batteryLevelIsEnough) {
+            blockers.insert(.batteryLevel)
+        }
+
+        if batteryStatus.isLowPowerModeEnabled {
+            blockers.insert(.lowPowerModeOn)
+        }
+
+        return blockers.count == 0 ? .go : .noGo(blockers: blockers)
     }
 
-    private func canUploadWith(networkConnectionInfo: NetworkConnectionInfo) -> Bool {
-        return networkConnectionInfo.reachability == .yes || networkConnectionInfo.reachability == .maybe
+    private func canUploadWith(_ networkConnectionInfo: NetworkConnectionInfo) -> Report {
+        let networkIsReachable = networkConnectionInfo.reachability == .yes || networkConnectionInfo.reachability == .maybe
+        return networkIsReachable ? .go : .noGo(blockers: [.networkCondition])
     }
 }

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -55,7 +55,14 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
             developerLogger?.info("⏳ (\(self.featureName)) Checking for next batch...")
 
-            let isSystemReady = self.uploadConditions.canPerformUpload()
+            let isSystemReady: Bool
+            let uploadConditionsReport = self.uploadConditions.canPerformUpload()
+            switch uploadConditionsReport {
+            case .go:
+                isSystemReady = true
+            case .noGo:
+                isSystemReady = false
+            }
             let nextBatch = isSystemReady ? self.fileReader.readNextBatch() : nil
 
             if let batch = nextBatch {

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -86,7 +86,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
                 }
             } else {
                 let batchLabel = nextBatch != nil ? "YES" : (isSystemReady ? "NO" : "NOT CHECKED")
-                let systemLabel = isSystemReady ? "✅" : "❌"
+                let systemLabel = isSystemReady ? "✅" : uploadConditionsReport.description
                 developerLogger?.info("💡 (\(self.featureName)) No upload. Batch to upload: \(batchLabel), System conditions: \(systemLabel)")
                 userLogger.debug("💡 (\(self.featureName)) No upload. Batch to upload: \(batchLabel), System conditions: \(systemLabel)")
 
@@ -94,6 +94,30 @@ internal class DataUploadWorker: DataUploadWorkerType {
             }
 
             self.scheduleNextUpload(after: self.delay.current)
+        }
+    }
+}
+
+extension DataUploadConditions.Blocker: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case let .battery(level: level, state: state):
+            return "🔋 Battery: \(state) \(level)%"
+        case .lowPowerModeOn:
+            return "🔌 Low Power Mode: on"
+        case let .networkReachability(description: description):
+            return "📡 Reachability: " + description
+        }
+    }
+}
+
+extension DataUploadConditions.Report: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .go:
+            return "✅"
+        case let .noGo(blockers: blockers):
+            return "❌ → " + blockers.map { $0.description }.joined(separator: "; ")
         }
     }
 }

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -58,7 +58,6 @@ internal class DataUploadWorker: DataUploadWorkerType {
             let blockersForUpload = self.uploadConditions.blockersForUpload()
             let isSystemReady = blockersForUpload.count == 0
             let nextBatch = isSystemReady ? self.fileReader.readNextBatch() : nil
-
             if let batch = nextBatch {
                 developerLogger?.info("⏳ (\(self.featureName)) Uploading batch...")
                 userLogger.debug("⏳ (\(self.featureName)) Uploading batch...")
@@ -80,9 +79,8 @@ internal class DataUploadWorker: DataUploadWorkerType {
                 }
             } else {
                 let batchLabel = nextBatch != nil ? "YES" : (isSystemReady ? "NO" : "NOT CHECKED")
-                let systemLabel = isSystemReady ? "✅" : blockersForUpload.description
-                developerLogger?.info("💡 (\(self.featureName)) No upload. Batch to upload: \(batchLabel), System conditions: \(systemLabel)")
-                userLogger.debug("💡 (\(self.featureName)) No upload. Batch to upload: \(batchLabel), System conditions: \(systemLabel)")
+                developerLogger?.info("💡 (\(self.featureName)) No upload. Batch to upload: \(batchLabel), System conditions: \(blockersForUpload.description)")
+                userLogger.debug("💡 (\(self.featureName)) No upload. Batch to upload: \(batchLabel), System conditions: \(blockersForUpload.description)")
 
                 self.delay.increase()
             }
@@ -107,6 +105,10 @@ extension DataUploadConditions.Blocker: CustomStringConvertible {
 
 extension Array where Element == DataUploadConditions.Blocker {
     var description: String {
-        "❌ [upload was skipped because: " + self.map { $0.description }.joined(separator: " AND ") + "]"
+        if self.isEmpty {
+            return "✅"
+        } else {
+            return "❌ [upload was skipped because: " + self.map { $0.description }.joined(separator: " AND ") + "]"
+        }
     }
 }

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -103,7 +103,7 @@ extension DataUploadConditions.Blocker: CustomStringConvertible {
     }
 }
 
-extension Array where Element == DataUploadConditions.Blocker {
+fileprivate extension Array where Element == DataUploadConditions.Blocker {
     var description: String {
         if self.isEmpty {
             return "✅"

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadConditionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadConditionsTests.swift
@@ -122,13 +122,7 @@ class DataUploadConditionsTests: XCTestCase {
         line: UInt = #line
     ) {
         let conditions = DataUploadConditions(batteryStatus: battery, networkConnectionInfo: network)
-        let canPerformUpload: Bool
-        switch conditions.canPerformUpload() {
-        case .go:
-            canPerformUpload = true
-        case .noGo:
-            canPerformUpload = false
-        }
+        let canPerformUpload = conditions.blockersForUpload().count == 0
         XCTAssertEqual(
             value,
             canPerformUpload,

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadConditionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadConditionsTests.swift
@@ -122,9 +122,16 @@ class DataUploadConditionsTests: XCTestCase {
         line: UInt = #line
     ) {
         let conditions = DataUploadConditions(batteryStatus: battery, networkConnectionInfo: network)
+        let canPerformUpload: Bool
+        switch conditions.canPerformUpload() {
+        case .go:
+            canPerformUpload = true
+        case .noGo:
+            canPerformUpload = false
+        }
         XCTAssertEqual(
             value,
-            conditions.canPerformUpload(),
+            canPerformUpload,
             "Expected `\(value)` but got `\(!value)` for:\n\(String(describing: battery?.current)) and\n\(String(describing: network.current))",
             file: file,
             line: line


### PR DESCRIPTION
### What and why?

This is a follow-up to RUMS-132 where some troubleshooting based on the console logs was a bit hindered by the lack of details at to why upload conditions were not met.

In this PR, we expose the underlying blockers to the upload conditions. It can be the battery state/level, low power mode, the network reachability.
The following details may appear in the console:

`🐶 → 19:00:10.949 [INFO] 💡 (logging) No upload. Batch to upload: NOT CHECKED, System conditions: ❌ → 🔋 Battery: unplugged 10%; 🔌 Low Power Mode: on; 📡 Reachability: no`

In the above example all three blockers appear, but it can be any combination.

### How?

The internal `DataUploadConditions.canPerformUpload` API is changed to return an enum `Report` that is either `.go` or `.noGo`. When `Report` is `.noGo` it will come with a list of `Blocker`s as an associated value. That list is then checked and printed by `DataUploadWorker`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
