### PR TITLE
RUMM-1071 Add integration tests for Crash Reporting

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		61B22E5A24F3E6B700DC26D2 /* RUMDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */; };
 		61B558CF2469561C001460D3 /* LoggerBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */; };
 		61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */; };
+		61B6811F25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B6811E25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift */; };
 		61B7885D25C180CB002675B5 /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; };
 		61B7886225C180CB002675B5 /* DDCrashReportingPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B7886125C180CB002675B5 /* DDCrashReportingPluginTests.swift */; };
 		61B7886425C180CB002675B5 /* DatadogCrashReporting.h in Headers */ = {isa = PBXBuildFile; fileRef = 61B7885625C180CB002675B5 /* DatadogCrashReporting.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -810,6 +811,7 @@
 		61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebugging.swift; sourceTree = "<group>"; };
 		61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerBuilderTests.swift; sourceTree = "<group>"; };
 		61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDGeneratorTests.swift; sourceTree = "<group>"; };
+		61B6811E25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingWithLoggingScenarioTests.swift; sourceTree = "<group>"; };
 		61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCrashReporting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61B7885625C180CB002675B5 /* DatadogCrashReporting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DatadogCrashReporting.h; sourceTree = "<group>"; };
 		61B7885725C180CB002675B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2294,6 +2296,22 @@
 			path = Debugging;
 			sourceTree = "<group>";
 		};
+		61B6811D25F0E8480015B4AF /* CrashReporting */ = {
+			isa = PBXGroup;
+			children = (
+				61B6811E25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift */,
+			);
+			path = CrashReporting;
+			sourceTree = "<group>";
+		};
+		61C1512F25ADC67500362D4B /* Processing */ = {
+			isa = PBXGroup;
+			children = (
+				61C1513025ADC68D00362D4B /* DataProcessorTests.swift */,
+			);
+			path = Processing;
+			sourceTree = "<group>";
+		};
 		61C3637E2436163400C4D4E6 /* DatadogPrivate */ = {
 			isa = PBXGroup;
 			children = (
@@ -2584,6 +2602,7 @@
 				61F3CD9D251106FA00C816E5 /* Logging */,
 				61F3CD9E251106FF00C816E5 /* Tracing */,
 				61F3CD9F2511070300C816E5 /* RUM */,
+				61B6811D25F0E8480015B4AF /* CrashReporting */,
 				611EA15325815EDC00BC0E56 /* TrackingConsent */,
 			);
 			path = Scenarios;
@@ -3553,6 +3572,7 @@
 				61441C4024617013003D8BB8 /* IntegrationTests.swift in Sources */,
 				61163C4A252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift in Sources */,
 				61B9ED212462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift in Sources */,
+				61B6811F25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift in Sources */,
 				61C2C20D24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift in Sources */,
 				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -905,6 +905,8 @@
 		61EF78B0257E2E7A00EDCCB3 /* MoveDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveDataMigrator.swift; sourceTree = "<group>"; };
 		61EF78B6257E37D500EDCCB3 /* MoveDataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveDataMigratorTests.swift; sourceTree = "<group>"; };
 		61EF78C0257F842000EDCCB3 /* FeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureTests.swift; sourceTree = "<group>"; };
+		61F1872325F657630022CE9A /* DatadogIntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = DatadogIntegrationTests.xctestplan; sourceTree = "<group>"; };
+		61F1872B25F658260022CE9A /* DatadogCrashReportingIntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = DatadogCrashReportingIntegrationTests.xctestplan; sourceTree = "<group>"; };
 		61F1A6192498A51700075390 /* CoreMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMocks.swift; sourceTree = "<group>"; };
 		61F1A620249A45E400075390 /* DDSpanContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSpanContextTests.swift; sourceTree = "<group>"; };
 		61F1A622249B811200075390 /* Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encoding.swift; sourceTree = "<group>"; };
@@ -2771,6 +2773,8 @@
 		9EF49F1524476FBD004F2CA0 /* DatadogIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				61F1872325F657630022CE9A /* DatadogIntegrationTests.xctestplan */,
+				61F1872B25F658260022CE9A /* DatadogCrashReportingIntegrationTests.xctestplan */,
 				9EF49F17244770AD004F2CA0 /* DatadogIntegrationTests.xcconfig */,
 				9EF49F1624476FBD004F2CA0 /* Info.plist */,
 			);

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		61B558CF2469561C001460D3 /* LoggerBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */; };
 		61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */; };
 		61B6811F25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B6811E25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift */; };
+		61B6815E25F135890015B4AF /* CrashReportingWithRUMScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B6815D25F135890015B4AF /* CrashReportingWithRUMScenarioTests.swift */; };
 		61B7885D25C180CB002675B5 /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; };
 		61B7886225C180CB002675B5 /* DDCrashReportingPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B7886125C180CB002675B5 /* DDCrashReportingPluginTests.swift */; };
 		61B7886425C180CB002675B5 /* DatadogCrashReporting.h in Headers */ = {isa = PBXBuildFile; fileRef = 61B7885625C180CB002675B5 /* DatadogCrashReporting.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -812,6 +813,7 @@
 		61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerBuilderTests.swift; sourceTree = "<group>"; };
 		61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDGeneratorTests.swift; sourceTree = "<group>"; };
 		61B6811E25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingWithLoggingScenarioTests.swift; sourceTree = "<group>"; };
+		61B6815D25F135890015B4AF /* CrashReportingWithRUMScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingWithRUMScenarioTests.swift; sourceTree = "<group>"; };
 		61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCrashReporting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61B7885625C180CB002675B5 /* DatadogCrashReporting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DatadogCrashReporting.h; sourceTree = "<group>"; };
 		61B7885725C180CB002675B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2300,6 +2302,7 @@
 			isa = PBXGroup;
 			children = (
 				61B6811E25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift */,
+				61B6815D25F135890015B4AF /* CrashReportingWithRUMScenarioTests.swift */,
 			);
 			path = CrashReporting;
 			sourceTree = "<group>";
@@ -3584,6 +3587,7 @@
 				611EA16625825FB300BC0E56 /* TrackingConsentScenarioTests.swift in Sources */,
 				61F3CD9A2510D8C500C816E5 /* Environment.swift in Sources */,
 				61F9CA9F2513978D000A5E61 /* RUMSessionMatcher.swift in Sources */,
+				61B6815E25F135890015B4AF /* CrashReportingWithRUMScenarioTests.swift in Sources */,
 				61F9CA92251266F7000A5E61 /* RUMNavigationControllerScenarioTests.swift in Sources */,
 				61410141251A454500E3C2D9 /* TracingCommonAsserts.swift in Sources */,
 				61441C4924618052003D8BB8 /* JSONDataMatcher.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
@@ -219,6 +219,15 @@
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:TargetSupport/DatadogIntegrationTests/DatadogIntegrationTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TargetSupport/DatadogIntegrationTests/DatadogCrashReportingIntegrationTests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
+++ b/Datadog/Example/Scenarios/CrashReporting/CrashReportingScenarios.swift
@@ -34,13 +34,14 @@ final class CrashReportingCollectOrSendWithRUMScenario: CrashReportingBaseScenar
             private let defaultPredicate = DefaultUIKitRUMViewsPredicate()
 
             func rumView(for viewController: UIViewController) -> RUMView? {
-                let defaultRUMView = defaultPredicate.rumView(for: viewController)
-                return .init(
-                    name: defaultRUMView!.name,
-                    attributes: [
-                        "custom-attribute": "This attribute will be attached to crash report."
-                    ]
-                )
+                return defaultPredicate.rumView(for: viewController).flatMap { defaultRUMView in
+                    return RUMView(
+                        name: defaultRUMView.name,
+                        attributes: [
+                            "custom-attribute": "This attribute will be attached to crash report."
+                        ]
+                    )
+                }
             }
         }
 

--- a/Datadog/TargetSupport/DatadogBenchmarkTests/DatadogBenchmarkTests.xcconfig
+++ b/Datadog/TargetSupport/DatadogBenchmarkTests/DatadogBenchmarkTests.xcconfig
@@ -5,4 +5,4 @@
 #include "../xcconfigs/MockServerAddress.local.xcconfig"
 
 // Add DatadogSDKTesting instrumentation (if available in current environment)
-#include "../xcconfigs/DatadogSDKTesting.local.xcconfig"
+#include? "../xcconfigs/DatadogSDKTesting.local.xcconfig"

--- a/Datadog/TargetSupport/DatadogIntegrationTests/DatadogCrashReportingIntegrationTests.xctestplan
+++ b/Datadog/TargetSupport/DatadogIntegrationTests/DatadogCrashReportingIntegrationTests.xctestplan
@@ -2,9 +2,11 @@
   "configurations" : [
     {
       "id" : "15325B2B-2C4A-4B53-88F7-B6C1E3B6BE98",
-      "name" : "TSAN",
+      "name" : "Default",
       "options" : {
-
+        "mainThreadCheckerEnabled" : false,
+        "uiTestingScreenshotsLifetime" : "keepNever",
+        "userAttachmentLifetime" : "keepNever"
       }
     }
   ],
@@ -27,8 +29,7 @@
       "containerPath" : "container:Datadog.xcodeproj",
       "identifier" : "61441C2924616F1D003D8BB8",
       "name" : "DatadogIntegrationTests"
-    },
-    "threadSanitizerEnabled" : true
+    }
   },
   "testTargets" : [
     {

--- a/Datadog/TargetSupport/DatadogIntegrationTests/DatadogCrashReportingIntegrationTests.xctestplan
+++ b/Datadog/TargetSupport/DatadogIntegrationTests/DatadogCrashReportingIntegrationTests.xctestplan
@@ -1,0 +1,57 @@
+{
+  "configurations" : [
+    {
+      "id" : "15325B2B-2C4A-4B53-88F7-B6C1E3B6BE98",
+      "name" : "TSAN",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:Datadog.xcodeproj",
+          "identifier" : "61133B81242393DE00786299",
+          "name" : "Datadog"
+        },
+        {
+          "containerPath" : "container:Datadog.xcodeproj",
+          "identifier" : "61B7885325C180CB002675B5",
+          "name" : "DatadogCrashReporting"
+        }
+      ]
+    },
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Datadog.xcodeproj",
+      "identifier" : "61441C2924616F1D003D8BB8",
+      "name" : "DatadogIntegrationTests"
+    },
+    "threadSanitizerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "IntegrationTests",
+        "LoggingScenarioTests",
+        "RUMManualInstrumentationScenarioTests",
+        "RUMModalViewsScenarioTests",
+        "RUMNavigationControllerScenarioTests",
+        "RUMResourcesScenarioTests",
+        "RUMScrubbingScenarioTests",
+        "RUMTabBarControllerScenarioTests",
+        "RUMTapActionScenarioTests",
+        "TracingManualInstrumentationScenarioTests",
+        "TracingURLSessionScenarioTests",
+        "TrackingConsentScenarioTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Datadog.xcodeproj",
+        "identifier" : "61441C2924616F1D003D8BB8",
+        "name" : "DatadogIntegrationTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Datadog/TargetSupport/DatadogIntegrationTests/DatadogIntegrationTests.xcconfig
+++ b/Datadog/TargetSupport/DatadogIntegrationTests/DatadogIntegrationTests.xcconfig
@@ -5,4 +5,4 @@
 #include "../xcconfigs/MockServerAddress.local.xcconfig"
 
 // Add DatadogSDKTesting instrumentation (if available in current environment)
-#include "../xcconfigs/DatadogSDKTesting.local.xcconfig"
+#include? "../xcconfigs/DatadogSDKTesting.local.xcconfig"

--- a/Datadog/TargetSupport/DatadogIntegrationTests/DatadogIntegrationTests.xctestplan
+++ b/Datadog/TargetSupport/DatadogIntegrationTests/DatadogIntegrationTests.xctestplan
@@ -1,0 +1,148 @@
+{
+  "configurations" : [
+    {
+      "id" : "D87CA41D-8EBB-4809-AC70-E3B8317FAAC7",
+      "name" : "TSAN",
+      "options" : {
+        "threadSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:Datadog.xcodeproj",
+          "identifier" : "61133B81242393DE00786299",
+          "name" : "Datadog"
+        },
+        {
+          "containerPath" : "container:Datadog.xcodeproj",
+          "identifier" : "61133BEF242397DA00786299",
+          "name" : "DatadogObjc"
+        }
+      ]
+    },
+    "environmentVariableEntries" : [
+      {
+        "key" : "DD_TEST_RUNNER",
+        "value" : "$(DD_TEST_RUNNER)"
+      },
+      {
+        "key" : "DATADOG_CLIENT_TOKEN",
+        "value" : "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+      },
+      {
+        "key" : "DD_ENV",
+        "value" : "$(DD_SDK_SWIFT_TESTING_ENV)"
+      },
+      {
+        "key" : "DD_SERVICE",
+        "value" : "$(DD_SDK_SWIFT_TESTING_SERVICE)"
+      },
+      {
+        "key" : "DD_DISABLE_SDKIOS_INTEGRATION",
+        "value" : "1"
+      },
+      {
+        "key" : "DD_DISABLE_HEADERS_INJECTION",
+        "value" : "1"
+      },
+      {
+        "key" : "DD_ENABLE_RECORD_PAYLOAD",
+        "value" : "1"
+      },
+      {
+        "key" : "GIT_REPOSITORY_URL",
+        "value" : "$(GIT_REPOSITORY_URL)"
+      },
+      {
+        "key" : "BITRISE_GIT_COMMIT",
+        "value" : "$(BITRISE_GIT_COMMIT)"
+      },
+      {
+        "key" : "BITRISE_SOURCE_DIR",
+        "value" : "$(BITRISE_SOURCE_DIR)"
+      },
+      {
+        "key" : "BITRISE_BUILD_NUMBER",
+        "value" : "$(BITRISE_BUILD_NUMBER)"
+      },
+      {
+        "key" : "BITRISE_BUILD_URL",
+        "value" : "$(BITRISE_BUILD_URL)"
+      },
+      {
+        "key" : "BITRISE_GIT_BRANCH",
+        "value" : "$(BITRISE_GIT_BRANCH)"
+      },
+      {
+        "key" : "BITRISEIO_GIT_BRANCH_DEST",
+        "value" : "$(BITRISEIO_GIT_BRANCH_DEST)"
+      },
+      {
+        "key" : "BITRISE_GIT_TAG",
+        "value" : "$(BITRISE_GIT_TAG)"
+      },
+      {
+        "key" : "GIT_CLONE_COMMIT_HASH",
+        "value" : "$(GIT_CLONE_COMMIT_HASH)"
+      },
+      {
+        "key" : "BITRISE_APP_TITLE",
+        "value" : "$(BITRISE_APP_TITLE)"
+      },
+      {
+        "key" : "BITRISE_BUILD_SLUG",
+        "value" : "$(BITRISE_BUILD_SLUG)"
+      },
+      {
+        "key" : "BITRISE_GIT_MESSAGE",
+        "value" : "$(BITRISE_GIT_MESSAGE)"
+      },
+      {
+        "key" : "GIT_CLONE_COMMIT_MESSAGE_SUBJECT",
+        "value" : "$(GIT_CLONE_COMMIT_MESSAGE_SUBJECT)"
+      },
+      {
+        "key" : "GIT_CLONE_COMMIT_MESSAGE_BODY",
+        "value" : "$(GIT_CLONE_COMMIT_MESSAGE_BODY)"
+      },
+      {
+        "key" : "GIT_CLONE_COMMIT_AUTHOR_NAME",
+        "value" : "$(GIT_CLONE_COMMIT_AUTHOR_NAME)"
+      },
+      {
+        "key" : "GIT_CLONE_COMMIT_AUTHOR_EMAIL",
+        "value" : "$(GIT_CLONE_COMMIT_AUTHOR_EMAIL)"
+      },
+      {
+        "key" : "GIT_CLONE_COMMIT_COMMITER_NAME",
+        "value" : "$(GIT_CLONE_COMMIT_COMMITER_NAME)"
+      },
+      {
+        "key" : "GIT_CLONE_COMMIT_COMMITER_EMAIL",
+        "value" : "$(GIT_CLONE_COMMIT_COMMITER_EMAIL)"
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Datadog.xcodeproj",
+      "identifier" : "61441C2924616F1D003D8BB8",
+      "name" : "DatadogIntegrationTests"
+    }
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "CrashReportingWithLoggingScenarioTests",
+        "CrashReportingWithRUMScenarioTests"
+      ],
+      "target" : {
+        "containerPath" : "container:Datadog.xcodeproj",
+        "identifier" : "61441C2924616F1D003D8BB8",
+        "name" : "DatadogIntegrationTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Datadog/TargetSupport/DatadogTests/DatadogTests.xcconfig
+++ b/Datadog/TargetSupport/DatadogTests/DatadogTests.xcconfig
@@ -2,4 +2,4 @@
 #include "../xcconfigs/Datadog.xcconfig"
 
 // Add DatadogSDKTesting instrumentation (if available in current environment)
-#include "../xcconfigs/DatadogSDKTesting.local.xcconfig"
+#include? "../xcconfigs/DatadogSDKTesting.local.xcconfig"

--- a/Datadog/TargetSupport/Example/Example.xcconfig
+++ b/Datadog/TargetSupport/Example/Example.xcconfig
@@ -2,4 +2,4 @@
 #include "../xcconfigs/Datadog.xcconfig"
 
 // Add DatadogSDKTesting instrumentation (if available in current environment)
-#include "../xcconfigs/DatadogSDKTesting.local.xcconfig"
+#include? "../xcconfigs/DatadogSDKTesting.local.xcconfig"

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -152,6 +152,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 loadingTime: original.view.loadingTime,
                 loadingType: original.view.loadingType,
                 longTask: original.view.longTask,
+                name: original.view.name,
                 referrer: original.view.referrer,
                 resource: original.view.resource,
                 timeSpent: original.view.timeSpent,

--- a/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
@@ -42,7 +42,6 @@ class CrashReportingWithLoggingScenarioTests: IntegrationTests, LoggingCommonAss
             clearPersistentData: false // do not clear data from previous session
         )
 
-        // Get expected number of `LogMatchers`
         let recordedRequests = try loggingServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
             try LogMatcher.from(requests: requests).count >= 1
         }
@@ -53,8 +52,9 @@ class CrashReportingWithLoggingScenarioTests: IntegrationTests, LoggingCommonAss
 
         let crashLog = logMatchers[0]
         crashLog.assertDate(matches: { Date().timeIntervalSince($0) < dataDeliveryTimeout * 2 })
-        crashLog.assertStatus(equals: "emergency")
 
+        // Assert crash report info
+        crashLog.assertStatus(equals: "emergency")
         crashLog.assertMessage(equals: "Illegal instruction")
         crashLog.assertAttributes(
             equal: [
@@ -67,7 +67,7 @@ class CrashReportingWithLoggingScenarioTests: IntegrationTests, LoggingCommonAss
             isTypeOf: String.self
         )
 
-        // Check if it has some user info encoded
+        // Assert user info
         crashLog.assertUserInfo(
             equals: (
                 id: "abcd-1234",
@@ -76,13 +76,13 @@ class CrashReportingWithLoggingScenarioTests: IntegrationTests, LoggingCommonAss
             )
         )
 
-        // Check if it has some network info encoded
+        // Assert network info
         crashLog.assertValue(
             forKeyPath: LogMatcher.JSONKey.networkReachability,
             matches: { LogMatcher.allowedNetworkReachabilityValues.contains($0) }
         )
 
-        // Check some other characteristics
+        // Assert other characteristics important for crash reporting
         crashLog.assertServiceName(equals: "ui-tests-service-name")
         crashLog.assertLoggerName(equals: "crash-reporter")
     }

--- a/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
@@ -1,0 +1,90 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+
+private extension ExampleApplication {
+    /// Tapping this button will crash the app.
+    func tapCallFatalError() {
+        buttons["Call fatalError()"].tap()
+    }
+}
+
+// swiftlint:disable trailing_closure
+class CrashReportingWithLoggingScenarioTests: IntegrationTests, LoggingCommonAsserts {
+    /// Launches the app, taps "Call fatalError()" button (leading to crash), then restarts the app
+    /// to have the crash report uploaded to logging endpoint.
+    ///
+    /// Note: To run this test on the local machine, debugger must be disconnected, otherwise it will catch the crash
+    /// before the SDK. CI runs all tests through CLI with no debugger attached.
+    func testCrashReportingCollectOrSendWithLoggingScenario() throws {
+        let loggingServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenarioClassName: "CrashReportingCollectOrSendWithLoggingScenario",
+            serverConfiguration: HTTPServerMockConfiguration(
+                logsEndpoint: loggingServerSession.recordingURL
+            ),
+            clearPersistentData: true
+        )
+
+        app.tapCallFatalError() // crash the app
+
+        app.launchWith(
+            testScenarioClassName: "CrashReportingCollectOrSendWithLoggingScenario",
+            serverConfiguration: HTTPServerMockConfiguration(
+                logsEndpoint: loggingServerSession.recordingURL
+            ),
+            clearPersistentData: false // do not clear data from previous session
+        )
+
+        // Get expected number of `LogMatchers`
+        let recordedRequests = try loggingServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            try LogMatcher.from(requests: requests).count >= 1
+        }
+        let logMatchers = try LogMatcher.from(requests: recordedRequests)
+
+        // Assert common things
+        assertLogging(requests: recordedRequests)
+
+        let crashLog = logMatchers[0]
+        crashLog.assertDate(matches: { Date().timeIntervalSince($0) < dataDeliveryTimeout * 2 })
+        crashLog.assertStatus(equals: "emergency")
+
+        crashLog.assertMessage(equals: "Illegal instruction")
+        crashLog.assertAttributes(
+            equal: [
+                LogMatcher.JSONKey.errorKind: "SIGILL (ILL_ILLOPC)",
+                LogMatcher.JSONKey.errorMessage: "Illegal instruction",
+            ]
+        )
+        crashLog.assertValue(
+            forKeyPath: LogMatcher.JSONKey.errorStack,
+            isTypeOf: String.self
+        )
+
+        // Check if it has some user info encoded
+        crashLog.assertUserInfo(
+            equals: (
+                id: "abcd-1234",
+                name: "foo",
+                email: "foo@example.com"
+            )
+        )
+
+        // Check if it has some network info encoded
+        crashLog.assertValue(
+            forKeyPath: LogMatcher.JSONKey.networkReachability,
+            matches: { LogMatcher.allowedNetworkReachabilityValues.contains($0) }
+        )
+
+        // Check some other characteristics
+        crashLog.assertServiceName(equals: "ui-tests-service-name")
+        crashLog.assertLoggerName(equals: "crash-reporter")
+    }
+}
+// swiftlint:enable trailing_closure

--- a/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithRUMScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithRUMScenarioTests.swift
@@ -1,0 +1,78 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+
+private extension ExampleApplication {
+    /// Tapping this button will crash the app.
+    func tapCallFatalError() {
+        buttons["Call fatalError()"].tap()
+    }
+}
+
+class CrashReportingWithRUMScenarioTests: IntegrationTests, RUMCommonAsserts {
+    /// Launches the app, taps "Call fatalError()" button (leading to crash), then restarts the app
+    /// to have the crash report uploaded to RUM endpoint.
+    ///
+    /// Note: To run this test on the local machine, debugger must be disconnected, otherwise it will catch the crash
+    /// before the SDK. CI runs all tests through CLI with no debugger attached.
+    func testCrashReportingCollectOrSendWithRUMScenario() throws {
+        let rumServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenarioClassName: "CrashReportingCollectOrSendWithRUMScenario",
+            serverConfiguration: HTTPServerMockConfiguration(
+                rumEndpoint: rumServerSession.recordingURL
+            ),
+            clearPersistentData: true
+        )
+
+        app.tapCallFatalError() // crash the app
+
+        app.launchWith(
+            testScenarioClassName: "CrashReportingCollectOrSendWithRUMScenario",
+            serverConfiguration: HTTPServerMockConfiguration(
+                rumEndpoint: rumServerSession.recordingURL
+            ),
+            clearPersistentData: false // do not clear data from previous session
+        )
+
+        // Pull requests until two RUM Sessions are received and the first one has associated RUM Error event
+        let recordedRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            let sessions = try RUMSessionMatcher.sessions(maxCount: 2, from: requests)
+            let thereAreTwoSessions = sessions.count == 2
+            let firstSessionHasError = sessions.first?.viewVisits.first?.errorEvents.count == 1
+            return thereAreTwoSessions && firstSessionHasError
+        }
+
+        assertRUM(requests: recordedRequests)
+
+        let sessions = try RUMSessionMatcher.sessions(maxCount: 2, from: recordedRequests)
+            .sorted { session1, session2 in
+                // Sort sessions by their "application_start" action date
+                return session1.viewVisits[0].actionEvents[0].date < session2.viewVisits[0].actionEvents[0].date
+            }
+        let crashedSession = try XCTUnwrap(sessions.first)
+
+        XCTAssertEqual(crashedSession.viewVisits[0].name, "Example.CrashReportingViewController")
+        XCTAssertEqual(
+            crashedSession.viewVisits[0].viewEvents.last?.view.crash?.count,
+            1,
+            "The RUM View should count the crash."
+        )
+        XCTAssertEqual(
+            crashedSession.viewVisits[0].errorEvents.count,
+            1,
+            "The RUM View should count 1 error in total."
+        )
+
+        let crashRUMError = try XCTUnwrap(crashedSession.viewVisits[0].errorEvents.last)
+        XCTAssertEqual(crashRUMError.error.message, "Illegal instruction")
+        XCTAssertEqual(crashRUMError.error.type, "SIGILL (ILL_ILLOPC)")
+        XCTAssertNotNil(crashRUMError.error.stack)
+    }
+}

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -45,12 +45,12 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.from(requests: requests)?.viewVisits.count == 3
+            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 3
         }
 
         assertRUM(requests: recordedRUMRequests)
 
-        let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
 
         let view1 = session.viewVisits[0]
         XCTAssertEqual(view1.name, "SendRUMFixture1View")

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
@@ -53,12 +53,12 @@ class RUMModalViewsScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.from(requests: requests)?.viewVisits.count == 9
+            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 9
         }
 
         assertRUM(requests: recordedRUMRequests)
 
-        let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
         let visits = session.viewVisits
         XCTAssertEqual(visits[0].name, "Screen")
         XCTAssertEqual(visits[0].path, "Example.RUMMVSViewController")

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -50,12 +50,12 @@ class RUMNavigationControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.from(requests: requests)?.viewVisits.count == 8
+            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 8
         }
 
         assertRUM(requests: recordedRUMRequests)
 
-        let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
         let visits = session.viewVisits
 
         XCTAssertEqual(visits[0].name, "Screen1")

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -106,12 +106,12 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         // Get RUM Sessions with expected number of View visits and Resources
         let rumRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.from(requests: requests)?.viewVisits.count == 2
+            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 2
         }
 
         assertRUM(requests: rumRequests)
 
-        let session = try XCTUnwrap(try RUMSessionMatcher.from(requests: rumRequests))
+        let session = try XCTUnwrap(try RUMSessionMatcher.singleSession(from: rumRequests))
         XCTAssertEqual(session.viewVisits.count, 2)
 
         // Asserts in `SendFirstPartyRequestsVC` RUM View

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
@@ -21,12 +21,12 @@ class RUMScrubbingScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         // Get RUM Session with expected number of RUM Errors
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.from(requests: requests)?.viewVisits.last?.errorEvents.count == 2
+            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.last?.errorEvents.count == 2
         }
 
         assertRUM(requests: recordedRUMRequests)
 
-        let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
 
         XCTAssertEqual(session.viewVisits.count, 1)
         let viewVisit = session.viewVisits[0]

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
@@ -45,12 +45,12 @@ class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.from(requests: requests)?.viewVisits.count == 9
+            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 9
         }
 
         assertRUM(requests: recordedRUMRequests)
 
-        let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
         let visits = session.viewVisits
 
         XCTAssertEqual(session.viewVisits[0].name, "Screen A")

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -108,12 +108,12 @@ class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.from(requests: requests)?.viewVisits.count == 7
+            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 7
         }
 
         assertRUM(requests: recordedRUMRequests)
 
-        let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
 
         XCTAssertEqual(session.viewVisits[0].name, "MenuView")
         XCTAssertEqual(session.viewVisits[0].path, "Example.RUMTASScreen1ViewController")

--- a/Tests/DatadogIntegrationTests/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
@@ -192,12 +192,12 @@ class TrackingConsentScenarioTests: IntegrationTests, LoggingCommonAsserts, Trac
         // from this session to be send, but no RUM, Logging nor Tracing events from the first
         // session should be recorded.
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.from(requests: requests)?.viewVisits.count == 1
+            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 1
         }
 
         assertRUM(requests: recordedRUMRequests)
 
-        let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRUMRequests))
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
         XCTAssertEqual(session.viewVisits.count, 1)
         XCTAssertEqual(session.viewVisits[0].path, "Example.TSHomeViewController")
 
@@ -284,12 +284,12 @@ class TrackingConsentScenarioTests: IntegrationTests, LoggingCommonAsserts, Trac
         andSentTo serverSession: ServerSession
     ) throws {
         let recordedRequests = try serverSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.from(requests: requests)?.viewVisits.count == 4
+            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 4
         }
 
         assertRUM(requests: recordedRequests)
 
-        let session = try XCTUnwrap(RUMSessionMatcher.from(requests: recordedRequests))
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRequests))
         XCTAssertEqual(session.viewVisits[0].path, "Example.TSHomeViewController")
         XCTAssertGreaterThan(session.viewVisits[0].actionEvents.count, 0)
 

--- a/Tests/DatadogIntegrationTests/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
@@ -151,7 +151,7 @@ class TrackingConsentScenarioTests: IntegrationTests, LoggingCommonAsserts, Trac
                 tracesEndpoint: tracingServerSession.recordingURL,
                 rumEndpoint: rumServerSession.recordingURL
             ),
-            clearPeristentData: false // do not clear data from previous session
+            clearPersistentData: false // do not clear data from previous session
         )
 
         try assertLoggingDataWasCollected(withConsent: "granted", andSentTo: loggingServerSession)
@@ -185,7 +185,7 @@ class TrackingConsentScenarioTests: IntegrationTests, LoggingCommonAsserts, Trac
                 tracesEndpoint: tracingServerSession.recordingURL,
                 rumEndpoint: rumServerSession.recordingURL
             ),
-            clearPeristentData: false // do not clear data from previous session
+            clearPersistentData: false // do not clear data from previous session
         )
 
         // Because the app was restarted with consent `.granted`, we expect data

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -9,13 +9,13 @@ import XCTest
 /// Convenient interface to navigate through Example app's main screen.
 class ExampleApplication: XCUIApplication {
     /// Launches the app by providing mock server configuration.
-    /// If `clearPeristentData` is set to `true`, the app will clear all SDK data persisted in previous session(s).
+    /// If `clearPersistentData` is set `true`, the app will clear all SDK data persisted in previous session(s).
     func launchWith(
         testScenarioClassName: String,
         serverConfiguration: HTTPServerMockConfiguration,
-        clearPeristentData: Bool = true
+        clearPersistentData: Bool = true
     ) {
-        if clearPeristentData {
+        if clearPersistentData {
             launchArguments = [
                 Environment.Argument.isRunningUITests
             ]

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -136,6 +136,8 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
             && sendRUMViewEvent.view.id == lastRUMViewEvent.view.id,
             "The `RUMViewEvent` sent must be linked to the same RUM Session as the last `RUMViewEvent`."
         )
+        XCTAssertEqual(sendRUMViewEvent.connectivity, lastRUMViewEvent.connectivity)
+        XCTAssertEqual(sendRUMViewEvent.usr, lastRUMViewEvent.usr)
         XCTAssertEqual(
             sendRUMViewEvent.view.crash?.count, 1, "The `RUMViewEvent` must include incremented crash count."
         )
@@ -147,6 +149,11 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertTrue(
             sendRUMViewEvent.view.isActive == false, "The `RUMViewEvent` must be marked as inactive."
         )
+        XCTAssertEqual(sendRUMViewEvent.view.name, lastRUMViewEvent.view.name)
+        XCTAssertEqual(sendRUMViewEvent.view.url, lastRUMViewEvent.view.url)
+        XCTAssertEqual(sendRUMViewEvent.view.error.count, lastRUMViewEvent.view.error.count)
+        XCTAssertEqual(sendRUMViewEvent.view.resource.count, lastRUMViewEvent.view.resource.count)
+        XCTAssertEqual(sendRUMViewEvent.view.action.count, lastRUMViewEvent.view.action.count)
         XCTAssertEqual(
             sendRUMViewEvent.date,
             crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -76,6 +76,7 @@ extension RUMViewEvent {
                 loadingTime: .mockRandom(),
                 loadingType: nil,
                 longTask: .init(count: .mockRandom()),
+                name: .mockRandom(),
                 referrer: .mockRandom(),
                 resource: .init(count: .mockRandom()),
                 timeSpent: .mockRandom(),

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -48,6 +48,12 @@ internal class LogMatcher: JSONDataMatcher {
         static let mobileNetworkCarrierISOCountryCode = "network.client.sim_carrier.iso_country"
         static let mobileNetworkCarrierRadioTechnology = "network.client.sim_carrier.technology"
         static let mobileNetworkCarrierAllowsVoIP = "network.client.sim_carrier.allows_voip"
+
+        // MARK: - Error info
+
+        static let errorKind = "error.kind"
+        static let errorMessage = "error.message"
+        static let errorStack = "error.stack"
     }
 
     /// Allowed values for `network.client.available_interfaces` attribute.

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -123,7 +123,7 @@ workflows:
         Runs integration tests from Datadog.xcworkspace.
     steps:
     - xcode-test:
-        title: Run integration tests - DatadogIntegrationTests on iOS Simulator
+        title: Run integration tests for RUM, Logging and Tracing (on iOS Simulator)
         inputs:
         - scheme: DatadogIntegrationTests
         - simulator_device: iPhone 11
@@ -131,7 +131,19 @@ workflows:
         - is_clean_build: 'no'
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
-        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Integration-tests.html"
+        - xcodebuild_test_options: -testPlan DatadogIntegrationTests
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogIntegration-tests.html"
+    - xcode-test:
+        title: Run integration tests for Crash Reporting (on iOS Simulator)
+        inputs:
+        - scheme: DatadogIntegrationTests
+        - simulator_device: iPhone 11
+        - should_build_before_test: 'no'
+        - is_clean_build: 'no'
+        - generate_code_coverage_files: 'yes'
+        - project_path: Datadog.xcworkspace
+        - xcodebuild_test_options: -testPlan DatadogCrashReportingIntegrationTests
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogCrashReportingIntegration-tests.html"
 
   check_dependency_managers:
     description: |-


### PR DESCRIPTION
### What and why?

🧪 This PR adds two integration tests for Crash Reporting feature. Both start with the same base scenario:
* _"launch the `Example` app → crash by tapping `fatalError()` button → launch the app again → ..."_

and differ by the assertion:

* _"... → assert that `RUMError` and `RUMView` events are sent if RUM is enabled"_,
* _"... → assert that `Log` is sent if RUM is disabled"_.

### How?

Two separate UI test cases are added. They use existing: `CrashReportingCollectOrSendWithLoggingScenario` and `CrashReportingCollectOrSendWithRUMScenario`.

To run Crash Reporting integration tests locally (from Xcode), debugger must be not attached. Otherwise, it captures the crash and interrupts the app processes.

To make it not disturbing for local test runs, I separated Crash Reporting tests from integration tests for other features. Now, the `DatadogIntegrationTests` schema uses two distinct test plans:

<img width="682" alt="Screenshot 2021-03-08 at 16 55 04" src="https://user-images.githubusercontent.com/2358722/110345599-0cb5ee80-802f-11eb-9026-655c94a1407b.png">

By default, `DatadogIntegrationTests.xctestplan` is selected, so regular tests with `CMD` + `U` can be run as usual (for RUM, Logging and Tracing). Running tests for Crash Reporting requires disconnecting debugger in schema settings and changing to `DatadogCrashReportingIntegrationTests.xctestplan` in tests navigator:

<img width="317" alt="Screenshot 2021-03-08 at 16 58 52" src="https://user-images.githubusercontent.com/2358722/110346324-bb5a2f00-802f-11eb-90b1-51e271572cf9.png">

Alternatively, we could add separate schema, but this would require duplicating all settings and Python / `swift-testing` instrumentation.

Both test plans are used explicitly in `bitrise.yml` for CI. All works fine, as with `xcodebuild` debugger is not attached.

With two separate test plans it is also possible to inject different ENV configuration for single schema. This is leveraged to disable `swift-testing` instrumentation for Crash Reporting integration tests (otherwise, `swift-testing` crash reporting interrupts with the SDK). Until the opt-out flag is added to `swift-testing` crash reporting, we won't be leveraging it for the 2 new tests added in this PR.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
