### PR TITLE
RUMM-1000 Add support for additional properties to the models generation pipeline

### DIFF
--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
@@ -16,6 +16,7 @@ internal class JSONSchema: Decodable {
         case title = "title"
         case description = "description"
         case properties = "properties"
+        case additionalProperties = "additionalProperties"
         case required = "required"
         case type = "type"
         case `enum` = "enum"
@@ -65,6 +66,7 @@ internal class JSONSchema: Decodable {
     private(set) var title: String?
     private(set) var description: String?
     private(set) var properties: [String: JSONSchema]?
+    private(set) var additionalProperties: JSONSchema?
     private(set) var required: [String]?
     private(set) var type: SchemaType?
     private(set) var `enum`: [String]?
@@ -142,6 +144,8 @@ internal class JSONSchema: Decodable {
         } else {
             self.properties = self.properties ?? otherSchema.properties
         }
+
+        self.additionalProperties = self.additionalProperties ?? otherSchema.additionalProperties
 
         // Required properties are accumulated.
         if let selfRequired = self.required, let otherRequired = otherSchema.required {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchemaToJSONTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchemaToJSONTypeTransformer.swift
@@ -94,8 +94,8 @@ internal class JSONSchemaToJSONTypeTransformer {
         let propertiesByName = schema.properties ?? [:]
         var properties: [JSONObject.Property] = []
 
-        try propertiesByName.forEach { propertyName, propertySchema in
-            let property = JSONObject.Property(
+        func property(from propertySchema: JSONSchema, _ propertyName: String, _ isRequired: Bool? = nil) throws -> JSONObject.Property {
+            return JSONObject.Property(
                 name: propertyName,
                 comment: propertySchema.description,
                 type: try transformSchemaToAnyType(propertySchema, named: propertyName),
@@ -105,29 +105,17 @@ internal class JSONSchemaToJSONTypeTransformer {
                     case .string(let value): return .string(value: value)
                     }
                 },
-                isRequired: schema.required?.contains(propertyName) ?? Defaults.isRequired,
+                isRequired: isRequired ?? schema.required?.contains(propertyName) ?? Defaults.isRequired,
                 isReadOnly: propertySchema.readOnly ?? Defaults.isReadOnly
             )
-
-            properties.append(property)
         }
+
+        try propertiesByName.forEach { properties.append(try property(from: $1, $0)) }
 
         let additionalProperties: JSONObject.Property?
         if let additionalPropertiesSchema = schema.additionalProperties {
             let propName = JSONSchema.CodingKeys.additionalProperties.rawValue
-            additionalProperties = JSONObject.Property(
-                name: propName,
-                comment: additionalPropertiesSchema.description,
-                type: try transformSchemaToAnyType(additionalPropertiesSchema, named: propName),
-                defaultValue: additionalPropertiesSchema.const.flatMap { const in
-                    switch const.value {
-                    case .integer(let value): return .integer(value: value)
-                    case .string(let value): return .string(value: value)
-                    }
-                },
-                isRequired: false,
-                isReadOnly: additionalPropertiesSchema.readOnly ?? Defaults.isReadOnly
-            )
+            additionalProperties = try property(from: additionalPropertiesSchema, propName, false)
         } else {
             additionalProperties = nil
         }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchemaToJSONTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchemaToJSONTypeTransformer.swift
@@ -99,7 +99,7 @@ internal class JSONSchemaToJSONTypeTransformer {
                 name: propertyName,
                 comment: propertySchema.description,
                 type: try transformSchemaToAnyType(propertySchema, named: propertyName),
-                defaultVaule: propertySchema.const.flatMap { const in
+                defaultValue: propertySchema.const.flatMap { const in
                     switch const.value {
                     case .integer(let value): return .integer(value: value)
                     case .string(let value): return .string(value: value)

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONType.swift
@@ -41,12 +41,18 @@ internal struct JSONObject: JSONType {
         let isReadOnly: Bool
     }
 
+    struct AdditionalProperties: JSONType {
+        let comment: String?
+        let type: JSONPrimitive
+        let isReadOnly: Bool
+    }
+
     let name: String
     let comment: String?
     let properties: [Property]
-    let additionalProperties: Property?
+    let additionalProperties: AdditionalProperties?
 
-    init(name: String, comment: String?, properties: [Property], additionalProperties: Property? = nil) {
+    init(name: String, comment: String?, properties: [Property], additionalProperties: AdditionalProperties? = nil) {
         self.name = name
         self.comment = comment
         self.properties = properties.sorted { property1, property2 in property1.name < property2.name }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONType.swift
@@ -36,7 +36,7 @@ internal struct JSONObject: JSONType {
         let name: String
         let comment: String?
         let type: JSONType
-        let defaultVaule: DefaultValue?
+        let defaultValue: DefaultValue?
         let isRequired: Bool
         let isReadOnly: Bool
     }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONType.swift
@@ -44,11 +44,13 @@ internal struct JSONObject: JSONType {
     let name: String
     let comment: String?
     let properties: [Property]
+    let additionalProperties: Property?
 
-    init(name: String, comment: String?, properties: [Property]) {
+    init(name: String, comment: String?, properties: [Property], additionalProperties: Property? = nil) {
         self.name = name
         self.comment = comment
         self.properties = properties.sorted { property1, property2 in property1.name < property2.name }
+        self.additionalProperties = additionalProperties
     }
 }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
@@ -13,6 +13,7 @@ internal protocol ObjcInteropType: AnyObject {}
 internal protocol ObjcInteropClass: ObjcInteropType {
     var bridgedSwiftStruct: SwiftStruct { get }
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] { set get }
+    var objcAdditionalPropertiesWrapper: ObjcInteropPropertyWrapper? { set get }
 }
 
 /// Schema of a root `@objc class` storing the mutable value of a `SwiftStruct`.
@@ -21,6 +22,8 @@ internal class ObjcInteropRootClass: ObjcInteropClass {
     let bridgedSwiftStruct: SwiftStruct
     /// `bridgedSwiftStruct's` property wrappers exposed to Objc.
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
+    /// `bridgedSwiftStruct's` additionalProperties property wrapper exposed to Objc.
+    var objcAdditionalPropertiesWrapper: ObjcInteropPropertyWrapper?
 
     init(bridgedSwiftStruct: SwiftStruct) {
         self.bridgedSwiftStruct = bridgedSwiftStruct
@@ -36,6 +39,8 @@ internal class ObjcInteropTransitiveClass: ObjcInteropClass {
     let bridgedSwiftStruct: SwiftStruct
     /// `bridgedSwiftStruct's` property wrappers exposed to Objc.
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
+    /// `bridgedSwiftStruct's` additionalProperties property wrapper exposed to Objc.
+    var objcAdditionalPropertiesWrapper: ObjcInteropPropertyWrapper?
 
     init(owner: ObjcInteropPropertyWrapper, bridgedSwiftStruct: SwiftStruct) {
         self.parentProperty = owner

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
@@ -19,11 +19,11 @@ internal protocol ObjcInteropClass: ObjcInteropType {
 internal class ObjcInteropRootClass: ObjcInteropClass {
     /// The `SwiftStruct` managed by this `@objc class`.
     let bridgedSwiftStruct: SwiftStruct
-    /// `managedSwiftStruct's` property wrappers exposed to Objc.
+    /// `bridgedSwiftStruct's` property wrappers exposed to Objc.
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
 
-    init(managedSwiftStruct: SwiftStruct) {
-        self.bridgedSwiftStruct = managedSwiftStruct
+    init(bridgedSwiftStruct: SwiftStruct) {
+        self.bridgedSwiftStruct = bridgedSwiftStruct
     }
 }
 
@@ -34,12 +34,12 @@ internal class ObjcInteropTransitiveClass: ObjcInteropClass {
 
     /// The nested `SwiftStruct` managed by this `@objc class`.
     let bridgedSwiftStruct: SwiftStruct
-    /// `managedSwiftStruct's` property wrappers exposed to Objc.
+    /// `bridgedSwiftStruct's` property wrappers exposed to Objc.
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
 
-    init(owner: ObjcInteropPropertyWrapper, managedSwiftStruct: SwiftStruct) {
+    init(owner: ObjcInteropPropertyWrapper, bridgedSwiftStruct: SwiftStruct) {
         self.parentProperty = owner
-        self.bridgedSwiftStruct = managedSwiftStruct
+        self.bridgedSwiftStruct = bridgedSwiftStruct
     }
 }
 
@@ -53,9 +53,9 @@ internal class ObjcInteropEnum: ObjcInteropType {
     /// The `SwiftEnum` exposed by this Obj-c enum.
     let bridgedSwiftEnum: SwiftEnum
 
-    init(owner: ObjcInteropPropertyWrapper, managedSwiftEnum: SwiftEnum) {
+    init(owner: ObjcInteropPropertyWrapper, bridgedSwiftEnum: SwiftEnum) {
         self.parentProperty = owner
-        self.bridgedSwiftEnum = managedSwiftEnum
+        self.bridgedSwiftEnum = bridgedSwiftEnum
     }
 }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
@@ -138,3 +138,13 @@ internal class ObjcInteropNSArray: ObjcInteropType {
         self.element = element
     }
 }
+
+internal class ObjcInteropNSDictionary: ObjcInteropType {
+    let key: ObjcInteropType
+    let value: ObjcInteropType
+
+    init(key: ObjcInteropType, value: ObjcInteropType) {
+        self.key = key
+        self.value = value
+    }
+}

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
@@ -13,7 +13,6 @@ internal protocol ObjcInteropType: AnyObject {}
 internal protocol ObjcInteropClass: ObjcInteropType {
     var bridgedSwiftStruct: SwiftStruct { get }
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] { set get }
-    var objcAdditionalPropertiesWrapper: ObjcInteropPropertyWrapper? { set get }
 }
 
 /// Schema of a root `@objc class` storing the mutable value of a `SwiftStruct`.
@@ -22,8 +21,6 @@ internal class ObjcInteropRootClass: ObjcInteropClass {
     let bridgedSwiftStruct: SwiftStruct
     /// `bridgedSwiftStruct's` property wrappers exposed to Objc.
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
-    /// `bridgedSwiftStruct's` additionalProperties property wrapper exposed to Objc.
-    var objcAdditionalPropertiesWrapper: ObjcInteropPropertyWrapper?
 
     init(bridgedSwiftStruct: SwiftStruct) {
         self.bridgedSwiftStruct = bridgedSwiftStruct
@@ -39,8 +36,6 @@ internal class ObjcInteropTransitiveClass: ObjcInteropClass {
     let bridgedSwiftStruct: SwiftStruct
     /// `bridgedSwiftStruct's` property wrappers exposed to Objc.
     var objcPropertyWrappers: [ObjcInteropPropertyWrapper] = []
-    /// `bridgedSwiftStruct's` additionalProperties property wrapper exposed to Objc.
-    var objcAdditionalPropertiesWrapper: ObjcInteropPropertyWrapper?
 
     init(owner: ObjcInteropPropertyWrapper, bridgedSwiftStruct: SwiftStruct) {
         self.parentProperty = owner

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
@@ -66,8 +66,10 @@ internal class SwiftToObjcInteropTypeTransformer {
         case let swiftArray as SwiftArray:
             return ObjcInteropNSArray(element: try objcInteropType(for: swiftArray.element))
         case let swiftDictionary as SwiftDictionary:
-            return ObjcInteropNSDictionary(key: try objcInteropType(for: swiftDictionary.key),
-                                           value: try objcInteropType(for: swiftDictionary.value))
+            return ObjcInteropNSDictionary(
+                key: try objcInteropType(for: swiftDictionary.key),
+                value: try objcInteropType(for: swiftDictionary.value)
+            )
         default:
             throw Exception.unimplemented(
                 "Cannot create `ObjcInteropType` type for \(type(of: swiftType))."

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
@@ -19,7 +19,7 @@ internal class SwiftToObjcInteropTypeTransformer {
 
         try takeRootSwiftStructs(from: swiftTypes)
             .forEach { rootStruct in
-                let rootClass = ObjcInteropRootClass(managedSwiftStruct: rootStruct)
+                let rootClass = ObjcInteropRootClass(bridgedSwiftStruct: rootStruct)
                 outputObjcInteropTypes.append(rootClass)
                 try generateTransitiveObjcInteropTypes(in: rootClass)
             }
@@ -48,7 +48,7 @@ internal class SwiftToObjcInteropTypeTransformer {
                     )
                     propertyWrapper.objcNestedClass = ObjcInteropTransitiveClass(
                         owner: propertyWrapper,
-                        managedSwiftStruct: swiftStruct
+                        bridgedSwiftStruct: swiftStruct
                     )
                     return propertyWrapper
                 case let swiftEnum as SwiftEnum:
@@ -58,7 +58,7 @@ internal class SwiftToObjcInteropTypeTransformer {
                     )
                     propertyWrapper.objcNestedEnum = ObjcInteropEnum(
                         owner: propertyWrapper,
-                        managedSwiftEnum: swiftEnum
+                        bridgedSwiftEnum: swiftEnum
                     )
                     return propertyWrapper
                 case let swiftArray as SwiftArray where swiftArray.element is SwiftEnum:
@@ -68,7 +68,7 @@ internal class SwiftToObjcInteropTypeTransformer {
                     )
                     propertyWrapper.objcNestedEnumsArray = ObjcInteropEnumArray(
                         owner: propertyWrapper,
-                        managedSwiftEnum: swiftArray.element as! SwiftEnum // swiftlint:disable:this force_cast
+                        bridgedSwiftEnum: swiftArray.element as! SwiftEnum // swiftlint:disable:this force_cast
                     )
                     return propertyWrapper
                 case let swiftArray as SwiftArray where swiftArray.element is SwiftPrimitiveType:
@@ -89,7 +89,7 @@ internal class SwiftToObjcInteropTypeTransformer {
                         )
                         propertyWrapper.objcNestedClass = ObjcInteropReferencedTransitiveClass(
                             owner: propertyWrapper,
-                            managedSwiftStruct: swiftStruct
+                            bridgedSwiftStruct: swiftStruct
                         )
                         return propertyWrapper
                     case let swiftEnum as SwiftEnum:
@@ -99,7 +99,7 @@ internal class SwiftToObjcInteropTypeTransformer {
                         )
                         propertyWrapper.objcNestedEnum = ObjcInteropReferencedEnum(
                             owner: propertyWrapper,
-                            managedSwiftEnum: swiftEnum
+                            bridgedSwiftEnum: swiftEnum
                         )
                         return propertyWrapper
                     default:

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
@@ -78,17 +78,13 @@ internal class SwiftToObjcInteropTypeTransformer {
                     )
                     propertyWrapper.objcInteropType = try objcInteropType(for: swiftArray)
                     return propertyWrapper
-                case let swiftDictionary as SwiftDictionary where swiftDictionary.value is SwiftPrimitiveType:
+                case let swiftDictionary as SwiftDictionary:
                     let propertyWrapper = ObjcInteropPropertyWrapperManagingSwiftStructProperty(
                         owner: objcClass,
                         swiftProperty: swiftProperty
                     )
                     propertyWrapper.objcInteropType = try objcInteropType(for: swiftDictionary)
                     return propertyWrapper
-                case let swiftDictionary as SwiftDictionary where swiftDictionary.key is SwiftEnum || swiftDictionary.value is SwiftEnum:
-                    throw Exception.unimplemented(
-                        "Objc Interop for `SwiftDictionary`s with an Enum as key or value is not supported."
-                    )
                 case let swifTypeReference as SwiftTypeReference:
                     let referencedType = try resolve(swiftTypeReference: swifTypeReference)
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
@@ -65,6 +65,9 @@ internal class SwiftToObjcInteropTypeTransformer {
             return ObjcInteropNSString(swiftString: swiftString)
         case let swiftArray as SwiftArray:
             return ObjcInteropNSArray(element: try objcInteropType(for: swiftArray.element))
+        case let swiftDictionary as SwiftDictionary:
+            return ObjcInteropNSDictionary(key: try objcInteropType(for: swiftDictionary.key),
+                                           value: try objcInteropType(for: swiftDictionary.value))
         default:
             throw Exception.unimplemented(
                 "Cannot create `ObjcInteropType` type for \(type(of: swiftType))."
@@ -117,6 +120,13 @@ internal class SwiftToObjcInteropTypeTransformer {
                 swiftProperty: swiftProperty
             )
             propertyWrapper.objcInteropType = try objcInteropType(for: swiftArray)
+            return propertyWrapper
+        case let swiftDictionary as SwiftDictionary where swiftDictionary.value is SwiftPrimitiveType:
+            let propertyWrapper = ObjcInteropPropertyWrapperManagingSwiftStructProperty(
+                owner: objcClass,
+                swiftProperty: swiftProperty
+            )
+            propertyWrapper.objcInteropType = try objcInteropType(for: swiftDictionary)
             return propertyWrapper
         case let swifTypeReference as SwiftTypeReference:
             let referencedType = try resolve(swiftTypeReference: swifTypeReference)

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
@@ -32,87 +32,17 @@ internal class SwiftToObjcInteropTypeTransformer {
     private func generateTransitiveObjcInteropTypes(in objcClass: ObjcInteropClass) throws {
         // Generate property wrappers
         objcClass.objcPropertyWrappers = try objcClass.bridgedSwiftStruct.properties
-            .map { swiftProperty in
-                switch swiftProperty.type {
-                case let swiftPrimitive as SwiftPrimitiveType:
-                    let propertyWrapper = ObjcInteropPropertyWrapperManagingSwiftStructProperty(
-                        owner: objcClass,
-                        swiftProperty: swiftProperty
-                    )
-                    propertyWrapper.objcInteropType = try objcInteropType(for: swiftPrimitive)
-                    return propertyWrapper
-                case let swiftStruct as SwiftStruct:
-                    let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedStruct(
-                        owner: objcClass,
-                        swiftProperty: swiftProperty
-                    )
-                    propertyWrapper.objcNestedClass = ObjcInteropTransitiveClass(
-                        owner: propertyWrapper,
-                        bridgedSwiftStruct: swiftStruct
-                    )
-                    return propertyWrapper
-                case let swiftEnum as SwiftEnum:
-                    let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedEnum(
-                        owner: objcClass,
-                        swiftProperty: swiftProperty
-                    )
-                    propertyWrapper.objcNestedEnum = ObjcInteropEnum(
-                        owner: propertyWrapper,
-                        bridgedSwiftEnum: swiftEnum
-                    )
-                    return propertyWrapper
-                case let swiftArray as SwiftArray where swiftArray.element is SwiftEnum:
-                    let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedEnumsArray(
-                        owner: objcClass,
-                        swiftProperty: swiftProperty
-                    )
-                    propertyWrapper.objcNestedEnumsArray = ObjcInteropEnumArray(
-                        owner: propertyWrapper,
-                        bridgedSwiftEnum: swiftArray.element as! SwiftEnum // swiftlint:disable:this force_cast
-                    )
-                    return propertyWrapper
-                case let swiftArray as SwiftArray where swiftArray.element is SwiftPrimitiveType:
-                    let propertyWrapper = ObjcInteropPropertyWrapperManagingSwiftStructProperty(
-                        owner: objcClass,
-                        swiftProperty: swiftProperty
-                    )
-                    propertyWrapper.objcInteropType = try objcInteropType(for: swiftArray)
-                    return propertyWrapper
-                case let swifTypeReference as SwiftTypeReference:
-                    let referencedType = try resolve(swiftTypeReference: swifTypeReference)
+            .map { try objcInteropPropertyWrapper(for: $0, in: objcClass) }
+        if let additionalProperties = objcClass.bridgedSwiftStruct.additionalProperties {
+            objcClass.objcAdditionalPropertiesWrapper = try objcInteropPropertyWrapper(for: additionalProperties, in: objcClass)
+        }
 
-                    switch referencedType {
-                    case let swiftStruct as SwiftStruct:
-                        let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedStruct(
-                            owner: objcClass,
-                            swiftProperty: swiftProperty
-                        )
-                        propertyWrapper.objcNestedClass = ObjcInteropReferencedTransitiveClass(
-                            owner: propertyWrapper,
-                            bridgedSwiftStruct: swiftStruct
-                        )
-                        return propertyWrapper
-                    case let swiftEnum as SwiftEnum:
-                        let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedEnum(
-                            owner: objcClass,
-                            swiftProperty: swiftProperty
-                        )
-                        propertyWrapper.objcNestedEnum = ObjcInteropReferencedEnum(
-                            owner: propertyWrapper,
-                            bridgedSwiftEnum: swiftEnum
-                        )
-                        return propertyWrapper
-                    default:
-                        throw Exception.illegal("Illegal reference type: \(swifTypeReference)")
-                    }
-                default:
-                    throw Exception.unimplemented(
-                        "Cannot generate @objc property wrapper for: \(type(of: swiftProperty.type))"
-                    )
-                }
-            }
+        var allPropertyWrappers = objcClass.objcPropertyWrappers
+        if let additionalPropertiesWrapper = objcClass.objcAdditionalPropertiesWrapper {
+            allPropertyWrappers.append(additionalPropertiesWrapper)
+        }
 
-        try objcClass.objcPropertyWrappers
+        try allPropertyWrappers
             .compactMap { $0 as? ObjcInteropPropertyWrapperForTransitiveType }
             .forEach { propertyWrapper in
                 // Store `ObjcInteropTypes` created for property wrappers
@@ -138,6 +68,86 @@ internal class SwiftToObjcInteropTypeTransformer {
         default:
             throw Exception.unimplemented(
                 "Cannot create `ObjcInteropType` type for \(type(of: swiftType))."
+            )
+        }
+    }
+
+    private func objcInteropPropertyWrapper(for swiftProperty: SwiftStruct.Property, in objcClass: ObjcInteropClass) throws -> ObjcInteropPropertyWrapper {
+        switch swiftProperty.type {
+        case let swiftPrimitive as SwiftPrimitiveType:
+            let propertyWrapper = ObjcInteropPropertyWrapperManagingSwiftStructProperty(
+                owner: objcClass,
+                swiftProperty: swiftProperty
+            )
+            propertyWrapper.objcInteropType = try objcInteropType(for: swiftPrimitive)
+            return propertyWrapper
+        case let swiftStruct as SwiftStruct:
+            let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedStruct(
+                owner: objcClass,
+                swiftProperty: swiftProperty
+            )
+            propertyWrapper.objcNestedClass = ObjcInteropTransitiveClass(
+                owner: propertyWrapper,
+                bridgedSwiftStruct: swiftStruct
+            )
+            return propertyWrapper
+        case let swiftEnum as SwiftEnum:
+            let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedEnum(
+                owner: objcClass,
+                swiftProperty: swiftProperty
+            )
+            propertyWrapper.objcNestedEnum = ObjcInteropEnum(
+                owner: propertyWrapper,
+                bridgedSwiftEnum: swiftEnum
+            )
+            return propertyWrapper
+        case let swiftArray as SwiftArray where swiftArray.element is SwiftEnum:
+            let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedEnumsArray(
+                owner: objcClass,
+                swiftProperty: swiftProperty
+            )
+            propertyWrapper.objcNestedEnumsArray = ObjcInteropEnumArray(
+                owner: propertyWrapper,
+                bridgedSwiftEnum: swiftArray.element as! SwiftEnum // swiftlint:disable:this force_cast
+            )
+            return propertyWrapper
+        case let swiftArray as SwiftArray where swiftArray.element is SwiftPrimitiveType:
+            let propertyWrapper = ObjcInteropPropertyWrapperManagingSwiftStructProperty(
+                owner: objcClass,
+                swiftProperty: swiftProperty
+            )
+            propertyWrapper.objcInteropType = try objcInteropType(for: swiftArray)
+            return propertyWrapper
+        case let swifTypeReference as SwiftTypeReference:
+            let referencedType = try resolve(swiftTypeReference: swifTypeReference)
+
+            switch referencedType {
+            case let swiftStruct as SwiftStruct:
+                let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedStruct(
+                    owner: objcClass,
+                    swiftProperty: swiftProperty
+                )
+                propertyWrapper.objcNestedClass = ObjcInteropReferencedTransitiveClass(
+                    owner: propertyWrapper,
+                    bridgedSwiftStruct: swiftStruct
+                )
+                return propertyWrapper
+            case let swiftEnum as SwiftEnum:
+                let propertyWrapper = ObjcInteropPropertyWrapperAccessingNestedEnum(
+                    owner: objcClass,
+                    swiftProperty: swiftProperty
+                )
+                propertyWrapper.objcNestedEnum = ObjcInteropReferencedEnum(
+                    owner: propertyWrapper,
+                    bridgedSwiftEnum: swiftEnum
+                )
+                return propertyWrapper
+            default:
+                throw Exception.illegal("Illegal reference type: \(swifTypeReference)")
+            }
+        default:
+            throw Exception.unimplemented(
+                "Cannot generate @objc property wrapper for: \(type(of: swiftProperty.type))"
             )
         }
     }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -99,8 +99,7 @@ internal class JSONToSwiftTypeTransformer {
         func readAdditionalProperties(from objectAdditionalProperties: JSONObject.Property?) throws -> SwiftStruct.Property? {
             if let additionalProperties = objectAdditionalProperties {
                 return try property(from: additionalProperties)
-            }
-            else {
+            } else {
                 return nil
             }
         }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -70,8 +70,7 @@ internal class JSONToSwiftTypeTransformer {
                 throw Exception.unimplemented("Transforming \(jsonObject) with both `properties` and `additionalProperties` is not supported.")
             }
             return SwiftDictionary(
-                key: SwiftPrimitive<String>(),
-                value: try transformJSONToAnyType(additionalProperties.type)
+                value: transformJSONtoPrimitive(additionalProperties.type)
             )
         } else {
             return try transformJSONToStruct(jsonObject)

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -78,33 +78,31 @@ internal class JSONToSwiftTypeTransformer {
             }
         }
 
-        /// Reads Struct properties.
-        func readProperties(from objectProperties: [JSONObject.Property]) throws -> [SwiftStruct.Property] {
-            return try objectProperties.map { jsonProperty in
-                return SwiftStruct.Property(
-                    name: jsonProperty.name,
-                    comment: jsonProperty.comment,
-                    type: try transformJSONToAnyType(jsonProperty.type),
-                    isOptional: !jsonProperty.isRequired,
-                    isMutable: !jsonProperty.isReadOnly,
-                    defaultValue: try readDefaultValue(for: jsonProperty),
-                    codingKey: jsonProperty.name
-                )
-            }
+        func property(from objectProperty: JSONObject.Property) throws -> SwiftStruct.Property {
+            return SwiftStruct.Property(
+                name: objectProperty.name,
+                comment: objectProperty.comment,
+                type: try transformJSONToAnyType(objectProperty.type),
+                isOptional: !objectProperty.isRequired,
+                isMutable: !objectProperty.isReadOnly,
+                defaultValue: try readDefaultValue(for: objectProperty),
+                codingKey: objectProperty.name
+            )
         }
 
         /// Reads Struct properties.
+        func readProperties(from objectProperties: [JSONObject.Property]) throws -> [SwiftStruct.Property] {
+            return try objectProperties.map { try property(from: $0) }
+        }
+
+        /// Reads Struct additional properties.
         func readAdditionalProperties(from objectAdditionalProperties: JSONObject.Property?) throws -> SwiftStruct.Property? {
-            guard let additionalProperties = objectAdditionalProperties else { return nil }
-            return SwiftStruct.Property(
-                    name: additionalProperties.name,
-                    comment: additionalProperties.comment,
-                    type: try transformJSONToAnyType(additionalProperties.type),
-                    isOptional: !additionalProperties.isRequired,
-                    isMutable: !additionalProperties.isReadOnly,
-                    defaultValue: try readDefaultValue(for: additionalProperties),
-                    codingKey: additionalProperties.name
-                )
+            if let additionalProperties = objectAdditionalProperties {
+                return try property(from: additionalProperties)
+            }
+            else {
+                return nil
+            }
         }
 
         return SwiftStruct(

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -66,7 +66,7 @@ internal class JSONToSwiftTypeTransformer {
         func readProperties(from objectProperties: [JSONObject.Property]) throws -> [SwiftStruct.Property] {
             /// Reads Struct property default value.
             func readDefaultValue(for objectProperty: JSONObject.Property) throws -> SwiftPropertyDefaultValue? {
-                return objectProperty.defaultVaule.ifNotNil { value in
+                return objectProperty.defaultValue.ifNotNil { value in
                     switch value {
                     case .integer(let intValue):
                         return intValue
@@ -87,7 +87,7 @@ internal class JSONToSwiftTypeTransformer {
                     type: try transformJSONToAnyType(jsonProperty.type),
                     isOptional: !jsonProperty.isRequired,
                     isMutable: !jsonProperty.isReadOnly,
-                    defaultVaule: try readDefaultValue(for: jsonProperty),
+                    defaultValue: try readDefaultValue(for: jsonProperty),
                     codingKey: jsonProperty.name
                 )
             }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -96,10 +96,13 @@ internal class JSONToSwiftTypeTransformer {
         /// Reads Struct properties.
         func readAdditionalProperties(from objectAdditionalProperties: JSONObject.Property?) throws -> SwiftStruct.Property? {
             guard let additionalProperties = objectAdditionalProperties else { return nil }
+            let type = SwiftDictionary(key: SwiftPrimitive<String>(), value:
+                try transformJSONToAnyType(additionalProperties.type)
+            )
             return SwiftStruct.Property(
                     name: additionalProperties.name,
                     comment: additionalProperties.comment,
-                    type: try transformJSONToAnyType(additionalProperties.type),
+                    type: type,
                     isOptional: !additionalProperties.isRequired,
                     isMutable: !additionalProperties.isReadOnly,
                     defaultValue: try readDefaultValue(for: additionalProperties),

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -96,13 +96,10 @@ internal class JSONToSwiftTypeTransformer {
         /// Reads Struct properties.
         func readAdditionalProperties(from objectAdditionalProperties: JSONObject.Property?) throws -> SwiftStruct.Property? {
             guard let additionalProperties = objectAdditionalProperties else { return nil }
-            let type = SwiftDictionary(key: SwiftPrimitive<String>(), value:
-                try transformJSONToAnyType(additionalProperties.type)
-            )
             return SwiftStruct.Property(
                     name: additionalProperties.name,
                     comment: additionalProperties.comment,
-                    type: type,
+                    type: try transformJSONToAnyType(additionalProperties.type),
                     isOptional: !additionalProperties.isRequired,
                     isMutable: !additionalProperties.isReadOnly,
                     defaultValue: try readDefaultValue(for: additionalProperties),

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -59,7 +59,6 @@ internal struct SwiftStruct: SwiftType {
     var name: String
     var comment: String?
     var properties: [Property]
-    var additionalProperties: Property?
     var conformance: [SwiftProtocol]
 }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -54,6 +54,7 @@ internal struct SwiftStruct: SwiftType {
     var name: String
     var comment: String?
     var properties: [Property]
+    var additionalProperties: Property?
     var conformance: [SwiftProtocol]
 }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -29,8 +29,8 @@ internal struct SwiftArray: SwiftType {
 }
 
 internal struct SwiftDictionary: SwiftType {
-    var key: SwiftType
-    var value: SwiftType
+    let key = SwiftPrimitive<String>()
+    var value: SwiftPrimitiveType
 }
 
 internal struct SwiftEnum: SwiftType {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -47,7 +47,7 @@ internal struct SwiftStruct: SwiftType {
         var type: SwiftType
         var isOptional: Bool
         var isMutable: Bool
-        var defaultVaule: SwiftPropertyDefaultValue?
+        var defaultValue: SwiftPropertyDefaultValue?
         var codingKey: String
     }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -28,6 +28,11 @@ internal struct SwiftArray: SwiftType {
     var element: SwiftType
 }
 
+internal struct SwiftDictionary: SwiftType {
+    var key: SwiftType
+    var value: SwiftType
+}
+
 internal struct SwiftEnum: SwiftType {
     struct Case: SwiftType, SwiftPropertyDefaultValue {
         var label: String

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/BasePrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/BasePrinter.swift
@@ -36,6 +36,12 @@ public class BasePrinter {
         output += "\n"
     }
 
+    func indent(_ codeBlock: () throws -> Void) throws {
+        indentRight()
+        try codeBlock()
+        indentLeft()
+    }
+
     func indentRight() {
         indentationLevel += 1
     }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/BasePrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/BasePrinter.swift
@@ -36,12 +36,6 @@ public class BasePrinter {
         output += "\n"
     }
 
-    func indent(_ codeBlock: () throws -> Void) throws {
-        indentRight()
-        try codeBlock()
-        indentLeft()
-    }
-
     func indentRight() {
         indentationLevel += 1
     }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -81,7 +81,7 @@ internal class ObjcInteropPrinter: BasePrinter {
             try objcInteropRootClass.objcPropertyWrappers.forEach { propertyWrapper in
                 try print(objcInteropPropertyWrapper: propertyWrapper)
             }
-        if let additionalPropertiesWrapper = objcInteropRootClass.objcAdditionalPropertiesWrapper  {
+        if let additionalPropertiesWrapper = objcInteropRootClass.objcAdditionalPropertiesWrapper {
             try print(objcInteropPropertyWrapper: additionalPropertiesWrapper)
         }
         indentLeft()
@@ -105,7 +105,7 @@ internal class ObjcInteropPrinter: BasePrinter {
             try objcInteropNestedClass.objcPropertyWrappers.forEach { propertyWrapper in
                 try print(objcInteropPropertyWrapper: propertyWrapper)
             }
-        if let additionalPropertiesWrapper = objcInteropNestedClass.objcAdditionalPropertiesWrapper  {
+        if let additionalPropertiesWrapper = objcInteropNestedClass.objcAdditionalPropertiesWrapper {
             try print(objcInteropPropertyWrapper: additionalPropertiesWrapper)
         }
         indentLeft()

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -81,6 +81,9 @@ internal class ObjcInteropPrinter: BasePrinter {
             try objcInteropRootClass.objcPropertyWrappers.forEach { propertyWrapper in
                 try print(objcInteropPropertyWrapper: propertyWrapper)
             }
+        if let additionalPropertiesWrapper = objcInteropRootClass.objcAdditionalPropertiesWrapper  {
+            try print(objcInteropPropertyWrapper: additionalPropertiesWrapper)
+        }
         indentLeft()
         writeLine("}")
     }
@@ -102,6 +105,9 @@ internal class ObjcInteropPrinter: BasePrinter {
             try objcInteropNestedClass.objcPropertyWrappers.forEach { propertyWrapper in
                 try print(objcInteropPropertyWrapper: propertyWrapper)
             }
+        if let additionalPropertiesWrapper = objcInteropNestedClass.objcAdditionalPropertiesWrapper  {
+            try print(objcInteropPropertyWrapper: additionalPropertiesWrapper)
+        }
         indentLeft()
         writeLine("}")
     }
@@ -263,7 +269,11 @@ internal class ObjcInteropPrinter: BasePrinter {
         let swiftProperty = propertyWrapper.bridgedSwiftProperty
         let objcPropertyName = swiftProperty.name
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
-        let objcTypeName = try objcInteropTypeName(for: propertyWrapper.objcInteropType)
+        var objcTypeName = try objcInteropTypeName(for: propertyWrapper.objcInteropType)
+        // TODO: RUMM-1000 Add support for Dictionary upstream instead of dealing with it at print time.
+        if objcPropertyName == "additionalProperties" {
+            objcTypeName = "[String: " + objcTypeName + "]"
+        }
         let asObjcCast = try swiftToObjcCast(for: propertyWrapper.objcInteropType).ifNotNil { asObjcCast in
             asObjcCast + objcPropertyOptionality
         } ?? ""

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -81,9 +81,6 @@ internal class ObjcInteropPrinter: BasePrinter {
             try objcInteropRootClass.objcPropertyWrappers.forEach { propertyWrapper in
                 try print(objcInteropPropertyWrapper: propertyWrapper)
             }
-        if let additionalPropertiesWrapper = objcInteropRootClass.objcAdditionalPropertiesWrapper {
-            try print(objcInteropPropertyWrapper: additionalPropertiesWrapper)
-        }
         indentLeft()
         writeLine("}")
     }
@@ -105,9 +102,6 @@ internal class ObjcInteropPrinter: BasePrinter {
             try objcInteropNestedClass.objcPropertyWrappers.forEach { propertyWrapper in
                 try print(objcInteropPropertyWrapper: propertyWrapper)
             }
-        if let additionalPropertiesWrapper = objcInteropNestedClass.objcAdditionalPropertiesWrapper {
-            try print(objcInteropPropertyWrapper: additionalPropertiesWrapper)
-        }
         indentLeft()
         writeLine("}")
     }
@@ -363,9 +357,11 @@ internal class ObjcInteropPrinter: BasePrinter {
                 .unwrapOrThrow(.illegal("Cannot print `objcToSwiftCast()` for `SwiftArray` with elements of type: \(type(of: swiftArray.element))"))
             return ".map { $0\(elementCast) }"
         case let swiftDictionary as SwiftDictionary:
+            let keyCast = try objcToSwiftCast(for: swiftDictionary.key)
+                .unwrapOrThrow(.illegal("Cannot print `objcToSwiftCast()` for `SwiftDictionary` with keys of type: \(type(of: swiftDictionary.key))"))
             let valueCast = try objcToSwiftCast(for: swiftDictionary.value)
                 .unwrapOrThrow(.illegal("Cannot print `objcToSwiftCast()` for `SwiftDictionary` with values of type: \(type(of: swiftDictionary.value))"))
-            return ".map { $0\(valueCast) }"
+            return ".reduce(into: [:]) { $0[$1.0\(keyCast)] = $1.1\(valueCast)"
         case _ as SwiftPrimitive<String>:
             return nil // `String` <> `NSString` interoperability doesn't require casting
         default:

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -357,8 +357,7 @@ internal class ObjcInteropPrinter: BasePrinter {
                 .unwrapOrThrow(.illegal("Cannot print `objcToSwiftCast()` for `SwiftArray` with elements of type: \(type(of: swiftArray.element))"))
             return ".map { $0\(elementCast) }"
         case let swiftDictionary as SwiftDictionary:
-            let keyCast = try objcToSwiftCast(for: swiftDictionary.key)
-                .unwrapOrThrow(.illegal("Cannot print `objcToSwiftCast()` for `SwiftDictionary` with keys of type: \(type(of: swiftDictionary.key))"))
+            let keyCast = try objcToSwiftCast(for: swiftDictionary.key) ?? ""
             let valueCast = try objcToSwiftCast(for: swiftDictionary.value)
                 .unwrapOrThrow(.illegal("Cannot print `objcToSwiftCast()` for `SwiftDictionary` with values of type: \(type(of: swiftDictionary.value))"))
             return ".reduce(into: [:]) { $0[$1.0\(keyCast)] = $1.1\(valueCast)"

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
@@ -56,7 +56,7 @@ public class SwiftPrinter: BasePrinter {
             let name = property.name
             let type = try typeDeclaration(property.type)
             let optionality = property.isOptional ? "?" : ""
-            let defaultValue: String? = try property.defaultVaule.ifNotNil { value in
+            let defaultValue: String? = try property.defaultValue.ifNotNil { value in
                 switch value {
                 case let integerValue as Int:
                     return " = \(integerValue)"

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
@@ -8,7 +8,8 @@ import Foundation
 
 /// Generates Swift code from `SwiftTypes`.
 public class SwiftPrinter: BasePrinter {
-    public func print(swiftTypes: [SwiftType], includeDynamicCodingKeys: Bool = true) throws -> String {
+    // TODO: RUMM-1000 include DynamicCodingKeys by default for additional properties
+    public func print(swiftTypes: [SwiftType], includeDynamicCodingKeys: Bool = false) throws -> String {
         reset()
 
         if includeDynamicCodingKeys {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
@@ -92,8 +92,8 @@ public class SwiftPrinter: BasePrinter {
     private func printNestedTypes(in swiftStruct: SwiftStruct) throws {
         let nestedTypes = swiftStruct.properties.map { $0.type }
         try nestedTypes.forEach { type in
-            let nestedStruct = (type as? SwiftStruct) ?? ((type as? SwiftArray)?.element as? SwiftStruct) ?? ((type as? SwiftDictionary)?.value as? SwiftStruct)
-            let nestedEnum = (type as? SwiftEnum) ?? ((type as? SwiftArray)?.element as? SwiftEnum) ?? ((type as? SwiftDictionary)?.value as? SwiftEnum)
+            let nestedStruct = (type as? SwiftStruct) ?? ((type as? SwiftArray)?.element as? SwiftStruct)
+            let nestedEnum = (type as? SwiftEnum) ?? ((type as? SwiftArray)?.element as? SwiftEnum)
 
             if let nestedStruct = nestedStruct {
                 writeEmptyLine()

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -36,7 +36,7 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
         case let array as SwiftArray:
             return try transform(array: array)
         case let dictionary as SwiftDictionary:
-            return try transform(dictionary: dictionary)
+            return transform(dictionary: dictionary)
         case let `enum` as SwiftEnum:
             let transformed = transform(enum: `enum`)
             return isSharedType(transformed) ? try replaceWithSharedTypeReference(transformed) : transformed
@@ -56,9 +56,9 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
         }
     }
 
-    private func transform(dictionary: SwiftDictionary) throws -> SwiftDictionary {
+    private func transform(dictionary: SwiftDictionary) -> SwiftDictionary {
         var dictionary = dictionary
-        dictionary.value = try transformAny(type: dictionary.value)
+        dictionary.value = transform(primitive: dictionary.value)
         return dictionary
     }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -35,6 +35,8 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
             return transform(primitive: primitive)
         case let array as SwiftArray:
             return try transform(array: array)
+        case let dictionary as SwiftDictionary:
+            return try transform(dictionary: dictionary)
         case let `enum` as SwiftEnum:
             let transformed = transform(enum: `enum`)
             return isSharedType(transformed) ? try replaceWithSharedTypeReference(transformed) : transformed
@@ -52,6 +54,12 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
         } else {
             return primitive
         }
+    }
+
+    private func transform(dictionary: SwiftDictionary) throws -> SwiftDictionary {
+        var dictionary = dictionary
+        dictionary.value = try transformAny(type: dictionary.value)
+        return dictionary
     }
 
     private func transform(array: SwiftArray) throws -> SwiftArray {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -104,7 +104,10 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
         `struct`.name = format(structName: `struct`.name)
         `struct`.properties = try `struct`.properties
             .map { try transform(structProperty: $0) }
-        if let additionalProperties = `struct`.additionalProperties {
+        if var additionalProperties = `struct`.additionalProperties {
+            // Store additional/runtime declared properties in a Dictionary indexed by their names:
+            additionalProperties.type = SwiftDictionary(key: SwiftPrimitive<String>(),
+                                                        value: additionalProperties.type)
             `struct`.additionalProperties = try transform(structProperty: additionalProperties)
         }
         if context.parent == nil {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -104,8 +104,6 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
         `struct`.name = format(structName: `struct`.name)
         `struct`.properties = try `struct`.properties
             .map { try transform(structProperty: $0) }
-            // TODO: RUMM-1000 should remove this filter
-            .filter { property in property.name != "customTimings" }
         if let additionalProperties = `struct`.additionalProperties {
             `struct`.additionalProperties = try transform(structProperty: additionalProperties)
         }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -98,6 +98,9 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
             .map { try transform(structProperty: $0) }
             // TODO: RUMM-1000 should remove this filter
             .filter { property in property.name != "customTimings" }
+        if let additionalProperties = `struct`.additionalProperties {
+            `struct`.additionalProperties = try transform(structProperty: additionalProperties)
+        }
         if context.parent == nil {
             `struct`.conformance = [rumDataModelProtocol] // Conform root structs to `RUMDataModel`
         } else {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -106,14 +106,6 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
             .map { try transform(structProperty: $0) }
             // TODO: RUMM-1000 should remove this filter
             .filter { property in property.name != "customTimings" }
-        if var additionalProperties = `struct`.additionalProperties {
-            // Store additional/runtime declared properties in a Dictionary indexed by their names:
-            additionalProperties.type = SwiftDictionary(
-                key: SwiftPrimitive<String>(),
-                value: additionalProperties.type
-            )
-            `struct`.additionalProperties = try transform(structProperty: additionalProperties)
-        }
         if context.parent == nil {
             `struct`.conformance = [rumDataModelProtocol] // Conform root structs to `RUMDataModel`
         } else {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -104,6 +104,8 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
         `struct`.name = format(structName: `struct`.name)
         `struct`.properties = try `struct`.properties
             .map { try transform(structProperty: $0) }
+            // TODO: RUMM-1000 should remove this filter
+            .filter { property in property.name != "customTimings" }
         if var additionalProperties = `struct`.additionalProperties {
             // Store additional/runtime declared properties in a Dictionary indexed by their names:
             additionalProperties.type = SwiftDictionary(key: SwiftPrimitive<String>(),

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -88,7 +88,7 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
             var structProperty = structProperty
             structProperty.name = format(propertyName: structProperty.name)
             structProperty.type = try transformAny(type: structProperty.type)
-            structProperty.defaultVaule = structProperty.defaultVaule.ifNotNil { transform(defaultValue: $0) }
+            structProperty.defaultValue = structProperty.defaultValue.ifNotNil { transform(defaultValue: $0) }
             return structProperty
         }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -108,8 +108,10 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
             .filter { property in property.name != "customTimings" }
         if var additionalProperties = `struct`.additionalProperties {
             // Store additional/runtime declared properties in a Dictionary indexed by their names:
-            additionalProperties.type = SwiftDictionary(key: SwiftPrimitive<String>(),
-                                                        value: additionalProperties.type)
+            additionalProperties.type = SwiftDictionary(
+                key: SwiftPrimitive<String>(),
+                value: additionalProperties.type
+            )
             `struct`.additionalProperties = try transform(structProperty: additionalProperties)
         }
         if context.parent == nil {

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
@@ -164,12 +164,9 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                         comment: "Description of a property with nested additional properties.",
                         properties: [],
                         additionalProperties:
-                            JSONObject.Property(
-                                name: "additionalProperties",
+                            JSONObject.AdditionalProperties(
                                 comment: nil,
                                 type: JSONPrimitive.integer,
-                                defaultValue: nil,
-                                isRequired: false,
                                 isReadOnly: true
                             )
                     ),
@@ -178,12 +175,9 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                     isReadOnly: true
                 )
             ],
-            additionalProperties: JSONObject.Property(
-                name: "additionalProperties",
+            additionalProperties: JSONObject.AdditionalProperties(
                 comment: "Additional properties of Foo.",
                 type: JSONPrimitive.string,
-                defaultValue: nil,
-                isRequired: false,
                 isReadOnly: true
             )
         )

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
@@ -74,9 +74,24 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                                 "enum": ["option1", "option2", "option3", "option4"]
                             },
                             "readOnly": false
+                        },
+                        "propertyWithAdditionalProperties": {
+                            "type": "object",
+                            "description": "Description of a property with nested additional properties.",
+                            "additionalProperties": {
+                                 "type": "integer",
+                                 "minimum": 0,
+                                 "readOnly": true
+                            },
+                            "readOnly": true
                         }
                     },
-                    "required": ["property1"]
+                    "additionalProperties": {
+                        "type": "string",
+                        "description": "Additional properties of Foo.",
+                        "readOnly": true
+                    },
+                    "required": ["property1"],
                 }
             ]
         }
@@ -140,8 +155,37 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                     defaultValue: nil,
                     isRequired: false,
                     isReadOnly: false
+                ),
+                JSONObject.Property(
+                    name: "propertyWithAdditionalProperties",
+                    comment: "Description of a property with nested additional properties.",
+                    type: JSONObject(
+                        name: "propertyWithAdditionalProperties",
+                        comment: "Description of a property with nested additional properties.",
+                        properties: [],
+                        additionalProperties:
+                            JSONObject.Property(
+                                name: "additionalProperties",
+                                comment: nil,
+                                type: JSONPrimitive.integer,
+                                defaultValue: nil,
+                                isRequired: false,
+                                isReadOnly: true
+                            )
+                    ),
+                    defaultValue: nil,
+                    isRequired: false,
+                    isReadOnly: true
                 )
-            ]
+            ],
+            additionalProperties: JSONObject.Property(
+                name: "additionalProperties",
+                comment: "Additional properties of Foo.",
+                type: JSONPrimitive.string,
+                defaultValue: nil,
+                isRequired: false,
+                isReadOnly: true
+            )
         )
 
         let jsonSchema = try JSONSchemaReader()

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
@@ -97,7 +97,7 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                                 name: "property1",
                                 comment: "Description of Bar's `property1`.",
                                 type: JSONPrimitive.string,
-                                defaultVaule: nil,
+                                defaultValue: nil,
                                 isRequired: false,
                                 isReadOnly: true
                             ),
@@ -105,13 +105,13 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                                 name: "property2",
                                 comment: "Description of Bar's `property2`.",
                                 type: JSONPrimitive.string,
-                                defaultVaule: nil,
+                                defaultValue: nil,
                                 isRequired: true,
                                 isReadOnly: false
                             )
                         ]
                     ),
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     isRequired: false,
                     isReadOnly: true
                 ),
@@ -123,7 +123,7 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                         comment: "Description of Foo's `property1`.",
                         values: ["case1", "case2", "case3", "case4"]
                     ),
-                    defaultVaule: JSONObject.Property.DefaultValue.string(value: "case2"),
+                    defaultValue: JSONObject.Property.DefaultValue.string(value: "case2"),
                     isRequired: true,
                     isReadOnly: true
                 ),
@@ -137,7 +137,7 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                             values: ["option1", "option2", "option3", "option4"]
                         )
                     ),
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     isRequired: false,
                     isReadOnly: false
                 )

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -67,8 +67,37 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                     defaultValue: nil,
                     isRequired: false,
                     isReadOnly: false
+                ),
+                JSONObject.Property(
+                    name: "propertyWithAdditionalProperties",
+                    comment: "Description of a property with nested additional properties.",
+                    type: JSONObject(
+                        name: "propertyWithAdditionalProperties",
+                        comment: "Description of a property with nested additional properties.",
+                        properties: [],
+                        additionalProperties:
+                            JSONObject.Property(
+                                name: "additionalProperties",
+                                comment: nil,
+                                type: JSONPrimitive.integer,
+                                defaultValue: nil,
+                                isRequired: false,
+                                isReadOnly: true
+                            )
+                    ),
+                    defaultValue: nil,
+                    isRequired: false,
+                    isReadOnly: true
                 )
-            ]
+            ],
+            additionalProperties: JSONObject.Property(
+                name: "additionalProperties",
+                comment: "Additional properties of Foo.",
+                type: JSONPrimitive.string,
+                defaultValue: nil,
+                isRequired: false,
+                isReadOnly: true
+            )
         )
 
         let expected = SwiftStruct(
@@ -147,8 +176,40 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                     isMutable: true,
                     defaultValue: nil,
                     codingKey: "property2"
+                ),
+                SwiftStruct.Property(
+                    name: "propertyWithAdditionalProperties",
+                    comment: "Description of a property with nested additional properties.",
+                    type: SwiftStruct(
+                        name: "propertyWithAdditionalProperties",
+                        comment: "Description of a property with nested additional properties.",
+                        properties: [],
+                        additionalProperties: SwiftStruct.Property(
+                            name: "additionalProperties",
+                            comment: nil,
+                            type: SwiftPrimitive<Int>(),
+                            isOptional: true,
+                            isMutable: false,
+                            defaultValue: nil,
+                            codingKey: "additionalProperties"
+                        ),
+                        conformance: []
+                    ),
+                    isOptional: true,
+                    isMutable: false,
+                    defaultValue: nil,
+                    codingKey: "propertyWithAdditionalProperties"
                 )
             ],
+            additionalProperties: SwiftStruct.Property(
+                name: "additionalProperties",
+                comment: "Additional properties of Foo.",
+                type: SwiftPrimitive<String>(),
+                isOptional: true,
+                isMutable: false,
+                defaultValue: nil,
+                codingKey: "additionalProperties"
+            ),
             conformance: []
         )
 

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -171,18 +171,15 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         comment: "Description of a property with nested additional properties.",
                         properties: [],
                         additionalProperties:
-                            JSONObject.Property(
-                                name: "additionalProperties",
+                            JSONObject.AdditionalProperties(
                                 comment: nil,
                                 type: JSONPrimitive.integer,
-                                defaultValue: nil,
-                                isRequired: false,
-                                isReadOnly: true // how to reconcile with additionalProperties's required/readOnly?
+                                isReadOnly: true
                             )
                     ),
                     defaultValue: nil,
                     isRequired: false,
-                    isReadOnly: true // how to reconcile with additionalProperties's required/readOnly?
+                    isReadOnly: true
                 )
             ]
         )
@@ -194,10 +191,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                 SwiftStruct.Property(
                     name: "propertyWithAdditionalProperties",
                     comment: "Description of a property with nested additional properties.",
-                    type: SwiftDictionary(
-                        key: SwiftPrimitive<String>(),
-                        value: SwiftPrimitive<Int>()
-                    ),
+                    type: SwiftDictionary(value: SwiftPrimitive<Int>()),
                     isOptional: true,
                     isMutable: false,
                     defaultValue: nil,
@@ -234,12 +228,9 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                     isReadOnly: true
                                 )
                         ],
-                        additionalProperties: JSONObject.Property(
-                            name: "additionalProperties",
+                        additionalProperties: JSONObject.AdditionalProperties(
                             comment: "Additional properties of property1.",
                             type: JSONPrimitive.string,
-                            defaultValue: nil,
-                            isRequired: false,
                             isReadOnly: true
                         )
                     ),
@@ -283,12 +274,9 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                     isReadOnly: true
                 )
             ],
-            additionalProperties: JSONObject.Property(
-                name: "additionalProperties",
+            additionalProperties: JSONObject.AdditionalProperties(
                 comment: "Additional properties of Foo.",
                 type: JSONPrimitive.string,
-                defaultValue: nil,
-                isRequired: false,
                 isReadOnly: true
             )
         )
@@ -312,12 +300,9 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         comment: "Description of a property with nested additional properties.",
                         properties: [],
                         additionalProperties:
-                            JSONObject.Property(
-                                name: "additionalProperties",
+                            JSONObject.AdditionalProperties(
                                 comment: nil,
                                 type: JSONPrimitive.integer,
-                                defaultValue: nil,
-                                isRequired: false,
                                 isReadOnly: false
                             )
                     ),
@@ -336,7 +321,6 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                     name: "propertyWithAdditionalProperties",
                     comment: "Description of a property with nested additional properties.",
                     type: SwiftDictionary(
-                        key: SwiftPrimitive<String>(),
                         value: SwiftPrimitive<Int>()
                     ),
                     isOptional: false,

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -187,7 +187,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         additionalProperties: SwiftStruct.Property(
                             name: "additionalProperties",
                             comment: nil,
-                            type: SwiftPrimitive<Int>(),
+                            type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int>()),
                             isOptional: true,
                             isMutable: false,
                             defaultValue: nil,
@@ -204,7 +204,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
             additionalProperties: SwiftStruct.Property(
                 name: "additionalProperties",
                 comment: "Additional properties of Foo.",
-                type: SwiftPrimitive<String>(),
+                type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
                 isOptional: true,
                 isMutable: false,
                 defaultValue: nil,

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -24,7 +24,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                 name: "property1",
                                 comment: "Description of Bar's `property1`.",
                                 type: JSONPrimitive.string,
-                                defaultVaule: nil,
+                                defaultValue: nil,
                                 isRequired: false,
                                 isReadOnly: true
                             ),
@@ -32,13 +32,13 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                 name: "property2",
                                 comment: "Description of Bar's `property2`.",
                                 type: JSONPrimitive.string,
-                                defaultVaule: nil,
+                                defaultValue: nil,
                                 isRequired: true,
                                 isReadOnly: false
                             )
                         ]
                     ),
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     isRequired: false,
                     isReadOnly: true
                 ),
@@ -50,7 +50,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         comment: "Description of Foo's `property1`.",
                         values: ["case1", "case2", "case3", "case4"]
                     ),
-                    defaultVaule: JSONObject.Property.DefaultValue.string(value: "case2"),
+                    defaultValue: JSONObject.Property.DefaultValue.string(value: "case2"),
                     isRequired: true,
                     isReadOnly: true
                 ),
@@ -64,7 +64,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                             values: ["option1", "option2", "option3", "option4"]
                         )
                     ),
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     isRequired: false,
                     isReadOnly: false
                 )
@@ -88,7 +88,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                 type: SwiftPrimitive<String>(),
                                 isOptional: true,
                                 isMutable: false,
-                                defaultVaule: nil,
+                                defaultValue: nil,
                                 codingKey: "property1"
                             ),
                             SwiftStruct.Property(
@@ -97,7 +97,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                 type: SwiftPrimitive<String>(),
                                 isOptional: false,
                                 isMutable: true,
-                                defaultVaule: nil,
+                                defaultValue: nil,
                                 codingKey: "property2"
                             )
                         ],
@@ -105,7 +105,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                     ),
                     isOptional: true,
                     isMutable: true, // should be mutable as at least one of the `Bar's` properties is mutable
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     codingKey: "bar"
                 ),
                 SwiftStruct.Property(
@@ -124,7 +124,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                     ),
                     isOptional: false,
                     isMutable: false,
-                    defaultVaule: SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                    defaultValue: SwiftEnum.Case(label: "case2", rawValue: "case2"),
                     codingKey: "property1"
                 ),
                 SwiftStruct.Property(
@@ -145,7 +145,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                     ),
                     isOptional: true,
                     isMutable: true,
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     codingKey: "property2"
                 )
             ],

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -194,13 +194,16 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                 SwiftStruct.Property(
                     name: "propertyWithAdditionalProperties",
                     comment: "Description of a property with nested additional properties.",
-                    type: SwiftDictionary(key: SwiftPrimitive<String>(),
-                                          value: SwiftPrimitive<Int>()),
+                    type: SwiftDictionary(
+                        key: SwiftPrimitive<String>(),
+                        value: SwiftPrimitive<Int>()
+                    ),
                     isOptional: true,
                     isMutable: false,
                     defaultValue: nil,
                     codingKey: "propertyWithAdditionalProperties"
-                )],
+                )
+            ],
             conformance: []
         )
 
@@ -214,7 +217,8 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
         let object = JSONObject(
             name: "Foo",
             comment: "Description of Foo.",
-            properties: [JSONObject.Property(
+            properties: [
+                JSONObject.Property(
                     name: "bar",
                     comment: "Description of Foo's `bar`.",
                     type: JSONObject(
@@ -256,7 +260,8 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
         let object = JSONObject(
             name: "Foo",
             comment: "Description of Foo.",
-            properties: [JSONObject.Property(
+            properties: [
+                JSONObject.Property(
                     name: "bar",
                     comment: "Description of Foo's `bar`.",
                     type: JSONObject(
@@ -330,13 +335,16 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                 SwiftStruct.Property(
                     name: "propertyWithAdditionalProperties",
                     comment: "Description of a property with nested additional properties.",
-                    type: SwiftDictionary(key: SwiftPrimitive<String>(),
-                                          value: SwiftPrimitive<Int>()),
+                    type: SwiftDictionary(
+                        key: SwiftPrimitive<String>(),
+                        value: SwiftPrimitive<Int>()
+                    ),
                     isOptional: false,
                     isMutable: false,
                     defaultValue: nil,
                     codingKey: "propertyWithAdditionalProperties"
-                )],
+                )
+            ],
             conformance: []
         )
 

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -187,7 +187,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         additionalProperties: SwiftStruct.Property(
                             name: "additionalProperties",
                             comment: nil,
-                            type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int>()),
+                            type: SwiftPrimitive<Int>(),
                             isOptional: true,
                             isMutable: false,
                             defaultValue: nil,
@@ -204,7 +204,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
             additionalProperties: SwiftStruct.Property(
                 name: "additionalProperties",
                 comment: "Additional properties of Foo.",
-                type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
+                type: SwiftPrimitive<String>(),
                 isOptional: true,
                 isMutable: false,
                 defaultValue: nil,

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
@@ -18,7 +18,7 @@ final class ObjcInteropPrinterTests: XCTestCase {
 
         return """
         // MARK: - Swift
-        \(try swiftPrinter.print(swiftTypes: swiftTypes))
+        \(try swiftPrinter.print(swiftTypes: swiftTypes, includeDynamicCodingKeys: false))
         // MARK: - ObjcInterop
         \(try objcInteropPrinter.print(objcInteropTypes: objcInteropTypes))
         """
@@ -1315,7 +1315,7 @@ final class ObjcInteropPrinterTests: XCTestCase {
             ],
             additionalProperties: .mock(
                 propertyName: "additionalProperties",
-                type: SwiftPrimitive<String>(),
+                type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
                 isOptional: true,
                 isMutable: true
             ),

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
@@ -1575,7 +1575,7 @@ extension SwiftStruct.Property {
             type: type,
             isOptional: isOptional,
             isMutable: isMutable,
-            defaultVaule: nil,
+            defaultValue: nil,
             codingKey: propertyName
         )
     }

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
@@ -967,25 +967,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
             properties: [
                 .mock(
                     propertyName: "immutableStrings",
-                    type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
+                    type: SwiftDictionary(value: SwiftPrimitive<String>()),
                     isOptional: false,
                     isMutable: false
                 ),
                 .mock(
                     propertyName: "optionalImmutableStrings",
-                    type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
+                    type: SwiftDictionary(value: SwiftPrimitive<String>()),
                     isOptional: true,
                     isMutable: false
                 ),
                 .mock(
                     propertyName: "mutableStrings",
-                    type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
+                    type: SwiftDictionary(value: SwiftPrimitive<String>()),
                     isOptional: false,
                     isMutable: true
                 ),
                 .mock(
                     propertyName: "optionalMutableStrings",
-                    type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
+                    type: SwiftDictionary(value: SwiftPrimitive<String>()),
                     isOptional: true,
                     isMutable: true
                 ),
@@ -1050,25 +1050,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
             properties: [
                 .mock(
                     propertyName: "immutableInt64s",
-                    type: SwiftDictionary(key: SwiftPrimitive<Int64>(), value: SwiftPrimitive<Int64>()),
+                    type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                     isOptional: false,
                     isMutable: false
                 ),
                 .mock(
                     propertyName: "optionalImmutableInt64s",
-                    type: SwiftDictionary(key: SwiftPrimitive<Int64>(), value: SwiftPrimitive<Int64>()),
+                    type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                     isOptional: true,
                     isMutable: false
                 ),
                 .mock(
                     propertyName: "mutableInt64s",
-                    type: SwiftDictionary(key: SwiftPrimitive<Int64>(), value: SwiftPrimitive<Int64>()),
+                    type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                     isOptional: false,
                     isMutable: true
                 ),
                 .mock(
                     propertyName: "optionalMutableInt64s",
-                    type: SwiftDictionary(key: SwiftPrimitive<Int64>(), value: SwiftPrimitive<Int64>()),
+                    type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                     isOptional: true,
                     isMutable: true
                 ),
@@ -1080,13 +1080,13 @@ final class ObjcInteropPrinterTests: XCTestCase {
         // MARK: - Swift
 
         public struct Foo {
-            public let immutableInt64s: [Int64: Int64]
+            public let immutableInt64s: [String: Int64]
 
-            public let optionalImmutableInt64s: [Int64: Int64]?
+            public let optionalImmutableInt64s: [String: Int64]?
 
-            public var mutableInt64s: [Int64: Int64]
+            public var mutableInt64s: [String: Int64]
 
-            public var optionalMutableInt64s: [Int64: Int64]?
+            public var optionalMutableInt64s: [String: Int64]?
         }
 
         // MARK: - ObjcInterop
@@ -1100,22 +1100,22 @@ final class ObjcInteropPrinterTests: XCTestCase {
                 self.swiftModel = swiftModel
             }
 
-            @objc public var immutableInt64s: [NSNumber: NSNumber] {
-                root.swiftModel.immutableInt64s as [NSNumber: NSNumber]
+            @objc public var immutableInt64s: [String: NSNumber] {
+                root.swiftModel.immutableInt64s as [String: NSNumber]
             }
 
-            @objc public var optionalImmutableInt64s: [NSNumber: NSNumber]? {
-                root.swiftModel.optionalImmutableInt64s as [NSNumber: NSNumber]?
+            @objc public var optionalImmutableInt64s: [String: NSNumber]? {
+                root.swiftModel.optionalImmutableInt64s as [String: NSNumber]?
             }
 
-            @objc public var mutableInt64s: [NSNumber: NSNumber] {
-                set { root.swiftModel.mutableInt64s = newValue.reduce(into: [:]) { $0[$1.0.int64Value] = $1.1.int64Value }
-                get { root.swiftModel.mutableInt64s as [NSNumber: NSNumber] }
+            @objc public var mutableInt64s: [String: NSNumber] {
+                set { root.swiftModel.mutableInt64s = newValue.reduce(into: [:]) { $0[$1.0] = $1.1.int64Value }
+                get { root.swiftModel.mutableInt64s as [String: NSNumber] }
             }
 
-            @objc public var optionalMutableInt64s: [NSNumber: NSNumber]? {
-                set { root.swiftModel.optionalMutableInt64s = newValue?.reduce(into: [:]) { $0[$1.0.int64Value] = $1.1.int64Value }
-                get { root.swiftModel.optionalMutableInt64s as [NSNumber: NSNumber]? }
+            @objc public var optionalMutableInt64s: [String: NSNumber]? {
+                set { root.swiftModel.optionalMutableInt64s = newValue?.reduce(into: [:]) { $0[$1.0] = $1.1.int64Value }
+                get { root.swiftModel.optionalMutableInt64s as [String: NSNumber]? }
             }
         }
 
@@ -1124,58 +1124,6 @@ final class ObjcInteropPrinterTests: XCTestCase {
         let actual = try printSwiftWithObjcInterop(for: [fooStruct])
 
         XCTAssertEqual(expected, actual)
-    }
-
-    func testPrintingObjcInteropForSwiftStructWithEnumDictionaryProperties() throws {
-        func mockEnumeration(named name: String) -> SwiftEnum {
-            return SwiftEnum(
-                name: name,
-                comment: nil,
-                cases: [
-                    SwiftEnum.Case(label: "option1", rawValue: "option1"),
-                    SwiftEnum.Case(label: "option2", rawValue: "option2"),
-                    SwiftEnum.Case(label: "option3", rawValue: "option3"),
-                ],
-                conformance: []
-            )
-        }
-
-        let fooStruct = SwiftStruct(
-            name: "Foo",
-            comment: nil,
-            properties: [
-                .mock(
-                    propertyName: "immutableEnums",
-                    type: SwiftDictionary(key: SwiftPrimitive<Int64>(), value: mockEnumeration(named: "Options1")),
-                    isOptional: false,
-                    isMutable: false
-                ),
-                .mock(
-                    propertyName: "optionalImmutableEnums",
-                    type:SwiftDictionary(key: SwiftPrimitive<Int64>(), value: mockEnumeration(named: "Options2")),
-                    isOptional: true,
-                    isMutable: false
-                ),
-                .mock(
-                    propertyName: "immutableEnumKeys",
-                    type: SwiftDictionary(key: mockEnumeration(named: "Options1"), value: SwiftPrimitive<Int64>()),
-                    isOptional: false,
-                    isMutable: false
-                ),
-                .mock(
-                    propertyName: "optionalImmutableEnumKeys",
-                    type: SwiftDictionary(key: mockEnumeration(named: "Options1"), value: SwiftPrimitive<Int64>()),
-                    isOptional: true,
-                    isMutable: false
-                ),
-            ],
-            conformance: []
-        )
-
-        var error: Error? = nil
-        XCTAssertThrowsError(try printSwiftWithObjcInterop(for: [fooStruct])) { error = $0 }
-        let exception = try XCTUnwrap(error as? Exception)
-        XCTAssertTrue(exception.description.contains("not supported"))
     }
 
     // MARK: - Nested Swift Structs and Enums

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -25,7 +25,7 @@ final class SwiftPrinterTests: XCTestCase {
                             type: SwiftPrimitive<String>(),
                             isOptional: true,
                             isMutable: false,
-                            defaultVaule: nil,
+                            defaultValue: nil,
                             codingKey: "property1"
                         ),
                         SwiftStruct.Property(
@@ -34,7 +34,7 @@ final class SwiftPrinterTests: XCTestCase {
                             type: SwiftPrimitive<String>(),
                             isOptional: false,
                             isMutable: true,
-                            defaultVaule: nil,
+                            defaultValue: nil,
                             codingKey: "property2"
                         )
                     ],
@@ -42,7 +42,7 @@ final class SwiftPrinterTests: XCTestCase {
                 ),
                 isOptional: true,
                 isMutable: false,
-                defaultVaule: nil,
+                defaultValue: nil,
                 codingKey: "bar"
             ),
             SwiftStruct.Property(
@@ -61,7 +61,7 @@ final class SwiftPrinterTests: XCTestCase {
                 ),
                 isOptional: false,
                 isMutable: false,
-                defaultVaule: SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                defaultValue: SwiftEnum.Case(label: "case2", rawValue: "case2"),
                 codingKey: "bizz"
             ),
             SwiftStruct.Property(
@@ -82,7 +82,7 @@ final class SwiftPrinterTests: XCTestCase {
                 ),
                 isOptional: true,
                 isMutable: true,
-                defaultVaule: nil,
+                defaultValue: nil,
                 codingKey: "buzz"
             )
         ],

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -38,15 +38,6 @@ final class SwiftPrinterTests: XCTestCase {
                             codingKey: "property2"
                         )
                     ],
-                    additionalProperties: SwiftStruct.Property(
-                        name: "additionalProperties",
-                        comment: "Additional properties of Bar.",
-                        type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
-                        isOptional: true,
-                        isMutable: true,
-                        defaultValue: nil,
-                        codingKey: "additionalProperties"
-                    ),
                     conformance: [codableProtocol]
                 ),
                 isOptional: true,
@@ -93,17 +84,17 @@ final class SwiftPrinterTests: XCTestCase {
                 isMutable: true,
                 defaultValue: nil,
                 codingKey: "buzz"
+            ),
+            SwiftStruct.Property(
+                name: "propertiesByNames",
+                comment: "Description of FooBar's `propertiesByNames`.",
+                type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
+                isOptional: true,
+                isMutable: false,
+                defaultValue: nil,
+                codingKey: "propertiesByNames"
             )
         ],
-        additionalProperties: SwiftStruct.Property(
-            name: "additionalProperties",
-            comment: "Additional properties of FooBar.",
-            type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int>()),
-            isOptional: true,
-            isMutable: false,
-            defaultValue: nil,
-            codingKey: "additionalProperties"
-        ),
         conformance: [SwiftProtocol(name: "RUMDataModel", conformance: [codableProtocol])]
     )
 
@@ -120,17 +111,9 @@ final class SwiftPrinterTests: XCTestCase {
 
     func testPrintingSwiftStruct() throws {
         let printer = SwiftPrinter()
-        let actual = try printer.print(swiftTypes: [`struct`, `enum`], includeDynamicCodingKeys: true)
+        let actual = try printer.print(swiftTypes: [`struct`, `enum`])
 
         let expected = """
-
-        fileprivate struct DynamicCodingKey: CodingKey {
-            var stringValue: String
-            var intValue: Int?
-            init?(stringValue: String) { self.stringValue = stringValue }
-            init?(intValue: Int) { return nil }
-            init(_ string: String) { self.stringValue = string }
-        }
 
         /// Description of FooBar.
         public struct FooBar: RUMDataModel {
@@ -143,39 +126,14 @@ final class SwiftPrinterTests: XCTestCase {
             /// Description of FooBar's `buzz`.
             public var buzz: [Buzz]?
 
-            /// Additional properties of FooBar.
-            public let additionalProperties: [String: Int]?
+            /// Description of FooBar's `propertiesByNames`.
+            public let propertiesByNames: [String: String]?
 
             enum CodingKeys: String, CodingKey {
                 case bar = "bar"
                 case bizz = "bizz"
                 case buzz = "buzz"
-            }
-
-            func encode(to encoder: Encoder) throws {
-                var propsContainer = encoder.container(keyedBy: CodingKeys.self)
-                try propsContainer.encode(bar, forKey: .bar)
-                try propsContainer.encode(bizz, forKey: .bizz)
-                try propsContainer.encode(buzz, forKey: .buzz)
-
-                var addPropsContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-                try additionalProperties.forEach { key, value in
-                    try addPropsContainer.encode(value, forKey: DynamicCodingKey(key))
-                }
-            }
-
-            init(from decoder: Decoder) throws {
-                var propsContainer = decoder.container(keyedBy: CodingKeys.self)
-                bar = try propsContainer.decode(BAR.self, forKey: .bar)
-                bizz = try propsContainer.decode(Bizz.self, forKey: .bizz)
-                buzz = try propsContainer.decode([Buzz].self, forKey: .buzz)
-
-                var addPropsContainer = decoder.container(keyedBy: DynamicCodingKey.self)
-                let allKeys = addPropsContainer.allKeys
-                try allKeys.forEach { key in
-                    let value = try addPropsContainer.decode(Int.self, forKey: key)
-                    additionalProperties[key] = value
-                }
+                case propertiesByNames = "propertiesByNames"
             }
 
             /// Description of Bar.
@@ -186,36 +144,9 @@ final class SwiftPrinterTests: XCTestCase {
                 /// Description of Bar's `property2`.
                 public var property2: String
 
-                /// Additional properties of Bar.
-                public var additionalProperties: [String: String]?
-
                 enum CodingKeys: String, CodingKey {
                     case property1 = "property1"
                     case property2 = "property2"
-                }
-
-                func encode(to encoder: Encoder) throws {
-                    var propsContainer = encoder.container(keyedBy: CodingKeys.self)
-                    try propsContainer.encode(property1, forKey: .property1)
-                    try propsContainer.encode(property2, forKey: .property2)
-
-                    var addPropsContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-                    try additionalProperties.forEach { key, value in
-                        try addPropsContainer.encode(value, forKey: DynamicCodingKey(key))
-                    }
-                }
-
-                init(from decoder: Decoder) throws {
-                    var propsContainer = decoder.container(keyedBy: CodingKeys.self)
-                    property1 = try propsContainer.decode(String.self, forKey: .property1)
-                    property2 = try propsContainer.decode(String.self, forKey: .property2)
-
-                    var addPropsContainer = decoder.container(keyedBy: DynamicCodingKey.self)
-                    let allKeys = addPropsContainer.allKeys
-                    try allKeys.forEach { key in
-                        let value = try addPropsContainer.decode(String.self, forKey: key)
-                        additionalProperties[key] = value
-                    }
                 }
             }
 

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -38,6 +38,15 @@ final class SwiftPrinterTests: XCTestCase {
                             codingKey: "property2"
                         )
                     ],
+                    additionalProperties: SwiftStruct.Property(
+                        name: "additionalProperties",
+                        comment: "Additional properties of Bar.",
+                        type: SwiftPrimitive<String>(),
+                        isOptional: true,
+                        isMutable: true,
+                        defaultValue: nil,
+                        codingKey: "additionalProperties"
+                    ),
                     conformance: [codableProtocol]
                 ),
                 isOptional: true,
@@ -86,6 +95,15 @@ final class SwiftPrinterTests: XCTestCase {
                 codingKey: "buzz"
             )
         ],
+        additionalProperties: SwiftStruct.Property(
+            name: "additionalProperties",
+            comment: "Additional properties of FooBar.",
+            type: SwiftPrimitive<Int>(),
+            isOptional: true,
+            isMutable: false,
+            defaultValue: nil,
+            codingKey: "additionalProperties"
+        ),
         conformance: [SwiftProtocol(name: "RUMDataModel", conformance: [codableProtocol])]
     )
 
@@ -117,6 +135,9 @@ final class SwiftPrinterTests: XCTestCase {
             /// Description of FooBar's `buzz`.
             public var buzz: [Buzz]?
 
+            /// Additional properties of FooBar.
+            public let additionalProperties: [String: Int]?
+
             enum CodingKeys: String, CodingKey {
                 case bar = "bar"
                 case bizz = "bizz"
@@ -130,6 +151,9 @@ final class SwiftPrinterTests: XCTestCase {
 
                 /// Description of Bar's `property2`.
                 public var property2: String
+
+                /// Additional properties of Bar.
+                public var additionalProperties: [String: String]?
 
                 enum CodingKeys: String, CodingKey {
                     case property1 = "property1"

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -88,7 +88,7 @@ final class SwiftPrinterTests: XCTestCase {
             SwiftStruct.Property(
                 name: "propertiesByNames",
                 comment: "Description of FooBar's `propertiesByNames`.",
-                type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
+                type: SwiftDictionary(value: SwiftPrimitive<String>()),
                 isOptional: true,
                 isMutable: false,
                 defaultValue: nil,

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -120,7 +120,7 @@ final class SwiftPrinterTests: XCTestCase {
 
     func testPrintingSwiftStruct() throws {
         let printer = SwiftPrinter()
-        let actual = try printer.print(swiftTypes: [`struct`, `enum`])
+        let actual = try printer.print(swiftTypes: [`struct`, `enum`], includeDynamicCodingKeys: true)
 
         let expected = """
 

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -41,7 +41,7 @@ final class SwiftPrinterTests: XCTestCase {
                     additionalProperties: SwiftStruct.Property(
                         name: "additionalProperties",
                         comment: "Additional properties of Bar.",
-                        type: SwiftPrimitive<String>(),
+                        type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<String>()),
                         isOptional: true,
                         isMutable: true,
                         defaultValue: nil,
@@ -98,7 +98,7 @@ final class SwiftPrinterTests: XCTestCase {
         additionalProperties: SwiftStruct.Property(
             name: "additionalProperties",
             comment: "Additional properties of FooBar.",
-            type: SwiftPrimitive<Int>(),
+            type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int>()),
             isOptional: true,
             isMutable: false,
             defaultValue: nil,

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -124,6 +124,14 @@ final class SwiftPrinterTests: XCTestCase {
 
         let expected = """
 
+        fileprivate struct DynamicCodingKey: CodingKey {
+            var stringValue: String
+            var intValue: Int?
+            init?(stringValue: String) { self.stringValue = stringValue }
+            init?(intValue: Int) { return nil }
+            init(_ string: String) { self.stringValue = string }
+        }
+
         /// Description of FooBar.
         public struct FooBar: RUMDataModel {
             /// Description of Bar.
@@ -144,6 +152,32 @@ final class SwiftPrinterTests: XCTestCase {
                 case buzz = "buzz"
             }
 
+            func encode(to encoder: Encoder) throws {
+                var propsContainer = encoder.container(keyedBy: CodingKeys.self)
+                try propsContainer.encode(bar, forKey: .bar)
+                try propsContainer.encode(bizz, forKey: .bizz)
+                try propsContainer.encode(buzz, forKey: .buzz)
+
+                var addPropsContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+                try additionalProperties.forEach { key, value in
+                    try addPropsContainer.encode(value, forKey: DynamicCodingKey(key))
+                }
+            }
+
+            init(from decoder: Decoder) throws {
+                var propsContainer = decoder.container(keyedBy: CodingKeys.self)
+                bar = try propsContainer.decode(BAR.self, forKey: .bar)
+                bizz = try propsContainer.decode(Bizz.self, forKey: .bizz)
+                buzz = try propsContainer.decode([Buzz].self, forKey: .buzz)
+
+                var addPropsContainer = decoder.container(keyedBy: DynamicCodingKey.self)
+                let allKeys = addPropsContainer.allKeys
+                try allKeys.forEach { key in
+                    let value = try addPropsContainer.decode(Int.self, forKey: key)
+                    additionalProperties[key] = value
+                }
+            }
+
             /// Description of Bar.
             public struct BAR: Codable {
                 /// Description of Bar's `property1`.
@@ -158,6 +192,30 @@ final class SwiftPrinterTests: XCTestCase {
                 enum CodingKeys: String, CodingKey {
                     case property1 = "property1"
                     case property2 = "property2"
+                }
+
+                func encode(to encoder: Encoder) throws {
+                    var propsContainer = encoder.container(keyedBy: CodingKeys.self)
+                    try propsContainer.encode(property1, forKey: .property1)
+                    try propsContainer.encode(property2, forKey: .property2)
+
+                    var addPropsContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+                    try additionalProperties.forEach { key, value in
+                        try addPropsContainer.encode(value, forKey: DynamicCodingKey(key))
+                    }
+                }
+
+                init(from decoder: Decoder) throws {
+                    var propsContainer = decoder.container(keyedBy: CodingKeys.self)
+                    property1 = try propsContainer.decode(String.self, forKey: .property1)
+                    property2 = try propsContainer.decode(String.self, forKey: .property2)
+
+                    var addPropsContainer = decoder.container(keyedBy: DynamicCodingKey.self)
+                    let allKeys = addPropsContainer.allKeys
+                    try allKeys.forEach { key in
+                        let value = try addPropsContainer.decode(String.self, forKey: key)
+                        additionalProperties[key] = value
+                    }
                 }
             }
 

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
@@ -89,7 +89,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                 SwiftStruct.Property(
                     name: "propertiesByNames",
                     comment: "Description of Foobar's `propertiesByNames`",
-                    type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int>()),
+                    type: SwiftDictionary(value: SwiftPrimitive<Int>()),
                     isOptional: true,
                     isMutable: true,
                     defaultValue: nil,
@@ -182,7 +182,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     SwiftStruct.Property(
                         name: "propertiesByNames",
                         comment: "Description of Foobar's `propertiesByNames`",
-                        type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int64>()),
+                        type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                         isOptional: true,
                         isMutable: true,
                         defaultValue: nil,

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
@@ -87,6 +87,15 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     codingKey: "property2"
                 )
             ],
+            additionalProperties: SwiftStruct.Property(
+                name: "additionalProperties",
+                comment: "Additional properties of FooBar.",
+                type: SwiftPrimitive<Int>(),
+                isOptional: true,
+                isMutable: false,
+                defaultValue: nil,
+                codingKey: "additionalProperties"
+            ),
             conformance: []
         )
 
@@ -171,6 +180,15 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         codingKey: "property2"
                     )
                 ],
+                additionalProperties: SwiftStruct.Property(
+                    name: "additionalProperties",
+                    comment: "Additional properties of FooBar.",
+                    type: SwiftPrimitive<Int64>(),
+                    isOptional: true,
+                    isMutable: false,
+                    defaultValue: nil,
+                    codingKey: "additionalProperties"
+                ),
                 conformance: [SwiftProtocol(name: "RUMDataModel", conformance: [codableProtocol])]
             )
         ]

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
@@ -85,17 +85,17 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     isMutable: true,
                     defaultValue: nil,
                     codingKey: "property2"
+                ),
+                SwiftStruct.Property(
+                    name: "propertiesByNames",
+                    comment: "Description of Foobar's `propertiesByNames`",
+                    type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int>()),
+                    isOptional: true,
+                    isMutable: true,
+                    defaultValue: nil,
+                    codingKey: "propertiesByNames"
                 )
             ],
-            additionalProperties: SwiftStruct.Property(
-                name: "additionalProperties",
-                comment: "Additional properties of FooBar.",
-                type: SwiftPrimitive<Int>(),
-                isOptional: true,
-                isMutable: false,
-                defaultValue: nil,
-                codingKey: "additionalProperties"
-            ),
             conformance: []
         )
 
@@ -178,17 +178,17 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         isMutable: true,
                         defaultValue: nil,
                         codingKey: "property2"
+                    ),
+                    SwiftStruct.Property(
+                        name: "propertiesByNames",
+                        comment: "Description of Foobar's `propertiesByNames`",
+                        type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int64>()),
+                        isOptional: true,
+                        isMutable: true,
+                        defaultValue: nil,
+                        codingKey: "propertiesByNames"
                     )
                 ],
-                additionalProperties: SwiftStruct.Property(
-                    name: "additionalProperties",
-                    comment: "Additional properties of FooBar.",
-                    type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int64>()),
-                    isOptional: true,
-                    isMutable: false,
-                    defaultValue: nil,
-                    codingKey: "additionalProperties"
-                ),
                 conformance: [SwiftProtocol(name: "RUMDataModel", conformance: [codableProtocol])]
             )
         ]

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
@@ -26,7 +26,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                                 type: SwiftPrimitive<String>(),
                                 isOptional: true,
                                 isMutable: false,
-                                defaultVaule: nil,
+                                defaultValue: nil,
                                 codingKey: "property1"
                             ),
                             SwiftStruct.Property(
@@ -35,7 +35,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                                 type: SwiftPrimitive<String>(),
                                 isOptional: false,
                                 isMutable: true,
-                                defaultVaule: nil,
+                                defaultValue: nil,
                                 codingKey: "property2"
                             )
                         ],
@@ -43,7 +43,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     ),
                     isOptional: true,
                     isMutable: false,
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     codingKey: "bar"
                 ),
                 SwiftStruct.Property(
@@ -62,7 +62,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     ),
                     isOptional: false,
                     isMutable: false,
-                    defaultVaule: SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                    defaultValue: SwiftEnum.Case(label: "case2", rawValue: "case2"),
                     codingKey: "property1"
                 ),
                 SwiftStruct.Property(
@@ -83,7 +83,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     ),
                     isOptional: true,
                     isMutable: true,
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     codingKey: "property2"
                 )
             ],
@@ -110,7 +110,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                                     type: SwiftPrimitive<String>(),
                                     isOptional: true,
                                     isMutable: false,
-                                    defaultVaule: nil,
+                                    defaultValue: nil,
                                     codingKey: "property1"
                                 ),
                                 SwiftStruct.Property(
@@ -119,7 +119,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                                     type: SwiftPrimitive<String>(),
                                     isOptional: false,
                                     isMutable: true,
-                                    defaultVaule: nil,
+                                    defaultValue: nil,
                                     codingKey: "property2"
                                 )
                             ],
@@ -127,7 +127,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         ),
                         isOptional: true,
                         isMutable: false,
-                        defaultVaule: nil,
+                        defaultValue: nil,
                         codingKey: "bar"
                     ),
                     SwiftStruct.Property(
@@ -146,7 +146,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         ),
                         isOptional: false,
                         isMutable: false,
-                        defaultVaule: SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                        defaultValue: SwiftEnum.Case(label: "case2", rawValue: "case2"),
                         codingKey: "property1"
                     ),
                     SwiftStruct.Property(
@@ -167,7 +167,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         ),
                         isOptional: true,
                         isMutable: true,
-                        defaultVaule: nil,
+                        defaultValue: nil,
                         codingKey: "property2"
                     )
                 ],
@@ -194,7 +194,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     ),
                     isOptional: true,
                     isMutable: false,
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     codingKey: "connectivity"
                 ),
                 SwiftStruct.Property(
@@ -208,7 +208,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     ),
                     isOptional: true,
                     isMutable: false,
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     codingKey: "usr"
                 ),
                 SwiftStruct.Property(
@@ -222,7 +222,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     ),
                     isOptional: true,
                     isMutable: false,
-                    defaultVaule: nil,
+                    defaultValue: nil,
                     codingKey: "method"
                 )
             ],
@@ -242,7 +242,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         type: SwiftTypeReference(referencedTypeName: "RUMConnectivity"),
                         isOptional: true,
                         isMutable: false,
-                        defaultVaule: nil,
+                        defaultValue: nil,
                         codingKey: "connectivity"
                     ),
                     SwiftStruct.Property(
@@ -251,7 +251,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         type: SwiftTypeReference(referencedTypeName: "RUMUser"),
                         isOptional: true,
                         isMutable: false,
-                        defaultVaule: nil,
+                        defaultValue: nil,
                         codingKey: "usr"
                     ),
                     SwiftStruct.Property(
@@ -260,7 +260,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         type: SwiftTypeReference(referencedTypeName: "RUMMethod"),
                         isOptional: true,
                         isMutable: false,
-                        defaultVaule: nil,
+                        defaultValue: nil,
                         codingKey: "method"
                     )
                 ],

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
@@ -183,7 +183,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                 additionalProperties: SwiftStruct.Property(
                     name: "additionalProperties",
                     comment: "Additional properties of FooBar.",
-                    type: SwiftPrimitive<Int64>(),
+                    type: SwiftDictionary(key: SwiftPrimitive<String>(), value: SwiftPrimitive<Int64>()),
                     isOptional: true,
                     isMutable: false,
                     defaultValue: nil,


### PR DESCRIPTION
### What and why?

We ultimately want to add support for custom timings. This was previously introduced to the schema in [rum-events-format #25](https://github.com/DataDog/rum-events-format/pull/25) relying on [JSON Schema's `additionalProperty`](https://json-schema.org/draft/2019-09/json-schema-core.html#additionalProperties).

Our Swift/Objc pipeline that generates models from a schema doesn't know how to handle `additionalProperties` at this point. To prevent from mis-generating the model for custom timings [we previously had to put a dedicated filter](https://github.com/DataDog/dd-sdk-ios/pull/393/files#diff-dd3caa4e6db960eecd95024f6d7df904948b8f53b1026c00dd19a9627317ac3e) until we add the support for `additionalProperties`.

In this PR we add the plumbing needed for a basic support of `additionalProperty`. It will allow us to remove the filter and generate the model for custom timings.

### How?

As of 8e6fbbf the approach has been simplified. To sum-up, we model `additionalProperties` as dictionaries while adding a relatively restrictive support of `SwiftDictionary` (only primitive types).
Any future gaps between an improved use of JSON Schema in the input files and the current limitations of the pipeline should be caught by exceptions at runtime, and prior to shipping the generated code inside the SDK.

#### JSON

We add an `additionalProperties` property to the `JSONSchema`. It is optional and of type `JSONSchema` itself [as required by the spec](https://json-schema.org/draft/2019-09/json-schema-core.html#additionalProperties).

We map that schema to a `JSONObject.AdditionalProperties` struct which is a subset of a `JSONObject.Property`. It holds a `type` that is a `JSONPrimitive`, meaning that we only support `bool, double, integer, string` at this point. The mapping happens in the `JSONSchemaToJSONTypeTransformer`.

#### Swift

To support additional properties in `SwiftStruct`, we introduce a basic `SwiftDictionary`. Note that keys are `String` and values must be `SwiftPrimitiveType`, i.e. `Bool, Int, Int64, String, Double`.
From that point we can declare a `SwiftStruct.Property` of type `SwiftDictionary` to model JSONSchema's `additionalProperties`. The mapping from `JSONObject` to `SwiftStruct` is done in `JSONToSwiftTypeTransformer`.

`JSONToSwiftTypeTransformer` enforces a couple of new rules:
- A provided root object cannot map to a Dictionary, especially a root object cannot have `additionalProperties` that would require a mapping to a dictionary.
- A JSON object cannot hold both regular properties and `additionalProperties`.

#### Objc Interop

To mirror additions to the Swift type system and transformer, we introduce a `ObjcInteropNSDictionary` and add the expected mapping methods inside `SwiftToObjcInteropTypeTransformer`. 

#### RUM

We just add some basic expect methods to allow traversing a `SwiftDictionary` and transforming any primitive types, e.g. `Int` -> `Int64`.

#### Printers

This has been simplified a lot compared to the initial approach (41a1ac8d and before), they only need to know how to print dictionaries while converting some core Swift <-> Objc types.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference

### Next

- [ ] Run `tools/rum-models-generator/run.sh generate` to add custom timings
Spoiler this should generate something to resolve this:
```
... RUMDataModels.swift is out of sync with rum-events-format: 8b955a03d0fe0b2f032a02d6800c61ef3fc9fada
Difference was found when comparing it with template file:
>>>
111,113d110
<         /// User custom timings of the view
<         public let customTimings: [String: Int64]?
< 
172d168
<             case customTimings = "custom_timings"
<<<
```
