### PR TITLE
RUMM-1070 Send custom RUM attributes in crash reports

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		616CCE16250A467E009FED46 /* RUMAutoInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CCE15250A467E009FED46 /* RUMAutoInstrumentation.swift */; };
 		6170DC1C25C18729003AED5C /* DDCrashReportingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */; };
 		6170DC5125C18E57003AED5C /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
 		61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */; };
 		6179FFD3254ADB1700556A0B /* ObjcAppLaunchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */; };
 		6179FFDE254ADBEF00556A0B /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -744,6 +745,7 @@
 		616CCE15250A467E009FED46 /* RUMAutoInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMAutoInstrumentation.swift; sourceTree = "<group>"; };
 		6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportingPlugin.swift; sourceTree = "<group>"; };
 		6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogCrashReportingTests.xcconfig; sourceTree = "<group>"; };
+		6172472625D673D7007085B3 /* CrashContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextTests.swift; sourceTree = "<group>"; };
 		61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebuggingTests.swift; sourceTree = "<group>"; };
 		6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcAppLaunchHandler.h; sourceTree = "<group>"; };
 		6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcAppLaunchHandler.m; sourceTree = "<group>"; };
@@ -2650,6 +2652,7 @@
 			isa = PBXGroup;
 			children = (
 				61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */,
+				6172472625D673D7007085B3 /* CrashContextTests.swift */,
 			);
 			path = CrashContext;
 			sourceTree = "<group>";
@@ -3434,6 +3437,7 @@
 				61F3CDAB25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift in Sources */,
 				617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */,
 				61F2724925C943C500D54BF8 /* CrashReporterTests.swift in Sources */,
+				6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */,
 				61133C532423990D00786299 /* MobileDeviceTests.swift in Sources */,
 				61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */,

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
@@ -6,6 +6,7 @@
 
 import Datadog
 import DatadogCrashReporting
+import UIKit
 
 /// Scenario that launches single-view app which conditionally causes the a crash or uploads the crash report to Datadog.
 /// The condition is determined by crash report file presence:
@@ -26,8 +27,22 @@ final class CrashReportingCollectOrSendScenario: TestScenario {
     }
 
     func configureSDK(builder: Datadog.Configuration.Builder) {
+        class CustomPredicate: UIKitRUMViewsPredicate {
+            private let defaultPredicate = DefaultUIKitRUMViewsPredicate()
+
+            func rumView(for viewController: UIViewController) -> RUMView? {
+                let defaultRUMView = defaultPredicate.rumView(for: viewController)
+                return .init(
+                    path: defaultRUMView!.path,
+                    attributes: [
+                        "custom-attribute": "This attribute will be attached to crash report."
+                    ]
+                )
+            }
+        }
+
         _ = builder
-            .trackUIKitRUMViews()
+            .trackUIKitRUMViews(using: CustomPredicate())
             .enableCrashReporting(using: DDCrashReportingPlugin())
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
@@ -12,36 +12,151 @@ import Foundation
 /// Note: as it gets saved along with the crash report during process interruption, it's good
 /// to keep this data well-packed and as small as possible.
 internal struct CrashContext: Codable {
-    /// Codable representation of the public `TrackingConsent`.
-    /// Uses `Int8` for optimized packing.
-    enum TrackingConsent: Int8, Codable {
-        case granted
-        case notGranted
-        case pending
+    // MARK: - Initialization
+
+    init(
+        lastTrackingConsent: TrackingConsent,
+        lastRUMViewEvent: RUMEvent<RUMViewEvent>?
+    ) {
+        self.codableTrackingConsent = .init(from: lastTrackingConsent)
+        self.codableLastRUMViewEvent = lastRUMViewEvent.flatMap { .init(from: $0) }
     }
 
-    /// Last value of `TrackingConsent`.
-    var lastTrackingConsent: TrackingConsent
-    /// Last RUM View event.
-    var lastRUMViewEvent: RUMViewEvent?
+    // MARK: - Codable values
+
+    private var codableTrackingConsent: CodableTrackingConsent
+    private var codableLastRUMViewEvent: CodableRUMViewEvent?
 
     // TODO: RUMM-1049 Add Codable version of `UserInfo?`, `NetworkInfo?` and `CarrierInfo?`
 
     enum CodingKeys: String, CodingKey {
-        case lastTrackingConsent = "ltc"
-        case lastRUMViewEvent = "lre"
+        case codableTrackingConsent = "ctc"
+        case codableLastRUMViewEvent = "lre"
+    }
+
+    // MARK: - Setters & Getters using managed types
+
+    var lastTrackingConsent: TrackingConsent {
+        set { codableTrackingConsent = CodableTrackingConsent(from: newValue) }
+        get { codableTrackingConsent.managedValue }
+    }
+
+    var lastRUMViewEvent: RUMEvent<RUMViewEvent>? {
+        set { codableLastRUMViewEvent = newValue.flatMap { CodableRUMViewEvent(from: $0) } }
+        get { codableLastRUMViewEvent?.managedValue }
     }
 }
 
-// MARK: - Helpers
+// MARK: - Bridging managed types to Codable representation
 
-extension CrashContext.TrackingConsent {
-    /// Maps `public TrackingConsent` to `CrashContext.TrackingConsent`.
-    init(trackingConsent: TrackingConsent) {
-        switch trackingConsent {
+/// Codable representation of the public `TrackingConsent`. Uses `Int8` for optimized packing.
+private enum CodableTrackingConsent: Int8, Codable {
+    case granted
+    case notGranted
+    case pending
+
+    init(from managedValue: TrackingConsent) {
+        switch managedValue {
+        case .pending: self = .pending
         case .granted: self = .granted
         case .notGranted: self = .notGranted
-        case .pending: self = .pending
         }
+    }
+
+    var managedValue: TrackingConsent {
+        switch self {
+        case .pending: return .pending
+        case .granted: return .granted
+        case .notGranted: return .notGranted
+        }
+    }
+}
+
+private struct CodableRUMViewEvent: Codable {
+    let model: RUMViewEvent
+    let attributes: [String: Encodable]
+    let userInfoAttributes: [String: Encodable]
+
+    init(from managedValue: RUMEvent<RUMViewEvent>) {
+        self.model = managedValue.model
+        self.attributes = managedValue.attributes
+        self.userInfoAttributes = managedValue.userInfoAttributes
+    }
+
+    var managedValue: RUMEvent<RUMViewEvent> {
+        return .init(
+            model: model,
+            attributes: attributes,
+            userInfoAttributes: userInfoAttributes
+        )
+    }
+
+    // MARK: - Codable
+
+    enum CodingKeys: String, CodingKey {
+        case model = "mdl"
+        case attributes = "att"
+        case userInfoAttributes = "uia"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedAttributes = try container.decode([String: CodableValue].self, forKey: .attributes)
+        let decodedUserInfoAttributes = try container.decode([String: CodableValue].self, forKey: .userInfoAttributes)
+
+        self.model = try container.decode(RUMViewEvent.self, forKey: .model)
+        self.attributes = decodedAttributes.compactMapValues { $0 }
+        self.userInfoAttributes = decodedUserInfoAttributes.compactMapValues { $0 }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        let encodedAttributes = attributes.mapValues { EncodableValue($0) }
+        let encodedUserInfoAttributes = userInfoAttributes.mapValues { EncodableValue($0) }
+
+        try container.encode(model, forKey: .model)
+        try container.encode(encodedAttributes, forKey: .attributes)
+        try container.encode(encodedUserInfoAttributes, forKey: .userInfoAttributes)
+    }
+}
+
+// MARK: - Codable Helpers
+
+/// Helper type performing type erasure of encoded JSON types.
+/// It conforms to `Encodable`, so decoded value can be further serialized into exactly the same JSON representation.
+private struct CodableValue: Codable {
+    private let value: Encodable
+
+    init<T: Encodable>(value: T) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let bool = try? container.decode(Bool.self) {
+            self.init(value: bool)
+        } else if let uint64 = try? container.decode(UInt64.self) {
+            self.init(value: uint64)
+        } else if let int = try? container.decode(Int.self) {
+            self.init(value: int)
+        } else if let double = try? container.decode(Double.self) {
+            self.init(value: double)
+        } else if let string = try? container.decode(String.self) {
+            self.init(value: string)
+        } else if let array = try? container.decode([CodableValue].self) {
+            self.init(value: array)
+        } else if let dictionary = try? container.decode([String: CodableValue].self) {
+            self.init(value: dictionary)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Custom attribute at \(container.codingPath) cannot is not a `Codable` type supported by the SDK."
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -13,8 +13,8 @@ internal protocol CrashContextProviderType: class {
     /// Notifies on current `CrashContext` change.
     var onCrashContextChange: ((CrashContext) -> Void)? { set get }
 
-    /// Updates the `CrashContext` with last `RUMViewEvent` information.
-    func update(lastRUMViewEvent: RUMViewEvent)
+    /// Updates the `CrashContext` with last `RUMEvent<RUMViewEvent>` information.
+    func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>)
 
     /// Updates the `CrashContext` with last `TarckingConsent` information.
     func update(lastTrackingConsent: TrackingConsent)
@@ -38,7 +38,7 @@ internal class CrashContextProvider: CrashContextProviderType, ConsentSubscriber
         )
         self.unsafeCrashContext = CrashContext(
             // Set initial `TrackingConsent`
-            lastTrackingConsent: .init(trackingConsent: consentProvider.currentValue),
+            lastTrackingConsent: consentProvider.currentValue,
             lastRUMViewEvent: nil
         )
 
@@ -54,7 +54,7 @@ internal class CrashContextProvider: CrashContextProviderType, ConsentSubscriber
 
     var onCrashContextChange: ((CrashContext) -> Void)? = nil
 
-    func update(lastRUMViewEvent: RUMViewEvent) {
+    func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>) {
         queue.async { [weak self] in
             guard let self = self else {
                 return
@@ -66,7 +66,6 @@ internal class CrashContextProvider: CrashContextProviderType, ConsentSubscriber
         }
     }
 
-    /// Updates `CrashContext` with last `TarckingConsent` information.
     func update(lastTrackingConsent: TrackingConsent) {
         queue.async { [weak self] in
             guard let self = self else {
@@ -74,7 +73,7 @@ internal class CrashContextProvider: CrashContextProviderType, ConsentSubscriber
             }
 
             var context = self.unsafeCrashContext
-            context.lastTrackingConsent = .init(trackingConsent: lastTrackingConsent)
+            context.lastTrackingConsent = lastTrackingConsent
             self.unsafeCrashContext = context
         }
     }

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -108,7 +108,12 @@ internal class CrashReporter {
 
     // MARK: - CrashContext Encoding and Decoding
 
-    private let crashContextEncoder = JSONEncoder()
+    /// JSON encoder used for writing `CrashContext` into JSON `Data` injected to crash report.
+    /// Note: this `JSONEncoder` must have the same configuration as the `JSONEncoder` used later for writting payloads to uploadable files.
+    /// Otherwise the format of data read and uploaded from crash report context will be different than the format of data retrieved from the user
+    /// and written directly to uploadable file.
+    private let crashContextEncoder: JSONEncoder = .default()
+    /// JSON decoder used for reading `CrashContext` from JSON `Data` injected to crash report. 
     private let crashContextDecoder = JSONDecoder()
 
     private func encode(crashContext: CrashContext) -> Data? {

--- a/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
@@ -25,7 +25,7 @@ internal struct RUMWithCrashContextIntegration {
         self.crashContextProvider = crashContextProvider
     }
 
-    func update(lastRUMViewEvent: RUMViewEvent) {
+    func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>) {
         crashContextProvider?.update(lastRUMViewEvent: lastRUMViewEvent)
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -297,9 +297,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             )
         )
 
-        crashContextIntegration?.update(lastRUMViewEvent: eventData)
-
         let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes)
+
+        crashContextIntegration?.update(lastRUMViewEvent: event)
 
         dependencies.eventOutput.write(rumEvent: event)
     }

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -35,15 +35,15 @@ class CrashContextProviderTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(initialContext.lastTrackingConsent, .init(trackingConsent: initialTrackingConsent))
-        XCTAssertEqual(updatedContext?.lastTrackingConsent, .init(trackingConsent: randomTrackingConsent))
+        XCTAssertEqual(initialContext.lastTrackingConsent, initialTrackingConsent)
+        XCTAssertEqual(updatedContext?.lastTrackingConsent, randomTrackingConsent)
     }
 
     // MARK: - `RUMViewEvent` Integration
 
     func testWhenRUMWithCrashContextIntegrationIsUpdated_thenCrashContextProviderNotifiesNewContext() {
         let expectation = self.expectation(description: "Notify new crash context")
-        let randomRUMView: RUMViewEvent = .mockRandom()
+        let randomRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandomWith(model: RUMViewEvent.mockRandom())
 
         let crashContextProvider = CrashContextProvider(consentProvider: .mockAny())
         let rumWithCrashContextIntegration = RUMWithCrashContextIntegration(crashContextProvider: crashContextProvider)
@@ -56,12 +56,12 @@ class CrashContextProviderTests: XCTestCase {
             updatedContext = newContext
             expectation.fulfill()
         }
-        rumWithCrashContextIntegration.update(lastRUMViewEvent: randomRUMView)
+        rumWithCrashContextIntegration.update(lastRUMViewEvent: randomRUMViewEvent)
 
         // Then
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssertNil(initialContext.lastRUMViewEvent)
-        XCTAssertEqual(updatedContext?.lastRUMViewEvent, randomRUMView)
+        XCTAssertEqual(updatedContext?.lastRUMViewEvent, randomRUMViewEvent)
     }
 
     // MARK: - Thread safety
@@ -75,7 +75,7 @@ class CrashContextProviderTests: XCTestCase {
                 closures: [
                     { _ = provider.currentCrashContext },
                     { provider.update(lastTrackingConsent: .mockRandom()) },
-                    { provider.update(lastRUMViewEvent: .mockRandom()) },
+                    { provider.update(lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())) },
                 ],
                 iterations: 50
             )

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
@@ -1,0 +1,89 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class CrashContextTests: XCTestCase {
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    func testGivenContextWithTrackingConsentSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
+        let randomConsent: TrackingConsent = .mockRandom()
+
+        // Given
+        var context: CrashContext = .mockRandom()
+        context.lastTrackingConsent = randomConsent
+
+        // When
+        let serializedContext = try encoder.encode(context)
+
+        // Then
+        let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
+        XCTAssertEqual(deserializedContext.lastTrackingConsent, randomConsent)
+    }
+
+    func testGivenContextWithLastRUMViewEventSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
+        func createRandomAttributes() -> [String: Encodable] {
+            struct Foo: Encodable {
+                let bar: String = .mockRandom()
+                let bizz = Bizz()
+
+                struct Bizz: Encodable {
+                    let buzz: String = .mockRandom()
+                }
+            }
+
+            return [
+                "string-attribute": String.mockRandom(),
+                "int-attribute": Int.mockRandom(),
+                "uint64-attribute": UInt64.mockRandom(),
+                "double-attribute": Double.mockRandom(),
+                "bool-attribute": Bool.random(),
+                "int-array-attribute": [Int].mockRandom(),
+                "dictionary-attribute": [String: Int].mockRandom(),
+                "url-attribute": URL.mockRandom(),
+                "encodable-struct-attribute": Foo(),
+                "custom-encodable-attribute": JSONStringEncodableValue(Foo(), encodedUsing: encoder)
+            ]
+        }
+
+        let randomRUMViewEvent = RUMEvent(
+            model: RUMViewEvent.mockRandom(),
+            attributes: createRandomAttributes(),
+            userInfoAttributes: createRandomAttributes()
+        )
+
+        // Given
+        var context: CrashContext = .mockRandom()
+        context.lastRUMViewEvent = randomRUMViewEvent
+
+        // When
+        let serializedContext = try encoder.encode(context)
+
+        // Then
+        let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
+        try AssertEncodedRepresentationsEqual(deserializedContext.lastRUMViewEvent, randomRUMViewEvent)
+    }
+
+    // MARK: - Helpers
+
+    /// Asserts that JSON representations of two `Encodable` values are equal.
+    /// This allows us testing if the information is not lost due to type erasing done in `CrashContext` serialization.
+    private func AssertEncodedRepresentationsEqual<V: Encodable>(
+        _ value1: V,
+        _ value2: V,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let prettyEncoder = JSONEncoder()
+        prettyEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encodedValue1 = try prettyEncoder.encode(value1)
+        let encodedValue2 = try prettyEncoder.encode(value2)
+
+        XCTAssertEqual(encodedValue1.utf8String, encodedValue2.utf8String, file: file, line: line)
+    }
+}

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -34,7 +34,7 @@ class CrashReporterTests: XCTestCase {
 
         waitForExpectations(timeout: 0.5, handler: nil)
         XCTAssertEqual(integration.sentCrashReport, crashReport, "It should send the crash report retrieved from the `plugin`")
-        XCTAssertEqual(integration.sentCrashContext, crashContext, "It should send the crash context retrieved from the `plugin`")
+        XCTAssertEqual(integration.sentCrashContext?.data, crashContext.data, "It should send the crash context retrieved from the `plugin`")
         XCTAssertTrue(plugin.hasPurgedCrashReport == true, "It should ask to purge the crash report")
     }
 

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -22,7 +22,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(crashDate: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: .mockRandom()
+            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
         )
 
         // When
@@ -49,7 +49,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(crashDate: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: .mockRandom()
+            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
         )
 
         // When
@@ -70,7 +70,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(crashDate: .mockDecember15th2019At10AMUTC())
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: [.pending, .notGranted].randomElement()!,
-            lastRUMViewEvent: .mockRandom()
+            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
         )
 
         // When
@@ -115,7 +115,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(crashDate: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: lastRUMViewEvent
+            lastRUMViewEvent: .mockRandomWith(model: lastRUMViewEvent)
         )
 
         // When
@@ -172,7 +172,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         )
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: lastRUMViewEvent
+            lastRUMViewEvent: .mockRandomWith(model: lastRUMViewEvent)
         )
 
         // When

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -23,10 +23,10 @@ class RUMWithCrashContextIntegrationTests: XCTestCase {
 
         // Then
         let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration())
-        let randomRUMView: RUMViewEvent = .mockRandom()
-        rumWithCrashContextIntegration.update(lastRUMViewEvent: randomRUMView)
+        let randomRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandomWith(model: RUMViewEvent.mockRandom())
+        rumWithCrashContextIntegration.update(lastRUMViewEvent: randomRUMViewEvent)
 
-        XCTAssertEqual(crashContextProvider.currentCrashContext.lastRUMViewEvent, randomRUMView)
+        XCTAssertEqual(crashContextProvider.currentCrashContext.lastRUMViewEvent, randomRUMViewEvent)
     }
 
     func testWhenCrashReporterIsNotRegistered_itCannotBeInitialized() {

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -64,7 +64,7 @@ internal class CrashContextProviderMock: CrashContextProviderType {
         self.currentCrashContext = initialCrashContext
     }
 
-    func update(lastRUMViewEvent: RUMViewEvent) {}
+    func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>) {}
     func update(lastTrackingConsent: TrackingConsent) {}
 }
 
@@ -90,7 +90,7 @@ extension CrashContext {
 
     static func mockWith(
         lastTrackingConsent: TrackingConsent = .granted,
-        lastRUMViewEvent: RUMViewEvent? = nil
+        lastRUMViewEvent: RUMEvent<RUMViewEvent>? = nil
     ) -> CrashContext {
         return CrashContext(
             lastTrackingConsent: lastTrackingConsent,
@@ -101,17 +101,11 @@ extension CrashContext {
     static func mockRandom() -> CrashContext {
         return CrashContext(
             lastTrackingConsent: .mockRandom(),
-            lastRUMViewEvent: .mockRandom()
+            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
         )
     }
 
     var data: Data { try! JSONEncoder().encode(self) }
-}
-
-internal extension CrashContext.TrackingConsent {
-    static func mockRandom() -> CrashContext.TrackingConsent {
-        return CrashContext.TrackingConsent(trackingConsent: .mockRandom())
-    }
 }
 
 extension DDCrashReport: EquatableInTests {}

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -12,6 +12,7 @@ extension RUMViewEvent: EquatableInTests {}
 extension RUMResourceEvent: EquatableInTests {}
 extension RUMActionEvent: EquatableInTests {}
 extension RUMErrorEvent: EquatableInTests {}
+extension RUMEvent: EquatableInTests {}
 
 extension RUMUser {
     static func mockRandom() -> RUMUser {

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -79,9 +79,21 @@ extension Array {
     }
 }
 
+extension Array: RandomMockable where Element: RandomMockable {
+    static func mockRandom() -> [Element] {
+        return Array(repeating: .mockRandom(), count: 10)
+    }
+}
+
 extension Dictionary: AnyMockable where Key: AnyMockable, Value: AnyMockable {
     static func mockAny() -> Dictionary {
         return [Key.mockAny(): Value.mockAny()]
+    }
+}
+
+extension Dictionary: RandomMockable where Key: RandomMockable, Value: RandomMockable {
+    static func mockRandom() -> Dictionary {
+        return [Key.mockRandom(): Value.mockRandom()]
     }
 }
 
@@ -145,12 +157,16 @@ extension URL: AnyMockable, RandomMockable {
     }
 }
 
-extension String: AnyMockable {
+extension String: AnyMockable, RandomMockable {
     static func mockAny() -> String {
         return "abc"
     }
 
-    static func mockRandom(length: Int = 10) -> String {
+    static func mockRandom() -> String {
+        return mockRandom(length: 10)
+    }
+
+    static func mockRandom(length: Int) -> String {
         return mockRandom(
             among: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ",
             length: length
@@ -167,9 +183,13 @@ extension String: AnyMockable {
     }
 }
 
-extension Int: AnyMockable {
+extension Int: AnyMockable, RandomMockable {
     static func mockAny() -> Int {
         return 0
+    }
+
+    static func mockRandom() -> Int {
+        return .random(in: Int.min...Int.max)
     }
 }
 
@@ -178,9 +198,13 @@ extension Int64: AnyMockable, RandomMockable {
     static func mockRandom() -> Int64 { Int64.random(in: Int64.min..<Int64.max) }
 }
 
-extension UInt64: AnyMockable {
+extension UInt64: AnyMockable, RandomMockable {
     static func mockAny() -> UInt64 {
         return 0
+    }
+
+    static func mockRandom() -> UInt64 {
+        return .random(in: UInt64.min...UInt64.max)
     }
 }
 


### PR DESCRIPTION
### What and why?

🚚 This PR makes custom RUM attributes and User Info attributes appear in RUM crash reports.

Given that:
```swift
Datadog.setUserInfo(
   id: ..., 
   name: ..., 
   email: ..., 
   extraInfo: ["key-extraUserInfo": "value-extraUserInfo"]
)

Global.rum.startView(
   viewController: self, 
   attributes: ["custom-attribute": "This attribute will be attached to crash report."]
)
```
All attributes will appear in RUM Error along with the crash report:

<img width="556" alt="Screenshot 2021-02-12 at 13 11 28" src="https://user-images.githubusercontent.com/2358722/107766748-37fd3480-6d34-11eb-864b-ba78e767ea4a.png">


### How?

Instead of injecting the `RUMViewEvent` as the `lastRUMViewEvent` to the crash reporter, now we inject its entire envelope: `RUMView<RUMViewEvent>`. This envelope already contains `attributes` and `userInfoAttributes`.

The only challenging part was to implement deserialisation for `[String: Encodable]` in a way that ensures no information is lost. This is done by introducing type-erasing `CodableValue` type in `CrashContext`. This type serializes any `Encodable` to JSON type and retrieves it back with guaranteeing that next serialisation won't change the JSON representation.

For example, given one basic and one complex `Encodable`:
```swift
struct Foo: Encodable {
   let bar = "bizz"
}

let basic = 123
let complex = Foo()
```
When encoded into `CrashContext`, they become:
* basic → `123` - JSON numeral,
* complex → `{"bar" : "bizz"}` - JSON object.

Now, when decoded from `CrashContext` through `CodableValue`:
* basic → `123` - Swift integer,
* complex → `["bar" : "bizz"]` - Swift dictionary.

The `complex` encodable did lost its type information (it used to be `Foo`, now it's `[String: Encodable]`), but when serialised again, it will lead to the same JSON representation as originally.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
