### PR TITLE
RUMM-1038 add option to customize the `source` tag

### DIFF
--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -18,6 +18,7 @@ internal struct FeaturesConfiguration {
         let serviceName: String
         let environment: String
         let performance: PerformancePreset
+        let source: String
     }
 
     struct Logging {
@@ -110,6 +111,8 @@ extension FeaturesConfiguration {
         var tracesEndpoint = configuration.tracesEndpoint
         var rumEndpoint = configuration.rumEndpoint
 
+        let source = (configuration.additionalConfiguration["_dd.source"] as? String) ?? Datadog.Constants.ddsource
+
         if let datadogEndpoint = configuration.datadogEndpoint {
             // If `.set(endpoint:)` API was used, it should override the values
             // set by deprecated `.set(<feature>Endpoint:)` APIs.
@@ -143,7 +146,8 @@ extension FeaturesConfiguration {
                 batchSize: configuration.batchSize,
                 uploadFrequency: configuration.uploadFrequency,
                 bundleType: appContext.bundleType
-            )
+            ),
+            source: source
         )
 
         if configuration.loggingEnabled {

--- a/Sources/Datadog/Core/Upload/DataUploader.swift
+++ b/Sources/Datadog/Core/Upload/DataUploader.swift
@@ -15,8 +15,8 @@ internal class UploadURLProvider {
         let value: () -> URLQueryItem
 
         /// Creates `ddsource=ios` query item.
-        static func ddsource() -> QueryItemProvider {
-            let queryItem = URLQueryItem(name: "ddsource", value: Datadog.Constants.ddsource)
+        static func ddsource(source: String) -> QueryItemProvider {
+            let queryItem = URLQueryItem(name: "ddsource", value: source)
             return QueryItemProvider { queryItem }
         }
 

--- a/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
+++ b/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
@@ -79,7 +79,7 @@ internal final class InternalMonitoringFeature {
             uploadURLProvider: UploadURLProvider(
                 urlWithClientToken: configuration.logsUploadURLWithClientToken,
                 queryItemProviders: [
-                    .ddsource()
+                    .ddsource(source: configuration.common.source)
                 ]
             ),
             commonDependencies: commonDependencies,

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -85,7 +85,7 @@ internal final class LoggingFeature {
             uploadURLProvider: UploadURLProvider(
                 urlWithClientToken: configuration.uploadURLWithClientToken,
                 queryItemProviders: [
-                    .ddsource()
+                    .ddsource(source: configuration.common.source)
                 ]
             ),
             commonDependencies: commonDependencies,

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -89,7 +89,7 @@ internal final class RUMFeature {
             uploadURLProvider: UploadURLProvider(
                 urlWithClientToken: configuration.uploadURLWithClientToken,
                 queryItemProviders: [
-                    .ddsource(),
+                    .ddsource(source: configuration.common.source),
                     .ddtags(
                         tags: [
                             "service:\(configuration.common.serviceName)",

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -106,7 +106,8 @@ public class Tracer: OTTracer {
                 userInfoProvider: tracingFeature.userInfoProvider,
                 networkConnectionInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.networkConnectionInfoProvider : nil,
                 carrierInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.carrierInfoProvider : nil,
-                dateCorrector: tracingFeature.dateCorrector
+                dateCorrector: tracingFeature.dateCorrector,
+                source: tracingFeature.configuration.common.source
             ),
             spanOutput: SpanFileOutput(
                 fileWriter: tracingFeature.storage.writer,

--- a/Sources/Datadog/Tracing/Span/SpanBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanBuilder.swift
@@ -20,6 +20,8 @@ internal struct SpanBuilder {
     let carrierInfoProvider: CarrierInfoProviderType?
     /// Adjusts span's time (device time) to server time.
     let dateCorrector: DateCorrectorType
+    /// source tag to encode in span.
+    let source: String
 
     /// Encodes tag `Span` tag values as JSON string
     private let tagsJSONEncoder: JSONEncoder = .default()
@@ -58,6 +60,7 @@ internal struct SpanBuilder {
             startTime: dateCorrector.currentCorrection.applying(to: ddspan.startTime),
             duration: finishTime.timeIntervalSince(ddspan.startTime),
             isError: tagsReducer.extractedIsError ?? false,
+            source: source,
             tracerVersion: sdkVersion,
             applicationVersion: applicationVersion,
             networkConnectionInfo: networkConnectionInfoProvider?.current,

--- a/Sources/Datadog/Tracing/Span/SpanEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEncoder.swift
@@ -41,6 +41,7 @@ internal struct Span: Encodable {
     let startTime: Date
     let duration: TimeInterval
     let isError: Bool
+    let source: String
 
     // MARK: - Meta
 
@@ -159,7 +160,7 @@ internal struct SpanEncoder {
     /// Encodes default `meta.*` attributes
     private func encodeDefaultMeta(_ span: Span, to container: inout KeyedEncodingContainer<StaticCodingKeys>) throws {
         // NOTE: RUMM-299 only string values are supported for `meta.*` attributes
-        try container.encode(Datadog.Constants.ddsource, forKey: .source)
+        try container.encode(span.source, forKey: .source)
         try container.encode(span.tracerVersion, forKey: .tracerVersion)
         try container.encode(span.applicationVersion, forKey: .applicationVersion)
 

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -87,6 +87,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
             startTime: Date(),
             duration: Double.random(in: 0.0..<1.0),
             isError: false,
+            source: "ios",
             tracerVersion: "0.0.0",
             applicationVersion: "0.0.0",
             networkConnectionInfo: NetworkConnectionInfo(

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -9,10 +9,10 @@ import XCTest
 
 class DataUploadURLProviderTests: XCTestCase {
     func testDDSourceQueryItem() {
-        let item: UploadURLProvider.QueryItemProvider = .ddsource()
+        let item: UploadURLProvider.QueryItemProvider = .ddsource(source: "abc")
 
         XCTAssertEqual(item.value().name, "ddsource")
-        XCTAssertEqual(item.value().value, "ios")
+        XCTAssertEqual(item.value().value, "abc")
     }
 
     func testItBuildsValidURLUsingNoQueryItems() throws {
@@ -27,11 +27,11 @@ class DataUploadURLProviderTests: XCTestCase {
     func testItBuildsValidURLUsingAllQueryItems() throws {
         let urlProvider = UploadURLProvider(
             urlWithClientToken: URL(string: "https://api.example.com/v1/endpoint/abc")!,
-            queryItemProviders: [.ddsource(), .ddtags(tags: ["abc:def"])]
+            queryItemProviders: [.ddsource(source: "abc"), .ddtags(tags: ["abc:def"])]
         )
 
-        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=ios&ddtags=abc:def"))
-        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=ios&ddtags=abc:def"))
+        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=abc&ddtags=abc:def"))
+        XCTAssertEqual(urlProvider.url, URL(string: "https://api.example.com/v1/endpoint/abc?ddsource=abc&ddtags=abc:def"))
     }
 
     func testItEscapesWhitespacesInQueryItems() throws {

--- a/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
@@ -31,7 +31,8 @@ class InternalMonitoringFeatureTests: XCTestCase {
             configuration: .mockWith(
                 common: .mockWith(
                     applicationName: "FoobarApp",
-                    applicationVersion: "2.1.0"
+                    applicationVersion: "2.1.0",
+                    source: "abc"
                 )
             ),
             dependencies: .mockWith(
@@ -45,7 +46,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
 
         let request = server.waitAndReturnRequests(count: 1)[0]
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(request.url?.query, "ddsource=ios")
+        XCTAssertEqual(request.url?.query, "ddsource=abc")
         XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], "FoobarApp/2.1.0 CFNetwork (iPhone; iOS/13.3.1)")
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
     }

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -31,7 +31,8 @@ class LoggingFeatureTests: XCTestCase {
             configuration: .mockWith(
                 common: .mockWith(
                     applicationName: "FoobarApp",
-                    applicationVersion: "2.1.0"
+                    applicationVersion: "2.1.0",
+                    source: "abc"
                 )
             ),
             dependencies: .mockWith(
@@ -45,7 +46,7 @@ class LoggingFeatureTests: XCTestCase {
 
         let request = server.waitAndReturnRequests(count: 1)[0]
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(request.url?.query, "ddsource=ios")
+        XCTAssertEqual(request.url?.query, "ddsource=abc")
         XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], "FoobarApp/2.1.0 CFNetwork (iPhone; iOS/13.3.1)")
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
     }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -166,7 +166,8 @@ extension FeaturesConfiguration.Common {
         applicationBundleIdentifier: String = .mockAny(),
         serviceName: String = .mockAny(),
         environment: String = .mockAny(),
-        performance: PerformancePreset = .init(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp)
+        performance: PerformancePreset = .init(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
+        source: String = .mockAny()
     ) -> Self {
         return .init(
             applicationName: applicationName,
@@ -174,7 +175,8 @@ extension FeaturesConfiguration.Common {
             applicationBundleIdentifier: applicationBundleIdentifier,
             serviceName: serviceName,
             environment: environment,
-            performance: performance
+            performance: performance,
+            source: source
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -175,6 +175,7 @@ extension Span {
         startTime: Date = .mockAny(),
         duration: TimeInterval = .mockAny(),
         isError: Bool = .mockAny(),
+        source: String = .mockAny(),
         tracerVersion: String = .mockAny(),
         applicationVersion: String = .mockAny(),
         networkConnectionInfo: NetworkConnectionInfo? = .mockAny(),
@@ -192,6 +193,7 @@ extension Span {
             startTime: startTime,
             duration: duration,
             isError: isError,
+            source: source,
             tracerVersion: tracerVersion,
             applicationVersion: applicationVersion,
             networkConnectionInfo: networkConnectionInfo,
@@ -262,7 +264,8 @@ extension SpanBuilder {
         userInfoProvider: UserInfoProvider = .mockAny(),
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockAny(),
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny(),
-        dateCorrector: DateCorrectorType = DateCorrectorMock()
+        dateCorrector: DateCorrectorType = DateCorrectorMock(),
+        source: String = .mockAny()
     ) -> SpanBuilder {
         return SpanBuilder(
             applicationVersion: applicationVersion,
@@ -270,7 +273,8 @@ extension SpanBuilder {
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider,
-            dateCorrector: dateCorrector
+            dateCorrector: dateCorrector,
+            source: source
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -33,7 +33,8 @@ class RUMFeatureTests: XCTestCase {
                     applicationName: "FoobarApp",
                     applicationVersion: "2.1.0",
                     serviceName: "service-name",
-                    environment: "environment-name"
+                    environment: "environment-name",
+                    source: "abc"
                 )
             ),
             dependencies: .mockWith(
@@ -52,7 +53,7 @@ class RUMFeatureTests: XCTestCase {
         XCTAssertEqual(
             request.url?.query,
             """
-            ddsource=ios&ddtags=service:service-name,version:2.1.0,sdk_version:\(sdkVersion),env:environment-name
+            ddsource=abc&ddtags=service:service-name,version:2.1.0,sdk_version:\(sdkVersion),env:environment-name
             """
         )
         XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], "FoobarApp/2.1.0 CFNetwork (iPhone; iOS/13.3.1)")

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -33,7 +33,8 @@ class TracerTests: XCTestCase {
                     applicationVersion: "1.0.0",
                     applicationBundleIdentifier: "com.datadoghq.ios-sdk",
                     serviceName: "default-service-name",
-                    environment: "custom"
+                    environment: "custom",
+                    source: "abc"
                 )
             ),
             dependencies: .mockWith(
@@ -65,7 +66,7 @@ class TracerTests: XCTestCase {
               "type": "custom",
               "meta.tracer.version": "\(sdkVersion)",
               "meta.version": "1.0.0",
-              "meta._dd.source": "ios",
+              "meta._dd.source": "abc",
               "metrics._top_level": 1,
               "metrics._sampling_priority_v1": 1
             }


### PR DESCRIPTION
### What and why?

This is based on #456 , and let all feature use a customized `source` tag instead of the default value (`ios`).

### How?

We read the `_dd.source` tag from the `additionalConfiguration` dictionary and inject it:
 - in the `ddsource()` method when uploading log-based batches (Logs, RUM, InternalLogs)
 - in the `SpanBuilder` class when converting `DDSpan` to `Span` before the encoding step (APM)