### PR TITLE
RUMM-1234 DDNSURLSessionDelegate build errors fixed

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9E989A4225F640D100235FC3 /* AppStateListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E989A4125F640D100235FC3 /* AppStateListenerTests.swift */; };
 		9ED6A6B425F2901800CB2E29 /* AppStateListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */; };
+		9EE5AD8226205B82001E699E /* DDNSURLSessionDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE5AD8126205B82001E699E /* DDNSURLSessionDelegateTests.swift */; };
 		9EEA4871258B76A100EBDA9D /* Global+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEA4870258B76A100EBDA9D /* Global+objc.swift */; };
 		9EF963E82537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EF963E72537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift */; };
 		9EFD112C24B32D29003A1A2B /* FirstPartyURLsFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EFD112B24B32D29003A1A2B /* FirstPartyURLsFilter.swift */; };
@@ -971,6 +972,7 @@
 		9E989A4125F640D100235FC3 /* AppStateListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateListenerTests.swift; sourceTree = "<group>"; };
 		9E9EB37624468CE90002C80B /* Datadog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Datadog.modulemap; sourceTree = "<group>"; };
 		9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateListener.swift; sourceTree = "<group>"; };
+		9EE5AD8126205B82001E699E /* DDNSURLSessionDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNSURLSessionDelegateTests.swift; sourceTree = "<group>"; };
 		9EEA4870258B76A100EBDA9D /* Global+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Global+objc.swift"; sourceTree = "<group>"; };
 		9EF49F1624476FBD004F2CA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9EF49F17244770AD004F2CA0 /* DatadogIntegrationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogIntegrationTests.xcconfig; sourceTree = "<group>"; };
@@ -1386,6 +1388,7 @@
 				615A4A8824A34FD700233986 /* DDTracerTests.swift */,
 				615A4A8624A3452800233986 /* DDTracerConfigurationTests.swift */,
 				616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */,
+				9EE5AD8126205B82001E699E /* DDNSURLSessionDelegateTests.swift */,
 			);
 			path = DatadogObjc;
 			sourceTree = "<group>";
@@ -3443,6 +3446,7 @@
 				61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */,
 				61133C542423990D00786299 /* NetworkConnectionInfoProviderTests.swift in Sources */,
 				616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */,
+				9EE5AD8226205B82001E699E /* DDNSURLSessionDelegateTests.swift in Sources */,
 				6182374325D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift in Sources */,
 				61B558CF2469561C001460D3 /* LoggerBuilderTests.swift in Sources */,
 				61133C4A2423990D00786299 /* DDConfigurationTests.swift in Sources */,

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -6,15 +6,14 @@
 
 import Foundation
 
-/// In case that you are not able to use `DDURLSessionDelegate` or its subclasses in your `URLSession` instance,
-/// you can use `DDURLSessionDelegateProviding` protocol.
-/// Implement this protocol in your `URLSessionDelegate` class and forward required API calls to `DDURLSessionDelegate`.
+/// An interface for forwarding `URLSessionDelegate` calls to `DDURLSessionDelegate`.
+/// The implementation must ensure that required methods are called on the `ddURLSessionDelegate`.
 @objc
-public protocol URLSessionDelegateProviding: URLSessionDelegate {
+public protocol __URLSessionDelegateProviding: URLSessionDelegate {
     /// Datadog delegate object.
     /// The class implementing `DDURLSessionDelegateProviding` must ensure that following method calls are forwarded to `ddURLSessionDelegate`:
     // - `func urlSession(_:task:didFinishCollecting:)`
-    // - `func urlSession(_:task: didCompleteWithError:)`
+    // - `func urlSession(_:task:didCompleteWithError:)`
     var ddURLSessionDelegate: DDURLSessionDelegate { get }
 }
 
@@ -23,7 +22,7 @@ public protocol URLSessionDelegateProviding: URLSessionDelegate {
 ///
 /// All requests made with the `URLSession` instrumented with this delegate will be intercepted by the SDK.
 @objc
-open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDelegateProviding {
+open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, __URLSessionDelegateProviding {
     public var ddURLSessionDelegate: DDURLSessionDelegate {
         return self
     }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -6,12 +6,28 @@
 
 import Foundation
 
+/// In case that you are not able to use `DDURLSessionDelegate` or its subclasses in your `URLSession` instance,
+/// you can use `DDURLSessionDelegateProviding` protocol.
+/// Implement this protocol in your `URLSessionDelegate` class and forward required API calls to `DDURLSessionDelegate`.
+@objc
+public protocol URLSessionDelegateProviding: URLSessionDelegate {
+    /// Datadog delegate object.
+    /// The class implementing `DDURLSessionDelegateProviding` must ensure that following method calls are forwarded to `ddURLSessionDelegate`:
+    // - `func urlSession(_:task:didFinishCollecting:)`
+    // - `func urlSession(_:task: didCompleteWithError:)`
+    var ddURLSessionDelegate: DDURLSessionDelegate { get }
+}
+
 /// The `URLSession` delegate object which enables network requests instrumentation. **It must be
 /// used together with** `Datadog.Configuration.trackURLSession(firstPartyHosts:)`.
 ///
 /// All requests made with the `URLSession` instrumented with this delegate will be intercepted by the SDK.
 @objc
-open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate {
+open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDelegateProviding {
+    public var ddURLSessionDelegate: DDURLSessionDelegate {
+        return self
+    }
+
     var interceptor: URLSessionInterceptorType?
     let firstPartyURLsFilter: FirstPartyURLsFilter?
 

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
@@ -70,7 +70,7 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URLRequest, CompletionHandler?) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, urlRequest, completionHandler -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
+                    guard let interceptor = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
                         return previousImplementation(session, Self.selector, urlRequest, completionHandler)
                     }
                     let task: URLSessionDataTask
@@ -129,7 +129,7 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URL, CompletionHandler?) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, url, completionHandler -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
+                    guard let interceptor = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
                         return previousImplementation(session, Self.selector, url, completionHandler)
                     }
                     let task: URLSessionDataTask
@@ -183,7 +183,7 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URLRequest) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, urlRequest -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
+                    guard let interceptor = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
                         return previousImplementation(session, Self.selector, urlRequest)
                     }
                     let newRequest = interceptor.modify(request: urlRequest, session: session)
@@ -227,7 +227,7 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URL) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, url -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
+                    guard let interceptor = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
                         return previousImplementation(session, Self.selector, url)
                     }
                     let task = previousImplementation(session, Self.selector, url)

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
@@ -70,7 +70,7 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URLRequest, CompletionHandler?) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, urlRequest, completionHandler -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? DDURLSessionDelegate)?.interceptor else {
+                    guard let interceptor = (session.delegate as? URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
                         return previousImplementation(session, Self.selector, urlRequest, completionHandler)
                     }
                     let task: URLSessionDataTask
@@ -129,7 +129,7 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URL, CompletionHandler?) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, url, completionHandler -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? DDURLSessionDelegate)?.interceptor else {
+                    guard let interceptor = (session.delegate as? URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
                         return previousImplementation(session, Self.selector, url, completionHandler)
                     }
                     let task: URLSessionDataTask
@@ -183,7 +183,7 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URLRequest) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, urlRequest -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? DDURLSessionDelegate)?.interceptor else {
+                    guard let interceptor = (session.delegate as? URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
                         return previousImplementation(session, Self.selector, urlRequest)
                     }
                     let newRequest = interceptor.modify(request: urlRequest, session: session)
@@ -227,7 +227,7 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URL) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, url -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? DDURLSessionDelegate)?.interceptor else {
+                    guard let interceptor = (session.delegate as? URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
                         return previousImplementation(session, Self.selector, url)
                     }
                     let task = previousImplementation(session, Self.selector, url)

--- a/Sources/DatadogObjc/DDURLSessionDelegate+objc.swift
+++ b/Sources/DatadogObjc/DDURLSessionDelegate+objc.swift
@@ -8,4 +8,27 @@ import Foundation
 import Datadog
 
 @objc
-public class DDNSURLSessionDelegate: DDURLSessionDelegate {}
+open class DDNSURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDelegateProviding {
+    let swiftDelegate: DDURLSessionDelegate
+    public var ddURLSessionDelegate: DDURLSessionDelegate {
+        return swiftDelegate
+    }
+
+    @objc
+    override public init() {
+        swiftDelegate = DDURLSessionDelegate()
+    }
+
+    @objc
+    public init(additionalFirstPartyHosts: Set<String>) {
+        swiftDelegate = DDURLSessionDelegate(additionalFirstPartyHosts: additionalFirstPartyHosts)
+    }
+
+    open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        swiftDelegate.urlSession(session, task: task, didCompleteWithError: error)
+    }
+
+    open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        swiftDelegate.urlSession(session, task: task, didFinishCollecting: metrics)
+    }
+}

--- a/Sources/DatadogObjc/DDURLSessionDelegate+objc.swift
+++ b/Sources/DatadogObjc/DDURLSessionDelegate+objc.swift
@@ -8,8 +8,8 @@ import Foundation
 import Datadog
 
 @objc
-open class DDNSURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDelegateProviding {
-    let swiftDelegate: DDURLSessionDelegate
+open class DDNSURLSessionDelegate: NSObject, URLSessionTaskDelegate, __URLSessionDelegateProviding {
+    var swiftDelegate: DDURLSessionDelegate
     public var ddURLSessionDelegate: DDURLSessionDelegate {
         return swiftDelegate
     }

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -360,6 +360,10 @@ extension URLSession {
 }
 
 extension URLSessionTask {
+    static func mockAny() -> URLSessionTask {
+        return URLSessionTaskMock(request: .mockAny(), response: .mockAny())
+    }
+
     static func mockWith(request: URLRequest, response: HTTPURLResponse) -> URLSessionTask {
         return URLSessionTaskMock(request: request, response: response)
     }

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateAsSuperclassTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateAsSuperclassTests.swift
@@ -6,6 +6,18 @@
 
 import XCTest
 import Datadog
+import DatadogObjc
+
+@objc
+public class SubDDNSURLSessionDelegate: DDNSURLSessionDelegate {
+    override public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        super.urlSession(session, task: task, didCompleteWithError: error)
+    }
+
+    override public func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        super.urlSession(session, task: task, didFinishCollecting: metrics)
+    }
+}
 
 internal final class SubDDURLSessionDelegate: DDURLSessionDelegate {
     let property: String

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateAsSuperclassTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateAsSuperclassTests.swift
@@ -34,5 +34,6 @@ class DDURLSessionDelegateAsSuperclassTests: XCTestCase {
     func testSubclassability() {
         // Success: tests compile, failure: compilation error
         _ = SubDDURLSessionDelegate()
+        _ = SubDDNSURLSessionDelegate()
     }
 }

--- a/Tests/DatadogTests/DatadogObjc/DDNSURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDNSURLSessionDelegateTests.swift
@@ -1,0 +1,46 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+@testable import DatadogObjc
+
+private class DDURLSessionDelegateMock: DDURLSessionDelegate {
+    var calledDidFinishCollecting = false
+    var calledDidCompleteWithError = false
+
+    override func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        calledDidFinishCollecting = true
+    }
+
+    override func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        calledDidCompleteWithError = true
+    }
+}
+
+class DDNSURLSessionDelegateTests: XCTestCase {
+    func testInit() {
+        let delegate = DDNSURLSessionDelegate()
+        XCTAssertNil(delegate.swiftDelegate.firstPartyURLsFilter)
+    }
+
+    func testInitWithAdditionalFirstPartyHosts() {
+        let delegate = DDNSURLSessionDelegate(additionalFirstPartyHosts: ["foo.com"])
+        XCTAssertNotNil(delegate.swiftDelegate.firstPartyURLsFilter)
+    }
+
+    func testItForwardsCallsToSwiftDelegate() {
+        let swiftDelegate = DDURLSessionDelegateMock()
+        let objcDelegate = DDNSURLSessionDelegate()
+        objcDelegate.swiftDelegate = swiftDelegate
+
+        objcDelegate.urlSession(.shared, task: .mockAny(), didFinishCollecting: .mockAny())
+        objcDelegate.urlSession(.shared, task: .mockAny(), didCompleteWithError: ErrorMock())
+
+        XCTAssertTrue(swiftDelegate.calledDidFinishCollecting)
+        XCTAssertTrue(swiftDelegate.calledDidCompleteWithError)
+    }
+}


### PR DESCRIPTION
### What and why?

In order to ship standalone binaries of the SDK, we need to build our targets with `BUILD_LIBRARY_FOR_DISTRIBUTION` build flag. 
Yet, `@objc open DDNSURLSessionDelegate: DDURLSessionDelegate` line was giving compiler errors: 
either we needed to remove `@objc` or superclass `DDURLSessionDelegate`

### How?

In this PR, we removed superclass of `DDNSURLSessionDelegate` and needed to make some other changes to make auto-network-tracing work.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
