### PR TITLE
RUMM-1050 Send crash report as Log

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 		61FF282824B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */; };
 		61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */; };
 		61FF283024BC5E2D000B3D9B /* RUMEventFileOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */; };
+		61FF416225EE5FF400CE35EC /* CrashReportingWithLoggingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF416125EE5FF400CE35EC /* CrashReportingWithLoggingIntegrationTests.swift */; };
 		61FF9A4525AC5DEA001058CC /* RUMViewIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF9A4425AC5DEA001058CC /* RUMViewIdentity.swift */; };
 		9E26E6B924C87693000B3270 /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
 		9E307C3224C8846D0039607E /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
@@ -934,6 +935,7 @@
 		61FF282524B8A248000B3D9B /* RUMEventOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventOutput.swift; sourceTree = "<group>"; };
 		61FF282724B8A31E000B3D9B /* RUMEventMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventMatcher.swift; sourceTree = "<group>"; };
 		61FF282F24BC5E2D000B3D9B /* RUMEventFileOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMEventFileOutputTests.swift; sourceTree = "<group>"; };
+		61FF416125EE5FF400CE35EC /* CrashReportingWithLoggingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingWithLoggingIntegrationTests.swift; sourceTree = "<group>"; };
 		61FF9A4425AC5DEA001058CC /* RUMViewIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewIdentity.swift; sourceTree = "<group>"; };
 		9E26E6B824C87693000B3270 /* RUMDataModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMDataModels.swift; sourceTree = "<group>"; };
 		9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionsTests.swift; sourceTree = "<group>"; };
@@ -2166,6 +2168,7 @@
 			isa = PBXGroup;
 			children = (
 				6182374225D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift */,
+				61FF416125EE5FF400CE35EC /* CrashReportingWithLoggingIntegrationTests.swift */,
 			);
 			path = CrashReporting;
 			sourceTree = "<group>";
@@ -3433,6 +3436,7 @@
 				61F1A61A2498A51700075390 /* CoreMocks.swift in Sources */,
 				61E45BD22450F65B00F2C652 /* SpanBuilderTests.swift in Sources */,
 				61F2723F25C86DA400D54BF8 /* CrashReportingFeatureMocks.swift in Sources */,
+				61FF416225EE5FF400CE35EC /* CrashReportingWithLoggingIntegrationTests.swift in Sources */,
 				61A9238E256FCAA2009B9667 /* DateCorrectionTests.swift in Sources */,
 				61EF7890257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift in Sources */,
 				61E45BCF2450A6EC00F2C652 /* TracingUUIDTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -123,7 +123,12 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_TEST_SCENARIO_CLASS_NAME"
-            value = "CrashReportingCollectOrSendScenario"
+            value = "CrashReportingCollectOrSendWithRUMScenario"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_TEST_SCENARIO_CLASS_NAME"
+            value = "CrashReportingCollectOrSendWithLoggingScenario"
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReporting/CrashReportingViewController.swift
@@ -15,7 +15,7 @@ internal class CrashReportingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let testScenario = (appConfiguration.testScenario as! CrashReportingCollectOrSendScenario)
+        let testScenario = (appConfiguration.testScenario as! CrashReportingBaseScenario)
         sendingCrashReportLabel.isHidden = !testScenario.hadPendingCrashReportDataOnStartup
 
         addCrashVariantButtons()

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
@@ -15,7 +15,7 @@ import UIKit
 ///
 /// To test this scenario manually:
 ///  → disconnect debugger → run the Example app → tap the crash button  → run again to have the crash report uploaded.
-final class CrashReportingCollectOrSendScenario: TestScenario {
+internal class CrashReportingBaseScenario {
     static let storyboardName = "CrashReportingScenario"
 
     let hadPendingCrashReportDataOnStartup: Bool
@@ -25,7 +25,10 @@ final class CrashReportingCollectOrSendScenario: TestScenario {
         // before the SDK gets a chance to read & purge the crash report file.
         hadPendingCrashReportDataOnStartup = PersistenceHelpers.hasPendingCrashReportData()
     }
+}
 
+/// A `CrashReportingScenario` which uploads the crash report as RUM Error.
+final class CrashReportingCollectOrSendWithRUMScenario: CrashReportingBaseScenario, TestScenario {
     func configureSDK(builder: Datadog.Configuration.Builder) {
         class CustomPredicate: UIKitRUMViewsPredicate {
             private let defaultPredicate = DefaultUIKitRUMViewsPredicate()
@@ -43,6 +46,15 @@ final class CrashReportingCollectOrSendScenario: TestScenario {
 
         _ = builder
             .trackUIKitRUMViews(using: CustomPredicate())
+            .enableCrashReporting(using: DDCrashReportingPlugin())
+    }
+}
+
+/// A `CrashReportingScenario` which uploads the crash report as "EMERGENCY" Log.
+final class CrashReportingCollectOrSendWithLoggingScenario: CrashReportingBaseScenario, TestScenario {
+    func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder
+            .enableRUM(false) // disable RUM, so the crash report is sent with Logging
             .enableCrashReporting(using: DDCrashReportingPlugin())
     }
 }

--- a/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
+++ b/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
@@ -42,5 +42,5 @@ internal struct UserInfo {
     let email: String?
     let extraInfo: [AttributeKey: AttributeValue]
 
-    internal static let empty = UserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
+    internal static var empty: UserInfo { UserInfo(id: nil, name: nil, email: nil, extraInfo: [:]) }
 }

--- a/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
+++ b/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
@@ -14,8 +14,7 @@ internal class UserInfoProvider {
     private let publisher: ValuePublisher<UserInfo>
 
     init() {
-        let emptyUserInfo = UserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
-        self.publisher = ValuePublisher(initialValue: emptyUserInfo)
+        self.publisher = ValuePublisher(initialValue: .empty)
     }
 
     // MARK: - `UserInfo` Value
@@ -42,4 +41,6 @@ internal struct UserInfo {
     let name: String?
     let email: String?
     let extraInfo: [AttributeKey: AttributeValue]
+
+    internal static let empty = UserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
 }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
@@ -4,6 +4,8 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+import Foundation
+
 /// An integration sending crash reports as logs.
 internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration {
     struct Constants {

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
@@ -6,19 +6,86 @@
 
 /// An integration sending crash reports as logs.
 internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration {
+    struct Constants {
+        /// The logger name that will appear in `Log` sent to Datadog.
+        static let loggerName = "crash-reporter"
+    }
+
+    /// The output for writing logs. It uses the authorized data folder and is synchronized with the eventual
+    /// authorized output working simultaneously in the Logging feature.
+    private let logOutput: LogOutput
+    private let dateProvider: DateProvider
+    private let dateCorrector: DateCorrectorType
+
+    /// Global configuration set for the SDK (service name, environment, application version, ...)
+    private let configuration: FeaturesConfiguration.Common
+
     init(loggingFeature: LoggingFeature) {
-        // TODO: RUMM-1050 Create `LogOutput`
+        self.init(
+            logOutput: LogFileOutput(
+                fileWriter: loggingFeature.storage.arbitraryAuthorizedWriter,
+                // The RUM Errors integration is not set for this instance of the `LogFileOutput` we don't want to
+                // issue additional RUM Errors for crash reports. Those are send through `CrashReportingWithRUMIntegration`.
+                rumErrorsIntegration: nil
+            ),
+            dateProvider: loggingFeature.dateProvider,
+            dateCorrector: loggingFeature.dateCorrector,
+            configuration: loggingFeature.configuration.common
+        )
+    }
+
+    init(
+        logOutput: LogOutput,
+        dateProvider: DateProvider,
+        dateCorrector: DateCorrectorType,
+        configuration: FeaturesConfiguration.Common
+    ) {
+        self.logOutput = logOutput
+        self.dateProvider = dateProvider
+        self.dateCorrector = dateCorrector
+        self.configuration = configuration
     }
 
     func send(crashReport: DDCrashReport, with crashContext: CrashContext) {
-        // TODO: RUMM-1050 Send crash report as Log
-        // by writting it to the `LogOutput`
-        print(
-            """
-            🍿 Sending Crash Report using Logging integration
-            🔥 \(crashReport.type) [\(crashReport.message)]
-            🔎 crash context: \(String(describing: crashContext))
-            """
+        guard crashContext.lastTrackingConsent == .granted else {
+            return // Only authorized crash reports can be send
+        }
+
+        // The `crashReport.crashDate` uses system `Date` collected at the moment of crash, so we need to adjust it
+        // to the server time before processing. Following use of the current correction is not ideal, but this is the best
+        // approximation we can get.
+        let currentTimeCorrection = dateCorrector.currentCorrection
+
+        let crashDate = crashReport.date ?? dateProvider.currentDate()
+        let realCrashDate = currentTimeCorrection.applying(to: crashDate)
+
+        let log = createLog(from: crashReport, crashContext: crashContext, crashDate: realCrashDate)
+        logOutput.write(log: log)
+    }
+
+    // MARK: - Building Log
+
+    private func createLog(from crashReport: DDCrashReport, crashContext: CrashContext, crashDate: Date) -> Log {
+        return Log(
+            date: crashDate,
+            status: .emergency,
+            message: crashReport.message,
+            error: DDError(
+                type: crashReport.type,
+                message: crashReport.message,
+                stack: crashReport.stackTrace
+            ),
+            serviceName: configuration.serviceName,
+            environment: configuration.environment,
+            loggerName: Constants.loggerName,
+            loggerVersion: sdkVersion,
+            threadName: nil,
+            applicationVersion: configuration.applicationVersion,
+            userInfo: crashContext.lastUserInfo ?? .empty,
+            networkConnectionInfo: crashContext.lastNetworkConnectionInfo,
+            mobileCarrierInfo: crashContext.lastCarrierInfo,
+            attributes: .init(userAttributes: [:], internalAttributes: nil),
+            tags: nil
         )
     }
 }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -18,7 +18,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         static let viewEventAvailabilityThreshold: TimeInterval = 14_400 // 4 hours
     }
 
-    /// The output for writting RUM events. It uses the authorized data folder and is synchronized with the eventual
+    /// The output for writing RUM events. It uses the authorized data folder and is synchronized with the eventual
     /// authorized output working simultaneously in the RUM feature.
     private let rumEventOutput: RUMEventOutput
     private let dateProvider: DateProvider

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -29,7 +29,7 @@ public enum LogLevel: Int, Codable {
         }
     }
 
-    internal init(from logStatus: Log.Status) {
+    internal init?(from logStatus: Log.Status) {
         switch logStatus {
         case .debug:    self = .debug
         case .info:     self = .info
@@ -37,6 +37,7 @@ public enum LogLevel: Int, Codable {
         case .warn:     self = .warn
         case .error:    self = .error
         case .critical: self = .critical
+        case .emergency: return nil // unavailable in public `LogLevel` API.
         }
     }
 }

--- a/Sources/Datadog/Logging/Log/LogEncoder.swift
+++ b/Sources/Datadog/Logging/Log/LogEncoder.swift
@@ -16,6 +16,7 @@ internal struct Log: Encodable {
         case warn
         case error
         case critical
+        case emergency
     }
 
     let date: Date
@@ -26,7 +27,7 @@ internal struct Log: Encodable {
     let environment: String
     let loggerName: String
     let loggerVersion: String
-    let threadName: String
+    let threadName: String?
     let applicationVersion: String
     let userInfo: UserInfo
     let networkConnectionInfo: NetworkConnectionInfo?

--- a/Sources/Datadog/Utils/InternalLoggers.swift
+++ b/Sources/Datadog/Utils/InternalLoggers.swift
@@ -104,7 +104,7 @@ internal func createSDKUserLogger(
     return Logger(
         logBuilder: logBuilder,
         logOutput: ConditionalLogOutput(conditionedOutput: consoleOutput) { log in
-            let logSeverity = LogLevel(from: log.status).rawValue
+            let logSeverity = LogLevel(from: log.status)?.rawValue ?? .max
             let threshold = Datadog.verbosityLevel?.rawValue ?? .max
             return logSeverity >= threshold
         },

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
@@ -1,0 +1,94 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class CrashReportingWithLoggingIntegrationTests: XCTestCase {
+    private let logOutput = LogOutputMock()
+
+    // MARK: - Testing Conditional Uploads
+
+    func testWhenCrashReportHasUnauthorizedTrackingConsent_itIsNotSent() {
+        // Given
+        let crashReport: DDCrashReport = .mockWith(date: .mockDecember15th2019At10AMUTC())
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: [.pending, .notGranted].randomElement()!
+        )
+
+        // When
+        let integration = CrashReportingWithLoggingIntegration(
+            logOutput: logOutput,
+            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
+            dateCorrector: DateCorrectorMock(),
+            configuration: .mockAny()
+        )
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertNil(logOutput.recordedLog)
+    }
+
+    // MARK: - Testing Uploaded Data
+
+    func testWhenSendingCrashReport_itIncludesAllErrorInformation() throws {
+        let configuration: FeaturesConfiguration.Common = .mockWith(
+            applicationVersion: .mockRandom(),
+            serviceName: .mockRandom(),
+            environment: .mockRandom()
+        )
+        let dateCorrectionOffset: TimeInterval = .mockRandom()
+
+        // Given
+        let crashReport: DDCrashReport = .mockWith(
+            date: .mockDecember15th2019At10AMUTC(),
+            type: .mockRandom(),
+            message: .mockRandom(),
+            stackTrace: .mockRandom()
+        )
+        let crashContext: CrashContext = .mockWith(
+            lastUserInfo: Bool.random() ? .mockRandom() : .empty,
+            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom()),
+            lastNetworkConnectionInfo: .mockRandom(),
+            lastCarrierInfo: .mockRandom()
+        )
+
+        // When
+        let integration = CrashReportingWithLoggingIntegration(
+            logOutput: logOutput,
+            dateProvider: RelativeDateProvider(using: .mockRandomInThePast()),
+            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
+            configuration: configuration
+        )
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        let log = try XCTUnwrap(logOutput.recordedLog)
+        let expectedLog = Log(
+            date: crashReport.date!.addingTimeInterval(dateCorrectionOffset),
+            status: .emergency,
+            message: crashReport.message,
+            error: DDError(
+                type: crashReport.type,
+                message: crashReport.message,
+                stack: crashReport.stackTrace
+            ),
+            serviceName: configuration.serviceName,
+            environment: configuration.environment,
+            loggerName: CrashReportingWithLoggingIntegration.Constants.loggerName,
+            loggerVersion: sdkVersion,
+            threadName: nil,
+            applicationVersion: configuration.applicationVersion,
+            userInfo: crashContext.lastUserInfo!,
+            networkConnectionInfo: crashContext.lastNetworkConnectionInfo,
+            mobileCarrierInfo: crashContext.lastCarrierInfo,
+            attributes: .init(userAttributes: [:], internalAttributes: nil),
+            tags: nil
+        )
+
+        XCTAssertEqual(expectedLog, log)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -118,11 +118,11 @@ extension Log: RandomMockable {
             loggerVersion: .mockRandom(),
             threadName: .mockRandom(),
             applicationVersion: .mockRandom(),
-            userInfo: .init(id: .mockRandom(), name: .mockRandom(), email: .mockRandom(), extraInfo: [:]), // TODO: RUMM-1050 use `.mockRandom()`
-            networkConnectionInfo: .mockAny(), // TODO: RUMM-1050 use `.mockRandom()`
-            mobileCarrierInfo: .mockAny(), // TODO: RUMM-1050 use `.mockRandom()`
-            attributes: .mockAny(), // TODO: RUMM-1050 use `.mockRandom()`
-            tags: nil // TODO: RUMM-1050 use `.mockRandom()`
+            userInfo: .mockRandom(),
+            networkConnectionInfo: .mockRandom(),
+            mobileCarrierInfo: .mockRandom(),
+            attributes: .mockRandom(),
+            tags: .mockRandom()
         )
     }
 }
@@ -199,6 +199,13 @@ extension LogAttributes: Equatable {
         return LogAttributes(
             userAttributes: userAttributes,
             internalAttributes: internalAttributes
+        )
+    }
+
+    static func mockRandom() -> LogAttributes {
+        return .init(
+            userAttributes: mockRandomAttributes(),
+            internalAttributes: mockRandomAttributes()
         )
     }
 


### PR DESCRIPTION
### What and why?

🚚 This PR sends collected crash reports as Logs. 

When the app restarts after crash, we load the crash report, read its associated context and then:

* if the Logging feature is enabled,
* and the RUM feature is disabled,
* and the crash report was collected with tracking consent `.granted`,
* then the crash report is send as `Log` with severity set to `EMERGENCY` (as we do in `dd-sdk-android`).

Example:

<img width="930" alt="Screenshot 2021-03-02 at 12 28 57" src="https://user-images.githubusercontent.com/2358722/109647864-22707300-7b5a-11eb-95e0-7256ecc6cc68.png">


### How?

Everything was prepared in prior #422 and #427. This PR only adds the implementation in `CrashReportingWithLoggingIntegration` as it was previously done for `CrashReportingWithRUMIntegration`.

This PR also adds separate scenario in `Example` app, so now we can test integration with RUM and Logging separately:

<img width="464" alt="Screenshot 2021-03-02 at 13 25 08" src="https://user-images.githubusercontent.com/2358722/109648282-b9d5c600-7b5a-11eb-8423-b87e21db3e90.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
