### PR TITLE
RUMM-1078 Add RUMEventsMappingCompletion command to back propagate mapped/discarded events to Scopes

### DIFF
--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -31,6 +31,13 @@ internal struct FeaturesConfiguration {
     }
 
     struct RUM {
+        struct EventsMapper {
+            let viewEventMapper: RUMViewEventMapper?
+            let errorEventMapper: RUMErrorEventMapper?
+            let resourceEventMapper: RUMResourceEventMapper?
+            let actionEventMapper: RUMActionEventMapper?
+        }
+
         struct AutoInstrumentation {
             let uiKitRUMViewsPredicate: UIKitRUMViewsPredicate?
             let uiKitActionsTrackingEnabled: Bool
@@ -40,7 +47,7 @@ internal struct FeaturesConfiguration {
         let uploadURLWithClientToken: URL
         let applicationID: String
         let sessionSamplingRate: Float
-        let eventMapper: RUMEventsMapper
+        let eventMapper: EventsMapper
         /// RUM auto instrumentation configuration, `nil` if not enabled.
         let autoInstrumentation: AutoInstrumentation?
     }
@@ -162,7 +169,7 @@ extension FeaturesConfiguration {
                     ),
                     applicationID: rumApplicationID,
                     sessionSamplingRate: configuration.rumSessionsSamplingRate,
-                    eventMapper: RUMEventsMapper(
+                    eventMapper: RUM.EventsMapper(
                         viewEventMapper: configuration.rumViewEventMapper,
                         errorEventMapper: configuration.rumErrorEventMapper,
                         resourceEventMapper: configuration.rumResourceEventMapper,

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -53,19 +53,6 @@ internal final class RUMFeature {
 
     // MARK: - Initialization
 
-    static func createEventsMapper(
-        configuration: FeaturesConfiguration.RUM,
-        commonDependencies: FeaturesCommonDependencies
-    ) -> RUMEventsMapper {
-        return RUMEventsMapper(
-            dateProvider: commonDependencies.dateProvider,
-            viewEventMapper: configuration.eventMapper.viewEventMapper,
-            errorEventMapper: configuration.eventMapper.errorEventMapper,
-            resourceEventMapper: configuration.eventMapper.resourceEventMapper,
-            actionEventMapper: configuration.eventMapper.actionEventMapper
-        )
-    }
-
     static func createStorage(
         directories: FeatureDirectories,
         eventMapper: RUMEventsMapper,
@@ -121,10 +108,14 @@ internal final class RUMFeature {
         configuration: FeaturesConfiguration.RUM,
         commonDependencies: FeaturesCommonDependencies
     ) {
-        let eventsMapper = RUMFeature.createEventsMapper(
-            configuration: configuration,
-            commonDependencies: commonDependencies
+        let eventsMapper = RUMEventsMapper(
+            dateProvider: commonDependencies.dateProvider,
+            viewEventMapper: configuration.eventMapper.viewEventMapper,
+            errorEventMapper: configuration.eventMapper.errorEventMapper,
+            resourceEventMapper: configuration.eventMapper.resourceEventMapper,
+            actionEventMapper: configuration.eventMapper.actionEventMapper
         )
+
         let storage = RUMFeature.createStorage(
             directories: directories,
             eventMapper: eventsMapper,

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -48,7 +48,23 @@ internal final class RUMFeature {
     /// RUM upload worker.
     let upload: FeatureUpload
 
+    /// RUM events mapper.
+    let eventsMapper: RUMEventsMapper
+
     // MARK: - Initialization
+
+    static func createEventsMapper(
+        configuration: FeaturesConfiguration.RUM,
+        commonDependencies: FeaturesCommonDependencies
+    ) -> RUMEventsMapper {
+        return RUMEventsMapper(
+            dateProvider: commonDependencies.dateProvider,
+            viewEventMapper: configuration.eventMapper.viewEventMapper,
+            errorEventMapper: configuration.eventMapper.errorEventMapper,
+            resourceEventMapper: configuration.eventMapper.resourceEventMapper,
+            actionEventMapper: configuration.eventMapper.actionEventMapper
+        )
+    }
 
     static func createStorage(
         directories: FeatureDirectories,
@@ -105,15 +121,20 @@ internal final class RUMFeature {
         configuration: FeaturesConfiguration.RUM,
         commonDependencies: FeaturesCommonDependencies
     ) {
+        let eventsMapper = RUMFeature.createEventsMapper(
+            configuration: configuration,
+            commonDependencies: commonDependencies
+        )
         let storage = RUMFeature.createStorage(
             directories: directories,
-            eventMapper: configuration.eventMapper,
+            eventMapper: eventsMapper,
             commonDependencies: commonDependencies
         )
         let upload = RUMFeature.createUpload(storage: storage, configuration: configuration, commonDependencies: commonDependencies)
         self.init(
             storage: storage,
             upload: upload,
+            eventsMapper: eventsMapper,
             configuration: configuration,
             commonDependencies: commonDependencies
         )
@@ -122,6 +143,7 @@ internal final class RUMFeature {
     init(
         storage: FeatureStorage,
         upload: FeatureUpload,
+        eventsMapper: RUMEventsMapper,
         configuration: FeaturesConfiguration.RUM,
         commonDependencies: FeaturesCommonDependencies
     ) {
@@ -139,5 +161,6 @@ internal final class RUMFeature {
         // Initialize stacks
         self.storage = storage
         self.upload = upload
+        self.eventsMapper = eventsMapper
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -260,8 +260,11 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
 /// Signals the completion of mapping a RUM event (aka Data Scrubbing)
 internal struct RUMEventsMappingCompletionCommand<DM: RUMDataModel>: RUMCommand {
     enum Change {
+        /// The event was not changed with the Scrubbing API and it was passed to the writer unchanged.
         case none
+        /// The event was discarded with the Scrubbing API and it was not written.
         case discarded
+        /// The event was mutated with the Scrubbing API and its updated representation was passed to the writer.
         case mapped
     }
 

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -256,3 +256,17 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     let actionType: RUMUserActionType
     let name: String
 }
+
+/// Signals the completion of mapping a RUM event (aka Data Scrubbing)
+internal struct RUMEventsMappingCompletionCommand<DM: RUMDataModel>: RUMCommand {
+    enum Change {
+        case none
+        case discarded
+        case mapped
+    }
+
+    var time: Date
+    var attributes: [AttributeKey: AttributeValue]
+    let change: Change
+    let model: DM
+}

--- a/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
@@ -59,23 +59,6 @@ extension Array where Element: RUMScope {
     }
 }
 
-extension Dictionary where Value: RUMScope {
-    /// Propagates given `command` through a dictionary of scopes and manages their lifecycle by
-    /// removing scopes that get closed or discarded.
-    /// Also provides a callback with scopes to be removed to help keep external state consistent.
-    mutating func manage(byPropagatingCommand command: RUMCommand, callback: ((Value) -> Void)? = nil) {
-        filter { _, scope in
-            let managedScope = scope.manage(childScope: scope, byPropagatingCommand: command).scope
-            let shouldBeRemove = managedScope == nil
-            if shouldBeRemove {
-                callback?(scope)
-            }
-            return shouldBeRemove
-        }
-        .forEach { removeValue(forKey: $0.key) }
-    }
-}
-
 extension Dictionary where Key == AttributeKey, Value == AttributeValue {
     /// Merges given `rumCommandAttributes` to current dictionary, by overwriting values.
     mutating func merge(rumCommandAttributes: [AttributeKey: AttributeValue]?) {

--- a/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
@@ -6,11 +6,25 @@
 
 import Foundation
 
+internal enum RUMScopeState {
+    case open
+    case closing
+    case closed
+    case discarded
+}
+
 internal protocol RUMScope: class {
-    /// Processes given command. Returns:
-    /// * `true` if the scope should be kept open.
-    /// * `false` if the scope should be closed.
-    func process(command: RUMCommand) -> Bool
+    /// Tracks a given `RUMScope` state.
+    /// The state is updated based on the return value of `RUMScope.process`.
+    var state: RUMScopeState { set get }
+
+    /// Processes given command.
+    /// Returns a `RUMScopeState`
+    /// * `open` if the scope should be kept open.
+    /// * `closing` if the scope should be kept open a little longer.
+    /// * `closed` if the scope should be closed.
+    /// * `discarded` if the scope should be closed and any related state should be rolled back.
+    func process(command: RUMCommand) -> RUMScopeState
 }
 
 extension RUMScope {
@@ -18,23 +32,47 @@ extension RUMScope {
     /// removing it if it gets closed.
     ///
     /// Returns the `childScope` requested to be kept open, `nil` if it requests to close.
-    func manage<S: RUMScope>(childScope: S?, byPropagatingCommand command: RUMCommand) -> S? {
-        if childScope?.process(command: command) == false {
-            return nil
+    func manage<S: RUMScope>(childScope: S?, byPropagatingCommand command: RUMCommand) -> (state: RUMScopeState, scope: S?) {
+        let state = childScope?.process(command: command) ?? .closed
+        childScope?.state = state
+        if state == .closed || state == .discarded {
+            return (state, nil)
         } else {
-            return childScope
+            return (state, childScope)
         }
     }
+}
 
-    /// Propagates given `command` through array of child scopes and manages their lifecycle by
-    /// removing child scopes that get closed.
-    ///
-    /// Returns the `childScopes` array by removing scopes which requested to be closed.
-    func manage<S: RUMScope>(childScopes: [S], byPropagatingCommand command: RUMCommand) -> [S] {
-        return childScopes.filter { childScope in
-            let shouldBeKept = childScope.process(command: command)
-            return shouldBeKept
+extension Array where Element: RUMScope {
+    /// Propagates given `command` through array of scopes and manages their lifecycle by
+    /// removing scopes that get closed or discarded.
+    /// Also provides a callback with scopes to be removed to help keep external state consistent.
+    mutating func manage(byPropagatingCommand command: RUMCommand, callback: ((Element) -> Void)? = nil) {
+        removeAll { scope in
+            let managedScope = scope.manage(childScope: scope, byPropagatingCommand: command).scope
+            let shouldBeRemove = managedScope == nil
+            if shouldBeRemove {
+                callback?(scope)
+            }
+            return shouldBeRemove
         }
+    }
+}
+
+extension Dictionary where Value: RUMScope {
+    /// Propagates given `command` through a dictionary of scopes and manages their lifecycle by
+    /// removing scopes that get closed or discarded.
+    /// Also provides a callback with scopes to be removed to help keep external state consistent.
+    mutating func manage(byPropagatingCommand command: RUMCommand, callback: ((Value) -> Void)? = nil) {
+        filter { _, scope in
+            let managedScope = scope.manage(childScope: scope, byPropagatingCommand: command).scope
+            let shouldBeRemove = managedScope == nil
+            if shouldBeRemove {
+                callback?(scope)
+            }
+            return shouldBeRemove
+        }
+        .forEach { removeValue(forKey: $0.key) }
     }
 }
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -19,6 +19,8 @@ internal struct RUMScopeDependencies {
 }
 
 internal class RUMApplicationScope: RUMScope, RUMContextProvider {
+    var state: RUMScopeState
+
     // MARK: - Child Scopes
 
     /// Session scope. It gets created with the first `.startView` event.
@@ -36,6 +38,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         dependencies: RUMScopeDependencies,
         samplingRate: Float
     ) {
+        self.state = .open
         self.dependencies = dependencies
         self.samplingRate = samplingRate
         self.context = RUMContext(
@@ -54,9 +57,9 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
     // MARK: - RUMScope
 
-    func process(command: RUMCommand) -> Bool {
+    func process(command: RUMCommand) -> RUMScopeState {
         if let currentSession = sessionScope {
-            sessionScope = manage(childScope: sessionScope, byPropagatingCommand: command)
+            sessionScope = manage(childScope: sessionScope, byPropagatingCommand: command).scope
 
             if sessionScope == nil { // if session expired
                 refresh(expiredSession: currentSession, on: command)
@@ -70,7 +73,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             }
         }
 
-        return true
+        return .open
     }
 
     // MARK: - Private

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -19,7 +19,7 @@ internal class RUMResourceScope: RUMScope {
     /// The Resource url.
     let resourceURL: String
     /// The name used to identify this Resource.
-    fileprivate let resourceKey: String
+    let resourceKey: String
     /// Resource attributes.
     private var attributes: [AttributeKey: AttributeValue]
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -102,8 +102,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         userActionScopes.manage(byPropagatingCommand: command) { scope in
             if scope.state == .closed {
                 self.actionsCount += 1
+                needsViewUpdate = true
             }
-            needsViewUpdate = true
         }
         openUserActionScope = (userActionScopes.last != nil && userActionScopes.last?.state == .open) ? userActionScopes.last : nil
 
@@ -132,7 +132,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         case let command as RUMAddViewTimingCommand where isActiveView:
             customTimings[command.timingName] = command.time.timeIntervalSince(viewStartTime).toInt64Nanoseconds
             needsViewUpdate = true
-
         // Resource commands
         case let command as RUMStartResourceCommand where isActiveView:
             startResource(on: command)
@@ -155,7 +154,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         case let command as RUMEventsMappingCompletionCommand<RUMErrorEvent> where command.change != .discarded && command.isViewError && command.viewUUIDString == viewUUID.toRUMDataFormat:
             errorsCount += 1
             needsViewUpdate = true
-
         default:
             break
         }
@@ -168,8 +166,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 } else /* RUMEventsMappingCompletionCommand<RUMResourceEvent> */ {
                     self.resourcesCount += 1
                 }
+                needsViewUpdate = true
             }
-            needsViewUpdate = true
         }
 
         // Consider scope state and completion

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -177,8 +177,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             sendViewUpdateEvent(on: command)
         }
 
-        let hasNoPendingResources = resourceScopes.isEmpty && userActionScopes.isEmpty
-        let shouldComplete = !isActiveView && hasNoPendingResources
+        let hasNoPendingChildScopes = resourceScopes.isEmpty && userActionScopes.isEmpty
+        let shouldComplete = !isActiveView && hasNoPendingChildScopes
 
         return shouldComplete ? .closed : .open
     }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -155,6 +155,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 )
             }
             let monitor = RUMMonitor(rumFeature: rumFeature)
+            rumFeature.eventsMapper.commandSubscriber = monitor
             RUMAutoInstrumentation.instance?.subscribe(commandSubscriber: monitor)
             URLSessionAutoInstrumentation.instance?.subscribe(commandSubscriber: monitor)
             return monitor

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -25,6 +25,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
                 authorized: directory
             ),
             eventMapper: RUMEventsMapper(
+                dateProvider: SystemDateProvider(),
                 viewEventMapper: nil,
                 errorEventMapper: nil,
                 resourceEventMapper: nil,

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -53,7 +53,7 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
 
         let view1 = session.viewVisits[0]
-        XCTAssertEqual(view1.path, "SendRUMFixture1ViewController")
+        XCTAssertEqual(view1.name, "SendRUMFixture1ViewController")
         XCTAssertEqual(view1.path, "Example.SendRUMFixture1ViewController")
         XCTAssertEqual(view1.viewEvents.count, 7, "First view should receive 7 updates")
         XCTAssertEqual(view1.viewEvents.last?.view.action.count, 2)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -53,9 +53,9 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
 
         let view1 = session.viewVisits[0]
-        XCTAssertEqual(view1.name, "SendRUMFixture1View")
+        XCTAssertEqual(view1.path, "SendRUMFixture1ViewController")
         XCTAssertEqual(view1.path, "Example.SendRUMFixture1ViewController")
-        XCTAssertEqual(view1.viewEvents.count, 6, "First view should receive 6 updates")
+        XCTAssertEqual(view1.viewEvents.count, 7, "First view should receive 7 updates")
         XCTAssertEqual(view1.viewEvents.last?.view.action.count, 2)
         XCTAssertEqual(view1.viewEvents.last?.view.resource.count, 1)
         XCTAssertEqual(view1.viewEvents.last?.view.error.count, 1)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -53,7 +53,7 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
 
         let view1 = session.viewVisits[0]
-        XCTAssertEqual(view1.name, "SendRUMFixture1ViewController")
+        XCTAssertEqual(view1.name, "SendRUMFixture1View")
         XCTAssertEqual(view1.path, "Example.SendRUMFixture1ViewController")
         XCTAssertEqual(view1.viewEvents.count, 7, "First view should receive 7 updates")
         XCTAssertEqual(view1.viewEvents.last?.view.action.count, 2)

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -35,6 +35,7 @@ class RUMIntegrationsTests: XCTestCase {
         RUMFeature.instance = RUMFeature(
             storage: FeatureStorage(writer: NoOpFileWriter(), reader: NoOpFileReader()),
             upload: FeatureUpload(uploader: NoOpDataUploadWorker()),
+            eventsMapper: .mockNoOp(dateProvider: SystemDateProvider()),
             configuration: .mockWith(sessionSamplingRate: 0.0),
             commonDependencies: .mockAny()
         )

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -179,6 +179,26 @@ extension FeaturesConfiguration.Tracing {
     }
 }
 
+extension FeaturesConfiguration.RUM.EventsMapper {
+    static func mockNoOp() -> Self {
+        return mockWith()
+    }
+
+    static func mockWith(
+        viewEventMapper: RUMViewEventMapper? = nil,
+        errorEventMapper: RUMErrorEventMapper? = nil,
+        resourceEventMapper: RUMResourceEventMapper? = nil,
+        actionEventMapper: RUMActionEventMapper? = nil
+    ) -> Self {
+        return .init(
+            viewEventMapper: viewEventMapper,
+            errorEventMapper: errorEventMapper,
+            resourceEventMapper: resourceEventMapper,
+            actionEventMapper: actionEventMapper
+        )
+    }
+}
+
 extension FeaturesConfiguration.RUM {
     static func mockAny() -> Self { mockWith() }
 
@@ -187,7 +207,7 @@ extension FeaturesConfiguration.RUM {
         uploadURLWithClientToken: URL = .mockAny(),
         applicationID: String = .mockAny(),
         sessionSamplingRate: Float = 100.0,
-        eventMapper: RUMEventsMapper = .mockNoOp(),
+        eventMapper: EventsMapper = .mockNoOp(),
         autoInstrumentation: FeaturesConfiguration.RUM.AutoInstrumentation? = nil
     ) -> Self {
         return .init(

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -86,6 +86,10 @@ extension RUMViewEvent {
 
 extension RUMResourceEvent {
     static func mockRandom() -> RUMResourceEvent {
+        return mockWith()
+    }
+
+    static func mockWith(viewID: String = .mockRandom(), resourceID: String = .mockRandom(), resourceURL: String = .mockRandom()) -> RUMResourceEvent {
         return RUMResourceEvent(
             dd: .init(
                 spanId: .mockRandom(),
@@ -101,7 +105,7 @@ extension RUMResourceEvent {
                 download: .init(duration: .mockRandom(), start: .mockRandom()),
                 duration: .mockRandom(),
                 firstByte: .init(duration: .mockRandom(), start: .mockRandom()),
-                id: .mockRandom(),
+                id: resourceID,
                 method: .mockRandom(),
                 provider: .init(
                     domain: .mockRandom(),
@@ -113,7 +117,7 @@ extension RUMResourceEvent {
                 ssl: .init(duration: .mockRandom(), start: .mockRandom()),
                 statusCode: .mockRandom(),
                 type: [.xhr, .fetch, .image].randomElement()!,
-                url: .mockRandom()
+                url: resourceURL
             ),
             service: .mockRandom(),
             session: .init(
@@ -123,7 +127,7 @@ extension RUMResourceEvent {
             ),
             usr: .mockRandom(),
             view: .init(
-                id: .mockRandom(),
+                id: viewID,
                 referrer: .mockRandom(),
                 url: .mockRandom()
             )
@@ -133,12 +137,16 @@ extension RUMResourceEvent {
 
 extension RUMActionEvent {
     static func mockRandom() -> RUMActionEvent {
+        return mockWith()
+    }
+
+    static func mockWith(actionID: String = .mockRandom(), viewID: String = .mockRandom()) -> RUMActionEvent {
         return RUMActionEvent(
             dd: .init(),
             action: .init(
                 crash: .init(count: .mockRandom()),
                 error: .init(count: .mockRandom()),
-                id: .mockRandom(),
+                id: actionID,
                 loadingTime: .mockRandom(),
                 longTask: .init(count: .mockRandom()),
                 resource: .init(count: .mockRandom()),
@@ -156,7 +164,7 @@ extension RUMActionEvent {
             ),
             usr: .mockRandom(),
             view: .init(
-                id: .mockRandom(),
+                id: viewID,
                 referrer: .mockRandom(),
                 url: .mockRandom()
             )
@@ -166,6 +174,40 @@ extension RUMActionEvent {
 
 extension RUMErrorEvent {
     static func mockRandom() -> RUMErrorEvent {
+        return mockForResourceWith()
+    }
+
+    static func mockForViewWith(viewID: String = .mockRandom()) -> RUMErrorEvent {
+        return RUMErrorEvent(
+            dd: .init(),
+            action: .init(id: .mockRandom()),
+            application: .init(id: .mockRandom()),
+            connectivity: .mockRandom(),
+            date: .mockRandom(),
+            error: .init(
+                isCrash: .random(),
+                message: .mockRandom(),
+                resource: nil,
+                source: [.source, .network, .custom].randomElement()!,
+                stack: .mockRandom(),
+                type: .mockRandom()
+            ),
+            service: .mockRandom(),
+            session: .init(
+                hasReplay: nil,
+                id: .mockRandom(),
+                type: .user
+            ),
+            usr: .mockRandom(),
+            view: .init(
+                id: viewID,
+                referrer: .mockRandom(),
+                url: .mockRandom()
+            )
+        )
+    }
+
+    static func mockForResourceWith(viewID: String = .mockRandom(), resourceURL: String = .mockRandom()) -> RUMErrorEvent {
         return RUMErrorEvent(
             dd: .init(),
             action: .init(id: .mockRandom()),
@@ -183,7 +225,7 @@ extension RUMErrorEvent {
                         type: Bool.random() ? .firstParty : nil
                     ),
                     statusCode: .mockRandom(),
-                    url: .mockRandom()
+                    url: resourceURL
                 ),
                 source: [.source, .network, .custom].randomElement()!,
                 stack: .mockRandom(),
@@ -197,7 +239,7 @@ extension RUMErrorEvent {
             ),
             usr: .mockRandom(),
             view: .init(
-                id: .mockRandom(),
+                id: viewID,
                 referrer: .mockRandom(),
                 url: .mockRandom()
             )

--- a/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
@@ -63,7 +63,7 @@ class RUMCurrentContextTests: XCTestCase {
                 activeViewID: XCTUnwrap(applicationScope.sessionScope?.viewScopes.last?.viewUUID),
                 activeViewPath: XCTUnwrap(applicationScope.sessionScope?.viewScopes.last?.viewPath),
                 activeViewName: XCTUnwrap(applicationScope.sessionScope?.viewScopes.last?.viewName),
-                activeUserActionID: XCTUnwrap(applicationScope.sessionScope?.viewScopes.last?.userActionScope?.actionUUID)
+                activeUserActionID: XCTUnwrap(applicationScope.sessionScope?.viewScopes.last?.openUserActionScope?.actionUUID)
             )
         )
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -26,7 +26,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny(), samplingRate: 100)
 
         XCTAssertNil(scope.sessionScope)
-        XCTAssertTrue(scope.process(command: RUMStartViewCommand.mockAny()))
+        XCTAssertEqual(scope.process(command: RUMStartViewCommand.mockAny()), .open)
         XCTAssertNotNil(scope.sessionScope)
     }
 
@@ -55,9 +55,9 @@ class RUMApplicationScopeTests: XCTestCase {
     func testUntilSessionIsStarted_itIgnoresOtherCommands() {
         let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny(), samplingRate: 100)
 
-        XCTAssertTrue(scope.process(command: RUMStopViewCommand.mockAny()))
-        XCTAssertTrue(scope.process(command: RUMAddUserActionCommand.mockAny()))
-        XCTAssertTrue(scope.process(command: RUMStopResourceCommand.mockAny()))
+        XCTAssertEqual(scope.process(command: RUMStopViewCommand.mockAny()), .open)
+        XCTAssertEqual(scope.process(command: RUMAddUserActionCommand.mockAny()), .open)
+        XCTAssertEqual(scope.process(command: RUMStopResourceCommand.mockAny()), .open)
         XCTAssertNil(scope.sessionScope)
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -62,7 +62,7 @@ class RUMResourceScopeTests: XCTestCase {
         currentTime.addTimeInterval(2)
 
         // When
-        XCTAssertFalse(
+        XCTAssertEqual(
             scope.process(
                 command: RUMStopResourceCommand(
                     resourceKey: "/resource/1",
@@ -72,7 +72,8 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 200,
                     size: 1_024
                 )
-            )
+            ),
+            .closing
         )
 
         // Then
@@ -125,7 +126,7 @@ class RUMResourceScopeTests: XCTestCase {
         currentTime.addTimeInterval(2)
 
         // When
-        XCTAssertFalse(
+        XCTAssertEqual(
             scope.process(
                 command: RUMStopResourceWithErrorCommand(
                     resourceKey: "/resource/1",
@@ -135,7 +136,8 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 500,
                     attributes: ["foo": "bar"]
                 )
-            )
+            ),
+            .closing
         )
 
         // Then
@@ -219,11 +221,11 @@ class RUMResourceScopeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(scope.process(command: metricsCommand))
+        XCTAssertEqual(scope.process(command: metricsCommand), .open)
 
         currentTime.addTimeInterval(1)
 
-        XCTAssertFalse(
+        XCTAssertEqual(
             scope.process(
                 command: RUMStopResourceCommand(
                     resourceKey: "/resource/1",
@@ -233,7 +235,8 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 200,
                     size: 1_024
                 )
-            )
+            ),
+            .closing
         )
 
         // Then
@@ -326,13 +329,14 @@ class RUMResourceScopeTests: XCTestCase {
         )
 
         // When
-        XCTAssertFalse(
+        XCTAssertEqual(
             scope.process(
                 command: RUMStopResourceCommand.mockWith(
                     resourceKey: "/resource/1",
                     kind: kindBasedOnResponse
                 )
-            )
+            ),
+            .closing
         )
 
         // Then
@@ -361,10 +365,11 @@ class RUMResourceScopeTests: XCTestCase {
         currentTime.addTimeInterval(2)
 
         // When
-        XCTAssertFalse(
+        XCTAssertEqual(
             scope.process(
                 command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1")
-            )
+            ),
+            .closing
         )
 
         // Then
@@ -396,10 +401,11 @@ class RUMResourceScopeTests: XCTestCase {
         currentTime.addTimeInterval(2)
 
         // When
-        XCTAssertFalse(
+        XCTAssertEqual(
             scope.process(
                 command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1")
-            )
+            ),
+            .closing
         )
 
         // Then
@@ -428,10 +434,11 @@ class RUMResourceScopeTests: XCTestCase {
         currentTime.addTimeInterval(2)
 
         // When
-        XCTAssertFalse(
+        XCTAssertEqual(
             scope.process(
                 command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/1")
-            )
+            ),
+            .closing
         )
 
         // Then
@@ -463,10 +470,11 @@ class RUMResourceScopeTests: XCTestCase {
         currentTime.addTimeInterval(2)
 
         // When
-        XCTAssertFalse(
+        XCTAssertEqual(
             scope.process(
                 command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/1")
-            )
+            ),
+            .closing
         )
 
         // Then

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -57,7 +57,7 @@ class RUMUserActionScopeTests: XCTestCase {
             scope.process(
                 command: RUMEventsMappingCompletionCommand<RUMActionEvent>.mockWith(
                     model: RUMActionEvent.mockWith(
-                        actionID: scope.userActionScope!.actionUUID.toRUMDataFormat
+                        actionID: scope.openUserActionScope!.actionUUID.toRUMDataFormat
                     )
                 )
             ),

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -51,13 +51,14 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertNotEqual(scope.process(command: RUMStartViewCommand.mockWith(identity: mockView)), .closed)
         let mockUserActionCmd = RUMAddUserActionCommand.mockAny()
         XCTAssertEqual(scope.process(command: mockUserActionCmd), .open)
+        let actionID = scope.openUserActionScope!.actionUUID.toRUMDataFormat
         XCTAssertEqual(scope.process(command: RUMStopViewCommand.mockWith(identity: mockView)), .open)
 
         XCTAssertEqual(
             scope.process(
                 command: RUMEventsMappingCompletionCommand<RUMActionEvent>.mockWith(
                     model: RUMActionEvent.mockWith(
-                        actionID: scope.openUserActionScope!.actionUUID.toRUMDataFormat
+                        actionID: actionID
                     )
                 )
             ),

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -907,7 +907,8 @@ class RUMViewScopeTests: XCTestCase {
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
-            uri: "UIViewController",
+            path: "UIViewController",
+            name: "ViewController",
             attributes: [:],
             customTimings: [:],
             startTime: Date()

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -927,7 +927,7 @@ class RUMViewScopeTests: XCTestCase {
         )
         XCTAssertEqual(
             scope.process(
-                command: RUMAddUserActionCommand.mockWith()
+                command: RUMAddUserActionCommand.mockAny()
             ),
             .open
         )

--- a/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
@@ -105,10 +105,7 @@ class RUMEventsMapperTests: XCTestCase {
         // Given
         let mapper = RUMEventsMapper.mockWith(
             dateProvider: SystemDateProvider(),
-            viewEventMapper: { viewEvent in
-                XCTAssertEqual(viewEvent, originalViewEvent, "Mapper should be called with the original event.")
-                return nil
-            },
+            viewEventMapper: nil,
             errorEventMapper: { errorEvent in
                 XCTAssertEqual(errorEvent, originalErrorEvent, "Mapper should be called with the original event.")
                 return nil
@@ -173,7 +170,7 @@ class RUMEventsMapperTests: XCTestCase {
         // When
         let mapper = RUMEventsMapper.mockWith(
             dateProvider: SystemDateProvider(),
-            viewEventMapper: { _ in nil },
+            viewEventMapper: nil,
             errorEventMapper: { _ in nil },
             resourceEventMapper: { _ in nil },
             actionEventMapper: { _ in nil }
@@ -231,7 +228,7 @@ class RUMEventsMapperTests: XCTestCase {
         // Given
         let mapper = RUMEventsMapper.mockWith(
             dateProvider: SystemDateProvider(),
-            viewEventMapper: { _ in nil },
+            viewEventMapper: nil,
             errorEventMapper: { _ in nil },
             resourceEventMapper: { _ in nil },
             actionEventMapper: { _ in nil }

--- a/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
@@ -193,10 +193,10 @@ class RUMEventsMapperTests: XCTestCase {
         )
         let commandSubscriber = CommandSubscriberRecorder()
         mapper.commandSubscriber = commandSubscriber
-        let originalEvent: RUMViewEvent = .mockRandom()
+        let originalEvent = RUMResourceEvent.mockRandom()
 
         // When
-        let mappedEvent = try XCTUnwrap(mapper.map(event: RUMEvent<RUMViewEvent>.mockWith(model: originalEvent))?.model)
+        let mappedEvent = try XCTUnwrap(mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: originalEvent))?.model)
 
         // Then
         XCTAssertEqual(mappedEvent, originalEvent)
@@ -214,10 +214,10 @@ class RUMEventsMapperTests: XCTestCase {
         )
         let commandSubscriber = CommandSubscriberRecorder()
         mapper.commandSubscriber = commandSubscriber
-        let originalEvent: RUMViewEvent = .mockRandom()
+        let originalEvent = RUMResourceEvent.mockRandom()
 
         // When
-        let mappedEvent = try XCTUnwrap(mapper.map(event: RUMEvent<RUMViewEvent>.mockWith(model: originalEvent))?.model)
+        let mappedEvent = try XCTUnwrap(mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: originalEvent))?.model)
 
         // Then
         XCTAssertEqual(mappedEvent, originalEvent)
@@ -237,7 +237,7 @@ class RUMEventsMapperTests: XCTestCase {
         mapper.commandSubscriber = commandSubscriber
 
         // When
-        let mappedEvent = mapper.map(event: RUMEvent<RUMViewEvent>.mockWith(model: RUMViewEvent.mockRandom()))
+        let mappedEvent = mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: RUMResourceEvent.mockRandom()))
 
         // Then
         XCTAssertNil(mappedEvent)
@@ -249,10 +249,10 @@ class RUMEventsMapperTests: XCTestCase {
         let mapper = RUMEventsMapper.mockNoOp(dateProvider: SystemDateProvider())
         let commandSubscriber = CommandSubscriberRecorder()
         mapper.commandSubscriber = commandSubscriber
-        let originalEvent: RUMViewEvent = .mockRandom()
+        let originalEvent = RUMResourceEvent.mockRandom()
 
         // When
-        let mappedEvent = try XCTUnwrap(mapper.map(event: RUMEvent<RUMViewEvent>.mockWith(model: originalEvent))?.model)
+        let mappedEvent = try XCTUnwrap(mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: originalEvent))?.model)
 
         // Then
         XCTAssertEqual(mappedEvent, originalEvent)

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -905,7 +905,7 @@ class RUMMonitorTests: XCTestCase {
 
         let monitor = RUMMonitor.initialize()
 
-        monitor.startView(viewController: mockView, path: .mockAny())
+        monitor.startView(viewController: mockView)
         monitor.startResourceLoading(resourceKey: "/resource/1", url: .mockAny())
         monitor.stopResourceLoading(resourceKey: "/resource/1", response: .mockAny())
         monitor.addUserAction(type: .tap, name: .mockAny())


### PR DESCRIPTION
Please refer to #433 as a safer and simpler alternative. Leaving this one open until we agree on the solution.

### What and why?

Through the Data Scrubbing feature and the `RUMEventsMapper` API, we allow discarding events. Those events might be tracked by `RUMScope`s but their discarding is not accounted for at the moment. For example a `RUMViewScope` will track Action/Resource/Error counts based on commands and children scopes. Both commands and scopes will lead to issuing events that eventually go through the `RUMEventsMapper` when the client code decides which events to discard. Counts that are tracked by `RUMViewScope` are themselves sent inside `RUMViewEvent`s and they can be out of sync if children events have been discarded.

In this PR, we introduce a back propagation of events mapping/discarding so that Scopes can properly track/adjust their state ahead of sending `RUMEvent` to the backend.

### How?

Because `RUMScope` and the chain of `Writer`s (more specifically `DataProcessor` and `RUMEventsMapper`) are bound to different queues and threads respectively, concurrency is an important part of the problem to solve.

We chose to leverage the `RUMCommand`/`RUMCommandSubscriber`/`RUMScope` system to implement the back propagation.

We introduce some new `RUMEventsMappingCompletionCommand` to signal  the mapping/discarding of a `RUMEvent` and its associated `RUMDataModel`. This command is sent by the `RUMEventsMapper` to its `RUMCommandSubscriber`, which in reality is the `RUMMonitor` (i.e. the same entry point as public `RUMCommand`s).
The `RUMScope`s then expect and handle this new command to update their state.

We also add a more explicit `state` for `RUMScope`s. It was previously an implicit boolean state expressed by the output of the `RUMScope.process` method. It is now explicitly managed as the extra asynchronous step requires a new state case (`closing`).
As such the `RUMScope`s become some pretty basic finite state machines reacting to public and `RUMEventsMapper` commands.

We also refactor `RUMScope`'s management and routing of commands a little bit and enforce further the responsibility of `RUMScope`s to filter out commands for themselves instead of letting their parent `RUMScope`s have some tailored routing for them ahead of dispatching to them.

We have to use the `RUMSessionMatcher` in test cases where the added asynchrony makes it hard to predict the actual events sequence. We also had to include a few manual `RUMEventsMappingCompletionCommand` in tests isolated from `RUMEventsMapper` to complete the sequences and get to the final state. 
Also note that in some places, we inject the `RelativeDateProvider` that eventually gets to the `RUMEventsMapper` as this seemed to help with timing of events in the context of automated tests. 

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
