### PR TITLE
RUMM-701 NoOpTracer crash fix

### DIFF
--- a/Sources/Datadog/Tracing/DDNoOps.swift
+++ b/Sources/Datadog/Tracing/DDNoOps.swift
@@ -17,6 +17,7 @@ internal struct DDNoopTracer: OTTracer {
     func extract(reader: OTFormatReader) -> OTSpanContext? { DDNoopGlobals.context }
     func inject(spanContext: OTSpanContext, writer: OTFormatWriter) {}
     func startSpan(operationName: String, references: [OTReference]?, tags: [String: Encodable]?, startTime: Date?) -> OTSpan { DDNoopGlobals.span }
+    func startRootSpan(operationName: String, tags: [String: Encodable]?, startTime: Date?) -> OTSpan { DDNoopGlobals.span }
 }
 
 internal struct DDNoopSpan: OTSpan {


### PR DESCRIPTION
### What and why?

`OTTracer` protocol extension calls `startRootSpan` recursively by hoping the concrete type implements it
`NoOpTracer` didn't implement it and caused infinite loop/crash

### How?

`NoOpTracer` implements `startRootSpan` now

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
