### PR TITLE
RUMM-1320 Let user extra attributes use the usr prefix

### DIFF
--- a/Sources/Datadog/Core/Attributes/AttributesSanitizer.swift
+++ b/Sources/Datadog/Core/Attributes/AttributesSanitizer.swift
@@ -11,7 +11,7 @@ internal struct AttributesSanitizer {
     struct Constraints {
         /// Maximum number of nested levels in attribute name. E.g. `person.address.street` has 3 levels.
         /// If attribute name exceeds this number, extra levels are escaped by using `_` character (`one.two.(...).nine.ten_eleven_twelve`).
-        static let maxNestedLevelsInAttributeName: Int = 8
+        static let maxNestedLevelsInAttributeName: Int = 10
         /// Maximum number of attributes in log.
         /// If this number is exceeded, extra attributes will be ignored.
         static let maxNumberOfAttributes: Int = 128
@@ -30,9 +30,9 @@ internal struct AttributesSanitizer {
     ///
     ///     one.two.three.four.five.six.seven.eight_nine_ten_eleven
     ///
-    func sanitizeKeys<Value>(for attributes: [String: Value]) -> [String: Value] {
+    func sanitizeKeys<Value>(for attributes: [String: Value], prefixLevels: Int = 0) -> [String: Value] {
         let sanitizedAttributes: [(String, Value)] = attributes.map { key, value in
-            let sanitizedName = sanitize(attributeKey: key)
+            let sanitizedName = sanitize(attributeKey: key, prefixLevels: prefixLevels)
             if sanitizedName != key {
                 userLogger.warn(
                     """
@@ -47,8 +47,8 @@ internal struct AttributesSanitizer {
         return Dictionary(uniqueKeysWithValues: sanitizedAttributes)
     }
 
-    private func sanitize(attributeKey: String) -> String {
-        var dotsCount = 0
+    private func sanitize(attributeKey: String, prefixLevels: Int = 0) -> String {
+        var dotsCount = prefixLevels
         var sanitized = ""
         for char in attributeKey {
             if char == "." {

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -40,7 +40,7 @@ internal struct RUMEventEncoder {
             try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("context.\(attributeName)"))
         }
         try event.userInfoAttributes.forEach { attributeName, attributeValue in
-            try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("context.usr.\(attributeName)"))
+            try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("usr.\(attributeName)"))
         }
 
         // Encode `RUMDataModel`

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventSanitizer.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventSanitizer.swift
@@ -12,8 +12,8 @@ internal struct RUMEventSanitizer {
 
     func sanitize<DM: RUMDataModel>(event: RUMEvent<DM>) -> RUMEvent<DM> {
         // Sanitize attribute names
-        var sanitizedUserExtraInfo = attributesSanitizer.sanitizeKeys(for: event.userInfoAttributes)
-        var sanitizedAttributes = attributesSanitizer.sanitizeKeys(for: event.attributes)
+        var sanitizedUserExtraInfo = attributesSanitizer.sanitizeKeys(for: event.userInfoAttributes, prefixLevels: 1)
+        var sanitizedAttributes = attributesSanitizer.sanitizeKeys(for: event.attributes, prefixLevels: 1)
 
         // Limit to max number of attributes.
         // If any attributes need to be removed, we first reduce number of

--- a/Tests/DatadogIntegrationTests/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
@@ -205,7 +205,7 @@ class TrackingConsentScenarioTests: IntegrationTests, LoggingCommonAsserts, Trac
             .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
             .forEach { event in
                 XCTAssertEqual(
-                    try event.attribute(forKeyPath: "context.usr.current-consent-value"),
+                    try event.attribute(forKeyPath: "usr.current-consent-value"),
                     "GRANTED"
                 )
             }
@@ -308,7 +308,7 @@ class TrackingConsentScenarioTests: IntegrationTests, LoggingCommonAsserts, Trac
 
         try eventMatchers.forEach { event in
             XCTAssertEqual(
-                try event.attribute(forKeyPath: "context.usr.current-consent-value"),
+                try event.attribute(forKeyPath: "usr.current-consent-value"),
                 expectedConsentValue.uppercased()
             )
         }

--- a/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
@@ -72,9 +72,10 @@ class LogSanitizerTests: XCTestCase {
         XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six"])
         XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven"])
         XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight"])
-        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight_nine_ten"])
-        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
-        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine.ten"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine.ten_eleven"])
+        XCTAssertNotNil(sanitized.attributes.userAttributes["one.two.three.four.five.six.seven.eight.nine.ten_eleven_twelve"])
     }
 
     func testWhenUserAttributeNameIsInvalid_itIsIgnored() {

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
@@ -60,9 +60,9 @@ class RUMEventSanitizerTests: XCTestCase {
             XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six"])
             XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven"])
             XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight_nine_ten"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight.nine_ten"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
+            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
 
             XCTAssertEqual(sanitized.userInfoAttributes.count, 12)
             XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one"])
@@ -73,9 +73,9 @@ class RUMEventSanitizerTests: XCTestCase {
             XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six"])
             XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven"])
             XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight_nine_ten"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight.nine_ten"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
+            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
         }
 
         test(model: viewEvent)

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -616,9 +616,9 @@ class RUMMonitorTests: XCTestCase {
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 11)
         let expectedUserInfo = RUMUser(email: "foo@bar.com", id: "abc-123", name: "Foo")
         try rumEventMatchers.forEach { event in
-            XCTAssertEqual(try event.attribute(forKeyPath: "context.usr.str"), "value")
-            XCTAssertEqual(try event.attribute(forKeyPath: "context.usr.int"), 11_235)
-            XCTAssertEqual(try event.attribute(forKeyPath: "context.usr.bool"), true) // swiftlint:disable:this xct_specific_matcher
+            XCTAssertEqual(try event.attribute(forKeyPath: "usr.str"), "value")
+            XCTAssertEqual(try event.attribute(forKeyPath: "usr.int"), 11_235)
+            XCTAssertEqual(try event.attribute(forKeyPath: "usr.bool"), true) // swiftlint:disable:this xct_specific_matcher
         }
         try rumEventMatchers.forEachRUMEvent(ofType: RUMActionEvent.self) { action in
             XCTAssertEqual(action.usr, expectedUserInfo)

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanSanitizerTests.swift
@@ -55,9 +55,10 @@ class SpanSanitizerTests: XCTestCase {
         XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six"])
         XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven"])
         XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight"])
-        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight_nine_ten"])
-        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
-        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight.nine"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight.nine.ten"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight.nine.ten_eleven"])
+        XCTAssertNotNil(sanitized.userInfo.extraInfo["extra-info-one.two.three.four.five.six.seven.eight.nine.ten_eleven_twelve"])
 
         XCTAssertEqual(sanitized.tags.count, 12)
         XCTAssertNotNil(sanitized.tags["tag-one"])
@@ -68,9 +69,10 @@ class SpanSanitizerTests: XCTestCase {
         XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six"])
         XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven"])
         XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight"])
-        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight_nine_ten"])
-        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight_nine_ten_eleven"])
-        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight_nine_ten_eleven_twelve"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight.nine"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight.nine.ten"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight.nine.ten_eleven"])
+        XCTAssertNotNil(sanitized.tags["tag-one.two.three.four.five.six.seven.eight.nine.ten_eleven_twelve"])
     }
 
     func testWhenNumberOfAttributesExceedsLimit_itDropsExtraOnes() {


### PR DESCRIPTION
### What and why?

To align the data with the browser SDK, and make the infos more consistent, we keep all the usr custom attributes in the root `usr` object.