### PR TITLE
RUMM-1324 Fix RUM views tracking issue for iOS 11 (and make tests green for 11.x and 12.x)

### DIFF
--- a/Datadog/Example/Scenarios/TrackingConsent/TrackingConsent/TSConsentSettingViewController.swift
+++ b/Datadog/Example/Scenarios/TrackingConsent/TrackingConsent/TSConsentSettingViewController.swift
@@ -11,8 +11,8 @@ internal class TSConsentSettingViewController: UIViewController {
 
     @IBOutlet weak var consentValueControl: UISegmentedControl!
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
 
         switch homeViewController.currentConsentValue {
         case .granted: consentValueControl.selectedSegmentIndex = 0

--- a/Sources/Datadog/Utils/UIKitExtensions.swift
+++ b/Sources/Datadog/Utils/UIKitExtensions.swift
@@ -26,5 +26,8 @@ internal extension UIViewController {
 }
 
 internal extension Bundle {
-    var isUIKit: Bool { bundleURL.lastPathComponent == "UIKitCore.framework" }
+    var isUIKit: Bool {
+        return bundleURL.lastPathComponent == "UIKitCore.framework" // on iOS 12+
+            || bundleURL.lastPathComponent == "UIKit.framework" // on iOS 11
+    }
 }

--- a/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
@@ -34,8 +34,9 @@ class FeatureStorageTests: XCTestCase {
             let currentConsent = consentProvider.currentValue
             let nextConsent: TrackingConsent = .mockRandom(otherThan: currentConsent)
 
-            let stringValue = "current consent: \(currentConsent), next consent: \(nextConsent)"
-            storage.writer.write(value: stringValue)
+            // We write array because prior to iOS 13 the top-level element passed to JSON encoder must be array or object
+            let data = ["current consent: \(currentConsent), next consent: \(nextConsent)"]
+            storage.writer.write(value: data)
 
             consentProvider.changeConsent(to: nextConsent)
         }
@@ -46,10 +47,10 @@ class FeatureStorageTests: XCTestCase {
 
         let expectedAuthorizedValues = [
             // Data collected with `.granted` consent is allowed no matter of the next consent
-            "\"current consent: \(TrackingConsent.granted), next consent: \(TrackingConsent.pending)\"",
-            "\"current consent: \(TrackingConsent.granted), next consent: \(TrackingConsent.notGranted)\"",
+            "[\"current consent: \(TrackingConsent.granted), next consent: \(TrackingConsent.pending)\"]",
+            "[\"current consent: \(TrackingConsent.granted), next consent: \(TrackingConsent.notGranted)\"]",
             // Data collected with `.pending` consent is allowed only if the next consent was `.granted`
-            "\"current consent: \(TrackingConsent.pending), next consent: \(TrackingConsent.granted)\"",
+            "[\"current consent: \(TrackingConsent.pending), next consent: \(TrackingConsent.granted)\"]",
         ]
 
         XCTAssertEqual(
@@ -71,8 +72,9 @@ class FeatureStorageTests: XCTestCase {
         // swiftlint:disable opening_brace
         callConcurrently(
             closures: [
-                { storage.writer.write(value: "regular write") },
-                { storage.arbitraryAuthorizedWriter.write(value: "arbitrary write") }
+                // We write arrays because prior to iOS 13 the top-level element passed to JSON encoder must be array or object
+                { storage.writer.write(value: ["regular write"]) },
+                { storage.arbitraryAuthorizedWriter.write(value: ["arbitrary write"]) }
             ],
             iterations: 25
         )
@@ -81,8 +83,8 @@ class FeatureStorageTests: XCTestCase {
         // Then
         let dataWritten = readAllAuthorizedDataWritten(to: storage, limit: 50)
             .map { $0.utf8String }
-        XCTAssertEqual(dataWritten.filter { $0 == "\"regular write\"" }.count, 25)
-        XCTAssertEqual(dataWritten.filter { $0 == "\"arbitrary write\"" }.count, 25)
+        XCTAssertEqual(dataWritten.filter { $0 == "[\"regular write\"]" }.count, 25)
+        XCTAssertEqual(dataWritten.filter { $0 == "[\"arbitrary write\"]" }.count, 25)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
### What and why?

📦 This PR fixes RUM Views auto-instrumentation issue for iOS 11 and fixes unit tests issues for iOS 11.x and 12.x.

### How?

**RUM Views auto-instrumentation issue for iOS 11**

Views instrumentation opts-out from tracking "bare" UIKit view controllers. This is determined by checking if the vc class is defined inside `UIKitCore.framework`. This check was failing for iOS 11, because it ships `UIKit.framework` instead of `UIKitCore.framework`.

**Tests failures for iOS 11.x and 12.x**

Several encoding-related tests were fixed for versions prior to iOS 13. They were failing due to known limitation of JSON encoder on iOS 11 and 12 - it can only encode object or array as the root type.

### Running all unit tests nightly on iOS 11.x-14.x

To mitigate this kind of regression in the future, I was trying to configure nightly job for running tests on all iOS versions on Bitrise CI. Unfortunately, I couldn't find a good solution to set it up. I've contacted Bitrise support for guidance and recommendation. What I've tried so far:
* using distinct Bitrise stacks to spin separate workflows for iOS 11, 12, 13 and 14,
* installing additional simulators on Xcode 12.x stack with `xcode-install`.

The first approach requires patching `xcframeworks` to `frameworks` for Xcode 11.x and 10.x. I did it, but then faced the swift compiler issue, as some of the APIs are not available on older versions of the compiler. This way seems to be too error-prone and very hard to maintain. (note: supporting older versions of Xcode is not our focus as Apple [keeps the bar high, with enforcing Xcode 12 for App Store submissions](https://developer.apple.com/news/?id=ib31uj1j&utm_campaign=iOS%2BDev%2BWeekly&utm_medium=web&utm_source=iOS%2BDev%2BWeekly%2BIssue%2B504))

The second approach seems promising (simulator download takes `~1min` on Bitrise), but it's blocked by `xcode-install` failing with _"Please authenticate to install iOS ##.# Simulator..."_. This appears to come from required sudo permission. I've contacted Bitrise support to ask on that.

Until getting response from Bitrise support, we can consider this topic closed. Separate JIRA was created for configuring nightly run once we unblock this topic.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
