### PR TITLE
RUMM-1199 Fix `carthage --use-xcframeworks` build for DatadogCrashReporting

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -745,6 +745,7 @@
 		615AAC35251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMTabBarAutoInstrumentationScenario.storyboard; sourceTree = "<group>"; };
 		615C3154251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASVariousUIControllsViewController.swift; sourceTree = "<group>"; };
 		615C3195251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandlerTests.swift; sourceTree = "<group>"; };
+		615D9E2626048EAF006DC6D1 /* DatadogCrashReporting.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogCrashReporting.xcconfig; sourceTree = "<group>"; };
 		615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitExtensions.swift; sourceTree = "<group>"; };
 		6161247825CA9CA6009901BE /* CrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
 		6161249D25CAB340009901BE /* CrashContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContext.swift; sourceTree = "<group>"; };
@@ -2101,6 +2102,7 @@
 		6170DC0525C184FA003AED5C /* DatadogCrashReporting */ = {
 			isa = PBXGroup;
 			children = (
+				615D9E2626048EAF006DC6D1 /* DatadogCrashReporting.xcconfig */,
 				61B7885625C180CB002675B5 /* DatadogCrashReporting.h */,
 				61B7885725C180CB002675B5 /* Info.plist */,
 			);
@@ -4214,7 +4216,7 @@
 		};
 		61B7886525C180CB002675B5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
+			baseConfigurationReference = 615D9E2626048EAF006DC6D1 /* DatadogCrashReporting.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -4245,7 +4247,7 @@
 		};
 		61B7886625C180CB002675B5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
+			baseConfigurationReference = 615D9E2626048EAF006DC6D1 /* DatadogCrashReporting.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -4275,7 +4277,7 @@
 		};
 		61B7886725C180CB002675B5 /* Integration */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 61569894256D0E9A00C6AADA /* Base.xcconfig */;
+			baseConfigurationReference = 615D9E2626048EAF006DC6D1 /* DatadogCrashReporting.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/Datadog/TargetSupport/DatadogCrashReporting/DatadogCrashReporting.xcconfig
+++ b/Datadog/TargetSupport/DatadogCrashReporting/DatadogCrashReporting.xcconfig
@@ -1,0 +1,32 @@
+// Base configuration for DatadogCrashReporting target.
+// Note: all configuration here will be applied to `DatadogCrashReporting.framework` produced by Carthage.
+
+// Include base config
+#include "../xcconfigs/Base.xcconfig"
+
+// This setting adjusts `DatadogCrashReporting.xcframework` simulator slices produced
+// by `carthage update --use-xcframeworks` when installing the SDK so it can link
+// its dependencies properly with `ld` (`CrashReporter.xcframework` and `Datadog.xcframework`).
+//
+// `CrashReporter.xcframework` built from sources produces `ios-i386_x86_64-simulator` slice.
+// As mentioned in its `1.8.0` release note, it does not contain the `arm64` architecture.
+//
+// To ensure that `carthage update --use-xcframeworks` links resultant xcframeworks with no error
+// for simulator builds, the resultant slice for `DatadogCrashReporting.xcframework` must be a subset of the
+// architectures defined for its dependencies:
+// - CrashReporter.xcframework - `ios_i386_x86_64-simulator`
+// - Datadog.xcframework - `ios-arm64_x86_64-simulator`
+// - Kronos.xcframework - `ios-arm64_i386_x86_64-simulator`
+// 
+// The only subset of dependant slices is `ios_x86_64-simulator` and this is what we're enforcing here.
+// 
+// Without this adjustment excluding `arm64-simulator` the `ld` will fail for `carthage update --use-xcframeworks` 
+// as it will not find the `arm64` architecture in `CrashReporter.xcframework` slice.
+//
+// Note: this is only problematic when `carthage update --use-xcframeworks` builds `CrashReporter.xcframework` from source
+// and should not be an issue once pre-build xcframeworks support is added to Carthage: https://github.com/Carthage/Carthage/pull/3123
+// However, carthage always falls back to build from source if it can't download pre-build binaries, so this adjustment
+// will be still required.
+//
+ARCHS[sdk=iphonesimulator*] = x86_64
+ARCHS[sdk=iphoneos*] = $(ARCHS_STANDARD)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifeq (${ci}, true)
 		@rm -rf instrumented-tests/DatadogSDKTesting.zip
 		@rm -rf instrumented-tests/LICENSE
 		@gh release download ${DD_SDK_SWIFT_TESTING_VERSION} -D instrumented-tests -R https://github.com/DataDog/dd-sdk-swift-testing -p "DatadogSDKTesting.zip"
-		@unzip instrumented-tests/DatadogSDKTesting.zip -d instrumented-tests
+		@unzip -q instrumented-tests/DatadogSDKTesting.zip -d instrumented-tests
 		@[ -e "instrumented-tests/DatadogSDKTesting.xcframework" ] && echo "DatadogSDKTesting.xcframework - OK" || { echo "DatadogSDKTesting.xcframework - missing"; exit 1; }
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,15 @@ endef
 export DD_SDK_TESTING_XCCONFIG_CI
 
 define DD_SDK_BASE_XCCONFIG
-// To enable Internal Monitoring APIs:
-SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_SDK_ENABLE_INTERNAL_MONITORING
+// To enable Internal Monitoring APIs:\n
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_SDK_ENABLE_INTERNAL_MONITORING\n
+\n
+// To build only active architecture for all configurations.\n
+// TODO: RUMM-1200 We can perhaps remove this fix when carthage supports pre-build xcframeworks.\n
+//		 The only "problematic" dependency is `CrashReporter.xcframework` which doesn't produce\n
+//		 the `arm64-simulator` architecture when compiled from source. Its pre-build `CrashReporter.xcframework`\n
+//		 available since `1.8.0` contains the `ios-arm64_i386_x86_64-simulator` slice and should link fine in all configurations.\n
+ONLY_ACTIVE_ARCH = YES
 endef
 export DD_SDK_BASE_XCCONFIG
 

--- a/Tests/DatadogBenchmarkTests/BenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkTests.swift
@@ -42,6 +42,7 @@ class BenchmarkTests: XCTestCase {
 
         Datadog.initialize(
             appContext: .init(),
+            trackingConsent: .granted,
             configuration: Datadog.Configuration
                 .builderUsing(rumApplicationID: "rum-123", clientToken: "rum-abc", environment: "benchmarks")
                 .set(customLogsEndpoint: anyURL)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -67,7 +67,7 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view1.resourceEvents[0].resource.statusCode, 200)
         XCTAssertEqual(view1.resourceEvents[0].resource.type, .image)
         XCTAssertGreaterThan(view1.resourceEvents[0].resource.duration, 100_000_000 - 1) // ~0.1s
-        XCTAssertLessThan(view1.resourceEvents[0].resource.duration, 100_000_000 * 3) // less than 0.3s
+        XCTAssertLessThan(view1.resourceEvents[0].resource.duration, 1_000_000_000 * 30) // less than 30s (big enough to balance NTP sync)
         XCTAssertEqual(view1.errorEvents[0].error.type, "NSURLErrorDomain - -1011")
         XCTAssertEqual(view1.errorEvents[0].error.message, "Bad response.")
         XCTAssertEqual(

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Actions/UIApplicationSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Actions/UIApplicationSwizzlerTests.swift
@@ -6,7 +6,6 @@
 
 import XCTest
 @testable import Datadog
-@testable import Example
 
 extension UIApplicationSwizzler {
     func unswizzle() {

--- a/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/carthage/CTProject.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		615D9E662604B5AB006DC6D1 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */; };
+		615D9E672604B5AB006DC6D1 /* CrashReporter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		615D9E6B2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */; };
+		615D9E6C2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61C36419243752A500C4D4E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C36418243752A500C4D4E6 /* AppDelegate.swift */; };
 		61C3641B243752A500C4D4E6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3641A243752A500C4D4E6 /* SceneDelegate.swift */; };
 		61C3641D243752A500C4D4E6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3641C243752A500C4D4E6 /* ViewController.swift */; };
@@ -46,9 +50,11 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				615D9E672604B5AB006DC6D1 /* CrashReporter.xcframework in Embed Frameworks */,
 				9E9D5E8D25F90FC6002F12A0 /* Datadog.xcframework in Embed Frameworks */,
 				9E9D5E8B25F90FC6002F12A0 /* DatadogObjc.xcframework in Embed Frameworks */,
 				9E9D5E8925F90FC6002F12A0 /* Kronos.xcframework in Embed Frameworks */,
+				615D9E6C2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -58,6 +64,8 @@
 /* Begin PBXFileReference section */
 		615519322461CDB4002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519332461CDB4002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
+		615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = Carthage/Build/CrashReporter.xcframework; sourceTree = "<group>"; };
+		615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogCrashReporting.xcframework; path = Carthage/Build/DatadogCrashReporting.xcframework; sourceTree = "<group>"; };
 		61C36415243752A500C4D4E6 /* CTProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CTProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		61C36418243752A500C4D4E6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61C3641A243752A500C4D4E6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -81,9 +89,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				615D9E662604B5AB006DC6D1 /* CrashReporter.xcframework in Frameworks */,
 				9E9D5E8C25F90FC6002F12A0 /* Datadog.xcframework in Frameworks */,
 				9E9D5E8A25F90FC6002F12A0 /* DatadogObjc.xcframework in Frameworks */,
 				9E9D5E8825F90FC6002F12A0 /* Kronos.xcframework in Frameworks */,
+				615D9E6B2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,6 +180,8 @@
 		61C364492437547A00C4D4E6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */,
+				615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */,
 				9E9D5E8725F90FC6002F12A0 /* Datadog.xcframework */,
 				9E9D5E8625F90FC6002F12A0 /* DatadogObjc.xcframework */,
 				9E9D5E8525F90FC6002F12A0 /* Kronos.xcframework */,

--- a/xcconfigs/Base.xcconfig
+++ b/xcconfigs/Base.xcconfig
@@ -1,5 +1,5 @@
 // Base configuration file for all targets.
-// Note: all configuration here will be applied to `Datadog*.framework` built with Carthage.
+// Note: all configuration here will be applied to `Datadog*.framework` produced by Carthage.
 
 // Include internal base config (git-ignored, so excluded from Carthage build)
 #include? "Base.local.xcconfig"


### PR DESCRIPTION
### What and why?

⚙️ This PR updates the `DatadogCrashReporting` configuration so it builds well with `carthage --use-xcframeworks`.

### How?

Ideally, `carthage --use-xcframeworks` should download pre-built xcframework of [microsoft/plcrashreporter](https://github.com/microsoft/plcrashreporter), which includes `ios-arm64_i386_x86_64-simulator` slice for iOS Simulator. 

Unfortunately, pre-built xcframeworks are not yet supported in carthage (https://github.com/Carthage/Carthage/pull/3123) and it falls back to building `CrashReporter.xcframework` from source. In this case, the `arm64` architecture is not produced for `-simulator` slice (this is expected from `PLCR` [`1.8.0` release notes](https://github.com/microsoft/plcrashreporter/releases/tag/1.8.0)).

This PR updates the `DatadogCrashReporting` target to produce `-simulator` slice with no `arm64` architecture. This way, the linker in `carthage update` doesn't search for `arm64` in `CrashReporter.xcframework`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
