### PR TITLE
RUMM-1154 User can add attributes to auto instrumented RUM Resources

### DIFF
--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -54,6 +54,8 @@ internal struct FeaturesConfiguration {
         let userDefinedFirstPartyHosts: Set<String>
         /// URLs used internally by the SDK - they are not instrumented.
         let sdkInternalURLs: Set<String>
+        /// An optional RUM Resource attributes provider.
+        let rumAttributesProvider: URLSessionRUMAttributesProvider?
 
         /// If the Tracing instrumentation should be enabled.
         let instrumentTracing: Bool
@@ -215,6 +217,7 @@ extension FeaturesConfiguration {
                         tracesEndpoint.url,
                         rumEndpoint.url
                     ],
+                    rumAttributesProvider: configuration.rumResourceAttributesProvider,
                     instrumentTracing: configuration.tracingEnabled,
                     instrumentRUM: configuration.rumEnabled
                 )
@@ -227,6 +230,14 @@ extension FeaturesConfiguration {
                 )
                 consolePrint("\(error)")
             }
+        } else if configuration.rumResourceAttributesProvider != nil {
+            let error = ProgrammerError(
+                description: """
+                To use `.setRUMResourceAttributesProvider(_:)` URLSession tracking must be enabled
+                with `.trackURLSession(firstPartyHosts:)`.
+                """
+            )
+            consolePrint("\(error)")
         }
 
         if let crashReportingPlugin = configuration.crashReportingPlugin {

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -178,6 +178,7 @@ extension Datadog {
         private(set) var rumResourceEventMapper: RUMResourceEventMapper?
         private(set) var rumActionEventMapper: RUMActionEventMapper?
         private(set) var rumErrorEventMapper: RUMErrorEventMapper?
+        private(set) var rumResourceAttributesProvider: URLSessionRUMAttributesProvider?
         private(set) var batchSize: BatchSize
         private(set) var uploadFrequency: UploadFrequency
         private(set) var additionalConfiguration: [String: Any]
@@ -247,6 +248,7 @@ extension Datadog {
                     rumResourceEventMapper: nil,
                     rumActionEventMapper: nil,
                     rumErrorEventMapper: nil,
+                    rumResourceAttributesProvider: nil,
                     batchSize: .medium,
                     uploadFrequency: .average,
                     additionalConfiguration: [:],
@@ -497,6 +499,19 @@ extension Datadog {
             /// with dropping the RUM Error event entirely, so it won't be send to Datadog.
             public func setRUMErrorEventMapper(_ mapper: @escaping (RUMErrorEvent) -> RUMErrorEvent?) -> Builder {
                 configuration.rumErrorEventMapper = mapper
+                return self
+            }
+
+            /// Sets a closure to provide custom attributes for intercepted RUM Resources.
+            ///
+            /// The `provider` closure is called for each `URLSession` task intercepted by the SDK (each automatically collected RUM Resource).
+            /// The closure is called with session task information (`URLRequest`, `URLResponse?`, `Data?` and `Error?`) that can be used to identify the task, inspect its
+            /// values and return custom attributes for the RUM Resource.
+            ///
+            /// - Parameter provider: the closure called for each RUM Resource collected by the SDK. This closure is called with task information and may return custom attributes
+            ///                       for the RUM Resource or `nil` if no attributes should be attached.
+            public func setRUMResourceAttributesProvider(_ provider: @escaping (URLRequest, URLResponse?, Data?, Error?) -> [AttributeKey: AttributeValue]?) -> Builder {
+                configuration.rumResourceAttributesProvider = provider
                 return self
             }
 

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -12,8 +12,9 @@ import Foundation
 public protocol __URLSessionDelegateProviding: URLSessionDelegate {
     /// Datadog delegate object.
     /// The class implementing `DDURLSessionDelegateProviding` must ensure that following method calls are forwarded to `ddURLSessionDelegate`:
-    // - `func urlSession(_:task:didFinishCollecting:)`
-    // - `func urlSession(_:task:didCompleteWithError:)`
+    /// - `func urlSession(_:task:didFinishCollecting:)`
+    /// - `func urlSession(_:task:didCompleteWithError:)`
+    /// - `func urlSession(_:dataTask:didReceive:)`
     var ddURLSessionDelegate: DDURLSessionDelegate { get }
 }
 
@@ -22,7 +23,7 @@ public protocol __URLSessionDelegateProviding: URLSessionDelegate {
 ///
 /// All requests made with the `URLSession` instrumented with this delegate will be intercepted by the SDK.
 @objc
-open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, __URLSessionDelegateProviding {
+open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDataDelegate, __URLSessionDelegateProviding {
     public var ddURLSessionDelegate: DDURLSessionDelegate {
         return self
     }
@@ -75,5 +76,11 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, __URLSessionD
         // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
 
         interceptor?.taskCompleted(task: task, error: error)
+    }
+
+    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
+
+        interceptor?.taskReceivedData(task: dataTask, data: data)
     }
 }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterception.swift
@@ -16,6 +16,8 @@ internal class TaskInterception {
     internal let isFirstPartyRequest: Bool
     /// Task metrics collected during this interception.
     private(set) var metrics: ResourceMetrics?
+    /// Task data received during this interception. Can be `nil` if task completed with error.
+    private(set) var data: Data?
     /// Task completion collected during this interception.
     private(set) var completion: ResourceCompletion?
     /// Trace information propagated with the task. Not available when Tracing is disabled
@@ -33,6 +35,14 @@ internal class TaskInterception {
 
     func register(metrics: ResourceMetrics) {
         self.metrics = metrics
+    }
+
+    func register(nextData: Data) {
+        if data != nil {
+            self.data?.append(nextData)
+        } else {
+            self.data = nextData
+        }
     }
 
     func register(completion: ResourceCompletion) {

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
@@ -78,6 +78,9 @@ internal class URLSessionSwizzler {
                         var taskReference: URLSessionDataTask?
                         let newCompletionHandler: CompletionHandler = { data, response, error in
                             if let task = taskReference { // sanity check, should always succeed
+                                if let data = data {
+                                    interceptor.taskReceivedData(task: task, data: data)
+                                }
                                 interceptor.taskCompleted(task: task, error: error)
                             }
                             completionHandler?(data, response, error)
@@ -137,6 +140,9 @@ internal class URLSessionSwizzler {
                         var taskReference: URLSessionDataTask?
                         let newCompletionHandler: CompletionHandler = { data, response, error in
                             if let task = taskReference { // sanity check, should always succeed
+                                if let data = data {
+                                    interceptor.taskReceivedData(task: task, data: data)
+                                }
                                 interceptor.taskCompleted(task: task, error: error)
                             }
                             completionHandler?(data, response, error)

--- a/Sources/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
+++ b/Sources/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
@@ -22,6 +22,10 @@ public class DDEventMonitor: EventMonitor {
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         URLSessionInterceptor.shared?.taskCompleted(task: task, error: error)
     }
+
+    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        URLSessionInterceptor.shared?.taskReceivedData(task: dataTask, data: data)
+    }
 }
 
 /// An `Alamofire.RequestInterceptor` which instruments `Alamofire.Session` with Datadog RUM and Tracing.

--- a/Sources/DatadogObjc/DDURLSessionDelegate+objc.swift
+++ b/Sources/DatadogObjc/DDURLSessionDelegate+objc.swift
@@ -8,7 +8,7 @@ import Foundation
 import Datadog
 
 @objc
-open class DDNSURLSessionDelegate: NSObject, URLSessionTaskDelegate, __URLSessionDelegateProviding {
+open class DDNSURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDataDelegate, __URLSessionDelegateProviding {
     var swiftDelegate: DDURLSessionDelegate
     public var ddURLSessionDelegate: DDURLSessionDelegate {
         return swiftDelegate
@@ -30,5 +30,9 @@ open class DDNSURLSessionDelegate: NSObject, URLSessionTaskDelegate, __URLSessio
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
         swiftDelegate.urlSession(session, task: task, didFinishCollecting: metrics)
+    }
+
+    open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        swiftDelegate.urlSession(session, dataTask: dataTask, didReceive: data)
     }
 }

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -50,6 +50,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertNil(configuration.rumResourceEventMapper)
             XCTAssertNil(configuration.rumActionEventMapper)
             XCTAssertNil(configuration.rumErrorEventMapper)
+            XCTAssertNil(configuration.rumResourceAttributesProvider)
             XCTAssertEqual(configuration.batchSize, .medium)
             XCTAssertEqual(configuration.uploadFrequency, .average)
             XCTAssertEqual(configuration.additionalConfiguration.count, 0)
@@ -82,6 +83,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .setRUMErrorEventMapper { _ in mockRUMErrorEvent }
                 .setRUMResourceEventMapper { _ in mockRUMResourceEvent }
                 .setRUMActionEventMapper { _ in mockRUMActionEvent }
+                .setRUMResourceAttributesProvider { _, _, _, _ in ["foo": "bar"] }
                 .set(batchSize: .small)
                 .set(uploadFrequency: .frequent)
                 .set(additionalConfiguration: ["foo": 42, "bar": "something"])
@@ -125,6 +127,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.rumResourceEventMapper?(.mockRandom()), mockRUMResourceEvent)
             XCTAssertEqual(configuration.rumActionEventMapper?(.mockRandom()), mockRUMActionEvent)
             XCTAssertEqual(configuration.rumErrorEventMapper?(.mockRandom()), mockRUMErrorEvent)
+            XCTAssertEqual(configuration.rumResourceAttributesProvider?(.mockAny(), nil, nil, nil) as? [String: String], ["foo": "bar"])
             XCTAssertEqual(configuration.batchSize, .small)
             XCTAssertEqual(configuration.uploadFrequency, .frequent)
             XCTAssertEqual(configuration.additionalConfiguration["foo"] as? Int, 42)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -52,6 +52,7 @@ extension Datadog.Configuration {
         rumSessionsSamplingRate: Float = 100.0,
         rumUIKitViewsPredicate: UIKitRUMViewsPredicate? = nil,
         rumUIKitActionsTrackingEnabled: Bool = false,
+        rumResourceAttributesProvider: URLSessionRUMAttributesProvider? = nil,
         batchSize: BatchSize = .medium,
         uploadFrequency: UploadFrequency = .average,
         additionalConfiguration: [String: Any] = [:],
@@ -77,6 +78,7 @@ extension Datadog.Configuration {
             rumSessionsSamplingRate: rumSessionsSamplingRate,
             rumUIKitViewsPredicate: rumUIKitViewsPredicate,
             rumUIKitActionsTrackingEnabled: rumUIKitActionsTrackingEnabled,
+            rumResourceAttributesProvider: rumResourceAttributesProvider,
             batchSize: batchSize,
             uploadFrequency: uploadFrequency,
             additionalConfiguration: additionalConfiguration,
@@ -254,12 +256,14 @@ extension FeaturesConfiguration.URLSessionAutoInstrumentation {
     static func mockWith(
         userDefinedFirstPartyHosts: Set<String> = [],
         sdkInternalURLs: Set<String> = [],
+        rumAttributesProvider: URLSessionRUMAttributesProvider? = nil,
         instrumentTracing: Bool = true,
         instrumentRUM: Bool = true
     ) -> Self {
         return .init(
             userDefinedFirstPartyHosts: userDefinedFirstPartyHosts,
             sdkInternalURLs: sdkInternalURLs,
+            rumAttributesProvider: rumAttributesProvider,
             instrumentTracing: instrumentTracing,
             instrumentRUM: instrumentRUM
         )

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -41,7 +41,7 @@ protocol RandomMockable {
     static func mockRandom() -> Self
 }
 
-extension Data: AnyMockable {
+extension Data: AnyMockable, RandomMockable {
     static func mockAny() -> Data {
         return Data()
     }
@@ -52,6 +52,10 @@ extension Data: AnyMockable {
 
     static func mock(ofSize size: UInt64) -> Data {
         return mockRepeating(byte: 0x41, times: Int(size))
+    }
+
+    static func mockRandom() -> Data {
+        return mockRepeating(byte: .random(in: 0x00...0xFF), times: 256)
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/URLSessionAutoInstrumentationMocks.swift
@@ -18,10 +18,12 @@ class URLSessionInterceptorMock: URLSessionInterceptorType {
 
     var onRequestModified: ((URLRequest, URLSession?) -> Void)?
     var onTaskCreated: ((URLSessionTask, URLSession?) -> Void)?
+    var onTaskReceivedData: ((URLSessionTask, Data) -> Void)?
     var onTaskCompleted: ((URLSessionTask, Error?) -> Void)?
     var onTaskMetricsCollected: ((URLSessionTask, URLSessionTaskMetrics) -> Void)?
 
     var tasksCreated: [URLSessionTask] = []
+    var tasksReceivedData: [(task: URLSessionTask, data: Data)] = []
     var tasksCompleted: [(task: URLSessionTask, error: Error?)] = []
     var taskMetrics: [(task: URLSessionTask, metrics: URLSessionTaskMetrics)] = []
 
@@ -33,6 +35,15 @@ class URLSessionInterceptorMock: URLSessionInterceptorType {
     func taskCreated(task: URLSessionTask, session: URLSession?) {
         tasksCreated.append(task)
         onTaskCreated?(task, session)
+    }
+
+    func taskReceivedData(task: URLSessionTask, data: Data) {
+        if let existingEntryIndex = tasksReceivedData.firstIndex(where: { $0.task === task }) {
+            tasksReceivedData[existingEntryIndex].data.append(data)
+        } else {
+            tasksReceivedData.append((task: task, data: data))
+        }
+        onTaskReceivedData?(task, data)
     }
 
     func taskCompleted(task: URLSessionTask, error: Error?) {

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterceptionTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/TaskInterceptionTests.swift
@@ -19,6 +19,30 @@ class TaskInterceptionTests: XCTestCase {
         XCTAssertFalse(interception2.isFirstPartyRequest)
     }
 
+    func testWhenInterceptionReceivesData_itAppendsItToPreviousData() {
+        let chunk1 = "abc".utf8Data
+        let chunk2 = "def".utf8Data
+        let chunk3 = "ghi".utf8Data
+
+        let interception = TaskInterception(request: .mockAny(), isFirstParty: .random())
+        XCTAssertNil(interception.data)
+
+        // When
+        interception.register(nextData: chunk1)
+        let data1 = interception.data
+
+        interception.register(nextData: chunk2)
+        let data2 = interception.data
+
+        interception.register(nextData: chunk3)
+        let data3 = interception.data
+
+        // Then
+        XCTAssertEqual(data1, chunk1)
+        XCTAssertEqual(data2, chunk1 + chunk2)
+        XCTAssertEqual(data3, chunk1 + chunk2 + chunk3)
+    }
+
     func testWhenInterceptionReceivesBothMetricsAndCompletion_itIsConsideredDone() {
         let interception = TaskInterception(request: .mockAny(), isFirstParty: .mockAny())
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -42,6 +42,7 @@ class URLSessionSwizzlerTests: XCTestCase {
     func testGivenURLSessionWithDDURLSessionDelegate_whenUsingTaskWithURLRequestAndCompletion_itNotifiesCreationAndCompletionAndModifiesTheRequest() throws {
         let requestModified = expectation(description: "Modify request")
         let notifyTaskCreated = expectation(description: "Notify task creation")
+        let notifyTaskReceivedData = expectation(description: "Notify task received data")
         let notifyTaskCompleted = expectation(description: "Notify task completion")
         let completionHandlerCalled = expectation(description: "Call completion handler")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
@@ -54,6 +55,10 @@ class URLSessionSwizzlerTests: XCTestCase {
         interceptor.onTaskCreated = { _, session in
             XCTAssertNotNil(session)
             notifyTaskCreated.fulfill()
+        }
+        interceptor.onTaskReceivedData = { _, session in
+            XCTAssertNotNil(session)
+            notifyTaskReceivedData.fulfill()
         }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
@@ -67,7 +72,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         task.resume()
 
         // Then
-        wait(for: [requestModified, notifyTaskCreated, notifyTaskCompleted, completionHandlerCalled], timeout: 0.5, enforceOrder: true)
+        wait(for: [requestModified, notifyTaskCreated, notifyTaskReceivedData, notifyTaskCompleted, completionHandlerCalled], timeout: 2, enforceOrder: true)
 
         let requestSent = try XCTUnwrap(server.waitAndReturnRequests(count: 1).first)
         XCTAssertEqual(requestSent, interceptor.modifiedRequest, "The request should be modified")
@@ -79,6 +84,7 @@ class URLSessionSwizzlerTests: XCTestCase {
             requestModified.isInverted = true
         }
         let notifyTaskCreated = expectation(description: "Notify task creation")
+        let notifyTaskReceivedData = expectation(description: "Notify task received data")
         let notifyTaskCompleted = expectation(description: "Notify task completion")
         let completionHandlerCalled = expectation(description: "Call completion handler")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
@@ -92,6 +98,10 @@ class URLSessionSwizzlerTests: XCTestCase {
             XCTAssertNotNil(session)
             notifyTaskCreated.fulfill()
         }
+        interceptor.onTaskReceivedData = { _, session in
+            XCTAssertNotNil(session)
+            notifyTaskReceivedData.fulfill()
+        }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
@@ -104,7 +114,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         task.resume()
 
         // Then
-        wait(for: [requestModified, notifyTaskCreated, notifyTaskCompleted, completionHandlerCalled], timeout: 0.5, enforceOrder: true)
+        wait(for: [requestModified, notifyTaskCreated, notifyTaskReceivedData, notifyTaskCompleted, completionHandlerCalled], timeout: 2, enforceOrder: true)
 
         let requestSent = try XCTUnwrap(server.waitAndReturnRequests(count: 1).first)
         if #available(iOS 13.0, *) {
@@ -117,6 +127,7 @@ class URLSessionSwizzlerTests: XCTestCase {
     func testGivenURLSessionWithDDURLSessionDelegate_whenUsingTaskWithURLRequest_itNotifiesCreationAndCompletionAndModifiesTheRequest() throws {
         let requestModified = expectation(description: "Modify request")
         let notifyTaskCreated = expectation(description: "Notify task creation")
+        let notifyTaskReceivedData = expectation(description: "Notify task received data")
         let notifyTaskCompleted = expectation(description: "Notify task completion")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
@@ -129,6 +140,10 @@ class URLSessionSwizzlerTests: XCTestCase {
             XCTAssertNotNil(session)
             notifyTaskCreated.fulfill()
         }
+        interceptor.onTaskReceivedData = { _, session in
+            XCTAssertNotNil(session)
+            notifyTaskReceivedData.fulfill()
+        }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
@@ -139,7 +154,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         task.resume()
 
         // Then
-        wait(for: [requestModified, notifyTaskCreated, notifyTaskCompleted], timeout: 0.5, enforceOrder: true)
+        wait(for: [requestModified, notifyTaskCreated, notifyTaskReceivedData, notifyTaskCompleted], timeout: 2, enforceOrder: true)
 
         let requestSent = try XCTUnwrap(server.waitAndReturnRequests(count: 1).first)
         XCTAssertEqual(requestSent, interceptor.modifiedRequest, "The request should be modified.")
@@ -149,6 +164,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         let requestNotModified = expectation(description: "Do not modify request")
         requestNotModified.isInverted = true
         let notifyTaskCreated = expectation(description: "Notify task creation")
+        let notifyTaskReceivedData = expectation(description: "Notify task received data")
         let notifyTaskCompleted = expectation(description: "Notify task completion")
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
@@ -157,6 +173,10 @@ class URLSessionSwizzlerTests: XCTestCase {
         interceptor.onTaskCreated = { _, session in
             XCTAssertNotNil(session)
             notifyTaskCreated.fulfill()
+        }
+        interceptor.onTaskReceivedData = { _, session in
+            XCTAssertNotNil(session)
+            notifyTaskReceivedData.fulfill()
         }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
@@ -168,7 +188,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         task.resume()
 
         // Then
-        wait(for: [requestNotModified, notifyTaskCreated, notifyTaskCompleted], timeout: 0.5, enforceOrder: true)
+        wait(for: [requestNotModified, notifyTaskCreated, notifyTaskReceivedData, notifyTaskCompleted], timeout: 2, enforceOrder: true)
 
         let requestSent = try XCTUnwrap(server.waitAndReturnRequests(count: 1).first)
         XCTAssertNotEqual(requestSent, interceptor.modifiedRequest, "The request should not be modified.")
@@ -199,16 +219,16 @@ class URLSessionSwizzlerTests: XCTestCase {
         task2.resume()
 
         // Then
-        wait(for: [notifyTaskCreated, notifyTaskCompleted], timeout: 0.5, enforceOrder: true)
+        wait(for: [notifyTaskCreated, notifyTaskCompleted], timeout: 2, enforceOrder: false)
 
         _ = server.waitAndReturnRequests(count: 2)
     }
 
     func testGivenNonInterceptedSession_itDoesntCallInterceptor() throws {
-        let doNotModifyRequest = expectation(description: "Notify request modification")
+        let doNotModifyRequest = expectation(description: "Do not notify request modification")
         doNotModifyRequest.isInverted = true
         interceptor.onRequestModified = { _, _ in doNotModifyRequest.fulfill() }
-        let doNotNotifyTaskCreated = expectation(description: "Notify task creation")
+        let doNotNotifyTaskCreated = expectation(description: "Do not notify task creation")
         doNotNotifyTaskCreated.isInverted = true
         interceptor.onTaskCreated = { _, _ in doNotNotifyTaskCreated.fulfill() }
 
@@ -222,7 +242,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         let taskWithURLRequestWithCompletion = session.dataTask(with: URLRequest.mockAny()) { _, _, _ in }
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 2, handler: nil)
         XCTAssertNotNil(taskWithURL)
         XCTAssertNotNil(taskWithURLRequest)
         XCTAssertNotNil(taskWithURLWithCompletion)
@@ -232,15 +252,19 @@ class URLSessionSwizzlerTests: XCTestCase {
     // MARK: - Interception Values
 
     func testGivenSuccessfulTask_whenUsingSwizzledAPIs_itPassessAllValuesToTheInterceptor() {
-        let completionHandlersCalled = expectation(description: "Call completion handlers")
+        let completionHandlersCalled = expectation(description: "Call 2 completion handlers")
         completionHandlersCalled.expectedFulfillmentCount = 2
-        let notifyTaskCompleted = expectation(description: "Notify task completion")
+        let notifyTaskReceivedData = expectation(description: "Notify 4 tasks received data")
+        notifyTaskReceivedData.expectedFulfillmentCount = 4
+        let notifyTaskCompleted = expectation(description: "Notify 4 tasks completion")
         notifyTaskCompleted.expectedFulfillmentCount = 4
+
+        interceptor.onTaskReceivedData = { _, _ in notifyTaskReceivedData.fulfill() }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
         let expectedResponse: HTTPURLResponse = .mockResponseWith(statusCode: 200)
-        let expectedData: Data = .mock(ofSize: 10)
+        let expectedData: Data = .mockRandom()
         let server = ServerMock(delivery: .success(response: expectedResponse, data: expectedData))
         let session = interceptedSession()
 
@@ -268,7 +292,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         taskWithURL.resume()
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 2, handler: nil)
 
         _ = server.waitAndReturnRequests(count: 4)
         XCTAssertEqual(interceptor.tasksCreated.count, 4, "Interceptor should record all 4 tasks created.")
@@ -277,25 +301,33 @@ class URLSessionSwizzlerTests: XCTestCase {
         XCTAssertTrue(interceptor.tasksCreated[0] === taskWithURLRequestAndCompletion)
         XCTAssertTrue(interceptor.tasksCompleted[0].task === taskWithURLRequestAndCompletion)
         XCTAssertNil(interceptor.tasksCompleted[0].error)
+        XCTAssertEqual(interceptor.tasksReceivedData[0].data, expectedData)
 
         XCTAssertTrue(interceptor.tasksCreated[1] === taskWithURLAndCompletion)
         XCTAssertTrue(interceptor.tasksCompleted[1].task === taskWithURLAndCompletion)
         XCTAssertNil(interceptor.tasksCompleted[1].error)
+        XCTAssertEqual(interceptor.tasksReceivedData[1].data, expectedData)
 
         XCTAssertTrue(interceptor.tasksCreated[2] === taskWithURLRequest)
         XCTAssertTrue(interceptor.tasksCompleted[2].task === taskWithURLRequest)
         XCTAssertNil(interceptor.tasksCompleted[2].error)
+        XCTAssertEqual(interceptor.tasksReceivedData[2].data, expectedData)
 
         XCTAssertTrue(interceptor.tasksCreated[3] === taskWithURL)
         XCTAssertTrue(interceptor.tasksCompleted[3].task === taskWithURL)
         XCTAssertNil(interceptor.tasksCompleted[3].error)
+        XCTAssertEqual(interceptor.tasksReceivedData[3].data, expectedData)
     }
 
     func testGivenFailedTask_whenUsingSwizzledAPIs_itPassessAllValuesToTheInterceptor() {
-        let completionHandlersCalled = expectation(description: "Call completion handlers")
+        let completionHandlersCalled = expectation(description: "Call 2 completion handlers")
         completionHandlersCalled.expectedFulfillmentCount = 2
-        let notifyTaskCompleted = expectation(description: "Notify task completion")
+        let noTaskShouldReceiveData = expectation(description: "None of tasks should recieve data")
+        noTaskShouldReceiveData.isInverted = true
+        let notifyTaskCompleted = expectation(description: "Notify 4 tasks completion")
         notifyTaskCompleted.expectedFulfillmentCount = 4
+
+        interceptor.onTaskReceivedData = { _, _ in noTaskShouldReceiveData.fulfill() }
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
@@ -327,7 +359,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         taskWithURL.resume()
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 2, handler: nil)
 
         _ = server.waitAndReturnRequests(count: 4)
         XCTAssertEqual(interceptor.tasksCreated.count, 4, "Interceptor should record all 4 tasks created.")
@@ -348,5 +380,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         XCTAssertTrue(interceptor.tasksCreated[3] === taskWithURL)
         XCTAssertTrue(interceptor.tasksCompleted[3].task === taskWithURL)
         XCTAssertEqual((interceptor.tasksCompleted[3].error! as NSError).localizedDescription, "some error")
+
+        XCTAssertEqual(interceptor.tasksReceivedData.count, 0, "When tasks complete with failure, they should not receive data")
     }
 }

--- a/Tests/DatadogTests/DatadogObjc/DDNSURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDNSURLSessionDelegateTests.swift
@@ -11,6 +11,7 @@ import XCTest
 private class DDURLSessionDelegateMock: DDURLSessionDelegate {
     var calledDidFinishCollecting = false
     var calledDidCompleteWithError = false
+    var calledDidReceiveData = false
 
     override func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
         calledDidFinishCollecting = true
@@ -18,6 +19,10 @@ private class DDURLSessionDelegateMock: DDURLSessionDelegate {
 
     override func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         calledDidCompleteWithError = true
+    }
+
+    override func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        calledDidReceiveData = true
     }
 }
 
@@ -39,8 +44,10 @@ class DDNSURLSessionDelegateTests: XCTestCase {
 
         objcDelegate.urlSession(.shared, task: .mockAny(), didFinishCollecting: .mockAny())
         objcDelegate.urlSession(.shared, task: .mockAny(), didCompleteWithError: ErrorMock())
+        objcDelegate.urlSession(.shared, dataTask: URLSessionDataTask(), didReceive: .mockAny())
 
         XCTAssertTrue(swiftDelegate.calledDidFinishCollecting)
         XCTAssertTrue(swiftDelegate.calledDidCompleteWithError)
+        XCTAssertTrue(swiftDelegate.calledDidReceiveData)
     }
 }

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -74,6 +74,11 @@ internal class RUMSessionMatcher {
     /// Each `ViewVisit` is determined by unique `view.id` and groups all RUM events linked to that `view.id`.
     let viewVisits: [ViewVisit]
 
+    let viewEventMatchers: [RUMEventMatcher]
+    let actionEventMatchers: [RUMEventMatcher]
+    let resourceEventMatchers: [RUMEventMatcher]
+    let errorEventMatchers: [RUMEventMatcher]
+
     private init(sessionEventMatchers: [RUMEventMatcher]) throws {
         // Sort events so they follow increasing time order
         let sessionEventOrderedByTime = try sessionEventMatchers.sorted { firstEvent, secondEvent in
@@ -88,16 +93,20 @@ internal class RUMSessionMatcher {
 
         // Get RUM Events by kind:
 
-        let viewEventMatchers = eventsMatchersByType["view"] ?? []
+        self.viewEventMatchers = eventsMatchersByType["view"] ?? []
+        self.actionEventMatchers = eventsMatchersByType["action"] ?? []
+        self.resourceEventMatchers = eventsMatchersByType["resource"] ?? []
+        self.errorEventMatchers = eventsMatchersByType["error"] ?? []
+
         let viewEvents: [RUMViewEvent] = try viewEventMatchers.map { matcher in try matcher.model() }
 
-        let actionEvents: [RUMActionEvent] = try (eventsMatchersByType["action"] ?? [])
+        let actionEvents: [RUMActionEvent] = try actionEventMatchers
             .map { matcher in try matcher.model() }
 
-        let resourceEvents: [RUMResourceEvent] = try (eventsMatchersByType["resource"] ?? [])
+        let resourceEvents: [RUMResourceEvent] = try resourceEventMatchers
             .map { matcher in try matcher.model() }
 
-        let errorEvents: [RUMErrorEvent] = try (eventsMatchersByType["error"] ?? [])
+        let errorEvents: [RUMErrorEvent] = try errorEventMatchers
             .map { matcher in try matcher.model() }
 
         // Validate each group of events individually


### PR DESCRIPTION
### What and why?

📦 This PR adds `rumResourceAttributesProvider` API, which makes it possible to add extra attributes to RUM Resources collected automatically:

```swift
public func setRUMResourceAttributesProvider(
   _ provider: @escaping (URLRequest, URLResponse?, Data?, Error?) -> [AttributeKey: AttributeValue]?
)
```

The `provider` block is called for each `URLSessionTask` intercepted by the SDK. The implementation should look into task information and return custom attributes for RUM Resource, e.g. send redacted response headers or decode response body and send its additional context. This block is also called for RUM Errors created for resources failed on transport.

This is a counterpart of https://github.com/DataDog/dd-sdk-android/pull/520 introduced in `dd-sdk-android`.

### How?

The implementation starts with passing the `provider` block through configuration object to `URLSessionRUMResourcesHandler` as we do for other stuff. `URLSessionInterceptor` is extended with additional method: `taskReceivedData(task:data:)` which is called from two places:
* from `URLSesionSwizzler` - for requests sent with completion block,
* from `DDURLSessionDelegate` - for requests sent with no completion block.

About the public API, I considered few other choices:
* adding the `provider` parameter to `DDURLSessionDelegate.init()` - this would require also exposing it in `URLSessionInterceptor` (for no-delegate usage including Alamofire extension),
* adding the `provider` parameter to existing `.trackURLSession(firstPartyHosts:)` as both are mutually related - this would make the discovery of this new feature harder (the doc comment for `.trackURLSession` is already huge).

The proposed API should keep things simple: the feature can announced by its API name and the mutual relationship with `trackURLSession` is solved by installing misconfiguration warning.

All related unit tests pass on iOS 14.3, 13.4, 12.4 and 11.1.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
