### PR TITLE
Swift Package Manager - Add static library variants to allow use inside frameworks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,14 @@ let package = Package(
             name: "DatadogObjc",
             type: .dynamic,
             targets: ["DatadogObjc"]),
+        .library(
+            name: "DatadogStatic",
+            type: .static,
+            targets: ["Datadog"]),
+        .library(
+            name: "DatadogStaticObjc",
+            type: .static,
+            targets: ["DatadogObjc"]),
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION

### What and why?

Datadog cannot be added to a Framework via SPM due to the `dynamic` property being setting in `Package.swift`

When adding Datadog using SPM as a package to a framework, the `type: .dynamic` property causes Xcode to insist on embedding the Datadog inside the framework. The Embed Framework step is automatically created and removing, causes Datadog to be removed from the project. 

Note that with LaunchDarkly, the package only appears in `Link Binary with Libraries` as desired. 

Debug builds of the project will build and run fine. However, archiving and uploading to TestFlight will succeed but the archive produced is not valid and will crash on launch as the Datadog library is missing

#### Screenshot
<img width="680" alt="image" src="https://user-images.githubusercontent.com/151473/107292501-109d3200-6abe-11eb-907b-61b67952eec3.png">

#### Crash on Launch Log
```Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x0000000000000000, 0x0000000000000000
Exception Note:  EXC_CORPSE_NOTIFY
Termination Description: DYLD, dyld: Using shared cache: F1161374-C3FB-358B-897A-6C2AD68BB0CC | dependent dylib '@rpath/Datadog.framework/Datadog' not found for '/private/var/containers/Bundle/Application/8F88DB89-E6FF-48D8-9F50-52270379FC0C/Deputy.app/Frameworks/DeputyKit.framework/DeputyKit', tried but didn't find: 
'/usr/lib/swift/Datadog.framework/Datadog'
'/private/var/containers/Bundle/Application/8F88DB89-E6FF-48D8-9F50-52270379FC0C/Deputy.app/Frameworks/Datadog.framework/Datadog' 
'/private/var/containers/Bundle/Application/8F88DB89-E6FF-48D8-9F50-52270379FC0C/Deputy.app/Frameworks/DeputyKit.framework/Frameworks/Datadog.framework/Datadog' 
'/Users/distiller/project/app/DerivedData/Build/Intermediates.noindex/ArchiveIntermediates/Deputy/BuildProductsPath/Release-iphoneos/Datadog.framework/Datadog'
'/Users/distiller/project/app/../Carthage/Build/iOS/Datadog.framework/Datadog'
'@rpath/Datadog.framework/Datadog' '/System/Library/Frameworks/Datadog.framework/Datadog'
Highlighted by Thread:  0
```
### How?

Removal of the `type: .dynamic` property allows Xcode to choose the right course of action for the project. 

I am not sure if removing this property will cause issues for other applications but we are currently using ~20 other dependencies via SPM and this is the only one that sets the `dynamic` properly and causes this error. 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
