### PR TITLE
RUMM-1218 App going background stops active RUM view

### DIFF
--- a/Sources/Datadog/Core/System/AppStateListener.swift
+++ b/Sources/Datadog/Core/System/AppStateListener.swift
@@ -103,7 +103,10 @@ internal class AppStateListener: AppStateListening {
         return UIApplication.managedShared?.applicationState == .active
     }
 
-    init(dateProvider: DateProvider) {
+    init(
+        dateProvider: DateProvider,
+        notificationCenter: NotificationCenter = .default
+    ) {
         self.dateProvider = dateProvider
         let currentState = Snapshot(
             isActive: AppStateListener.isAppActive,
@@ -116,9 +119,8 @@ internal class AppStateListener: AppStateListening {
             )
         )
 
-        let nc = NotificationCenter.default
-        nc.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
-        nc.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
     @objc

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -33,25 +33,6 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
         nc.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
-    private weak var lastActiveAppVC: UIViewController?
-    @objc
-    private func appWillResignActive() {
-        if lastActiveAppVC != nil {
-            return
-        }
-        lastActiveAppVC = lastStartedViewController
-        stop(viewController: lastActiveAppVC)
-    }
-
-    @objc
-    private func appDidBecomeActive() {
-        if let vc = lastActiveAppVC,
-           let rumView = predicate.rumView(for: vc) {
-            start(viewController: vc, rumView: rumView)
-        }
-        lastActiveAppVC = nil
-    }
-
     // MARK: - UIKitRUMViewsHandlerType
 
     weak var subscriber: RUMCommandSubscriber?
@@ -74,6 +55,19 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
     }
 
     // MARK: - Private
+
+    @objc
+    private func appWillResignActive() {
+        stop(viewController: lastStartedViewController)
+    }
+
+    @objc
+    private func appDidBecomeActive() {
+        if let vc = lastStartedViewController,
+           let rumView = predicate.rumView(for: vc) {
+            start(viewController: vc, rumView: rumView)
+        }
+    }
 
     /// The `UIViewController` recently asked in `UIKitRUMViewsPredicate`.
     private weak var recentlyAskedViewController: UIViewController?

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -22,15 +22,15 @@ internal class UIKitRUMViewsHandler: UIKitRUMViewsHandlerType {
     init(
         predicate: UIKitRUMViewsPredicate,
         dateProvider: DateProvider,
-        inspector: UIKitHierarchyInspectorType = UIKitHierarchyInspector()
+        inspector: UIKitHierarchyInspectorType = UIKitHierarchyInspector(),
+        notificationCenter: NotificationCenter = .default
     ) {
         self.predicate = predicate
         self.dateProvider = dateProvider
         self.inspector = inspector
 
-        let nc = NotificationCenter.default
-        nc.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
-        nc.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
     // MARK: - UIKitRUMViewsHandlerType

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
@@ -18,12 +18,14 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
     private let commandSubscriber = RUMCommandSubscriberMock()
     private let predicate = UIKitRUMViewsPredicateMock()
     private let uiKitHierarchyInspector = UIKitHierarchyInspectorMock()
+    private let notificationCenter = NotificationCenter()
 
     private lazy var handler: UIKitRUMViewsHandler = {
         let handler = UIKitRUMViewsHandler(
             predicate: predicate,
             dateProvider: dateProvider,
-            inspector: uiKitHierarchyInspector
+            inspector: uiKitHierarchyInspector,
+            notificationCenter: notificationCenter
         )
         handler.subscribe(commandsSubscriber: commandSubscriber)
         return handler
@@ -207,9 +209,9 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
         handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
 
         // When
-        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
         dateProvider.advance(bySeconds: 1)
-        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
 
         // Then
         XCTAssertEqual(commandSubscriber.receivedCommands.count, 3)
@@ -234,9 +236,9 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
         predicate.result = .init(name: viewName, attributes: ["foo": "bar"])
 
         // When
-        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
         dateProvider.advance(bySeconds: 1)
-        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
 
         // Then
         XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
@@ -207,13 +207,9 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
         handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
 
         // When
-        for _ in 0..<3 {
-            NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
-        }
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
         dateProvider.advance(bySeconds: 1)
-        for _ in 0..<3 {
-            NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        }
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
 
         // Then
         XCTAssertEqual(commandSubscriber.receivedCommands.count, 3)
@@ -238,13 +234,9 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
         predicate.result = .init(name: viewName, attributes: ["foo": "bar"])
 
         // When
-        for _ in 0..<3 {
-            NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
-        }
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
         dateProvider.advance(bySeconds: 1)
-        for _ in 0..<3 {
-            NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        }
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
 
         // Then
         XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandlerTests.swift
@@ -59,8 +59,8 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
 
         // Given
         predicate.resultByViewController = [
-            view1: .init(name: .mockRandom()),
-            view2: .init(name: .mockRandom()),
+            view1: .init(name: .mockRandom(), attributes: ["key1": "val1"]),
+            view2: .init(name: .mockRandom(), attributes: ["key2": "val2"]),
         ]
 
         // When
@@ -74,8 +74,11 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
         let stopCommand = try XCTUnwrap(commandSubscriber.receivedCommands[1] as? RUMStopViewCommand)
         let startCommand2 = try XCTUnwrap(commandSubscriber.receivedCommands[2] as? RUMStartViewCommand)
         XCTAssertTrue(startCommand1.identity.equals(view1))
+        XCTAssertEqual(startCommand1.attributes as? [String: String], ["key1": "val1"])
         XCTAssertTrue(stopCommand.identity.equals(view1))
+        XCTAssertEqual(stopCommand.attributes.count, 0)
         XCTAssertTrue(startCommand2.identity.equals(view2))
+        XCTAssertEqual(startCommand2.attributes as? [String: String], ["key2": "val2"])
     }
 
     func testGivenAcceptingPredicate_whenViewDidAppear_itDoesNotStartTheSameRUMViewTwice() {
@@ -192,5 +195,58 @@ class UIKitRUMViewsHandlerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(predicate.numberOfCalls, 1)
+    }
+
+    func testGivenRUMViewStarted_whenAppStateChanges_itStopsAndRestartsRUMView() throws {
+        let viewName: String = .mockRandom()
+        let viewControllerClassName: String = .mockRandom()
+        let view = createMockView(viewControllerClassName: viewControllerClassName)
+
+        // Given
+        predicate.result = .init(name: viewName, attributes: ["foo": "bar"])
+        handler.notify_viewDidAppear(viewController: view, animated: .mockAny())
+
+        // When
+        for _ in 0..<3 {
+            NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        }
+        dateProvider.advance(bySeconds: 1)
+        for _ in 0..<3 {
+            NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        }
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 3)
+
+        let stopCommand = try XCTUnwrap(commandSubscriber.receivedCommands[1] as? RUMStopViewCommand)
+        XCTAssertTrue(stopCommand.identity.equals(view))
+        XCTAssertEqual(stopCommand.attributes.count, 0)
+        XCTAssertEqual(stopCommand.time, .mockDecember15th2019At10AMUTC())
+
+        let startCommand = try XCTUnwrap(commandSubscriber.receivedCommands[2] as? RUMStartViewCommand)
+        XCTAssertTrue(startCommand.identity.equals(view))
+        XCTAssertEqual(startCommand.path, viewControllerClassName)
+        XCTAssertEqual(startCommand.name, viewName)
+        XCTAssertEqual(startCommand.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(startCommand.time, .mockDecember15th2019At10AMUTC() + 1)
+    }
+
+    func testGivenRUMViewDidNotStart_whenAppStateChanges_itDoesNothing() throws {
+        let viewName: String = .mockRandom()
+
+        // Given
+        predicate.result = .init(name: viewName, attributes: ["foo": "bar"])
+
+        // When
+        for _ in 0..<3 {
+            NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+        }
+        dateProvider.advance(bySeconds: 1)
+        for _ in 0..<3 {
+            NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        }
+
+        // Then
+        XCTAssertEqual(commandSubscriber.receivedCommands.count, 0)
     }
 }


### PR DESCRIPTION
### What and why?

When the app goes to background, technically there is no active view. Previous behavior didn't match that.

### How?

When the app goes to background (by resigning active) `UIKitRUMViewsHandler` stops the last started RUM view and keeps a weak reference to it.
When the app comes back to foreground (IOW when it does become active) `UIKitRUMViewsHandler` re-starts that view.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
