### PR TITLE
RUMM-1172 AFExtension included in make bump

### DIFF
--- a/DatadogSDKAlamofireExtension.podspec.src
+++ b/DatadogSDKAlamofireExtension.podspec.src
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name         = "DatadogSDKAlamofireExtension"
+  s.module_name  = "DatadogAlamofireExtension"
+  s.version      = "__DATADOG_VERSION__"
+  s.summary      = "An Official Extensions of Datadog Swift SDK for Alamofire."
+  
+  s.homepage     = "https://www.datadoghq.com"
+  s.social_media_url   = "https://twitter.com/datadoghq"
+
+  s.license            = { :type => "Apache", :file => 'LICENSE' }
+  s.authors            = { 
+    "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
+    "Mert Buran" => "mert.buran@datadoghq.com",
+    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+  }
+
+  s.swift_version      = '5.1'
+  s.ios.deployment_target = '11.0'
+
+  # :tag must follow DatadogSDK version below
+  s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
+
+  s.source_files = ["Sources/DatadogExtensions/Alamofire/**/*.swift"]
+  s.dependency 'DatadogSDK', s.version.to_s
+  s.dependency 'Alamofire', '~> 5.0'
+end

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ bump:
 		echo "// GENERATED FILE: Do not edit directly\n\ninternal let sdkVersion = \"$$version\"" > Sources/Datadog/Versioning.swift; \
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDK.podspec.src > DatadogSDK.podspec; \
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKObjc.podspec.src > DatadogSDKObjc.podspec; \
+		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKAlamofireExtension.podspec.src > DatadogSDKAlamofireExtension.podspec; \
 		git add . ; \
 		git commit -m "Bumped version to $$version"; \
 		echo Bumped version to $$version


### PR DESCRIPTION
### What and why?

`make bump` wasn't bumping ` DatadogSDKAlamofireExtension.podspec` and in case the dev forgets to bump manually that leads to CI failure in release PRs.

### How?

Other `podspec` examples are followed (ie: `PodName.podspec.src` template) and this extension is included in `make bump` step.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
