### PR TITLE
RUMM-1064 AppStateListener added

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -431,6 +431,8 @@
 		9E58E8E324615EDA008E5063 /* JSONEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E58E8E224615EDA008E5063 /* JSONEncoderTests.swift */; };
 		9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */; };
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9E989A4225F640D100235FC3 /* AppStateListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E989A4125F640D100235FC3 /* AppStateListenerTests.swift */; };
+		9ED6A6B425F2901800CB2E29 /* AppStateListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */; };
 		9EEA4871258B76A100EBDA9D /* Global+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEA4870258B76A100EBDA9D /* Global+objc.swift */; };
 		9EF963E82537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EF963E72537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift */; };
 		9EFD112C24B32D29003A1A2B /* FirstPartyURLsFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFD112B24B32D29003A1A2B /* FirstPartyURLsFilter.swift */; };
@@ -966,7 +968,9 @@
 		9E58E8E224615EDA008E5063 /* JSONEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncoderTests.swift; sourceTree = "<group>"; };
 		9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjcExceptionHandler.m; sourceTree = "<group>"; };
 		9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjcExceptionHandler.h; sourceTree = "<group>"; };
+		9E989A4125F640D100235FC3 /* AppStateListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateListenerTests.swift; sourceTree = "<group>"; };
 		9E9EB37624468CE90002C80B /* Datadog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Datadog.modulemap; sourceTree = "<group>"; };
+		9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateListener.swift; sourceTree = "<group>"; };
 		9EEA4870258B76A100EBDA9D /* Global+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Global+objc.swift"; sourceTree = "<group>"; };
 		9EF49F1624476FBD004F2CA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9EF49F17244770AD004F2CA0 /* DatadogIntegrationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogIntegrationTests.xcconfig; sourceTree = "<group>"; };
@@ -1212,6 +1216,7 @@
 				61133BA32423979B00786299 /* MobileDevice.swift */,
 				61133BA42423979B00786299 /* NetworkConnectionInfoProvider.swift */,
 				61133BA52423979B00786299 /* BatteryStatusProvider.swift */,
+				9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -2309,6 +2314,7 @@
 				613F23E2252B05D7006CD2D7 /* URLFiltering */,
 				61B03874252724AB00518F3C /* URLSessionInterceptorTests.swift */,
 				613F23E3252B062F006CD2D7 /* TaskInterceptionTests.swift */,
+				9E989A4125F640D100235FC3 /* AppStateListenerTests.swift */,
 			);
 			path = Interception;
 			sourceTree = "<group>";
@@ -3285,6 +3291,7 @@
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				E1D202EA24C065CF00D1AF3A /* ActiveSpansPool.swift in Sources */,
 				61940C7C25668EC600A20043 /* URLSessionInterceptionHandler.swift in Sources */,
+				9ED6A6B425F2901800CB2E29 /* AppStateListener.swift in Sources */,
 				61F3CDA3251118FB00C816E5 /* UIKitRUMViewsHandler.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
 				619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */,
@@ -3524,6 +3531,7 @@
 				9EF963E82537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift in Sources */,
 				61133C552423990D00786299 /* BatteryStatusProviderTests.swift in Sources */,
 				61F3CDAB25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift in Sources */,
+				9E989A4225F640D100235FC3 /* AppStateListenerTests.swift in Sources */,
 				617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */,
 				61F2724925C943C500D54BF8 /* CrashReporterTests.swift in Sources */,
 				6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */,

--- a/Sources/Datadog/Core/System/AppStateListener.swift
+++ b/Sources/Datadog/Core/System/AppStateListener.swift
@@ -1,0 +1,138 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import class UIKit.UIApplication
+
+/// A data structure to represent recorded app states in a given period of time
+internal struct AppStateHistory: Equatable {
+    /// Snapshot of the app state at `date`
+    struct Snapshot: Equatable {
+        let isActive: Bool
+        let date: Date
+    }
+
+    var initialState: Snapshot
+    var changes = [Snapshot]()
+    var finalDate: Date
+    var finalState: Snapshot {
+        return Snapshot(
+            isActive: (changes.last ?? initialState).isActive,
+            date: finalDate
+        )
+    }
+
+    /// Limits or extrapolates app state history to the given range
+    /// This is useful when you record between 0...3t but you are concerned of t...2t only
+    /// - Parameter range: if outside of `initialState` and `finalState`, it extrapolates; otherwise it limits
+    /// - Returns: a history instance spanning the given range
+    func take(between range: ClosedRange<Date>) -> AppStateHistory {
+        var taken = self
+        // move initial state to lowerBound
+        taken.initialState = Snapshot(
+            isActive: isActive(at: range.lowerBound),
+            date: range.lowerBound
+        )
+        // move final state to upperBound
+        taken.finalDate = range.upperBound
+        // filter changes outside of the range
+        taken.changes = taken.changes.filter { range.contains($0.date) }
+        return taken
+    }
+
+    var foregroundDuration: TimeInterval {
+        var duration: TimeInterval = 0.0
+        var lastActiveStartDate: Date?
+        let allEvents = [initialState] + changes + [finalState]
+        for event in allEvents {
+            if let startDate = lastActiveStartDate {
+                duration += event.date.timeIntervalSince(startDate)
+            }
+            if event.isActive {
+                lastActiveStartDate = event.date
+            } else {
+                lastActiveStartDate = nil
+            }
+        }
+        return duration
+    }
+
+    var didRunInBackground: Bool {
+        return !initialState.isActive || !finalState.isActive
+    }
+
+    private func isActive(at date: Date) -> Bool {
+        if date <= initialState.date {
+            // we assume there was no change before initial state
+            return initialState.isActive
+        } else if finalState.date <= date {
+            // and no change after final state
+            return finalState.isActive
+        }
+        var active = initialState
+        for change in changes {
+            if date < change.date {
+                break
+            }
+            active = change
+        }
+        return active.isActive
+    }
+}
+
+internal protocol AppStateListening: class {
+    var history: AppStateHistory { get }
+}
+
+internal class AppStateListener: AppStateListening {
+    typealias Snapshot = AppStateHistory.Snapshot
+
+    private let dateProvider: DateProvider
+    private let publisher: ValuePublisher<AppStateHistory>
+
+    var history: AppStateHistory {
+        var current = publisher.currentValue
+        current.finalDate = dateProvider.currentDate()
+        return current
+    }
+
+    private static var isAppActive: Bool {
+        return UIApplication.managedShared?.applicationState == .active
+    }
+
+    init(dateProvider: DateProvider) {
+        self.dateProvider = dateProvider
+        let currentState = Snapshot(
+            isActive: AppStateListener.isAppActive,
+            date: dateProvider.currentDate()
+        )
+        self.publisher = ValuePublisher(
+            initialValue: AppStateHistory(
+                initialState: currentState,
+                finalDate: currentState.date
+            )
+        )
+
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        nc.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    @objc
+    private func appWillResignActive() {
+        let now = dateProvider.currentDate()
+        var value = publisher.currentValue
+        value.changes.append(Snapshot(isActive: false, date: now))
+        publisher.publishAsync(value)
+    }
+    @objc
+    private func appDidBecomeActive() {
+        let now = dateProvider.currentDate()
+        var value = publisher.currentValue
+        value.changes.append(Snapshot(isActive: true, date: now))
+        publisher.publishAsync(value)
+    }
+}

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -245,7 +245,8 @@ public class Datadog {
         if let urlSessionAutoInstrumentationConfiguration = configuration.urlSessionAutoInstrumentation {
             urlSessionAutoInstrumentation = URLSessionAutoInstrumentation(
                 configuration: urlSessionAutoInstrumentationConfiguration,
-                dateProvider: dateProvider
+                dateProvider: dateProvider,
+                appStateListener: AppStateListener(dateProvider: dateProvider)
             )
         }
 

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -15,6 +15,12 @@ public struct DDTags {
     ///
     /// Expects `String` value set for a tag.
     public static let resource = "resource.name"
+    /// Internal tag. `Integer` value. Measures elapsed time at app's foreground state in nanoseconds.
+    /// (duration - foregroundDuration) gives you the elapsed time while the app wasn't active (probably at background)
+    internal static let foregroundDuration = "foreground_duration"
+    /// Internal tag. `Bool` value.
+    /// `true` if span was started or ended while the app was not active, `false` otherwise.
+    internal static let isBackground = "is_background"
 
     /// Those keys used to encode information received from the user through `OpenTracingLogFields`, `OpenTracingTagKeys` or custom fields.
     /// Supported by Datadog platform.

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
@@ -22,7 +22,10 @@ internal class TaskInterception {
     /// or when the task was created through `URLSession.dataTask(with:url)` on some iOS13+.
     private(set) var spanContext: DDSpanContext?
 
-    init(request: URLRequest, isFirstParty: Bool) {
+    init(
+        request: URLRequest,
+        isFirstParty: Bool
+    ) {
         self.identifier = UUID()
         self.request = request
         self.isFirstPartyRequest = isFirstParty

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -37,22 +37,24 @@ public class URLSessionInterceptor: URLSessionInterceptorType {
 
     convenience init(
         configuration: FeaturesConfiguration.URLSessionAutoInstrumentation,
-        dateProvider: DateProvider
+        dateProvider: DateProvider,
+        appStateListener: AppStateListening
     ) {
         let handler: URLSessionInterceptionHandler
 
         if configuration.instrumentRUM {
             handler = URLSessionRUMResourcesHandler(dateProvider: dateProvider)
         } else {
-            handler = URLSessionTracingHandler()
+            handler = URLSessionTracingHandler(appStateListener: appStateListener)
         }
 
-        self.init(configuration: configuration, handler: handler)
+        self.init(configuration: configuration, handler: handler, appStateListener: appStateListener)
     }
 
     init(
         configuration: FeaturesConfiguration.URLSessionAutoInstrumentation,
-        handler: URLSessionInterceptionHandler
+        handler: URLSessionInterceptionHandler,
+        appStateListener: AppStateListening
     ) {
         self.defaultFirstPartyURLsFilter = FirstPartyURLsFilter(hosts: configuration.userDefinedFirstPartyHosts)
         self.internalURLsFilter = InternalURLsFilter(urls: configuration.sdkInternalURLs)

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
@@ -15,10 +15,15 @@ internal class URLSessionAutoInstrumentation {
 
     init?(
         configuration: FeaturesConfiguration.URLSessionAutoInstrumentation,
-        dateProvider: DateProvider
+        dateProvider: DateProvider,
+        appStateListener: AppStateListening
     ) {
         do {
-            self.interceptor = URLSessionInterceptor(configuration: configuration, dateProvider: dateProvider)
+            self.interceptor = URLSessionInterceptor(
+                configuration: configuration,
+                dateProvider: dateProvider,
+                appStateListener: appStateListener
+            )
             self.swizzler = try URLSessionSwizzler()
         } catch {
             consolePrint(

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -829,6 +829,12 @@ class CarrierInfoProviderMock: CarrierInfoProviderType, WrappedCarrierInfoProvid
     }
 }
 
+extension AppStateListener {
+    static func mockAny() -> AppStateListener {
+        return AppStateListener(dateProvider: SystemDateProvider())
+    }
+}
+
 extension EncodableValue {
     static func mockAny() -> EncodableValue {
         return EncodableValue(String.mockAny())

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
@@ -194,7 +194,8 @@ class DDURLSessionDelegateTests: XCTestCase {
         // given
         URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
             configuration: .mockAny(),
-            dateProvider: SystemDateProvider()
+            dateProvider: SystemDateProvider(),
+            appStateListener: AppStateListener.mockAny()
         )
         defer { URLSessionAutoInstrumentation.instance = nil }
 
@@ -212,7 +213,8 @@ class DDURLSessionDelegateTests: XCTestCase {
         // given
         URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
             configuration: .mockAny(),
-            dateProvider: SystemDateProvider()
+            dateProvider: SystemDateProvider(),
+            appStateListener: AppStateListener.mockAny()
         )
         defer { URLSessionAutoInstrumentation.instance = nil }
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/AppStateListenerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/AppStateListenerTests.swift
@@ -1,0 +1,195 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class AppStateHistoryTests: XCTestCase {
+    func testForegroundDurationWithoutChanges() {
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let history = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate),
+            changes: [],
+            finalDate: startDate + 1.0
+        )
+
+        XCTAssertEqual(history.foregroundDuration, 1.0)
+    }
+
+    func testForegroundDuration() {
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let history = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate),
+            changes: [
+                .init(isActive: false, date: startDate + 1.0),
+                .init(isActive: true, date: startDate + 2.0),
+                .init(isActive: false, date: startDate + 3.0),
+                .init(isActive: true, date: startDate + 4.0)
+            ],
+            finalDate: startDate + 5.0
+        )
+
+        XCTAssertEqual(history.foregroundDuration, 3.0)
+    }
+
+    func testForegroundDurationWithMissingChange() {
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let history = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate),
+            changes: [
+                .init(isActive: false, date: startDate + 1.0),
+                .init(isActive: false, date: startDate + 3.0)
+            ],
+            finalDate: startDate + 5.0
+        )
+
+        XCTAssertEqual(history.foregroundDuration, 1.0)
+    }
+
+    func testExtrapolation() {
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let history = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate),
+            changes: [],
+            finalDate: startDate + 5.0
+        )
+        let extrapolatedHistory = history.take(
+            between: (startDate - 5.0)...(startDate + 15.0)
+        )
+
+        let expectedHistory = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate - 5.0),
+            changes: [],
+            finalDate: startDate + 15.0
+        )
+        XCTAssertEqual(extrapolatedHistory, expectedHistory)
+    }
+
+    func testLimiting() {
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let history = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate),
+            changes: [],
+            finalDate: startDate + 20.0
+        )
+        let limitedHistory = history.take(
+            between: (startDate + 5.0)...(startDate + 10.0)
+        )
+
+        let expectedHistory = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate + 5.0),
+            changes: [],
+            finalDate: startDate + 10.0
+        )
+        XCTAssertEqual(limitedHistory, expectedHistory)
+    }
+
+    func testLimitingWithChanges() {
+        let startDate = Date(timeIntervalSinceReferenceDate: 0.0)
+        let firstChanges = (0...100).map { _ in
+            AppStateHistory.Snapshot(
+                isActive: false,
+                date: startDate + TimeInterval.random(in: 1...1_000)
+            )
+        }
+        let lastChanges = (0...100).map { _ in
+            AppStateHistory.Snapshot(
+                isActive: true,
+                date: startDate + TimeInterval.random(in: 2_000...3_000)
+            )
+        }
+        var allChanges = (firstChanges + lastChanges)
+        allChanges.append(.init(isActive: true, date: startDate + 1_200))
+        allChanges.append(.init(isActive: false, date: startDate + 1_500))
+        allChanges.sort { $0.date < $1.date }
+        let history = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate),
+            changes: allChanges,
+            finalDate: startDate + 4_000
+        )
+
+        let limitedHistory = history.take(
+            between: (startDate + 1_250)...(startDate + 1_750)
+        )
+
+        let expectedHistory = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate + 1_250),
+            changes: [.init(isActive: false, date: startDate + 1_500)],
+            finalDate: startDate + 1_750
+        )
+        XCTAssertEqual(limitedHistory, expectedHistory)
+    }
+}
+
+class AppStateListenerTests: XCTestCase {
+    func testWhenAppResignActiveAndBecomeActive_thenAppStateHistoryIsRecorded() {
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let listener = AppStateListener(
+            dateProvider: RelativeDateProvider(startingFrom: startDate, advancingBySeconds: 1.0)
+        )
+
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        let expected = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate),
+            changes: [
+                .init(isActive: false, date: startDate + 1.0),
+                .init(isActive: true, date: startDate + 2.0)
+            ],
+            finalDate: startDate + 3.0
+        )
+        XCTAssertEqual(listener.history, expected)
+    }
+
+    func testWhenAppBecomeActiveAndResignActive_thenAppStateHistoryIsRecorded() {
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let listener = AppStateListener(
+            dateProvider: RelativeDateProvider(startingFrom: startDate, advancingBySeconds: 1.0)
+        )
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+
+        let expected = AppStateHistory(
+            initialState: .init(isActive: true, date: startDate),
+            changes: [
+                .init(isActive: true, date: startDate + 1.0),
+                .init(isActive: false, date: startDate + 2.0)
+            ],
+            finalDate: startDate + 3.0
+        )
+        XCTAssertEqual(listener.history, expected)
+    }
+
+    func testWhenAppStateHistoryIsRetrieved_thenFinalDateOfHistoryChanges() {
+        let startDate = Date.mockDecember15th2019At10AMUTC()
+        let listener = AppStateListener(
+            dateProvider: RelativeDateProvider(startingFrom: startDate, advancingBySeconds: 1.0)
+        )
+        let history1 = listener.history
+        let history2 = listener.history
+
+        XCTAssertEqual(history2.finalState.date.timeIntervalSince(history1.finalState.date), 1.0)
+    }
+
+    func testWhenAppStateListenerIsCalledFromDifferentThreads_thenItWorks() {
+        let listener = AppStateListener(dateProvider: SystemDateProvider())
+        DispatchQueue.concurrentPerform(iterations: 10_000) { iteration in
+            // write
+            if iteration < 1_000 {
+                let nc = NotificationCenter.default
+                nc.post(
+                    name: (Bool.random() ?
+                            UIApplication.willResignActiveNotification :
+                            UIApplication.didBecomeActiveNotification),
+                    object: nil
+                )
+            }
+            // read
+            XCTAssertFalse(listener.history.changes.isEmpty)
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
@@ -38,19 +38,22 @@ class URLSessionInterceptorTests: XCTestCase {
 
     // MARK: - Initialization
 
-    func testGivenOnlyTracingInstrumentationEnabled_whenInitializing_itRegistersTracingHandler() {
+    func testGivenOnlyTracingInstrumentationEnabled_whenInitializing_itRegistersTracingHandler() throws {
         // Given
         let instrumentTracing = true
         let instrumentRUM = false
 
         // When
+        let appStateListener = AppStateListener.mockAny()
         let interceptor = URLSessionInterceptor(
             configuration: .mockWith(instrumentTracing: instrumentTracing, instrumentRUM: instrumentRUM),
-            dateProvider: SystemDateProvider()
+            dateProvider: SystemDateProvider(),
+            appStateListener: appStateListener
         )
 
         // Then
-        XCTAssertTrue(interceptor.handler is URLSessionTracingHandler)
+        let tracingHandler = try XCTUnwrap(interceptor.handler as? URLSessionTracingHandler)
+        XCTAssert(tracingHandler.appStateListener === appStateListener)
         XCTAssertTrue(
             interceptor.injectTracingHeadersToFirstPartyRequests,
             "Tracing headers should be injected when only Tracing instrumentation is enabled."
@@ -69,7 +72,8 @@ class URLSessionInterceptorTests: XCTestCase {
         // When
         let interceptor = URLSessionInterceptor(
             configuration: .mockWith(instrumentTracing: instrumentTracing, instrumentRUM: instrumentRUM),
-            dateProvider: SystemDateProvider()
+            dateProvider: SystemDateProvider(),
+            appStateListener: AppStateListener.mockAny()
         )
 
         // Then
@@ -92,7 +96,8 @@ class URLSessionInterceptorTests: XCTestCase {
         // When
         let interceptor = URLSessionInterceptor(
             configuration: .mockWith(instrumentTracing: instrumentTracing, instrumentRUM: instrumentRUM),
-            dateProvider: SystemDateProvider()
+            dateProvider: SystemDateProvider(),
+            appStateListener: AppStateListener.mockAny()
         )
 
         // Then
@@ -126,7 +131,8 @@ class URLSessionInterceptorTests: XCTestCase {
         // Given
         let interceptor = URLSessionInterceptor(
             configuration: mockConfiguration(tracingInstrumentationEnabled: true, rumInstrumentationEnabled: true),
-            handler: handler
+            handler: handler,
+            appStateListener: AppStateListener.mockAny()
         )
         Global.sharedTracer = Tracer.mockAny()
         defer { Global.sharedTracer = DDNoopGlobals.tracer }
@@ -176,7 +182,8 @@ class URLSessionInterceptorTests: XCTestCase {
         // Given
         let interceptor = URLSessionInterceptor(
             configuration: mockConfiguration(tracingInstrumentationEnabled: true, rumInstrumentationEnabled: false),
-            handler: handler
+            handler: handler,
+            appStateListener: AppStateListener.mockAny()
         )
         Global.sharedTracer = Tracer.mockAny()
         defer { Global.sharedTracer = DDNoopGlobals.tracer }
@@ -205,7 +212,8 @@ class URLSessionInterceptorTests: XCTestCase {
         // Given
         let interceptor = URLSessionInterceptor(
             configuration: mockConfiguration(tracingInstrumentationEnabled: false, rumInstrumentationEnabled: true),
-            handler: handler
+            handler: handler,
+            appStateListener: AppStateListener.mockAny()
         )
         Global.sharedTracer = Tracer.mockAny()
         defer { Global.sharedTracer = DDNoopGlobals.tracer }
@@ -225,7 +233,8 @@ class URLSessionInterceptorTests: XCTestCase {
         // Given
         let interceptor = URLSessionInterceptor(
             configuration: mockConfiguration(tracingInstrumentationEnabled: true, rumInstrumentationEnabled: .random()),
-            handler: handler
+            handler: handler,
+            appStateListener: AppStateListener.mockAny()
         )
         XCTAssertTrue(Global.sharedTracer is DDNoopTracer)
 
@@ -260,7 +269,8 @@ class URLSessionInterceptorTests: XCTestCase {
         // Given
         let interceptor = URLSessionInterceptor(
             configuration: mockConfiguration(tracingInstrumentationEnabled: true, rumInstrumentationEnabled: .random()),
-            handler: handler
+            handler: handler,
+            appStateListener: AppStateListener.mockAny()
         )
         Global.sharedTracer = Tracer.mockAny()
         defer { Global.sharedTracer = DDNoopGlobals.tracer }
@@ -359,7 +369,8 @@ class URLSessionInterceptorTests: XCTestCase {
         // Given
         let interceptor = URLSessionInterceptor(
             configuration: mockConfiguration(tracingInstrumentationEnabled: false, rumInstrumentationEnabled: true),
-            handler: handler
+            handler: handler,
+            appStateListener: AppStateListener.mockAny()
         )
 
         let interceptedFirstPartyRequest = interceptor.modify(request: firstPartyRequest)
@@ -421,7 +432,8 @@ class URLSessionInterceptorTests: XCTestCase {
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
         let interceptor = URLSessionInterceptor(
             configuration: mockConfiguration(tracingInstrumentationEnabled: true, rumInstrumentationEnabled: true),
-            handler: handler
+            handler: handler,
+            appStateListener: AppStateListener.mockAny()
         )
 
         let requests = [firstPartyRequest, thirdPartyRequest, internalRequest]

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
@@ -24,7 +24,8 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
         // When
         URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
             configuration: .mockAny(),
-            dateProvider: SystemDateProvider()
+            dateProvider: SystemDateProvider(),
+            appStateListener: AppStateListener.mockAny()
         )
         defer {
             URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
@@ -42,7 +43,8 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
 
         URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
             configuration: .mockAny(),
-            dateProvider: SystemDateProvider()
+            dateProvider: SystemDateProvider(),
+            appStateListener: AppStateListener.mockAny()
         )
         defer {
             URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()


### PR DESCRIPTION
### The problem

We are seeing spans in APM that have duration longer than hours, even days.
We realized that those are caused by the app going background and staying there for long time.
The span finishes only once the app goes back to foreground and this can result in spans longer than hours.

### What and why?

The problem above happens since the app gets suspended/paused at background and picks up where it left off when it comes back to foreground.
We cannot change this behavior from our SDK, therefore we decided to provide more information so that our users can tell when their network requests take too long from when their apps stay at background for too long.

### How?

We will add `foreground_duration: TimeInterval` and `isBackground: Bool` tags/metrics to `Span`s.
1. `TaskInterception` will be responsible for adding these to the `Span`
2. `AppStateListener` will be responsible for listening to app state along the lifetime of interception and providing `AppStateHistory` data structure
3. `foregroundDuration` and `isBackground` are properties of `AppStateHistory` data structure

~In this PR, we implemented 2nd and 3rd steps. In the next PR, we will implement 1st step by plugging `AppStateListener` into `TaskInterception`~ It's done in this PR as it was not that major.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference

### TODO

- [x] `TaskInterception`/`URLSessionTracingHandler` needs new test cases
- [ ] Verify `foreground_duration` is sent as numerical value and can be queried
