### PR TITLE
RUMM-1078 Adjust Scopes state for dropped events

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -40,6 +40,11 @@ internal class RUMResourceScope: RUMScope {
     /// Span context passed to the RUM backend in order to generate the APM span for underlying resource.
     private let spanContext: RUMSpanContext?
 
+    /// Callback called when a `RUMResourceEvent` is submitted for storage.
+    private let onResourceEventSent: () -> Void
+    /// Callback called when a `RUMErrorEvent` is submitted for storage.
+    private let onErrorEventSent: () -> Void
+
     init(
         context: RUMContext,
         dependencies: RUMScopeDependencies,
@@ -51,7 +56,9 @@ internal class RUMResourceScope: RUMScope {
         httpMethod: RUMMethod,
         isFirstPartyResource: Bool?,
         resourceKindBasedOnRequest: RUMResourceType?,
-        spanContext: RUMSpanContext?
+        spanContext: RUMSpanContext?,
+        onResourceEventSent: @escaping () -> Void,
+        onErrorEventSent: @escaping () -> Void
     ) {
         self.context = context
         self.dependencies = dependencies
@@ -65,6 +72,8 @@ internal class RUMResourceScope: RUMScope {
         self.isFirstPartyResource = isFirstPartyResource
         self.resourceKindBasedOnRequest = resourceKindBasedOnRequest
         self.spanContext = spanContext
+        self.onResourceEventSent = onResourceEventSent
+        self.onErrorEventSent = onErrorEventSent
     }
 
     // MARK: - RUMScope
@@ -72,10 +81,14 @@ internal class RUMResourceScope: RUMScope {
     func process(command: RUMCommand) -> Bool {
         switch command {
         case let command as RUMStopResourceCommand where command.resourceKey == resourceKey:
-            sendResourceEvent(on: command)
+            if sendResourceEvent(on: command) {
+                onResourceEventSent()
+            }
             return false
         case let command as RUMStopResourceWithErrorCommand where command.resourceKey == resourceKey:
-            sendErrorEvent(on: command)
+            if sendErrorEvent(on: command) {
+                onErrorEventSent()
+            }
             return false
         case let command as RUMAddResourceMetricsCommand where command.resourceKey == resourceKey:
             addMetrics(from: command)
@@ -92,7 +105,7 @@ internal class RUMResourceScope: RUMScope {
 
     // MARK: - Sending RUM Events
 
-    private func sendResourceEvent(on command: RUMStopResourceCommand) {
+    private func sendResourceEvent(on command: RUMStopResourceCommand) -> Bool {
         attributes.merge(rumCommandAttributes: command.attributes)
 
         let resourceStartTime: Date
@@ -181,12 +194,12 @@ internal class RUMResourceScope: RUMScope {
 
         if let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes) {
             dependencies.eventOutput.write(rumEvent: event)
-        } else {
-            // TODO: RUMM-1078 Adjust counts for dropped events
+            return true
         }
+        return false
     }
 
-    private func sendErrorEvent(on command: RUMStopResourceWithErrorCommand) {
+    private func sendErrorEvent(on command: RUMStopResourceWithErrorCommand) -> Bool {
         attributes.merge(rumCommandAttributes: command.attributes)
 
         let eventData = RUMErrorEvent(
@@ -223,9 +236,9 @@ internal class RUMResourceScope: RUMScope {
 
         if let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes) {
             dependencies.eventOutput.write(rumEvent: event)
-        } else {
-            // TODO: RUMM-1078 Adjust counts for dropped events
+            return true
         }
+        return false
     }
 
     // MARK: - Resource provider helpers

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -13,7 +13,7 @@ internal class RUMResourceScope: RUMScope {
     private let dependencies: RUMScopeDependencies
 
     /// This Resource's UUID.
-    private let resourceUUID: RUMUUID
+    let resourceUUID: RUMUUID
     /// The name used to identify this Resource.
     private let resourceKey: String
     /// Resource attributes.

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -45,6 +45,9 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
     /// Number of Resources that started but not yet ended during this User Action's lifespan.
     private var activeResourcesCount: Int = 0
 
+    /// Callback called when a `RUMActionEvent` is submitted for storage.
+    private let onActionEventSent: () -> Void
+
     init(
         parent: RUMContextProvider,
         dependencies: RUMScopeDependencies,
@@ -53,7 +56,8 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         attributes: [AttributeKey: AttributeValue],
         startTime: Date,
         dateCorrection: DateCorrection,
-        isContinuous: Bool
+        isContinuous: Bool,
+        onActionEventSent: @escaping () -> Void
     ) {
         self.parent = parent
         self.dependencies = dependencies
@@ -65,6 +69,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         self.dateCorrection = dateCorrection
         self.isContinuous = isContinuous
         self.lastActivityTime = startTime
+        self.onActionEventSent = onActionEventSent
     }
 
     // MARK: - RUMContextProvider
@@ -80,18 +85,24 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
     func process(command: RUMCommand) -> Bool {
         if let expirationTime = possibleExpirationTime(currentTime: command.time),
            allResourcesCompletedLoading() {
-            sendActionEvent(completionTime: expirationTime)
+            if sendActionEvent(completionTime: expirationTime) {
+                onActionEventSent()
+            }
             return false
         }
 
         lastActivityTime = command.time
         switch command {
         case is RUMStopViewCommand:
-            sendActionEvent(completionTime: command.time)
+            if sendActionEvent(completionTime: command.time) {
+                onActionEventSent()
+            }
             return false
         case let command as RUMStopUserActionCommand:
             name = command.name ?? name
-            sendActionEvent(completionTime: command.time, on: command)
+            if sendActionEvent(completionTime: command.time, on: command) {
+                onActionEventSent()
+            }
             return false
         case is RUMStartResourceCommand:
             activeResourcesCount += 1
@@ -111,7 +122,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
 
     // MARK: - Sending RUM Events
 
-    private func sendActionEvent(completionTime: Date, on command: RUMCommand? = nil) {
+    private func sendActionEvent(completionTime: Date, on command: RUMCommand? = nil) -> Bool {
         if let commandAttributes = command?.attributes {
             attributes.merge(rumCommandAttributes: commandAttributes)
         }
@@ -144,9 +155,9 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
 
         if let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes) {
             dependencies.eventOutput.write(rumEvent: event)
-        } else {
-            // TODO: RUMM-1078 Adjust counts for dropped events
+            return true
         }
+        return false
     }
 
     // MARK: - Private

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -539,6 +539,70 @@ extension RUMViewScope {
     }
 }
 
+extension RUMResourceScope {
+    // swiftlint:disable function_default_parameter_at_end
+    static func mockWith(
+        context: RUMContext,
+        dependencies: RUMScopeDependencies,
+        resourceKey: String = .mockAny(),
+        attributes: [AttributeKey: AttributeValue] = [:],
+        startTime: Date = .mockAny(),
+        dateCorrection: DateCorrection,
+        url: String = .mockAny(),
+        httpMethod: RUMMethod = .mockAny(),
+        isFirstPartyResource: Bool? = nil,
+        resourceKindBasedOnRequest: RUMResourceType? = nil,
+        spanContext: RUMSpanContext? = nil,
+        onResourceEventSent: @escaping () -> Void = {},
+        onErrorEventSent: @escaping () -> Void = {}
+    ) -> RUMResourceScope {
+        return RUMResourceScope(
+            context: context,
+            dependencies: dependencies,
+            resourceKey: resourceKey,
+            attributes: attributes,
+            startTime: startTime,
+            dateCorrection: dateCorrection,
+            url: url,
+            httpMethod: httpMethod,
+            isFirstPartyResource: isFirstPartyResource,
+            resourceKindBasedOnRequest: resourceKindBasedOnRequest,
+            spanContext: spanContext,
+            onResourceEventSent: onResourceEventSent,
+            onErrorEventSent: onErrorEventSent
+        )
+    }
+    // swiftlint:enable function_default_parameter_at_end
+}
+
+extension RUMUserActionScope {
+    // swiftlint:disable function_default_parameter_at_end
+    static func mockWith(
+        parent: RUMContextProvider,
+        dependencies: RUMScopeDependencies = .mockAny(),
+        name: String = .mockAny(),
+        actionType: RUMUserActionType = [.tap, .scroll, .swipe, .custom].randomElement()!,
+        attributes: [AttributeKey: AttributeValue] = [:],
+        startTime: Date = .mockAny(),
+        dateCorrection: DateCorrection,
+        isContinuous: Bool = .mockAny(),
+        onActionEventSent: @escaping () -> Void = {}
+    ) -> RUMUserActionScope {
+        return RUMUserActionScope(
+                parent: parent,
+                dependencies: dependencies,
+                name: name,
+                actionType: actionType,
+                attributes: attributes,
+                startTime: startTime,
+                dateCorrection: dateCorrection,
+                isContinuous: isContinuous,
+                onActionEventSent: onActionEventSent
+        )
+    }
+    // swiftlint:enable function_default_parameter_at_end
+}
+
 class RUMContextProviderMock: RUMContextProvider {
     init(context: RUMContext = .mockAny()) {
         self.context = context

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -20,18 +20,13 @@ class RUMResourceScopeTests: XCTestCase {
     )
 
     func testDefaultContext() {
-        let scope = RUMResourceScope(
+        let scope = RUMResourceScope.mockWith(
             context: context,
             dependencies: .mockAny(),
             resourceKey: .mockAny(),
             attributes: [:],
             startTime: .mockAny(),
-            dateCorrection: .zero,
-            url: .mockAny(),
-            httpMethod: .mockAny(),
-            isFirstPartyResource: nil,
-            resourceKindBasedOnRequest: nil,
-            spanContext: nil
+            dateCorrection: .zero
         )
 
         XCTAssertEqual(scope.context.rumApplicationID, context.rumApplicationID)
@@ -45,7 +40,7 @@ class RUMResourceScopeTests: XCTestCase {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
-        let scope = RUMResourceScope(
+        let scope = RUMResourceScope.mockWith(
             context: context,
             dependencies: dependencies,
             resourceKey: "/resource/1",
@@ -108,7 +103,7 @@ class RUMResourceScopeTests: XCTestCase {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
-        let scope = RUMResourceScope(
+        let scope = RUMResourceScope.mockWith(
             context: context,
             dependencies: dependencies,
             resourceKey: "/resource/1",
@@ -116,10 +111,7 @@ class RUMResourceScopeTests: XCTestCase {
             startTime: currentTime,
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
-            httpMethod: .post,
-            isFirstPartyResource: nil,
-            resourceKindBasedOnRequest: nil,
-            spanContext: nil
+            httpMethod: .post
         )
 
         currentTime.addTimeInterval(2)
@@ -164,7 +156,7 @@ class RUMResourceScopeTests: XCTestCase {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
-        let scope = RUMResourceScope(
+        let scope = RUMResourceScope.mockWith(
             context: context,
             dependencies: dependencies,
             resourceKey: "/resource/1",
@@ -172,10 +164,7 @@ class RUMResourceScopeTests: XCTestCase {
             startTime: currentTime,
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
-            httpMethod: .post,
-            isFirstPartyResource: nil,
-            resourceKindBasedOnRequest: nil,
-            spanContext: nil
+            httpMethod: .post
         )
 
         currentTime.addTimeInterval(2)
@@ -274,18 +263,14 @@ class RUMResourceScopeTests: XCTestCase {
     func testGivenMultipleResourceScopes_whenSendingResourceEvents_eachEventHasUniqueResourceID() throws {
         let resourceKey: String = .mockAny()
         func createScope(url: String) -> RUMResourceScope {
-            RUMResourceScope(
+            RUMResourceScope.mockWith(
                 context: context,
                 dependencies: dependencies,
                 resourceKey: resourceKey,
                 attributes: [:],
                 startTime: .mockAny(),
                 dateCorrection: .zero,
-                url: url,
-                httpMethod: .mockAny(),
-                isFirstPartyResource: nil,
-                resourceKindBasedOnRequest: nil,
-                spanContext: nil
+                url: url
             )
         }
 
@@ -311,7 +296,7 @@ class RUMResourceScopeTests: XCTestCase {
         let kindBasedOnResponse = kinds.randomElement()!
 
         // Given
-        let scope = RUMResourceScope(
+        let scope = RUMResourceScope.mockWith(
             context: context,
             dependencies: dependencies,
             resourceKey: "/resource/1",
@@ -321,8 +306,7 @@ class RUMResourceScopeTests: XCTestCase {
             url: .mockAny(),
             httpMethod: .post,
             isFirstPartyResource: nil,
-            resourceKindBasedOnRequest: kindBasedOnRequest,
-            spanContext: nil
+            resourceKindBasedOnRequest: kindBasedOnRequest
         )
 
         // When
@@ -344,7 +328,7 @@ class RUMResourceScopeTests: XCTestCase {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
-        let scope = RUMResourceScope(
+        let scope = RUMResourceScope.mockWith(
             context: context,
             dependencies: dependencies,
             resourceKey: "/resource/1",
@@ -379,7 +363,7 @@ class RUMResourceScopeTests: XCTestCase {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
-        let scope = RUMResourceScope(
+        let scope = RUMResourceScope.mockWith(
             context: context,
             dependencies: dependencies,
             resourceKey: "/resource/1",
@@ -411,7 +395,7 @@ class RUMResourceScopeTests: XCTestCase {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
-        let scope = RUMResourceScope(
+        let scope = RUMResourceScope.mockWith(
             context: context,
             dependencies: dependencies,
             resourceKey: "/resource/1",
@@ -420,9 +404,7 @@ class RUMResourceScopeTests: XCTestCase {
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
             httpMethod: .post,
-            isFirstPartyResource: true,
-            resourceKindBasedOnRequest: nil,
-            spanContext: nil
+            isFirstPartyResource: true
         )
 
         currentTime.addTimeInterval(2)
@@ -446,7 +428,7 @@ class RUMResourceScopeTests: XCTestCase {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
-        let scope = RUMResourceScope(
+        let scope = RUMResourceScope.mockWith(
             context: context,
             dependencies: dependencies,
             resourceKey: "/resource/1",
@@ -455,9 +437,7 @@ class RUMResourceScopeTests: XCTestCase {
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
             httpMethod: .post,
-            isFirstPartyResource: false,
-            resourceKindBasedOnRequest: nil,
-            spanContext: nil
+            isFirstPartyResource: false
         )
 
         currentTime.addTimeInterval(2)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -22,7 +22,7 @@ class RUMUserActionScopeTests: XCTestCase {
     )
 
     func testDefaultContext() {
-        let scope = RUMUserActionScope(
+        let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             name: .mockAny(),
@@ -63,7 +63,7 @@ class RUMUserActionScopeTests: XCTestCase {
 
     func testWhenContinuousUserActionEnds_itSendsActionEvent() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
-        let scope = RUMUserActionScope(
+        let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             name: .mockAny(),
@@ -105,7 +105,7 @@ class RUMUserActionScopeTests: XCTestCase {
 
     func testWhenContinuousUserActionExpires_itSendsActionEvent() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
-        let scope = RUMUserActionScope(
+        let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             name: .mockAny(),
@@ -130,7 +130,7 @@ class RUMUserActionScopeTests: XCTestCase {
 
     func testWhileContinuousUserActionIsActive_itTracksCompletedResources() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
-        let scope = RUMUserActionScope(
+        let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             name: .mockAny(),
@@ -182,7 +182,7 @@ class RUMUserActionScopeTests: XCTestCase {
 
     func testWhileContinuousUserActionIsActive_itCountsViewErrors() throws {
         var currentTime = Date()
-        let scope = RUMUserActionScope(
+        let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             name: .mockAny(),
@@ -215,7 +215,7 @@ class RUMUserActionScopeTests: XCTestCase {
 
     func testWhenContinuousUserActionStopsWithName_itChangesItsName() throws {
         var currentTime = Date()
-        let scope = RUMUserActionScope(
+        let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             name: .mockAny(),
@@ -246,7 +246,7 @@ class RUMUserActionScopeTests: XCTestCase {
 
     func testWhenDiscreteUserActionTimesOut_itSendsActionEvent() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
-        let scope = RUMUserActionScope(
+        let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             name: .mockAny(),
@@ -273,7 +273,7 @@ class RUMUserActionScopeTests: XCTestCase {
 
     func testWhileDiscreteUserActionIsActive_itDoesNotComplete_untilAllTrackedResourcesAreCompleted() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
-        let scope = RUMUserActionScope(
+        let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             name: .mockAny(),
@@ -328,7 +328,7 @@ class RUMUserActionScopeTests: XCTestCase {
 
     func testWhileDiscreteUserActionIsActive_itCountsViewErrors() throws {
         var currentTime = Date()
-        let scope = RUMUserActionScope(
+        let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
             name: .mockAny(),

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -890,6 +890,45 @@ class RUMMonitorTests: XCTestCase {
         XCTAssertEqual(session.viewVisits[0].errorEvents[0].error.message, "Modified error message")
     }
 
+    func testDroppingEventsBeforeTheyGetSent() throws {
+            RUMFeature.instance = .mockByRecordingRUMEventMatchers(
+                directories: temporaryFeatureDirectories,
+                configuration: .mockWith(
+                    eventMapper: .mockWith(
+                        errorEventMapper: { _ in nil },
+                        resourceEventMapper: { _ in nil },
+                        actionEventMapper: { event in
+                            return event.action.type == .applicationStart ? event : nil
+                        }
+                    )
+                )
+            )
+            defer { RUMFeature.instance = nil }
+
+            let monitor = RUMMonitor.initialize()
+
+            monitor.startView(viewController: mockView)
+            monitor.startResourceLoading(resourceKey: "/resource/1", url: .mockAny())
+            monitor.stopResourceLoading(resourceKey: "/resource/1", response: .mockAny())
+            monitor.addUserAction(type: .tap, name: .mockAny())
+            monitor.addError(message: .mockAny())
+
+            let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 2)
+            let sessions = try RUMSessionMatcher.groupMatchersBySessions(rumEventMatchers)
+
+            XCTAssertEqual(sessions.count, 1, "All events should belong to a single RUM Session")
+            let session = sessions[0]
+
+            XCTAssertNotEqual(session.viewVisits[0].viewEvents.count, 0)
+            let lastEvent = session.viewVisits[0].viewEvents.last!
+            XCTAssertEqual(lastEvent.view.resource.count, 0, "resource.count should reflect all resource events being dropped.")
+            XCTAssertEqual(lastEvent.view.action.count, 1, "action.count should reflect all action events being dropped.")
+            XCTAssertEqual(lastEvent.view.error.count, 0, "error.count should reflect all error events being dropped.")
+            XCTAssertEqual(session.viewVisits[0].resourceEvents.count, 0)
+            XCTAssertEqual(session.viewVisits[0].actionEvents.count, 1)
+            XCTAssertEqual(session.viewVisits[0].errorEvents.count, 0)
+        }
+
     // MARK: - Thread safety
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {


### PR DESCRIPTION
### What and why?

This is the second part (after #433) to the alternative solution to #425 / RUMM-1078.

### How?

In that PR, we just use the return value of `RUMEventBuilder` to revert values of any variables that need it.
We add some callbacks from `RUMResourceScope`/`RUMUserActionsScope` back to `RUMViewScope` to help with reverting some state in `RUMViewScope` as well.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
