### PR TITLE
RUMM-957 Inject application context to crash reports

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -214,6 +214,8 @@
 		615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */; };
 		615F197C25B5A64B00BE14B5 /* UIKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */; };
 		6161247925CA9CA6009901BE /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6161247825CA9CA6009901BE /* CrashReporter.swift */; };
+		6161249E25CAB340009901BE /* CrashContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6161249D25CAB340009901BE /* CrashContext.swift */; };
+		616124A725CAC268009901BE /* CrashContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616124A625CAC268009901BE /* CrashContextProvider.swift */; };
 		6164AE89252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6164AE88252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift */; };
 		6164AF06252C9004000D78C4 /* ObjcSendFirstPartyRequestsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6164AF05252C9004000D78C4 /* ObjcSendFirstPartyRequestsViewController.m */; };
 		6164AF0E252C9016000D78C4 /* ObjcSendThirdPartyRequestsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6164AF0D252C9016000D78C4 /* ObjcSendThirdPartyRequestsViewController.m */; };
@@ -393,6 +395,7 @@
 		61F9CABA2513A7F5000A5E61 /* RUMSessionMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA982513977A000A5E61 /* RUMSessionMatcher.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
+		61FC5F3525CC1898006BB4DE /* CrashContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */; };
 		61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */; };
 		61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */; };
 		61FF282424B8A1C3000B3D9B /* RUMEventFileOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282324B8A1C3000B3D9B /* RUMEventFileOutput.swift */; };
@@ -717,6 +720,8 @@
 		615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandlerTests.swift; sourceTree = "<group>"; };
 		615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensions.swift; sourceTree = "<group>"; };
 		6161247825CA9CA6009901BE /* CrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
+		6161249D25CAB340009901BE /* CrashContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContext.swift; sourceTree = "<group>"; };
+		616124A625CAC268009901BE /* CrashContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextProvider.swift; sourceTree = "<group>"; };
 		6164AE88252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendThirdPartyRequestsViewController.swift; sourceTree = "<group>"; };
 		6164AF04252C9004000D78C4 /* ObjcSendFirstPartyRequestsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcSendFirstPartyRequestsViewController.h; sourceTree = "<group>"; };
 		6164AF05252C9004000D78C4 /* ObjcSendFirstPartyRequestsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcSendFirstPartyRequestsViewController.m; sourceTree = "<group>"; };
@@ -898,6 +903,7 @@
 		61F9CA982513977A000A5E61 /* RUMSessionMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionMatcher.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
+		61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextProviderTests.swift; sourceTree = "<group>"; };
 		61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilder.swift; sourceTree = "<group>"; };
 		61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilderTests.swift; sourceTree = "<group>"; };
 		61FF282324B8A1C3000B3D9B /* RUMEventFileOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutput.swift; sourceTree = "<group>"; };
@@ -1964,6 +1970,15 @@
 			path = TabBarAutoInstrumentation;
 			sourceTree = "<group>";
 		};
+		616124AF25CAC26B009901BE /* CrashContext */ = {
+			isa = PBXGroup;
+			children = (
+				6161249D25CAB340009901BE /* CrashContext.swift */,
+				616124A625CAC268009901BE /* CrashContextProvider.swift */,
+			);
+			path = CrashContext;
+			sourceTree = "<group>";
+		};
 		6164AE7D252B4CE2000D78C4 /* URLSession */ = {
 			isa = PBXGroup;
 			children = (
@@ -2384,6 +2399,7 @@
 				61DE332525C826E4008E3EC2 /* CrashReportingFeature.swift */,
 				61DE333525C8278A008E3EC2 /* DDCrashReportingPluginType.swift */,
 				6161247825CA9CA6009901BE /* CrashReporter.swift */,
+				616124AF25CAC26B009901BE /* CrashContext */,
 			);
 			path = CrashReporting;
 			sourceTree = "<group>";
@@ -2505,6 +2521,7 @@
 			isa = PBXGroup;
 			children = (
 				61F2724825C943C500D54BF8 /* CrashReporterTests.swift */,
+				61FC5F3325CC187D006BB4DE /* CrashContext */,
 			);
 			path = CrashReporting;
 			sourceTree = "<group>";
@@ -2610,6 +2627,14 @@
 				61F9CA7F25125C01000A5E61 /* RUMNCSScreen3ViewController.swift */,
 			);
 			path = NavigationControllerAutoInstrumentation;
+			sourceTree = "<group>";
+		};
+		61FC5F3325CC187D006BB4DE /* CrashContext */ = {
+			isa = PBXGroup;
+			children = (
+				61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */,
+			);
+			path = CrashContext;
 			sourceTree = "<group>";
 		};
 		61FF281F24B89807000B3D9B /* RUMEvent */ = {
@@ -3110,6 +3135,7 @@
 				61E909ED24A24DD3005EA2DE /* OTSpan.swift in Sources */,
 				61133BDE2423979B00786299 /* CompilationConditions.swift in Sources */,
 				61FF9A4525AC5DEA001058CC /* RUMViewIdentity.swift in Sources */,
+				616124A725CAC268009901BE /* CrashContextProvider.swift in Sources */,
 				61E909F324A24DD3005EA2DE /* OTSpanContext.swift in Sources */,
 				61E909F024A24DD3005EA2DE /* OTTracer.swift in Sources */,
 				61E909F124A24DD3005EA2DE /* OTReference.swift in Sources */,
@@ -3207,6 +3233,7 @@
 				61133BD32423979B00786299 /* File.swift in Sources */,
 				61DE333625C8278A008E3EC2 /* DDCrashReportingPluginType.swift in Sources */,
 				6112B10225C83D4E00B37771 /* CrashReportingWithLoggingIntegration.swift in Sources */,
+				6161249E25CAB340009901BE /* CrashContext.swift in Sources */,
 				61D447E224917F8F00649287 /* DateFormatting.swift in Sources */,
 				61133BE72423979B00786299 /* LogUtilityOutputs.swift in Sources */,
 				61133BDA2423979B00786299 /* HTTPHeaders.swift in Sources */,
@@ -3322,6 +3349,7 @@
 				61133C5C2423990D00786299 /* DataUploadWorkerTests.swift in Sources */,
 				616B6684259CAE3300968EE8 /* DDGlobalTests.swift in Sources */,
 				61E909F624A32D1C005EA2DE /* GlobalTests.swift in Sources */,
+				61FC5F3525CC1898006BB4DE /* CrashContextProviderTests.swift in Sources */,
 				9E58E8E324615EDA008E5063 /* JSONEncoderTests.swift in Sources */,
 				61133C692423990D00786299 /* LogFileOutputTests.swift in Sources */,
 				618715F724DC0CDE00FC0F69 /* RUMCommandTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -396,6 +396,8 @@
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		61FC5F3525CC1898006BB4DE /* CrashContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */; };
+		61FC5F4525CC23C9006BB4DE /* RUMWithCrashContextIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F4425CC23C9006BB4DE /* RUMWithCrashContextIntegration.swift */; };
+		61FC5F4E25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F4D25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift */; };
 		61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */; };
 		61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */; };
 		61FF282424B8A1C3000B3D9B /* RUMEventFileOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282324B8A1C3000B3D9B /* RUMEventFileOutput.swift */; };
@@ -904,6 +906,8 @@
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextProviderTests.swift; sourceTree = "<group>"; };
+		61FC5F4425CC23C9006BB4DE /* RUMWithCrashContextIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMWithCrashContextIntegration.swift; sourceTree = "<group>"; };
+		61FC5F4D25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMWithCrashContextIntegrationTests.swift; sourceTree = "<group>"; };
 		61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilder.swift; sourceTree = "<group>"; };
 		61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilderTests.swift; sourceTree = "<group>"; };
 		61FF282324B8A1C3000B3D9B /* RUMEventFileOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutput.swift; sourceTree = "<group>"; };
@@ -1569,6 +1573,7 @@
 				6156CB9724DEFD44008CB2B2 /* LoggingWithRUMIntegration.swift */,
 				6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */,
 				6156CB9B24E18224008CB2B2 /* TracingWithRUMIntegration.swift */,
+				61FC5F4425CC23C9006BB4DE /* RUMWithCrashContextIntegration.swift */,
 				E13A880B257922EC004FB174 /* EnvironmentSpanIntegration.swift */,
 				6112B11C25C84E7F00B37771 /* CrashReporting */,
 			);
@@ -1581,6 +1586,7 @@
 				61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */,
 				61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */,
 				61DE6B1525066973004EFCB3 /* TracingWithRUMErrorsIntegrationTests.swift */,
+				61FC5F4D25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift */,
 			);
 			path = FeaturesIntegration;
 			sourceTree = "<group>";
@@ -3132,6 +3138,7 @@
 				6112B10B25C849C000B37771 /* CrashReportingWithRUMIntegration.swift in Sources */,
 				61E917D12465423600E6C631 /* TracerConfiguration.swift in Sources */,
 				61C576C6256E65BD00295F7C /* DateCorrector.swift in Sources */,
+				61FC5F4525CC23C9006BB4DE /* RUMWithCrashContextIntegration.swift in Sources */,
 				61E909ED24A24DD3005EA2DE /* OTSpan.swift in Sources */,
 				61133BDE2423979B00786299 /* CompilationConditions.swift in Sources */,
 				61FF9A4525AC5DEA001058CC /* RUMViewIdentity.swift in Sources */,
@@ -3293,6 +3300,7 @@
 				61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61C2C20924C0C75500C0321C /* RUMSessionScopeTests.swift in Sources */,
 				61E45ED12451A8730061DAC7 /* SpanMatcher.swift in Sources */,
+				61FC5F4E25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift in Sources */,
 				61C36470243B5C8300C4D4E6 /* ServerMock.swift in Sources */,
 				6198D27124C6E3B700493501 /* RUMViewScopeTests.swift in Sources */,
 				61EF78C1257F842000EDCCB3 /* FeatureTests.swift in Sources */,

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
@@ -26,6 +26,8 @@ final class CrashReportingCollectOrSendScenario: TestScenario {
     }
 
     func configureSDK(builder: Datadog.Configuration.Builder) {
-        _ = builder.enableCrashReporting(using: DDCrashReportingPlugin())
+        _ = builder
+            .trackUIKitRUMViews()
+            .enableCrashReporting(using: DDCrashReportingPlugin())
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
@@ -1,0 +1,47 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Describes current Datadog SDK context, so the app state information can be attached to
+/// the crash report and retrieved back when the application is started again.
+///
+/// Note: as it gets saved along with the crash report during process interruption, it's good
+/// to keep this data well-packed and as small as possible.
+internal struct CrashContext: Codable {
+    /// Codable representation of the public `TrackingConsent`.
+    /// Uses `Int8` for optimized packing.
+    enum TrackingConsent: Int8, Codable {
+        case granted
+        case notGranted
+        case pending
+    }
+
+    /// Last value of `TrackingConsent`.
+    var lastTrackingConsent: TrackingConsent
+    /// Last RUM View event.
+    var lastRUMViewEvent: RUMViewEvent?
+
+    // TODO: RUMM-1049 Add Codable version of `UserInfo?`, `NetworkInfo?` and `CarrierInfo?`
+
+    enum CodingKeys: String, CodingKey {
+        case lastTrackingConsent = "ltc"
+        case lastRUMViewEvent = "lre"
+    }
+}
+
+// MARK: - Helpers
+
+extension CrashContext.TrackingConsent {
+    /// Maps `public TrackingConsent` to `CrashContext.TrackingConsent`.
+    init(trackingConsent: TrackingConsent) {
+        switch trackingConsent {
+        case .granted: self = .granted
+        case .notGranted: self = .notGranted
+        case .pending: self = .pending
+        }
+    }
+}

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// An interface for writing  the `CrashContext`
+/// An interface for writing and reading  the `CrashContext`
 internal protocol CrashContextProviderType: class {
     /// Returns current `CrashContext` value.
     var currentCrashContext: CrashContext { get }

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -1,0 +1,69 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// An interface for writing  the `CrashContext`
+internal protocol CrashContextProviderType: class {
+    /// Returns current `CrashContext` value.
+    var currentCrashContext: CrashContext { get }
+    /// Notifies on current `CrashContext` change.
+    var onCrashContextChange: ((CrashContext) -> Void)? { set get }
+
+    /// Updates the `CrashContext` with last `RUMViewEvent` information.
+    func update(lastRUMViewEvent: RUMViewEvent)
+
+    /// Updates the `CrashContext` with last `TarckingConsent` information.
+    func update(lastTrackingConsent: TrackingConsent)
+}
+
+/// Manages the `CrashContext` reads and writes in a thread-safe manner.
+internal class CrashContextProvider: CrashContextProviderType {
+    /// Queue for synchronizing internal operations.
+    private let queue: DispatchQueue
+    /// Unsychronized `CrashContext`. The `queue` must be used to synchronize its mutation.
+    private var unsafeCrashContext: CrashContext {
+        willSet { onCrashContextChange?(newValue) }
+    }
+
+    // MARK: - Initializer
+
+    init(consentProvider: ConsentProvider) {
+        self.queue = DispatchQueue(
+            label: "com.datadoghq.crash-context",
+            target: .global(qos: .utility)
+        )
+        self.unsafeCrashContext = CrashContext(
+            lastTrackingConsent: .init(trackingConsent: consentProvider.currentValue),
+            lastRUMViewEvent: nil
+        )
+    }
+
+    // MARK: - CrashContextProviderType
+
+    var currentCrashContext: CrashContext {
+        queue.sync { unsafeCrashContext }
+    }
+
+    var onCrashContextChange: ((CrashContext) -> Void)? = nil
+
+    func update(lastRUMViewEvent: RUMViewEvent) {
+        queue.async { [unowned self] in
+            var context = self.unsafeCrashContext
+            context.lastRUMViewEvent = lastRUMViewEvent
+            self.unsafeCrashContext = context
+        }
+    }
+
+    /// Updates `CrashContext` with last `TarckingConsent` information.
+    func update(lastTrackingConsent: TrackingConsent) {
+        queue.async { [unowned self] in
+            var context = self.unsafeCrashContext
+            context.lastTrackingConsent = .init(trackingConsent: lastTrackingConsent)
+            self.unsafeCrashContext = context
+        }
+    }
+}

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -7,47 +7,131 @@
 import Foundation
 
 internal class CrashReporter {
+    /// Queue for synchronizing internal operations.
+    private let queue: DispatchQueue
+
     /// An interface for accessing the `DDCrashReportingPlugin` from `DatadogCrashReporting`.
     let plugin: DDCrashReportingPluginType
-    /// Integration enabling sending crash reports as Logs. `nil` if the Logging feature is disabled.
-    let loggingIntegration: CrashReportingIntegration?
-    /// Integration enabling sending crash reports as RUM Errors. `nil` if the RUM feature is disabled.
-    let rumIntegration: CrashReportingIntegration?
+    /// Integration enabling sending crash reports as Logs or RUM Errors.
+    let loggingOrRUMIntegration: CrashReportingIntegration
 
-    init(
-        crashReportingFeature: CrashReportingFeature,
-        loggingIntegration: CrashReportingIntegration?,
-        rumIntegration: CrashReportingIntegration?
-    ) {
-        self.plugin = crashReportingFeature.configuration.crashReportingPlugin
-        self.loggingIntegration = loggingIntegration
-        self.rumIntegration = rumIntegration
+    let crashContextProvider: CrashContextProviderType
+
+    // MARK: - Initialization
+
+    convenience init?(crashReportingFeature: CrashReportingFeature) {
+        let loggingOrRUMIntegration: CrashReportingIntegration?
+
+        // If RUM rum is enabled prefer it for sending crash reports, otherwise use Logging feature.
+        if let rumFeature = RUMFeature.instance {
+            loggingOrRUMIntegration = CrashReportingWithRUMIntegration(rumFeature: rumFeature)
+        } else if let loggingFeature = LoggingFeature.instance {
+            loggingOrRUMIntegration = CrashReportingWithLoggingIntegration(loggingFeature: loggingFeature)
+        } else {
+            loggingOrRUMIntegration = nil
+        }
+
+        guard let availableLoggingOrRUMIntegration = loggingOrRUMIntegration else {
+            // This case is not reachable in higher abstraction but we add sanity warning.
+            userLogger.error(
+                """
+                In order to use Crash Reporting, RUM or Logging feature must be enabled.
+                Make sure `.enableRUM(true)` or `.enableLogging(true)` are configured
+                when initializing Datadog SDK.
+                """
+            )
+            return nil
+        }
+
+        self.init(
+            crashReportingPlugin: crashReportingFeature.configuration.crashReportingPlugin,
+            crashContextProvider: CrashContextProvider(
+                consentProvider: crashReportingFeature.consentProvider
+            ),
+            loggingOrRUMIntegration: availableLoggingOrRUMIntegration
+        )
     }
 
-    func sendCrashReportIfFound() {
-        let loggingIntegration = self.loggingIntegration
-        let rumIntegration = self.rumIntegration
+    init(
+        crashReportingPlugin: DDCrashReportingPluginType,
+        crashContextProvider: CrashContextProviderType,
+        loggingOrRUMIntegration: CrashReportingIntegration
+    ) {
+        self.queue = DispatchQueue(
+            label: "com.datadoghq.crash-reporter",
+            target: .global(qos: .utility)
+        )
+        self.plugin = crashReportingPlugin
+        self.loggingOrRUMIntegration = loggingOrRUMIntegration
+        self.crashContextProvider = crashContextProvider
 
-        plugin.readPendingCrashReport { crashReport in
-            if let availableCrashReport = crashReport {
-                if let enabledRUMIntegration = rumIntegration {
-                    enabledRUMIntegration.send(crashReport: availableCrashReport)
-                    return true
-                } else if let enabledLoggingIntegration = loggingIntegration {
-                    enabledLoggingIntegration.send(crashReport: availableCrashReport)
-                    return true
-                } else {
-                    userLogger.warn(
-                        """
-                        Pending crash report was found, but it cannot be send as both Logging and RUM features
-                        are disabled. Make sure `.enableRUM(true)` or `.enableLogging(true)` are configured
-                        when initializind Datadog SDK.
-                        """
-                    )
+        // Inject current `CrashContext`
+        self.inject(currentCrashContext: crashContextProvider.currentCrashContext)
+
+        // Register for future `CrashContext` changes
+        self.crashContextProvider.onCrashContextChange = { [unowned self] newCrashContext in
+            self.inject(currentCrashContext: newCrashContext)
+        }
+    }
+
+    // MARK: - Interaction with `DatadogCrashReporting` plugin
+
+    func sendCrashReportIfFound() {
+        queue.async {
+            self.plugin.readPendingCrashReport { [unowned self] crashReport in
+                guard let availableCrashReport = crashReport else {
                     return false
                 }
+
+                let crashContext = crashReport?.context.flatMap { self.decode(crashContextData: $0) }
+                self.loggingOrRUMIntegration.send(crashReport: availableCrashReport, with: crashContext)
+                return true
             }
-            return false
+        }
+    }
+
+    private func inject(currentCrashContext: CrashContext) {
+        queue.async {
+            if let crashContextData = self.encode(crashContext: currentCrashContext) {
+                self.plugin.inject(context: crashContextData)
+            }
+        }
+    }
+
+    // MARK: - CrashContext Encoding and Decoding
+
+    private let crashContextEncoder = JSONEncoder()
+    private let crashContextDecoder = JSONDecoder()
+
+    private func encode(crashContext: CrashContext) -> Data? {
+        do {
+            return try crashContextEncoder.encode(crashContext)
+        } catch {
+            userLogger.warn(
+                """
+                Failed to encode crash report context. The app state information associated with eventual crash
+                report may be not in sync with the current state of the application.
+
+                Error details: \(error)
+                """
+            )
+            return nil
+        }
+    }
+
+    private func decode(crashContextData: Data) -> CrashContext? {
+        do {
+            return try crashContextDecoder.decode(CrashContext.self, from: crashContextData)
+        } catch {
+            userLogger.error(
+                """
+                Failed to decode crash report context. The app state information associated with the crash
+                report won't be in sync with the state of the application when it crashed.
+
+                Error details: \(error)
+                """
+            )
+            return nil
         }
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -69,7 +69,10 @@ internal class CrashReporter {
         self.inject(currentCrashContext: crashContextProvider.currentCrashContext)
 
         // Register for future `CrashContext` changes
-        self.crashContextProvider.onCrashContextChange = { [unowned self] newCrashContext in
+        self.crashContextProvider.onCrashContextChange = { [weak self] newCrashContext in
+            guard let self = self else {
+                return
+            }
             self.inject(currentCrashContext: newCrashContext)
         }
     }
@@ -78,8 +81,8 @@ internal class CrashReporter {
 
     func sendCrashReportIfFound() {
         queue.async {
-            self.plugin.readPendingCrashReport { [unowned self] crashReport in
-                guard let availableCrashReport = crashReport else {
+            self.plugin.readPendingCrashReport { [weak self] crashReport in
+                guard let self = self, let availableCrashReport = crashReport else {
                     return false
                 }
 

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -18,9 +18,18 @@ internal final class CrashReportingFeature {
 
     let configuration: FeaturesConfiguration.CrashReporting
 
-    // TODO: RUMM-960 / RUMM-1050 Bundle dependencies required for sending Crash Reports to Datadog
+    // MARK: - Dependencies
 
-    init(configuration: FeaturesConfiguration.CrashReporting) {
+    let consentProvider: ConsentProvider
+
+    // TODO: RUMM-1049 Bundle `UserInfoProvider`, `NetworkInfoProvider` and `CarrierInfoProvider`
+    // for enriching the `CrashContext`
+
+    init(
+        configuration: FeaturesConfiguration.CrashReporting,
+        commonDependencies: FeaturesCommonDependencies
+    ) {
         self.configuration = configuration
+        self.consentProvider = commonDependencies.consentProvider
     }
 }

--- a/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
+++ b/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
@@ -19,29 +19,45 @@ public class DDCrashReport: NSObject {
     internal let signalDetails: String?
     // TODO: RUMM-1053 - consider providing / formatting this characteristic of the crash report
     internal let stackTrace: String?
+    /// The last context injected through `inject(context:)`
+    internal let context: Data?
 
     public init(
         crashDate: Date?,
         signalCode: String?,
         signalName: String?,
         signalDetails: String?,
-        stackTrace: String?
+        stackTrace: String?,
+        context: Data?
     ) {
         self.crashDate = crashDate
         self.signalCode = signalCode
         self.signalName = signalName
         self.signalDetails = signalDetails
         self.stackTrace = stackTrace
+        self.context = context
     }
 }
 
 /// An interface for enabling crash reporting feature in Datadog SDK.
 /// It is implemented by `DDCrashReportingPlugin` from `DatadogCrashReporting` framework.
+///
+/// The SDK calls each API on a background thread and succeeding calls are synchronized.
 @objc
 public protocol DDCrashReportingPluginType: class {
     /// Reads unprocessed crash report if available.
     /// - Parameter completion: the completion block called with the value of `DDCrashReport` if a crash report is available
     /// or with `nil` otherwise. The value returned by the receiver should indicate if the crash report was processed correctly (`true`)
     /// or something went wrong (`false)`. Depending on the returned value, the crash report will be purged or perserved for future read.
+    ///
+    /// The SDK calls this method on a background thread. The implementation is free to choice any thread
+    /// for executing the  `completion`.
     func readPendingCrashReport(completion: (DDCrashReport?) -> Bool)
+
+    /// Injects custom data for describing the application state in the crash report.
+    /// This data will be attached to produced crash report and will be available in `DDCrashReport`.
+    ///
+    /// The SDK calls this method for each significant application state change.
+    /// It is called on a background thread and succeeding calls are synchronized.
+    func inject(context: Data)
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -226,7 +226,8 @@ public class Datadog {
 
         if let crashReportingConfiguration = configuration.crashReporting {
             crashReporting = CrashReportingFeature(
-                configuration: crashReportingConfiguration
+                configuration: crashReportingConfiguration,
+                commonDependencies: commonDependencies
             )
         }
 
@@ -258,13 +259,7 @@ public class Datadog {
         // After everything is set up, if the Crash Reporting feature was enabled,
         // register crash reporter and send crash report if available:
         if let crashReportingFeature = CrashReportingFeature.instance {
-            Global.crashReporter = CrashReporter(
-                crashReportingFeature: crashReportingFeature,
-                loggingIntegration: LoggingFeature.instance
-                    .flatMap { CrashReportingWithLoggingIntegration(loggingFeature: $0) },
-                rumIntegration: RUMFeature.instance
-                    .flatMap { CrashReportingWithRUMIntegration(rumFeature: $0) }
-            )
+            Global.crashReporter = CrashReporter(crashReportingFeature: crashReportingFeature)
             Global.crashReporter?.sendCrashReportIfFound()
         }
     }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingIntegration.swift
@@ -6,5 +6,5 @@
 
 /// An integration for sending crash reports to Datadog.
 internal protocol CrashReportingIntegration {
-    func send(crashReport: DDCrashReport)
+    func send(crashReport: DDCrashReport, with crashContext: CrashContext?)
 }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
@@ -10,13 +10,14 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
         // TODO: RUMM-1050 Create `LogOutput`
     }
 
-    func send(crashReport: DDCrashReport) {
+    func send(crashReport: DDCrashReport, with crashContext: CrashContext?) {
         // TODO: RUMM-1050 Send crash report as Log
         // by writting it to the `LogOutput`
         print(
             """
             🍿 Sending Crash Report using Logging integration
             🔥 \(crashReport.signalName ?? "") [\(crashReport.signalDetails ?? "")]
+            🔎 crash context: \(String(describing: crashContext))
             """
         )
     }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -10,13 +10,14 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         // TODO: RUMM-960 Create `RUMEventOutput`
     }
 
-    func send(crashReport: DDCrashReport) {
+    func send(crashReport: DDCrashReport, with crashContext: CrashContext?) {
         // TODO: RUMM-960 Send crash report as RUM Errors (followed by RUM View update)
         // by writting it to the `RUMEventOutput`
         print(
             """
             🍿 Sending Crash Report using RUM integration
             🔥 \(crashReport.signalName ?? "") [\(crashReport.signalDetails ?? "")]
+            🔎 crash context: \(String(describing: crashContext))
             """
         )
     }

--- a/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Updates `CrashContext` passed to crash reporter with the last `RUMViewEvent`.
+/// When the app restarts after crash, this event is used to create and send `RUMErrorEvent` describing the crash.
+internal struct RUMWithCrashContextIntegration {
+    private weak var crashContextProvider: CrashContextProviderType?
+
+    init?() {
+        if let crashContextProvider = Global.crashReporter?.crashContextProvider {
+            self.init(crashContextProvider: crashContextProvider)
+        } else {
+            return nil
+        }
+    }
+
+    init(crashContextProvider: CrashContextProviderType) {
+        self.crashContextProvider = crashContextProvider
+    }
+
+    func update(lastRUMViewEvent: RUMViewEvent) {
+        crashContextProvider?.update(lastRUMViewEvent: lastRUMViewEvent)
+    }
+}

--- a/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Updates `CrashContext` passed to crash reporter with the last `RUMViewEvent`.
 /// When the app restarts after crash, this event is used to create and send `RUMErrorEvent` describing the crash.
+///
+/// This integration isolates the direct link between RUM and Crash Reporting.
 internal struct RUMWithCrashContextIntegration {
     private weak var crashContextProvider: CrashContextProviderType?
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -52,6 +52,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     /// Current version of this View to use for RUM `documentVersion`.
     private var version: UInt = 0
 
+    /// Integration with Crash Reporting. It updates the context of crash reporter with last `RUMViewEvent` information.
+    /// `nil` if Crash Reporting feature is not enabled.
+    private let crashContextIntegration: RUMWithCrashContextIntegration?
+
     init(
         parent: RUMContextProvider,
         dependencies: RUMScopeDependencies,
@@ -70,6 +74,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         self.viewURI = uri
         self.viewStartTime = startTime
         self.dateCorrection = dependencies.dateCorrector.currentCorrection
+        self.crashContextIntegration = RUMWithCrashContextIntegration()
     }
 
     // MARK: - RUMContextProvider
@@ -289,6 +294,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 url: viewURI
             )
         )
+
+        Global.crashReporter?.crashContextProvider.update(lastRUMViewEvent: eventData)
 
         let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes, customTimings: customTimings)
         dependencies.eventOutput.write(rumEvent: event)

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -295,7 +295,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             )
         )
 
-        Global.crashReporter?.crashContextProvider.update(lastRUMViewEvent: eventData)
+        crashContextIntegration?.update(lastRUMViewEvent: eventData)
 
         let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes, customTimings: customTimings)
         dependencies.eventOutput.write(rumEvent: event)

--- a/Sources/DatadogCrashReporting/DDCrashReportingPlugin.swift
+++ b/Sources/DatadogCrashReporting/DDCrashReportingPlugin.swift
@@ -54,6 +54,10 @@ public class DDCrashReportingPlugin: NSObject, DDCrashReportingPluginType {
             consolePrint("🔥 DatadogCrashReporting error: failed to load crash report: \(error)")
         }
     }
+
+    public func inject(context: Data) {
+        DDCrashReportingPlugin.thirdPartyCrashReporter?.inject(context: context)
+    }
 }
 
 // MARK: - Utils

--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -29,6 +29,10 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
         return try ddCrashReport(from: plCrashReportData)
     }
 
+    func inject(context: Data) {
+        crashReporter.customData = context
+    }
+
     func purgePendingCrashReport() throws {
         try crashReporter.purgePendingCrashReportAndReturnError()
     }
@@ -47,7 +51,8 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
             stackTrace: PLCrashReportTextFormatter.stringValue(
                 for: plCrashReport,
                 with: PLCrashReportTextFormatiOS
-            )
+            ),
+            context: plCrashReport.customData
         )
     }
 

--- a/Sources/DatadogCrashReporting/ThirdPartyCrashReporter.swift
+++ b/Sources/DatadogCrashReporting/ThirdPartyCrashReporter.swift
@@ -18,6 +18,9 @@ internal protocol ThirdPartyCrashReporter {
     /// Loads pending crash report.
     func loadPendingCrashReport() throws -> DDCrashReport
 
+    /// Injects custom `context` to the crash reporter so it will be attached to the `DDCrashReport`.
+    func inject(context: Data)
+
     /// Deletes the available crash report.
     func purgePendingCrashReport() throws
 }

--- a/Tests/DatadogCrashReportingTests/DDCrashReportingPluginTests.swift
+++ b/Tests/DatadogCrashReportingTests/DDCrashReportingPluginTests.swift
@@ -82,6 +82,19 @@ class DDCrashReportingPluginTests: XCTestCase {
         waitForExpectations(timeout: 0.5, handler: nil)
     }
 
+    // MARK: - Injecting Crash Context
+
+    func testItForwardsCrashContextToCrashReporter() throws {
+        let crashReporter = try ThirdPartyCrashReporterMock()
+        let plugin = DDCrashReportingPlugin { crashReporter }
+        defer { DDCrashReportingPlugin.thirdPartyCrashReporter = nil }
+
+        let context = "some context".data(using: .utf8)!
+        plugin.inject(context: context)
+
+        XCTAssertEqual(crashReporter.injectedContext, context)
+    }
+
     // MARK: - Handling Errors
 
     func testGivenPendingCrashReport_whenItsLoadingFails_itPrintsError() throws {

--- a/Tests/DatadogCrashReportingTests/Mocks.swift
+++ b/Tests/DatadogCrashReportingTests/Mocks.swift
@@ -13,6 +13,8 @@ internal class ThirdPartyCrashReporterMock: ThirdPartyCrashReporter {
     var pendingCrashReport: DDCrashReport?
     var pendingCrashReportError: Error?
 
+    var injectedContext: Data?
+
     var hasPurgedPendingCrashReport = false
     var hasPurgedPendingCrashReportError: Error?
 
@@ -33,6 +35,10 @@ internal class ThirdPartyCrashReporterMock: ThirdPartyCrashReporter {
         return pendingCrashReport!
     }
 
+    func inject(context: Data) {
+        injectedContext = context
+    }
+
     func purgePendingCrashReport() throws {
         if let error = hasPurgedPendingCrashReportError {
             throw error
@@ -48,7 +54,8 @@ internal extension DDCrashReport {
             signalCode: "any signal",
             signalName: "any name",
             signalDetails: "any details",
-            stackTrace: "any stack trace"
+            stackTrace: "any stack trace",
+            context: "any context".data(using: .utf8)
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
@@ -73,7 +73,7 @@ class FeatureStorageTests: XCTestCase {
     /// Returns random consent value other than the given one.
     private func randomConsent(otherThan consent: TrackingConsent? = nil) -> TrackingConsent {
         while true {
-            let randomConsent: TrackingConsent = [.granted, .pending, .notGranted].randomElement()!
+            let randomConsent: TrackingConsent = .mockRandom()
             if randomConsent != consent {
                 return randomConsent
             }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writting/ConsentAwareDataWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writting/ConsentAwareDataWriterTests.swift
@@ -158,7 +158,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
         XCTAssertEqual(try directories.unauthorized.files().count, 10)
 
         // When
-        let initialConsent: TrackingConsent = [.granted, .pending, .notGranted].randomElement()!
+        let initialConsent: TrackingConsent = .mockRandom()
         _ = ConsentAwareDataWriter(
             consentProvider: ConsentProvider(initialConsent: initialConsent),
             readWriteQueue: queue,
@@ -251,11 +251,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
     // MARK: - Thread Safety
 
     func testChangingConsentAndCallingWriterFromDifferentThreadsShouldNotCrash() {
-        func randomConsent() -> TrackingConsent {
-            return [.granted, .pending, .notGranted].randomElement()!
-        }
-
-        let consentProvider = ConsentProvider(initialConsent: randomConsent())
+        let consentProvider = ConsentProvider(initialConsent: .mockRandom())
         let writer = ConsentAwareDataWriter(
             consentProvider: consentProvider,
             readWriteQueue: queue,
@@ -265,7 +261,7 @@ class ConsentAwareDataWriterTests: XCTestCase {
 
         DispatchQueue.concurrentPerform(iterations: 10_000) { iteration in
             if iteration % 2 == 0 {
-                consentProvider.changeConsent(to: randomConsent())
+                consentProvider.changeConsent(to: .mockRandom())
             } else {
                 writer.write(value: "data \(iteration)")
             }

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -1,0 +1,67 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class CrashContextProviderTests: XCTestCase {
+    func testWhenInitialized_itProvidesInitialContext() {
+        let initialTrackingConsent: TrackingConsent = .mockRandom()
+
+        // When
+        let provider = CrashContextProvider(
+            consentProvider: .init(initialConsent: initialTrackingConsent)
+        )
+
+        // Then
+        XCTAssertEqual(
+            provider.currentCrashContext.lastTrackingConsent,
+            .init(trackingConsent: initialTrackingConsent)
+        )
+        XCTAssertNil(provider.currentCrashContext.lastRUMViewEvent)
+    }
+
+    func testWhenRUMViewChanges_itNotifiesNewContext() {
+        let expectation = self.expectation(description: "Notify new crash context value")
+        let randomRUMView: RUMViewEvent = .mockRandom()
+        let provider = CrashContextProvider(
+            consentProvider: .init(initialConsent: .mockRandom())
+        )
+        provider.onCrashContextChange = { newContext in
+            XCTAssertEqual(newContext.lastRUMViewEvent, randomRUMView)
+            expectation.fulfill()
+        }
+
+        // When
+        provider.update(lastRUMViewEvent: randomRUMView)
+
+        // Then
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(provider.currentCrashContext.lastRUMViewEvent, randomRUMView)
+    }
+
+    func testWhenTrackingConsentChanges_itNotifiesNewContext() {
+        let expectation = self.expectation(description: "Notify new crash context value")
+        let randomTrackingConsent: TrackingConsent = .mockRandom()
+        let provider = CrashContextProvider(
+            consentProvider: .init(initialConsent: .mockRandom())
+        )
+        provider.onCrashContextChange = { newContext in
+            XCTAssertEqual(newContext.lastTrackingConsent, .init(trackingConsent: randomTrackingConsent))
+            expectation.fulfill()
+        }
+
+        // When
+        provider.update(lastTrackingConsent: randomTrackingConsent)
+
+        // Then
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(
+            provider.currentCrashContext.lastTrackingConsent,
+            .init(trackingConsent: randomTrackingConsent)
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -7,7 +7,7 @@
 import XCTest
 @testable import Datadog
 
-/// This suite tests if `CrashContextProvider` gets updated by different SDK componetns, each delivering
+/// This suite tests if `CrashContextProvider` gets updated by different SDK components, each delivering
 /// separate part of the `CrashContext` information.
 ///
 /// Individual tests should not rely directly on `update(_:)` methods of the `CrashContextProvider`.

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMWithCrashContextIntegrationTests: XCTestCase {
+    func testWhenCrashReporterIsRegistered_itUpdatesCrashContextWithLastRUMView() throws {
+        let crashContextProvider = CrashContextProvider(
+            consentProvider: .mockAny()
+        )
+
+        // When
+        Global.crashReporter = CrashReporter(
+            crashReportingPlugin: CrashReportingPluginMock(),
+            crashContextProvider: crashContextProvider,
+            loggingOrRUMIntegration: CrashReportingIntegrationMock()
+        )
+        defer { Global.crashReporter = nil }
+
+        // Then
+        let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration())
+        let randomRUMView: RUMViewEvent = .mockRandom()
+        rumWithCrashContextIntegration.update(lastRUMViewEvent: randomRUMView)
+
+        XCTAssertEqual(crashContextProvider.currentCrashContext.lastRUMViewEvent, randomRUMView)
+    }
+
+    func testWhenCrashReporterIsNotRegistered_itCannotBeInitialized() {
+        // When
+        XCTAssertNil(Global.crashReporter)
+
+        // Then
+        XCTAssertNil(RUMWithCrashContextIntegration())
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -14,6 +14,12 @@ extension TrackingConsent {
     }
 }
 
+extension ConsentProvider {
+    static func mockAny() -> ConsentProvider {
+        return ConsentProvider(initialConsent: .mockRandom())
+    }
+}
+
 extension Datadog.Configuration {
     static func mockAny() -> Datadog.Configuration { .mockWith() }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -60,13 +60,25 @@ internal class CrashContextProviderMock: CrashContextProviderType {
     private(set) var currentCrashContext: CrashContext
     var onCrashContextChange: ((CrashContext) -> Void)?
 
-    init(initialCrashContext: CrashContext) {
+    init(initialCrashContext: CrashContext = .mockAny()) {
         self.currentCrashContext = initialCrashContext
     }
 
     func update(lastRUMViewEvent: RUMViewEvent) {}
-
     func update(lastTrackingConsent: TrackingConsent) {}
+}
+
+class CrashReportingIntegrationMock: CrashReportingIntegration {
+    var sentCrashReport: DDCrashReport?
+    var sentCrashContext: CrashContext?
+
+    func send(crashReport: DDCrashReport, with crashContext: CrashContext?) {
+        sentCrashReport = crashReport
+        sentCrashContext = crashContext
+        didSendCrashReport?()
+    }
+
+    var didSendCrashReport: (() -> Void)?
 }
 
 extension CrashContext: EquatableInTests {}

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -7,10 +7,22 @@
 @testable import Datadog
 
 extension CrashReportingFeature {
+    /// Mocks the Crash Reporting feature instance which doesn't load crash reports.
+    static func mockNoOp() -> CrashReportingFeature {
+        return CrashReportingFeature(
+            configuration: .mockWith(crashReportingPlugin: NoopCrashReportingPlugin()),
+            commonDependencies: .mockAny()
+        )
+    }
+
     static func mockWith(
-        configuration: FeaturesConfiguration.CrashReporting = .mockAny()
+        configuration: FeaturesConfiguration.CrashReporting = .mockAny(),
+        dependencies: FeaturesCommonDependencies = .mockAny()
     ) -> CrashReportingFeature {
-        return CrashReportingFeature(configuration: configuration)
+        return CrashReportingFeature(
+            configuration: configuration,
+            commonDependencies: dependencies
+        )
     }
 }
 
@@ -19,23 +31,75 @@ internal class CrashReportingPluginMock: DDCrashReportingPluginType {
     var pendingCrashReport: DDCrashReport?
     /// If the plugin was asked to delete the crash report.
     var hasPurgedCrashReport: Bool?
+    /// Custom app state data injected to the plugin.
+    var injectedContextData: Data?
 
     func readPendingCrashReport(completion: (DDCrashReport?) -> Bool) {
         hasPurgedCrashReport = completion(pendingCrashReport)
+        didReadPendingCrashReport?()
+    }
+
+    /// Notifies the `readPendingCrashReport(completion:)` return.
+    var didReadPendingCrashReport: (() -> Void)?
+
+    func inject(context: Data) {
+        injectedContextData = context
+        didInjectContext?()
+    }
+
+    /// Notifies the `inject(context:)` return.
+    var didInjectContext: (() -> Void)?
+}
+
+internal class NoopCrashReportingPlugin: DDCrashReportingPluginType {
+    func readPendingCrashReport(completion: (DDCrashReport?) -> Bool) {}
+    func inject(context: Data) {}
+}
+
+internal class CrashContextProviderMock: CrashContextProviderType {
+    private(set) var currentCrashContext: CrashContext
+    var onCrashContextChange: ((CrashContext) -> Void)?
+
+    init(initialCrashContext: CrashContext) {
+        self.currentCrashContext = initialCrashContext
+    }
+
+    func update(lastRUMViewEvent: RUMViewEvent) {}
+
+    func update(lastTrackingConsent: TrackingConsent) {}
+}
+
+extension CrashContext: EquatableInTests {}
+
+extension CrashContext {
+    static func mockAny() -> CrashContext {
+        return CrashContext(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: nil
+        )
+    }
+
+    static func mockRandom() -> CrashContext {
+        return CrashContext(
+            lastTrackingConsent: .mockRandom(),
+            lastRUMViewEvent: .mockRandom()
+        )
+    }
+
+    var data: Data { try! JSONEncoder().encode(self) }
+}
+
+internal extension CrashContext.TrackingConsent {
+    static func mockRandom() -> CrashContext.TrackingConsent {
+        return CrashContext.TrackingConsent(trackingConsent: .mockRandom())
     }
 }
 
 extension DDCrashReport: EquatableInTests {}
 
 internal extension DDCrashReport {
-    static func mockRandom() -> DDCrashReport {
-        return mockWith(
-            crashDate: .mockRandomInThePast(),
-            signalCode: .mockRandom(),
-            signalName: .mockRandom(),
-            signalDetails: .mockRandom(),
-            stackTrace: .mockRandom()
-        )
+    static func mockAny() -> DDCrashReport {
+        return .mockWith()
     }
 
     static func mockWith(
@@ -43,14 +107,27 @@ internal extension DDCrashReport {
         signalCode: String? = .mockAny(),
         signalName: String? = .mockAny(),
         signalDetails: String? = .mockAny(),
-        stackTrace: String? = .mockAny()
+        stackTrace: String? = .mockAny(),
+        context: Data? = .mockAny()
     ) -> DDCrashReport {
         return DDCrashReport(
             crashDate: crashDate,
             signalCode: signalCode,
             signalName: signalName,
             signalDetails: signalDetails,
-            stackTrace: stackTrace
+            stackTrace: stackTrace,
+            context: context
+        )
+    }
+
+    static func mockRandomWith(context: CrashContext) -> DDCrashReport {
+        return mockWith(
+            crashDate: .mockRandomInThePast(),
+            signalCode: .mockRandom(),
+            signalName: .mockRandom(),
+            signalDetails: .mockRandom(),
+            stackTrace: .mockRandom(),
+            context: context.data
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -876,7 +876,7 @@ class RUMMonitorTests: XCTestCase {
 
     // MARK: - Integration with Crash Reporting
 
-    func testGivenRegisteredCrashReporer_whenRUMViewEventIsSend_itIsUpdatedInCurrentCrashContext() throws {
+    func testGivenRegisteredCrashReporter_whenRUMViewEventIsSend_itIsUpdatedInCurrentCrashContext() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance = nil }
 

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -83,6 +83,7 @@ class DDConfigurationTests: XCTestCase {
 
         class CrashReportingPluginMock: NSObject, DDCrashReportingPluginType {
             func readPendingCrashReport(completion: (DDCrashReport?) -> Bool) {}
+            func inject(context: Data) {}
         }
 
         let crashReportingPlugin = CrashReportingPluginMock()


### PR DESCRIPTION
### What and why?

🚚 This PR implements injection of a last `RUMViewEvent` and current `TrackingConsent` values to crash reporter, so they can be retrieved when the app restarts after crash.

Those values are necessary for:
* considering if the crash report can be send regarding the user tracking policy,
* sending the crash report as a `RUMErrorEvent` associated with the RUM session identifier from the crashed session.

### How?

`CrashContext` structure was introduced for bundling SDK state values. For now it has only two properties:
```swift
struct CrashContext: Codable {
    /// Last value of `TrackingConsent`.
    var lastTrackingConsent: TrackingConsent
    /// Last RUM View event.
    var lastRUMViewEvent: RUMViewEvent?
}
```
More will be added in `RUMM-1049` (including User Info, Network Info and Carrier Info).

The `CrashContext` value is constructed in `Datadog` SDK and passed to the `DatadogCrashReporting` through `DDCrashReportingPluginType` (plugin) interface. Raw `Data` is used as the transfer object to limit the dependency on SDK.

`CrashContext` value is managed by the `CrashContextProvider` object. It's role is to receive partial updates to the context from different SDK components and notify the plugin with the new context on each change:
* updates for the `lastTrackingConsent` come from the subscription to existing `ConsentProvider`;
* updates for the `lastRUMViewEvent` come from the `RUMViewScope` (through `RUMWithCrashContextIntegration` type to not make the `RUM` module depend directly on the `CrashReporting`).

Architecture wrap-up:

<img width="1351" alt="Screenshot 2021-02-04 at 16 39 08" src="https://user-images.githubusercontent.com/2358722/106917715-d1ab5d00-6708-11eb-8d52-2e4bef10e3ff.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
