### PR TITLE
RUMM-1053 Improve the `error.message` for Crash Reports

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		6170DC5125C18E57003AED5C /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
 		617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */; };
+		617247B825DAB0E2007085B3 /* PLCrashReportFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617247B725DAB0E2007085B3 /* PLCrashReportFormatter.swift */; };
 		61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */; };
 		6179FFD3254ADB1700556A0B /* ObjcAppLaunchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */; };
 		6179FFDE254ADBEF00556A0B /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -401,6 +402,7 @@
 		61FC5F3525CC1898006BB4DE /* CrashContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */; };
 		61FC5F4525CC23C9006BB4DE /* RUMWithCrashContextIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F4425CC23C9006BB4DE /* RUMWithCrashContextIntegration.swift */; };
 		61FC5F4E25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F4D25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift */; };
+		61FCBFE725DBBE8700CCF864 /* PLCrashReportFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FCBFE625DBBE8700CCF864 /* PLCrashReportFormatterTests.swift */; };
 		61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */; };
 		61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */; };
 		61FF282424B8A1C3000B3D9B /* RUMEventFileOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282324B8A1C3000B3D9B /* RUMEventFileOutput.swift */; };
@@ -749,6 +751,7 @@
 		6172472625D673D7007085B3 /* CrashContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextTests.swift; sourceTree = "<group>"; };
 		617247AD25DA9BEA007085B3 /* CrashReportingObjcHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrashReportingObjcHelpers.h; sourceTree = "<group>"; };
 		617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CrashReportingObjcHelpers.m; sourceTree = "<group>"; };
+		617247B725DAB0E2007085B3 /* PLCrashReportFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLCrashReportFormatter.swift; sourceTree = "<group>"; };
 		61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebuggingTests.swift; sourceTree = "<group>"; };
 		6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcAppLaunchHandler.h; sourceTree = "<group>"; };
 		6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcAppLaunchHandler.m; sourceTree = "<group>"; };
@@ -915,6 +918,7 @@
 		61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextProviderTests.swift; sourceTree = "<group>"; };
 		61FC5F4425CC23C9006BB4DE /* RUMWithCrashContextIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMWithCrashContextIntegration.swift; sourceTree = "<group>"; };
 		61FC5F4D25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMWithCrashContextIntegrationTests.swift; sourceTree = "<group>"; };
+		61FCBFE625DBBE8700CCF864 /* PLCrashReportFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLCrashReportFormatterTests.swift; sourceTree = "<group>"; };
 		61FF281D24B8968D000B3D9B /* RUMEventBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilder.swift; sourceTree = "<group>"; };
 		61FF282024B8981D000B3D9B /* RUMEventBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventBuilderTests.swift; sourceTree = "<group>"; };
 		61FF282324B8A1C3000B3D9B /* RUMEventFileOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutput.swift; sourceTree = "<group>"; };
@@ -2090,6 +2094,7 @@
 			children = (
 				61F2729A25C95EB200D54BF8 /* Mocks.swift */,
 				61B7886125C180CB002675B5 /* DDCrashReportingPluginTests.swift */,
+				61FCBFE525DBBE7D00CCF864 /* PLCrashReporterIntegration */,
 			);
 			name = DatadogCrashReportingTests;
 			path = ../Tests/DatadogCrashReportingTests;
@@ -2554,6 +2559,7 @@
 			isa = PBXGroup;
 			children = (
 				61F2728A25C9561A00D54BF8 /* PLCrashReporterIntegration.swift */,
+				617247B725DAB0E2007085B3 /* PLCrashReportFormatter.swift */,
 			);
 			path = PLCrashReporterIntegration;
 			sourceTree = "<group>";
@@ -2660,6 +2666,14 @@
 				6172472625D673D7007085B3 /* CrashContextTests.swift */,
 			);
 			path = CrashContext;
+			sourceTree = "<group>";
+		};
+		61FCBFE525DBBE7D00CCF864 /* PLCrashReporterIntegration */ = {
+			isa = PBXGroup;
+			children = (
+				61FCBFE625DBBE8700CCF864 /* PLCrashReportFormatterTests.swift */,
+			);
+			path = PLCrashReporterIntegration;
 			sourceTree = "<group>";
 		};
 		61FF281F24B89807000B3D9B /* RUMEvent */ = {
@@ -3574,6 +3588,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				617247B825DAB0E2007085B3 /* PLCrashReportFormatter.swift in Sources */,
 				61F2728B25C9561A00D54BF8 /* PLCrashReporterIntegration.swift in Sources */,
 				6170DC1C25C18729003AED5C /* DDCrashReportingPlugin.swift in Sources */,
 				61F2727425C9509D00D54BF8 /* ThirdPartyCrashReporter.swift in Sources */,
@@ -3585,6 +3600,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61B7886225C180CB002675B5 /* DDCrashReportingPluginTests.swift in Sources */,
+				61FCBFE725DBBE8700CCF864 /* PLCrashReportFormatterTests.swift in Sources */,
 				61F272B125C95ED800D54BF8 /* Mocks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		6170DC1C25C18729003AED5C /* DDCrashReportingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */; };
 		6170DC5125C18E57003AED5C /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
+		617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */; };
 		61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */; };
 		6179FFD3254ADB1700556A0B /* ObjcAppLaunchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */; };
 		6179FFDE254ADBEF00556A0B /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -746,6 +747,8 @@
 		6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportingPlugin.swift; sourceTree = "<group>"; };
 		6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogCrashReportingTests.xcconfig; sourceTree = "<group>"; };
 		6172472625D673D7007085B3 /* CrashContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextTests.swift; sourceTree = "<group>"; };
+		617247AD25DA9BEA007085B3 /* CrashReportingObjcHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrashReportingObjcHelpers.h; sourceTree = "<group>"; };
+		617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CrashReportingObjcHelpers.m; sourceTree = "<group>"; };
 		61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebuggingTests.swift; sourceTree = "<group>"; };
 		6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcAppLaunchHandler.h; sourceTree = "<group>"; };
 		6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcAppLaunchHandler.m; sourceTree = "<group>"; };
@@ -1030,6 +1033,8 @@
 			children = (
 				6111543525C993C2007C84C9 /* CrashReportingScenario.storyboard */,
 				6111543E25C996A5007C84C9 /* CrashReportingViewController.swift */,
+				617247AD25DA9BEA007085B3 /* CrashReportingObjcHelpers.h */,
+				617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */,
 			);
 			path = CrashReporting;
 			sourceTree = "<group>";
@@ -3504,6 +3509,7 @@
 				6193DCCE251B6201009B8011 /* RUMTASScreen1ViewController.swift in Sources */,
 				61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */,
 				61441C992461A649003D8BB8 /* DebugLoggingViewController.swift in Sources */,
+				617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */,
 				6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */,
 				6111544825C9A88B007C84C9 /* PersistenceHelper.swift in Sources */,
 				61D50C462580EF19006038A3 /* TracingScenarios.swift in Sources */,

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingObjcHelpers.h
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingObjcHelpers.h
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CrashReportingObjcHelpers : NSObject
+
+- (void) throwUncaughtNSException;
+- (void) dereferenceNullPointer;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingObjcHelpers.m
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingObjcHelpers.m
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+#import "CrashReportingObjcHelpers.h"
+
+@implementation CrashReportingObjcHelpers
+
+- (void)throwUncaughtNSException {
+    id object = [NSObject new];
+    [(NSDictionary*)object objectForKey:@"foo"];
+}
+
+- (void)dereferenceNullPointer {
+    int* pointer = NULL;
+    *pointer = 1;
+}
+
+@end

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingScenario.storyboard
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingScenario.storyboard
@@ -17,49 +17,33 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending crash report... " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RxJ-Ne-sYn">
-                                <rect key="frame" x="115.5" y="437.5" width="183" height="21"/>
-                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XgZ-fe-9bf">
-                                <rect key="frame" x="107" y="468.5" width="200" height="44"/>
-                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="bSD-p3-lol"/>
-                                    <constraint firstAttribute="height" constant="44" id="nsh-hL-Hoc"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <state key="normal" title="Crash The App">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="7"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="didTapCrashTheApp:" destination="svZ-CV-H7D" eventType="touchUpInside" id="cSS-Oz-nmZ"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="06E-eL-L8c">
+                                <rect key="frame" x="8" y="433" width="398" height="30"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending crash report... " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RxJ-Ne-sYn">
+                                        <rect key="frame" x="0.0" y="0.0" width="398" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="pWR-S0-8GJ"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" red="0.4705848098" green="0.27062672380000002" blue="0.70971673729999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vOa-RY-Cv0"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="XgZ-fe-9bf" firstAttribute="top" secondItem="RxJ-Ne-sYn" secondAttribute="bottom" constant="10" id="JXx-03-Dkm"/>
-                            <constraint firstItem="RxJ-Ne-sYn" firstAttribute="centerX" secondItem="4zU-Jd-E7f" secondAttribute="centerX" id="iRh-lc-dML"/>
-                            <constraint firstItem="XgZ-fe-9bf" firstAttribute="centerX" secondItem="4zU-Jd-E7f" secondAttribute="centerX" id="ixA-NO-9MA"/>
-                            <constraint firstItem="RxJ-Ne-sYn" firstAttribute="centerY" secondItem="4zU-Jd-E7f" secondAttribute="centerY" id="y1a-X1-ndR"/>
+                            <constraint firstItem="06E-eL-L8c" firstAttribute="leading" secondItem="vOa-RY-Cv0" secondAttribute="leading" constant="8" id="8Fm-NV-S1D"/>
+                            <constraint firstItem="06E-eL-L8c" firstAttribute="centerY" secondItem="4zU-Jd-E7f" secondAttribute="centerY" id="pvp-LH-AvX"/>
+                            <constraint firstItem="vOa-RY-Cv0" firstAttribute="trailing" secondItem="06E-eL-L8c" secondAttribute="trailing" constant="8" id="qa4-Mp-lG8"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="nWs-H8-pOo"/>
                     <connections>
-                        <outlet property="crashTheAppButton" destination="XgZ-fe-9bf" id="rWd-L2-Lwo"/>
                         <outlet property="sendingCrashReportLabel" destination="RxJ-Ne-sYn" id="OxV-Uu-mOI"/>
+                        <outlet property="verticalStackView" destination="06E-eL-L8c" id="f8M-bP-xim"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="a6m-Nu-QWl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
@@ -8,23 +8,61 @@ import UIKit
 
 internal class CrashReportingViewController: UIViewController {
     @IBOutlet weak var sendingCrashReportLabel: UILabel!
-    @IBOutlet weak var crashTheAppButton: UIButton!
+    @IBOutlet weak var verticalStackView: UIStackView!
+
+    private let objc = CrashReportingObjcHelpers()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         let testScenario = (appConfiguration.testScenario as! CrashReportingCollectOrSendScenario)
+        sendingCrashReportLabel.isHidden = !testScenario.hadPendingCrashReportDataOnStartup
 
-        if testScenario.hadPendingCrashReportDataOnStartup {
-            sendingCrashReportLabel.isHidden = false
-            crashTheAppButton.isHidden = true
-        } else {
-            sendingCrashReportLabel.isHidden = true
-            crashTheAppButton.isHidden = false
-        }
+        addCrashVariantButtons()
     }
 
-    @IBAction func didTapCrashTheApp(_ sender: Any) {
-        fatalError("The 'Crash The App' button was tapped.")
+    private func addCrashVariantButtons() {
+        func addButton(titled title: String, action selector: Selector) {
+            let button = UIButton(type: .custom)
+            button.backgroundColor = #colorLiteral(red: 0.4705882353, green: 0.2705882353, blue: 0.7098039216, alpha: 1)
+            button.setTitle(title, for: .normal)
+            button.layer.masksToBounds = true
+            button.layer.cornerRadius = 7
+            button.addTarget(nil, action: selector, for: .touchUpInside)
+            verticalStackView.addArrangedSubview(button)
+        }
+
+        addButton(titled: "Call fatalError()", action: #selector(callFatalError))
+        addButton(titled: "Throw uncaught NSException", action: #selector(throwUncaughtNSException))
+        addButton(titled: "Explicitly unwrap `nil` optional", action: #selector(explicitlyUnwrapOptionalNil))
+        addButton(titled: "Implicitly unwrap `nil` optional", action: #selector(implicitlyUnwrapOptionalNil))
+        addButton(titled: "Access array outside its bounds", action: #selector(accessArrayOutsideItsBounds))
+        addButton(titled: "Dereference null pointer", action: #selector(dereferenceNullPointer))
+    }
+
+    @objc func callFatalError() {
+        fatalError("Called fatalError().")
+    }
+
+    @objc func throwUncaughtNSException() {
+        objc.throwUncaughtNSException() // `[NSObject objectForKey:]: unrecognized selector sent to instance 0x...`
+    }
+
+    @objc func explicitlyUnwrapOptionalNil() {
+        let nilOptional: String? = nil
+        _ = nilOptional! // Unexpectedly found nil while unwrapping an Optional value
+    }
+
+    @objc func implicitlyUnwrapOptionalNil() {
+        let nilOptional: String! = nil
+        _ = nilOptional.lowercased() // Unexpectedly found nil while implicitly unwrapping an Optional value
+    }
+
+    @objc func accessArrayOutsideItsBounds() {
+        _ = [1, 2, 3][10] // Fatal error: Index out of range.
+    }
+
+    @objc func dereferenceNullPointer() {
+        objc.dereferenceNullPointer()
     }
 }

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
@@ -34,6 +34,7 @@ internal class CrashReportingViewController: UIViewController {
 
         addButton(titled: "Call fatalError()", action: #selector(callFatalError))
         addButton(titled: "Throw uncaught NSException", action: #selector(throwUncaughtNSException))
+        addButton(titled: "Force try! Swift Error", action: #selector(forceTrySwiftError))
         addButton(titled: "Explicitly unwrap `nil` optional", action: #selector(explicitlyUnwrapOptionalNil))
         addButton(titled: "Implicitly unwrap `nil` optional", action: #selector(implicitlyUnwrapOptionalNil))
         addButton(titled: "Access array outside its bounds", action: #selector(accessArrayOutsideItsBounds))
@@ -46,6 +47,15 @@ internal class CrashReportingViewController: UIViewController {
 
     @objc func throwUncaughtNSException() {
         objc.throwUncaughtNSException() // `[NSObject objectForKey:]: unrecognized selector sent to instance 0x...`
+    }
+
+    @objc func forceTrySwiftError() {
+        struct Exception: Error, CustomDebugStringConvertible {
+            let debugDescription = "Exception description."
+        }
+
+        func throwException() throws { throw Exception() }
+        try! throwException()
     }
 
     @objc func explicitlyUnwrapOptionalNil() {

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
@@ -8,13 +8,13 @@ import Datadog
 import DatadogCrashReporting
 import UIKit
 
-/// Scenario that launches single-view app which conditionally causes the a crash or uploads the crash report to Datadog.
-/// The condition is determined by crash report file presence:
+/// Scenario that launches single-view app which can cause a crash and/or upload the crash report to Datadog.
+/// It includes the condition determined by crash report file presence:
 /// * if the file is not there, the UI for crashing the app is presented,
-/// * if the file is there, the UI for uploading the crash repot is shown.
+/// * if the file is there, the UI for crashing the app is presented and _"Sending crash report..."_ label is shown.
 ///
 /// To test this scenario manually:
-///  → disconnect debugger → run the Example app so it presents "Crash The App" button → crash  → run again.
+///  → disconnect debugger → run the Example app → tap the crash button  → run again to have the crash report uploaded.
 final class CrashReportingCollectOrSendScenario: TestScenario {
     static let storyboardName = "CrashReportingScenario"
 

--- a/Datadog/TargetSupport/Example/Example-Bridging-Header.h
+++ b/Datadog/TargetSupport/Example/Example-Bridging-Header.h
@@ -7,3 +7,5 @@
 //
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
+
+#import "CrashReportingObjcHelpers.h"

--- a/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
+++ b/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
@@ -10,30 +10,26 @@ import Foundation
 @objc
 public class DDCrashReport: NSObject {
     /// The date of the crash occurrence.
-    internal let crashDate: Date?
-    // TODO: RUMM-1053 - consider providing / formatting this characteristic of the crash report
-    internal let signalCode: String?
-    // TODO: RUMM-1053 - consider providing / formatting this characteristic of the crash report
-    internal let signalName: String?
-    // TODO: RUMM-1053 - consider providing / formatting this characteristic of the crash report
-    internal let signalDetails: String?
-    // TODO: RUMM-1053 - consider providing / formatting this characteristic of the crash report
-    internal let stackTrace: String?
+    internal let date: Date?
+    /// Crash report type - used to group similar crash reports.
+    internal let type: String
+    /// Crash report message - if possible, it should provide additional troubleshooting information in addition to the crash type.
+    internal let message: String
+    /// Unsymbolicated stack trace of the crash.
+    internal let stackTrace: String
     /// The last context injected through `inject(context:)`
     internal let context: Data?
 
     public init(
-        crashDate: Date?,
-        signalCode: String?,
-        signalName: String?,
-        signalDetails: String?,
-        stackTrace: String?,
+        date: Date?,
+        type: String,
+        message: String,
+        stackTrace: String,
         context: Data?
     ) {
-        self.crashDate = crashDate
-        self.signalCode = signalCode
-        self.signalName = signalName
-        self.signalDetails = signalDetails
+        self.date = date
+        self.type = type
+        self.message = message
         self.stackTrace = stackTrace
         self.context = context
     }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
@@ -16,7 +16,7 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
         print(
             """
             🍿 Sending Crash Report using Logging integration
-            🔥 \(crashReport.signalName ?? "") [\(crashReport.signalDetails ?? "")]
+            🔥 \(crashReport.type) [\(crashReport.message)]
             🔎 crash context: \(String(describing: crashContext))
             """
         )

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -62,7 +62,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         // approximation we can get.
         let currentTimeCorrection = dateCorrector.currentCorrection
 
-        let crashDate = crashReport.crashDate ?? dateProvider.currentDate()
+        let crashDate = crashReport.date ?? dateProvider.currentDate()
         let realCrashDate = currentTimeCorrection.applying(to: crashDate)
         let realDateNow = currentTimeCorrection.applying(to: dateProvider.currentDate())
 
@@ -83,10 +83,9 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
     private func createRUMError(from crashReport: DDCrashReport, and lastRUMViewEvent: RUMEvent<RUMViewEvent>, crashDate: Date) -> RUMEvent<RUMErrorEvent> {
         let lastRUMView = lastRUMViewEvent.model
 
-        // TODO: RUMM-1053 come up with better formatting of following values
-        let errorMessage = crashReport.signalDetails ?? "<unkown>"
-        let errorStackTrace = crashReport.stackTrace ?? "<unkown>"
-        let errorType = (crashReport.signalName ?? "<unknown>") + " - " + (crashReport.signalCode ?? "<unknown>")
+        let errorType = crashReport.type
+        let errorMessage = crashReport.message
+        let errorStackTrace = crashReport.stackTrace
 
         let rumError = RUMErrorEvent(
             dd: .init(),

--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReportFormatter.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReportFormatter.swift
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import CrashReporter
+import Datadog
+
+/// A convenience interface of the`PLCrashReport` to enable its testability.
+internal protocol PLCrashReportType {
+    var timestamp: Date? { get }
+    var signalName: String? { get }
+    var signalCode: String? { get }
+    var exceptionName: String? { get }
+    var exceptionReason: String? { get }
+    var formattedStackTrace: String? { get }
+    var contextData: Data? { get }
+}
+
+extension PLCrashReport: PLCrashReportType {
+    var timestamp: Date? { systemInfo?.timestamp }
+    var signalName: String? { signalInfo?.name }
+    var signalCode: String? { signalInfo?.code }
+    var exceptionName: String? { hasExceptionInfo ? exceptionInfo?.exceptionName : nil }
+    var exceptionReason: String? { hasExceptionInfo ? exceptionInfo?.exceptionReason : nil }
+    var formattedStackTrace: String? { PLCrashReportTextFormatter.stringValue(for: self, with: PLCrashReportTextFormatiOS) }
+    var contextData: Data? { customData }
+}
+
+/// Formats the `PLCrashReport` to Datadog format (`DDCrashReport`).
+internal struct PLCrashReportFormatter {
+    private let unknown = "<unknown>"
+    private let unavailable = "<unavailable>"
+
+    func ddCrashReport(from crashReport: PLCrashReportType) -> DDCrashReport {
+        return DDCrashReport(
+            date: crashReport.timestamp,
+            type: readType(from: crashReport),
+            message: readMessage(from: crashReport),
+            stackTrace: readStackTrace(from: crashReport),
+            context: crashReport.contextData
+        )
+    }
+
+    // MARK: - Private
+
+    private func readType(from crashReport: PLCrashReportType) -> String {
+        return "\(crashReport.signalName ?? unknown) (\(crashReport.signalCode ?? unknown))"
+    }
+
+    private func readMessage(from crashReport: PLCrashReportType) -> String {
+        if crashReport.exceptionName != nil || crashReport.exceptionReason != nil {
+            // If the crash was caused by an uncaught exception
+            let exceptionName = crashReport.exceptionName // e.g. `NSInvalidArgumentException`
+            let exceptionReason = crashReport.exceptionReason // e.g. `-[NSObject objectForKey:]: unrecognized selector sent to instance 0x...`
+            return "Terminating app due to uncaught exception '\(exceptionName ?? unknown)', reason: '\(exceptionReason ?? unknown)'."
+        } else {
+            // Use signal description available in OS
+            guard let signalName = crashReport.signalName else { // e.g. SIGILL
+                return unknown
+            }
+
+            let knownSignalNames = Mirror(reflecting: sys_signame)
+                .children
+                .compactMap { $0.value as? UnsafePointer<Int8> }
+                .map { String(cString: $0).uppercased() } // [HUP, INT, QUIT, ILL, TRAP, ABRT, ...]
+
+            let knownSignalDescriptions = Mirror(reflecting: sys_siglist)
+                .children
+                .compactMap { $0.value as? UnsafePointer<Int8> }
+                .map { String(cString: $0) } // [Hangup, Interrupt, Quit, Illegal instruction, ...]
+
+            if knownSignalNames.count == knownSignalDescriptions.count { // sanity check
+                if let index = knownSignalNames.firstIndex(where: { signalName == "SIG\($0)" }) {
+                    return knownSignalDescriptions[index]
+                }
+            }
+
+            return unknown
+        }
+    }
+
+    private func readStackTrace(from crashReport: PLCrashReportType) -> String {
+        return crashReport.formattedStackTrace ?? unavailable
+    }
+}

--- a/Tests/DatadogCrashReportingTests/Mocks.swift
+++ b/Tests/DatadogCrashReportingTests/Mocks.swift
@@ -50,10 +50,9 @@ internal class ThirdPartyCrashReporterMock: ThirdPartyCrashReporter {
 internal extension DDCrashReport {
     static func mockAny() -> DDCrashReport {
         return DDCrashReport(
-            crashDate: Date(),
-            signalCode: "any signal",
-            signalName: "any name",
-            signalDetails: "any details",
+            date: Date(),
+            type: "any type",
+            message: "any message",
             stackTrace: "any stack trace",
             context: "any context".data(using: .utf8)
         )

--- a/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/PLCrashReportFormatterTests.swift
+++ b/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/PLCrashReportFormatterTests.swift
@@ -1,0 +1,166 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogCrashReporting
+@testable import Datadog
+
+class PLCrashReportFormatterTests: XCTestCase {
+    private struct PLCrashReportMock: PLCrashReportType {
+        var timestamp: Date? = nil
+        var signalName: String? = nil
+        var signalCode: String? = nil
+        var exceptionName: String? = nil
+        var exceptionReason: String? = nil
+        var formattedStackTrace: String? = nil
+        var contextData: Data? = nil
+    }
+
+    private let formatter = PLCrashReportFormatter()
+
+    func testItReadsDateFromPLCrashReportTimestamp() {
+        let crashReportWithTimestamp = PLCrashReportMock(timestamp: Date())
+        let crashReportWithNoTimestamp = PLCrashReportMock(timestamp: nil)
+
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReportWithTimestamp).date,
+            crashReportWithTimestamp.timestamp
+        )
+        XCTAssertNil(
+            formatter.ddCrashReport(from: crashReportWithNoTimestamp).date
+        )
+    }
+
+    func testItReadsTypeFromPLCrashReportSignalInfo() {
+        let crashReport1 = PLCrashReportMock(signalName: "SIGNAME", signalCode: "SIG_CODE")
+        let crashReport2 = PLCrashReportMock(signalName: "SIGNAME", signalCode: nil)
+        let crashReport3 = PLCrashReportMock(signalName: nil, signalCode: "SIG_CODE")
+        let crashReport4 = PLCrashReportMock(signalName: nil, signalCode: nil)
+
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReport1).type,
+            "SIGNAME (SIG_CODE)"
+        )
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReport2).type,
+            "SIGNAME (<unknown>)"
+        )
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReport3).type,
+            "<unknown> (SIG_CODE)"
+        )
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReport4).type,
+            "<unknown> (<unknown>)"
+        )
+    }
+
+    func testWhenPLCrashReportHasExceptionInfo_thenItReadsMessageFromIt() {
+        let crashReport1 = PLCrashReportMock(exceptionName: "ExceptionName", exceptionReason: "Exception reason")
+        let crashReport2 = PLCrashReportMock(exceptionName: "ExceptionName", exceptionReason: nil)
+        let crashReport3 = PLCrashReportMock(exceptionName: nil, exceptionReason: "Exception reason")
+
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReport1).message,
+            "Terminating app due to uncaught exception 'ExceptionName', reason: 'Exception reason'."
+        )
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReport2).message,
+            "Terminating app due to uncaught exception 'ExceptionName', reason: '<unknown>'."
+        )
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReport3).message,
+            "Terminating app due to uncaught exception '<unknown>', reason: 'Exception reason'."
+        )
+    }
+
+    func testWhenPLCrashReportHasNoExceptionInfo_thenItReadsMessageFromSignalInfo() {
+        let signalDescriptionByName = [
+            "SIGSIGNAL 0": "Signal 0",
+            "SIGHUP": "Hangup",
+            "SIGINT": "Interrupt",
+            "SIGQUIT": "Quit",
+            "SIGILL": "Illegal instruction",
+            "SIGTRAP": "Trace/BPT trap",
+            "SIGABRT": "Abort trap",
+            "SIGEMT": "EMT trap",
+            "SIGFPE": "Floating point exception",
+            "SIGKILL": "Killed",
+            "SIGBUS": "Bus error",
+            "SIGSEGV": "Segmentation fault",
+            "SIGSYS": "Bad system call",
+            "SIGPIPE": "Broken pipe",
+            "SIGALRM": "Alarm clock",
+            "SIGTERM": "Terminated",
+            "SIGURG": "Urgent I/O condition",
+            "SIGSTOP": "Suspended (signal)",
+            "SIGTSTP": "Suspended",
+            "SIGCONT": "Continued",
+            "SIGCHLD": "Child exited",
+            "SIGTTIN": "Stopped (tty input)",
+            "SIGTTOU": "Stopped (tty output)",
+            "SIGIO": "I/O possible",
+            "SIGXCPU": "Cputime limit exceeded",
+            "SIGXFSZ": "Filesize limit exceeded",
+            "SIGVTALRM": "Virtual timer expired",
+            "SIGPROF": "Profiling timer expired",
+            "SIGWINCH": "Window size changes",
+            "SIGINFO": "Information request",
+            "SIGUSR1": "User defined signal 1",
+            "SIGUSR2": "User defined signal 2",
+            "UNKNOWN_SIGNAL_NAME": "<unknown>", // sanity check
+        ]
+
+        signalDescriptionByName.forEach { signalName, signalDescription in
+            let crashReport = PLCrashReportMock(signalName: signalName)
+            XCTAssertEqual(
+                formatter.ddCrashReport(from: crashReport).message,
+                signalDescription
+            )
+        }
+    }
+
+    func testWhenPLCrashReportHasNoExceptionInfoAndNoSignalInfo_thenMessageDefaultsToUknown() {
+        let crashReport = PLCrashReportMock(
+            signalName: nil,
+            signalCode: nil,
+            exceptionName: nil,
+            exceptionReason: nil
+        )
+
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReport).message,
+            "<unknown>"
+        )
+    }
+
+    func testItReadsStackTraceFromPLCrashReportTimestamp() {
+        let crashReportWithStackTrace = PLCrashReportMock(formattedStackTrace: "stack trace")
+        let crashReportWithNoStackTrace = PLCrashReportMock(formattedStackTrace: nil)
+
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReportWithStackTrace).stackTrace,
+            crashReportWithStackTrace.formattedStackTrace
+        )
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReportWithNoStackTrace).stackTrace,
+            "<unavailable>"
+        )
+    }
+
+    func testItReadsContextDataFromPLCrashReportCustomData() {
+        let crashReportWithCustomData = PLCrashReportMock(contextData: "some data".data(using: .utf8))
+        let crashReportWithNoCustomData = PLCrashReportMock(contextData: nil)
+
+        XCTAssertEqual(
+            formatter.ddCrashReport(from: crashReportWithCustomData).context,
+            crashReportWithCustomData.contextData
+        )
+        XCTAssertNil(
+            formatter.ddCrashReport(from: crashReportWithNoCustomData).context
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -19,7 +19,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let currentDate: Date = .mockDecember15th2019At10AMUTC()
         let crashDate: Date = currentDate.secondsAgo(.random(in: 0..<secondsIn4Hours))
 
-        let crashReport: DDCrashReport = .mockWith(crashDate: crashDate)
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
             lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
@@ -46,7 +46,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let currentDate: Date = .mockDecember15th2019At10AMUTC()
         let crashDate: Date = currentDate.secondsAgo(.random(in: secondsIn4Hours..<TimeInterval.greatestFiniteMagnitude))
 
-        let crashReport: DDCrashReport = .mockWith(crashDate: crashDate)
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
             lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
@@ -67,7 +67,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
     func testWhenCrashReportHasUnauthorizedTrackingConsent_itIsNotSent() throws {
         // Given
-        let crashReport: DDCrashReport = .mockWith(crashDate: .mockDecember15th2019At10AMUTC())
+        let crashReport: DDCrashReport = .mockWith(date: .mockDecember15th2019At10AMUTC())
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: [.pending, .notGranted].randomElement()!,
             lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
@@ -87,7 +87,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
     func testWhenCrashReportHasNoAssociatedLastRUMViewEvent_itIsNotSent() throws {
         // Given
-        let crashReport: DDCrashReport = .mockWith(crashDate: .mockDecember15th2019At10AMUTC())
+        let crashReport: DDCrashReport = .mockWith(date: .mockDecember15th2019At10AMUTC())
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
             lastRUMViewEvent: nil
@@ -112,7 +112,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
         // Given
         let crashDate: Date = .mockDecember15th2019At10AMUTC()
-        let crashReport: DDCrashReport = .mockWith(crashDate: crashDate)
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
             lastRUMViewEvent: .mockRandomWith(model: lastRUMViewEvent)
@@ -160,10 +160,9 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         // Given
         let crashDate: Date = .mockDecember15th2019At10AMUTC()
         let crashReport: DDCrashReport = .mockWith(
-            crashDate: crashDate,
-            signalCode: "SIG_CODE",
-            signalName: "SIG_NAME",
-            signalDetails: "Signal details",
+            date: crashDate,
+            type: "SIG_CODE (SIG_NAME)",
+            message: "Signal details",
             stackTrace: """
             0: stack-trace line 0
             1: stack-trace line 1
@@ -203,7 +202,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         )
         XCTAssertEqual(
             sendRUMErrorEvent.error.type,
-            "SIG_NAME - SIG_CODE"
+            "SIG_CODE (SIG_NAME)"
         )
         XCTAssertEqual(
             sendRUMErrorEvent.error.message,

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -116,18 +116,16 @@ internal extension DDCrashReport {
     }
 
     static func mockWith(
-        crashDate: Date? = .mockAny(),
-        signalCode: String? = .mockAny(),
-        signalName: String? = .mockAny(),
-        signalDetails: String? = .mockAny(),
-        stackTrace: String? = .mockAny(),
+        date: Date? = .mockAny(),
+        type: String = .mockAny(),
+        message: String = .mockAny(),
+        stackTrace: String = .mockAny(),
         context: Data? = .mockAny()
     ) -> DDCrashReport {
         return DDCrashReport(
-            crashDate: crashDate,
-            signalCode: signalCode,
-            signalName: signalName,
-            signalDetails: signalDetails,
+            date: date,
+            type: type,
+            message: message,
             stackTrace: stackTrace,
             context: context
         )
@@ -135,10 +133,9 @@ internal extension DDCrashReport {
 
     static func mockRandomWith(context: CrashContext) -> DDCrashReport {
         return mockWith(
-            crashDate: .mockRandomInThePast(),
-            signalCode: .mockRandom(),
-            signalName: .mockRandom(),
-            signalDetails: .mockRandom(),
+            date: .mockRandomInThePast(),
+            type: .mockRandom(),
+            message: .mockRandom(),
             stackTrace: .mockRandom(),
             context: context.data
         )


### PR DESCRIPTION
### What and why?

📦 This PR aims at improving `error.type` and `error.message` for Crash Reports by providing additional troubleshooting information for devs.

### How?

I've spent most of my time researching possible improvements and considering when and where they can be applied. To examine multiple variants, I updated the Crash Reporting scenario in the `Example` app with new cases:

<img width="353" alt="Screenshot 2021-02-16 at 14 58 34" src="https://user-images.githubusercontent.com/2358722/108072661-73b33980-7067-11eb-9eea-3a25afcba7da.png">


After all, this resultant PR improves only the case where the crash originates from unhandled Objective-C exception. In such scenario, the `PLCrashReporter` records the exception info and provides it on the `PLCrashReport`, so we can consume it and pass to RUM Error.

Tapping above buttons bottom-up results with following `error.type` and `error.message` being sent:

<img width="1256" alt="crash-reporting-vague" src="https://user-images.githubusercontent.com/2358722/108073027-e1f7fc00-7067-11eb-8e6c-e1b510c94ec6.png">

### Other improvements

This PR also disables on-device symbolication of crash reports. Applying it on-device gives more readable reports, but also makes backend-side symbolication impossible. We may consider enabling it in the future (while still sending unsymbolicated reports to backend) → `RUMM-1088`.

I also updated the `DDCrashReport` structure to contain digested information: `type`, `message`, `stackTrace`, instead of their raw representation from `DatadogCrashReporting` (`signalCode`, `signalName`, ...). This should better shape responsibilities of both modules, as now `DCR` is responsible for building and formatting the crash report, and `Datadog's` role is only to send it with RUM or Logger.

### Further iterations on error messages

Getting more from crash reports is not an one-off effort and will need to be continued with next iterations after we start symbolicating stack frames. Full data should enable further possibilities of crash diagnostics and inferring their root causes. To schedule this work, I created `RUMM-1088` where I describe more conclusions from my research.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
