### PR TITLE
Update to dd-sdk-testing-swift version 0.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ tools:
 		@echo "OK 👌"
 
 # The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
-DD_SDK_SWIFT_TESTING_VERSION = 0.5.1
+DD_SDK_SWIFT_TESTING_VERSION = 0.6.0
 
 define DD_SDK_TESTING_XCCONFIG_CI
 FRAMEWORK_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n


### PR DESCRIPTION
### What and why?

Update dd-sdk-testing-swift to version 0.6.0

### How?

Updated version number in Makefile