### PR TITLE
RUMM-1352 Fix pip3 issue on CI when running `dogfood.py`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,4 @@ ship:
 		@echo "pod trunk push --allow-warnings DatadogSDKObjc.podspec"
 
 dogfood:
-		@brew list gh &>/dev/null || brew install gh
-		@pip install GitPython==3.1.14
-		@./tools/dogfooding/dogfood.py
+		@cd tools/dogfooding && $(MAKE)

--- a/tools/dogfooding/Makefile
+++ b/tools/dogfooding/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all
+
+all:
+	@brew list gh &>/dev/null || brew install gh
+ifeq ($(wildcard venv),)
+	@echo "⚙️  Creating Python venv in $(PWD)"
+	python3 -m venv venv
+endif
+	venv/bin/pip3 install GitPython==3.1.14
+	venv/bin/python3 dogfood.py

--- a/tools/dogfooding/dogfood.py
+++ b/tools/dogfooding/dogfood.py
@@ -35,7 +35,7 @@ def run_main() -> int:
         dd_sdk_ios_commit = DogfoodedCommit()
 
         # Resolve and read `dd-sdk-ios` dependencies:
-        dd_sdk_package_path = '.' if 'CI' in os.environ else '../..'
+        dd_sdk_package_path = '../..'
         os.system(f'swift package --package-path {dd_sdk_package_path} resolve')
         dd_sdk_ios_package = PackageResolvedFile(path=f'{dd_sdk_package_path}/Package.resolved')
         kronos_dependency = dd_sdk_ios_package.read_dependency(package_name='Kronos')
@@ -100,9 +100,10 @@ def run_main() -> int:
 
 
 if __name__ == "__main__":
+    print(f'ℹ️ Launch dir: {sys.argv[0]}')
     launch_dir = os.path.dirname(sys.argv[0])
-    print(f'ℹ️ Launch dir {launch_dir}')
-    if os.path.basename(launch_dir) == 'dd-sdk-ios':
-        os.chdir('tools/dogfooding')
+    launch_dir = '.' if launch_dir == '' else launch_dir
+    if launch_dir == 'tools/dogfooding':
         print(f'    → changing current directory to: {os.getcwd()}')
+        os.chdir('tools/dogfooding')
     sys.exit(run_main())


### PR DESCRIPTION
### What and why?

⚙️ `make dogfood` stopped working on CI after recent Bitrise maintenance due to:
```shell
make: pip: No such file or directory
```

With short investigation I discovered that the result of `pip install GitPython` is now changed - once the dependency is installed, it's not seen from `python` interpreter. Aligning it to `pip3 install` and `python3` didn't help as well. Adding `--user` flag to `pip3 install` is not solving it neither.

### How?

As the use of global `pip3 install` and `python3` seems unstable in CI VMs, I switched to using [`venv`](https://docs.python.org/3.9/library/venv.html). Now, `make dogfood` creates a clean Python 3 `venv` and uses its `pip3` and `python3` to install dependencies and run scripts.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
