### PR TITLE
RUMM-1229 δ Collect internal telemetry for Crash Reporting while dogfooding

### DIFF
--- a/Sources/Datadog/Core/Persistence/Files/Directory.swift
+++ b/Sources/Datadog/Core/Persistence/Files/Directory.swift
@@ -28,10 +28,16 @@ internal struct Directory {
         return File(url: fileURL)
     }
 
-    /// Returns file with given name.
+    /// Checks if a file with given `fileName` exists in this directory.
+    func hasFile(named fileName: String) -> Bool {
+        let fileURL = url.appendingPathComponent(fileName, isDirectory: false)
+        return FileManager.default.fileExists(atPath: fileURL.path)
+    }
+
+    /// Returns file with given name or throws an error if file does not exist.
     func file(named fileName: String) throws -> File {
         let fileURL = url.appendingPathComponent(fileName, isDirectory: false)
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        guard hasFile(named: fileName) else {
             throw InternalError(description: "File does not exist at path: \(fileURL.path)")
         }
         return File(url: fileURL)

--- a/Sources/Datadog/Core/Persistence/FilesOrchestrator.swift
+++ b/Sources/Datadog/Core/Persistence/FilesOrchestrator.swift
@@ -61,6 +61,10 @@ internal class FilesOrchestrator {
 
     private func reuseLastWritableFileIfPossible(writeSize: UInt64) -> WritableFile? {
         if let lastFileName = lastWritableFileName {
+            if !directory.hasFile(named: lastFileName) {
+                return nil // this is expected if the last writable file was deleted after upload
+            }
+
             do {
                 let lastFile = try directory.file(named: lastFileName)
                 let lastFileCreationDate = fileCreationDateFrom(fileName: lastFile.name)
@@ -74,7 +78,7 @@ internal class FilesOrchestrator {
                     return lastFile
                 }
             } catch {
-                internalMonitor?.sdkLogger.warn("Failed to read previously used writable file", error: error)
+                internalMonitor?.sdkLogger.warn("Failed to reuse last writable file", error: error)
             }
         }
 

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -90,6 +90,11 @@ internal class CrashReporter {
                     return false
                 }
 
+#if DD_SDK_ENABLE_INTERNAL_MONITORING
+                InternalMonitoringFeature.instance?.monitor.sdkLogger
+                    .debug("Loaded pending crash report", attributes: availableCrashReport.diagnosticInfo)
+#endif
+
                 guard let crashContext = availableCrashReport.context.flatMap({ self.decode(crashContextData: $0) }) else {
                     // `CrashContext` is malformed and and cannot be read. Return `true` to let the crash reporter
                     // purge this crash report as we are not able to process it respectively.
@@ -132,6 +137,8 @@ internal class CrashReporter {
                 Error details: \(error)
                 """
             )
+            InternalMonitoringFeature.instance?.monitor.sdkLogger
+                .error("Failed to encode crash report context", error: error)
             return nil
         }
     }
@@ -148,6 +155,8 @@ internal class CrashReporter {
                 Error details: \(error)
                 """
             )
+            InternalMonitoringFeature.instance?.monitor.sdkLogger
+                .error("Failed to decode crash report context", error: error)
             return nil
         }
     }

--- a/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
+++ b/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
@@ -20,6 +20,13 @@ public class DDCrashReport: NSObject {
     /// The last context injected through `inject(context:)`
     internal let context: Data?
 
+#if DD_SDK_ENABLE_INTERNAL_MONITORING
+    /// Additional diagnositc information about the crash report, collected for `DatadogCrashReporting` observability.
+    /// Available only if internal monitoring is enabled, disabled by default.
+    /// See: `Datadog.Configuration.Builder.enableInternalMonitoring(clientToken:)`.
+    public var diagnosticInfo: [String: Encodable] = [:]
+#endif
+
     public init(
         date: Date?,
         type: String,

--- a/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
+++ b/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
@@ -21,7 +21,7 @@ public class DDCrashReport: NSObject {
     internal let context: Data?
 
 #if DD_SDK_ENABLE_INTERNAL_MONITORING
-    /// Additional diagnositc information about the crash report, collected for `DatadogCrashReporting` observability.
+    /// Additional diagnostic information about the crash report, collected for `DatadogCrashReporting` observability.
     /// Available only if internal monitoring is enabled, disabled by default.
     /// See: `Datadog.Configuration.Builder.enableInternalMonitoring(clientToken:)`.
     public var diagnosticInfo: [String: Encodable] = [:]

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -54,6 +54,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         }
 
         guard let lastRUMViewEvent = crashContext.lastRUMViewEvent else {
+            InternalMonitoringFeature.instance?.monitor.sdkLogger.error("Attempt to send crash report through RUM integration, but last `RUMViewEvent` is missing")
             return // This integration requires crash report with associated `RUMViewEvent`
         }
 

--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -31,7 +31,13 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
     func loadPendingCrashReport() throws -> DDCrashReport {
         let crashReportData = try crashReporter.loadPendingCrashReportDataAndReturnError()
         let crashReport = try PLCrashReport(data: crashReportData)
-        return formatter.ddCrashReport(from: crashReport)
+        let ddCrashReport = formatter.ddCrashReport(from: crashReport)
+#if DD_SDK_ENABLE_INTERNAL_MONITORING
+        ddCrashReport.diagnosticInfo = [
+            "diagnostic-info": PLCrashReportDiagnosticInfo(crashReport)
+        ]
+#endif
+        return ddCrashReport
     }
 
     func inject(context: Data) {
@@ -42,3 +48,53 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
         try crashReporter.purgePendingCrashReportAndReturnError()
     }
 }
+
+#if DD_SDK_ENABLE_INTERNAL_MONITORING
+/// Diagnositc information about the crash report, collected for `DatadogCrashReporting` observability.
+/// Available only if internal monitoring is enabled, disabled by default.
+/// See: `Datadog.Configuration.Builder.enableInternalMonitoring(clientToken:)`.
+private struct PLCrashReportDiagnosticInfo: Encodable {
+    private let numberOfImages: Int
+    private let numberOfSystemImages: Int
+    private let numberOfUserImages: Int
+    private let hasCrashDate: Bool
+    private let numberOfThreads: Int
+    private let numberOfStackFramesPerThread: [String: Int]
+    private let numberOfStackFramesInCrashedThread: Int
+
+    init(_ crashReport: PLCrashReport) {
+        let images = crashReport.images?.compactMap { $0 as? PLCrashReportBinaryImageInfo }
+        self.numberOfImages = images?.count ?? -1
+
+        var userImagesCount = 0
+        var systemImagesCount = 0
+        images?.forEach { image in
+            if (image.imageName ?? "").hasPrefix("/private/var") {
+                // e.g. `/private/var/containers/Bundle/Application/<UUID>/Example.app/Frameworks/<F>.framework/<F>`
+                userImagesCount += 1
+            } else {
+                // e.g. `/usr/lib/libobjc-trampolines.dylib` or `/System/Library/PrivateFrameworks/AssertionServices.framework/AssertionServices`
+                systemImagesCount += 1
+            }
+        }
+        self.numberOfUserImages = userImagesCount
+        self.numberOfSystemImages = systemImagesCount
+
+        self.hasCrashDate = crashReport.timestamp != nil
+
+        let threads = crashReport.threads?.compactMap { $0 as? PLCrashReportThreadInfo }
+        self.numberOfThreads = threads?.count ?? -1
+
+        var numberOfStackFramesInCrashedThread = -1
+        var stackFramesByThread: [String: Int] = [:]
+        threads?.forEach { thread in
+            stackFramesByThread["thread-\(thread.threadNumber)"] = thread.stackFrames?.count ?? -1
+            if thread.crashed {
+                numberOfStackFramesInCrashedThread = thread.stackFrames?.count ?? -1
+            }
+        }
+        self.numberOfStackFramesPerThread = stackFramesByThread
+        self.numberOfStackFramesInCrashedThread = numberOfStackFramesInCrashedThread
+    }
+}
+#endif

--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -50,7 +50,7 @@ internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
 }
 
 #if DD_SDK_ENABLE_INTERNAL_MONITORING
-/// Diagnositc information about the crash report, collected for `DatadogCrashReporting` observability.
+/// Diagnostic information about the crash report, collected for `DatadogCrashReporting` observability.
 /// Available only if internal monitoring is enabled, disabled by default.
 /// See: `Datadog.Configuration.Builder.enableInternalMonitoring(clientToken:)`.
 private struct PLCrashReportDiagnosticInfo: Encodable {

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Files/DirectoryTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Files/DirectoryTests.swift
@@ -53,14 +53,37 @@ class DirectoryTests: XCTestCase {
         XCTAssertTrue(fileManager.fileExists(atPath: file.url.path))
     }
 
-    func testItRetrievesFile() throws {
+    func testItChecksIfFileExists() throws {
         let directory = try Directory(withSubdirectoryPath: uniqueSubdirectoryName())
         defer { directory.delete() }
+
+        XCTAssertFalse(directory.hasFile(named: "foo"))
+        _ = try directory.createFile(named: "foo")
+        XCTAssertTrue(directory.hasFile(named: "foo"))
+    }
+
+    func testWhenFileExists_ItCanBeRetrieved() throws {
+        let directory = try Directory(withSubdirectoryPath: uniqueSubdirectoryName())
+        defer { directory.delete() }
+
+        // When
         _ = try directory.createFile(named: "abcd")
 
+        // Then
         let file = try directory.file(named: "abcd")
         XCTAssertEqual(file.url, directory.url.appendingPathComponent("abcd"))
         XCTAssertTrue(fileManager.fileExists(atPath: file.url.path))
+    }
+
+    func testWhenFileDoesNotExist_ItThrowsErrorWhenRetrieving() throws {
+        let directory = try Directory(withSubdirectoryPath: uniqueSubdirectoryName())
+        defer { directory.delete() }
+
+        // When
+        XCTAssertFalse(directory.hasFile(named: "foo"))
+
+        // Then
+        XCTAssertThrowsError(try directory.file(named: "foo"))
     }
 
     func testItRetrievesAllFiles() throws {


### PR DESCRIPTION
### What and why?

📦 This PR improves internal monitoring data send to Datadog while dogfooding.

### How?

There are two things improved:
* **Got rid of _"Failed to read previously used writable file"_ false-positive warning.** It was reported each time when the last writable file is accessed after successful upload - in such case the file is missing (as it's deleted by the upload worker) which is expected behaviour and should not be reported as warning.

<img width="644" alt="Screenshot 2021-03-31 at 13 58 38" src="https://user-images.githubusercontent.com/2358722/113140926-57d7b180-9229-11eb-9448-e66200f26482.png">

* **Collect Crash Reports telemetry for further analysis.** I've added some error logs in crash reporting feature and included `DEBUG` logs for shipping useful diagnostic info about the crash reports:

<img width="358" alt="Screenshot 2021-03-31 at 13 56 48" src="https://user-images.githubusercontent.com/2358722/113141296-d2083600-9229-11eb-8b49-67d11f0ec5c6.png">



### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
