### PR TITLE
Make trace propagation HTTP headers available to ObjC

### DIFF
--- a/Sources/DatadogObjc/Tracing/Propagation/HTTPHeadersWriter+objc.swift
+++ b/Sources/DatadogObjc/Tracing/Propagation/HTTPHeadersWriter+objc.swift
@@ -11,6 +11,10 @@ import class Datadog.HTTPHeadersWriter
 public class DDHTTPHeadersWriter: NSObject {
     let swiftHTTPHeadersWriter = HTTPHeadersWriter()
 
+    @objc public var tracePropagationHTTPHeaders: [String: String] {
+        swiftHTTPHeadersWriter.tracePropagationHTTPHeaders
+    }
+
     @objc
     override public init() {}
 }

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -236,8 +236,7 @@ class DDTracerTests: XCTestCase {
             "x-datadog-trace-id": "1",
             "x-datadog-parent-id": "2",
         ]
-        let swiftWritter = objcWriter.swiftHTTPHeadersWriter
-        XCTAssertEqual(swiftWritter.tracePropagationHTTPHeaders, expectedHTTPHeaders)
+        XCTAssertEqual(objcWriter.tracePropagationHTTPHeaders, expectedHTTPHeaders)
     }
 
     func testInjectingSpanContextToInvalidCarrierOrFormat() throws {


### PR DESCRIPTION
Create `tracePropagationHTTPHeaders` property exposed to ObjC in `DDHTTPHeadersWriter`

### What and why?

As per iOS Trace Collection, users of the SDK may want to manually propagate traces, rather than relying on interceptors provided by the SDK.

Trace propagation HTTP headers are not accessible via `DDHTTPHeadersWriter`, the Objective-C variant/facade class to `HTTPHeadersWriter`.

A `DDHTTPHeadersWriter`'s underlying `HTTPHeadersWriter.tracePropagationHTTPHeaders` should be accessible through a public property exposed to Objective-C.

Resolves #420. 

### How?

Create `tracePropagationHTTPHeaders` property exposed to ObjC in `DDHTTPHeadersWriter`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
