### PR TITLE
RUMM-1206 Make `DatadogCrashReporting` static in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         ),
         .library(
             name: "DatadogCrashReporting",
-            type: .dynamic,
+            type: .static,
             targets: ["DatadogCrashReporting"]
         ),
     ],

--- a/dependency-manager-tests/spm/Makefile
+++ b/dependency-manager-tests/spm/Makefile
@@ -10,3 +10,11 @@ test:
 		@cp -r SPMProject.xcodeproj.src SPMProject.xcodeproj
 		@sed "s|REMOTE_GIT_BRANCH|${GIT_BRANCH}|g" SPMProject.xcodeproj.src/project.pbxproj > SPMProject.xcodeproj/project.pbxproj
 		@echo "OK 👌"
+
+create-src-from-xcodeproj:
+		@echo "⚙️  Creating 'SPMProject.xcodeproj.src' from SPMProject.xcodeproj"
+		rm -rf SPMProject.xcodeproj.src
+		cp -r SPMProject.xcodeproj SPMProject.xcodeproj.src
+		rm SPMProject.xcodeproj.src/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+		sed "s|\"${GIT_BRANCH}\"|REMOTE_GIT_BRANCH|g" SPMProject.xcodeproj/project.pbxproj > SPMProject.xcodeproj.src/project.pbxproj
+		@echo "OK 👌"

--- a/dependency-manager-tests/spm/README.md
+++ b/dependency-manager-tests/spm/README.md
@@ -6,4 +6,12 @@ After pushing current branch to remote, run:
 ```bash
 $ make
 ```
-Then, open `SPMProject.xcodeproj` to check if SPM is able to fetch `Datadog` dependency from current branch and build the project.
+This will create the `SPMProject.xcodeproj` from `SPMProject.xcodeproj.src` by replacing the `REMOTE_GIT_BRANCH` string with the name of the remote branch.
+
+Launch the `SPMProject.xcodeproj` to check if SPM is able to fetch `Datadog` package from remote and build the project.
+
+If you need to update the setup in `SPMProject.xcodeproj`, use:
+```bash
+make create-src-from-xcodeproj
+```
+to apply it back to the `SPMProject.xcodeproj.src`, so it can be committed to git.

--- a/dependency-manager-tests/spm/README.md
+++ b/dependency-manager-tests/spm/README.md
@@ -6,12 +6,12 @@ After pushing current branch to remote, run:
 ```bash
 $ make
 ```
-This will create the `SPMProject.xcodeproj` from `SPMProject.xcodeproj.src` by replacing the `REMOTE_GIT_BRANCH` string with the name of the remote branch.
+This creates the `SPMProject.xcodeproj` from `SPMProject.xcodeproj.src` by replacing the `REMOTE_GIT_BRANCH` string with the name of the remote branch.
 
-Launch the `SPMProject.xcodeproj` to check if SPM is able to fetch `Datadog` package from remote and build the project.
+Launch the `SPMProject.xcodeproj` to check if SPM is able to fetch the `Datadog` package from remote and build the project.
 
-If you need to update the setup in `SPMProject.xcodeproj`, use:
+To update the setup in `SPMProject.xcodeproj`, use:
 ```bash
 make create-src-from-xcodeproj
 ```
-to apply it back to the `SPMProject.xcodeproj.src`, so it can be committed to git.
+to apply the change back to the `SPMProject.xcodeproj.src`, so it can be committed to git.

--- a/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
+++ b/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
@@ -14,8 +14,8 @@
 		61C363E624374D6000C4D4E6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61C363E424374D6000C4D4E6 /* LaunchScreen.storyboard */; };
 		61C363F124374D6100C4D4E6 /* SPMProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363F024374D6100C4D4E6 /* SPMProjectTests.swift */; };
 		61C363FC24374D6100C4D4E6 /* SPMProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363FB24374D6100C4D4E6 /* SPMProjectUITests.swift */; };
-		61C4DBDE25C2FB0B0058DED4 /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 61C4DBDD25C2FB0B0058DED4 /* DatadogCrashReporting */; };
-		61C4DBDF25C2FB0B0058DED4 /* DatadogCrashReporting in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 61C4DBDD25C2FB0B0058DED4 /* DatadogCrashReporting */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		61DA9CB4260BA1FA00366408 /* DatadogCrashReporting in Frameworks */ = {isa = PBXBuildFile; productRef = 61DA9CB3260BA1FA00366408 /* DatadogCrashReporting */; };
+		61DA9CB6260BA1FA00366408 /* DatadogStatic in Frameworks */ = {isa = PBXBuildFile; productRef = 61DA9CB5260BA1FA00366408 /* DatadogStatic */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,7 +42,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				61C4DBDF25C2FB0B0058DED4 /* DatadogCrashReporting in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -72,7 +71,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				61C4DBDE25C2FB0B0058DED4 /* DatadogCrashReporting in Frameworks */,
+				61DA9CB4260BA1FA00366408 /* DatadogCrashReporting in Frameworks */,
+				61DA9CB6260BA1FA00366408 /* DatadogStatic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -182,7 +182,8 @@
 			);
 			name = SPMProject;
 			packageProductDependencies = (
-				61C4DBDD25C2FB0B0058DED4 /* DatadogCrashReporting */,
+				61DA9CB3260BA1FA00366408 /* DatadogCrashReporting */,
+				61DA9CB5260BA1FA00366408 /* DatadogStatic */,
 			);
 			productName = SPMProject;
 			productReference = 61C363D624374D5F00C4D4E6 /* SPMProject.app */;
@@ -689,10 +690,15 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		61C4DBDD25C2FB0B0058DED4 /* DatadogCrashReporting */ = {
+		61DA9CB3260BA1FA00366408 /* DatadogCrashReporting */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 61C3640924374DF200C4D4E6 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
 			productName = DatadogCrashReporting;
+		};
+		61DA9CB5260BA1FA00366408 /* DatadogStatic */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 61C3640924374DF200C4D4E6 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */;
+			productName = DatadogStatic;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
### What and why?

📦 This PR adds necessary change for linking `DatadogCrashReporting` in `Package.swift`
```diff
-            type: .dynamic,
+            type: .static,
```

### How?

This change is required to avoid following compiler errors in the apps using both `DatadogStatic` and `DatadogCrashReporting`:
```
Swift package product 'Kronos' is linked as a static library by 'SPMProject' and 'Datadog'. This will result in duplication of library code.
Swift package target '_Datadog_Private' is linked as a static library by 'SPMProject' and 'Datadog'. This will result in duplication of library code.
Swift package target 'Datadog' is linked as a static library by 'SPMProject' and 'Datadog'. This will result in duplication of library code.
```

From now on, to use Datadog crash reporting feature, apps must link `DatadogStatic` along with `DatadogCrashReporting`:

<img width="539" alt="Screenshot 2021-03-24 at 18 03 26" src="https://user-images.githubusercontent.com/2358722/112352674-404d7580-8ccb-11eb-8ab3-154dd9165d4d.png">

This PR also updates `SPMProject` with the above setup.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
