### PR TITLE
Filter out NSURLErrorCancelled

### DIFF
--- a/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
+++ b/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
@@ -54,7 +54,7 @@ internal class URLSessionTracingHandler: URLSessionInterceptionHandler {
         span.setTag(key: OTTags.httpUrl, value: url)
         span.setTag(key: OTTags.httpMethod, value: method)
 
-        if let error = resourceCompletion.error {
+        if let error = resourceCompletion.error as NSError?, !(error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled) {
             span.setTag(key: OTTags.error, value: true)
 
             let dderror = DDError(error: error)


### PR DESCRIPTION
### What and why?

DD swizzles itself into my app's network tasks and logs errors which I can then view in APM: extremely useful. 

What's not so useful is when I implement cancelling of unneeded tasks in my app, and watch my error rate go through the roof with a load of `NSURLErrorCancelled`.

This PR seeks to filter out instances of `NSURLErrorCancelled` and to not report them to DD.

### How?

One line change to filter out `NSURLErrorCancelled` in `URLSessionTracingHandler.swift`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
