### PR TITLE
Fix `homebrew` on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,10 @@ ONLY_ACTIVE_ARCH = YES
 endef
 export DD_SDK_BASE_XCCONFIG
 
+# Installs tools and dependencies with homebrew.
+# Do not call 'brew update' and instead let Bitrise use its own brew bottle mirror.
 dependencies:
 		@echo "⚙️  Installing dependencies..."
-		@brew update
 		@brew list swiftlint &>/dev/null || brew install swiftlint
 		@brew upgrade carthage
 		@carthage bootstrap --platform iOS --use-xcframeworks


### PR DESCRIPTION
### What and why?

🧰 This PR fixes the recent `brew install` issues on CI.

### How?

As discussed in this [Bitrise forum thread](https://discuss.bitrise.io/t/how-to-change-brew-core-from-mirror-to-official/16033), Bitrise uses its own mirror for retrieving brew dependencies specs, so calling `brew update` without changing to the official source doesn't make sense.

We don't need to pull dependencies from official source, so using Bitrise mirror seems enough for our needs.

The issue was that with recent changes to Bitrise CI the `brew update` in our tooling was impacting brew bottles and leaving the VM's `brew` in a malformed state.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
