### PR TITLE
RUMM-1049 Inject user, network and carrier info to Crash Reports

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -101,6 +101,8 @@
 		6114FE2F257687310084E372 /* ConsentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE2E257687300084E372 /* ConsentProvider.swift */; };
 		6114FE3B25768AA90084E372 /* ConsentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE3A25768AA90084E372 /* ConsentProviderTests.swift */; };
 		6115299725E3BEF9004F740E /* UIKitExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6115299625E3BEF9004F740E /* UIKitExtensionsTests.swift */; };
+		611529A525E3DD51004F740E /* ValuePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611529A425E3DD51004F740E /* ValuePublisher.swift */; };
+		611529AE25E3E429004F740E /* ValuePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611529AD25E3E429004F740E /* ValuePublisherTests.swift */; };
 		61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */; };
 		61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */; };
 		61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */; };
@@ -617,6 +619,8 @@
 		6114FE2E257687300084E372 /* ConsentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentProvider.swift; sourceTree = "<group>"; };
 		6114FE3A25768AA90084E372 /* ConsentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentProviderTests.swift; sourceTree = "<group>"; };
 		6115299625E3BEF9004F740E /* UIKitExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensionsTests.swift; sourceTree = "<group>"; };
+		611529A425E3DD51004F740E /* ValuePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValuePublisher.swift; sourceTree = "<group>"; };
+		611529AD25E3E429004F740E /* ValuePublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValuePublisherTests.swift; sourceTree = "<group>"; };
 		61163C36252DDD60007DD5BF /* RUMMVSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSViewController.swift; sourceTree = "<group>"; };
 		61163C3D252E0015007DD5BF /* RUMMVSModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMVSModalViewController.swift; sourceTree = "<group>"; };
 		61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMModalViewsScenarioTests.swift; sourceTree = "<group>"; };
@@ -1170,6 +1174,7 @@
 				9E58E8E024615C75008E5063 /* JSONEncoder.swift */,
 				61363D9C24D999F70084CD6F /* DDError.swift */,
 				6139CD702589FAFD007E8BB7 /* Retrying.swift */,
+				611529A425E3DD51004F740E /* ValuePublisher.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2531,6 +2536,7 @@
 			children = (
 				61E917CE2464270500E6C631 /* EncodableValueTests.swift */,
 				6139CD762589FEE3007E8BB7 /* RetryingTests.swift */,
+				611529AD25E3E429004F740E /* ValuePublisherTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3253,6 +3259,7 @@
 				61B0385A2527247000518F3C /* DDURLSessionDelegate.swift in Sources */,
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
 				6149FB3A2529D17F00EE387A /* InternalURLsFilter.swift in Sources */,
+				611529A525E3DD51004F740E /* ValuePublisher.swift in Sources */,
 				618DCFD724C7265300589570 /* RUMUUID.swift in Sources */,
 				61B038662527247800518F3C /* URLSessionInterceptor.swift in Sources */,
 				61B03898252724DE00518F3C /* TracingHTTPHeaders.swift in Sources */,
@@ -3458,6 +3465,7 @@
 				61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */,
 				61133C4E2423990D00786299 /* UIKitMocks.swift in Sources */,
 				61B0387B252724AB00518F3C /* URLSessionTracingHandlerTests.swift in Sources */,
+				611529AE25E3E429004F740E /* ValuePublisherTests.swift in Sources */,
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
 				6115299725E3BEF9004F740E /* UIKitExtensionsTests.swift in Sources */,
 				614B0A4D24EBD71500A2A780 /* RUMUserInfoProviderTests.swift in Sources */,

--- a/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
+++ b/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
@@ -15,16 +15,17 @@ internal class UserInfoProvider {
 
     init() {
         let emptyUserInfo = UserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
-        // Synchronous `updatesModel` makes the `value` setter a blocking call.
-        // This ensures that the new value of the `UserInfo`` will be applied immediately
-        // to all data sent from the the same thread.
-        self.publisher = ValuePublisher(initialValue: emptyUserInfo, updatesModel: .synchronous)
+        self.publisher = ValuePublisher(initialValue: emptyUserInfo)
     }
 
     // MARK: - `UserInfo` Value
 
     var value: UserInfo {
-        set { publisher.currentValue = newValue }
+        set {
+            // Synchronous update ensures that the new value of the consent will be applied immediately
+            // to all data sent from the the same thread.
+            publisher.publishSync(newValue)
+        }
         get { publisher.currentValue }
     }
 

--- a/Sources/Datadog/Core/Persistence/Privacy/ConsentProvider.swift
+++ b/Sources/Datadog/Core/Persistence/Privacy/ConsentProvider.swift
@@ -14,10 +14,7 @@ internal class ConsentProvider {
     private let publisher: ValuePublisher<TrackingConsent>
 
     init(initialConsent: TrackingConsent) {
-        // Synchronous `updatesModel` makes the `changeConsent(to:)` a blocking call.
-        // This ensures that the new value of the consent will be applied immediately
-        // to all data sent from the the same thread.
-        self.publisher = ValuePublisher(initialValue: initialConsent, updatesModel: .synchronous)
+        self.publisher = ValuePublisher(initialValue: initialConsent)
     }
 
     // MARK: - Consent Value
@@ -27,7 +24,9 @@ internal class ConsentProvider {
 
     /// Sets the new value of `TrackingConsent` and notifies all subscribers.
     func changeConsent(to newValue: TrackingConsent) {
-        publisher.currentValue = newValue
+        // Synchronous update ensures that the new value of the consent will be applied immediately
+        // to all data sent from the the same thread.
+        publisher.publishSync(newValue)
     }
 
     // MARK: - Managing Subscribers

--- a/Sources/Datadog/Core/Persistence/Privacy/ConsentProvider.swift
+++ b/Sources/Datadog/Core/Persistence/Privacy/ConsentProvider.swift
@@ -6,46 +6,33 @@
 
 import Foundation
 
-internal protocol ConsentSubscriber: class {
-    func consentChanged(from oldValue: TrackingConsent, to newValue: TrackingConsent)
-}
+/// An observer for `TrackingConsent` value.
+internal typealias TrackingConsentObserver = ValueObserver
 
 /// Provides the current `TrackingConsent` value and notifies all subscribers on its change.
 internal class ConsentProvider {
-    private let queue = DispatchQueue(
-        label: "com.datadoghq.tracking-consent",
-        target: .global(qos: .userInteractive)
-    )
-    private var subscribers: [ConsentSubscriber] = []
+    private let publisher: ValuePublisher<TrackingConsent>
 
     init(initialConsent: TrackingConsent) {
-        self.unsafeCurrentValue = initialConsent
+        // Synchronous `updatesModel` makes the `changeConsent(to:)` a blocking call.
+        // This ensures that the new value of the consent will be applied immediately
+        // to all data sent from the the same thread.
+        self.publisher = ValuePublisher(initialValue: initialConsent, updatesModel: .synchronous)
     }
 
     // MARK: - Consent Value
 
-    /// Unsychronized consent value. Use `self.currentValue` setter & getter.
-    private var unsafeCurrentValue: TrackingConsent
-
     /// The current value of`TrackingConsent`.
-    private(set) var currentValue: TrackingConsent {
-        get { queue.sync { unsafeCurrentValue } }
-        set { queue.async { self.unsafeCurrentValue = newValue } }
-    }
+    var currentValue: TrackingConsent { publisher.currentValue }
 
     /// Sets the new value of `TrackingConsent` and notifies all subscribers.
     func changeConsent(to newValue: TrackingConsent) {
-        let oldValue = currentValue
-        currentValue = newValue
-
-        subscribers.forEach { subscriber in
-            subscriber.consentChanged(from: oldValue, to: newValue)
-        }
+        publisher.currentValue = newValue
     }
 
     // MARK: - Managing Subscribers
 
-    func subscribe(consentSubscriber: ConsentSubscriber) {
-        subscribers.append(consentSubscriber)
+    func subscribe<Observer: TrackingConsentObserver>(_ subscriber: Observer) where Observer.ObservedValue == TrackingConsent {
+        publisher.subscribe(subscriber)
     }
 }

--- a/Sources/Datadog/Core/Persistence/Writting/ConsentAwareDataWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/ConsentAwareDataWriter.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Writes data to different folders depending on current the value of the `TrackingConsent`.
 /// When the value of `TrackingConsent` changes, it may move data from unauthorized folder to the authorized one or wipe it out entirely.
 /// It synchronizes the work of underlying `FileWriters` on given read/write queue.
-internal class ConsentAwareDataWriter: Writer, ConsentSubscriber {
+internal class ConsentAwareDataWriter: Writer, TrackingConsentObserver {
     /// Queue used to synchronize reads and writes for the feature.
     internal let readWriteQueue: DispatchQueue
     /// Creates data processors depending on the tracking consent value.
@@ -31,7 +31,7 @@ internal class ConsentAwareDataWriter: Writer, ConsentSubscriber {
         self.dataMigratorFactory = dataMigratorFactory
         self.processor = dataProcessorFactory.resolveProcessor(for: consentProvider.currentValue)
 
-        consentProvider.subscribe(consentSubscriber: self)
+        consentProvider.subscribe(self)
 
         let initialDataMigrator = dataMigratorFactory.resolveInitialMigrator()
         readWriteQueue.async { initialDataMigrator.migrate() }
@@ -45,9 +45,9 @@ internal class ConsentAwareDataWriter: Writer, ConsentSubscriber {
         }
     }
 
-    // MARK: - ConsentSubscriber
+    // MARK: - TrackingConsentObserver
 
-    func consentChanged(from oldValue: TrackingConsent, to newValue: TrackingConsent) {
+    func onValueChanged(oldValue: TrackingConsent, newValue: TrackingConsent) {
         readWriteQueue.async {
             self.processor = self.dataProcessorFactory.resolveProcessor(for: newValue)
             self.dataMigratorFactory

--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -7,7 +7,7 @@
 import CoreTelephony
 
 /// Network connection details specific to cellular radio access.
-internal struct CarrierInfo {
+internal struct CarrierInfo: Equatable {
     // swiftlint:disable identifier_name
     enum RadioAccessTechnology: String, Codable, CaseIterable {
         case GPRS

--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -9,7 +9,7 @@ import CoreTelephony
 /// Network connection details specific to cellular radio access.
 internal struct CarrierInfo {
     // swiftlint:disable identifier_name
-    enum RadioAccessTechnology: String, Encodable, CaseIterable {
+    enum RadioAccessTechnology: String, Codable, CaseIterable {
         case GPRS
         case Edge
         case WCDMA

--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -89,17 +89,14 @@ internal class CarrierInfoProvider: CarrierInfoProviderType {
 
     init(wrappedProvider: WrappedCarrierInfoProvider) {
         self.wrappedProvider = wrappedProvider
-        // Asynchronous `updatesModel` makes the `current` getter a non-blocking call.
-        // This ensures that the value form `NetworkConnectionInfoProvider` can be obtained
-        // as fast as possible and the eventual observers will be notified asynchronously.
-        self.publisher = ValuePublisher(initialValue: nil, updatesModel: .asynchronous)
+        self.publisher = ValuePublisher(initialValue: nil)
     }
 
     var current: CarrierInfo? {
         let nextValue = wrappedProvider.current
         // `CarrierInfo` subscribers are notified as a side-effect of retrieving the
         // current `CarrierInfo` value.
-        publisher.currentValue = nextValue
+        publisher.publishAsync(nextValue)
         return nextValue
     }
 

--- a/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
+++ b/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
@@ -9,7 +9,7 @@ import Network
 /// Network connection details.
 internal struct NetworkConnectionInfo {
     /// Tells if network is reachable.
-    enum Reachability: String, Encodable, CaseIterable {
+    enum Reachability: String, Codable, CaseIterable {
         /// The network is reachable.
         case yes
         /// The network might be reachable after trying.
@@ -19,7 +19,7 @@ internal struct NetworkConnectionInfo {
     }
 
     /// Network connection interfaces.
-    enum Interface: String, Encodable, CaseIterable {
+    enum Interface: String, Codable, CaseIterable {
         case wifi
         case wiredEthernet
         case cellular

--- a/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
+++ b/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
@@ -43,7 +43,7 @@ internal protocol NetworkConnectionInfoProviderType {
     /// Current `NetworkConnectionInfo`. It might return `nil` for the first attempt(s),
     /// shortly after provider's initialization, until underlying monitor does not warm up.
     var current: NetworkConnectionInfo? { get }
-
+    /// Subscribes for `NetworkConnectionInfo` updates.
     func subscribe<Observer: NetworkConnectionInfoObserver>(_ subscriber: Observer) where Observer.ObservedValue == NetworkConnectionInfo?
 }
 
@@ -73,7 +73,7 @@ internal class NetworkConnectionInfoProvider: NetworkConnectionInfoProviderType 
 
     var current: NetworkConnectionInfo? {
         let nextValue = wrappedProvider.current
-        // `NetworkConnectionInfo` are notified as a side-effect of retrieving the
+        // `NetworkConnectionInfo` subscribers are notified as a side-effect of retrieving the
         // current `NetworkConnectionInfo` value.
         publisher.currentValue = nextValue
         return nextValue

--- a/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
+++ b/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
@@ -68,17 +68,14 @@ internal class NetworkConnectionInfoProvider: NetworkConnectionInfoProviderType 
 
     init(wrappedProvider: WrappedNetworkConnectionInfoProvider) {
         self.wrappedProvider = wrappedProvider
-        // Asynchronous `updatesModel` makes the `current` getter a non-blocking call.
-        // This ensures that the value form `NetworkConnectionInfoProvider` can be obtained
-        // as fast as possible and the eventual observers will be notified asynchronously.
-        self.publisher = ValuePublisher(initialValue: nil, updatesModel: .asynchronous)
+        self.publisher = ValuePublisher(initialValue: nil)
     }
 
     var current: NetworkConnectionInfo? {
         let nextValue = wrappedProvider.current
         // `NetworkConnectionInfo` subscribers are notified as a side-effect of retrieving the
         // current `NetworkConnectionInfo` value.
-        publisher.currentValue = nextValue
+        publisher.publishAsync(nextValue)
         return nextValue
     }
 

--- a/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
+++ b/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
@@ -7,7 +7,7 @@
 import Network
 
 /// Network connection details.
-internal struct NetworkConnectionInfo {
+internal struct NetworkConnectionInfo: Equatable {
     /// Tells if network is reachable.
     enum Reachability: String, Codable, CaseIterable {
         /// The network is reachable.

--- a/Sources/Datadog/Core/Utils/ValuePublisher.swift
+++ b/Sources/Datadog/Core/Utils/ValuePublisher.swift
@@ -12,6 +12,9 @@ internal protocol ValueObserver {
 
     /// Notifies this observer on the value change. Called on the publisher's queue.
     /// If the `ObservedValue` conforms to `Equatable`, only distinct changes will be notified.
+    ///
+    /// **Note:** as this method is executed on the publisher's queue, call to `publisher.publishSync(_:)`
+    /// from its implementation will result in deadlock. If the observed value must be updated, use `publishAsync(_:)` instead.
     func onValueChanged(oldValue: ObservedValue, newValue: ObservedValue)
 }
 

--- a/Sources/Datadog/Core/Utils/ValuePublisher.swift
+++ b/Sources/Datadog/Core/Utils/ValuePublisher.swift
@@ -1,0 +1,85 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Manages the `Value` in a thread safe manner and notifies subscribed `ValueObservers` on its change.
+internal class ValuePublisher<Value> {
+    /// Type erasure for `ValueObserver` types.
+    private struct AnyObserver<ObservedValue> {
+        let notifyValueChanged: (ObservedValue, ObservedValue) -> Void
+
+        init<Observer: ValueObserver>(wrapped: Observer) where Observer.ObservedValue == ObservedValue {
+            self.notifyValueChanged = wrapped.onValueChanged
+        }
+    }
+
+    /// The queue used to synchronize the access to the `unsafeValue`.
+    /// Concurrent queue is used for performant reads, `.barrier` must be used to make writes exclusive.
+    private let concurrentQueue = DispatchQueue(
+        label: "com.datadoghq.value-publisher-\(type(of: Value.self))",
+        attributes: .concurrent
+    )
+    /// The array of value observers - must be accessed from the `queue`.
+    private var unsafeObservers: [AnyObserver<Value>]
+    /// The managed `Value` - must be accessed from the `queue`.
+    private var unsafeValue: Value
+
+    /// The model used for synchronizing `currentValue` updates.
+    enum UpdatesModel {
+        /// The `currentValue` will be updated synchronously, blocking the caller thread.
+        case synchronous
+        /// The `currentValue` will be updated asynchronously, without blocking the caller thread.
+        case asynchronous
+    }
+
+    /// The synchronization model for updating the `unsafeValue`.
+    private let updatesModel: UpdatesModel
+
+    init(initialValue: Value, updatesModel: UpdatesModel) {
+        self.unsafeValue = initialValue
+        self.unsafeObservers = []
+        self.updatesModel = updatesModel
+    }
+
+    /// Registers an observer that will be notified on the value changes.
+    /// All calls to the `observer` will be synchronised using internal concurrent queue.
+    func subscribe<Observer: ValueObserver>(_ observer: Observer) where Observer.ObservedValue == Value {
+        concurrentQueue.async(flags: .barrier) {
+            self.unsafeObservers.append(AnyObserver(wrapped: observer))
+        }
+    }
+
+    var currentValue: Value {
+        get {
+            concurrentQueue.sync { unsafeValue }
+        }
+        set {
+            switch updatesModel {
+            case .synchronous:
+                concurrentQueue.sync(flags: .barrier) { updateAndNotifyObservers(newValue: newValue) }
+            case .asynchronous:
+                concurrentQueue.async(flags: .barrier) { self.updateAndNotifyObservers(newValue: newValue) }
+            }
+        }
+    }
+
+    private func updateAndNotifyObservers(newValue: Value) {
+        let oldValue = self.unsafeValue
+        self.unsafeValue = newValue
+        self.unsafeObservers.forEach { observer in
+            observer.notifyValueChanged(oldValue, newValue)
+        }
+    }
+}
+
+/// An observer subscribing to a `ValuePublisher`.
+internal protocol ValueObserver {
+    associatedtype ObservedValue
+
+    /// Notifies this observer on the value change. Called on the publisher's queue.
+    func onValueChanged(oldValue: ObservedValue, newValue: ObservedValue)
+}

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
@@ -36,8 +36,6 @@ internal struct CrashContext: Codable {
     private var codableLastNetworkConnectionInfo: CodableNetworkConnectionInfo?
     private var codableLastCarrierInfo: CodableCarrierInfo?
 
-    // TODO: RUMM-1049 Add Codable version of `UserInfo?`, `NetworkInfo?` and `CarrierInfo?`
-
     enum CodingKeys: String, CodingKey {
         case codableTrackingConsent = "ctc"
         case codableLastRUMViewEvent = "lre"

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
@@ -18,12 +18,14 @@ internal struct CrashContext: Codable {
         lastTrackingConsent: TrackingConsent,
         lastUserInfo: UserInfo,
         lastRUMViewEvent: RUMEvent<RUMViewEvent>?,
-        lastNetworkConnectionInfo: NetworkConnectionInfo?
+        lastNetworkConnectionInfo: NetworkConnectionInfo?,
+        lastCarrierInfo: CarrierInfo?
     ) {
         self.codableTrackingConsent = .init(from: lastTrackingConsent)
         self.codableLastUserInfo = .init(from: lastUserInfo)
         self.codableLastRUMViewEvent = lastRUMViewEvent.flatMap { .init(from: $0) }
         self.codableLastNetworkConnectionInfo = lastNetworkConnectionInfo.flatMap { .init(from: $0) }
+        self.codableLastCarrierInfo = lastCarrierInfo.flatMap { .init(from: $0) }
     }
 
     // MARK: - Codable values
@@ -32,6 +34,7 @@ internal struct CrashContext: Codable {
     private var codableLastUserInfo: CodableUserInfo?
     private var codableLastRUMViewEvent: CodableRUMViewEvent?
     private var codableLastNetworkConnectionInfo: CodableNetworkConnectionInfo?
+    private var codableLastCarrierInfo: CodableCarrierInfo?
 
     // TODO: RUMM-1049 Add Codable version of `UserInfo?`, `NetworkInfo?` and `CarrierInfo?`
 
@@ -40,6 +43,7 @@ internal struct CrashContext: Codable {
         case codableLastRUMViewEvent = "lre"
         case codableLastUserInfo = "lui"
         case codableLastNetworkConnectionInfo = "lni"
+        case codableLastCarrierInfo = "lci"
     }
 
     // MARK: - Setters & Getters using managed types
@@ -62,6 +66,11 @@ internal struct CrashContext: Codable {
     var lastNetworkConnectionInfo: NetworkConnectionInfo? {
         set { codableLastNetworkConnectionInfo = newValue.flatMap { CodableNetworkConnectionInfo(from: $0) } }
         get { codableLastNetworkConnectionInfo?.managedValue }
+    }
+
+    var lastCarrierInfo: CarrierInfo? {
+        set { codableLastCarrierInfo = newValue.flatMap { CodableCarrierInfo(from: $0) } }
+        get { codableLastCarrierInfo?.managedValue }
     }
 }
 
@@ -224,6 +233,38 @@ private struct CodableNetworkConnectionInfo: Codable {
         case supportsIPv6 = "si6"
         case isExpensive = "ise"
         case isConstrained = "isc"
+    }
+}
+
+private struct CodableCarrierInfo: Codable {
+    private let carrierName: String?
+    private let carrierISOCountryCode: String?
+    private let carrierAllowsVOIP: Bool
+    private let radioAccessTechnology: CarrierInfo.RadioAccessTechnology
+
+    init(from managedValue: CarrierInfo) {
+        self.carrierName = managedValue.carrierName
+        self.carrierISOCountryCode = managedValue.carrierISOCountryCode
+        self.carrierAllowsVOIP = managedValue.carrierAllowsVOIP
+        self.radioAccessTechnology = managedValue.radioAccessTechnology
+    }
+
+    var managedValue: CarrierInfo {
+        return .init(
+            carrierName: carrierName,
+            carrierISOCountryCode: carrierISOCountryCode,
+            carrierAllowsVOIP: carrierAllowsVOIP,
+            radioAccessTechnology: radioAccessTechnology
+        )
+    }
+
+    // MARK: - Codable
+
+    enum CodingKeys: String, CodingKey {
+        case carrierName = "crn"
+        case carrierISOCountryCode = "cri"
+        case carrierAllowsVOIP = "cra"
+        case radioAccessTechnology = "rdt"
     }
 }
 

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -16,7 +16,7 @@ internal protocol CrashContextProviderType: class {
     /// Updates the `CrashContext` with last `RUMEvent<RUMViewEvent>` information.
     func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>)
 
-    /// Updates the `CrashContext` with last `TarckingConsent` information.
+    /// Updates the `CrashContext` with last `TrackingConsent` information.
     func update(lastTrackingConsent: TrackingConsent)
 }
 
@@ -39,7 +39,8 @@ internal class CrashContextProvider: CrashContextProviderType, ConsentSubscriber
         self.unsafeCrashContext = CrashContext(
             // Set initial `TrackingConsent`
             lastTrackingConsent: consentProvider.currentValue,
-            lastRUMViewEvent: nil
+            lastRUMViewEvent: nil,
+            lastUserInfo: nil
         )
 
         // Subscribe for `TrackingConsent` updates

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -40,7 +40,8 @@ internal class CrashContextProvider: CrashContextProviderType, ConsentSubscriber
             // Set initial `TrackingConsent`
             lastTrackingConsent: consentProvider.currentValue,
             lastRUMViewEvent: nil,
-            lastUserInfo: nil
+            lastUserInfo: nil, // TODO: RUMM-1049 provide default value
+            lastNetworkConnectionInfo: nil // TODO: RUMM-1049 provide default value
         )
 
         // Subscribe for `TrackingConsent` updates

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -51,12 +51,18 @@ internal class CrashContextProvider: CrashContextProviderType {
         self.unsafeCrashContext.lastNetworkConnectionInfo = newValue
     }
 
+    /// Updates `CrashContext` with last `CarrierInfo` information.
+    private lazy var carrierInfoUpdater = ContextValueUpdater<CarrierInfo?>(queue: queue) { newValue in
+        self.unsafeCrashContext.lastCarrierInfo = newValue
+    }
+
     // MARK: - Initializer
 
     init(
         consentProvider: ConsentProvider,
         userInfoProvider: UserInfoProvider,
-        networkConnectionInfoProvider: NetworkConnectionInfoProviderType
+        networkConnectionInfoProvider: NetworkConnectionInfoProviderType,
+        carrierInfoProvider: CarrierInfoProviderType
     ) {
         self.queue = DispatchQueue(
             label: "com.datadoghq.crash-context",
@@ -68,13 +74,14 @@ internal class CrashContextProvider: CrashContextProviderType {
             lastUserInfo: userInfoProvider.value,
             lastRUMViewEvent: nil,
             lastNetworkConnectionInfo: networkConnectionInfoProvider.current,
-            lastCarrierInfo: nil // TODO: RUMM-1049 set default and subscribe for updates
+            lastCarrierInfo: carrierInfoProvider.current
         )
 
         // Subscribe for context updates
         consentProvider.subscribe(trackingConsentUpdater)
         userInfoProvider.subscribe(userInfoUpdater)
         networkConnectionInfoProvider.subscribe(networkConnectionInfoUpdater)
+        carrierInfoProvider.subscribe(carrierInfoUpdater)
     }
 
     // MARK: - CrashContextProviderType

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -37,20 +37,26 @@ internal class CrashContextProvider: CrashContextProviderType {
     }
 
     /// Updates `CrashContext` with last `TrackingConsent` information.
-    private lazy var trackingConsentUpdater = ContextValueUpdater<TrackingConsent>(queue: queue) { newTrackingConsent in
-        self.unsafeCrashContext.lastTrackingConsent = newTrackingConsent
+    private lazy var trackingConsentUpdater = ContextValueUpdater<TrackingConsent>(queue: queue) { newValue in
+        self.unsafeCrashContext.lastTrackingConsent = newValue
     }
 
     /// Updates `CrashContext` with last `UserInfo` information.
-    private lazy var userInfoUpdater = ContextValueUpdater<UserInfo>(queue: queue) { newUserInfo in
-        self.unsafeCrashContext.lastUserInfo = newUserInfo
+    private lazy var userInfoUpdater = ContextValueUpdater<UserInfo>(queue: queue) { newValue in
+        self.unsafeCrashContext.lastUserInfo = newValue
+    }
+
+    /// Updates `CrashContext` with last `NetworkConnectionInfo` information.
+    private lazy var networkConnectionInfoUpdater = ContextValueUpdater<NetworkConnectionInfo?>(queue: queue) { newValue in
+        self.unsafeCrashContext.lastNetworkConnectionInfo = newValue
     }
 
     // MARK: - Initializer
 
     init(
         consentProvider: ConsentProvider,
-        userInfoProvider: UserInfoProvider
+        userInfoProvider: UserInfoProvider,
+        networkConnectionInfoProvider: NetworkConnectionInfoProviderType
     ) {
         self.queue = DispatchQueue(
             label: "com.datadoghq.crash-context",
@@ -61,12 +67,13 @@ internal class CrashContextProvider: CrashContextProviderType {
             lastTrackingConsent: consentProvider.currentValue,
             lastUserInfo: userInfoProvider.value,
             lastRUMViewEvent: nil,
-            lastNetworkConnectionInfo: nil // TODO: RUMM-1049 provide default value
+            lastNetworkConnectionInfo: networkConnectionInfoProvider.current
         )
 
         // Subscribe for context updates
         consentProvider.subscribe(trackingConsentUpdater)
         userInfoProvider.subscribe(userInfoUpdater)
+        networkConnectionInfoProvider.subscribe(networkConnectionInfoUpdater)
     }
 
     // MARK: - CrashContextProviderType

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -67,7 +67,8 @@ internal class CrashContextProvider: CrashContextProviderType {
             lastTrackingConsent: consentProvider.currentValue,
             lastUserInfo: userInfoProvider.value,
             lastRUMViewEvent: nil,
-            lastNetworkConnectionInfo: networkConnectionInfoProvider.current
+            lastNetworkConnectionInfo: networkConnectionInfoProvider.current,
+            lastCarrierInfo: nil // TODO: RUMM-1049 set default and subscribe for updates
         )
 
         // Subscribe for context updates

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -21,7 +21,7 @@ internal protocol CrashContextProviderType: class {
 }
 
 /// Manages the `CrashContext` reads and writes in a thread-safe manner.
-internal class CrashContextProvider: CrashContextProviderType, ConsentSubscriber {
+internal class CrashContextProvider: CrashContextProviderType, TrackingConsentObserver {
     /// Queue for synchronizing internal operations.
     private let queue: DispatchQueue
     /// Unsychronized `CrashContext`. The `queue` must be used to synchronize its mutation.
@@ -45,7 +45,7 @@ internal class CrashContextProvider: CrashContextProviderType, ConsentSubscriber
         )
 
         // Subscribe for `TrackingConsent` updates
-        consentProvider.subscribe(consentSubscriber: self)
+        consentProvider.subscribe(self)
     }
 
     // MARK: - CrashContextProviderType
@@ -80,9 +80,9 @@ internal class CrashContextProvider: CrashContextProviderType, ConsentSubscriber
         }
     }
 
-    // MARK: - ConsentSubscriber
+    // MARK: - TrackingConsentObserver
 
-    func consentChanged(from oldValue: TrackingConsent, to newValue: TrackingConsent) {
+    func onValueChanged(oldValue: TrackingConsent, newValue: TrackingConsent) {
         update(lastTrackingConsent: newValue)
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -48,7 +48,8 @@ internal class CrashReporter {
             crashContextProvider: CrashContextProvider(
                 consentProvider: crashReportingFeature.consentProvider,
                 userInfoProvider: crashReportingFeature.userInfoProvider,
-                networkConnectionInfoProvider: crashReportingFeature.networkConnectionInfoProvider
+                networkConnectionInfoProvider: crashReportingFeature.networkConnectionInfoProvider,
+                carrierInfoProvider: crashReportingFeature.carrierInfoProvider
             ),
             loggingOrRUMIntegration: availableLoggingOrRUMIntegration
         )

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -47,7 +47,8 @@ internal class CrashReporter {
             crashReportingPlugin: crashReportingFeature.configuration.crashReportingPlugin,
             crashContextProvider: CrashContextProvider(
                 consentProvider: crashReportingFeature.consentProvider,
-                userInfoProvider: crashReportingFeature.userInfoProvider
+                userInfoProvider: crashReportingFeature.userInfoProvider,
+                networkConnectionInfoProvider: crashReportingFeature.networkConnectionInfoProvider
             ),
             loggingOrRUMIntegration: availableLoggingOrRUMIntegration
         )

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -49,7 +49,8 @@ internal class CrashReporter {
                 consentProvider: crashReportingFeature.consentProvider,
                 userInfoProvider: crashReportingFeature.userInfoProvider,
                 networkConnectionInfoProvider: crashReportingFeature.networkConnectionInfoProvider,
-                carrierInfoProvider: crashReportingFeature.carrierInfoProvider
+                carrierInfoProvider: crashReportingFeature.carrierInfoProvider,
+                rumViewEventProvider: crashReportingFeature.rumViewEventProvider
             ),
             loggingOrRUMIntegration: availableLoggingOrRUMIntegration
         )

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -46,7 +46,8 @@ internal class CrashReporter {
         self.init(
             crashReportingPlugin: crashReportingFeature.configuration.crashReportingPlugin,
             crashContextProvider: CrashContextProvider(
-                consentProvider: crashReportingFeature.consentProvider
+                consentProvider: crashReportingFeature.consentProvider,
+                userInfoProvider: crashReportingFeature.userInfoProvider
             ),
             loggingOrRUMIntegration: availableLoggingOrRUMIntegration
         )

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -21,6 +21,7 @@ internal final class CrashReportingFeature {
     // MARK: - Dependencies
 
     let consentProvider: ConsentProvider
+    let userInfoProvider: UserInfoProvider
 
     // TODO: RUMM-1049 Bundle `UserInfoProvider`, `NetworkInfoProvider` and `CarrierInfoProvider`
     // for enriching the `CrashContext`
@@ -31,5 +32,6 @@ internal final class CrashReportingFeature {
     ) {
         self.configuration = configuration
         self.consentProvider = commonDependencies.consentProvider
+        self.userInfoProvider = commonDependencies.userInfoProvider
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -20,10 +20,16 @@ internal final class CrashReportingFeature {
 
     // MARK: - Dependencies
 
+    /// Publishes recent `ConsentProvider` value so it can be persisted in `CrashContext`.
     let consentProvider: ConsentProvider
+    /// Publishes recent `UserInfo` value so it can be persisted in `CrashContext`.
     let userInfoProvider: UserInfoProvider
+    /// Publishes recent `NetworkConnectionInfo` value so it can be persisted in `CrashContext`.
     let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
+    /// Publishes recent `CarrierInfo` value so it can be persisted in `CrashContext`.
     let carrierInfoProvider: CarrierInfoProviderType
+    /// Publishes recent `RUMEvent<RUMViewEvent>` value so it can be persisted in `CrashContext`.
+    let rumViewEventProvider: ValuePublisher<RUMEvent<RUMViewEvent>?>
 
     init(
         configuration: FeaturesConfiguration.CrashReporting,
@@ -34,5 +40,6 @@ internal final class CrashReportingFeature {
         self.userInfoProvider = commonDependencies.userInfoProvider
         self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
         self.carrierInfoProvider = commonDependencies.carrierInfoProvider
+        self.rumViewEventProvider = ValuePublisher(initialValue: nil, updatesModel: .asynchronous)
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -23,9 +23,7 @@ internal final class CrashReportingFeature {
     let consentProvider: ConsentProvider
     let userInfoProvider: UserInfoProvider
     let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
-
-    // TODO: RUMM-1049 Bundle `UserInfoProvider`, `NetworkInfoProvider` and `CarrierInfoProvider`
-    // for enriching the `CrashContext`
+    let carrierInfoProvider: CarrierInfoProviderType
 
     init(
         configuration: FeaturesConfiguration.CrashReporting,
@@ -35,5 +33,6 @@ internal final class CrashReportingFeature {
         self.consentProvider = commonDependencies.consentProvider
         self.userInfoProvider = commonDependencies.userInfoProvider
         self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
+        self.carrierInfoProvider = commonDependencies.carrierInfoProvider
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -22,6 +22,7 @@ internal final class CrashReportingFeature {
 
     let consentProvider: ConsentProvider
     let userInfoProvider: UserInfoProvider
+    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
 
     // TODO: RUMM-1049 Bundle `UserInfoProvider`, `NetworkInfoProvider` and `CarrierInfoProvider`
     // for enriching the `CrashContext`
@@ -33,5 +34,6 @@ internal final class CrashReportingFeature {
         self.configuration = configuration
         self.consentProvider = commonDependencies.consentProvider
         self.userInfoProvider = commonDependencies.userInfoProvider
+        self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -40,6 +40,6 @@ internal final class CrashReportingFeature {
         self.userInfoProvider = commonDependencies.userInfoProvider
         self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
         self.carrierInfoProvider = commonDependencies.carrierInfoProvider
-        self.rumViewEventProvider = ValuePublisher(initialValue: nil, updatesModel: .asynchronous)
+        self.rumViewEventProvider = ValuePublisher(initialValue: nil)
     }
 }

--- a/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
@@ -26,6 +26,6 @@ internal struct RUMWithCrashContextIntegration {
     }
 
     func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>) {
-        rumViewEventProvider?.currentValue = lastRUMViewEvent
+        rumViewEventProvider?.publishAsync(lastRUMViewEvent)
     }
 }

--- a/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
@@ -11,21 +11,21 @@ import Foundation
 ///
 /// This integration isolates the direct link between RUM and Crash Reporting.
 internal struct RUMWithCrashContextIntegration {
-    private weak var crashContextProvider: CrashContextProviderType?
+    private weak var rumViewEventProvider: ValuePublisher<RUMEvent<RUMViewEvent>?>?
 
     init?() {
-        if let crashContextProvider = Global.crashReporter?.crashContextProvider {
-            self.init(crashContextProvider: crashContextProvider)
+        if let crashReportingFeature = CrashReportingFeature.instance {
+            self.init(rumViewEventProvider: crashReportingFeature.rumViewEventProvider)
         } else {
             return nil
         }
     }
 
-    init(crashContextProvider: CrashContextProviderType) {
-        self.crashContextProvider = crashContextProvider
+    init(rumViewEventProvider: ValuePublisher<RUMEvent<RUMViewEvent>?>) {
+        self.rumViewEventProvider = rumViewEventProvider
     }
 
     func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>) {
-        crashContextProvider?.update(lastRUMViewEvent: lastRUMViewEvent)
+        rumViewEventProvider?.currentValue = lastRUMViewEvent
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
@@ -19,7 +19,7 @@ class FeatureStorageTests: XCTestCase {
     }
 
     func testWhenWrittingDataAndChangingConsent_thenOnlyAuthorizedDataCanBeRead() {
-        let consentProvider = ConsentProvider(initialConsent: randomConsent())
+        let consentProvider = ConsentProvider(initialConsent: .mockRandom())
 
         // Given
         let storage = FeatureStorage(
@@ -33,7 +33,7 @@ class FeatureStorageTests: XCTestCase {
         // When
         (0..<100).forEach { _ in
             let currentConsent = consentProvider.currentValue
-            let nextConsent = randomConsent(otherThan: currentConsent)
+            let nextConsent: TrackingConsent = .mockRandom(otherThan: currentConsent)
 
             let stringValue = "current consent: \(currentConsent), next consent: \(nextConsent)"
             storage.writer.write(value: stringValue)
@@ -137,15 +137,5 @@ class FeatureStorageTests: XCTestCase {
         }
 
         return dataAuthorizedForUpload
-    }
-
-    /// Returns random consent value other than the given one.
-    private func randomConsent(otherThan consent: TrackingConsent? = nil) -> TrackingConsent {
-        while true {
-            let randomConsent: TrackingConsent = .mockRandom()
-            if randomConsent != consent {
-                return randomConsent
-            }
-        }
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Privacy/ConsentProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Privacy/ConsentProviderTests.swift
@@ -7,14 +7,6 @@
 import XCTest
 @testable import Datadog
 
-private class ConsentSubscriberMock: ConsentSubscriber {
-    var consentChange: (oldValue: TrackingConsent, newValue: TrackingConsent)?
-
-    func consentChanged(from oldValue: TrackingConsent, to newValue: TrackingConsent) {
-        consentChange = (oldValue: oldValue, newValue: newValue)
-    }
-}
-
 class ConsentProviderTests: XCTestCase {
     func testGivenInitialConsentSet_whenTheValueChanges_itCanBeRetrieved() {
         let initialConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
@@ -34,21 +26,25 @@ class ConsentProviderTests: XCTestCase {
     func testGivenInitialConsentSet_whenTheValueChanges_itNotifiesAllSubscribers() {
         let initialConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
         let newConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
-        let subscribers = (0..<5).map { _ in ConsentSubscriberMock() }
+
+        let expectation = self.expectation(description: "Notify all 5 observers")
+        expectation.expectedFulfillmentCount = 5
+        let subscribers = (0..<5).map { _ in
+            ValueObserverMock<TrackingConsent> { _, _ in expectation.fulfill() }
+        }
 
         // Given
         let provider = ConsentProvider(initialConsent: initialConsent)
-        subscribers.forEach { subscriber in
-            provider.subscribe(consentSubscriber: subscriber)
-        }
+        subscribers.forEach { subscriber in provider.subscribe(subscriber) }
 
         // When
         provider.changeConsent(to: newConsent)
 
         // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
         subscribers.forEach { subscriber in
-            XCTAssertEqual(subscriber.consentChange?.oldValue, initialConsent)
-            XCTAssertEqual(subscriber.consentChange?.newValue, newConsent)
+            XCTAssertEqual(subscriber.lastChange?.oldValue, initialConsent)
+            XCTAssertEqual(subscriber.lastChange?.newValue, newConsent)
         }
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Privacy/ConsentProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Privacy/ConsentProviderTests.swift
@@ -9,8 +9,8 @@ import XCTest
 
 class ConsentProviderTests: XCTestCase {
     func testGivenInitialConsentSet_whenTheValueChanges_itCanBeRetrieved() {
-        let initialConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
-        let newConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
+        let initialConsent: TrackingConsent = .mockRandom()
+        let newConsent: TrackingConsent = .mockRandom(otherThan: initialConsent)
 
         // Given
         let provider = ConsentProvider(initialConsent: initialConsent)
@@ -24,8 +24,8 @@ class ConsentProviderTests: XCTestCase {
     }
 
     func testGivenInitialConsentSet_whenTheValueChanges_itNotifiesAllSubscribers() {
-        let initialConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
-        let newConsent: TrackingConsent = [.granted, .notGranted, .pending].randomElement()!
+        let initialConsent: TrackingConsent = .mockRandom()
+        let newConsent: TrackingConsent = .mockRandom(otherThan: initialConsent)
 
         let expectation = self.expectation(description: "Notify all 5 observers")
         expectation.expectedFulfillmentCount = 5

--- a/Tests/DatadogTests/Datadog/Core/System/CarrierInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/System/CarrierInfoProviderTests.swift
@@ -20,7 +20,9 @@ class CarrierInfoProviderTests: XCTestCase {
             serviceSubscriberCellularProviders: [serviceID: CTCarrierMock(carrierName: "Carrier", isoCountryCode: "US", allowsVOIP: true)]
         )
 
-        let provider = CarrierInfoProvider(networkInfo: telephonyNetworkInfo)
+        let provider = CarrierInfoProvider(
+            wrappedProvider: iOSCarrierInfoProvider(networkInfo: telephonyNetworkInfo)
+        )
 
         XCTAssertEqual(provider.current?.carrierName, "Carrier")
         XCTAssertEqual(provider.current?.carrierISOCountryCode, "US")
@@ -33,7 +35,9 @@ class CarrierInfoProviderTests: XCTestCase {
             serviceSubscriberCellularProviders: [:]
         )
 
-        let provider = CarrierInfoProvider(networkInfo: telephonyNetworkInfo)
+        let provider = CarrierInfoProvider(
+            wrappedProvider: iOSCarrierInfoProvider(networkInfo: telephonyNetworkInfo)
+        )
 
         XCTAssertNil(provider.current)
     }

--- a/Tests/DatadogTests/Datadog/Core/System/NetworkConnectionInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/System/NetworkConnectionInfoProviderTests.swift
@@ -12,7 +12,7 @@ import SystemConfiguration
 class NetworkConnectionInfoProviderTests: XCTestCase {
     /// Constantly pulls the `NetworkConnectionInfo` from given provider and fulfils the expectation if value is received.
     private func pullNetworkConnectionInfo(
-        from provider: iOSSpecificNetworkConnectionInfoProvider,
+        from provider: NetworkConnectionInfoProvider,
         on queue: DispatchQueue,
         thenFulfill expectation: XCTestExpectation
     ) {
@@ -27,7 +27,9 @@ class NetworkConnectionInfoProviderTests: XCTestCase {
 
     func testNWPathNetworkConnectionInfoProviderGivesValue() {
         if #available(iOS 12.0, *) {
-            let provider = NWPathNetworkConnectionInfoProvider()
+            let provider = NetworkConnectionInfoProvider(
+                wrappedProvider: NWPathNetworkConnectionInfoProvider()
+            )
 
             pullNetworkConnectionInfo(
                 from: provider,
@@ -41,7 +43,9 @@ class NetworkConnectionInfoProviderTests: XCTestCase {
 
     func testNWPathNetworkConnectionInfoProviderCanBeSafelyAccessedFromConcurrentThreads() {
         if #available(iOS 12.0, *) {
-            let provider = NWPathNetworkConnectionInfoProvider()
+            let provider = NetworkConnectionInfoProvider(
+                wrappedProvider: NWPathNetworkConnectionInfoProvider()
+            )
 
             DispatchQueue.concurrentPerform(iterations: 1_000) { _ in
                 _ = provider.current
@@ -69,7 +73,9 @@ class NetworkConnectionInfoProviderTests: XCTestCase {
     // MARK: - iOS 11
 
     func testiOS11NetworkConnectionInfoProviderGivesValue() {
-        let provider = iOS11NetworkConnectionInfoProvider()
+        let provider = NetworkConnectionInfoProvider(
+            wrappedProvider: iOS11NetworkConnectionInfoProvider()
+        )
 
         pullNetworkConnectionInfo(
             from: provider,
@@ -81,7 +87,9 @@ class NetworkConnectionInfoProviderTests: XCTestCase {
     }
 
     func testiOS11NetworkConnectionInfoProviderCanBeSafelyAccessedFromConcurrentThreads() {
-        let provider = iOS11NetworkConnectionInfoProvider()
+        let provider = NetworkConnectionInfoProvider(
+            wrappedProvider: iOS11NetworkConnectionInfoProvider()
+        )
 
         DispatchQueue.concurrentPerform(iterations: 1_000) { _ in
             _ = provider.current

--- a/Tests/DatadogTests/Datadog/Core/System/NetworkConnectionInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/System/NetworkConnectionInfoProviderTests.swift
@@ -10,9 +10,9 @@ import SystemConfiguration
 @testable import Datadog
 
 class NetworkConnectionInfoProviderTests: XCTestCase {
-    /// Constantly pulls the `NetworkConnectionInfo` from given provider and fulfills the expectation if value is received.
+    /// Constantly pulls the `NetworkConnectionInfo` from given provider and fulfils the expectation if value is received.
     private func pullNetworkConnectionInfo(
-        from provider: NetworkConnectionInfoProviderType,
+        from provider: iOSSpecificNetworkConnectionInfoProvider,
         on queue: DispatchQueue,
         thenFulfill expectation: XCTestExpectation
     ) {

--- a/Tests/DatadogTests/Datadog/Core/Utils/ValuePublisherTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Utils/ValuePublisherTests.swift
@@ -1,0 +1,96 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+private extension ValuePublisher.UpdatesModel {
+    static func random() -> ValuePublisher.UpdatesModel {
+        return [.synchronous, .asynchronous].randomElement()!
+    }
+}
+
+class ValuePublisherTests: XCTestCase {
+    func testWhenInitialized_itStoresInitialValue() {
+        let randomInt: Int = .mockRandom()
+
+        // When
+        let publisher = ValuePublisher<Int>(initialValue: randomInt, updatesModel: .random())
+
+        // Then
+        XCTAssertEqual(publisher.currentValue, randomInt)
+    }
+
+    func testWhenValueChanges_itStoresUpdatedValue() {
+        let publisher = ValuePublisher<Int>(initialValue: .mockRandom(), updatesModel: .random())
+
+        // When
+        let randomInt: Int = .mockRandom()
+        publisher.currentValue = randomInt
+
+        // Then
+        XCTAssertEqual(publisher.currentValue, randomInt)
+    }
+
+    func testWhenValueChanges_itNotifiesObservers() {
+        let numberOfObservers = 10
+        let initialValue: Int = .mockRandom()
+        let newValue: Int = .mockRandom()
+
+        let expectation = self.expectation(description: "All observers received new value")
+        expectation.expectedFulfillmentCount = numberOfObservers
+
+        let observers: [ValueObserverMock<Int>] = (0..<numberOfObservers).map { _ in
+            ValueObserverMock<Int> { old, new in
+                XCTAssertEqual(old, initialValue)
+                XCTAssertEqual(new, newValue)
+                expectation.fulfill()
+            }
+        }
+
+        let publisher = ValuePublisher<Int>(initialValue: initialValue, updatesModel: .random())
+        observers.forEach { publisher.subscribe($0) }
+
+        // When
+        publisher.currentValue = newValue
+
+        // Then
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    // MARK: - Thread safety
+
+    func testValueCanBeWrittenAndReadOnAnyThread() {
+        let publisher = ValuePublisher<Int>(initialValue: .mockRandom(), updatesModel: .random())
+
+        // swiftlint:disable opening_brace
+        callConcurrently(
+            closures: [
+                { publisher.currentValue = .mockRandom() },
+                { _ = publisher.currentValue },
+                { publisher.subscribe(ValueObserverMock<Int>()) }
+            ],
+            iterations: 50
+        )
+        // swiftlint:enable opening_brace
+    }
+
+    func testSubscribersAreNotifiedOnSingleThread() {
+        let publisher = ValuePublisher<Int>(initialValue: .mockRandom(), updatesModel: .random())
+
+        // State mutated by the `IntObserverMock` - the `ValuePublisher` ensures its thread safety
+        var mutableState: Bool = .random()
+
+        let observer = ValueObserverMock<Int> { _, _ in
+            mutableState.toggle()
+        }
+        publisher.subscribe(observer)
+
+        DispatchQueue.concurrentPerform(iterations: 100) { _ in
+            publisher.currentValue = .mockRandom()
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -18,7 +18,7 @@ class CrashContextProviderTests: XCTestCase {
     func testWhenTrackingConsentValueChangesInConsentProvider_thenCrashContextProviderNotifiesNewContext() {
         let expectation = self.expectation(description: "Notify new crash context")
         let initialTrackingConsent: TrackingConsent = .mockRandom()
-        let randomTrackingConsent: TrackingConsent = .mockRandom()
+        let randomTrackingConsent: TrackingConsent = .mockRandom(otherThan: initialTrackingConsent)
 
         let trackingConsentProvider = ConsentProvider(initialConsent: initialTrackingConsent)
         let crashContextProvider = CrashContextProvider(

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -70,6 +70,37 @@ class CrashContextProviderTests: XCTestCase {
         XCTAssertEqual(updatedContext?.lastRUMViewEvent, randomRUMViewEvent)
     }
 
+    // MARK: - `UserInfo` Integration
+
+    func testWhenUserInfoValueChangesInUserInfoProvider_thenCrashContextProviderNotifiesNewContext() {
+        let expectation = self.expectation(description: "Notify new crash context")
+        let initialUserInfo: UserInfo = .mockRandom()
+        let randomUserInfo: UserInfo = .mockRandom()
+
+        let userInfoProvider = UserInfoProvider()
+        userInfoProvider.value = initialUserInfo
+
+        let crashContextProvider = CrashContextProvider(
+            consentProvider: .mockAny(),
+            userInfoProvider: userInfoProvider
+        )
+
+        let initialContext = crashContextProvider.currentCrashContext
+        var updatedContext: CrashContext?
+
+        // When
+        crashContextProvider.onCrashContextChange = { newContext in
+            updatedContext = newContext
+            expectation.fulfill()
+        }
+        userInfoProvider.value = randomUserInfo
+
+        // Then
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(initialContext.lastUserInfo, initialUserInfo)
+        XCTAssertEqual(updatedContext?.lastUserInfo, randomUserInfo)
+    }
+
     // MARK: - Thread safety
 
     func testWhenContextIsWrittenAndReadFromDifferentThreads_itRunsAllOperationsSafely() {

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -48,10 +48,7 @@ class CrashContextProviderTests: XCTestCase {
         let expectation = self.expectation(description: "Notify new crash context")
         let randomRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandomWith(model: RUMViewEvent.mockRandom())
 
-        let rumViewEventProvider = ValuePublisher<RUMEvent<RUMViewEvent>?>(
-            initialValue: randomRUMViewEvent,
-            updatesModel: .synchronous
-        )
+        let rumViewEventProvider = ValuePublisher<RUMEvent<RUMViewEvent>?>(initialValue: randomRUMViewEvent)
         let crashContextProvider = CrashContextProvider(
             consentProvider: .mockAny(),
             userInfoProvider: .mockAny(),
@@ -211,7 +208,7 @@ class CrashContextProviderTests: XCTestCase {
                         carrierInfoWrappedProvider.set(current: .mockRandom())
                         _ = carrierInfoMainProvider.current
                     },
-                    { rumViewEventProvider.currentValue = .mockRandomWith(model: RUMViewEvent.mockRandom()) },
+                    { rumViewEventProvider.publishSyncOrAsync(.mockRandomWith(model: RUMViewEvent.mockRandom())) },
                 ],
                 iterations: 50
             )

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
@@ -49,12 +49,7 @@ class CrashContextTests: XCTestCase {
     }
 
     func testGivenContextWithUserInfoSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
-        let randomUserInfo = UserInfo(
-            id: .mockRandom(),
-            name: .mockRandom(),
-            email: .mockRandom(),
-            extraInfo: mockRandomAttributes()
-        )
+        let randomUserInfo: UserInfo = .mockRandom()
 
         // Given
         var context: CrashContext = .mockRandom()
@@ -72,6 +67,21 @@ class CrashContextTests: XCTestCase {
             dictionary1: deserializedContext.lastUserInfo!.extraInfo,
             dictionary2: randomUserInfo.extraInfo
         )
+    }
+
+    func testGivenContextWithNetworkConnectionInfoSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
+        let randomNetworkConnectionInfo: NetworkConnectionInfo = .mockRandom()
+
+        // Given
+        var context: CrashContext = .mockRandom()
+        context.lastNetworkConnectionInfo = randomNetworkConnectionInfo
+
+        // When
+        let serializedContext = try encoder.encode(context)
+
+        // Then
+        let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
+        XCTAssertEqual(deserializedContext.lastNetworkConnectionInfo, randomNetworkConnectionInfo)
     }
 
     // MARK: - Helpers

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
@@ -84,6 +84,21 @@ class CrashContextTests: XCTestCase {
         XCTAssertEqual(deserializedContext.lastNetworkConnectionInfo, randomNetworkConnectionInfo)
     }
 
+    func testGivenContextWithCarrierInfoSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
+        let randomCarrierInfo: CarrierInfo = .mockRandom()
+
+        // Given
+        var context: CrashContext = .mockRandom()
+        context.lastCarrierInfo = randomCarrierInfo
+
+        // When
+        let serializedContext = try encoder.encode(context)
+
+        // Then
+        let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
+        XCTAssertEqual(deserializedContext.lastCarrierInfo, randomCarrierInfo)
+    }
+
     // MARK: - Helpers
 
     /// Asserts that JSON representations of two `Encodable` values are equal.

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -10,7 +10,7 @@ import XCTest
 class CrashReporterTests: XCTestCase {
     // MARK: - Sending Crash Report
 
-    func testGivenPendingCrashReport_whenLoggingOrRUMIntegrationIsEnabled_itSendsAndPurgesTheCrashReport() {
+    func testGivenPendingCrashReport_whenLoggingOrRUMIntegrationIsEnabled_itSendsAndPurgesTheCrashReport() throws {
         let expectation = self.expectation(description: "`LoggingOrRUMIntegration` sends the crash report")
         let crashContext: CrashContext = .mockRandom()
         let crashReport: DDCrashReport = .mockRandomWith(context: crashContext)
@@ -34,7 +34,12 @@ class CrashReporterTests: XCTestCase {
 
         waitForExpectations(timeout: 0.5, handler: nil)
         XCTAssertEqual(integration.sentCrashReport, crashReport, "It should send the crash report retrieved from the `plugin`")
-        XCTAssertEqual(integration.sentCrashContext?.data, crashContext.data, "It should send the crash context retrieved from the `plugin`")
+        AssertDictionariesEqual(
+            try integration.sentCrashContext!.data.toJSONObject(),
+            try crashContext.data.toJSONObject(),
+            "It should send the crash context retrieved from the `plugin`"
+        )
+
         XCTAssertTrue(plugin.hasPurgedCrashReport == true, "It should ask to purge the crash report")
     }
 
@@ -94,7 +99,7 @@ class CrashReporterTests: XCTestCase {
 
     // MARK: - Crash Context Injection
 
-    func testWhenInitialized_itInjectsInitialCrashContextToThePlugin() {
+    func testWhenInitialized_itInjectsInitialCrashContextToThePlugin() throws {
         let expectation = self.expectation(description: "`plugin` received initial crash context")
         let plugin = CrashReportingPluginMock()
         plugin.didInjectContext = { expectation.fulfill() }
@@ -107,14 +112,17 @@ class CrashReporterTests: XCTestCase {
             loggingOrRUMIntegration: CrashReportingIntegrationMock()
         )
 
-        withExtendedLifetime(crashReporter) {
+        try withExtendedLifetime(crashReporter) {
             // Then
             waitForExpectations(timeout: 0.5, handler: nil)
-            XCTAssertEqual(plugin.injectedContextData, initialCrashContext.data)
+            AssertDictionariesEqual(
+                try plugin.injectedContextData!.toJSONObject(),
+                try initialCrashContext.data.toJSONObject()
+            )
         }
     }
 
-    func testWhenCrashContextChanges_itInjectsNewCrashContextToThePlugin() {
+    func testWhenCrashContextChanges_itInjectsNewCrashContextToThePlugin() throws {
         let expectation = self.expectation(description: "`plugin` received initial and updated crash contexts")
         expectation.expectedFulfillmentCount = 2
         let plugin = CrashReportingPluginMock()
@@ -127,14 +135,17 @@ class CrashReporterTests: XCTestCase {
             loggingOrRUMIntegration: CrashReportingIntegrationMock()
         )
 
-        withExtendedLifetime(crashReporter) {
+        try withExtendedLifetime(crashReporter) {
             // When
             let updatedCrashContext: CrashContext = .mockRandom()
             crashContextProvider.onCrashContextChange?(updatedCrashContext)
 
             // Then
             waitForExpectations(timeout: 2, handler: nil)
-            XCTAssertEqual(plugin.injectedContextData, updatedCrashContext.data)
+            AssertDictionariesEqual(
+                try plugin.injectedContextData!.toJSONObject(),
+                try updatedCrashContext.data.toJSONObject()
+            )
         }
     }
 

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -8,33 +8,22 @@ import XCTest
 @testable import Datadog
 
 class RUMWithCrashContextIntegrationTests: XCTestCase {
-    func testWhenCrashReporterIsRegistered_itUpdatesCrashContextWithLastRUMView() throws {
-        let crashContextProvider = CrashContextProvider(
-            consentProvider: .mockAny(),
-            userInfoProvider: .mockAny(),
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
-            carrierInfoProvider: CarrierInfoProviderMock.mockAny()
-        )
-
+    func testWhenCrashReportingIsEnabled_itUpdatesCrashContextWithLastRUMView() throws {
         // When
-        Global.crashReporter = CrashReporter(
-            crashReportingPlugin: CrashReportingPluginMock(),
-            crashContextProvider: crashContextProvider,
-            loggingOrRUMIntegration: CrashReportingIntegrationMock()
-        )
-        defer { Global.crashReporter = nil }
+        CrashReportingFeature.instance = .mockNoOp()
+        defer { CrashReportingFeature.instance = nil }
 
         // Then
         let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration())
         let randomRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandomWith(model: RUMViewEvent.mockRandom())
         rumWithCrashContextIntegration.update(lastRUMViewEvent: randomRUMViewEvent)
 
-        XCTAssertEqual(crashContextProvider.currentCrashContext.lastRUMViewEvent, randomRUMViewEvent)
+        XCTAssertEqual(CrashReportingFeature.instance?.rumViewEventProvider.currentValue, randomRUMViewEvent)
     }
 
-    func testWhenCrashReporterIsNotRegistered_itCannotBeInitialized() {
+    func testWhenCrashReportingIsNotEnabled_itCannotBeInitialized() {
         // When
-        XCTAssertNil(Global.crashReporter)
+        XCTAssertNil(CrashReportingFeature.instance)
 
         // Then
         XCTAssertNil(RUMWithCrashContextIntegration())

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -10,7 +10,8 @@ import XCTest
 class RUMWithCrashContextIntegrationTests: XCTestCase {
     func testWhenCrashReporterIsRegistered_itUpdatesCrashContextWithLastRUMView() throws {
         let crashContextProvider = CrashContextProvider(
-            consentProvider: .mockAny()
+            consentProvider: .mockAny(),
+            userInfoProvider: .mockAny()
         )
 
         // When

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -12,7 +12,8 @@ class RUMWithCrashContextIntegrationTests: XCTestCase {
         let crashContextProvider = CrashContextProvider(
             consentProvider: .mockAny(),
             userInfoProvider: .mockAny(),
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny()
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
+            carrierInfoProvider: CarrierInfoProviderMock.mockAny()
         )
 
         // When

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -11,7 +11,8 @@ class RUMWithCrashContextIntegrationTests: XCTestCase {
     func testWhenCrashReporterIsRegistered_itUpdatesCrashContextWithLastRUMView() throws {
         let crashContextProvider = CrashContextProvider(
             consentProvider: .mockAny(),
-            userInfoProvider: .mockAny()
+            userInfoProvider: .mockAny(),
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny()
         )
 
         // When

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -548,7 +548,7 @@ extension UserInfo: AnyMockable, RandomMockable {
             id: .mockRandom(),
             name: .mockRandom(),
             email: .mockRandom(),
-            extraInfo: [String: String].mockRandom()
+            extraInfo: mockRandomAttributes()
         )
     }
 }
@@ -652,7 +652,13 @@ extension NetworkConnectionInfo.Reachability {
     }
 }
 
-extension NetworkConnectionInfo {
+extension NetworkConnectionInfo.Interface: RandomMockable {
+    static func mockRandom() -> NetworkConnectionInfo.Interface {
+        return allCases.randomElement()!
+    }
+}
+
+extension NetworkConnectionInfo: RandomMockable {
     static func mockAny() -> NetworkConnectionInfo {
         return mockWith()
     }
@@ -672,6 +678,17 @@ extension NetworkConnectionInfo {
             supportsIPv6: supportsIPv6,
             isExpensive: isExpensive,
             isConstrained: isConstrained
+        )
+    }
+
+    static func mockRandom() -> NetworkConnectionInfo {
+        return NetworkConnectionInfo(
+            reachability: .mockRandom(),
+            availableInterfaces: .mockRandom(),
+            supportsIPv4: .random(),
+            supportsIPv6: .random(),
+            isExpensive: .random(),
+            isConstrained: .random()
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -534,13 +534,22 @@ struct LaunchTimeProviderMock: LaunchTimeProviderType {
     var launchTime: TimeInterval? = nil
 }
 
-extension UserInfo {
+extension UserInfo: AnyMockable, RandomMockable {
     static func mockAny() -> UserInfo {
         return mockEmpty()
     }
 
     static func mockEmpty() -> UserInfo {
         return UserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
+    }
+
+    static func mockRandom() -> UserInfo {
+        return .init(
+            id: .mockRandom(),
+            name: .mockRandom(),
+            email: .mockRandom(),
+            extraInfo: [String: String].mockRandom()
+        )
     }
 }
 
@@ -761,6 +770,35 @@ extension EncodableValue {
     static func mockAny() -> EncodableValue {
         return EncodableValue(String.mockAny())
     }
+}
+
+// MARK: - Attributes Mock
+
+private let mockAttributesEncoder = JSONEncoder()
+
+/// Creates randomized `[String: Encodable]` attributes
+func mockRandomAttributes() -> [String: Encodable] {
+    struct Foo: Encodable {
+        let bar: String = .mockRandom()
+        let bizz = Bizz()
+
+        struct Bizz: Encodable {
+            let buzz: String = .mockRandom()
+        }
+    }
+
+    return [
+        "string-attribute": String.mockRandom(),
+        "int-attribute": Int.mockRandom(),
+        "uint64-attribute": UInt64.mockRandom(),
+        "double-attribute": Double.mockRandom(),
+        "bool-attribute": Bool.random(),
+        "int-array-attribute": [Int].mockRandom(),
+        "dictionary-attribute": [String: Int].mockRandom(),
+        "url-attribute": URL.mockRandom(),
+        "encodable-struct-attribute": Foo(),
+        "custom-encodable-attribute": JSONStringEncodableValue(Foo(), encodedUsing: mockAttributesEncoder)
+    ]
 }
 
 // MARK: - Global Dependencies Mocks

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -12,6 +12,15 @@ extension TrackingConsent {
     static func mockRandom() -> TrackingConsent {
         return [.granted, .notGranted, .pending].randomElement()!
     }
+
+    static func mockRandom(otherThan consent: TrackingConsent? = nil) -> TrackingConsent {
+        while true {
+            let randomConsent: TrackingConsent = .mockRandom()
+            if randomConsent != consent {
+                return randomConsent
+            }
+        }
+    }
 }
 
 extension ConsentProvider {
@@ -693,8 +702,6 @@ extension NetworkConnectionInfo: RandomMockable {
     }
 }
 
-extension NetworkConnectionInfo: EquatableInTests {}
-
 class NetworkConnectionInfoProviderMock: NetworkConnectionInfoProviderType {
     private let queue = DispatchQueue(label: "com.datadoghq.NetworkConnectionInfoProviderMock")
     private var _current: NetworkConnectionInfo?
@@ -765,8 +772,6 @@ extension CarrierInfo: RandomMockable {
         )
     }
 }
-
-extension CarrierInfo: EquatableInTests {}
 
 class CarrierInfoProviderMock: CarrierInfoProviderType {
     private let queue = DispatchQueue(label: "com.datadoghq.CarrierInfoProviderMock")

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -702,7 +702,7 @@ extension NetworkConnectionInfo: RandomMockable {
     }
 }
 
-class NetworkConnectionInfoProviderMock: NetworkConnectionInfoProviderType {
+class NetworkConnectionInfoProviderMock: NetworkConnectionInfoProviderType, WrappedNetworkConnectionInfoProvider {
     private let queue = DispatchQueue(label: "com.datadoghq.NetworkConnectionInfoProviderMock")
     private var _current: NetworkConnectionInfo?
 
@@ -773,7 +773,7 @@ extension CarrierInfo: RandomMockable {
     }
 }
 
-class CarrierInfoProviderMock: CarrierInfoProviderType {
+class CarrierInfoProviderMock: CarrierInfoProviderType, WrappedCarrierInfoProvider {
     private let queue = DispatchQueue(label: "com.datadoghq.CarrierInfoProviderMock")
     private var _current: CarrierInfo?
 

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -729,11 +729,15 @@ class NetworkConnectionInfoProviderMock: NetworkConnectionInfoProviderType {
     }
 }
 
-extension CarrierInfo.RadioAccessTechnology {
+extension CarrierInfo.RadioAccessTechnology: RandomMockable {
     static func mockAny() -> CarrierInfo.RadioAccessTechnology { .LTE }
+
+    static func mockRandom() -> CarrierInfo.RadioAccessTechnology {
+        return allCases.randomElement()!
+    }
 }
 
-extension CarrierInfo {
+extension CarrierInfo: RandomMockable {
     static func mockAny() -> CarrierInfo {
         return mockWith()
     }
@@ -749,6 +753,15 @@ extension CarrierInfo {
             carrierISOCountryCode: carrierISOCountryCode,
             carrierAllowsVOIP: carrierAllowsVOIP,
             radioAccessTechnology: radioAccessTechnology
+        )
+    }
+
+    static func mockRandom() -> CarrierInfo {
+        return CarrierInfo(
+            carrierName: .mockRandom(),
+            carrierISOCountryCode: .mockRandom(),
+            carrierAllowsVOIP: .random(),
+            radioAccessTechnology: .mockRandom()
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -713,7 +713,7 @@ class NetworkConnectionInfoProviderMock: NetworkConnectionInfoProviderType {
         queue.sync { _current }
     }
 
-    func subscribe<Observer: ValueObserver>(_ subscriber: Observer) where Observer.ObservedValue == NetworkConnectionInfo? {
+    func subscribe<Observer: NetworkConnectionInfoObserver>(_ subscriber: Observer) where Observer.ObservedValue == NetworkConnectionInfo? {
     }
 
     // MARK: - Mocking
@@ -784,6 +784,9 @@ class CarrierInfoProviderMock: CarrierInfoProviderType {
 
     var current: CarrierInfo? {
         queue.sync { _current }
+    }
+
+    func subscribe<Observer: CarrierInfoObserver>(_ subscriber: Observer) where Observer.ObservedValue == CarrierInfo? {
     }
 
     // MARK: - Mocking

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -815,7 +815,18 @@ extension EncodableValue {
 
 extension ValuePublisher where Value: AnyMockable {
     static func mockAny() -> ValuePublisher {
-        return .init(initialValue: .mockAny(), updatesModel: .synchronous)
+        return .init(initialValue: .mockAny())
+    }
+}
+
+extension ValuePublisher {
+    /// Publishes `newValue` using `publishSync(:_)` or `publishAsync(:_)`.
+    func publishSyncOrAsync(_ newValue: Value) {
+        if Bool.random() {
+            publishSync(newValue)
+        } else {
+            publishAsync(newValue)
+        }
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -789,6 +789,22 @@ extension EncodableValue {
     }
 }
 
+internal class ValueObserverMock<Value>: ValueObserver {
+    typealias ObservedValue = Value
+
+    private(set) var onValueChange: ((Value, Value) -> Void)?
+    private(set) var lastChange: (oldValue: Value, newValue: Value)?
+
+    init(onValueChange: ((Value, Value) -> Void)? = nil) {
+        self.onValueChange = onValueChange
+    }
+
+    func onValueChanged(oldValue: Value, newValue: Value) {
+        lastChange = (oldValue, newValue)
+        onValueChange?(oldValue, newValue)
+    }
+}
+
 // MARK: - Attributes Mock
 
 private let mockAttributesEncoder = JSONEncoder()

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -813,6 +813,12 @@ extension EncodableValue {
     }
 }
 
+extension ValuePublisher where Value: AnyMockable {
+    static func mockAny() -> ValuePublisher {
+        return .init(initialValue: .mockAny(), updatesModel: .synchronous)
+    }
+}
+
 internal class ValueObserverMock<Value>: ValueObserver {
     typealias ObservedValue = Value
 

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -713,6 +713,9 @@ class NetworkConnectionInfoProviderMock: NetworkConnectionInfoProviderType {
         queue.sync { _current }
     }
 
+    func subscribe<Observer: ValueObserver>(_ subscriber: Observer) where Observer.ObservedValue == NetworkConnectionInfo? {
+    }
+
     // MARK: - Mocking
 
     static func mockAny() -> NetworkConnectionInfoProviderMock {

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -90,18 +90,21 @@ extension CrashContext {
 
     static func mockWith(
         lastTrackingConsent: TrackingConsent = .granted,
-        lastRUMViewEvent: RUMEvent<RUMViewEvent>? = nil
+        lastRUMViewEvent: RUMEvent<RUMViewEvent>? = nil,
+        lastUserInfo: UserInfo = .mockAny()
     ) -> CrashContext {
         return CrashContext(
             lastTrackingConsent: lastTrackingConsent,
-            lastRUMViewEvent: lastRUMViewEvent
+            lastRUMViewEvent: lastRUMViewEvent,
+            lastUserInfo: lastUserInfo
         )
     }
 
     static func mockRandom() -> CrashContext {
         return CrashContext(
             lastTrackingConsent: .mockRandom(),
-            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
+            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom()),
+            lastUserInfo: .mockRandom()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -91,12 +91,14 @@ extension CrashContext {
     static func mockWith(
         lastTrackingConsent: TrackingConsent = .granted,
         lastRUMViewEvent: RUMEvent<RUMViewEvent>? = nil,
-        lastUserInfo: UserInfo = .mockAny()
+        lastUserInfo: UserInfo = .mockAny(),
+        lastNetworkConnectionInfo: NetworkConnectionInfo? = .mockAny()
     ) -> CrashContext {
         return CrashContext(
             lastTrackingConsent: lastTrackingConsent,
             lastRUMViewEvent: lastRUMViewEvent,
-            lastUserInfo: lastUserInfo
+            lastUserInfo: lastUserInfo,
+            lastNetworkConnectionInfo: lastNetworkConnectionInfo
         )
     }
 
@@ -104,7 +106,8 @@ extension CrashContext {
         return CrashContext(
             lastTrackingConsent: .mockRandom(),
             lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom()),
-            lastUserInfo: .mockRandom()
+            lastUserInfo: .mockRandom(),
+            lastNetworkConnectionInfo: .mockRandom()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -63,8 +63,6 @@ internal class CrashContextProviderMock: CrashContextProviderType {
     init(initialCrashContext: CrashContext = .mockAny()) {
         self.currentCrashContext = initialCrashContext
     }
-
-    func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>) {}
 }
 
 class CrashReportingIntegrationMock: CrashReportingIntegration {

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -91,13 +91,15 @@ extension CrashContext {
         lastTrackingConsent: TrackingConsent = .granted,
         lastUserInfo: UserInfo = .mockAny(),
         lastRUMViewEvent: RUMEvent<RUMViewEvent>? = nil,
-        lastNetworkConnectionInfo: NetworkConnectionInfo? = .mockAny()
+        lastNetworkConnectionInfo: NetworkConnectionInfo? = .mockAny(),
+        lastCarrierInfo: CarrierInfo? = .mockAny()
     ) -> CrashContext {
         return CrashContext(
             lastTrackingConsent: lastTrackingConsent,
             lastUserInfo: lastUserInfo,
             lastRUMViewEvent: lastRUMViewEvent,
-            lastNetworkConnectionInfo: lastNetworkConnectionInfo
+            lastNetworkConnectionInfo: lastNetworkConnectionInfo,
+            lastCarrierInfo: lastCarrierInfo
         )
     }
 
@@ -106,7 +108,8 @@ extension CrashContext {
             lastTrackingConsent: .mockRandom(),
             lastUserInfo: .mockRandom(),
             lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom()),
-            lastNetworkConnectionInfo: .mockRandom()
+            lastNetworkConnectionInfo: .mockRandom(),
+            lastCarrierInfo: .mockRandom()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -65,7 +65,6 @@ internal class CrashContextProviderMock: CrashContextProviderType {
     }
 
     func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>) {}
-    func update(lastTrackingConsent: TrackingConsent) {}
 }
 
 class CrashReportingIntegrationMock: CrashReportingIntegration {
@@ -90,14 +89,14 @@ extension CrashContext {
 
     static func mockWith(
         lastTrackingConsent: TrackingConsent = .granted,
-        lastRUMViewEvent: RUMEvent<RUMViewEvent>? = nil,
         lastUserInfo: UserInfo = .mockAny(),
+        lastRUMViewEvent: RUMEvent<RUMViewEvent>? = nil,
         lastNetworkConnectionInfo: NetworkConnectionInfo? = .mockAny()
     ) -> CrashContext {
         return CrashContext(
             lastTrackingConsent: lastTrackingConsent,
-            lastRUMViewEvent: lastRUMViewEvent,
             lastUserInfo: lastUserInfo,
+            lastRUMViewEvent: lastRUMViewEvent,
             lastNetworkConnectionInfo: lastNetworkConnectionInfo
         )
     }
@@ -105,8 +104,8 @@ extension CrashContext {
     static func mockRandom() -> CrashContext {
         return CrashContext(
             lastTrackingConsent: .mockRandom(),
-            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom()),
             lastUserInfo: .mockRandom(),
+            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom()),
             lastNetworkConnectionInfo: .mockRandom()
         )
     }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -84,6 +84,12 @@ struct RUMDataModelMock: RUMDataModel, Equatable {
 
 // MARK: - Component Mocks
 
+extension RUMEvent: AnyMockable where DM == RUMViewEvent {
+    static func mockAny() -> RUMEvent<RUMViewEvent> {
+        return .mockWith(model: RUMViewEvent.mockRandom())
+    }
+}
+
 extension RUMEvent {
     static func mockWith<DM: RUMDataModel>(
         model: DM,

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -55,6 +55,12 @@ extension Data: AnyMockable {
     }
 }
 
+extension Optional: AnyMockable where Wrapped: AnyMockable {
+    static func mockAny() -> Self {
+        return .some(.mockAny())
+    }
+}
+
 extension Array where Element == Data {
     /// Returns chunks of mocked data. Accumulative size of all chunks equals `totalSize`.
     static func mockChunksOf(totalSize: UInt64, maxChunkSize: UInt64) -> [Data] {

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -911,19 +911,11 @@ class RUMMonitorTests: XCTestCase {
         )
         defer { RUMFeature.instance = nil }
 
-        let crashContextProvider = CrashContextProvider(
-            consentProvider: .mockAny(),
-            userInfoProvider: .mockAny(),
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
-            carrierInfoProvider: CarrierInfoProviderMock.mockAny()
-        )
+        CrashReportingFeature.instance = .mockNoOp()
+        defer { CrashReportingFeature.instance = nil }
 
         // Given
-        Global.crashReporter = CrashReporter(
-            crashReportingPlugin: CrashReportingPluginMock(),
-            crashContextProvider: crashContextProvider,
-            loggingOrRUMIntegration: CrashReportingIntegrationMock()
-        )
+        Global.crashReporter = CrashReporter(crashReportingFeature: CrashReportingFeature.instance!)
         defer { Global.crashReporter = nil }
 
         // When
@@ -934,16 +926,17 @@ class RUMMonitorTests: XCTestCase {
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 2)
         let lastRUMViewEventSent: RUMViewEvent = try rumEventMatchers[1].model()
 
+        let currentCrashContext = try XCTUnwrap(Global.crashReporter?.crashContextProvider.currentCrashContext)
         XCTAssertEqual(
-            crashContextProvider.currentCrashContext.lastRUMViewEvent?.model,
+            currentCrashContext.lastRUMViewEvent?.model,
             lastRUMViewEventSent
         )
         XCTAssertEqual(
-            crashContextProvider.currentCrashContext.lastRUMViewEvent?.attributes as? [String: String],
+            currentCrashContext.lastRUMViewEvent?.attributes as? [String: String],
             randomViewEventAttributes
         )
         XCTAssertEqual(
-            crashContextProvider.currentCrashContext.lastRUMViewEvent?.userInfoAttributes as? [String: String],
+            currentCrashContext.lastRUMViewEvent?.userInfoAttributes as? [String: String],
             randomUserInfoAttributes
         )
     }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -913,7 +913,8 @@ class RUMMonitorTests: XCTestCase {
 
         let crashContextProvider = CrashContextProvider(
             consentProvider: .mockAny(),
-            userInfoProvider: .mockAny()
+            userInfoProvider: .mockAny(),
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny()
         )
 
         // Given

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -914,7 +914,8 @@ class RUMMonitorTests: XCTestCase {
         let crashContextProvider = CrashContextProvider(
             consentProvider: .mockAny(),
             userInfoProvider: .mockAny(),
-            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny()
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
+            carrierInfoProvider: CarrierInfoProviderMock.mockAny()
         )
 
         // Given

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -911,7 +911,10 @@ class RUMMonitorTests: XCTestCase {
         )
         defer { RUMFeature.instance = nil }
 
-        let crashContextProvider = CrashContextProvider(consentProvider: .mockAny())
+        let crashContextProvider = CrashContextProvider(
+            consentProvider: .mockAny(),
+            userInfoProvider: .mockAny()
+        )
 
         // Given
         Global.crashReporter = CrashReporter(

--- a/Tests/DatadogTests/Helpers/XCTestCase.swift
+++ b/Tests/DatadogTests/Helpers/XCTestCase.swift
@@ -35,4 +35,92 @@ extension XCTestCase {
             randomizedClosures[iteration]()
         }
     }
+
+    /// Asserts that two dictionaries are equal.
+    /// It uses debug string representation of values to check equality of `Any` values.
+    func AssertDictionariesEqual(
+        _ dictionary1: [String: Any],
+        _ dictionary2: [String: Any],
+        _ message: String? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        AssertDictionariesEqual(
+            dictionary1,
+            dictionary2,
+            keyPath: "",
+            message: message ?? "",
+            file: file,
+            line: line
+        )
+    }
+
+    private func AssertDictionariesEqual(
+        _ dictionary1: [String: Any],
+        _ dictionary2: [String: Any],
+        keyPath: String,
+        message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        if dictionary1.keys.count != dictionary2.keys.count {
+            XCTFail(
+                """
+                🔥 Failure: \(message)
+
+                Both dictionaries have different number of keys:
+                    * (1) \(dictionary1.keys.count) keys
+                    * (2) \(dictionary2.keys.count) keys
+                """,
+                file: file,
+                line: line
+            )
+            return
+        }
+
+        for (key, value1) in dictionary1 {
+            let currentKeyPath = keyPath.isEmpty ? "\(key)" : "\(keyPath).\(key)"
+
+            guard let value2 = dictionary2[key] else {
+                XCTFail(
+                    """
+                    🔥 Failure: \(message)
+
+                    Second dictionary doesn't define value for key path: '\(currentKeyPath)'
+                    """,
+                    file: file,
+                    line: line
+                )
+                return
+            }
+
+            if let nestedDictionary1 = value1 as? [String: Any],
+               let nestedDictionary2 = value2 as? [String: Any] {
+                AssertDictionariesEqual(
+                    nestedDictionary1,
+                    nestedDictionary2,
+                    keyPath: currentKeyPath,
+                    message: message,
+                    file: file,
+                    line: line
+                )
+            } else {
+                let value1Description = String(describing: value1)
+                let value2Description = String(describing: value2)
+                XCTAssertEqual(
+                    value1Description,
+                    value2Description,
+                    """
+                    🔥 Failure: \(message)
+
+                    The value for key path '\(currentKeyPath)' is different in both dictionaries:
+                        * (1): \(value1Description)
+                        * (2): \(value2Description)
+                    """,
+                    file: file,
+                    line: line
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
### What and why?

🚛 This PR updates the crash context with last `UserInfo`, `NetworkConnectionInfo` and `CarrierInfo` values. Later (in `RUMM-1050`) it will be possible to read those values and associate to the `Log` containing the crash report.

### How?

There are 5 pieces of information injected to the `CrashContext` and 4 of those already had a related `*Provider`:
* last `TrackingConsent` → managed through `ConsentProvider`,
* last `RUMViewEvent`,
* last `UserInfo` → managed through `UserInfoProvider`,
* last `NetworkConnectionInfo` → managed through `NetworkConnectionInfoProvider`,
* last `CarrierInfo` → managed through `CarrierInfoProvider`.

This PRs updates those providers to work in publish / subscribe model - whenever a new value is available, all subscribed observers are notified on its change.

#### Publish / Subscribe model

This PR adds the `subscribe()` API to each provider, so their values can be observed by `ValueObserver`, e.g.:
```swift
internal class UserInfoProvider {
   // ...
 
  func subscribe<Observer: ValueObserver>(_ subscriber: Observer) {
      // ...
   }
}
```

To not repeat thread safety and subscribers management logic, I've introduced a generic `ValuePublisher` type, which is used internally by all 4 providers:
```swift
internal class ValuePublisher<Value> {
    var currentValue: Value {
       set { /* set new value and notify subscribers */ }
       get { /* get value */ }
    }

   func subscribe<Observer: ValueObserver>(_ subscriber: Observer) where Observer.ObservedValue == Value {
      // register subscriber
   }
}
```
I choosed concurrent `DispatchQueues` with `.barrier` for thread synchronization. It's my thoughtful decision after reading [this benchmarks](https://dmytro-anokhin.medium.com/concurrency-in-swift-reader-writer-lock-4f255ae73422) and considering different lock APIs (including `pthread_rwlock_t()`).

#### Notification model

There are two distinct notification models used:
* Notify **on value write** - implemented by `ConsentProvider` and `UserInfoProvider`. Those providers are updated by the user, so we can intercept the "value change" and actively notify observers. Interception is done synchronously (the caller thread waits until observers are called). This is to ensure the user `"John"` is always associated with the `"message"` log in following example:
```swift
// on a single thread:
Datadog.setUserInfo(name: "John")
logger.info("message")
```
* Notify **on value read** - implemented by `NetworkConnectionInfoProvider` and `CarrierInfoProvider`. Those providers are never updated actively. Instead, a passive information is pulled by different SDK components. In this case, the interception is done asynchronously, as a side effect of reading the value from a provider. Observers are notified asynchronously and the value reader gets it as fast as possible.

To keep the number of notifications minimal, observers for `Equatable` values are only notified on distinct value changes.

#### `UserInfo`, `NetworkConnectionInfo` and `CarrierInfo` serialization

Similar to `TrackingConsent` and `RUMViewEvent`, the value must be encoded and decoded in `CrashReporter`. The same pattern was used for new values → `CrashContext.swift` defines private `Codable` conformance. Few new helpers were required in tests to build assertions for `[String: Any]` dictionaries.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
