### PR TITLE
RUMM-1104 Add `SpanEvent` scrubbing API - cleanup

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */; };
 		61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */; };
 		61B9ED212462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B9ED202462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift */; };
+		61BAD46A26415FCE001886CA /* OTSpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BAD46926415FCE001886CA /* OTSpanTests.swift */; };
 		61BB2B1B244A185D009F3F56 /* PerformancePreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */; };
 		61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBD19424ED4E9E0023E65F /* FeaturesConfiguration.swift */; };
 		61BBD19724ED50040023E65F /* FeaturesConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */; };
@@ -843,6 +844,7 @@
 		61B9ED1B2461E12000C0DCFF /* SendTracesFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendTracesFixtureViewController.swift; sourceTree = "<group>"; };
 		61B9ED1E2461E57700C0DCFF /* UITestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsHelpers.swift; sourceTree = "<group>"; };
 		61B9ED202462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingManualInstrumentationScenarioTests.swift; sourceTree = "<group>"; };
+		61BAD46926415FCE001886CA /* OTSpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTSpanTests.swift; sourceTree = "<group>"; };
 		61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePreset.swift; sourceTree = "<group>"; };
 		61BBD19424ED4E9E0023E65F /* FeaturesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesConfiguration.swift; sourceTree = "<group>"; };
 		61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturesConfigurationTests.swift; sourceTree = "<group>"; };
@@ -1419,6 +1421,7 @@
 				61F187FA25FA7D820022CE9A /* InternalMonitoring */,
 				61216278247D20D500AC5D67 /* FeaturesIntegration */,
 				61133C352423990D00786299 /* Utils */,
+				61BAD46826415FA2001886CA /* OpenTracing */,
 			);
 			path = Datadog;
 			sourceTree = "<group>";
@@ -2350,6 +2353,14 @@
 				61B6815D25F135890015B4AF /* CrashReportingWithRUMScenarioTests.swift */,
 			);
 			path = CrashReporting;
+			sourceTree = "<group>";
+		};
+		61BAD46826415FA2001886CA /* OpenTracing */ = {
+			isa = PBXGroup;
+			children = (
+				61BAD46926415FCE001886CA /* OTSpanTests.swift */,
+			);
+			path = OpenTracing;
 			sourceTree = "<group>";
 		};
 		61C3637E2436163400C4D4E6 /* DatadogPrivate */ = {
@@ -3555,6 +3566,7 @@
 				617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */,
 				61F2724925C943C500D54BF8 /* CrashReporterTests.swift in Sources */,
 				6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */,
+				61BAD46A26415FCE001886CA /* OTSpanTests.swift in Sources */,
 				6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */,
 				61133C532423990D00786299 /* MobileDeviceTests.swift in Sources */,
 				61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */,

--- a/Sources/Datadog/OpenTracing/OTSpan.swift
+++ b/Sources/Datadog/OpenTracing/OTSpan.swift
@@ -122,7 +122,6 @@ public extension OTSpan {
     /// - parameter stack: A string detailing the state of the stack when the error was caught. Note that it can also be any details that could help further triaging and investigation of the error downstream, it doesn't have to be an actual stack trace. Also note that an empty string means skipping the `stack` parameter.
     /// - parameter file: A string identifying the file where the error was caught. The default is `#fileID` which means `ModuleName/Filename.extension`, consider an helpful yet concise identifier when overriding the default. Note that an empty string means skipping the `file` and `line` parameters.
     /// - parameter line: The line number in the file where the error was caught.
-    /// - parameter includeFileInStack: Whether or not the `file` and `line` should be included in the stack, the default is `true` and can be overriden if the `file`/`line` are extraneous.
     func setError(
         kind: String,
         message: String,

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -88,14 +88,14 @@ internal class DDSpan: OTSpan {
     func setBaggageItem(key: String, value: String) {
         let isFinished = queue.sync { self.warnIfFinished("setBaggageItem(key:value:)") }
         if !isFinished {
-            // Baggage items must accessed outside `tracer.queue` as it uses that queue for internal sync.
+            // Baggage items must be accessed outside the `tracer.queue` as it uses that queue for internal sync.
             ddContext.baggageItems.set(key: key, value: value)
         }
     }
 
     func baggageItem(withKey key: String) -> String? {
         let isFinished = queue.sync { self.warnIfFinished("baggageItem(withKey:)") }
-        // Baggage items must accessed outside `tracer.queue` as it uses that queue for internal sync.
+        // Baggage items must be accessed outside the `tracer.queue` as it uses that queue for internal sync.
         return !isFinished ? ddContext.baggageItems.get(key: key) : nil
     }
 
@@ -137,7 +137,7 @@ internal class DDSpan: OTSpan {
 
     /// Sends span event for given `DDSpan`.
     private func sendSpan(finishTime: Date) {
-        // Baggage items must accessed outside `tracer.queue` as it uses that queue for internal sync.
+        // Baggage items must be accessed outside the `tracer.queue` as it uses that queue for internal sync.
         let baggageItems = ddContext.baggageItems.all
 
         // This queue adds performance optimisation by reading all `unsafe*` values in one block and performing

--- a/Sources/DatadogObjc/Tracer+objc.swift
+++ b/Sources/DatadogObjc/Tracer+objc.swift
@@ -134,20 +134,24 @@ public class DDTracer: NSObject, DatadogObjc.OTTracer {
     // MARK: - Private
 
     private func castTagsToSwift(_ tags: NSDictionary) -> [String: Encodable] {
-        guard let dictionary = tags as? [String: Any] else {
-            return [:]
-        }
+        var validTags: [String: Encodable] = [:]
 
-        return dictionary.mapValues { objcTagValue in
-            // As underlying `Datadog.JSONStringEncodableValue` provides special handling for `String` and `URL`
-            // when converting those `Encodables` to lossless JSON string representation, we have to cast them directly:
-            if let stringValue = objcTagValue as? String {
-                return stringValue
-            } else if let urlValue = objcTagValue as? URL {
-                return urlValue
-            } else {
-                return AnyEncodable(objcTagValue)
+        tags.forEach { tagKey, tagValue in
+            if let stringKey = tagKey as? String {
+                let encodableValue: Encodable = {
+                    if let stringValue = tagValue as? String {
+                        return stringValue
+                    } else if let urlValue = tagValue as? URL {
+                        return urlValue
+                    } else {
+                        return AnyEncodable(tagValue)
+                    }
+                }()
+
+                validTags[stringKey] = encodableValue
             }
         }
+
+        return validTags
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -223,9 +223,14 @@ extension LogAttributes: Equatable {
 
 /// `LogOutput` recording received logs.
 class LogOutputMock: LogOutput {
+    var onLogRecorded: ((Log) -> Void)?
+
     var recordedLog: Log?
+    var allRecordedLogs: [Log] = []
 
     func write(log: Log) {
         recordedLog = log
+        allRecordedLogs.append(log)
+        onLogRecorded?(log)
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -122,16 +122,14 @@ extension DDSpan {
         context: DDSpanContext = .mockAny(),
         operationName: String = .mockAny(),
         startTime: Date = .mockAny(),
-        tags: [String: Encodable] = [:],
-        logFields: [[String: Encodable]] = []
+        tags: [String: Encodable] = [:]
     ) -> DDSpan {
         return DDSpan(
             tracer: tracer,
             context: context,
             operationName: operationName,
             startTime: startTime,
-            tags: tags,
-            logFields: logFields
+            tags: tags
         )
     }
 }
@@ -317,12 +315,14 @@ extension SpanEventBuilder {
 
 /// `SpanOutput` recording received spans.
 class SpanOutputMock: SpanOutput {
-    var onSpanRecorded: ((SpanEvent?) -> Void)?
-    var recordedSpan: SpanEvent? = nil {
-        didSet { onSpanRecorded?(recordedSpan) }
-    }
+    var onSpanRecorded: ((SpanEvent) -> Void)?
+
+    var lastRecordedSpan: SpanEvent?
+    var allRecordedSpans: [SpanEvent] = []
 
     func write(span: SpanEvent) {
-        recordedSpan = span
+        lastRecordedSpan = span
+        allRecordedSpans.append(span)
+        onSpanRecorded?(span)
     }
 }

--- a/Tests/DatadogTests/Datadog/OpenTracing/OTSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/OpenTracing/OTSpanTests.swift
@@ -1,0 +1,239 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+private class MockSpan: OTSpan {
+    var context: OTSpanContext = DDNoopGlobals.context
+    func tracer() -> OTTracer { DDNoopGlobals.tracer }
+    func setOperationName(_ operationName: String) {}
+    func setTag(key: String, value: Encodable) {}
+    func setBaggageItem(key: String, value: String) {}
+    func baggageItem(withKey key: String) -> String? { nil }
+    func setActive() -> OTSpan { self }
+    func finish(at time: Date) {}
+
+    var logs: [[String: Encodable]] = []
+
+    func log(fields: [String: Encodable], timestamp: Date) {
+        logs.append(fields)
+    }
+}
+
+private extension Dictionary where Key == String, Value == Encodable {
+    func otEvent() throws -> String {
+        try XCTUnwrap(self[OTLogFields.event] as? String)
+    }
+
+    func otKind() throws -> String {
+        try XCTUnwrap(self[OTLogFields.errorKind] as? String)
+    }
+
+    func otMessage() throws -> String {
+        try XCTUnwrap(self[OTLogFields.message] as? String)
+    }
+
+    func otStack() throws -> String {
+        try XCTUnwrap(self[OTLogFields.stack] as? String)
+    }
+}
+
+class OTSpanTests: XCTestCase {
+    // MARK: - Test Error Conveniences
+
+    func testWhenSettingErrorFromSwiftError_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        #sourceLocation(file: "File.swift", line: 42)
+        span.setError(ErrorMock("swift error description"))
+        #sourceLocation()
+        span.finish()
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "ErrorMock")
+        XCTAssertEqual(try span.logs[0].otMessage(), "swift error description")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            DatadogTests/File.swift:42
+            swift error description
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromSwiftErrorWithFileAndLine_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        span.setError(ErrorMock("swift error description"), file: "File.swift", line: 42)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "ErrorMock")
+        XCTAssertEqual(try span.logs[0].otMessage(), "swift error description")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            File.swift:42
+            swift error description
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromNSError_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        #sourceLocation(file: "File.swift", line: 42)
+        span.setError(
+            NSError(
+                domain: "DDSpan",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "ns error description"]
+            )
+        )
+        #sourceLocation()
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "DDSpan - 1")
+        XCTAssertEqual(try span.logs[0].otMessage(), "ns error description")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            DatadogTests/File.swift:42
+            Error Domain=DDSpan Code=1 "ns error description" UserInfo={NSLocalizedDescription=ns error description}
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromArguments_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        #sourceLocation(file: "File.swift", line: 42)
+        span.setError(kind: "custom kind", message: "DDSpan Error")
+        #sourceLocation()
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "custom kind")
+        XCTAssertEqual(try span.logs[0].otMessage(), "DDSpan Error")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            DatadogTests/File.swift:42
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromArgumentsWithStack_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        let stack = """
+        Thread 0 Crashed:
+        0   app                                 0x0000000102bc0d8c 0x102bb8000 + 36236
+        1   UIKitCore                           0x00000001b513d9ac 0x1b4739000 + 10504620
+        """
+        span.setError(kind: "custom kind", message: "custom message", stack: stack)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "custom kind")
+        XCTAssertEqual(try span.logs[0].otMessage(), "custom message")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            DatadogTests/OTSpanTests.swift:158
+            Thread 0 Crashed:
+            0   app                                 0x0000000102bc0d8c 0x102bb8000 + 36236
+            1   UIKitCore                           0x00000001b513d9ac 0x1b4739000 + 10504620
+            """
+        )
+    }
+
+    func testWhenSettingErrorFromArgumentsWithFileAndLine_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        span.setError(kind: "custom kind", message: "custom message", file: "File.swift", line: 42)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "custom kind")
+        XCTAssertEqual(try span.logs[0].otMessage(), "custom message")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            File.swift:42
+            """
+        )
+    }
+
+    func testWhenSettingErrorWithEmptyFileLineAndStack_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        span.setError(ErrorMock("swift error description"), file: "", line: 0)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "ErrorMock")
+        XCTAssertEqual(try span.logs[0].otMessage(), "swift error description")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            swift error description
+            """
+        )
+    }
+
+    func testWhenSettingErrorWithEmptyFileLineAndNonEmptyStack_itLogsErrorFields() throws {
+        // Given
+        let span = MockSpan()
+
+        // When
+        span.setError(ErrorMock("the stack"), file: "", line: 0)
+
+        // Then
+        XCTAssertEqual(span.logs.count, 1)
+        XCTAssertEqual(span.logs[0].count, 4)
+        XCTAssertEqual(try span.logs[0].otEvent(), "error")
+        XCTAssertEqual(try span.logs[0].otKind(), "ErrorMock")
+        XCTAssertEqual(try span.logs[0].otMessage(), "the stack")
+        XCTAssertEqual(
+            try span.logs[0].otStack(),
+            """
+            the stack
+            """
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -967,30 +967,6 @@ class TracerTests: XCTestCase {
         )
     }
 
-    func testWhenSpanStateChangesFromDifferentThreads_itChangesSpanState() {
-        TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance = nil }
-        let tracer = Tracer.initialize(configuration: .init())
-        let span = tracer.startSpan(operationName: "some span", childOf: nil).dd
-
-        let closures: [(DDSpan) -> Void] = [
-            // swiftlint:disable opening_brace
-            { span in span.setTag(key: .mockRandom(), value: "value") },
-            { span in span.setBaggageItem(key: .mockRandom(), value: "value") },
-            { span in _ = span.baggageItem(withKey: .mockRandom()) },
-            { span in _ = span.context.forEachBaggageItem { _, _ in return false } },
-            { span in span.log(fields: [.mockRandom(): "value"]) }
-            // swiftlint:enable opening_brace
-        ]
-        /// Calls given closures on each span cuncurrently
-        let iterations = 100
-        DispatchQueue.concurrentPerform(iterations: iterations) { iteration in
-            closures.forEach { $0(span) }
-        }
-        XCTAssertEqual(span.tags.count, iterations)
-        XCTAssertEqual(span.logFields.count, iterations)
-    }
-
     // MARK: - Usage errors
 
     func testGivenDatadogNotInitialized_whenInitializingTracer_itPrintsError() {
@@ -1058,6 +1034,7 @@ class TracerTests: XCTestCase {
         span.log(fields: ["bar": "bizz"])
 
         // then
+        tracer.dd.queue.sync {} // wait synchronizing span's internal state
         XCTAssertEqual(output.recordedLog?.status, .warn)
         XCTAssertEqual(output.recordedLog?.message, "The log for span \"foo\" will not be send, because the Logging feature is disabled.")
 

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -60,7 +60,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recordedSpan)
+        let span = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(span.traceID.rawValue, 100)
         XCTAssertEqual(span.spanID.rawValue, 200)
         XCTAssertEqual(span.operationName, "urlsession.request")
@@ -94,7 +94,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recordedSpan)
+        let span = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
         XCTAssertFalse(span.isError)
         XCTAssertEqual(span.duration, 2)
@@ -132,7 +132,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recordedSpan)
+        let span = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
         XCTAssertEqual(span.resource, request.url!.absoluteString)
         XCTAssertEqual(span.duration, 30)
@@ -194,7 +194,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let span = try XCTUnwrap(spanOutput.recordedSpan)
+        let span = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
         XCTAssertEqual(span.resource, "404")
         XCTAssertEqual(span.duration, 2)
@@ -248,7 +248,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
-        XCTAssertNil(spanOutput.recordedSpan)
+        XCTAssertNil(spanOutput.lastRecordedSpan)
     }
 
     func testGivenThirdPartyInterception_whenInterceptionCompletes_itDoesNotSendTheSpan() throws {
@@ -273,7 +273,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
-        XCTAssertNil(spanOutput.recordedSpan)
+        XCTAssertNil(spanOutput.lastRecordedSpan)
         XCTAssertNil(logOutput.recordedLog)
     }
 
@@ -298,7 +298,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
-        let recordedSpan = try XCTUnwrap(spanOutput.recordedSpan)
+        let recordedSpan = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(recordedSpan.tags[DDTags.foregroundDuration], "10000000000")
         XCTAssertEqual(recordedSpan.tags[DDTags.isBackground], "false")
     }


### PR DESCRIPTION
### What and why?

📦 This is the final PR for `SpanEvent` scrubbing feature. It cleans things up in `DDSpan` implementation, mainly reducing the number of queue synchronisations that we were doing there.

This cleanup is possible due to refactoring done in #478 - where entire `SpanEvent` creation was moved to secondary thread.

### How?

Before #478, the `SpanBuilder` was reading span information from `DDSpan` partially:
```swift
_ = ddspan.operationName
_ = ddspan.tags
...
```
and each read [required thread synchronisation on the property getter](https://github.com/DataDog/dd-sdk-ios/blob/658dee7b6515aa296f09e43016759c4f6fa85164/Sources/Datadog/Tracing/DDSpan.swift#L22-L46).

After #478 all properties are read in bulk and no longer require thread sync. This PR removes the old property getters that are no longer used. It also cleans up tests for `DDSpan` by separating `OTSpan.setError(_:)` tests to separate file.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
