### PR TITLE
RUMM-1087 Test schemes are hidden from make_distro_builds

### DIFF
--- a/tools/standalone-binary-distro/make_distro_builds.sh
+++ b/tools/standalone-binary-distro/make_distro_builds.sh
@@ -21,7 +21,9 @@ OUT_FILENAME="Datadog-$SDK_VERSION.zip"
 # create temporary xcconfig for carthage build
 set -euo pipefail
 xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
-trap 'rm -f "$xcconfig" ;' INT TERM HUP EXIT
+# carthage may try to build schemes in dependency-manager-tests folder, so we hide it temporarily
+mv dependency-manager-tests/ .dependency-manager-tests/
+trap 'rm -f "$xcconfig" ; mv .dependency-manager-tests/ dependency-manager-tests/ ;' INT TERM HUP EXIT
 echo "BUILD_LIBRARY_FOR_DISTRIBUTION = YES" >> $xcconfig
 export XCODE_XCCONFIG_FILE="$xcconfig"
 
@@ -34,6 +36,9 @@ carthage bootstrap --no-build
 
 echo "carthage build..."
 carthage build --platform iOS --use-xcframeworks --no-skip-current
+# reset trap
+trap - INT TERM HUP EXIT
+rm -f "$xcconfig"; mv .dependency-manager-tests/ dependency-manager-tests/ ;
 
 # zip artifacts
 cd Carthage/Build/

--- a/tools/standalone-binary-distro/make_distro_builds.sh
+++ b/tools/standalone-binary-distro/make_distro_builds.sh
@@ -21,24 +21,34 @@ OUT_FILENAME="Datadog-$SDK_VERSION.zip"
 # create temporary xcconfig for carthage build
 set -euo pipefail
 xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
-# carthage may try to build schemes in dependency-manager-tests folder, so we hide it temporarily
-mv dependency-manager-tests/ .dependency-manager-tests/
-trap 'rm -f "$xcconfig" ; mv .dependency-manager-tests/ dependency-manager-tests/ ;' INT TERM HUP EXIT
-echo "BUILD_LIBRARY_FOR_DISTRIBUTION = YES" >> $xcconfig
 export XCODE_XCCONFIG_FILE="$xcconfig"
 
-# clear existing carthage artifacts
-rm -rf Carthage/
+# Prepares the repository folder for building xcframeworks.
+prepare() {
+   echo "BUILD_LIBRARY_FOR_DISTRIBUTION = YES" >> $xcconfig
+   # carthage may try to build schemes in dependency-manager-tests folder, so we hide it temporarily
+   mv dependency-manager-tests/ .dependency-manager-tests/ 
+   rm -rf Carthage/
+}
 
-# fetch 3rd party deps via carthage
-echo "carthage bootstrap with no build..."
-carthage bootstrap --no-build
+# Resets repository changes made in 'prepare()'
+cleanup() {
+   rm -f "$xcconfig"
+   mv .dependency-manager-tests/ dependency-manager-tests/
+}
 
-echo "carthage build..."
-carthage build --platform iOS --use-xcframeworks --no-skip-current
-# reset trap
-trap - INT TERM HUP EXIT
-rm -f "$xcconfig"; mv .dependency-manager-tests/ dependency-manager-tests/ ;
+build_xcframeworks() {
+  trap cleanup INT TERM HUP EXIT
+   echo "carthage bootstrap with no build..."
+   carthage bootstrap --no-build
+   echo "carthage build..."
+   carthage build --platform iOS --use-xcframeworks --no-skip-current
+   trap - INT TERM HUP EXIT
+}
+
+prepare
+build_xcframeworks
+cleanup
 
 # zip artifacts
 cd Carthage/Build/


### PR DESCRIPTION
### What and why?

`dependency-manager-tests` schemes can be tried by `carthage build`

### How?

We hide this folder temporarily

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
