### PR TITLE
RUMM-1050 Refactor logs and spans processing in Logger and Tracer

### DIFF
--- a/Sources/Datadog/Core/Utils/DDError.swift
+++ b/Sources/Datadog/Core/Utils/DDError.swift
@@ -11,7 +11,9 @@ internal struct DDError: Equatable {
     let type: String
     let message: String
     let stack: String
+}
 
+extension DDError {
     init(error: Error) {
         if isNSErrorOrItsSubclass(error) {
             let nsError = error as NSError

--- a/Sources/Datadog/Core/Utils/EncodableValue.swift
+++ b/Sources/Datadog/Core/Utils/EncodableValue.swift
@@ -47,7 +47,7 @@ internal struct JSONStringEncodableValue: Encodable {
     /// Encoder used to encode `encodable` as JSON String value.
     /// It is invoked lazily at `encoder.encode(jsonStringEncodableValue)` so its encoding errors can be propagated in master-type encoding.
     private let jsonEncoder: JSONEncoder
-    private let encodable: EncodableValue
+    internal let encodable: EncodableValue
 
     init(_ value: Encodable, encodedUsing jsonEncoder: JSONEncoder) {
         self.jsonEncoder = jsonEncoder

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -15,6 +15,30 @@ public enum LogLevel: Int, Codable {
     case warn
     case error
     case critical
+
+    // MARK: - `LogLevel` <> `Log.Status` conversion
+
+    internal var asLogStatus: Log.Status {
+        switch self {
+        case .debug:    return .debug
+        case .info:     return .info
+        case .notice:   return .notice
+        case .warn:     return .warn
+        case .error:    return .error
+        case .critical: return .critical
+        }
+    }
+
+    internal init(from logStatus: Log.Status) {
+        switch logStatus {
+        case .debug:    self = .debug
+        case .info:     self = .info
+        case .notice:   self = .notice
+        case .warn:     self = .warn
+        case .error:    self = .error
+        case .critical: self = .critical
+        }
+    }
 }
 
 /// Because `Logger` is a common name widely used across different projects, the `Datadog.Logger` may conflict when
@@ -33,8 +57,10 @@ public enum LogLevel: Int, Codable {
 public typealias DDLogger = Logger
 
 public class Logger {
-    /// Writes `Log` objects to output.
-    let logOutput: LogOutput
+    /// Builds the `Log` from user input; `nil` for no-op logger.
+    internal let logBuilder: LogBuilder?
+    /// Writes the `Log` to file; `nil` for no-op logger.
+    internal let logOutput: LogOutput?
     /// Provides date for log creation.
     private let dateProvider: DateProvider
     /// Attributes associated with every log.
@@ -51,12 +77,14 @@ public class Logger {
     internal let environmentSpanIntegration = LoggingWithEnvironmentSpanIntegration()
 
     init(
-        logOutput: LogOutput,
+        logBuilder: LogBuilder?,
+        logOutput: LogOutput?,
         dateProvider: DateProvider,
         identifier: String,
         rumContextIntegration: LoggingWithRUMContextIntegration?,
         activeSpanIntegration: LoggingWithActiveSpanIntegration?
     ) {
+        self.logBuilder = logBuilder
         self.logOutput = logOutput
         self.dateProvider = dateProvider
         self.queue = DispatchQueue(
@@ -217,7 +245,9 @@ public class Logger {
     // MARK: - Private
 
     private func log(level: LogLevel, message: String, error: Error?, messageAttributes: [String: Encodable]?) {
-        let date = dateProvider.currentDate()
+        guard let logBuilder = logBuilder, let logOutput = logOutput else {
+            return // ignore, as the `Logger` is no-op
+        }
 
         var combinedUserAttributes = messageAttributes ?? [:]
         combinedUserAttributes = queue.sync {
@@ -240,17 +270,19 @@ public class Logger {
             return self.loggerTags
         }
 
-        logOutput.writeLogWith(
+        let log = logBuilder.createLogWith(
             level: level,
             message: message,
             error: error.flatMap { DDError(error: $0) },
-            date: date,
+            date: dateProvider.currentDate(),
             attributes: LogAttributes(
                 userAttributes: combinedUserAttributes,
                 internalAttributes: combinedInternalAttributes
             ),
             tags: tags
         )
+
+        logOutput.write(log: log)
     }
 
     // MARK: - Logger.Builder
@@ -357,7 +389,8 @@ public class Logger {
             } catch {
                 consolePrint("\(error)")
                 return Logger(
-                    logOutput: NoOpLogOutput(),
+                    logBuilder: nil,
+                    logOutput: nil,
                     dateProvider: SystemDateProvider(),
                     identifier: "no-op",
                     rumContextIntegration: nil,
@@ -375,8 +408,11 @@ public class Logger {
                 )
             }
 
+            let (logBuilder, logOutput) = resolveLogBuilderAndOutput(for: loggingFeature) ?? (nil, nil)
+
             return Logger(
-                logOutput: resolveLogsOutput(for: loggingFeature),
+                logBuilder: logBuilder,
+                logOutput: logOutput,
                 dateProvider: loggingFeature.dateProvider,
                 identifier: resolveLoggerName(for: loggingFeature),
                 rumContextIntegration: (RUMFeature.isEnabled && bundleWithRUM) ? LoggingWithRUMContextIntegration() : nil,
@@ -384,7 +420,7 @@ public class Logger {
             )
         }
 
-        private func resolveLogsOutput(for loggingFeature: LoggingFeature) -> LogOutput {
+        private func resolveLogBuilderAndOutput(for loggingFeature: LoggingFeature) -> (LogBuilder, LogOutput)? {
             let logBuilder = LogBuilder(
                 applicationVersion: loggingFeature.configuration.common.applicationVersion,
                 environment: loggingFeature.configuration.common.environment,
@@ -398,34 +434,33 @@ public class Logger {
 
             switch (useFileOutput, useConsoleLogFormat) {
             case (true, let format?):
-                return CombinedLogOutput(
+                let logOutput = CombinedLogOutput(
                     combine: [
                         LogFileOutput(
-                            logBuilder: logBuilder,
                             fileWriter: loggingFeature.storage.writer,
                             rumErrorsIntegration: LoggingWithRUMErrorsIntegration()
                         ),
                         LogConsoleOutput(
-                            logBuilder: logBuilder,
                             format: format,
                             timeZone: .current
                         )
                     ]
                 )
+                return (logBuilder, logOutput)
             case (true, nil):
-                return LogFileOutput(
-                    logBuilder: logBuilder,
+                let logOutput = LogFileOutput(
                     fileWriter: loggingFeature.storage.writer,
                     rumErrorsIntegration: LoggingWithRUMErrorsIntegration()
                 )
+                return (logBuilder, logOutput)
             case (false, let format?):
-                return LogConsoleOutput(
-                    logBuilder: logBuilder,
+                let logOutput = LogConsoleOutput(
                     format: format,
                     timeZone: .current
                 )
+                return (logBuilder, logOutput)
             case (false, nil):
-                return NoOpLogOutput()
+                return nil
             }
         }
 

--- a/Sources/Datadog/Logging/Log/LogBuilder.swift
+++ b/Sources/Datadog/Logging/Log/LogBuilder.swift
@@ -6,6 +6,13 @@
 
 import Foundation
 
+internal struct LogAttributes {
+    /// Log attributes received from the user. They are subject for sanitization.
+    let userAttributes: [String: Encodable]
+    /// Log attributes added internally by the SDK. They are not a subject for sanitization.
+    let internalAttributes: [String: Encodable]?
+}
+
 /// Builds `Log` representation (for later serialization) from data received from user.
 internal struct LogBuilder {
     /// Application version to write in log.
@@ -28,7 +35,7 @@ internal struct LogBuilder {
     func createLogWith(level: LogLevel, message: String, error: DDError?, date: Date, attributes: LogAttributes, tags: Set<String>) -> Log {
         return Log(
             date: dateCorrector?.currentCorrection.applying(to: date) ?? date,
-            status: logStatus(for: level),
+            status: level.asLogStatus,
             message: message,
             error: error,
             serviceName: serviceName,
@@ -43,17 +50,6 @@ internal struct LogBuilder {
             attributes: attributes,
             tags: !tags.isEmpty ? Array(tags) : nil
         )
-    }
-
-    private func logStatus(for level: LogLevel) -> Log.Status {
-        switch level {
-        case .debug:    return .debug
-        case .info:     return .info
-        case .notice:   return .notice
-        case .warn:     return .warn
-        case .error:    return .error
-        case .critical: return .critical
-        }
     }
 
     private func getCurrentThreadName() -> String {

--- a/Sources/Datadog/Logging/Log/LogEncoder.swift
+++ b/Sources/Datadog/Logging/Log/LogEncoder.swift
@@ -9,7 +9,7 @@ import Foundation
 /// `Encodable` representation of log. It gets sanitized before encoding.
 /// All mutable properties are subject of sanitization.
 internal struct Log: Encodable {
-    enum Status: String, Encodable {
+    enum Status: String, Encodable, CaseIterable {
         case debug
         case info
         case notice

--- a/Sources/Datadog/Logging/LogOutputs/LogConsoleOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogConsoleOutput.swift
@@ -13,12 +13,10 @@ internal protocol ConsoleLogFormatter {
 
 /// `LogOutput` which prints logs to console.
 internal struct LogConsoleOutput: LogOutput {
-    private let logBuilder: LogBuilder
     private let formatter: ConsoleLogFormatter
     private let printingFunction: (String) -> Void
 
     init(
-        logBuilder: LogBuilder,
         format: Logger.Builder.ConsoleLogFormat,
         timeZone: TimeZone,
         printingFunction: @escaping (String) -> Void = { consolePrint($0) }
@@ -33,12 +31,10 @@ internal struct LogConsoleOutput: LogOutput {
         case .jsonWith(let prefix):
             self.formatter = JSONLogFormatter(prefix: prefix)
         }
-        self.logBuilder = logBuilder
         self.printingFunction = printingFunction
     }
 
-    func writeLogWith(level: LogLevel, message: String, error: DDError?, date: Date, attributes: LogAttributes, tags: Set<String>) {
-        let log = logBuilder.createLogWith(level: level, message: message, error: error, date: date, attributes: attributes, tags: tags)
+    func write(log: Log) {
         printingFunction(formatter.format(log: log))
     }
 }

--- a/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
@@ -6,18 +6,16 @@
 
 import Foundation
 
-/// `LogOutput` which saves logs to file.
+/// `LogOutput` writing logs to file.
 internal struct LogFileOutput: LogOutput {
-    let logBuilder: LogBuilder
     let fileWriter: Writer
     /// Integration with RUM Errors.
     let rumErrorsIntegration: LoggingWithRUMErrorsIntegration?
 
-    func writeLogWith(level: LogLevel, message: String, error: DDError?, date: Date, attributes: LogAttributes, tags: Set<String>) {
-        let log = logBuilder.createLogWith(level: level, message: message, error: error, date: date, attributes: attributes, tags: tags)
+    func write(log: Log) {
         fileWriter.write(value: log)
 
-        if level.rawValue >= LogLevel.error.rawValue {
+        if log.status == .error || log.status == .critical {
             rumErrorsIntegration?.addError(for: log)
         }
     }

--- a/Sources/Datadog/Logging/LogOutputs/LogOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogOutput.swift
@@ -6,14 +6,7 @@
 
 import Foundation
 
-internal struct LogAttributes {
-    /// Log attributes received from the user. They are subject for sanitization.
-    let userAttributes: [String: Encodable]
-    /// Log attributes added internally by the SDK. They are not a subject for sanitization.
-    let internalAttributes: [String: Encodable]?
-}
-
-/// Type writting logs to some destination.
+/// An interface for writing logs to some destination.
 internal protocol LogOutput {
-    func writeLogWith(level: LogLevel, message: String, error: DDError?, date: Date, attributes: LogAttributes, tags: Set<String>)
+    func write(log: Log)
 }

--- a/Sources/Datadog/Logging/LogOutputs/LogUtilityOutputs.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogUtilityOutputs.swift
@@ -6,12 +6,6 @@
 
 import Foundation
 
-/// `LogOutput` which does nothing.
-internal struct NoOpLogOutput: LogOutput {
-    func writeLogWith(level: LogLevel, message: String, error: DDError?, date: Date, attributes: LogAttributes, tags: Set<String>) {}
-}
-
-/// Combines one or more `LogOutputs` into one.
 internal struct CombinedLogOutput: LogOutput {
     let combinedOutputs: [LogOutput]
 
@@ -19,18 +13,19 @@ internal struct CombinedLogOutput: LogOutput {
         self.combinedOutputs = outputs
     }
 
-    func writeLogWith(level: LogLevel, message: String, error: DDError?, date: Date, attributes: LogAttributes, tags: Set<String>) {
-        combinedOutputs.forEach { $0.writeLogWith(level: level, message: message, error: error, date: date, attributes: attributes, tags: tags) }
+    func write(log: Log) {
+        combinedOutputs.forEach { $0.write(log: log) }
     }
 }
 
+/// Sends the log to `conditionedOutput` only if the `condition` is met.
 internal struct ConditionalLogOutput: LogOutput {
     let conditionedOutput: LogOutput
-    let condition: (LogLevel) -> Bool
+    let condition: (Log) -> Bool
 
-    func writeLogWith(level: LogLevel, message: String, error: DDError?, date: Date, attributes: LogAttributes, tags: Set<String>) {
-        if condition(level) {
-            conditionedOutput.writeLogWith(level: level, message: message, error: error, date: date, attributes: attributes, tags: tags)
+    func write(log: Log) {
+        if condition(log) {
+            conditionedOutput.write(log: log)
         }
     }
 }

--- a/Sources/Datadog/RUM/RUMEventOutputs/RUMEventOutput.swift
+++ b/Sources/Datadog/RUM/RUMEventOutputs/RUMEventOutput.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 
+/// An interface for writing RUM events to some destination.
 internal protocol RUMEventOutput {
     func write<DM: RUMDataModel>(rumEvent: RUMEvent<DM>)
 }

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -109,7 +109,7 @@ internal class DDSpan: OTSpan {
         if let activity = activityReference {
             ddTracer.activeSpansPool.removeSpan(activityReference: activity)
         }
-        ddTracer.write(span: self, finishTime: time)
+        ddTracer.write(ddspan: self, finishTime: time)
     }
 
     @discardableResult

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -10,8 +10,6 @@ import Foundation
 internal struct SpanBuilder {
     /// Application version to encode in span.
     let applicationVersion: String
-    /// Environment to encode in span.
-    let environment: String
     /// Service name to encode in span.
     let serviceName: String
     /// Shared user info provider.

--- a/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
+++ b/Sources/Datadog/Tracing/SpanOutputs/SpanFileOutput.swift
@@ -8,12 +8,12 @@ import Foundation
 
 /// `SpanOutput` which saves spans to file.
 internal struct SpanFileOutput: SpanOutput {
-    let spanBuilder: SpanBuilder
     let fileWriter: Writer
+    /// Environment to encode in span.
+    let environment: String
 
-    func write(ddspan: DDSpan, finishTime: Date) {
-        let span = spanBuilder.createSpan(from: ddspan, finishTime: finishTime)
-        let envelope = SpanEnvelope(span: span, environment: spanBuilder.environment)
+    func write(span: Span) {
+        let envelope = SpanEnvelope(span: span, environment: environment)
         fileWriter.write(value: envelope)
     }
 }

--- a/Sources/Datadog/Tracing/SpanOutputs/SpanOutput.swift
+++ b/Sources/Datadog/Tracing/SpanOutputs/SpanOutput.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Type writting spans to some destination.
+/// An interface for writing spans to some destination.
 internal protocol SpanOutput {
-    func write(ddspan: DDSpan, finishTime: Date)
+    func write(span: Span)
 }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writting/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writting/FileWriterTests.swift
@@ -70,7 +70,7 @@ class FileWriterTests: XCTestCase {
         writer.write(value: ["key2": "value3 that makes it exceed 17 bytes"]) // will be dropped
 
         XCTAssertEqual(try temporaryDirectory.files()[0].read(), #"{"key1":"value1"}"#.utf8Data) // same content as before
-        XCTAssertEqual(output.recordedLog?.level, .error)
+        XCTAssertEqual(output.recordedLog?.status, .error)
         XCTAssertEqual(output.recordedLog?.message, "🔥 Failed to write log: data exceeds the maximum size of 17 bytes.")
     }
 
@@ -92,7 +92,7 @@ class FileWriterTests: XCTestCase {
 
         writer.write(value: FailingEncodableMock(errorMessage: "failed to encode `FailingEncodable`."))
 
-        XCTAssertEqual(output.recordedLog?.level, .error)
+        XCTAssertEqual(output.recordedLog?.status, .error)
         XCTAssertEqual(output.recordedLog?.message, "🔥 Failed to write log: failed to encode `FailingEncodable`.")
     }
 
@@ -117,7 +117,7 @@ class FileWriterTests: XCTestCase {
         writer.write(value: ["won't be written"])
         try? temporaryDirectory.files()[0].makeReadWrite()
 
-        XCTAssertEqual(output.recordedLog?.level, .error)
+        XCTAssertEqual(output.recordedLog?.status, .error)
         XCTAssertNotNil(output.recordedLog?.message)
         XCTAssertTrue(output.recordedLog!.message.contains("You don’t have permission"))
     }

--- a/Tests/DatadogTests/Datadog/Core/System/Time/DateCorrectionTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/System/Time/DateCorrectionTests.swift
@@ -65,7 +65,7 @@ class DateCorrectorTests: XCTestCase {
 
         // Then
         let log = try XCTUnwrap(userLogOutput.recordedLog)
-        XCTAssertEqual(log.level, .info)
+        XCTAssertEqual(log.status, .info)
         XCTAssertEqual(
             log.message,
             """
@@ -84,7 +84,7 @@ class DateCorrectorTests: XCTestCase {
 
         // Then
         let log = try XCTUnwrap(userLogOutput.recordedLog)
-        XCTAssertEqual(log.level, .warn)
+        XCTAssertEqual(log.status, .warn)
         XCTAssertEqual(
             log.message,
             """

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -553,7 +553,7 @@ class LoggerTests: XCTestCase {
         logger.info("info message")
 
         // then
-        XCTAssertEqual(output.recordedLog?.level, .warn)
+        XCTAssertEqual(output.recordedLog?.status, .warn)
         try XCTAssertTrue(
             XCTUnwrap(output.recordedLog?.message)
                 .contains("RUM feature is enabled, but no `RUMMonitor` is registered. The RUM integration with Logging will not work.")
@@ -658,7 +658,7 @@ class LoggerTests: XCTestCase {
         logger.info("info message")
 
         // then
-        XCTAssertEqual(output.recordedLog?.level, .warn)
+        XCTAssertEqual(output.recordedLog?.status, .warn)
         try XCTAssertTrue(
             XCTUnwrap(output.recordedLog?.message)
                 .contains("Tracing feature is enabled, but no `Tracer` is registered. The Tracing integration with Logging will not work.")
@@ -823,7 +823,8 @@ class LoggerTests: XCTestCase {
             printFunction.printedMessage,
             "🔥 Datadog SDK usage error: `Datadog.initialize()` must be called prior to `Logger.builder.build()`."
         )
-        XCTAssertTrue(logger.logOutput is NoOpLogOutput)
+        XCTAssertNil(logger.logBuilder)
+        XCTAssertNil(logger.logOutput)
     }
 
     func testGivenLoggingFeatureDisabled_whenInitializingLogger_itPrintsError() throws {
@@ -848,7 +849,8 @@ class LoggerTests: XCTestCase {
             printFunction.printedMessage,
             "🔥 Datadog SDK usage error: `Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."
         )
-        XCTAssertTrue(logger.logOutput is NoOpLogOutput)
+        XCTAssertNil(logger.logBuilder)
+        XCTAssertNil(logger.logOutput)
 
         try Datadog.deinitializeOrThrow()
     }

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogConsoleOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogConsoleOutputTests.swift
@@ -9,27 +9,25 @@ import XCTest
 
 // swiftlint:disable multiline_arguments_brackets trailing_closure
 class LogConsoleOutputTests: XCTestCase {
-    private let error = DDError(error: ErrorMock("description"))
+    private let log: Log = .mockWith(date: .mockDecember15th2019At10AMUTC(), status: .info, message: "Info message.")
 
     func testItPrintsLogsUsingShortFormat() {
         var messagePrinted: String = ""
 
         let output1 = LogConsoleOutput(
-            logBuilder: .mockAny(),
             format: .short,
             timeZone: .UTC,
             printingFunction: { messagePrinted = $0 }
         )
-        output1.writeLogWith(level: .info, message: "Info message.", error: error, date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
+        output1.write(log: log)
         XCTAssertEqual(messagePrinted, "10:00:00.000 [INFO] Info message.")
 
         let output2 = LogConsoleOutput(
-            logBuilder: .mockAny(),
             format: .shortWith(prefix: "🐶 "),
             timeZone: .UTC,
             printingFunction: { messagePrinted = $0 }
         )
-        output2.writeLogWith(level: .info, message: "Info message.", error: error, date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
+        output2.write(log: log)
         XCTAssertEqual(messagePrinted, "🐶 10:00:00.000 [INFO] Info message.")
     }
 
@@ -37,12 +35,11 @@ class LogConsoleOutputTests: XCTestCase {
         var messagePrinted: String = ""
 
         let output = LogConsoleOutput(
-            logBuilder: .mockAny(),
             format: .short,
             timeZone: .EET,
             printingFunction: { messagePrinted = $0 }
         )
-        output.writeLogWith(level: .info, message: "Info message.", error: error, date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
+        output.write(log: log)
         XCTAssertEqual(messagePrinted, "12:00:00.000 [INFO] Info message.")
     }
 
@@ -50,22 +47,20 @@ class LogConsoleOutputTests: XCTestCase {
         var messagePrinted: String = ""
 
         let output1 = LogConsoleOutput(
-            logBuilder: .mockAny(),
             format: .json,
             timeZone: .mockAny(),
             printingFunction: { messagePrinted = $0 }
         )
-        output1.writeLogWith(level: .info, message: "Info message.", error: error, date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
+        output1.write(log: log)
         try LogMatcher.fromJSONObjectData(messagePrinted.utf8Data)
             .assertMessage(equals: "Info message.")
 
         let output2 = LogConsoleOutput(
-            logBuilder: .mockAny(),
             format: .jsonWith(prefix: "🐶 → "),
             timeZone: .mockAny(),
             printingFunction: { messagePrinted = $0 }
         )
-        output2.writeLogWith(level: .info, message: "Info message.", error: error, date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
+        output2.write(log: log)
         XCTAssertTrue(messagePrinted.hasPrefix("🐶 → "))
         try LogMatcher.fromJSONObjectData(messagePrinted.removingPrefix("🐶 → ").utf8Data)
             .assertMessage(equals: "Info message.")

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
@@ -21,7 +21,6 @@ class LogFileOutputTests: XCTestCase {
     func testItWritesLogToFileAsJSON() throws {
         let fileCreationDateProvider = RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC())
         let output = LogFileOutput(
-            logBuilder: .mockAny(),
             fileWriter: FileWriter(
                 dataFormat: LoggingFeature.dataFormat,
                 orchestrator: FilesOrchestrator(
@@ -36,20 +35,24 @@ class LogFileOutputTests: XCTestCase {
             rumErrorsIntegration: nil
         )
 
-        output.writeLogWith(level: .info, message: "log message 1", error: nil, date: .mockAny(), attributes: .mockAny(), tags: [])
+        let log1: Log = .mockWith(status: .info, message: "log message 1")
+        output.write(log: log1)
 
         fileCreationDateProvider.advance(bySeconds: 1)
 
-        output.writeLogWith(level: .info, message: "log message 2", error: nil, date: .mockAny(), attributes: .mockAny(), tags: [])
+        let log2: Log = .mockWith(status: .warn, message: "log message 2")
+        output.write(log: log2)
 
         let log1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())
         let log1Data = try temporaryDirectory.file(named: log1FileName).read()
         let log1Matcher = try LogMatcher.fromJSONObjectData(log1Data)
+        log1Matcher.assertStatus(equals: "info")
         log1Matcher.assertMessage(equals: "log message 1")
 
         let log2FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
         let log2Data = try temporaryDirectory.file(named: log2FileName).read()
         let log2Matcher = try LogMatcher.fromJSONObjectData(log2Data)
+        log2Matcher.assertStatus(equals: "warn")
         log2Matcher.assertMessage(equals: "log message 2")
     }
 }

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogUtilityOutputsTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogUtilityOutputsTests.swift
@@ -9,30 +9,33 @@ import XCTest
 
 class CombinedLogOutputTests: XCTestCase {
     func testCombinedLogOutput_writesLogToAllCombinedOutputs() {
+        let randomLog: Log = .mockRandom()
+
         let output1 = LogOutputMock()
         let output2 = LogOutputMock()
         let output3 = LogOutputMock()
 
-        let error = DDError(error: ErrorMock("desc"))
         let combinedOutput = CombinedLogOutput(combine: [output1, output2, output3])
-        combinedOutput.writeLogWith(level: .info, message: "info message", error: error, date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
+        combinedOutput.write(log: randomLog)
 
-        XCTAssertEqual(output1.recordedLog, .init(level: .info, message: "info message", error: error, date: .mockDecember15th2019At10AMUTC()))
-        XCTAssertEqual(output2.recordedLog, .init(level: .info, message: "info message", error: error, date: .mockDecember15th2019At10AMUTC()))
-        XCTAssertEqual(output3.recordedLog, .init(level: .info, message: "info message", error: error, date: .mockDecember15th2019At10AMUTC()))
+        XCTAssertEqual(output1.recordedLog, randomLog)
+        XCTAssertEqual(output2.recordedLog, randomLog)
+        XCTAssertEqual(output3.recordedLog, randomLog)
     }
 
-    func testConditionalLogOutput_writesLogToCombinedOutputOnlyIfConditionIsMet() {
+    func testConditionalLogOutput_writesLogToConditionedOutputOnlyIfConditionIsMet() {
+        let randomLog: Log = .mockRandom()
+
         let output1 = LogOutputMock()
         let conditionalOutput1 = ConditionalLogOutput(conditionedOutput: output1) { _ in true }
 
-        conditionalOutput1.writeLogWith(level: .info, message: "info message", error: nil, date: .mockDecember15th2019At10AMUTC(), attributes: .mockAny(), tags: [])
-        XCTAssertEqual(output1.recordedLog, .init(level: .info, message: "info message", date: .mockDecember15th2019At10AMUTC()))
+        conditionalOutput1.write(log: randomLog)
+        XCTAssertEqual(output1.recordedLog, randomLog)
 
         let output2 = LogOutputMock()
         let conditionalOutput2 = ConditionalLogOutput(conditionedOutput: output2) { _ in false }
 
-        conditionalOutput2.writeLogWith(level: .info, message: "info message", error: nil, date: .mockAny(), attributes: .mockAny(), tags: [])
+        conditionalOutput2.write(log: randomLog)
         XCTAssertNil(output2.recordedLog)
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -739,6 +739,16 @@ extension EncodableValue {
     }
 }
 
+extension DDError: RandomMockable {
+    static func mockRandom() -> DDError {
+        return DDError(
+            type: .mockRandom(),
+            message: .mockRandom(),
+            stack: .mockRandom()
+        )
+    }
+}
+
 // MARK: - Global Dependencies Mocks
 
 /// Mock which can be used to intercept messages printed by `developerLogger` or

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -133,7 +133,7 @@ extension Log.Status: RandomMockable {
     }
 
     static func mockRandom() -> Log.Status {
-        return [.debug, .info, .notice, .warn, .error, .critical].randomElement()!
+        return allCases.randomElement()!
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -229,7 +229,10 @@ extension Tracer {
 
     static func mockWith(
         spanOutput: SpanOutput = SpanOutputMock(),
-        logOutput: LoggingForTracingAdapter.AdaptedLogOutput = .init(loggingOutput: LogOutputMock()),
+        logOutput: LoggingForTracingAdapter.AdaptedLogOutput = .init(
+            logBuilder: .mockAny(),
+            loggingOutput: LogOutputMock()
+        ),
         dateProvider: DateProvider = SystemDateProvider(),
         tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator(),
         globalTags: [String: Encodable]? = nil,

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -228,6 +228,7 @@ extension Tracer {
     }
 
     static func mockWith(
+        spanBuilder: SpanBuilder = .mockAny(),
         spanOutput: SpanOutput = SpanOutputMock(),
         logOutput: LoggingForTracingAdapter.AdaptedLogOutput = .init(
             logBuilder: .mockAny(),
@@ -239,6 +240,7 @@ extension Tracer {
         rumContextIntegration: TracingWithRUMContextIntegration? = nil
     ) -> Tracer {
         return Tracer(
+            spanBuilder: spanBuilder,
             spanOutput: spanOutput,
             logOutput: logOutput,
             dateProvider: dateProvider,
@@ -256,7 +258,6 @@ extension SpanBuilder {
 
     static func mockWith(
         applicationVersion: String = .mockAny(),
-        environment: String = .mockAny(),
         serviceName: String = .mockAny(),
         userInfoProvider: UserInfoProvider = .mockAny(),
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockAny(),
@@ -265,7 +266,6 @@ extension SpanBuilder {
     ) -> SpanBuilder {
         return SpanBuilder(
             applicationVersion: applicationVersion,
-            environment: environment,
             serviceName: serviceName,
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
@@ -277,17 +277,12 @@ extension SpanBuilder {
 
 /// `SpanOutput` recording received spans.
 class SpanOutputMock: SpanOutput {
-    struct Recorded {
-        let span: DDSpan
-        let finishTime: Date
+    var onSpanRecorded: ((Span?) -> Void)?
+    var recordedSpan: Span? = nil {
+        didSet { onSpanRecorded?(recordedSpan) }
     }
 
-    var onSpanRecorded: ((Recorded?) -> Void)?
-    var recorded: Recorded? = nil {
-        didSet { onSpanRecorded?(recorded) }
-    }
-
-    func write(ddspan: DDSpan, finishTime: Date) {
-        recorded = Recorded(span: ddspan, finishTime: finishTime)
+    func write(span: Span) {
+        recordedSpan = span
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1051,7 +1051,7 @@ class RUMMonitorTests: XCTestCase {
 
         // Then
         resourcesHandler.notify_taskInterceptionCompleted(interception: TaskInterception(request: .mockAny(), isFirstParty: .mockAny()))
-        XCTAssertEqual(output.recordedLog?.level, .warn)
+        XCTAssertEqual(output.recordedLog?.status, .warn)
         XCTAssertEqual(
             output.recordedLog?.message,
             """
@@ -1061,7 +1061,7 @@ class RUMMonitorTests: XCTestCase {
         )
 
         viewsHandler.notify_viewDidAppear(viewController: mockView, animated: .mockAny())
-        XCTAssertEqual(output.recordedLog?.level, .warn)
+        XCTAssertEqual(output.recordedLog?.status, .warn)
         XCTAssertEqual(
             output.recordedLog?.message,
             """
@@ -1077,7 +1077,7 @@ class RUMMonitorTests: XCTestCase {
             application: .shared,
             event: .mockWith(touches: [.mockWith(phase: .ended, view: mockUIControl)])
         )
-        XCTAssertEqual(output.recordedLog?.level, .warn)
+        XCTAssertEqual(output.recordedLog?.status, .warn)
         XCTAssertEqual(
             output.recordedLog?.message,
             """

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -35,7 +35,7 @@ class TracerConfigurationTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDefaultTracer() {
+    func testDefaultTracer() throws {
         let tracer = Tracer.initialize(
             configuration: .init()
         ).dd
@@ -55,11 +55,11 @@ class TracerConfigurationTests: XCTestCase {
         XCTAssertNil(spanBuilder.networkConnectionInfoProvider)
         XCTAssertNil(spanBuilder.carrierInfoProvider)
 
-        guard let tracingLogBuilder = (tracer.logOutput?.loggingOutput as? LogFileOutput)?.logBuilder else {
-            XCTFail()
-            return
-        }
-
+        XCTAssertTrue(
+            tracer.logOutput?.loggingOutput is LogFileOutput,
+            "When Logging feature is enabled Tracer should use logger pointing to `LogFileOutput`."
+        )
+        let tracingLogBuilder = try XCTUnwrap(tracer.logOutput?.logBuilder)
         XCTAssertEqual(tracingLogBuilder.applicationVersion, "1.2.3")
         XCTAssertEqual(tracingLogBuilder.environment, "tests")
         XCTAssertEqual(tracingLogBuilder.serviceName, "service-name")
@@ -80,7 +80,7 @@ class TracerConfigurationTests: XCTestCase {
         XCTAssertNil(tracer2.rumContextIntegration)
     }
 
-    func testCustomizedTracer() {
+    func testCustomizedTracer() throws {
         let tracer = Tracer.initialize(
             configuration: .init(
                 serviceName: "custom-service-name",
@@ -104,11 +104,11 @@ class TracerConfigurationTests: XCTestCase {
         XCTAssertTrue(spanBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
         XCTAssertTrue(spanBuilder.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
 
-        guard let tracingLogBuilder = (tracer.logOutput?.loggingOutput as? LogFileOutput)?.logBuilder else {
-            XCTFail()
-            return
-        }
-
+        XCTAssertTrue(
+            tracer.logOutput?.loggingOutput is LogFileOutput,
+            "When Logging feature is enabled Tracer should use logger pointing to `LogFileOutput`."
+        )
+        let tracingLogBuilder = try XCTUnwrap(tracer.logOutput?.logBuilder)
         XCTAssertEqual(tracingLogBuilder.applicationVersion, "1.2.3")
         XCTAssertEqual(tracingLogBuilder.environment, "tests")
         XCTAssertEqual(tracingLogBuilder.serviceName, "custom-service-name")

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -42,18 +42,13 @@ class TracerConfigurationTests: XCTestCase {
 
         XCTAssertNil(tracer.rumContextIntegration)
 
-        guard let spanBuilder = (tracer.spanOutput as? SpanFileOutput)?.spanBuilder else {
-            XCTFail()
-            return
-        }
-
         let feature = TracingFeature.instance!
-        XCTAssertEqual(spanBuilder.applicationVersion, "1.2.3")
-        XCTAssertEqual(spanBuilder.environment, "tests")
-        XCTAssertEqual(spanBuilder.serviceName, "service-name")
-        XCTAssertTrue(spanBuilder.userInfoProvider === feature.userInfoProvider)
-        XCTAssertNil(spanBuilder.networkConnectionInfoProvider)
-        XCTAssertNil(spanBuilder.carrierInfoProvider)
+        XCTAssertEqual((tracer.spanOutput as? SpanFileOutput)?.environment, "tests")
+        XCTAssertEqual(tracer.spanBuilder.applicationVersion, "1.2.3")
+        XCTAssertEqual(tracer.spanBuilder.serviceName, "service-name")
+        XCTAssertTrue(tracer.spanBuilder.userInfoProvider === feature.userInfoProvider)
+        XCTAssertNil(tracer.spanBuilder.networkConnectionInfoProvider)
+        XCTAssertNil(tracer.spanBuilder.carrierInfoProvider)
 
         XCTAssertTrue(
             tracer.logOutput?.loggingOutput is LogFileOutput,
@@ -91,18 +86,13 @@ class TracerConfigurationTests: XCTestCase {
 
         XCTAssertNil(tracer.rumContextIntegration)
 
-        guard let spanBuilder = (tracer.spanOutput as? SpanFileOutput)?.spanBuilder else {
-            XCTFail()
-            return
-        }
-
         let feature = TracingFeature.instance!
-        XCTAssertEqual(spanBuilder.applicationVersion, "1.2.3")
-        XCTAssertEqual(spanBuilder.serviceName, "custom-service-name")
-        XCTAssertEqual(spanBuilder.environment, "tests")
-        XCTAssertTrue(spanBuilder.userInfoProvider === feature.userInfoProvider)
-        XCTAssertTrue(spanBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
-        XCTAssertTrue(spanBuilder.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
+        XCTAssertEqual((tracer.spanOutput as? SpanFileOutput)?.environment, "tests")
+        XCTAssertEqual(tracer.spanBuilder.applicationVersion, "1.2.3")
+        XCTAssertEqual(tracer.spanBuilder.serviceName, "custom-service-name")
+        XCTAssertTrue(tracer.spanBuilder.userInfoProvider === feature.userInfoProvider)
+        XCTAssertTrue(tracer.spanBuilder.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
+        XCTAssertTrue(tracer.spanBuilder.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
 
         XCTAssertTrue(
             tracer.logOutput?.loggingOutput is LogFileOutput,

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -797,7 +797,7 @@ class TracerTests: XCTestCase {
         span.finish()
 
         // then
-        XCTAssertEqual(output.recordedLog?.level, .warn)
+        XCTAssertEqual(output.recordedLog?.status, .warn)
         try XCTAssertTrue(
             XCTUnwrap(output.recordedLog?.message)
                 .contains("RUM feature is enabled, but no `RUMMonitor` is registered. The RUM integration with Tracing will not work.")
@@ -1042,7 +1042,7 @@ class TracerTests: XCTestCase {
         span.log(fields: ["bar": "bizz"])
 
         // then
-        XCTAssertEqual(output.recordedLog?.level, .warn)
+        XCTAssertEqual(output.recordedLog?.status, .warn)
         XCTAssertEqual(output.recordedLog?.message, "The log for span \"foo\" will not be send, because the Logging feature is disabled.")
 
         try Datadog.deinitializeOrThrow()
@@ -1097,7 +1097,7 @@ class TracerTests: XCTestCase {
 
         // Then
         tracingHandler.notify_taskInterceptionCompleted(interception: TaskInterception(request: .mockAny(), isFirstParty: true))
-        XCTAssertEqual(output.recordedLog?.level, .warn)
+        XCTAssertEqual(output.recordedLog?.status, .warn)
         XCTAssertEqual(
             output.recordedLog?.message,
             """

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -9,10 +9,17 @@ import XCTest
 
 class URLSessionTracingHandlerTests: XCTestCase {
     private let spanOutput = SpanOutputMock()
+    private let logOutput = LogOutputMock()
     private let handler = URLSessionTracingHandler()
 
     override func setUp() {
-        Global.sharedTracer = Tracer.mockWith(spanOutput: spanOutput)
+        Global.sharedTracer = Tracer.mockWith(
+            spanOutput: spanOutput,
+            logOutput: .init(
+                logBuilder: .mockAny(),
+                loggingOutput: logOutput
+            )
+        )
         super.setUp()
     }
 
@@ -46,12 +53,15 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recorded?.span)
-        let spanDuration = spanOutput.recorded?.finishTime.timeIntervalSince(span.startTime)
-        XCTAssertEqual(span.context.dd.traceID.rawValue, 100)
-        XCTAssertEqual(span.context.dd.spanID.rawValue, 200)
+        let span = try XCTUnwrap(spanOutput.recordedSpan)
+        XCTAssertEqual(span.traceID.rawValue, 100)
+        XCTAssertEqual(span.spanID.rawValue, 200)
         XCTAssertEqual(span.operationName, "urlsession.request")
-        XCTAssertEqual(spanDuration, 1)
+        XCTAssertFalse(span.isError)
+        XCTAssertEqual(span.duration, 1)
+
+        let log = logOutput.recordedLog
+        XCTAssertNil(log)
     }
 
     func testGivenFirstPartyInterceptionWithNoError_whenInterceptionCompletes_itEncodesRequestInfoInSpan() throws {
@@ -77,18 +87,21 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recorded?.span)
-        let spanDuration = spanOutput.recorded?.finishTime.timeIntervalSince(span.startTime)
+        let span = try XCTUnwrap(spanOutput.recordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
-        XCTAssertEqual(spanDuration, 2)
-        XCTAssertEqual(span.tags[DDTags.resource] as? String, request.url!.absoluteString)
-        XCTAssertEqual(span.tags[OTTags.httpUrl] as? String, request.url!.absoluteString)
-        XCTAssertEqual(span.tags[OTTags.httpMethod] as? String, "POST")
-        XCTAssertEqual(span.tags[OTTags.httpStatusCode] as? Int, 200)
-        XCTAssertEqual(span.tags.count, 4)
+        XCTAssertFalse(span.isError)
+        XCTAssertEqual(span.duration, 2)
+        XCTAssertEqual(span.resource, request.url!.absoluteString)
+        XCTAssertEqual(span.tags[OTTags.httpUrl]?.encodable.value as? String, request.url!.absoluteString)
+        XCTAssertEqual(span.tags[OTTags.httpMethod]?.encodable.value as? String, "POST")
+        XCTAssertEqual(span.tags[OTTags.httpStatusCode]?.encodable.value as? Int, 200)
+        XCTAssertEqual(span.tags.count, 3)
+
+        let log = logOutput.recordedLog
+        XCTAssertNil(log)
     }
 
-    func testGivenFirstPartyInterceptionWithNetworkError_whenInterceptionCompletes_itEncodesRequestInfoInSpan() throws {
+    func testGivenFirstPartyInterceptionWithNetworkError_whenInterceptionCompletes_itEncodesRequestInfoInSpanAndSendsLog() throws {
         let spanSentExpectation = expectation(description: "Send span")
         spanOutput.onSpanRecorded = { _ in spanSentExpectation.fulfill() }
 
@@ -112,29 +125,49 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recorded?.span)
-        let spanDuration = spanOutput.recorded?.finishTime.timeIntervalSince(span.startTime)
+        let span = try XCTUnwrap(spanOutput.recordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
-        XCTAssertEqual(spanDuration, 30)
-        XCTAssertEqual(span.tags.count, 3)
-        XCTAssertEqual(span.tags[DDTags.resource] as? String, request.url!.absoluteString)
-        XCTAssertEqual(span.tags[OTTags.httpUrl] as? String, request.url!.absoluteString)
-        XCTAssertEqual(span.tags[OTTags.httpMethod] as? String, "GET")
-
-        XCTAssertEqual(span.logFields.count, 1)
-        let logFields = span.logFields.first!
-        XCTAssertEqual(logFields[OTLogFields.event] as? String, "error")
-        XCTAssertEqual(logFields[OTLogFields.errorKind] as? String, "domain - 123")
-        XCTAssertEqual(logFields[OTLogFields.message] as? String, "network error")
-        let stack = try XCTUnwrap(logFields[OTLogFields.stack] as? String)
-        XCTAssertTrue(
-            stack.contains(
-                #"Error Domain=domain Code=123 "network error" UserInfo={NSLocalizedDescription=network error}"#
-            )
+        XCTAssertEqual(span.resource, request.url!.absoluteString)
+        XCTAssertEqual(span.duration, 30)
+        XCTAssertTrue(span.isError)
+        XCTAssertEqual(span.tags[OTTags.httpUrl]?.encodable.value as? String, request.url!.absoluteString)
+        XCTAssertEqual(span.tags[OTTags.httpMethod]?.encodable.value as? String, "GET")
+        XCTAssertEqual(span.tags[DDTags.errorType]?.encodable.value as? String, "domain - 123")
+        XCTAssertEqual(
+            span.tags[DDTags.errorStack]?.encodable.value as? String,
+            "Error Domain=domain Code=123 \"network error\" UserInfo={NSLocalizedDescription=network error}"
         )
+        XCTAssertEqual(span.tags[DDTags.errorMessage]?.encodable.value as? String, "network error")
+        XCTAssertEqual(span.tags.count, 5)
+
+        let log = try XCTUnwrap(logOutput.recordedLog, "It should send error log")
+        XCTAssertEqual(log.status, .error)
+        XCTAssertEqual(log.message, "network error")
+        XCTAssertEqual(
+            log.attributes.internalAttributes?[LoggingForTracingAdapter.TracingAttributes.traceID] as? String,
+            "\(span.traceID.rawValue)"
+        )
+        XCTAssertEqual(
+            log.attributes.internalAttributes?[LoggingForTracingAdapter.TracingAttributes.spanID] as? String,
+            "\(span.spanID.rawValue)"
+        )
+        XCTAssertEqual(
+            log.attributes.internalAttributes?[OTLogFields.errorKind] as? String,
+            "domain - 123"
+        )
+        XCTAssertEqual(log.attributes.internalAttributes?.count, 3)
+        XCTAssertEqual(
+            log.attributes.userAttributes[OTLogFields.event] as? String,
+            "error"
+        )
+        XCTAssertEqual(
+            log.attributes.userAttributes[OTLogFields.stack] as? String,
+            "Error Domain=domain Code=123 \"network error\" UserInfo={NSLocalizedDescription=network error}"
+        )
+        XCTAssertEqual(log.attributes.userAttributes.count, 2)
     }
 
-    func testGivenFirstPartyInterceptionWithServerError_whenInterceptionCompletes_itEncodesRequestInfoInSpan() throws {
+    func testGivenFirstPartyInterceptionWithClientError_whenInterceptionCompletes_itEncodesRequestInfoInSpanAndSendsLog() throws {
         let spanSentExpectation = expectation(description: "Send span")
         spanOutput.onSpanRecorded = { _ in spanSentExpectation.fulfill() }
 
@@ -157,21 +190,47 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recorded?.span)
-        let spanDuration = spanOutput.recorded?.finishTime.timeIntervalSince(span.startTime)
+        let span = try XCTUnwrap(spanOutput.recordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
-        XCTAssertEqual(spanDuration, 2)
-        XCTAssertEqual(span.tags[DDTags.resource] as? String, "404")
-        XCTAssertEqual(span.tags[OTTags.httpUrl] as? String, request.url!.absoluteString)
-        XCTAssertEqual(span.tags[OTTags.httpMethod] as? String, "GET")
-        XCTAssertEqual(span.tags[OTTags.httpStatusCode] as? Int, 404)
-        XCTAssertEqual(span.tags.count, 4)
+        XCTAssertEqual(span.resource, "404")
+        XCTAssertEqual(span.duration, 2)
+        XCTAssertTrue(span.isError)
+        XCTAssertEqual(span.tags[OTTags.httpUrl]?.encodable.value as? String, request.url!.absoluteString)
+        XCTAssertEqual(span.tags[OTTags.httpMethod]?.encodable.value as? String, "GET")
+        XCTAssertEqual(span.tags[OTTags.httpStatusCode]?.encodable.value as? Int, 404)
+        XCTAssertEqual(span.tags[DDTags.errorType]?.encodable.value as? String, "HTTPURLResponse - 404")
+        XCTAssertEqual(span.tags[DDTags.errorMessage]?.encodable.value as? String, "404 not found")
+        XCTAssertEqual(
+            span.tags[DDTags.errorStack]?.encodable.value as? String,
+            "Error Domain=HTTPURLResponse Code=404 \"404 not found\" UserInfo={NSLocalizedDescription=404 not found}"
+        )
+        XCTAssertEqual(span.tags.count, 6)
 
-        XCTAssertEqual(span.logFields.count, 1)
-        let logFields = span.logFields.first!
-        XCTAssertEqual(logFields[OTLogFields.event] as? String, "error")
-        XCTAssertEqual(logFields[OTLogFields.errorKind] as? String, "HTTPURLResponse - 404")
-        XCTAssertEqual(logFields[OTLogFields.message] as? String, "404 not found")
+        let log = try XCTUnwrap(logOutput.recordedLog, "It should send error log")
+        XCTAssertEqual(log.status, .error)
+        XCTAssertEqual(log.message, "404 not found")
+        XCTAssertEqual(
+            log.attributes.internalAttributes?[LoggingForTracingAdapter.TracingAttributes.traceID] as? String,
+            "\(span.traceID.rawValue)"
+        )
+        XCTAssertEqual(
+            log.attributes.internalAttributes?[LoggingForTracingAdapter.TracingAttributes.spanID] as? String,
+            "\(span.spanID.rawValue)"
+        )
+        XCTAssertEqual(
+            log.attributes.internalAttributes?[OTLogFields.errorKind] as? String,
+            "HTTPURLResponse - 404"
+        )
+        XCTAssertEqual(log.attributes.internalAttributes?.count, 3)
+        XCTAssertEqual(
+            log.attributes.userAttributes[OTLogFields.event] as? String,
+            "error"
+        )
+        XCTAssertEqual(
+            log.attributes.userAttributes[OTLogFields.stack] as? String,
+            "Error Domain=HTTPURLResponse Code=404 \"404 not found\" UserInfo={NSLocalizedDescription=404 not found}"
+        )
+        XCTAssertEqual(log.attributes.userAttributes.count, 2)
     }
 
     func testGivenFirstPartyIncompleteInterception_whenInterceptionCompletes_itDoesNotSendTheSpan() throws {
@@ -188,7 +247,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
-        XCTAssertNil(spanOutput.recorded?.span)
+        XCTAssertNil(spanOutput.recordedSpan)
     }
 
     func testGivenThirdPartyInterception_whenInterceptionCompletes_itDoesNotSendTheSpan() throws {
@@ -213,6 +272,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
-        XCTAssertNil(spanOutput.recorded?.span)
+        XCTAssertNil(spanOutput.recordedSpan)
+        XCTAssertNil(logOutput.recordedLog)
     }
 }

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
@@ -217,7 +217,7 @@ class DDSpanTests: XCTestCase {
 
         fixtures.forEach { tracerMethod, expectedConsoleWarning in
             tracerMethod()
-            XCTAssertEqual(output.recordedLog?.level, .warn)
+            XCTAssertEqual(output.recordedLog?.status, .warn)
             XCTAssertEqual(output.recordedLog?.message, expectedConsoleWarning)
         }
     }

--- a/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/SpanOutputs/SpanFileOutputTests.swift
@@ -20,7 +20,6 @@ class SpanFileOutputTests: XCTestCase {
 
     func testItWritesSpanToFileAsJSON() throws {
         let output = SpanFileOutput(
-            spanBuilder: .mockAny(),
             fileWriter: FileWriter(
                 dataFormat: TracingFeature.dataFormat,
                 orchestrator: FilesOrchestrator(
@@ -28,23 +27,17 @@ class SpanFileOutputTests: XCTestCase {
                     performance: PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
                     dateProvider: SystemDateProvider()
                 )
-            )
-        )
-
-        let ddspan: DDSpan = .mockWith(
-            context: .mockWith(
-                traceID: 29,
-                spanID: 1,
-                parentSpanID: nil
             ),
-            operationName: "operation",
-            startTime: .mockDecember15th2019At10AMUTC()
+            environment: .mockRandom()
         )
 
-        output.write(ddspan: ddspan, finishTime: .mockDecember15th2019At10AMUTC(addingTimeInterval: 0.5))
+        let span: Span = .mockWith(operationName: .mockRandom(), duration: 2)
+        output.write(span: span)
 
         let fileData = try temporaryDirectory.files()[0].read()
         let matcher = try SpanMatcher.fromJSONObjectData(fileData)
-        XCTAssertEqual(try matcher.operationName(), "operation")
+        XCTAssertEqual(try matcher.operationName(), span.operationName)
+        XCTAssertEqual(try matcher.environment(), output.environment)
+        XCTAssertEqual(try matcher.duration(), 2_000_000_000)
     }
 }

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/WarningsTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/WarningsTests.swift
@@ -16,7 +16,9 @@ class WarningsTests: XCTestCase {
         userLogger = .mockWith(logOutput: output, dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()))
 
         XCTAssertTrue(warn(if: true, message: "message"))
-        XCTAssertEqual(output.recordedLog, .init(level: .warn, message: "message", date: .mockDecember15th2019At10AMUTC()))
+        XCTAssertEqual(output.recordedLog?.status, .warn)
+        XCTAssertEqual(output.recordedLog?.message, "message")
+        XCTAssertEqual(output.recordedLog?.date, .mockDecember15th2019At10AMUTC())
 
         output.recordedLog = nil
 
@@ -27,10 +29,9 @@ class WarningsTests: XCTestCase {
 
         let failingCast: () -> DDSpan? = { warnIfCannotCast(value: DDNoopSpan()) }
         XCTAssertNil(failingCast())
-        XCTAssertEqual(
-            output.recordedLog,
-            .init(level: .warn, message: "🔥 Using DDNoopSpan while DDSpan was expected.", date: .mockDecember15th2019At10AMUTC())
-        )
+        XCTAssertEqual(output.recordedLog?.status, .warn)
+        XCTAssertEqual(output.recordedLog?.message, "🔥 Using DDNoopSpan while DDSpan was expected.")
+        XCTAssertEqual(output.recordedLog?.date, .mockDecember15th2019At10AMUTC())
 
         output.recordedLog = nil
 

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -19,7 +19,8 @@ class InternalLoggersTests: XCTestCase {
     // MARK: - User Logger
 
     func testWhenSDKIsNotInitialized_itUsesNoOpUserLogger() {
-        XCTAssertTrue(userLogger.logOutput is NoOpLogOutput)
+        XCTAssertNil(userLogger.logBuilder)
+        XCTAssertNil(userLogger.logOutput)
     }
 
     func testGivenDefaultSDKConfiguration_whenInitialized_itUsesWorkingUserLogger() throws {


### PR DESCRIPTION
### What and why?

🧰 This PR applies small refactoring to `Logs` and `Spans` processing within `Logger` and `Tracer`. This is required to continue the work on crash reporting, where we need to build the `Log` value for the crash report and pass it to the `LogFileOutput` without using `LogBuilder`.

The `LogBuilder` cannot be used in crash reporting, as its role is to decorate `Log` with a current process information (network / carrier / user info). Crash reporting passes this information through `CrashContext`.

Existing `LogFileOutput` cannot be used in crash reporting, as it takes raw log information and uses `LogBuilder` internally. Crash reporting requires `write(log: Log)` interface for `LogOutput`.

### How?

Before this PR, there was this asymmetry in the events processing for our 3 features:
```swift
// Logging:
let rawUserLog: (level: LogLevel, message: String, error: Error?, messageAttributes: [String: Encodable]?) = // ...
logOutput.writeLogWith(rawUserLog) // internally, in `LogFileOutput` the `LogBuilder` was building `Log` from `rawUserLog`

// Tracing:
let rawUserSpan: (ddspan: DDSpan, finishTime: Date) = // ...
spanOutput.writeSpan(rawUserSpan) // internally, in `SpanFileOutput` the `SpanBuilder` was building `Span` from `rawUserSpan`

// RUM:
let rawRUMEvent: (model: RUMDataModel, attributes: [String: Encodable]) = // ...
let rumEvent = rumEventBuilder.createRUMEvent(rawRUMEvent)
let rumEventOutput.write(rumEvent)
```

Logging and Tracing outputs were "smarter" comparing to RUM output. They were using `LogBuilder` and `SpanBuilder` internally to transform information received from the user into serializable `Log` or `Span`. This transformation was not visible on the stream level: `rawInformation → output`. On the other side, RUM abstraction is more streamlined and acts as a simple stream: `rawInformation → serializableInformation  → output`.

This PR uniforms the data stream for all 3 features, so now it's using the same level of abstraction. In pseudocode:
```swift
// Logging, Tracing, RUM:
let rawInformation = /* (log | span | RUM event) info */
let serializableInformation = (log|span|rumEvent)Builder.create(from: rawInformation)
output.write(serializableInformation)
```

### Benefits

This unlocks the work on crash reporting, where an `ERROR` `Log` must be created from `DDCrashReport` without using the `LogBuilder`.

This refactoring makes many interfaces and tests cleaner, as now the amount of (raw) information is reduced upstream and what's passed downstream is simply `Log`, `Span` or `RUMEvent`.

This also makes many tests more solid, as the `LogOutput` and `SpanOutput` mocks now expect a concrete `Log` / `Span` values, instead of raw non-digested pieces of information. This made me update few tests with a clear and concrete assertions on what's received by the mock outputs, instead of just asserting if they receive what's passed to the surface.

Last, this uniforms the processing of `Logs` and `Spans` with existing processing models for RUM events.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
