### PR TITLE
RUMM-1104 Add `SpanEvent` scrubbing API - implement event mapper

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */; };
 		61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */; };
 		61B9ED212462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED202462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift */; };
+		61BAD46A26415FCE001886CA /* OTSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BAD46926415FCE001886CA /* OTSpanTests.swift */; };
 		61BB2B1B244A185D009F3F56 /* PerformancePreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */; };
 		61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBD19424ED4E9E0023E65F /* FeaturesConfiguration.swift */; };
 		61BBD19724ED50040023E65F /* FeaturesConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */; };
@@ -843,6 +844,7 @@
 		61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendTracesFixtureViewController.swift; sourceTree = "<group>"; };
 		61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsHelpers.swift; sourceTree = "<group>"; };
 		61B9ED202462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingManualInstrumentationScenarioTests.swift; sourceTree = "<group>"; };
+		61BAD46926415FCE001886CA /* OTSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTSpanTests.swift; sourceTree = "<group>"; };
 		61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePreset.swift; sourceTree = "<group>"; };
 		61BBD19424ED4E9E0023E65F /* FeaturesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesConfiguration.swift; sourceTree = "<group>"; };
 		61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesConfigurationTests.swift; sourceTree = "<group>"; };
@@ -1419,6 +1421,7 @@
 				61F187FA25FA7D820022CE9A /* InternalMonitoring */,
 				61216278247D20D500AC5D67 /* FeaturesIntegration */,
 				61133C352423990D00786299 /* Utils */,
+				61BAD46826415FA2001886CA /* OpenTracing */,
 			);
 			path = Datadog;
 			sourceTree = "<group>";
@@ -2350,6 +2353,14 @@
 				61B6815D25F135890015B4AF /* CrashReportingWithRUMScenarioTests.swift */,
 			);
 			path = CrashReporting;
+			sourceTree = "<group>";
+		};
+		61BAD46826415FA2001886CA /* OpenTracing */ = {
+			isa = PBXGroup;
+			children = (
+				61BAD46926415FCE001886CA /* OTSpanTests.swift */,
+			);
+			path = OpenTracing;
 			sourceTree = "<group>";
 		};
 		61C3637E2436163400C4D4E6 /* DatadogPrivate */ = {
@@ -3555,6 +3566,7 @@
 				617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */,
 				61F2724925C943C500D54BF8 /* CrashReporterTests.swift in Sources */,
 				6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */,
+				61BAD46A26415FCE001886CA /* OTSpanTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */,
 				61133C532423990D00786299 /* MobileDeviceTests.swift in Sources */,
 				61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */; };
 		618715FC24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715FB24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift */; };
 		618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618C365E248E85B400520CDE /* DateFormattingTests.swift */; };
+		618D9DE7263AD78900A3FAD2 /* SpanEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D9DE6263AD78900A3FAD2 /* SpanEventMapper.swift */; };
 		618DCFD724C7265300589570 /* RUMUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFD624C7265300589570 /* RUMUUID.swift */; };
 		618DCFD924C7269500589570 /* RUMUUIDGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFD824C7269500589570 /* RUMUUIDGenerator.swift */; };
 		618DCFDF24C75FD300589570 /* RUMScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFDE24C75FD300589570 /* RUMScopeTests.swift */; };
@@ -267,6 +268,7 @@
 		619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */; };
 		61A763DC252DB2B3005A23F2 /* NSURLSessionBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */; };
 		61A9238E256FCAA2009B9667 /* DateCorrectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A9238D256FCAA2009B9667 /* DateCorrectionTests.swift */; };
+		61AADBDD263C7ECF008ABC6F /* EquatableInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AADBDC263C7ECF008ABC6F /* EquatableInTests.swift */; };
 		61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */; };
 		61AD4E3824531500006E34EA /* DataFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3724531500006E34EA /* DataFormat.swift */; };
 		61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AD4E3924534075006E34EA /* TracingFeatureTests.swift */; };
@@ -789,6 +791,7 @@
 		618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMapping.swift; sourceTree = "<group>"; };
 		618715FB24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMappingTests.swift; sourceTree = "<group>"; };
 		618C365E248E85B400520CDE /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
+		618D9DE6263AD78900A3FAD2 /* SpanEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanEventMapper.swift; sourceTree = "<group>"; };
 		618DCFD624C7265300589570 /* RUMUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUUID.swift; sourceTree = "<group>"; };
 		618DCFD824C7269500589570 /* RUMUUIDGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUUIDGenerator.swift; sourceTree = "<group>"; };
 		618DCFDE24C75FD300589570 /* RUMScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMScopeTests.swift; sourceTree = "<group>"; };
@@ -813,6 +816,7 @@
 		61A763DA252DB2B3005A23F2 /* NSURLSessionBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionBridge.h; sourceTree = "<group>"; };
 		61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionBridge.m; sourceTree = "<group>"; };
 		61A9238D256FCAA2009B9667 /* DateCorrectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCorrectionTests.swift; sourceTree = "<group>"; };
+		61AADBDC263C7ECF008ABC6F /* EquatableInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquatableInTests.swift; sourceTree = "<group>"; };
 		61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingFeatureMocks.swift; sourceTree = "<group>"; };
 		61AD4E3724531500006E34EA /* DataFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataFormat.swift; sourceTree = "<group>"; };
 		61AD4E3924534075006E34EA /* TracingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingFeatureTests.swift; sourceTree = "<group>"; };
@@ -1559,6 +1563,7 @@
 			children = (
 				61B038C52527259300518F3C /* XCTestCase.swift */,
 				61133C452423990D00786299 /* SwiftExtensions.swift */,
+				61AADBDC263C7ECF008ABC6F /* EquatableInTests.swift */,
 				61133C462423990D00786299 /* TestsDirectory.swift */,
 				61133C472423990D00786299 /* DatadogExtensions.swift */,
 				61F1A622249B811200075390 /* Encoding.swift */,
@@ -2224,6 +2229,14 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		618D9DE5263AD77600A3FAD2 /* Scrubbing */ = {
+			isa = PBXGroup;
+			children = (
+				618D9DE6263AD78900A3FAD2 /* SpanEventMapper.swift */,
+			);
+			path = Scrubbing;
+			sourceTree = "<group>";
+		};
 		618DCFD524C7264100589570 /* UUIDs */ = {
 			isa = PBXGroup;
 			children = (
@@ -2389,6 +2402,7 @@
 				61C5A87E24509A0C00DA608C /* DDSpanContext.swift */,
 				61C5A8A324509FAA00DA608C /* Span */,
 				61C5A87F24509A0C00DA608C /* SpanOutputs */,
+				618D9DE5263AD77600A3FAD2 /* Scrubbing */,
 				61C5A88224509A0C00DA608C /* Propagation */,
 				617CEB372456BC2200AD4669 /* UUIDs */,
 				613F2405252B37B0006CD2D7 /* AutoInstrumentation */,
@@ -3277,6 +3291,7 @@
 				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
 				6139CD712589FAFD007E8BB7 /* Retrying.swift in Sources */,
 				61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */,
+				618D9DE7263AD78900A3FAD2 /* SpanEventMapper.swift in Sources */,
 				6114FE2F257687310084E372 /* ConsentProvider.swift in Sources */,
 				61F3CDA52511190E00C816E5 /* UIViewControllerSwizzler.swift in Sources */,
 				6156CB9024DDA8BE008CB2B2 /* RUMCurrentContext.swift in Sources */,
@@ -3463,6 +3478,7 @@
 				61133C612423990D00786299 /* HTTPClientTests.swift in Sources */,
 				61133C6A2423990D00786299 /* DatadogTests.swift in Sources */,
 				61B0387C252724AB00518F3C /* DDURLSessionDelegateTests.swift in Sources */,
+				61AADBDD263C7ECF008ABC6F /* EquatableInTests.swift in Sources */,
 				61133C5E2423990D00786299 /* DataUploadDelayTests.swift in Sources */,
 				61B0387A252724AB00518F3C /* FirstPartyURLsFilterTests.swift in Sources */,
 				61133C5C2423990D00786299 /* DataUploadWorkerTests.swift in Sources */,

--- a/Datadog/Example/Scenarios/Tracing/TracingScenarios.swift
+++ b/Datadog/Example/Scenarios/Tracing/TracingScenarios.swift
@@ -20,6 +20,13 @@ final class TracingURLSessionScenario: URLSessionBaseScenario, TestScenario {
     override func configureSDK(builder: Datadog.Configuration.Builder) {
         _ = builder
             .enableRUM(false)
+            .setSpanEventMapper { spanEvent in
+                var mutableSpanEvent = spanEvent
+                if mutableSpanEvent.tags[OTTags.httpUrl] != nil {
+                    mutableSpanEvent.tags[OTTags.httpUrl] = "redacted"
+                }
+                return mutableSpanEvent
+            }
 
         super.configureSDK(builder: builder)
     }
@@ -34,6 +41,13 @@ final class TracingNSURLSessionScenario: URLSessionBaseScenario, TestScenario {
     override func configureSDK(builder: Datadog.Configuration.Builder) {
         _ = builder
             .enableRUM(false)
+            .setSpanEventMapper { spanEvent in
+                var mutableSpanEvent = spanEvent
+                if mutableSpanEvent.tags[OTTags.httpUrl] != nil {
+                    mutableSpanEvent.tags[OTTags.httpUrl] = "redacted"
+                }
+                return mutableSpanEvent
+            }
 
         super.configureSDK(builder: builder)
     }

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -29,6 +29,7 @@ internal struct FeaturesConfiguration {
     struct Tracing {
         let common: Common
         let uploadURLWithClientToken: URL
+        let spanEventMapper: SpanEventMapper?
     }
 
     struct RUM {
@@ -168,7 +169,8 @@ extension FeaturesConfiguration {
                 uploadURLWithClientToken: try ifValid(
                     endpointURLString: tracesEndpoint.url,
                     clientToken: configuration.clientToken
-                )
+                ),
+                spanEventMapper: configuration.spanEventMapper
             )
         }
 

--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -7,9 +7,9 @@
 import CoreTelephony
 
 /// Network connection details specific to cellular radio access.
-internal struct CarrierInfo: Equatable {
+public struct CarrierInfo: Equatable {
     // swiftlint:disable identifier_name
-    enum RadioAccessTechnology: String, Codable, CaseIterable {
+    public enum RadioAccessTechnology: String, Codable, CaseIterable {
         case GPRS
         case Edge
         case WCDMA
@@ -25,10 +25,14 @@ internal struct CarrierInfo: Equatable {
     }
     // swiftlint:enable identifier_name
 
-    let carrierName: String?
-    let carrierISOCountryCode: String?
-    let carrierAllowsVOIP: Bool
-    let radioAccessTechnology: RadioAccessTechnology
+    /// The name of the user’s home cellular service provider.
+    public let carrierName: String?
+    /// The ISO country code for the user’s cellular service provider.
+    public let carrierISOCountryCode: String?
+    /// Indicates if the carrier allows making VoIP calls on its network.
+    public let carrierAllowsVOIP: Bool
+    /// The radio access technology used for cellular connection.
+    public let radioAccessTechnology: RadioAccessTechnology
 }
 
 /// An observer for `CarrierInfo` value.

--- a/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
+++ b/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
@@ -7,9 +7,9 @@
 import Network
 
 /// Network connection details.
-internal struct NetworkConnectionInfo: Equatable {
+public struct NetworkConnectionInfo: Equatable {
     /// Tells if network is reachable.
-    enum Reachability: String, Codable, CaseIterable {
+    public enum Reachability: String, Codable, CaseIterable {
         /// The network is reachable.
         case yes
         /// The network might be reachable after trying.
@@ -19,7 +19,7 @@ internal struct NetworkConnectionInfo: Equatable {
     }
 
     /// Network connection interfaces.
-    enum Interface: String, Codable, CaseIterable {
+    public enum Interface: String, Codable, CaseIterable {
         case wifi
         case wiredEthernet
         case cellular
@@ -27,12 +27,18 @@ internal struct NetworkConnectionInfo: Equatable {
         case other
     }
 
-    let reachability: Reachability
-    let availableInterfaces: [Interface]?
-    let supportsIPv4: Bool?
-    let supportsIPv6: Bool?
-    let isExpensive: Bool?
-    let isConstrained: Bool?
+    /// Network reachability status.
+    public let reachability: Reachability
+    /// Available network interfaces.
+    public let availableInterfaces: [Interface]?
+    /// A Boolean indicating whether the connection supports IPv4 traffic.
+    public let supportsIPv4: Bool?
+    /// A Boolean indicating whether the connection supports IPv6 traffic.
+    public let supportsIPv6: Bool?
+    /// A Boolean indicating if the connection uses an interface that is considered expensive, such as Cellular or a Personal Hotspot.
+    public let isExpensive: Bool?
+    /// A Boolean indicating if the connection uses an interface in Low Data Mode.
+    public let isConstrained: Bool?
 }
 
 /// An observer for `NetworkConnectionInfo` value.

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -171,6 +171,7 @@ extension Datadog {
 
         private(set) var serviceName: String?
         private(set) var firstPartyHosts: Set<String>?
+        private(set) var spanEventMapper: SpanEventMapper?
         private(set) var rumSessionsSamplingRate: Float
         private(set) var rumUIKitViewsPredicate: UIKitRUMViewsPredicate?
         private(set) var rumUIKitActionsTrackingEnabled: Bool
@@ -241,6 +242,7 @@ extension Datadog {
                     rumEndpoint: .us,
                     serviceName: nil,
                     firstPartyHosts: nil,
+                    spanEventMapper: nil,
                     rumSessionsSamplingRate: 100.0,
                     rumUIKitViewsPredicate: nil,
                     rumUIKitActionsTrackingEnabled: false,
@@ -386,6 +388,18 @@ extension Datadog {
             /// - Parameter firstPartyHosts: empty set by default
             public func trackURLSession(firstPartyHosts: Set<String> = []) -> Builder {
                 configuration.firstPartyHosts = firstPartyHosts
+                return self
+            }
+
+            /// Sets the custom mapper for `SpanEvent`. This can be used to modify spans before they are send to Datadog.
+            /// - Parameter mapper: the closure taking `SpanEvent` as input and expecting `SpanEvent` as output.
+            /// The implementation should obtain a mutable version of the `SpanEvent`, modify it and return it.
+            ///
+            /// **NOTE** The mapper intentionally prevents from returning a `nil` to drop the `SpanEvent` entirely, this ensures that all spans are sent to Datadog.
+            ///
+            /// Use the `trackURLSession(firstPartyHosts:)` API to confiture tracing only the hosts that you are interested in.
+            public func setSpanEventMapper(_ mapper: @escaping (SpanEvent) -> SpanEvent) -> Builder {
+                configuration.spanEventMapper = mapper
                 return self
             }
 

--- a/Sources/Datadog/OpenTracing/OTSpan.swift
+++ b/Sources/Datadog/OpenTracing/OTSpan.swift
@@ -122,7 +122,6 @@ public extension OTSpan {
     /// - parameter stack: A string detailing the state of the stack when the error was caught. Note that it can also be any details that could help further triaging and investigation of the error downstream, it doesn't have to be an actual stack trace. Also note that an empty string means skipping the `stack` parameter.
     /// - parameter file: A string identifying the file where the error was caught. The default is `#fileID` which means `ModuleName/Filename.extension`, consider an helpful yet concise identifier when overriding the default. Note that an empty string means skipping the `file` and `line` parameters.
     /// - parameter line: The line number in the file where the error was caught.
-    /// - parameter includeFileInStack: Whether or not the `file` and `line` should be included in the stack, the default is `true` and can be overriden if the `file`/`line` are extraneous.
     func setError(
         kind: String,
         message: String,

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -106,7 +106,8 @@ public class Tracer: OTTracer {
                 networkConnectionInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.networkConnectionInfoProvider : nil,
                 carrierInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.carrierInfoProvider : nil,
                 dateCorrector: tracingFeature.dateCorrector,
-                source: tracingFeature.configuration.common.source
+                source: tracingFeature.configuration.common.source,
+                eventsMapper: tracingFeature.configuration.spanEventMapper
             ),
             spanOutput: SpanFileOutput(
                 fileWriter: tracingFeature.storage.writer,

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -24,32 +24,16 @@ internal class DDSpan: OTSpan {
     /// Writes span logs to output. `nil` if Logging feature is disabled.
     private let logOutput: LoggingForTracingAdapter.AdaptedLogOutput?
 
-    /// Unsynchronized span operation name. Use `self.operationName` setter & getter.
+    /// Queue used for synchronizing mutable properties access.
+    private let queue: DispatchQueue
+    /// Unsynchronized span operation name. Must be accessed on `queue`.
     private var unsafeOperationName: String
-    private(set) var operationName: String {
-        get { ddTracer.queue.sync { unsafeOperationName } }
-        set { ddTracer.queue.async { self.unsafeOperationName = newValue } }
-    }
-
-    /// Unsynchronized span tags. Use `self.tags` setter & getter.
+    /// Unsynchronized span tags.  Must be accessed on `queue`.
     private var unsafeTags: [String: Encodable]
-    var tags: [String: Encodable] {
-        ddTracer.queue.sync { unsafeTags }
-    }
-
-    /// Unsychronized span log fields. Use `self.logFields` setter & getter.
+    /// Unsychronized span log fields.  Must be accessed on `queue`.
     private var unsafeLogFields: [[String: Encodable]]
-    /// A collection of all log fields send for this span.
-    var logFields: [[String: Encodable]] {
-        ddTracer.queue.sync { unsafeLogFields }
-    }
-
-    /// Unsychronized span completion. Use `self.isFinished` setter & getter.
+    /// Unsychronized span completion.  Must be accessed on `queue`.
     private var unsafeIsFinished: Bool
-    private(set) var isFinished: Bool {
-        get { ddTracer.queue.sync { unsafeIsFinished } }
-        set { ddTracer.queue.async { self.unsafeIsFinished = newValue } }
-    }
 
     private var activityReference: ActivityReference?
 
@@ -58,8 +42,7 @@ internal class DDSpan: OTSpan {
         context: DDSpanContext,
         operationName: String,
         startTime: Date,
-        tags: [String: Encodable],
-        logFields: [[String: Encodable]] = []
+        tags: [String: Encodable]
     ) {
         self.ddTracer = tracer
         self.ddContext = context
@@ -67,10 +50,11 @@ internal class DDSpan: OTSpan {
         self.spanBuilder = tracer.spanBuilder
         self.spanOutput = tracer.spanOutput
         self.logOutput = tracer.logOutput
+        self.queue = ddTracer.queue // share the queue among all spans
         self.unsafeOperationName = operationName
         self.unsafeTags = tags
+        self.unsafeLogFields = []
         self.unsafeIsFinished = false
-        self.unsafeLogFields = logFields
     }
 
     // MARK: - Open Tracing interface
@@ -84,33 +68,35 @@ internal class DDSpan: OTSpan {
     }
 
     func setOperationName(_ operationName: String) {
-        if warnIfFinished("setOperationName(_:)") {
-            return
+        queue.async {
+            if self.warnIfFinished("setOperationName(_:)") {
+                return
+            }
+            self.unsafeOperationName = operationName
         }
-        self.operationName = operationName
     }
 
     func setTag(key: String, value: Encodable) {
-        if warnIfFinished("setTag(key:value:)") {
-            return
-        }
-        ddTracer.queue.async {
+        queue.async {
+            if self.warnIfFinished("setTag(key:value:)") {
+                return
+            }
             self.unsafeTags[key] = value
         }
     }
 
     func setBaggageItem(key: String, value: String) {
-        if warnIfFinished("setBaggageItem(key:value:)") {
-            return
+        let isFinished = queue.sync { self.warnIfFinished("setBaggageItem(key:value:)") }
+        if !isFinished {
+            // Baggage items must be accessed outside the `tracer.queue` as it uses that queue for internal sync.
+            ddContext.baggageItems.set(key: key, value: value)
         }
-        ddContext.baggageItems.set(key: key, value: value)
     }
 
     func baggageItem(withKey key: String) -> String? {
-        if warnIfFinished("baggageItem(withKey:)") {
-            return nil
-        }
-        return ddContext.baggageItems.get(key: key)
+        let isFinished = queue.sync { self.warnIfFinished("baggageItem(withKey:)") }
+        // Baggage items must be accessed outside the `tracer.queue` as it uses that queue for internal sync.
+        return !isFinished ? ddContext.baggageItems.get(key: key) : nil
     }
 
     @discardableResult
@@ -123,38 +109,42 @@ internal class DDSpan: OTSpan {
     }
 
     func log(fields: [String: Encodable], timestamp: Date) {
-        if warnIfFinished("log(fields:timestamp:)") {
-            return
-        }
-        ddTracer.queue.async {
+        queue.async {
+            if self.warnIfFinished("log(fields:timestamp:)") {
+                return
+            }
             self.unsafeLogFields.append(fields)
         }
         sendSpanLogs(fields: fields, date: timestamp)
     }
 
     func finish(at time: Date) {
-        if warnIfFinished("finish(at:)") {
-            return
+        let isFinished: Bool = queue.sync {
+            let wasFinished = self.warnIfFinished("finish(at:)")
+            self.unsafeIsFinished = true
+            return wasFinished
         }
-        isFinished = true
-        if let activity = activityReference {
-            ddTracer.activeSpansPool.removeSpan(activityReference: activity)
+
+        if !isFinished {
+            if let activity = activityReference {
+                ddTracer.activeSpansPool.removeSpan(activityReference: activity)
+            }
+            sendSpan(finishTime: time)
         }
-        sendSpan(finishTime: time)
     }
 
     // MARK: - Writting SpanEvent
 
     /// Sends span event for given `DDSpan`.
     private func sendSpan(finishTime: Date) {
-        // Baggage items must be read before entering the `tracer.queue` as it uses that queue for internal sync.
+        // Baggage items must be accessed outside the `tracer.queue` as it uses that queue for internal sync.
         let baggageItems = ddContext.baggageItems.all
 
         // This queue adds performance optimisation by reading all `unsafe*` values in one block and performing
         // the `builder.createSpan()` off the main thread. This is important as the span creation includes
         // attributes encoding to JSON string values (for tags and extra user info). It captures `self` strongly
         // as it is very likely to be deallocated after return.
-        ddTracer.queue.async {
+        queue.async {
             let span = self.spanBuilder.createSpanEvent(
                 traceID: self.ddContext.traceID,
                 spanID: self.ddContext.spanID,
@@ -172,7 +162,9 @@ internal class DDSpan: OTSpan {
 
     private func sendSpanLogs(fields: [String: Encodable], date: Date) {
         guard let logOutput = logOutput else {
-            userLogger.warn("The log for span \"\(operationName)\" will not be send, because the Logging feature is disabled.")
+            queue.async {
+                userLogger.warn("The log for span \"\(self.unsafeOperationName)\" will not be send, because the Logging feature is disabled.")
+            }
             return
         }
         logOutput.writeLog(withSpanContext: ddContext, fields: fields, date: date)
@@ -182,8 +174,8 @@ internal class DDSpan: OTSpan {
 
     private func warnIfFinished(_ methodName: String) -> Bool {
         return warn(
-            if: isFinished,
-            message: "🔥 Calling `\(methodName)` on a finished span (\"\(operationName)\") is not allowed."
+            if: unsafeIsFinished,
+            message: "🔥 Calling `\(methodName)` on a finished span (\"\(unsafeOperationName)\") is not allowed."
         )
     }
 }

--- a/Sources/Datadog/Tracing/Scrubbing/SpanEventMapper.swift
+++ b/Sources/Datadog/Tracing/Scrubbing/SpanEventMapper.swift
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Data scrubbing interface.
+/// It takes `SpanEvent` and returns modified `SpanEvent`.
+internal typealias SpanEventMapper = (SpanEvent) -> SpanEvent

--- a/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
@@ -20,8 +20,10 @@ internal struct SpanEventBuilder {
     let carrierInfoProvider: CarrierInfoProviderType?
     /// Adjusts span's time (device time) to server time.
     let dateCorrector: DateCorrectorType
-    /// source tag to encode in span.
+    /// Source tag to encode in span (e.g. `ios` for native iOS).
     let source: String
+    /// Span events mapper configured by the user, `nil` if not set.
+    let eventsMapper: SpanEventMapper?
 
     func createSpanEvent(
         traceID: TracingUUID,
@@ -73,7 +75,11 @@ internal struct SpanEventBuilder {
             tags: tags
         )
 
-        return span
+        if let eventMapper = eventsMapper {
+            return eventMapper(span)
+        } else {
+            return span
+        }
     }
 
     // MARK: - Attributes Conversion

--- a/Sources/Datadog/Tracing/Span/SpanEventEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEventEncoder.swift
@@ -29,40 +29,60 @@ internal struct SpanEventsEnvelope: Encodable {
     }
 }
 
-/// `Encodable` representation of span.
-/// All mutable properties are subject of sanitization.
-internal struct SpanEvent: Encodable {
-    let traceID: TracingUUID
-    let spanID: TracingUUID
-    let parentID: TracingUUID?
-    let operationName: String
-    let serviceName: String
-    let resource: String
-    let startTime: Date
-    let duration: TimeInterval
-    let isError: Bool
-    let source: String
+/// Individual span event sent do Datadog.
+public struct SpanEvent: Encodable {
+    /// The id of the trace this span belongs to.
+    internal let traceID: TracingUUID
+    /// The unique id of this span.
+    internal let spanID: TracingUUID
+    /// The id this span's parent or `nil` if this is the root span.
+    internal let parentID: TracingUUID?
+    /// The operation name set for this span.
+    public var operationName: String
+    /// The service name configured for tracer.
+    public let serviceName: String
+    /// The resource name associated with this span.
+    /// For automatically tracked spans, it is set to the request URL.
+    /// For all other spands it fallbacks to `operationName`.
+    public var resource: String
+    /// The start time of this span.
+    public let startTime: Date
+    /// The span duration.
+    public let duration: TimeInterval
+    /// Indicates if there was an error information collected for this span.
+    public let isError: Bool
+    /// Name of the component sourcing the span, for iOS SDK it is set to `ios`.
+    internal let source: String
 
     // MARK: - Meta
 
-    let tracerVersion: String
-    let applicationVersion: String
-    let networkConnectionInfo: NetworkConnectionInfo?
-    let mobileCarrierInfo: CarrierInfo?
+    /// The SDK version.
+    public let tracerVersion: String
+    /// The client application version.
+    public let applicationVersion: String
+    /// The network connection information from the moment the span was completed.
+    public let networkConnectionInfo: NetworkConnectionInfo?
+    /// The mobile carrier information from the moment the span was completed.
+    public let mobileCarrierInfo: CarrierInfo?
 
-    struct UserInfo {
-        let id: String?
-        let name: String?
-        let email: String?
-        var extraInfo: [String: String]
+    public struct UserInfo {
+        /// User ID, if any.
+        public let id: String?
+        /// Name representing the user, if any.
+        public let name: String?
+        /// User email, if any.
+        public let email: String?
+        /// User custom attributes, if any.
+        public var extraInfo: [String: String]
     }
 
-    var userInfo: UserInfo
+    /// Custom user information configured globally for the SDK.
+    public var userInfo: UserInfo
 
-    /// Custom tags, received from the user.
-    var tags: [String: String]
+    /// Tags associated with the span.
+    public var tags: [String: String]
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         let sanitizedSpan = SpanSanitizer().sanitize(span: self)
         try SpanEventEncoder().encode(sanitizedSpan, to: encoder)
     }

--- a/Sources/DatadogObjc/Tracer+objc.swift
+++ b/Sources/DatadogObjc/Tracer+objc.swift
@@ -134,20 +134,24 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
     // MARK: - Private
 
     private func castTagsToSwift(_ tags: NSDictionary) -> [String: Encodable] {
-        guard let dictionary = tags as? [String: Any] else {
-            return [:]
-        }
+        var validTags: [String: Encodable] = [:]
 
-        return dictionary.mapValues { objcTagValue in
-            // As underlying `Datadog.JSONStringEncodableValue` provides special handling for `String` and `URL`
-            // when converting those `Encodables` to lossless JSON string representation, we have to cast them directly:
-            if let stringValue = objcTagValue as? String {
-                return stringValue
-            } else if let urlValue = objcTagValue as? URL {
-                return urlValue
-            } else {
-                return AnyEncodable(objcTagValue)
+        tags.forEach { tagKey, tagValue in
+            if let stringKey = tagKey as? String {
+                let encodableValue: Encodable = {
+                    if let stringValue = tagValue as? String {
+                        return stringValue
+                    } else if let urlValue = tagValue as? URL {
+                        return urlValue
+                    } else {
+                        return AnyEncodable(tagValue)
+                    }
+                }()
+
+                validTags[stringKey] = encodableValue
             }
         }
+
+        return validTags
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/Tracing/TracingURLSessionScenarioTests.swift
@@ -101,6 +101,10 @@ class TracingURLSessionScenarioTests: IntegrationTests, TracingCommonAsserts {
         XCTAssertEqual(try taskWithRequest.operationName(), "urlsession.request")
         XCTAssertEqual(try taskWithBadURL.operationName(), "urlsession.request")
 
+        XCTAssertEqual(try taskWithURL.meta.custom(keyPath: "meta.http.url"), "redacted")
+        XCTAssertEqual(try taskWithRequest.meta.custom(keyPath: "meta.http.url"), "redacted")
+        XCTAssertEqual(try taskWithBadURL.meta.custom(keyPath: "meta.http.url"), "redacted")
+
         XCTAssertEqual(try taskWithURL.metrics.isRootSpan(), 1)
         XCTAssertEqual(try taskWithRequest.metrics.isRootSpan(), 1)
         XCTAssertEqual(try taskWithBadURL.metrics.isRootSpan(), 1)

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -43,6 +43,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.rumEndpoint, .us)
             XCTAssertNil(configuration.serviceName)
             XCTAssertNil(configuration.firstPartyHosts)
+            XCTAssertNil(configuration.spanEventMapper)
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 100.0)
             XCTAssertNil(configuration.rumUIKitViewsPredicate)
             XCTAssertFalse(configuration.rumUIKitActionsTrackingEnabled)
@@ -58,6 +59,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
     }
 
     func testCustomizedBuilder() {
+        let mockSpanEvent: SpanEvent = .mockAny()
         let mockRUMViewEvent: RUMViewEvent = .mockRandom()
         let mockRUMErrorEvent: RUMErrorEvent = .mockRandom()
         let mockRUMResourceEvent: RUMResourceEvent = .mockRandom()
@@ -76,6 +78,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .set(customTracesEndpoint: URL(string: "https://api.custom.traces/")!)
                 .set(customRUMEndpoint: URL(string: "https://api.custom.rum/")!)
                 .set(rumSessionsSamplingRate: 42.5)
+                .setSpanEventMapper { _ in mockSpanEvent }
                 .trackURLSession(firstPartyHosts: ["example.com"])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock())
                 .trackUIKitActions(false)
@@ -122,6 +125,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.firstPartyHosts, ["example.com"])
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 42.5)
             XCTAssertTrue(configuration.rumUIKitViewsPredicate is UIKitRUMViewsPredicateMock)
+            XCTAssertEqual(configuration.spanEventMapper?(.mockRandom()), mockSpanEvent)
             XCTAssertFalse(configuration.rumUIKitActionsTrackingEnabled)
             XCTAssertEqual(configuration.rumViewEventMapper?(.mockRandom()), mockRUMViewEvent)
             XCTAssertEqual(configuration.rumResourceEventMapper?(.mockRandom()), mockRUMResourceEvent)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -199,11 +199,13 @@ extension FeaturesConfiguration.Tracing {
 
     static func mockWith(
         common: FeaturesConfiguration.Common = .mockAny(),
-        uploadURLWithClientToken: URL = .mockAny()
+        uploadURLWithClientToken: URL = .mockAny(),
+        spanEventMapper: SpanEventMapper? = nil
     ) -> Self {
         return .init(
             common: common,
-            uploadURLWithClientToken: uploadURLWithClientToken
+            uploadURLWithClientToken: uploadURLWithClientToken,
+            spanEventMapper: spanEventMapper
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -223,9 +223,14 @@ extension LogAttributes: Equatable {
 
 /// `LogOutput` recording received logs.
 class LogOutputMock: LogOutput {
+    var onLogRecorded: ((Log) -> Void)?
+
     var recordedLog: Log?
+    var allRecordedLogs: [Log] = []
 
     func write(log: Log) {
         recordedLog = log
+        allRecordedLogs.append(log)
+        onLogRecorded?(log)
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -122,16 +122,14 @@ extension DDSpan {
         context: DDSpanContext = .mockAny(),
         operationName: String = .mockAny(),
         startTime: Date = .mockAny(),
-        tags: [String: Encodable] = [:],
-        logFields: [[String: Encodable]] = []
+        tags: [String: Encodable] = [:]
     ) -> DDSpan {
         return DDSpan(
             tracer: tracer,
             context: context,
             operationName: operationName,
             startTime: startTime,
-            tags: tags,
-            logFields: logFields
+            tags: tags
         )
     }
 }
@@ -317,12 +315,14 @@ extension SpanEventBuilder {
 
 /// `SpanOutput` recording received spans.
 class SpanOutputMock: SpanOutput {
-    var onSpanRecorded: ((SpanEvent?) -> Void)?
-    var recordedSpan: SpanEvent? = nil {
-        didSet { onSpanRecorded?(recordedSpan) }
-    }
+    var onSpanRecorded: ((SpanEvent) -> Void)?
+
+    var lastRecordedSpan: SpanEvent?
+    var allRecordedSpans: [SpanEvent] = []
 
     func write(span: SpanEvent) {
-        recordedSpan = span
+        lastRecordedSpan = span
+        allRecordedSpans.append(span)
+        onSpanRecorded?(span)
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -164,7 +164,9 @@ class RelativeTracingUUIDGenerator: TracingUUIDGenerator {
     }
 }
 
-extension SpanEvent {
+extension SpanEvent: EquatableInTests {}
+
+extension SpanEvent: AnyMockable, RandomMockable {
     static func mockWith(
         traceID: TracingUUID = .mockAny(),
         spanID: TracingUUID = .mockAny(),
@@ -202,9 +204,32 @@ extension SpanEvent {
             tags: tags
         )
     }
+
+    static func mockAny() -> SpanEvent { .mockWith() }
+
+    static func mockRandom() -> SpanEvent {
+        return SpanEvent(
+            traceID: .init(rawValue: .mockRandom()),
+            spanID: .init(rawValue: .mockRandom()),
+            parentID: .init(rawValue: .mockRandom()),
+            operationName: .mockRandom(),
+            serviceName: .mockRandom(),
+            resource: .mockRandom(),
+            startTime: .mockRandomInThePast(),
+            duration: .mockRandom(),
+            isError: .random(),
+            source: .mockRandom(),
+            tracerVersion: .mockRandom(),
+            applicationVersion: .mockRandom(),
+            networkConnectionInfo: .mockRandom(),
+            mobileCarrierInfo: .mockRandom(),
+            userInfo: .mockRandom(),
+            tags: .mockRandom()
+        )
+    }
 }
 
-extension SpanEvent.UserInfo {
+extension SpanEvent.UserInfo: AnyMockable, RandomMockable {
     static func mockWith(
         id: String? = .mockAny(),
         name: String? = .mockAny(),
@@ -220,6 +245,15 @@ extension SpanEvent.UserInfo {
     }
 
     static func mockAny() -> SpanEvent.UserInfo { .mockWith() }
+
+    static func mockRandom() -> SpanEvent.UserInfo {
+        return SpanEvent.UserInfo(
+            id: .mockRandom(),
+            name: .mockRandom(),
+            email: .mockRandom(),
+            extraInfo: .mockRandom()
+        )
+    }
 }
 
 // MARK: - Component Mocks
@@ -265,7 +299,8 @@ extension SpanEventBuilder {
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType = NetworkConnectionInfoProviderMock.mockAny(),
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny(),
         dateCorrector: DateCorrectorType = DateCorrectorMock(),
-        source: String = .mockAny()
+        source: String = .mockAny(),
+        eventsMapper: SpanEventMapper? = nil
     ) -> SpanEventBuilder {
         return SpanEventBuilder(
             applicationVersion: applicationVersion,
@@ -274,7 +309,8 @@ extension SpanEventBuilder {
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider,
             dateCorrector: dateCorrector,
-            source: source
+            source: source,
+            eventsMapper: eventsMapper
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/OpenTracing/OTSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/OpenTracing/OTSpanTests.swift
@@ -1,0 +1,239 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+private class MockSpan: OTSpan {
+    var context: OTSpanContext = DDNoopGlobals.context
+    func tracer() -> OTTracer { DDNoopGlobals.tracer }
+    func setOperationName(_ operationName: String) {}
+    func setTag(key: String, value: Encodable) {}
+    func setBaggageItem(key: String, value: String) {}
+    func baggageItem(withKey key: String) -> String? { nil }
+    func setActive() -> OTSpan { self }
+    func finish(at time: Date) {}
+
+    var logs: [[String: Encodable]] = []
+
+    func log(fields: [String: Encodable], timestamp: Date) {
+        logs.append(fields)
+    }
+}
+
+private extension Dictionary where Key == String, Value == Encodable {
+    func otEvent() throws -> String {
+        try XCTUnwrap(self[OTLogFields.event] as? String)
+    }
+
+    func otKind() throws -> String {
+        try XCTUnwrap(self[OTLogFields.errorKind] as? String)
+    }
+
+    func otMessage() throws -> String {
+        try XCTUnwrap(self[OTLogFields.message] as? String)
+    }
+
+    func otStack() throws -> String {
+        try XCTUnwrap(self[OTLogFields.stack] as? String)
+    }
+}
+
+class OTSpanTests: XCTestCase {
+    // MARK: - Test Error Conveniences
+
+    func testWhenSettingErrorFromSwiftError_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        #sourceLocation(file: "File.swift", line: 42)
+        span.setError(ErrorMock("swift error description"))
+        #sourceLocation()
+        span.finish()
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "ErrorMock")
+        XCTAssertEqual(try span.logs[0].otMessage(), "swift error description")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            DatadogTests/File.swift:42
+            swift error description
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromSwiftErrorWithFileAndLine_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        span.setError(ErrorMock("swift error description"), file: "File.swift", line: 42)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "ErrorMock")
+        XCTAssertEqual(try span.logs[0].otMessage(), "swift error description")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            File.swift:42
+            swift error description
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromNSError_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        #sourceLocation(file: "File.swift", line: 42)
+        span.setError(
+            NSError(
+                domain: "DDSpan",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "ns error description"]
+            )
+        )
+        #sourceLocation()
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "DDSpan - 1")
+        XCTAssertEqual(try span.logs[0].otMessage(), "ns error description")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            DatadogTests/File.swift:42
+            Error Domain=DDSpan Code=1 "ns error description" UserInfo={NSLocalizedDescription=ns error description}
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromArguments_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        #sourceLocation(file: "File.swift", line: 42)
+        span.setError(kind: "custom kind", message: "DDSpan Error")
+        #sourceLocation()
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "custom kind")
+        XCTAssertEqual(try span.logs[0].otMessage(), "DDSpan Error")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            DatadogTests/File.swift:42
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromArgumentsWithStack_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        let stack = """
+        Thread 0 Crashed:
+        0   app                                 0x0000000102bc0d8c 0x102bb8000 + 36236
+        1   UIKitCore                           0x00000001b513d9ac 0x1b4739000 + 10504620
+        """
+        span.setError(kind: "custom kind", message: "custom message", stack: stack)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "custom kind")
+        XCTAssertEqual(try span.logs[0].otMessage(), "custom message")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            DatadogTests/OTSpanTests.swift:158
+            Thread 0 Crashed:
+            0   app                                 0x0000000102bc0d8c 0x102bb8000 + 36236
+            1   UIKitCore                           0x00000001b513d9ac 0x1b4739000 + 10504620
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromArgumentsWithFileAndLine_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        span.setError(kind: "custom kind", message: "custom message", file: "File.swift", line: 42)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "custom kind")
+        XCTAssertEqual(try span.logs[0].otMessage(), "custom message")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            File.swift:42
+            """
+        )
+    }
+
+    func testWhenSettingErrorWithEmptyFileLineAndStack_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        span.setError(ErrorMock("swift error description"), file: "", line: 0)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "ErrorMock")
+        XCTAssertEqual(try span.logs[0].otMessage(), "swift error description")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            swift error description
+            """
+        )
+    }
+
+    func testWhenSettingErrorWithEmptyFileLineAndNonEmptyStack_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        span.setError(ErrorMock("the stack"), file: "", line: 0)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "ErrorMock")
+        XCTAssertEqual(try span.logs[0].otMessage(), "the stack")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            the stack
+            """
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -967,30 +967,6 @@ class TracerTests: XCTestCase {
         )
     }
 
-    func testWhenSpanStateChangesFromDifferentThreads_itChangesSpanState() {
-        TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance = nil }
-        let tracer = Tracer.initialize(configuration: .init())
-        let span = tracer.startSpan(operationName: "some span", childOf: nil).dd
-
-        let closures: [(DDSpan) -> Void] = [
-            // swiftlint:disable opening_brace
-            { span in span.setTag(key: .mockRandom(), value: "value") },
-            { span in span.setBaggageItem(key: .mockRandom(), value: "value") },
-            { span in _ = span.baggageItem(withKey: .mockRandom()) },
-            { span in _ = span.context.forEachBaggageItem { _, _ in return false } },
-            { span in span.log(fields: [.mockRandom(): "value"]) }
-            // swiftlint:enable opening_brace
-        ]
-        /// Calls given closures on each span cuncurrently
-        let iterations = 100
-        DispatchQueue.concurrentPerform(iterations: iterations) { iteration in
-            closures.forEach { $0(span) }
-        }
-        XCTAssertEqual(span.tags.count, iterations)
-        XCTAssertEqual(span.logFields.count, iterations)
-    }
-
     // MARK: - Usage errors
 
     func testGivenDatadogNotInitialized_whenInitializingTracer_itPrintsError() {
@@ -1058,6 +1034,7 @@ class TracerTests: XCTestCase {
         span.log(fields: ["bar": "bizz"])
 
         // then
+        tracer.dd.queue.sync {} // wait synchronizing span's internal state
         XCTAssertEqual(output.recordedLog?.status, .warn)
         XCTAssertEqual(output.recordedLog?.message, "The log for span \"foo\" will not be send, because the Logging feature is disabled.")
 

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -60,7 +60,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recordedSpan)
+        let span = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(span.traceID.rawValue, 100)
         XCTAssertEqual(span.spanID.rawValue, 200)
         XCTAssertEqual(span.operationName, "urlsession.request")
@@ -94,7 +94,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recordedSpan)
+        let span = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
         XCTAssertFalse(span.isError)
         XCTAssertEqual(span.duration, 2)
@@ -132,7 +132,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recordedSpan)
+        let span = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
         XCTAssertEqual(span.resource, request.url!.absoluteString)
         XCTAssertEqual(span.duration, 30)
@@ -194,7 +194,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recordedSpan)
+        let span = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
         XCTAssertEqual(span.resource, "404")
         XCTAssertEqual(span.duration, 2)
@@ -248,7 +248,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
-        XCTAssertNil(spanOutput.recordedSpan)
+        XCTAssertNil(spanOutput.lastRecordedSpan)
     }
 
     func testGivenThirdPartyInterception_whenInterceptionCompletes_itDoesNotSendTheSpan() throws {
@@ -273,7 +273,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
-        XCTAssertNil(spanOutput.recordedSpan)
+        XCTAssertNil(spanOutput.lastRecordedSpan)
         XCTAssertNil(logOutput.recordedLog)
     }
 
@@ -298,7 +298,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
-        let recordedSpan = try XCTUnwrap(spanOutput.recordedSpan)
+        let recordedSpan = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(recordedSpan.tags[DDTags.foregroundDuration], "10000000000")
         XCTAssertEqual(recordedSpan.tags[DDTags.isBackground], "false")
     }

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanEventBuilderTests.swift
@@ -39,6 +39,32 @@ class SpanEventBuilderTests: XCTestCase {
         XCTAssertEqual(span.tags, ["foo": "bar", "bizz": "123"])
     }
 
+    func testGivenBuilderWithEventMapper_whenEventIsModified_itBuildsModifiedEvent() throws {
+        let builder: SpanEventBuilder = .mockWith(
+            eventsMapper: { span in
+                var mutableSpan = span
+                mutableSpan.operationName = "modified operation name"
+                mutableSpan.tags = .mockRandom()
+                return mutableSpan
+            }
+        )
+
+        let span = builder.createSpanEvent(
+            traceID: .mockAny(),
+            spanID: .mockAny(),
+            parentSpanID: .mockAny(),
+            operationName: "original operation name",
+            startTime: .mockAny(),
+            finishTime: .mockAny(),
+            tags: [:],
+            baggageItems: [:],
+            logFields: []
+        )
+
+        XCTAssertEqual(span.operationName, "modified operation name")
+        XCTAssertGreaterThan(span.tags.count, 0)
+    }
+
     func testBuildingSpanWithErrorTagSet() {
         let builder: SpanEventBuilder = .mockAny()
 

--- a/Tests/DatadogTests/Helpers/EquatableInTests.swift
+++ b/Tests/DatadogTests/Helpers/EquatableInTests.swift
@@ -1,0 +1,80 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Utility protocol adding `Equatable` conformance to any arbitrary type.
+/// The equatabiliity is determined based on comparing type mirrors and values.
+protocol EquatableInTests: Equatable {}
+
+extension EquatableInTests {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return equals(lhs: lhs, rhs: rhs)
+    }
+}
+
+private func equals<T>(lhs: T, rhs: T) -> Bool {
+    return equalsAny(lhs: lhs, rhs: rhs)
+}
+
+private func equalsAny(lhs: Any, rhs: Any) -> Bool {
+    let lhsMirror = Mirror(reflecting: lhs)
+    let rhsMirror = Mirror(reflecting: rhs)
+
+    if lhsMirror.displayStyle != rhsMirror.displayStyle {
+        return false // different types
+    }
+
+    if lhsMirror.children.count != rhsMirror.children.count {
+        return false // different number of children
+    }
+
+    if lhsMirror.children.count == 0, rhsMirror.children.count == 0 {
+        return String(describing: lhs) == String(describing: rhs) // plain values, comopare debug strings
+    }
+
+    switch (lhsMirror.displayStyle, rhsMirror.displayStyle) {
+    case (.dictionary?, .dictionary?): // two dictionaries
+        print("Two dictionaries: \(lhs) vs \(rhs)")
+        let lhsDictionary = lhs as! [String: Any]
+        let rhsDictionary = rhs as! [String: Any]
+
+        if lhsDictionary.keys.count != rhsDictionary.keys.count {
+            return false // difference on number of keys
+        }
+
+        for (lhsKey, lhsValue) in lhsDictionary {
+            if let rhsValue = rhsDictionary[lhsKey] {
+                if !equalsAny(lhs: lhsValue, rhs: rhsValue) {
+                    return false // difference on key values
+                }
+            } else {
+                return false // difference on key names
+            }
+        }
+
+        return true // dictionaries are equal
+    case (.set?, .set?): // two sets
+        let lhsSet = lhs as! Set<AnyHashable>
+        let rhsSet = rhs as! Set<AnyHashable>
+
+        let setsEqual = lhsSet == rhsSet // if sets are equal
+        return setsEqual
+    default:
+        break // other than dictionary or set, continue...
+    }
+
+    let lhsChildren = lhsMirror.children.map { $0.value }
+    let rhsChildren = rhsMirror.children.map { $0.value }
+
+    for (lhsChild, rhsChild) in zip(lhsChildren, rhsChildren) { // compare each child
+        if !equalsAny(lhs: lhsChild, rhs: rhsChild) {
+            return false // childs are different
+        }
+    }
+
+    return true
+}

--- a/Tests/DatadogTests/Helpers/SwiftExtensions.swift
+++ b/Tests/DatadogTests/Helpers/SwiftExtensions.swift
@@ -26,15 +26,6 @@ extension Optional {
     }
 }
 
-/// Utility protocol adding `Equatable` conformance to any type, based on `String(describing:)` comparison.
-protocol EquatableInTests: Equatable {}
-
-extension EquatableInTests {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        return String(describing: lhs) == String(describing: rhs)
-    }
-}
-
 extension Date {
     func secondsAgo(_ seconds: TimeInterval) -> Date {
         return addingTimeInterval(-seconds)


### PR DESCRIPTION
### What and why?

📦 This PR adds the actual implementation of `SpanEvents` scrubbing - the `SpanEvents` mapper API:
```swift
public func setSpanEventMapper(_ mapper: @escaping (SpanEvent) -> SpanEvent)
```

### How?

Similar to how RUM events mapper works, the mapper is set up from public interface and passed to the `SpanBuilder` through `FeaturesConfiguration` structure. If the mapper is configured, the builder asks it for redacted version of the `SpanEvent`.

This required making `SpanEvent` public along with some of its dependencies (notably `NetworkConnectionInfo` and `CarrierInfo`).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
