### PR TITLE
RUMM-1197 Expose user `extraInfo` to Objc

### DIFF
--- a/Sources/DatadogObjc/Datadog+objc.swift
+++ b/Sources/DatadogObjc/Datadog+objc.swift
@@ -102,8 +102,8 @@ public class DDDatadog: NSObject {
     }
 
     @objc
-    public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil) {
-        Datadog.setUserInfo(id: id, name: name, email: email)
+    public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:]) {
+        Datadog.setUserInfo(id: id, name: name, email: email, extraInfo: castAttributesToSwift(extraInfo))
     }
 
     @objc

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -6,7 +6,7 @@
 
 import XCTest
 @testable import Datadog
-import DatadogObjc
+@testable import DatadogObjc
 
 /// This tests verify that objc-compatible `DatadogObjc` wrapper properly interacts with`Datadog` public API (swift).
 class DDDatadogTests: XCTestCase {
@@ -74,17 +74,31 @@ class DDDatadogTests: XCTestCase {
             trackingConsent: randomConsent().objc,
             configuration: DDConfiguration.builder(clientToken: "abcefghi", environment: "tests").build()
         )
-        let userInfo = Datadog.instance?.userInfoProvider
+        let userInfo = try XCTUnwrap(Datadog.instance?.userInfoProvider)
 
-        DDDatadog.setUserInfo(id: "id", name: "name", email: "email")
-        XCTAssertEqual(userInfo?.value.id, "id")
-        XCTAssertEqual(userInfo?.value.name, "name")
-        XCTAssertEqual(userInfo?.value.email, "email")
+        DDDatadog.setUserInfo(
+            id: "id",
+            name: "name",
+            email: "email",
+            extraInfo: [
+                "attribute-int": 42,
+                "attribute-double": 42.5,
+                "attribute-string": "string value"
+            ]
+        )
+        XCTAssertEqual(userInfo.value.id, "id")
+        XCTAssertEqual(userInfo.value.name, "name")
+        XCTAssertEqual(userInfo.value.email, "email")
+        let extraInfo = try XCTUnwrap(userInfo.value.extraInfo as? [String: AnyEncodable])
+        XCTAssertEqual(extraInfo["attribute-int"]?.value as? Int, 42)
+        XCTAssertEqual(extraInfo["attribute-double"]?.value as? Double, 42.5)
+        XCTAssertEqual(extraInfo["attribute-string"]?.value as? String, "string value")
 
-        DDDatadog.setUserInfo(id: nil, name: nil, email: nil)
-        XCTAssertNil(userInfo?.value.id)
-        XCTAssertNil(userInfo?.value.name)
-        XCTAssertNil(userInfo?.value.email)
+        DDDatadog.setUserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
+        XCTAssertNil(userInfo.value.id)
+        XCTAssertNil(userInfo.value.name)
+        XCTAssertNil(userInfo.value.email)
+        XCTAssertTrue(userInfo.value.extraInfo.isEmpty)
 
         try Datadog.deinitializeOrThrow()
     }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -11,7 +11,7 @@ public class DDDatadog: NSObject
  public static func initialize(appContext: DDAppContext,trackingConsent: DDTrackingConsent,configuration: DDConfiguration)
  public static func setVerbosityLevel(_ verbosityLevel: DDSDKVerbosityLevel)
  public static func verbosityLevel() -> DDSDKVerbosityLevel
- public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil)
+ public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
  public static func setTrackingConsent(consent: DDTrackingConsent)
 public class DDEndpoint: NSObject
  public static func eu() -> DDEndpoint


### PR DESCRIPTION
### What and why?

🚚 This PR makes the `extraInfo` attribute visible for Objective-C in `Datadog.setUserInfo()` API.

### How?

Added missing attribute + tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
