### PR TITLE
RUMM-1362 Automate dogfooding in more products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ instrumented-tests/DatadogSDKTesting.*
 instrumented-tests/LICENSE
 
 *.local.xcconfig
+
+# Ignore files for Python tools:
+.idea
+venv
+*.pyc
+__pycache__

--- a/tools/dogfooding/.gitignore
+++ b/tools/dogfooding/.gitignore
@@ -1,3 +1,0 @@
-.idea
-venv
-*.pyc

--- a/tools/dogfooding/dogfood.py
+++ b/tools/dogfooding/dogfood.py
@@ -41,8 +41,8 @@ def dogfood(dry_run: bool, repository_url: str, repository_name: str, repository
     os.system(f'swift package --package-path {dd_sdk_package_path} resolve')
     dd_sdk_ios_package = PackageResolvedFile(path=f'{dd_sdk_package_path}/Package.resolved')
 
-    # Clone `datadog-ios` repository to temporary location and update its `Package.resolved` so it points
-    # to the current `dd-sdk-ios` commit. After that, push changes to `datadog-ios` and create dogfooding PR.
+    # Clone dependant repo to temporary location and update its `Package.resolved` so it points
+    # to the current `dd-sdk-ios` commit. After that, push changes to dependant repo and create dogfooding PR.
     with TemporaryDirectory() as temp_dir:
         with remember_cwd():
             repository = Repository.clone(
@@ -86,7 +86,7 @@ def dogfood(dry_run: bool, repository_url: str, repository_name: str, repository
 
             package.save()
 
-            # Push changes to `datadog-ios`:
+            # Push changes to dependant repo:
             repository.commit(
                 message=f'Dogfooding dd-sdk-ios commit: {dd_sdk_ios_commit.hash}\n\n' +
                         f'Dogfooded commit message: {dd_sdk_ios_commit.message}',

--- a/tools/nightly-unit-tests/.gitignore
+++ b/tools/nightly-unit-tests/.gitignore
@@ -1,8 +1,3 @@
-.idea
-venv
-*.pyc
-__pycache__
-
 # Ignore `bitrise.yml` generated from `bitrise.yml.src`
 bitrise.yml
 


### PR DESCRIPTION
### What and why?

🐶 This PR updates `dogfooding` tool to update `dd-sdk-ios` and submit PR to more products.

### How?

I updated the Python script to take dependant repository as parameter. I also added support for any number of dependencies in `dd-sdk-ios`, instead of hardcoding only `Kronos` and `PLCrashReporter`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
