### PR TITLE
RUMM-1097 Fix `DefaultUIKitRUMViewsPredicate` for Objc view controllers

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		6114FE23257671F00084E372 /* ConsentAwareDataWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */; };
 		6114FE2F257687310084E372 /* ConsentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE2E257687300084E372 /* ConsentProvider.swift */; };
 		6114FE3B25768AA90084E372 /* ConsentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE3A25768AA90084E372 /* ConsentProviderTests.swift */; };
+		6115299725E3BEF9004F740E /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6115299625E3BEF9004F740E /* UIKitExtensionsTests.swift */; };
 		61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */; };
 		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
 		61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */; };
@@ -543,6 +544,7 @@
 		6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentAwareDataWriterTests.swift; sourceTree = "<group>"; };
 		6114FE2E257687300084E372 /* ConsentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentProvider.swift; sourceTree = "<group>"; };
 		6114FE3A25768AA90084E372 /* ConsentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentProviderTests.swift; sourceTree = "<group>"; };
+		6115299625E3BEF9004F740E /* UIKitExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensionsTests.swift; sourceTree = "<group>"; };
 		61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSViewController.swift; sourceTree = "<group>"; };
 		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
 		61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMModalViewsScenarioTests.swift; sourceTree = "<group>"; };
@@ -1310,6 +1312,7 @@
 			children = (
 				61133C362423990D00786299 /* InternalLoggersTests.swift */,
 				9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */,
+				6115299625E3BEF9004F740E /* UIKitExtensionsTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3061,6 +3064,7 @@
 				61133C4E2423990D00786299 /* UIKitMocks.swift in Sources */,
 				61B0387B252724AB00518F3C /* URLSessionTracingHandlerTests.swift in Sources */,
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
+				6115299725E3BEF9004F740E /* UIKitExtensionsTests.swift in Sources */,
 				614B0A4D24EBD71500A2A780 /* RUMUserInfoProviderTests.swift in Sources */,
 				9EF963E82537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift in Sources */,
 				61133C552423990D00786299 /* BatteryStatusProviderTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -320,6 +320,7 @@
 		61D6FF7E24E53D3B00D0E375 /* BenchmarkMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D6FF7D24E53D3B00D0E375 /* BenchmarkMocks.swift */; };
 		61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980B924E28D0100E03345 /* RUMIntegrations.swift */; };
 		61D980BC24E293F600E03345 /* RUMIntegrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */; };
+		61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */; };
 		61DC6D922539E3E300FFAA22 /* LoggingCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DC6D912539E3E300FFAA22 /* LoggingCommonAsserts.swift */; };
 		61E36A11254B2280001AD6F2 /* LaunchTimeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E36A10254B2280001AD6F2 /* LaunchTimeProvider.swift */; };
 		61E45BCF2450A6EC00F2C652 /* TracingUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */; };
@@ -772,6 +773,8 @@
 		61D6FF7D24E53D3B00D0E375 /* BenchmarkMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkMocks.swift; sourceTree = "<group>"; };
 		61D980B924E28D0100E03345 /* RUMIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrations.swift; sourceTree = "<group>"; };
 		61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrationsTests.swift; sourceTree = "<group>"; };
+		61DB33B025DEDFC200F7EA71 /* CustomObjcViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomObjcViewController.h; sourceTree = "<group>"; };
+		61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomObjcViewController.m; sourceTree = "<group>"; };
 		61DC6D912539E3E300FFAA22 /* LoggingCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingCommonAsserts.swift; sourceTree = "<group>"; };
 		61E36A10254B2280001AD6F2 /* LaunchTimeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchTimeProvider.swift; sourceTree = "<group>"; };
 		61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDTests.swift; sourceTree = "<group>"; };
@@ -1362,6 +1365,8 @@
 				61F1A622249B811200075390 /* Encoding.swift */,
 				61A763DA252DB2B3005A23F2 /* NSURLSessionBridge.h */,
 				61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */,
+				61DB33B025DEDFC200F7EA71 /* CustomObjcViewController.h */,
+				61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2951,6 +2956,7 @@
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
 				61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
+				61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */,
 				61F3CDAD25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift in Sources */,
 				61D980BC24E293F600E03345 /* RUMIntegrationsTests.swift in Sources */,
 				61363D9F24D99BAA0084CD6F /* DDErrorTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -98,7 +98,12 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_TEST_SCENARIO_CLASS_NAME"
-            value = "RUMResourcesScenario"
+            value = "RUMURLSessionResourcesScenario"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_TEST_SCENARIO_CLASS_NAME"
+            value = "RUMNSURLSessionResourcesScenario"
             isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
+++ b/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
@@ -123,12 +123,25 @@ final class RUMTapActionScenario: TestScenario {
 
 /// Scenario which uses RUM and Tracing auto instrumentation features to track bunch of network requests
 /// sent with `URLSession` from two VCs. The first VC calls first party resources, the second one calls third parties.
-final class RUMResourcesScenario: URLSessionBaseScenario, TestScenario {
+final class RUMURLSessionResourcesScenario: URLSessionBaseScenario, TestScenario {
     static let storyboardName = "URLSessionScenario"
 
     override func configureSDK(builder: Datadog.Configuration.Builder) {
         _ = builder
-            .trackUIKitRUMViews(using: DefaultUIKitRUMViewsPredicate())
+            .trackUIKitRUMViews()
+
+        super.configureSDK(builder: builder) // applies the `trackURLSession(firstPartyHosts:)`
+    }
+}
+
+/// Scenario which uses RUM and Tracing auto instrumentation features to track bunch of network requests
+/// sent with `NSURLSession` from two VCs. The first VC calls first party resources, the second one calls third parties.
+final class RUMNSURLSessionResourcesScenario: URLSessionBaseScenario, TestScenario {
+    static let storyboardName = "NSURLSessionScenario"
+
+    override func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder
+            .trackUIKitRUMViews()
 
         super.configureSDK(builder: builder) // applies the `trackURLSession(firstPartyHosts:)`
     }

--- a/Datadog/Example/Scenarios/TrackingConsent/TrackingConsentScenarios.swift
+++ b/Datadog/Example/Scenarios/TrackingConsent/TrackingConsentScenarios.swift
@@ -10,7 +10,7 @@ import Datadog
 internal class TrackingConsentBaseScenario {
     func configureSDK(builder: Datadog.Configuration.Builder) {
         _ = builder
-            .trackUIKitRUMViews(using: DefaultUIKitRUMViewsPredicate())
+            .trackUIKitRUMViews()
             .trackUIKitActions(true)
             .trackURLSession(firstPartyHosts: ["datadoghq.com"])
     }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
@@ -59,7 +59,9 @@ public struct DefaultUIKitRUMViewsPredicate: UIKitRUMViewsPredicate {
 
     public func rumView(for viewController: UIViewController) -> RUMView? {
         guard !isUIKit(class: type(of: viewController)) else {
-            // do not track bare UIKit's view controllers (UINavigationController, UITabBarController, ...)
+            // Part of our heuristic for (auto) tracking view controllers is to ignore
+            // container view controllers coming from `UIKit` if they are not subclassed.
+            // This condition is wider and it ignores all view controllers defined in `UIKit` bundle.
             return nil
         }
 
@@ -71,7 +73,6 @@ public struct DefaultUIKitRUMViewsPredicate: UIKitRUMViewsPredicate {
 
     /// If given `class` comes from UIKit framework.
     private func isUIKit(`class`: AnyClass) -> Bool {
-        let bundle = Bundle(for: `class`)
-        return bundle.bundleURL.lastPathComponent == "UIKitCore.framework"
+        return Bundle(for: `class`).isUIKit
     }
 }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicate.swift
@@ -58,15 +58,20 @@ public struct DefaultUIKitRUMViewsPredicate: UIKitRUMViewsPredicate {
     public init () {}
 
     public func rumView(for viewController: UIViewController) -> RUMView? {
-        let canonicalClassName = viewController.canonicalClassName
-        let isCustomClass = canonicalClassName.contains(".") // custom class contains module prefix
-
-        if isCustomClass {
-            var view = RUMView(name: canonicalClassName)
-            view.path = canonicalClassName
-            return view
-        } else {
+        guard !isUIKit(class: type(of: viewController)) else {
+            // do not track bare UIKit's view controllers (UINavigationController, UITabBarController, ...)
             return nil
         }
+
+        let canonicalClassName = viewController.canonicalClassName
+        var view = RUMView(name: canonicalClassName)
+        view.path = canonicalClassName
+        return view
+    }
+
+    /// If given `class` comes from UIKit framework.
+    private func isUIKit(`class`: AnyClass) -> Bool {
+        let bundle = Bundle(for: `class`)
+        return bundle.bundleURL.lastPathComponent == "UIKitCore.framework"
     }
 }

--- a/Sources/Datadog/Utils/UIKitExtensions.swift
+++ b/Sources/Datadog/Utils/UIKitExtensions.swift
@@ -24,3 +24,7 @@ internal extension UIViewController {
         return NSStringFromClass(type(of: self))
     }
 }
+
+internal extension Bundle {
+    var isUIKit: Bool { bundleURL.lastPathComponent == "UIKitCore.framework" }
+}

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicateTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicateTests.swift
@@ -17,6 +17,7 @@ class UIKitRUMViewsPredicateTests: XCTestCase {
         let rumView = predicate.rumView(for: customViewController)
 
         // Then
+        XCTAssertEqual(rumView?.name, "Module.CustomViewController")
         XCTAssertEqual(rumView?.path, "Module.CustomViewController")
         XCTAssertTrue(rumView!.attributes.isEmpty)
     }

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicateTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsPredicateTests.swift
@@ -8,17 +8,31 @@ import XCTest
 import Datadog
 
 class UIKitRUMViewsPredicateTests: XCTestCase {
-    func testGivenDefaultPredicate_whenAskingForCustomViewController_itNamesTheViewByItsClassName() {
+    func testGivenDefaultPredicate_whenAskingForCustomSwiftViewController_itNamesTheViewByItsClassName() {
         // Given
         let predicate = DefaultUIKitRUMViewsPredicate()
 
         // When
-        let customViewController = createMockView(viewControllerClassName: "Module.CustomViewController")
+        let customViewController = createMockView(viewControllerClassName: "CustomSwiftViewController")
         let rumView = predicate.rumView(for: customViewController)
 
         // Then
-        XCTAssertEqual(rumView?.name, "Module.CustomViewController")
-        XCTAssertEqual(rumView?.path, "Module.CustomViewController")
+        XCTAssertEqual(rumView?.name, "CustomSwiftViewController")
+        XCTAssertEqual(rumView?.path, "CustomSwiftViewController")
+        XCTAssertTrue(rumView!.attributes.isEmpty)
+    }
+
+    func testGivenDefaultPredicate_whenAskingForCustomObjcViewController_itNamesTheViewByItsClassName() {
+        // Given
+        let predicate = DefaultUIKitRUMViewsPredicate()
+
+        // When
+        let customViewController = CustomObjcViewController()
+        let rumView = predicate.rumView(for: customViewController)
+
+        // Then
+        XCTAssertEqual(rumView?.name, "CustomObjcViewController")
+        XCTAssertEqual(rumView?.path, "CustomObjcViewController")
         XCTAssertTrue(rumView!.attributes.isEmpty)
     }
 

--- a/Tests/DatadogTests/Datadog/Utils/UIKitExtensionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/UIKitExtensionsTests.swift
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+import UIKit
+@testable import Datadog
+
+class CustomSwiftViewController: UIViewController {}
+
+class UIKitExtensionsTests: XCTestCase {
+    func testViewControllerCanonicalClassName() {
+        let swiftViewController = CustomSwiftViewController()
+        let objcViewController = CustomObjcViewController()
+
+        XCTAssertEqual(swiftViewController.canonicalClassName, "DatadogTests.CustomSwiftViewController")
+        XCTAssertEqual(objcViewController.canonicalClassName, "CustomObjcViewController")
+    }
+
+    func testBundleIsUIKit() {
+        let someUIKitClasses: [AnyClass] = [
+            UIViewController.self,
+            UIButton.self,
+            UINavigationBar.self,
+            UIScrollView.self
+        ]
+
+        let someNonUIKitClasses: [AnyClass] = [
+            CustomSwiftViewController.self,
+            CustomObjcViewController.self,
+            OperationQueue.self,
+        ]
+
+        someUIKitClasses.forEach { XCTAssertTrue(Bundle(for: $0).isUIKit) }
+        someNonUIKitClasses.forEach { XCTAssertFalse(Bundle(for: $0).isUIKit) }
+    }
+}

--- a/Tests/DatadogTests/Helpers/CustomObjcViewController.h
+++ b/Tests/DatadogTests/Helpers/CustomObjcViewController.h
@@ -4,5 +4,12 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-#import "NSURLSessionBridge.h"
-#import "CustomObjcViewController.h"
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CustomObjcViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/DatadogTests/Helpers/CustomObjcViewController.m
+++ b/Tests/DatadogTests/Helpers/CustomObjcViewController.m
@@ -4,5 +4,16 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-#import "NSURLSessionBridge.h"
 #import "CustomObjcViewController.h"
+
+@interface CustomObjcViewController ()
+
+@end
+
+@implementation CustomObjcViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+}
+
+@end


### PR DESCRIPTION
### What and why?

🐛 When RUM Views auto instrumentation was enabled, no `UIViewController` defined in `Objc` was tracked. No matter if the SDK was configured in Objc:
```objc
[configuration trackUIKitRUMViews];
```
or swift:
```swift
.trackUIKitRUMViews()
```

### How?

The problem was caused by the filtering logic done in `DefaultUIKitRUMViewsPredicate`:
```swift
public func rumView(for viewController: UIViewController) -> RUMView? {
   let canonicalClassName = NSStringFromClass(type(of: viewController))
   let isCustomClass = canonicalClassName.contains(".") // custom class contains module prefix

   if isCustomClass {
      // ... capture the view
   } else {
      return nil // ignore the view
   }
}
```
`isCustomClass` was meant to indicate if the `viewController` is a custom VC provided by the user app (`true`) or is a standard VC coming from `UIKit` (`false`). This was to ignore all the "system" view controllers like `UINavigationViewController`, `UITabBarController` etc.

🐛 The implementation was based on the observation that custom Swift VCs are prefixed with module name when inspecting their name through `NSStringFromClass()` (e.g. `MyApp.LoginViewController`). This turned out to be not true for custom Objc VCs, which have no module prefix.

🌟 The fix is to change the way we recognise custom VC. Now we lookup the `Bundle` that the class is loaded from and we simply filter out all VCs coming from `UIKitCore.framework` bundle.

### Why it was not catched before?

This bug was not visible, because we didn't have any tests covering Obj-C view controllers and RUM Views predicate.

### How to prevent it in the future?

I added one unit test for covering this exact scenario and configured one of the integration tests to also work with Objective-C view controllers (to cover other potential issues of mixed Swift <> Objc codebase instrumentation).

The integration test was done by splitting the existing `RUMResourcesScenario` into two separate scenarios: `RUMURLSessionResourcesScenario` and `RUMNSURLSessionResourcesScenario`. They both have identical setup, storyboards and view controller implementations. The prior defines its VCs in Swift, the latter in Objective-C. It didn't require adding anything new in the UI, as those tests are based on the existing `URLSession` + `NSURLSession` scenarios.

<img width="1117" alt="Screenshot 2021-02-18 at 18 41 48" src="https://user-images.githubusercontent.com/2358722/108398132-fa5b4880-7218-11eb-82f6-e036cafe50cb.png">

As a bonus 🎁 we gain integration coverage for RUM Resources tracked from Obj-c code.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
