### PR TITLE
RUMM-1160 make bump was breaking static pod support

### DIFF
--- a/DatadogSDK.podspec.src
+++ b/DatadogSDK.podspec.src
@@ -22,8 +22,8 @@ Pod::Spec.new do |s|
   s.source_files = ["Sources/Datadog/**/*.swift",
                     "Sources/_Datadog_Private/**/*.{h,m}",
                     "Datadog/TargetSupport/Datadog/Datadog.h"]
-  s.public_header_files = "Datadog/TargetSupport/Datadog/Datadog.h"
-  s.private_header_files = "Sources/_Datadog_Private/include/*.h"
-  s.module_map = "Sources/Datadog/Datadog.modulemap"
+  s.public_header_files = ["Datadog/TargetSupport/Datadog/Datadog.h", 
+                           "Sources/_Datadog_Private/include/*.h"]
+                           
   s.dependency 'Kronos', '~> 4.1'
 end


### PR DESCRIPTION
### What and why?

The fix was made in `DatadogSDK.podspec` but `DatadogSDK.podpspec.src` was forgotten

### How?

`DatadogSDK.podpspec.src` is fixed

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
