### PR TITLE
RUMM-960 Send crash report as RUM Error

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */; };
 		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
 		61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */; };
+		6116563B25D2A6C90070EC03 /* ArbitraryDataWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6116563A25D2A6C90070EC03 /* ArbitraryDataWriter.swift */; };
 		611720D52524D9FB00634D9E /* DDURLSessionDelegate+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */; };
 		611EA12D2580F42600BC0E56 /* TrackingConsentScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611EA12C2580F42600BC0E56 /* TrackingConsentScenarios.swift */; };
 		611EA13C2580F77400BC0E56 /* TrackingConsentScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 611EA13B2580F77400BC0E56 /* TrackingConsentScenario.storyboard */; };
@@ -611,6 +612,7 @@
 		61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSViewController.swift; sourceTree = "<group>"; };
 		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
 		61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMModalViewsScenarioTests.swift; sourceTree = "<group>"; };
+		6116563A25D2A6C90070EC03 /* ArbitraryDataWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArbitraryDataWriter.swift; sourceTree = "<group>"; };
 		611720D42524D9FB00634D9E /* DDURLSessionDelegate+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DDURLSessionDelegate+objc.swift"; sourceTree = "<group>"; };
 		611EA12C2580F42600BC0E56 /* TrackingConsentScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingConsentScenarios.swift; sourceTree = "<group>"; };
 		611EA13B2580F77400BC0E56 /* TrackingConsentScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TrackingConsentScenario.storyboard; sourceTree = "<group>"; };
@@ -1737,6 +1739,7 @@
 			children = (
 				613E79272577B0EE00DFCC17 /* Writer.swift */,
 				6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */,
+				6116563A25D2A6C90070EC03 /* ArbitraryDataWriter.swift */,
 				61133BA72423979B00786299 /* FileWriter.swift */,
 				619E16D62577C19F00B2516B /* Processing */,
 			);
@@ -3145,6 +3148,7 @@
 				61E909F324A24DD3005EA2DE /* OTSpanContext.swift in Sources */,
 				61E909F024A24DD3005EA2DE /* OTTracer.swift in Sources */,
 				61E909F124A24DD3005EA2DE /* OTReference.swift in Sources */,
+				6116563B25D2A6C90070EC03 /* ArbitraryDataWriter.swift in Sources */,
 				61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */,
 				61E909EF24A24DD3005EA2DE /* Global.swift in Sources */,
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */; };
 		617CD0DD24CEDDD300B0B557 /* RUMUserActionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */; };
 		617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617CEB382456BC3A00AD4669 /* TracingUUID.swift */; };
+		6182374325D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6182374225D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift */; };
 		618715F724DC0CDE00FC0F69 /* RUMCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */; };
 		618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */; };
 		618715FC24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715FB24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift */; };
@@ -751,6 +752,7 @@
 		617B954124BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMonitorConfigurationTests.swift; sourceTree = "<group>"; };
 		617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScopeTests.swift; sourceTree = "<group>"; };
 		617CEB382456BC3A00AD4669 /* TracingUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUID.swift; sourceTree = "<group>"; };
+		6182374225D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingWithRUMIntegrationTests.swift; sourceTree = "<group>"; };
 		618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommandTests.swift; sourceTree = "<group>"; };
 		618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMapping.swift; sourceTree = "<group>"; };
 		618715FB24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMappingTests.swift; sourceTree = "<group>"; };
@@ -855,7 +857,6 @@
 		61DC6D912539E3E300FFAA22 /* LoggingCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingCommonAsserts.swift; sourceTree = "<group>"; };
 		61DE332525C826E4008E3EC2 /* CrashReportingFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingFeature.swift; sourceTree = "<group>"; };
 		61DE333525C8278A008E3EC2 /* DDCrashReportingPluginType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportingPluginType.swift; sourceTree = "<group>"; };
-		61DE6B1525066973004EFCB3 /* TracingWithRUMErrorsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingWithRUMErrorsIntegrationTests.swift; sourceTree = "<group>"; };
 		61E36A10254B2280001AD6F2 /* LaunchTimeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTimeProvider.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDTests.swift; sourceTree = "<group>"; };
 		61E45BD12450F65B00F2C652 /* SpanBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanBuilderTests.swift; sourceTree = "<group>"; };
@@ -1586,8 +1587,8 @@
 			children = (
 				61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */,
 				61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */,
-				61DE6B1525066973004EFCB3 /* TracingWithRUMErrorsIntegrationTests.swift */,
 				61FC5F4D25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift */,
+				6182374125D3DFB8006A375B /* CrashReporting */,
 			);
 			path = FeaturesIntegration;
 			sourceTree = "<group>";
@@ -2134,6 +2135,14 @@
 				61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */,
 			);
 			path = UUIDs;
+			sourceTree = "<group>";
+		};
+		6182374125D3DFB8006A375B /* CrashReporting */ = {
+			isa = PBXGroup;
+			children = (
+				6182374225D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift */,
+			);
+			path = CrashReporting;
 			sourceTree = "<group>";
 		};
 		618715FA24DC5EE700FC0F69 /* DataModels */ = {
@@ -3339,6 +3348,7 @@
 				61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */,
 				61133C542423990D00786299 /* NetworkConnectionInfoProviderTests.swift in Sources */,
 				616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */,
+				6182374325D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift in Sources */,
 				61B558CF2469561C001460D3 /* LoggerBuilderTests.swift in Sources */,
 				61C1513125ADC68D00362D4B /* DataProcessorTests.swift in Sources */,
 				61133C4A2423990D00786299 /* DDConfigurationTests.swift in Sources */,

--- a/Sources/Datadog/Core/Persistence/Writting/ArbitraryDataWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/ArbitraryDataWriter.swift
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Writes data to single folder, no matter of the value of `TrackingConsent`.
+/// It synchronizes the work of underlying `FileWriter` on given read/write queue.
+internal class ArbitraryDataWriter: Writer {
+    /// Queue used to synchronize reads and writes for the feature.
+    internal let readWriteQueue: DispatchQueue
+    /// Data processor for used to process & write data.
+    private let dataProcessor: DataProcessor
+
+    init(
+        readWriteQueue: DispatchQueue,
+        dataProcessor: DataProcessor
+    ) {
+        self.readWriteQueue = readWriteQueue
+        self.dataProcessor = dataProcessor
+    }
+
+    // MARK: - Writer
+
+    func write<T>(value: T) where T: Encodable {
+        readWriteQueue.async {
+            self.dataProcessor.write(value: value)
+        }
+    }
+}

--- a/Sources/Datadog/Core/Persistence/Writting/ArbitraryDataWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/ArbitraryDataWriter.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Writes data to single folder, no matter of the value of `TrackingConsent`.
+/// Writes data to single folder, regardless of the value of `TrackingConsent`.
 /// It synchronizes the work of underlying `FileWriter` on given read/write queue.
 internal class ArbitraryDataWriter: Writer {
     /// Queue used to synchronize reads and writes for the feature.

--- a/Sources/Datadog/Core/Persistence/Writting/ConsentAwareDataWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/ConsentAwareDataWriter.swift
@@ -6,7 +6,8 @@
 
 import Foundation
 
-/// Writes data to different folders depending on the tracking consent value.
+/// Writes data to different folders depending on current the value of the `TrackingConsent`.
+/// When the value of `TrackingConsent` changes, it may move data from unauthorized folder to the authorized one or wipe it out entirely.
 /// It synchronizes the work of underlying `FileWriters` on given read/write queue.
 internal class ConsentAwareDataWriter: Writer, ConsentSubscriber {
     /// Queue used to synchronize reads and writes for the feature.

--- a/Sources/Datadog/Core/Persistence/Writting/Processing/DataProcessor.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/Processing/DataProcessor.swift
@@ -31,6 +31,7 @@ internal struct DataProcessorFactory {
 }
 
 /// The processing pipeline for writing data.
+/// It uses `EventMapper` to redact or drop data before it gets written.
 internal final class DataProcessor: Writer {
     private let fileWriter: Writer
     private let eventMapper: EventMapper?

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -86,7 +86,12 @@ internal class CrashReporter {
                     return false
                 }
 
-                let crashContext = crashReport?.context.flatMap { self.decode(crashContextData: $0) }
+                guard let crashContext = availableCrashReport.context.flatMap({ self.decode(crashContextData: $0) }) else {
+                    // `CrashContext` is malformed and and cannot be read. Return `true` to let the crash reporter
+                    // purge this crash report as we are not able to process it respectively.
+                    return true
+                }
+
                 self.loggingOrRUMIntegration.send(crashReport: availableCrashReport, with: crashContext)
                 return true
             }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingIntegration.swift
@@ -6,5 +6,5 @@
 
 /// An integration for sending crash reports to Datadog.
 internal protocol CrashReportingIntegration {
-    func send(crashReport: DDCrashReport, with crashContext: CrashContext?)
+    func send(crashReport: DDCrashReport, with crashContext: CrashContext)
 }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
@@ -10,7 +10,7 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
         // TODO: RUMM-1050 Create `LogOutput`
     }
 
-    func send(crashReport: DDCrashReport, with crashContext: CrashContext?) {
+    func send(crashReport: DDCrashReport, with crashContext: CrashContext) {
         // TODO: RUMM-1050 Send crash report as Log
         // by writting it to the `LogOutput`
         print(

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
+
 /// An integration sending crash reports as RUM Errors.
 internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
     struct Constants {

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -6,19 +6,156 @@
 
 /// An integration sending crash reports as RUM Errors.
 internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
-    init(rumFeature: RUMFeature) {
-        // TODO: RUMM-960 Create `RUMEventOutput`
+    struct Constants {
+        /// Maximum time since the crash (in seconds) enabling us to send the RUM View event to associate it with the interrupted RUM Session:
+        /// * if the app is restarted earlier than crash time + this interval, then we send both the `RUMErrorEvent` and `RUMViewEvent`,
+        /// * if the app is restarted later than crash time + this interval, then we only send `RUMErrorEvent`.
+        ///
+        /// This condition originates from RUM backend constraints on processing `RUMViewEvents` in stale sessions. If the session does not
+        /// receive any updates for a long time, then sending some significantly later may lead to inconsistency.
+        static let viewEventAvailabilityThreshold: TimeInterval = 14_400 // 4 hours
     }
 
-    func send(crashReport: DDCrashReport, with crashContext: CrashContext) {
-        // TODO: RUMM-960 Send crash report as RUM Errors (followed by RUM View update)
-        // by writting it to the `RUMEventOutput`
-        print(
-            """
-            🍿 Sending Crash Report using RUM integration
-            🔥 \(crashReport.signalName ?? "") [\(crashReport.signalDetails ?? "")]
-            🔎 crash context: \(String(describing: crashContext))
-            """
+    /// The output for writting RUM events. It uses the authorized data folder and is synchronized with the eventual
+    /// authorized output working simultaneously in the RUM feature.
+    private let rumEventOutput: RUMEventOutput
+    private let dateProvider: DateProvider
+    private let dateCorrector: DateCorrectorType
+
+    // MARK: - Initialization
+
+    init(rumFeature: RUMFeature) {
+        self.init(
+            rumEventOutput: RUMEventFileOutput(
+                fileWriter: rumFeature.storage.arbitraryAuthorizedWriter
+            ),
+            dateProvider: rumFeature.dateProvider,
+            dateCorrector: rumFeature.dateCorrector
         )
+    }
+
+    init(
+        rumEventOutput: RUMEventOutput,
+        dateProvider: DateProvider,
+        dateCorrector: DateCorrectorType
+    ) {
+        self.rumEventOutput = rumEventOutput
+        self.dateProvider = dateProvider
+        self.dateCorrector = dateCorrector
+    }
+
+    // MARK: - CrashReportingIntegration
+
+    func send(crashReport: DDCrashReport, with crashContext: CrashContext) {
+        guard crashContext.lastTrackingConsent == .granted else {
+            return // Only authorized crash reports can be send
+        }
+
+        guard let lastRUMViewEvent = crashContext.lastRUMViewEvent else {
+            return // This integration requires crash report with associated `RUMViewEvent`
+        }
+
+        // The `crashReport.crashDate` uses system `Date` collected at the moment of crash, so we need to adjust it
+        // to the server time before processing. Following use of the current correction is not ideal, but this is the best
+        // approximation we can get.
+        let currentTimeCorrection = dateCorrector.currentCorrection
+
+        let crashDate = crashReport.crashDate ?? dateProvider.currentDate()
+        let realCrashDate = currentTimeCorrection.applying(to: crashDate)
+        let realDateNow = currentTimeCorrection.applying(to: dateProvider.currentDate())
+
+        if realDateNow.timeIntervalSince(realCrashDate) < Constants.viewEventAvailabilityThreshold {
+            let rumError = createRUMError(from: crashReport, and: lastRUMViewEvent, crashDate: realCrashDate)
+            let rumView = updateRUMViewWithNewError(lastRUMViewEvent, crashDate: realCrashDate)
+            rumEventOutput.write(rumEvent: rumError)
+            rumEventOutput.write(rumEvent: rumView)
+        } else {
+            let rumError = createRUMError(from: crashReport, and: lastRUMViewEvent, crashDate: realCrashDate)
+            rumEventOutput.write(rumEvent: rumError)
+        }
+    }
+
+    // MARK: - Building RUM events
+
+    /// Creates the `RUMEvent<RUMErrorEvent>` based on the session information from `lastRUMViewEvent` and `DDCrashReport` details.
+    private func createRUMError(from crashReport: DDCrashReport, and lastRUMViewEvent: RUMViewEvent, crashDate: Date) -> RUMEvent<RUMErrorEvent> {
+        // TODO: RUMM-1053 come up with better formatting of following values
+        let errorMessage = crashReport.signalDetails ?? "<unkown>"
+        let errorStackTrace = crashReport.stackTrace ?? "<unkown>"
+        let errorType = (crashReport.signalName ?? "<unknown>") + " - " + (crashReport.signalCode ?? "<unknown>")
+
+        let eventData = RUMErrorEvent(
+            dd: .init(),
+            action: nil,
+            application: .init(id: lastRUMViewEvent.application.id),
+            connectivity: lastRUMViewEvent.connectivity,
+            date: crashDate.timeIntervalSince1970.toInt64Milliseconds,
+            error: .init(
+                isCrash: true,
+                message: errorMessage,
+                resource: nil,
+                source: .source,
+                stack: errorStackTrace,
+                type: errorType
+            ),
+            service: lastRUMViewEvent.service,
+            session: .init(
+                hasReplay: lastRUMViewEvent.session.hasReplay,
+                id: lastRUMViewEvent.session.id,
+                type: .user
+            ),
+            usr: lastRUMViewEvent.usr,
+            view: .init(
+                id: lastRUMViewEvent.view.id,
+                referrer: lastRUMViewEvent.view.referrer,
+                url: lastRUMViewEvent.view.url
+            )
+        )
+
+        // TODO: RUMM-1070 - `attributes` and `userInfoAttributes` recorded in `lastRUMViewEvent` should also be included there.
+        // This requires encoding the entire `RUMEvent<RUMViewEvent>` in `CrashContext`, not only `RUMViewEvent` as it's done now.
+        return RUMEvent(model: eventData, attributes: [:], userInfoAttributes: [:])
+    }
+
+    /// Creates the `RUMEvent<RUMViewEvent>` updating given `lastRUMViewEvent` with crash information.
+    private func updateRUMViewWithNewError(_ rumViewEvent: RUMViewEvent, crashDate: Date) -> RUMEvent<RUMViewEvent> {
+        let original = rumViewEvent
+        let eventData = RUMViewEvent(
+            dd: .init(documentVersion: original.dd.documentVersion + 1),
+            application: original.application,
+            connectivity: original.connectivity,
+            date: crashDate.timeIntervalSince1970.toInt64Milliseconds,
+            service: original.service,
+            session: original.session,
+            usr: original.usr,
+            view: .init(
+                action: original.view.action,
+                crash: .init(count: 1),
+                cumulativeLayoutShift: original.view.cumulativeLayoutShift,
+                customTimings: original.view.customTimings,
+                domComplete: original.view.domComplete,
+                domContentLoaded: original.view.domContentLoaded,
+                domInteractive: original.view.domInteractive,
+                error: original.view.error,
+                firstContentfulPaint: original.view.firstContentfulPaint,
+                firstInputDelay: original.view.firstInputDelay,
+                firstInputTime: original.view.firstInputTime,
+                id: original.view.id,
+                isActive: false,
+                largestContentfulPaint: original.view.largestContentfulPaint,
+                loadEvent: original.view.loadEvent,
+                loadingTime: original.view.loadingTime,
+                loadingType: original.view.loadingType,
+                longTask: original.view.longTask,
+                referrer: original.view.referrer,
+                resource: original.view.resource,
+                timeSpent: original.view.timeSpent,
+                url: original.view.url
+            )
+        )
+
+        // TODO: RUMM-1070 - `attributes` and `userInfoAttributes` recorded in `lastRUMViewEvent` should also be included there.
+        // This requires encoding the entire `RUMEvent<RUMViewEvent>` in `CrashContext`, not only `RUMViewEvent` as it's done now.
+        return RUMEvent(model: eventData, attributes: [:], userInfoAttributes: [:])
     }
 }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -10,7 +10,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         // TODO: RUMM-960 Create `RUMEventOutput`
     }
 
-    func send(crashReport: DDCrashReport, with crashContext: CrashContext?) {
+    func send(crashReport: DDCrashReport, with crashContext: CrashContext) {
         // TODO: RUMM-960 Send crash report as RUM Errors (followed by RUM View update)
         // by writting it to the `RUMEventOutput`
         print(

--- a/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
@@ -42,7 +42,7 @@ class FeatureStorageTests: XCTestCase {
         }
 
         // Then
-        let authorizedValues = readAllAuthorizedDataWritten(to: storage)
+        let authorizedValues = readAllAuthorizedDataWritten(to: storage, limit: 100)
             .map { $0.utf8String }
 
         let expectedAuthorizedValues = [
@@ -81,7 +81,7 @@ class FeatureStorageTests: XCTestCase {
         // swiftlint:enable opening_brace
 
         // Then
-        let dataWritten = readAllAuthorizedDataWritten(to: storage)
+        let dataWritten = readAllAuthorizedDataWritten(to: storage, limit: 50)
             .map { $0.utf8String }
         XCTAssertEqual(dataWritten.filter { $0 == "\"regular write\"" }.count, 25)
         XCTAssertEqual(dataWritten.filter { $0 == "\"arbitrary write\"" }.count, 25)
@@ -114,22 +114,25 @@ class FeatureStorageTests: XCTestCase {
         }
 
         // Then
-        let dataWritten = readAllAuthorizedDataWritten(to: storage)
+        let dataWritten = readAllAuthorizedDataWritten(to: storage, limit: 4)
             .map { $0.utf8String }
         XCTAssertEqual(dataWritten, ["\"value\"", "\"value\"", "\"redact\"", "\"redact\""])
     }
 
     // MARK: - Helpers
 
-    private func readAllAuthorizedDataWritten(to storage: FeatureStorage) -> [Data] {
+    private func readAllAuthorizedDataWritten(
+        to storage: FeatureStorage,
+        limit: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> [Data] {
         var dataAuthorizedForUpload: [Data] = []
 
-        while true {
+        (0..<limit).forEach { _ in
             if let nextBatch = storage.reader.readNextBatch() {
                 dataAuthorizedForUpload.append(nextBatch.data)
                 storage.reader.markBatchAsRead(nextBatch)
-            } else {
-                break
             }
         }
 

--- a/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
@@ -18,7 +18,7 @@ class FeatureStorageTests: XCTestCase {
         super.tearDown()
     }
 
-    func testGivenAnyFeatureStorage_whenWrittingDataAndChangingConsent_thenOnlyAuthorizedDataCanBeRead() {
+    func testWhenWrittingDataAndChangingConsent_thenOnlyAuthorizedDataCanBeRead() {
         let consentProvider = ConsentProvider(initialConsent: randomConsent())
 
         // Given
@@ -42,18 +42,9 @@ class FeatureStorageTests: XCTestCase {
         }
 
         // Then
-        var dataAuthorizedForUpload: [Data] = []
+        let authorizedValues = readAllAuthorizedDataWritten(to: storage)
+            .map { $0.utf8String }
 
-        while true {
-            if let nextBatch = storage.reader.readNextBatch() {
-                dataAuthorizedForUpload.append(nextBatch.data)
-                storage.reader.markBatchAsRead(nextBatch)
-            } else {
-                break
-            }
-        }
-
-        let authorizedValues = dataAuthorizedForUpload.map { $0.utf8String }
         let expectedAuthorizedValues = [
             // Data collected with `.granted` consent is allowed no matter of the next consent
             "\"current consent: \(TrackingConsent.granted), next consent: \(TrackingConsent.pending)\"",
@@ -68,7 +59,82 @@ class FeatureStorageTests: XCTestCase {
         )
     }
 
+    func testWhenArbitraryWriterIsUsedInParallelWithRegularWriter_thenAllDataIsWrittenSafely() {
+        // Given
+        let storage = FeatureStorage(
+            featureName: .mockAny(),
+            dataFormat: DataFormat(prefix: "", suffix: "", separator: "#"),
+            directories: temporaryFeatureDirectories,
+            eventMapper: nil,
+            commonDependencies: .mockWith(consentProvider: .init(initialConsent: .granted))
+        )
+
+        // When
+        // swiftlint:disable opening_brace
+        callConcurrently(
+            closures: [
+                { storage.writer.write(value: "regular write") },
+                { storage.arbitraryAuthorizedWriter.write(value: "arbitrary write") }
+            ],
+            iterations: 25
+        )
+        // swiftlint:enable opening_brace
+
+        // Then
+        let dataWritten = readAllAuthorizedDataWritten(to: storage)
+            .map { $0.utf8String }
+        XCTAssertEqual(dataWritten.filter { $0 == "\"regular write\"" }.count, 25)
+        XCTAssertEqual(dataWritten.filter { $0 == "\"arbitrary write\"" }.count, 25)
+    }
+
+    func testGivenStorageWithEventMapper_whenWrittingData_itMapsValuesWrittenWithBothRegularAndArbitraryWriters() {
+        class EventMapperMock: EventMapper {
+            func map<T: Encodable>(event: T) -> T? {
+                switch event as! String {
+                case "drop": return nil
+                case "secret": return "redact" as? T
+                default: return event
+                }
+            }
+        }
+
+        // Given
+        let storage = FeatureStorage(
+            featureName: .mockAny(),
+            dataFormat: DataFormat(prefix: "", suffix: "", separator: "#"),
+            directories: temporaryFeatureDirectories,
+            eventMapper: EventMapperMock(),
+            commonDependencies: .mockWith(consentProvider: .init(initialConsent: .granted))
+        )
+
+        // When
+        ["value", "secret", "drop"].forEach { event in
+            storage.writer.write(value: event)
+            storage.arbitraryAuthorizedWriter.write(value: event)
+        }
+
+        // Then
+        let dataWritten = readAllAuthorizedDataWritten(to: storage)
+            .map { $0.utf8String }
+        XCTAssertEqual(dataWritten, ["\"value\"", "\"value\"", "\"redact\"", "\"redact\""])
+    }
+
     // MARK: - Helpers
+
+    private func readAllAuthorizedDataWritten(to storage: FeatureStorage) -> [Data] {
+        var dataAuthorizedForUpload: [Data] = []
+
+        while true {
+            if let nextBatch = storage.reader.readNextBatch() {
+                dataAuthorizedForUpload.append(nextBatch.data)
+                storage.reader.markBatchAsRead(nextBatch)
+            } else {
+                break
+            }
+        }
+
+        return dataAuthorizedForUpload
+    }
 
     /// Returns random consent value other than the given one.
     private func randomConsent(otherThan consent: TrackingConsent? = nil) -> TrackingConsent {

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -65,7 +65,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).count, 1)
     }
 
-    func testWhenCrashReportHasUnauthorizedTrackingConsent_itIsNotSend() throws {
+    func testWhenCrashReportHasUnauthorizedTrackingConsent_itIsNotSent() throws {
         // Given
         let crashReport: DDCrashReport = .mockWith(crashDate: .mockDecember15th2019At10AMUTC())
         let crashContext: CrashContext = .mockWith(
@@ -85,7 +85,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(rumEventOutput.recordedEvents.count, 0)
     }
 
-    func testWhenCrashReportHasNoAssociatedLastRUMViewEvent_itIsNotSend() throws {
+    func testWhenCrashReportHasNoAssociatedLastRUMViewEvent_itIsNotSent() throws {
         // Given
         let crashReport: DDCrashReport = .mockWith(crashDate: .mockDecember15th2019At10AMUTC())
         let crashContext: CrashContext = .mockWith(

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -1,0 +1,221 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class CrashReportingWithRUMIntegrationTests: XCTestCase {
+    private let rumEventOutput = RUMEventOutputMock()
+
+    // MARK: - Testing Conditional Uploads
+
+    func testWhenSendingCrashReportCollectedLessThan4HoursAgo_itSendsBothRUMErrorAndRUMViewEvent() throws {
+        let secondsIn4Hours: TimeInterval = 4 * 60 * 60
+
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: 0..<secondsIn4Hours))
+
+        let crashReport: DDCrashReport = .mockWith(crashDate: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: .mockRandom()
+        )
+
+        // When
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: 0)
+        )
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 2)
+        XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).count, 1)
+        XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).count, 1)
+    }
+
+    func testWhenSendingCrashReportCollectedMoreThan4HoursAgo_itSendsOnlyRUMError() throws {
+        let secondsIn4Hours: TimeInterval = 4 * 60 * 60
+
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: secondsIn4Hours..<TimeInterval.greatestFiniteMagnitude))
+
+        let crashReport: DDCrashReport = .mockWith(crashDate: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: .mockRandom()
+        )
+
+        // When
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: 0)
+        )
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 1)
+        XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).count, 1)
+    }
+
+    func testWhenCrashReportHasUnauthorizedTrackingConsent_itIsNotSend() throws {
+        // Given
+        let crashReport: DDCrashReport = .mockWith(crashDate: .mockDecember15th2019At10AMUTC())
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: [.pending, .notGranted].randomElement()!,
+            lastRUMViewEvent: .mockRandom()
+        )
+
+        // When
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
+            dateCorrector: DateCorrectorMock()
+        )
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0)
+    }
+
+    func testWhenCrashReportHasNoAssociatedLastRUMViewEvent_itIsNotSend() throws {
+        // Given
+        let crashReport: DDCrashReport = .mockWith(crashDate: .mockDecember15th2019At10AMUTC())
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: nil
+        )
+
+        // When
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
+            dateCorrector: DateCorrectorMock()
+        )
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0)
+    }
+
+    // MARK: - Testing Uploaded Data
+
+    func testWhenSendingRUMViewEvent_itIncludesErrorInformation() throws {
+        let lastRUMViewEvent: RUMViewEvent = .mockRandom()
+
+        // Given
+        let crashDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashReport: DDCrashReport = .mockWith(crashDate: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: lastRUMViewEvent
+        )
+
+        // When
+        let dateCorrectionOffset: TimeInterval = .mockRandom()
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: crashDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset)
+        )
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        let sendRUMViewEvent = try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self)[0].model
+
+        XCTAssertTrue(
+            sendRUMViewEvent.application.id == lastRUMViewEvent.application.id
+            && sendRUMViewEvent.session.id == lastRUMViewEvent.session.id
+            && sendRUMViewEvent.view.id == lastRUMViewEvent.view.id,
+            "The `RUMViewEvent` sent must be linked to the same RUM Session as the last `RUMViewEvent`."
+        )
+        XCTAssertEqual(
+            sendRUMViewEvent.view.crash?.count, 1, "The `RUMViewEvent` must include incremented crash count."
+        )
+        XCTAssertEqual(
+            sendRUMViewEvent.dd.documentVersion,
+            lastRUMViewEvent.dd.documentVersion + 1,
+            "The `RUMViewEvent` sent must contain incremented document version."
+        )
+        XCTAssertTrue(
+            sendRUMViewEvent.view.isActive == false, "The `RUMViewEvent` must be marked as inactive."
+        )
+        XCTAssertEqual(
+            sendRUMViewEvent.date,
+            crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds,
+            "The `RUMViewEvent` sent must include crash date corrected by current correction offset."
+        )
+    }
+
+    func testWhenSendingRUMErrorEvent_itIncludesCrashInformation() throws {
+        let lastRUMViewEvent: RUMViewEvent = .mockRandom()
+
+        // Given
+        let crashDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashReport: DDCrashReport = .mockWith(
+            crashDate: crashDate,
+            signalCode: "SIG_CODE",
+            signalName: "SIG_NAME",
+            signalDetails: "Signal details",
+            stackTrace: """
+            0: stack-trace line 0
+            1: stack-trace line 1
+            2: stack-trace line 2
+            """
+        )
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: lastRUMViewEvent
+        )
+
+        // When
+        let dateCorrectionOffset: TimeInterval = .mockRandom()
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: crashDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset)
+        )
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        let sendRUMErrorEvent = try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self)[0].model
+
+        XCTAssertTrue(
+            sendRUMErrorEvent.application.id == lastRUMViewEvent.application.id
+            && sendRUMErrorEvent.session.id == lastRUMViewEvent.session.id
+            && sendRUMErrorEvent.view.id == lastRUMViewEvent.view.id,
+            "The `RUMErrorEvent` sent must be linked to the same RUM Session as the last `RUMViewEvent`."
+        )
+        XCTAssertTrue(
+            sendRUMErrorEvent.error.isCrash == true, "The `RUMErrorEvent` sent must be marked as crash."
+        )
+        XCTAssertEqual(
+            sendRUMErrorEvent.date,
+            crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds,
+            "The `RUMErrorEvent` sent must include crash date corrected by current correction offset."
+        )
+        XCTAssertEqual(
+            sendRUMErrorEvent.error.type,
+            "SIG_NAME - SIG_CODE"
+        )
+        XCTAssertEqual(
+            sendRUMErrorEvent.error.message,
+            "Signal details"
+        )
+        XCTAssertEqual(
+            sendRUMErrorEvent.error.stack,
+            """
+            0: stack-trace line 0
+            1: stack-trace line 1
+            2: stack-trace line 2
+            """
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -33,7 +33,11 @@ class RUMIntegrationsTests: XCTestCase {
 
     func testGivenRUMMonitorRegistered_whenSessionIsSampled_itProvidesEmptyRUMContextAttributes() throws {
         RUMFeature.instance = RUMFeature(
-            storage: FeatureStorage(writer: NoOpFileWriter(), reader: NoOpFileReader()),
+            storage: FeatureStorage(
+                writer: NoOpFileWriter(),
+                reader: NoOpFileReader(),
+                arbitraryAuthorizedWriter: NoOpFileWriter()
+            ),
             upload: FeatureUpload(uploader: NoOpDataUploadWorker()),
             configuration: .mockWith(sessionSamplingRate: 0.0),
             commonDependencies: .mockAny()

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -72,7 +72,7 @@ class CrashReportingIntegrationMock: CrashReportingIntegration {
     var sentCrashReport: DDCrashReport?
     var sentCrashContext: CrashContext?
 
-    func send(crashReport: DDCrashReport, with crashContext: CrashContext?) {
+    func send(crashReport: DDCrashReport, with crashContext: CrashContext) {
         sentCrashReport = crashReport
         sentCrashContext = crashContext
         didSendCrashReport?()

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -85,9 +85,16 @@ extension CrashContext: EquatableInTests {}
 
 extension CrashContext {
     static func mockAny() -> CrashContext {
+        return mockWith()
+    }
+
+    static func mockWith(
+        lastTrackingConsent: TrackingConsent = .granted,
+        lastRUMViewEvent: RUMViewEvent? = nil
+    ) -> CrashContext {
         return CrashContext(
-            lastTrackingConsent: .granted,
-            lastRUMViewEvent: nil
+            lastTrackingConsent: lastTrackingConsent,
+            lastRUMViewEvent: lastRUMViewEvent
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DataUploadWorkerMock.swift
@@ -42,8 +42,13 @@ class DataUploadWorkerMock: DataUploadWorkerType {
             self?.readNextBatch()
         }
         let originalReader = featureStorage.reader
+        let originalArbitraryWriter = featureStorage.arbitraryAuthorizedWriter
         reader = originalReader
-        return FeatureStorage(writer: observedWriter, reader: originalReader)
+        return FeatureStorage(
+            writer: observedWriter,
+            reader: originalReader,
+            arbitraryAuthorizedWriter: originalArbitraryWriter
+        )
     }
 
     private func readNextBatch() {

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -10,7 +10,7 @@ extension LoggingFeature {
     /// Mocks the feature instance which performs no writes and no uploads.
     static func mockNoOp() -> LoggingFeature {
         return LoggingFeature(
-            storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader()),
+            storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader(), arbitraryAuthorizedWriter: NoOpFileWriter()),
             upload: .init(uploader: NoOpDataUploadWorker()),
             configuration: .mockAny(),
             commonDependencies: .mockAny()

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -119,7 +119,7 @@ extension RUMEventBuilder {
 }
 
 class RUMEventOutputMock: RUMEventOutput {
-    private var recordedEvents: [Any] = []
+    private(set) var recordedEvents: [Any] = []
 
     func recordedEvents<E>(ofType type: E.Type, file: StaticString = #file, line: UInt = #line) throws -> [E] {
         return recordedEvents.compactMap { event in event as? E }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -11,7 +11,7 @@ extension RUMFeature {
     /// Mocks feature instance which performs no writes and no uploads.
     static func mockNoOp() -> RUMFeature {
         return RUMFeature(
-            storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader()),
+            storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader(), arbitraryAuthorizedWriter: NoOpFileWriter()),
             upload: .init(uploader: NoOpDataUploadWorker()),
             configuration: .mockAny(),
             commonDependencies: .mockAny()

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -10,7 +10,7 @@ extension TracingFeature {
     /// Mocks feature instance which performs no writes and no uploads.
     static func mockNoOp() -> TracingFeature {
         return TracingFeature(
-            storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader()),
+            storage: .init(writer: NoOpFileWriter(), reader: NoOpFileReader(), arbitraryAuthorizedWriter: NoOpFileWriter()),
             upload: .init(uploader: NoOpDataUploadWorker()),
             configuration: .mockAny(),
             commonDependencies: .mockAny(),


### PR DESCRIPTION
### What and why?

🚚 This PR sends collected crash reports as RUM Errors. 

When the app restarts after crash, we load the crash report, read its associated context and then:
* if the crash report was collected with tracking consent `.granted`,
* and the crash report was collected with RUM feature enabled,
* then the crash report is send as `RUMError` and it gets linked to the RUM Session which was interrupted.

Additionally, the `crash.count` gets updated on the last RUM View of the interrupted session.

### How?

This mostly required adding the implementation in `CrashReportingWithRUMIntegration's`:
```swift
func send(crashReport: DDCrashReport, with crashContext: CrashContext)
```

As Crash Reporting does its own consideration of `TrackingConsent`, to bypass the `ConsentAwareDataWriter`, I introduced additional `writer` on the `FeatureStorage`:
```swift
/// An arbitrary `Writer` which always writes data to authorized folder.
/// Should be only used by components which implement their own consideration of the `TrackingConsent` value
/// associated with data written.
let arbitraryAuthorizedWriter: Writer
```

### Manual Testing

This feature can be easily tested with the scenario introduced in #400.

### Integration Tests

I made the attempt on adding an integration test for the scenario introduced in #400, however this includes few additional challenges that weren't solved before. Thus, I'm detaching this work to `RUMM-1071`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
