### PR TITLE
RUMM-1213 Allow additional configuration when initializing the SDK

### DIFF
--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -180,6 +180,7 @@ extension Datadog {
         private(set) var rumErrorEventMapper: RUMErrorEventMapper?
         private(set) var batchSize: BatchSize
         private(set) var uploadFrequency: UploadFrequency
+        private(set) var additionalConfiguration: [String: Any]
 
         /// The client token autorizing internal monitoring data to be sent to Datadog org.
         private(set) var internalMonitoringClientToken: String?
@@ -248,6 +249,7 @@ extension Datadog {
                     rumErrorEventMapper: nil,
                     batchSize: .medium,
                     uploadFrequency: .average,
+                    additionalConfiguration: [:],
                     internalMonitoringClientToken: nil
                 )
             }
@@ -560,6 +562,14 @@ extension Datadog {
             /// - Parameter uploadFrequency: `.average` by default.
             public func set(uploadFrequency: UploadFrequency) -> Builder {
                 configuration.uploadFrequency = uploadFrequency
+                return self
+            }
+
+            /// Sets additional configuration attributes.
+            /// This can be used to tweak internal features of the SDK.
+            /// - Parameter additionalConfiguration: `[:]` by default.
+            public func set(additionalConfiguration: [String: Any]) -> Builder {
+                configuration.additionalConfiguration = additionalConfiguration
                 return self
             }
 

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -278,6 +278,11 @@ public class DDConfigurationBuilder: NSObject {
     }
 
     @objc
+    public func set(additionalConfiguration: [String: Any]) {
+        _ = sdkBuilder.set(additionalConfiguration: castAttributesToSwift(additionalConfiguration))
+    }
+
+    @objc
     public func build() -> DDConfiguration {
         return DDConfiguration(sdkConfiguration: sdkBuilder.build())
     }

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -279,7 +279,7 @@ public class DDConfigurationBuilder: NSObject {
 
     @objc
     public func set(additionalConfiguration: [String: Any]) {
-        _ = sdkBuilder.set(additionalConfiguration: castAttributesToSwift(additionalConfiguration))
+        _ = sdkBuilder.set(additionalConfiguration: additionalConfiguration)
     }
 
     @objc

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -52,6 +52,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertNil(configuration.rumErrorEventMapper)
             XCTAssertEqual(configuration.batchSize, .medium)
             XCTAssertEqual(configuration.uploadFrequency, .average)
+            XCTAssertEqual(configuration.additionalConfiguration.count, 0)
         }
     }
 
@@ -83,6 +84,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .setRUMActionEventMapper { _ in mockRUMActionEvent }
                 .set(batchSize: .small)
                 .set(uploadFrequency: .frequent)
+                .set(additionalConfiguration: ["foo": 42, "bar": "something"])
 
             return builder
         }
@@ -125,6 +127,8 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.rumErrorEventMapper?(.mockRandom()), mockRUMErrorEvent)
             XCTAssertEqual(configuration.batchSize, .small)
             XCTAssertEqual(configuration.uploadFrequency, .frequent)
+            XCTAssertEqual(configuration.additionalConfiguration["foo"] as? Int, 42)
+            XCTAssertEqual(configuration.additionalConfiguration["bar"] as? String, "something")
         }
 
         XCTAssertTrue(rumConfigurationWithDefaultValues.rumUIKitViewsPredicate is DefaultUIKitRUMViewsPredicate)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -54,6 +54,7 @@ extension Datadog.Configuration {
         rumUIKitActionsTrackingEnabled: Bool = false,
         batchSize: BatchSize = .medium,
         uploadFrequency: UploadFrequency = .average,
+        additionalConfiguration: [String: Any] = [:],
         internalMonitoringClientToken: String? = nil
     ) -> Datadog.Configuration {
         return Datadog.Configuration(
@@ -78,6 +79,7 @@ extension Datadog.Configuration {
             rumUIKitActionsTrackingEnabled: rumUIKitActionsTrackingEnabled,
             batchSize: batchSize,
             uploadFrequency: uploadFrequency,
+            additionalConfiguration: additionalConfiguration,
             internalMonitoringClientToken: internalMonitoringClientToken
         )
     }

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -159,8 +159,8 @@ class DDConfigurationTests: XCTestCase {
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.uploadFrequency, .rare)
 
         objcBuilder.set(additionalConfiguration: ["foo": 42, "bar": "something"])
-        XCTAssertEqual((objcBuilder.build().sdkConfiguration.additionalConfiguration["foo"] as? AnyEncodable)?.value as? Int, 42)
-        XCTAssertEqual((objcBuilder.build().sdkConfiguration.additionalConfiguration["bar"]as? AnyEncodable)?.value as? String, "something")
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.additionalConfiguration["foo"] as? Int, 42)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.additionalConfiguration["bar"] as? String, "something")
     }
 
     func testScrubbingRUMEvents() {

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -63,6 +63,7 @@ class DDConfigurationTests: XCTestCase {
             XCTAssertNil(configuration.rumResourceEventMapper)
             XCTAssertNil(configuration.rumActionEventMapper)
             XCTAssertNil(configuration.rumErrorEventMapper)
+            XCTAssertEqual(configuration.additionalConfiguration.count, 0)
         }
     }
 
@@ -156,6 +157,10 @@ class DDConfigurationTests: XCTestCase {
 
         objcBuilder.set(uploadFrequency: .rare)
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.uploadFrequency, .rare)
+
+        objcBuilder.set(additionalConfiguration: ["foo": 42, "bar": "something"])
+        XCTAssertEqual((objcBuilder.build().sdkConfiguration.additionalConfiguration["foo"] as? AnyEncodable)?.value as? Int, 42)
+        XCTAssertEqual((objcBuilder.build().sdkConfiguration.additionalConfiguration["bar"]as? AnyEncodable)?.value as? String, "something")
     }
 
     func testScrubbingRUMEvents() {


### PR DESCRIPTION
### What and why?

Let customer set additional configuration as a Dictionary. This will be used to configure internal settings of the SDK
