### PR TITLE
RUMM-1087 Kronos update to 4.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "lyft/Kronos" ~> 4.1
+github "lyft/Kronos" ~> 4.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "lyft/Kronos" "4.1.1"
+github "lyft/Kronos" "4.2.1"

--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
   s.public_header_files = "Datadog/TargetSupport/Datadog/Datadog.h"
   s.private_header_files = "Sources/_Datadog_Private/include/*.h"
   s.module_map = "Sources/Datadog/Datadog.modulemap"
-  s.dependency 'Kronos', '~> 4.1'
+  s.dependency 'Kronos', '~> 4.2'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["DatadogObjc"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/lyft/Kronos.git", .upToNextMinor(from: "4.1.0"))
+        .package(url: "https://github.com/lyft/Kronos.git", .upToNextMinor(from: "4.2.0"))
     ],
     targets: [
         .target(

--- a/xcconfigs/Base.xcconfig
+++ b/xcconfigs/Base.xcconfig
@@ -1,5 +1,1 @@
 // Base configuration file, included by all targets.
-
-// Required after adding `lyft/Kronos` dependency through Carthage.
-// Otherwise build fails with "module 'Kronos' was created for incompatible target arm64-apple-ios8.0"
-EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64


### PR DESCRIPTION
### What happens?

[`Kronos`](https://github.com/MobileNativeFoundation/Kronos) version is updated to `4.2`
`Base.xcconfig EXCLUDED_ARCHS` is also removed

### Why?

With this PR, `dd-sdk-ios` can be built for `arm64-simulator` too.
That is the last obstacle before shipping proper `xcframework` binaries.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
