### PR TITLE
make createSpanText accessible to implementing modules

### DIFF
--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -183,9 +183,7 @@ public class Tracer: OTTracer {
         return activeSpansPool.getActiveSpan()
     }
 
-    // MARK: - Internal
-
-    internal func createSpanContext(parentSpanContext: DDSpanContext? = nil) -> DDSpanContext {
+    public func createSpanContext(parentSpanContext: DDSpanContext? = nil) -> DDSpanContext {
         return DDSpanContext(
             traceID: parentSpanContext?.traceID ?? (environmentSpanIntegration.environmentSpanContext?.traceID ?? tracingUUIDGenerator.generateUnique()),
             spanID: tracingUUIDGenerator.generateUnique(),
@@ -193,6 +191,8 @@ public class Tracer: OTTracer {
             baggageItems: BaggageItems(targetQueue: queue, parentSpanItems: parentSpanContext?.baggageItems)
         )
     }
+
+    // MARK: - Internal
 
     internal func startSpan(spanContext: DDSpanContext, operationName: String, tags: [String: Encodable]? = nil, startTime: Date? = nil) -> OTSpan {
         var combinedTags = globalTags ?? [:]


### PR DESCRIPTION
### What and why?

Libraries that extend dd-sdk-ios do not have access to generating span or trace IDs. This is very likely by design, however, it excludes community SDKs like [datadog_flutter](https://github.com/greenbits/datadog_flutter). This PR allows access of `createSpanContext` in modules (such as a Flutter plugin). 

This may be an [overly simplistic implementation](https://github.com/greenbits/datadog_flutter/compare/unsound-null-safety...add-trace?expand=1), and I'm likely not understanding the large complexity behind trace IDs. But I figured that, either way, a PR would be some answer. 

### How?

`internal` access is converted to `public` access.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference

^ Not sure on the JIRA or Issue? Is this a public JIRA?