### PR TITLE
RUMM-1229 δ Enable crash reporting telemetry in dogfooding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,9 @@ let package = Package(
             name: "DatadogObjc",
             dependencies: [
                 "Datadog",
+            ],
+            swiftSettings: [
+                .define("DD_SDK_ENABLE_INTERNAL_MONITORING"),
             ]
         ),
         .target(
@@ -68,6 +71,9 @@ let package = Package(
             dependencies: [
                 "Datadog",
                 .product(name: "CrashReporter", package: "PLCrashReporter"),
+            ],
+            swiftSettings: [
+                .define("DD_SDK_ENABLE_INTERNAL_MONITORING"),
             ]
         )
     ]


### PR DESCRIPTION
### What and why?

⚙️ This PR ships an improvement to our dogfooding system. This will expose internal monitoring APIs to crash reporting module, which will be leveraged when dogfooding #457.

### How?

By compiling the `DatadogCrashReporting` module with `DD_SDK_ENABLE_INTERNAL_MONITORING`, we expose particular APIs invented for the internal monitoring feature.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
