### PR TITLE
RUMM-957 Add `Example` app scenario for testing Crash Reporting feature

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */; };
+		6111542525C992F8007C84C9 /* CrashReportingScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111542425C992F8007C84C9 /* CrashReportingScenarios.swift */; };
+		6111543625C993C2007C84C9 /* CrashReportingScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6111543525C993C2007C84C9 /* CrashReportingScenario.storyboard */; };
+		6111543F25C996A5007C84C9 /* CrashReportingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111543E25C996A5007C84C9 /* CrashReportingViewController.swift */; };
+		6111544825C9A88B007C84C9 /* PersistenceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111544725C9A88B007C84C9 /* PersistenceHelper.swift */; };
 		6111C58225C0081F00F5C4A2 /* RUMDataModels+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */; };
 		61122ECE25B1B74500F9C7F5 /* SpanSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */; };
 		61122ED425B1B84D00F9C7F5 /* RUMEventSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */; };
@@ -504,6 +508,10 @@
 
 /* Begin PBXFileReference section */
 		6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingWithActiveSpanIntegration.swift; sourceTree = "<group>"; };
+		6111542425C992F8007C84C9 /* CrashReportingScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingScenarios.swift; sourceTree = "<group>"; };
+		6111543525C993C2007C84C9 /* CrashReportingScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CrashReportingScenario.storyboard; sourceTree = "<group>"; };
+		6111543E25C996A5007C84C9 /* CrashReportingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingViewController.swift; sourceTree = "<group>"; };
+		6111544725C9A88B007C84C9 /* PersistenceHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceHelper.swift; sourceTree = "<group>"; };
 		6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMDataModels+objc.swift"; sourceTree = "<group>"; };
 		61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSanitizer.swift; sourceTree = "<group>"; };
 		61122ED325B1B84D00F9C7F5 /* RUMEventSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventSanitizer.swift; sourceTree = "<group>"; };
@@ -994,6 +1002,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6111542325C992D9007C84C9 /* CrashReporting */ = {
+			isa = PBXGroup;
+			children = (
+				6111542425C992F8007C84C9 /* CrashReportingScenarios.swift */,
+				6111543425C993AC007C84C9 /* CrashReporting */,
+			);
+			path = CrashReporting;
+			sourceTree = "<group>";
+		};
+		6111543425C993AC007C84C9 /* CrashReporting */ = {
+			isa = PBXGroup;
+			children = (
+				6111543525C993C2007C84C9 /* CrashReportingScenario.storyboard */,
+				6111543E25C996A5007C84C9 /* CrashReportingViewController.swift */,
+			);
+			path = CrashReporting;
+			sourceTree = "<group>";
+		};
 		6111C58025C0080C00F5C4A2 /* RUM */ = {
 			isa = PBXGroup;
 			children = (
@@ -1606,6 +1632,7 @@
 				61337030250F829E00236D58 /* Logging */,
 				61337033250F847500236D58 /* Tracing */,
 				61337036250F84F100236D58 /* RUM */,
+				6111542325C992D9007C84C9 /* CrashReporting */,
 				611EA12B2580F40E00BC0E56 /* TrackingConsent */,
 				6164AE7D252B4CE2000D78C4 /* URLSession */,
 			);
@@ -1865,6 +1892,7 @@
 				61441C902461A648003D8BB8 /* ConsoleOutputInterceptor.swift */,
 				61441C912461A648003D8BB8 /* UIButton+Disabling.swift */,
 				61441C922461A648003D8BB8 /* UIViewController+KeyboardControlling.swift */,
+				6111544725C9A88B007C84C9 /* PersistenceHelper.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2951,6 +2979,7 @@
 				61337039250F852E00236D58 /* RUMManualInstrumentationScenario.storyboard in Resources */,
 				6193DCA4251B5691009B8011 /* RUMTapActionScenario.storyboard in Resources */,
 				6167ACC7251A0BCE0012B4D0 /* NSURLSessionScenario.storyboard in Resources */,
+				6111543625C993C2007C84C9 /* CrashReportingScenario.storyboard in Resources */,
 				61441C0E24616DEC003D8BB8 /* Assets.xcassets in Resources */,
 				6137E649252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard in Resources */,
 				61441C0C24616DE9003D8BB8 /* Main.storyboard in Resources */,
@@ -3403,8 +3432,10 @@
 				61441C952461A649003D8BB8 /* ConsoleOutputInterceptor.swift in Sources */,
 				61D50C5A2580EFF3006038A3 /* URLSessionScenarios.swift in Sources */,
 				614CADCE250FCA0200B93D2D /* TestScenarios.swift in Sources */,
+				6111542525C992F8007C84C9 /* CrashReportingScenarios.swift in Sources */,
 				61441C972461A649003D8BB8 /* UIViewController+KeyboardControlling.swift in Sources */,
 				61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */,
+				6111543F25C996A5007C84C9 /* CrashReportingViewController.swift in Sources */,
 				61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */,
 				61D50C542580EF41006038A3 /* RUMScenarios.swift in Sources */,
 				61C2C20B24C1045300C0321C /* SendRUMFixture1ViewController.swift in Sources */,
@@ -3422,6 +3453,7 @@
 				61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */,
 				61441C992461A649003D8BB8 /* DebugLoggingViewController.swift in Sources */,
 				6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */,
+				6111544825C9A88B007C84C9 /* PersistenceHelper.swift in Sources */,
 				61D50C462580EF19006038A3 /* TracingScenarios.swift in Sources */,
 				618DCFE324C766FB00589570 /* SendRUMFixture3ViewController.swift in Sources */,
 				61441C962461A649003D8BB8 /* UIButton+Disabling.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -116,6 +116,11 @@
             value = "RUMScrubbingScenario"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_TEST_SCENARIO_CLASS_NAME"
+            value = "CrashReportingCollectOrSendScenario"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -6,7 +6,6 @@
 
 import UIKit
 import Datadog
-import DatadogCrashReporting
 
 protocol AppConfiguration {
     /// The tracking consent value applied when initializing the SDK.
@@ -40,7 +39,6 @@ struct ExampleAppConfiguration: AppConfiguration {
             .set(serviceName: serviceName)
             .set(batchSize: .small)
             .set(uploadFrequency: .frequent)
-            .enableCrashReporting(using: DDCrashReportingPlugin())
 
         // If the app was launched with test scenarion ENV, apply the scenario configuration
         if let testScenario = testScenario {
@@ -65,7 +63,7 @@ struct UITestsAppConfiguration: AppConfiguration {
 
     init() {
         if Environment.shouldClearPersistentData() {
-            deletePersistedSDKData()
+            PersistenceHelpers.deleteAllSDKData()
         }
     }
 
@@ -115,24 +113,5 @@ struct UITestsAppConfiguration: AppConfiguration {
 
     func initialStoryboard() -> UIStoryboard? {
         return UIStoryboard(name: type(of: testScenario!).storyboardName, bundle: nil)
-    }
-
-    private func deletePersistedSDKData() {
-        guard let cachesDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-            return
-        }
-
-        do {
-            let dataDirectories = try FileManager.default
-                .contentsOfDirectory(at: cachesDirectoryURL, includingPropertiesForKeys: [.isDirectoryKey, .canonicalPathKey])
-                .filter { $0.absoluteString.contains("com.datadoghq") }
-
-            try dataDirectories.forEach { url in
-                try FileManager.default.removeItem(at: url)
-                print("🧹 Deleted SDK data directory: \(url)")
-            }
-        } catch {
-            print("🔥 Failed to delete SDK data directory: \(error)")
-        }
     }
 }

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingScenario.storyboard
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingScenario.storyboard
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="svZ-CV-H7D">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Crash Reporting View Controller-->
+        <scene sceneID="GCQ-MZ-FBH">
+            <objects>
+                <viewController id="svZ-CV-H7D" customClass="CrashReportingViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="4zU-Jd-E7f">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending crash report... " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RxJ-Ne-sYn">
+                                <rect key="frame" x="115.5" y="437.5" width="183" height="21"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XgZ-fe-9bf">
+                                <rect key="frame" x="107" y="468.5" width="200" height="44"/>
+                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="bSD-p3-lol"/>
+                                    <constraint firstAttribute="height" constant="44" id="nsh-hL-Hoc"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Crash The App">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="7"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="didTapCrashTheApp:" destination="svZ-CV-H7D" eventType="touchUpInside" id="cSS-Oz-nmZ"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vOa-RY-Cv0"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="XgZ-fe-9bf" firstAttribute="top" secondItem="RxJ-Ne-sYn" secondAttribute="bottom" constant="10" id="JXx-03-Dkm"/>
+                            <constraint firstItem="RxJ-Ne-sYn" firstAttribute="centerX" secondItem="4zU-Jd-E7f" secondAttribute="centerX" id="iRh-lc-dML"/>
+                            <constraint firstItem="XgZ-fe-9bf" firstAttribute="centerX" secondItem="4zU-Jd-E7f" secondAttribute="centerX" id="ixA-NO-9MA"/>
+                            <constraint firstItem="RxJ-Ne-sYn" firstAttribute="centerY" secondItem="4zU-Jd-E7f" secondAttribute="centerY" id="y1a-X1-ndR"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="nWs-H8-pOo"/>
+                    <connections>
+                        <outlet property="crashTheAppButton" destination="XgZ-fe-9bf" id="rWd-L2-Lwo"/>
+                        <outlet property="sendingCrashReportLabel" destination="RxJ-Ne-sYn" id="OxV-Uu-mOI"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="a6m-Nu-QWl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1026" y="1233"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal class CrashReportingViewController: UIViewController {
+    @IBOutlet weak var sendingCrashReportLabel: UILabel!
+    @IBOutlet weak var crashTheAppButton: UIButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let testScenario = (appConfiguration.testScenario as! CrashReportingCollectOrSendScenario)
+
+        if testScenario.hadPendingCrashReportDataOnStartup {
+            sendingCrashReportLabel.isHidden = false
+            crashTheAppButton.isHidden = true
+        } else {
+            sendingCrashReportLabel.isHidden = true
+            crashTheAppButton.isHidden = false
+        }
+    }
+
+    @IBAction func didTapCrashTheApp(_ sender: Any) {
+        fatalError("The 'Crash The App' button was tapped.")
+    }
+}

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+import DatadogCrashReporting
+
+/// Scenario that launches single-view app which conditionally causes the a crash or uploads the crash report to Datadog.
+/// The condition is determined by crash report file presence:
+/// * if the file is not there, the UI for crashing the app is presented,
+/// * if the file is there, the UI for uploading the crash repot is shown.
+///
+/// To test this scenario manually:
+///  → disconnect debugger → run the Example app so it presents "Crash The App" button → crash  → run again.
+final class CrashReportingCollectOrSendScenario: TestScenario {
+    static let storyboardName = "CrashReportingScenario"
+
+    let hadPendingCrashReportDataOnStartup: Bool
+
+    init() {
+        // The scenario gets instantiated on app startup, so this value is captured
+        // before the SDK gets a chance to read & purge the crash report file.
+        hadPendingCrashReportDataOnStartup = PersistenceHelpers.hasPendingCrashReportData()
+    }
+
+    func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder.enableCrashReporting(using: DDCrashReportingPlugin())
+    }
+}

--- a/Datadog/Example/Utils/PersistenceHelper.swift
+++ b/Datadog/Example/Utils/PersistenceHelper.swift
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct PersistenceHelpers {
+    /// Deletes data directories for all features (Logging, Tracing, RUM and Crash Reporting).
+    static func deleteAllSDKData() {
+        do {
+            try FileManager.default
+                .getCacheSubdirectories()
+                .filter { isFeatureDirectory($0) || isCrashReporterDirectory($0) }
+                .forEach { FileManager.default.delete($0) }
+        } catch {
+            print("🔥 Failed to delete SDK data directory: \(error)")
+        }
+    }
+
+    /// Checks if there is a pending crash report file.
+    static func hasPendingCrashReportData() -> Bool {
+        do {
+            guard let crashReportsDirectory = try FileManager.default
+                    .getCacheSubdirectories()
+                    .filter(isCrashReporterDirectory)
+                    .first
+            else {
+                return false
+            }
+
+            return FileManager.default
+                .recursivelyFindFiles(in: crashReportsDirectory)
+                .contains { isCrashReportFile($0) }
+        } catch {
+            print("🔥 Failed to inspect crash reports directory: \(error)")
+            return false
+        }
+    }
+
+    // MARK: - Private
+
+    private static func isFeatureDirectory(_ url: URL) -> Bool {
+        url.absoluteString.contains("com.datadoghq")
+    }
+
+    private static func isCrashReporterDirectory(_ url: URL) -> Bool {
+        url.absoluteString.contains("com.plausiblelabs")
+    }
+
+    private static func isCrashReportFile(_ url: URL) -> Bool {
+        do {
+            let attributes = try url.resourceValues(forKeys:[.nameKey])
+            return attributes.name?.hasSuffix("plcrash") ?? false
+        } catch {
+            print("🔥 Failed to inspect file name: \(error)")
+            return false
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension FileManager {
+    /// Lists urls for subdirectories of `caches` directory
+    func getCacheSubdirectories() throws -> [URL] {
+        guard let cachesDirectoryURL = urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            fatalError("🔥 Cannot obtain \"caches\" directory URL")
+        }
+        return try contentsOfDirectory(
+            at: cachesDirectoryURL,
+            includingPropertiesForKeys: [.isDirectoryKey, .canonicalPathKey]
+        )
+    }
+
+    /// Deletes file or directory at given `url`.
+    func delete(_ url: URL) {
+        do {
+            print("🧹 Deleting directory: \(url)")
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            print("🧹🔥 Failed: \(error)")
+        }
+    }
+
+    /// Recursively finds all files in given directory `url`.
+    func recursivelyFindFiles(in directoryURL: URL) -> [URL] {
+        guard let enumerator = self.enumerator(
+                at: directoryURL,
+                includingPropertiesForKeys: [.isRegularFileKey]
+        ) else {
+            print("🔥 Failed to recursively enumerate file names in \(directoryURL)")
+            return []
+        }
+        var files: [URL] = []
+        for case let fileURL as URL in enumerator { files.append(fileURL) }
+        return files
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR adds single test scenario in `Example` app to play with the Crash Reporting feature. Later (in `RUMM-960`) it will be used to send the crash report to Python server and run assertions in integration tests.

### How?

The `CrashReportingCollectOrSendScenario` scenario consists of a single View Controller with conditionally displayed UI:

<img width="504" alt="Screenshot 2021-02-04 at 15 25 44" src="https://user-images.githubusercontent.com/2358722/106906631-abcc8b00-66fd-11eb-8c10-a5a881c9708b.png">

If the scenario is started with no crash report file on disc, it displays the _"Crash The App"_ button. Once pressed, it issues a `fatalError()` and terminates the process.

When a crash report file is found on startup, it displays the _"Sending crash report..."_ label, meaning that it found the crash report and it expects the SDK to send it.

Once the actual `RUMError` upload is implemented in `RUMM-960`, it will be sending real data to Datadog.

### Manual Testing

To test this scenario manually, enable `CrashReportingCollectOrSendScenario` in Example schema's `ENV`, then:
→ disconnect debugger → run the Example app so it presents "Crash The App" button → crash  → connect debugger → run again → notice the breakpoint hit in `CrashReportingWithRUMIntegration`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
