### PR TITLE
RUMM-1087 Standalone binary distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,10 @@ ship:
 		pod spec lint --allow-warnings DatadogSDK.podspec
 		pod trunk push --allow-warnings --synchronous DatadogSDK.podspec
 		pod repo update
-		pod spec lint --allow-warnings DatadogSDKObjc.podspec
-		pod trunk push --allow-warnings DatadogSDKObjc.podspec
+		./tools/standalone-binary-distro/make_distro_builds.sh
+		# DatadogSDKObjc.podspec needs to be tried after ~1 hour
+		# pod spec lint --allow-warnings DatadogSDKObjc.podspec
+		# pod trunk push --allow-warnings DatadogSDKObjc.podspec
 
 dogfood:
 		@brew list gh &>/dev/null || brew install gh

--- a/Makefile
+++ b/Makefile
@@ -101,9 +101,9 @@ ship:
 		pod trunk push --allow-warnings --synchronous DatadogSDK.podspec
 		pod repo update
 		./tools/standalone-binary-distro/make_distro_builds.sh
-		# DatadogSDKObjc.podspec needs to be tried after ~1 hour
-		# pod spec lint --allow-warnings DatadogSDKObjc.podspec
-		# pod trunk push --allow-warnings DatadogSDKObjc.podspec
+		@echo "⚠️ DatadogSDKObjc.podspec needs to be tried after ~1 hour:"
+		@echo "pod spec lint --allow-warnings DatadogSDKObjc.podspec"
+		@echo "pod trunk push --allow-warnings DatadogSDKObjc.podspec"
 
 dogfood:
 		@brew list gh &>/dev/null || brew install gh

--- a/tools/standalone-binary-distro/make_distro_builds.sh
+++ b/tools/standalone-binary-distro/make_distro_builds.sh
@@ -1,0 +1,46 @@
+#!/bin/zsh
+
+gh auth status;
+if [[ $? != 0 ]]; then
+  exit 1
+fi
+
+SDK_VERSION=$(git describe --exact-match --tags)
+if [[ $? != 0 ]]; then
+  echo "❌ Aborting: HEAD doesn't have a tag!"  
+  exit 2
+elif [[ `git status --porcelain` ]]; then
+  echo "❌ Aborting: Working directory has changes!"
+  exit 3
+elif [ ! -f "Cartfile" ]; then
+	echo "❌ Aborting: \`make_distro_builds.sh\` must be run from the same place with `Cartfile`"
+  exit 4
+fi
+OUT_FILENAME="Datadog-$SDK_VERSION.zip"
+
+# create temporary xcconfig for carthage build
+set -euo pipefail
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig" ;' INT TERM HUP EXIT
+echo "BUILD_LIBRARY_FOR_DISTRIBUTION = YES" >> $xcconfig
+export XCODE_XCCONFIG_FILE="$xcconfig"
+
+# clear existing carthage artifacts
+rm -rf Carthage/
+rm Cartfile.resolved
+
+# fetch 3rd party deps via carthage
+echo "carthage bootstrap with no build..."
+carthage bootstrap --no-build
+
+echo "carthage build..."
+carthage build --platform iOS --use-xcframeworks --no-skip-current
+
+# zip artifacts
+cd Carthage/Build/
+zip --symlinks -r $OUT_FILENAME *.xcframework
+mv $OUT_FILENAME ../../$OUT_FILENAME
+cd ../../
+
+# upload zip
+gh release upload $SDK_VERSION $OUT_FILENAME -R DataDog/dd-sdk-ios

--- a/tools/standalone-binary-distro/make_distro_builds.sh
+++ b/tools/standalone-binary-distro/make_distro_builds.sh
@@ -27,7 +27,6 @@ export XCODE_XCCONFIG_FILE="$xcconfig"
 
 # clear existing carthage artifacts
 rm -rf Carthage/
-rm Cartfile.resolved
 
 # fetch 3rd party deps via carthage
 echo "carthage bootstrap with no build..."
@@ -39,8 +38,6 @@ carthage build --platform iOS --use-xcframeworks --no-skip-current
 # zip artifacts
 cd Carthage/Build/
 zip --symlinks -r $OUT_FILENAME *.xcframework
-mv $OUT_FILENAME ../../$OUT_FILENAME
-cd ../../
 
 # upload zip
 gh release upload $SDK_VERSION $OUT_FILENAME -R DataDog/dd-sdk-ios


### PR DESCRIPTION
### What and why?

We need to provide our SDK as pre-build binaries to the users who don't use any package managers.

### How?

We build our SDK with `carthage --use-xcframeworks --no-skip-current` and then will upload the zipped `Carthage/Build/` folder to Github release

I tried the script in my personal fork first, you can see the output [here](https://github.com/buranmert/dd-sdk-ios/releases/tag/0.0.1)

### TODO

- [ ] https://github.com/DataDog/dd-sdk-ios/pull/461 should be merged first

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
