### PR TITLE
RUMM-1222 Update to swiftlint `0.43.x`

### DIFF
--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -96,7 +96,7 @@ public class Datadog {
     /// If set, a debugging outline will be displayed on top of the application, describing the name of the active RUM View.
     /// May be used to debug issues with RUM instrumentation in your app.
     /// Default is `false`.
-    public static var debugRUM: Bool = false {
+    public static var debugRUM = false {
         didSet {
             (Global.rum as? RUMMonitor)?.enableRUMDebugging(debugRUM)
         }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -39,7 +39,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     /// Tells if this View is the active one.
     /// `true` for every new started View.
     /// `false` if the View was stopped or any other View was started.
-    private(set) var isActiveView: Bool = true
+    private(set) var isActiveView = true
     /// Tells if this scope has received the "start" command.
     /// If `didReceiveStartCommand == true` and another "start" command is received for this View this scope is marked as inactive.
     private var didReceiveStartCommand = false

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -1,6 +1,6 @@
 # Set of Swift Lint rules enforced for Swift code under `Sources/*` directory
 
-whitelist_rules: # we enable lint rules explicitly - only the ones listed below are active
+only_rules: # we enable lint rules explicitly - only the ones listed below are active
   - attributes
   - closing_brace
   - closure_end_indentation
@@ -90,12 +90,12 @@ custom_rules:
     severity: error
 
 included:
-  - Sources
-  - instrumented-tests/http-server-mock/Sources
-  - tools/api-surface/Sources
-  - tools/api-surface/Fixtures/Sources
-  - tools/rum-models-generator/Sources
-  - tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/Output # lint generation fixture
-  - dependency-manager-tests/carthage/CTProject
-  - dependency-manager-tests/cocoapods/CPProject
-  - dependency-manager-tests/spm/SPMProject
+  - ../../Sources
+  - ../../instrumented-tests/http-server-mock/Sources
+  - ../../tools/api-surface/Sources
+  - ../../tools/api-surface/Fixtures/Sources
+  - ../../tools/rum-models-generator/Sources
+  - ../../tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/Output # lint generation fixture
+  - ../../dependency-manager-tests/carthage/CTProject
+  - ../../dependency-manager-tests/cocoapods/CPProject
+  - ../../dependency-manager-tests/spm/SPMProject

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -1,6 +1,6 @@
 # Set of Swift Lint rules enforced for Swift code under `Tests/*` directory
 
-whitelist_rules: # we enable lint rules explicitly - only the ones listed below are active
+only_rules: # we enable lint rules explicitly - only the ones listed below are active
   - attributes
   - closing_brace
   - closure_end_indentation
@@ -75,13 +75,13 @@ custom_rules:
     severity: error
 
 included:
-  - Tests
-  - instrumented-tests/http-server-mock/Tests
-  - tools/api-surface/Tests
-  - tools/rum-models-generator/Tests
-  - dependency-manager-tests/carthage/CTProjectTests
-  - dependency-manager-tests/carthage/CTProjectUITests
-  - dependency-manager-tests/cocoapods/CTProjectTests
-  - dependency-manager-tests/cocoapods/CTProjectUITests
-  - dependency-manager-tests/spm/SPMProjectTests
-  - dependency-manager-tests/spm/SPMProjectUITests
+  - ../../Tests
+  - ../../instrumented-tests/http-server-mock/Tests
+  - ../../tools/api-surface/Tests
+  - ../../tools/rum-models-generator/Tests
+  - ../../dependency-manager-tests/carthage/CTProjectTests
+  - ../../dependency-manager-tests/carthage/CTProjectUITests
+  - ../../dependency-manager-tests/cocoapods/CTProjectTests
+  - ../../dependency-manager-tests/cocoapods/CTProjectUITests
+  - ../../dependency-manager-tests/spm/SPMProjectTests
+  - ../../dependency-manager-tests/spm/SPMProjectUITests


### PR DESCRIPTION
### What and why?

🐞 This PR updates `swiftlint` configuration to `0.43.x`.

### How?

According to [`0.43.x` release notes](https://github.com/realm/SwiftLint/releases/tag/0.43.0), all paths must be relative to the `.yml` location, not to the `swiftlint` invocation dir.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
