### PR TITLE
RUMM-1206 Automate dogfooding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build
 /.build
 /.swiftpm
+Package.resolved
 Carthage/Build
 Carthage/Checkouts
 

--- a/Makefile
+++ b/Makefile
@@ -106,3 +106,8 @@ ship:
 		pod repo update
 		pod spec lint --allow-warnings DatadogSDKObjc.podspec
 		pod trunk push --allow-warnings DatadogSDKObjc.podspec
+
+dogfood:
+		@brew list gh &>/dev/null || brew install gh
+		@pip install GitPython==3.1.14
+		@./tools/dogfooding/dogfood.py

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -213,3 +213,16 @@ workflows:
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/cocoapods/CPProject.xcworkspace"
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CPProject-tests.html"
+
+  create_dogfooding_pr:
+    description: |-
+        Creates PRs to repositories using `dd-sdk-ios`.
+    steps:
+    - script:
+        title: Create PR to Datadog mobile app project
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make dogfood ci=${CI}
+

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -16,6 +16,10 @@ workflows:
     - check_dependency_managers
     - _deploy_artifacts
 
+  push_to_dogfooding:
+    after_run:
+    - create_dogfooding_pr
+
   _make_dependencies:
     description: |-
         Does `make dependencies` to prepare source code in repo for building and testing.

--- a/tools/dogfooding/.gitignore
+++ b/tools/dogfooding/.gitignore
@@ -1,0 +1,3 @@
+.idea
+venv
+*.pyc

--- a/tools/dogfooding/src/dogfooded_commit.py
+++ b/tools/dogfooding/src/dogfooded_commit.py
@@ -1,0 +1,36 @@
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-2020 Datadog, Inc.
+# -----------------------------------------------------------
+
+import os
+from git import Repo, Actor
+
+
+class DogfoodedCommit:
+    """
+    Reads the git information for the commit being dogfooded.
+    * when running on CI - reads it from CI ENV
+    * when running locally - reads it from `dd-sdk-ios` repo git info
+    """
+
+    def __init__(self):
+        if 'CI' in os.environ:
+            print('ℹ️ Running on CI')
+            print('    → reading git author from ENV')
+            self.author = Actor(
+                name=os.environ['GIT_CLONE_COMMIT_AUTHOR_NAME'],
+                email=os.environ['GIT_CLONE_COMMIT_AUTHOR_EMAIL']
+            )
+            self.hash = os.environ['GIT_CLONE_COMMIT_HASH']
+            self.message = os.environ['GIT_CLONE_COMMIT_MESSAGE_SUBJECT']
+        else:
+            print('ℹ️ Running locally')
+            print('    → reading git author from the last commit in dd-sdk-ios')
+            dd_sdk_ios_repo = Repo(path='../../')
+            self.author = dd_sdk_ios_repo.head.commit.author
+            self.hash = dd_sdk_ios_repo.head.commit.hexsha
+            self.message = dd_sdk_ios_repo.head.commit.message
+
+        self.hash_short = self.hash[0:8]

--- a/tools/dogfooding/src/package_resolved.py
+++ b/tools/dogfooding/src/package_resolved.py
@@ -1,0 +1,108 @@
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-2020 Datadog, Inc.
+# -----------------------------------------------------------
+
+import json
+from copy import deepcopy
+
+
+class PackageResolvedFile:
+    """
+    Abstracts operations on `Package.resolved` file.
+    """
+
+    __SUPPORTED_PACKAGE_RESOLVED_VERSION = 1
+
+    def __init__(self, path: str):
+        print(f'⚙️ Opening {path}')
+        self.path = path
+        with open(path, 'r') as file:
+            self.packages = json.load(file)
+            version = self.packages['version']
+            if version != self.__SUPPORTED_PACKAGE_RESOLVED_VERSION:
+                raise Exception(
+                    f'{path} uses version {version} but `package_resolved.py` supports ' +
+                    f'version {self.__SUPPORTED_PACKAGE_RESOLVED_VERSION}. Update `package_resolved.py` to new format.'
+                )
+
+    def update_dependency(self, package_name: str, new_branch, new_revision, new_version):
+        """
+        Updates dependency resolution values.
+        :param package_name: the name of the package to update
+        :param new_branch: the new branch name (pass `None` for `null`)
+        :param new_revision: the new revision (pass `None` for `null`)
+        :param new_version: the new version name (pass `None` for `null`)
+        :return:
+        """
+        package = self.__get_package(package_name=package_name)
+
+        # Individual package pin looks this:
+        # {
+        #     "package": "DatadogSDK",
+        #     "repositoryURL": "https://github.com/DataDog/dd-sdk-ios",
+        #     "state": {
+        #         "branch": "dogfooding",
+        #         "revision": "4e93a8f1f662d9126074a0f355b4b6d20f9f30a7",
+        #         "version": null
+        #     }
+        # }
+
+        old_state = deepcopy(package['state'])
+
+        package['state']['branch'] = new_branch
+        package['state']['revision'] = new_revision
+        package['state']['version'] = new_version
+
+        new_state = deepcopy(package['state'])
+
+        diff = old_state.items() ^ new_state.items()
+
+        if len(diff) > 0:
+            print(f'✏️️ Updated "{package_name}":')
+            print(f'    → old: {old_state}')
+            print(f'    → new: {new_state}')
+        else:
+            print(f'✏️️ "{package_name}" is up-to-date')
+
+    def read_dependency(self, package_name):
+        """
+        Returns resolution info for given dependency.
+        :param package_name: the name of dependency
+        :return: `state` object from `Package.resolved`
+        """
+        package = self.__get_package(package_name=package_name)
+        return deepcopy(package['state'])
+
+    def get_number_of_dependencies(self):
+        """
+        :return: number of dependencies
+        """
+        return len(self.packages['object']['pins'])
+
+    def save(self):
+        """
+        Saves changes to initial `path`.
+        """
+        print(f'⚙️ Saving {self.path}')
+        with open(self.path, 'w') as file:
+            json.dump(
+                self.packages,
+                fp=file,
+                indent=2,  # preserve `swift package` indentation
+                sort_keys=True  # preserve `swift package` packages sorting
+            )
+            file.write('\n')  # add new line to the EOF
+
+    def __get_package(self, package_name: str):
+        pins = self.packages['object']['pins']
+        package_pins = [index for index, p in enumerate(pins) if p['package'] == package_name]
+
+        if len(package_pins) == 0:
+            raise Exception(
+                f'{self.path} does not contain pin named "{package_name}"'
+            )
+
+        package_pin_index = package_pins[0]
+        return self.packages['object']['pins'][package_pin_index]

--- a/tools/dogfooding/src/repository.py
+++ b/tools/dogfooding/src/repository.py
@@ -1,0 +1,77 @@
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-2020 Datadog, Inc.
+# -----------------------------------------------------------
+
+
+import os
+from git import Repo, Actor
+
+
+class Repository:
+    """
+    Abstracts operations on the target repository.
+    """
+
+    def __init__(self, repo: Repo):
+        self.repo = repo
+
+    @staticmethod
+    def clone(ssh: str, repository_name: str, temp_dir: str):
+        """
+        Clones the git repository using GH CLI.
+        The GH CLI must be authentication by the environment.
+        :returns git.Repo object
+        """
+        print('ℹ️️ Logging GH CLI authentication status:')
+        os.system('gh auth status')
+
+        print(f'ℹ️️ Changing current directory to: {temp_dir}')
+        os.chdir(temp_dir)
+
+        print(f'⚙️ Cloning {ssh}')
+        result = os.system(f'gh repo clone {ssh}')
+
+        if result > 0:
+            raise Exception(
+                f'Unable to clone GH repository ({ssh}). Check GH CLI authentication status in above logs.'
+            )
+        else:
+            print(f'    → changing current directory to: {repository_name}')
+            os.chdir(repository_name)
+            return Repository(repo=Repo(path=os.getcwd()))
+
+    def create_branch(self, branch_name):
+        """
+        Creates and checks out a git branch.
+        :param branch_name: the name of the branch
+        """
+        print(f'⚙️️️️ Creating git branch: {branch_name}')
+        self.repo.git.checkout('HEAD', b=branch_name)
+
+    def commit(self, message: str, author: Actor):
+        """
+        Creates commit with current changes.
+        :param message: commit message
+        :param author: author of the commit (git.Actor object)
+        """
+        print(f'⚙️️️️ Committing changes on behalf of {author.name} ({author.email})')
+        print('    → commit message:')
+        print(message)
+        self.repo.git.add(update=True)
+        self.repo.index.commit(message=message, author=author)
+
+    def push(self):
+        """
+        Pushes current branch to the remote.
+        """
+        print(f'⚙️️️️ Pushing to remote')
+        origin = self.repo.remote(name="origin")
+        self.repo.git.push("--set-upstream", "--force", origin, self.repo.head.ref)
+
+    def create_pr(self, title: str, description: str):
+        print(f'⚙️️ Creating draft PR')
+        print(f'    → title: {title}')
+        print(f'    → description: {description}')
+        os.system(f'gh pr create --title "{title}" --body "{description}" --draft')

--- a/tools/license/check-license.sh
+++ b/tools/license/check-license.sh
@@ -17,6 +17,7 @@ function files {
 		-not -path "*Carthage/Build/*" \
 		-not -path "*Carthage/Checkouts/*" \
 		-not -path "./tools/rum-models-generator/rum-events-format/*" \
+		-not -path "*/tools/dogfooding/venv/*" \
 		-not -path "./instrumented-tests/DatadogSDKTesting.xcframework/*" \
 		-not -name "OTSpan.swift" \
 		-not -name "OTFormat.swift" \


### PR DESCRIPTION
### What and why?

🚚 This PR automates dogfooding of `dd-sdk-ios`.

With this setup, dogfooding can be started by any push to the `dogfooding` branch. Because `dogfooding` branch is _protected_, this means: by any PR merged to `dogfooding`, which gives us streamlined and simple workflow for starting, discussing and running dogfooding process.

### How?

The `make dogfood` command run on CI launches the `tools/dogfooding/dogfood.py` script, which:
* clones the dependant repository to temporary folder,
* starts a `dogfooding-<sha>` branch,
* updates the `Package.resolved` file with the last commit hash from `dd-sdk-ios/dogfooding`,
* commits and pushes the change to dependant repository,
* starts a draft PR in dependant repository to run its own automation.

I took the `dogfood.py` template from @xgouchet and updated it to the existing Bitrise setup and SPM dependency system. In particular, I switched from using [GH API](https://docs.github.com/en/rest) to [`gh` CLI](https://cli.github.com/manual/), which is already provisioned in our CI.

Last, I configured the `push_to_dogfooding` trigger on Bitrise:

<img width="1781" alt="Screenshot 2021-03-29 at 18 12 40" src="https://user-images.githubusercontent.com/2358722/112868224-1a094a80-90bc-11eb-8c20-f1b5f97a0d67.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
