### PR TITLE
RUMM-1139 δ Create nightly E2E tests setup

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -257,6 +257,8 @@
 		618DCFE124C766F500589570 /* SendRUMFixture2ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFE024C766F500589570 /* SendRUMFixture2ViewController.swift */; };
 		618DCFE324C766FB00589570 /* SendRUMFixture3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFE224C766FB00589570 /* SendRUMFixture3ViewController.swift */; };
 		618F9843265BC486009959F8 /* E2EInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F9842265BC486009959F8 /* E2EInstrumentationTests.swift */; };
+		618F984E265BC905009959F8 /* E2EConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F984D265BC905009959F8 /* E2EConfig.swift */; };
+		618F984F265BC905009959F8 /* E2EConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F984D265BC905009959F8 /* E2EConfig.swift */; };
 		6193DCA4251B5691009B8011 /* RUMTapActionScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6193DCA3251B5691009B8011 /* RUMTapActionScenario.storyboard */; };
 		6193DCCE251B6201009B8011 /* RUMTASScreen1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCCD251B6201009B8011 /* RUMTASScreen1ViewController.swift */; };
 		6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCE0251B692C009B8011 /* RUMTASTableViewController.swift */; };
@@ -862,6 +864,7 @@
 		618F9842265BC486009959F8 /* E2EInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EInstrumentationTests.swift; sourceTree = "<group>"; };
 		618F9844265BC486009959F8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		618F984C265BC53E009959F8 /* E2EInstrumentationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = E2EInstrumentationTests.xcconfig; sourceTree = "<group>"; };
+		618F984D265BC905009959F8 /* E2EConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EConfig.swift; sourceTree = "<group>"; };
 		6193DCA3251B5691009B8011 /* RUMTapActionScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMTapActionScenario.storyboard; sourceTree = "<group>"; };
 		6193DCCD251B6201009B8011 /* RUMTASScreen1ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASScreen1ViewController.swift; sourceTree = "<group>"; };
 		6193DCE0251B692C009B8011 /* RUMTASTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASTableViewController.swift; sourceTree = "<group>"; };
@@ -2396,6 +2399,7 @@
 		6199362C265BA959009D7EA8 /* E2E */ = {
 			isa = PBXGroup;
 			children = (
+				618F984D265BC905009959F8 /* E2EConfig.swift */,
 				6199362D265BA959009D7EA8 /* E2EAppDelegate.swift */,
 				61993636265BA95A009D7EA8 /* Assets.xcassets */,
 				61993638265BA95A009D7EA8 /* LaunchScreen.storyboard */,
@@ -4001,6 +4005,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				618F984E265BC905009959F8 /* E2EConfig.swift in Sources */,
 				6199362E265BA959009D7EA8 /* E2EAppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4009,6 +4014,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				618F984F265BC905009959F8 /* E2EConfig.swift in Sources */,
 				61993668265BBEDC009D7EA8 /* E2ETests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -265,6 +265,14 @@
 		6199362E265BA959009D7EA8 /* E2EAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6199362D265BA959009D7EA8 /* E2EAppDelegate.swift */; };
 		61993637265BA95A009D7EA8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 61993636265BA95A009D7EA8 /* Assets.xcassets */; };
 		6199363A265BA95A009D7EA8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61993638265BA95A009D7EA8 /* LaunchScreen.storyboard */; };
+		61993654265BB6A6009D7EA8 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; };
+		61993655265BB6A6009D7EA8 /* CrashReporter.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		61993656265BB6A6009D7EA8 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
+		61993657265BB6A6009D7EA8 /* Datadog.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6199365A265BB6A6009D7EA8 /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; };
+		6199365B265BB6A6009D7EA8 /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6199365E265BB6A6009D7EA8 /* Kronos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; };
+		6199365F265BB6A6009D7EA8 /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		619E16D82577C1CB00B2516B /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16D72577C1CB00B2516B /* DataProcessor.swift */; };
 		619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16E82578E73E00B2516B /* DataMigrator.swift */; };
 		619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */; };
@@ -504,6 +512,20 @@
 			remoteGlobalIDString = 61B7885325C180CB002675B5;
 			remoteInfo = DatadogCrashReporting;
 		};
+		61993658265BB6A6009D7EA8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 61133B81242393DE00786299;
+			remoteInfo = Datadog;
+		};
+		6199365C265BB6A6009D7EA8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 61B7885325C180CB002675B5;
+			remoteInfo = DatadogCrashReporting;
+		};
 		61B7885E25C180CB002675B5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 61133B79242393DE00786299 /* Project object */;
@@ -539,6 +561,20 @@
 				61441C4E24619498003D8BB8 /* Datadog.framework in ⚙️ Embed Framework Dependencies */,
 				614ED39B260357FA00C8C519 /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */,
 				61570006246AAE5E00E96950 /* DatadogObjc.framework in ⚙️ Embed Framework Dependencies */,
+			);
+			name = "⚙️ Embed Framework Dependencies";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61993660265BB6A6009D7EA8 /* ⚙️ Embed Framework Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				61993655265BB6A6009D7EA8 /* CrashReporter.xcframework in ⚙️ Embed Framework Dependencies */,
+				6199365F265BB6A6009D7EA8 /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */,
+				61993657265BB6A6009D7EA8 /* Datadog.framework in ⚙️ Embed Framework Dependencies */,
+				6199365B265BB6A6009D7EA8 /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */,
 			);
 			name = "⚙️ Embed Framework Dependencies";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1066,6 +1102,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61993656265BB6A6009D7EA8 /* Datadog.framework in Frameworks */,
+				6199365A265BB6A6009D7EA8 /* DatadogCrashReporting.framework in Frameworks */,
+				6199365E265BB6A6009D7EA8 /* Kronos.xcframework in Frameworks */,
+				61993654265BB6A6009D7EA8 /* CrashReporter.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3069,10 +3109,13 @@
 				61993627265BA958009D7EA8 /* Sources */,
 				61993628265BA958009D7EA8 /* Frameworks */,
 				61993629265BA958009D7EA8 /* Resources */,
+				61993660265BB6A6009D7EA8 /* ⚙️ Embed Framework Dependencies */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				61993659265BB6A6009D7EA8 /* PBXTargetDependency */,
+				6199365D265BB6A6009D7EA8 /* PBXTargetDependency */,
 			);
 			name = E2E;
 			productName = E2E;
@@ -3858,6 +3901,16 @@
 			isa = PBXTargetDependency;
 			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
 			targetProxy = 6170DC5225C18E57003AED5C /* PBXContainerItemProxy */;
+		};
+		61993659265BB6A6009D7EA8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 61133B81242393DE00786299 /* Datadog */;
+			targetProxy = 61993658265BB6A6009D7EA8 /* PBXContainerItemProxy */;
+		};
+		6199365D265BB6A6009D7EA8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
+			targetProxy = 6199365C265BB6A6009D7EA8 /* PBXContainerItemProxy */;
 		};
 		61B7885F25C180CB002675B5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -262,6 +262,9 @@
 		6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCE0251B692C009B8011 /* RUMTASTableViewController.swift */; };
 		6193DCE8251B9AB1009B8011 /* RUMTASCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCE7251B9AB1009B8011 /* RUMTASCollectionViewController.swift */; };
 		6198D27124C6E3B700493501 /* RUMViewScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */; };
+		6199362E265BA959009D7EA8 /* E2EAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6199362D265BA959009D7EA8 /* E2EAppDelegate.swift */; };
+		61993637265BA95A009D7EA8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 61993636265BA95A009D7EA8 /* Assets.xcassets */; };
+		6199363A265BA95A009D7EA8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61993638265BA95A009D7EA8 /* LaunchScreen.storyboard */; };
 		619E16D82577C1CB00B2516B /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16D72577C1CB00B2516B /* DataProcessor.swift */; };
 		619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16E82578E73E00B2516B /* DataMigrator.swift */; };
 		619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */; };
@@ -812,6 +815,12 @@
 		6193DCE0251B692C009B8011 /* RUMTASTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASTableViewController.swift; sourceTree = "<group>"; };
 		6193DCE7251B9AB1009B8011 /* RUMTASCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASCollectionViewController.swift; sourceTree = "<group>"; };
 		6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewScopeTests.swift; sourceTree = "<group>"; };
+		6199362B265BA958009D7EA8 /* E2E.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = E2E.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6199362D265BA959009D7EA8 /* E2EAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EAppDelegate.swift; sourceTree = "<group>"; };
+		61993636265BA95A009D7EA8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		61993639265BA95A009D7EA8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		6199363B265BA95A009D7EA8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		61993641265BAD2D009D7EA8 /* E2E.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = E2E.xcconfig; sourceTree = "<group>"; };
 		619E16D72577C1CB00B2516B /* DataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProcessor.swift; sourceTree = "<group>"; };
 		619E16E82578E73E00B2516B /* DataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrator.swift; sourceTree = "<group>"; };
 		619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllDataMigrator.swift; sourceTree = "<group>"; };
@@ -1053,6 +1062,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		61993628265BA958009D7EA8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		61B7885125C180CB002675B5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1124,6 +1140,7 @@
 				61441C3524617013003D8BB8 /* DatadogIntegrationTests */,
 				61133C07242397F200786299 /* TargetSupport */,
 				61441C0324616DE9003D8BB8 /* Example */,
+				6199362C265BA959009D7EA8 /* E2E */,
 				61133B83242393DE00786299 /* Products */,
 				61133C6F2423993200786299 /* Frameworks */,
 			);
@@ -1140,6 +1157,7 @@
 				61441C6824619FE4003D8BB8 /* DatadogBenchmarkTests.xctest */,
 				61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */,
 				61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */,
+				6199362B265BA958009D7EA8 /* E2E.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1344,6 +1362,7 @@
 				61441C762461A01D003D8BB8 /* DatadogBenchmarkTests */,
 				9EF49F1524476FBD004F2CA0 /* DatadogIntegrationTests */,
 				61441C9E2461AF4D003D8BB8 /* Example */,
+				61993640265BAC34009D7EA8 /* E2E */,
 			);
 			path = TargetSupport;
 			sourceTree = "<group>";
@@ -2277,6 +2296,25 @@
 			path = TapActionAutoInstrumentation;
 			sourceTree = "<group>";
 		};
+		6199362C265BA959009D7EA8 /* E2E */ = {
+			isa = PBXGroup;
+			children = (
+				6199362D265BA959009D7EA8 /* E2EAppDelegate.swift */,
+				61993636265BA95A009D7EA8 /* Assets.xcassets */,
+				61993638265BA95A009D7EA8 /* LaunchScreen.storyboard */,
+			);
+			path = E2E;
+			sourceTree = "<group>";
+		};
+		61993640265BAC34009D7EA8 /* E2E */ = {
+			isa = PBXGroup;
+			children = (
+				6199363B265BA95A009D7EA8 /* Info.plist */,
+				61993641265BAD2D009D7EA8 /* E2E.xcconfig */,
+			);
+			path = E2E;
+			sourceTree = "<group>";
+		};
 		619E16D42577C11B00B2516B /* Writting */ = {
 			isa = PBXGroup;
 			children = (
@@ -3024,6 +3062,23 @@
 			productReference = 61441C6824619FE4003D8BB8 /* DatadogBenchmarkTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		6199362A265BA958009D7EA8 /* E2E */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6199363F265BA95A009D7EA8 /* Build configuration list for PBXNativeTarget "E2E" */;
+			buildPhases = (
+				61993627265BA958009D7EA8 /* Sources */,
+				61993628265BA958009D7EA8 /* Frameworks */,
+				61993629265BA958009D7EA8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = E2E;
+			productName = E2E;
+			productReference = 6199362B265BA958009D7EA8 /* E2E.app */;
+			productType = "com.apple.product-type.application";
+		};
 		61B7885325C180CB002675B5 /* DatadogCrashReporting */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 61B7886B25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReporting" */;
@@ -3070,7 +3125,7 @@
 		61133B79242393DE00786299 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1230;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = Datadog;
 				TargetAttributes = {
@@ -3096,6 +3151,9 @@
 					61441C6724619FE4003D8BB8 = {
 						CreatedOnToolsVersion = 11.4;
 						TestTargetID = 61441C0124616DE9003D8BB8;
+					};
+					6199362A265BA958009D7EA8 = {
+						CreatedOnToolsVersion = 12.5;
 					};
 					61B7885325C180CB002675B5 = {
 						CreatedOnToolsVersion = 12.3;
@@ -3128,6 +3186,7 @@
 				61441C6724619FE4003D8BB8 /* DatadogBenchmarkTests */,
 				61441C2924616F1D003D8BB8 /* DatadogIntegrationTests */,
 				61441C0124616DE9003D8BB8 /* Example */,
+				6199362A265BA958009D7EA8 /* E2E */,
 			);
 		};
 /* End PBXProject section */
@@ -3187,6 +3246,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61993629265BA958009D7EA8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6199363A265BA95A009D7EA8 /* LaunchScreen.storyboard in Resources */,
+				61993637265BA95A009D7EA8 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3724,6 +3792,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		61993627265BA958009D7EA8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6199362E265BA959009D7EA8 /* E2EAppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		61B7885025C180CB002675B5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3813,6 +3889,14 @@
 			isa = PBXVariantGroup;
 			children = (
 				61441C1024616DEC003D8BB8 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		61993638265BA95A009D7EA8 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				61993639265BA95A009D7EA8 /* Base */,
 			);
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
@@ -4276,6 +4360,66 @@
 			};
 			name = Integration;
 		};
+		6199363C265BA95A009D7EA8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61993641265BAD2D009D7EA8 /* E2E.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/E2E/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.E2E;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		6199363D265BA95A009D7EA8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61993641265BAD2D009D7EA8 /* E2E.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/E2E/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.E2E;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		6199363E265BA95A009D7EA8 /* Integration */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61993641265BAD2D009D7EA8 /* E2E.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/E2E/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.E2E;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Integration;
+		};
 		61B7886525C180CB002675B5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 615D9E2626048EAF006DC6D1 /* DatadogCrashReporting.xcconfig */;
@@ -4631,6 +4775,16 @@
 				61441C7124619FE4003D8BB8 /* Debug */,
 				61441C7224619FE4003D8BB8 /* Release */,
 				61441C7324619FE4003D8BB8 /* Integration */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6199363F265BA95A009D7EA8 /* Build configuration list for PBXNativeTarget "E2E" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6199363C265BA95A009D7EA8 /* Debug */,
+				6199363D265BA95A009D7EA8 /* Release */,
+				6199363E265BA95A009D7EA8 /* Integration */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		618DCFDF24C75FD300589570 /* RUMScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFDE24C75FD300589570 /* RUMScopeTests.swift */; };
 		618DCFE124C766F500589570 /* SendRUMFixture2ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFE024C766F500589570 /* SendRUMFixture2ViewController.swift */; };
 		618DCFE324C766FB00589570 /* SendRUMFixture3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFE224C766FB00589570 /* SendRUMFixture3ViewController.swift */; };
+		618F9843265BC486009959F8 /* E2EInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618F9842265BC486009959F8 /* E2EInstrumentationTests.swift */; };
 		6193DCA4251B5691009B8011 /* RUMTapActionScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6193DCA3251B5691009B8011 /* RUMTapActionScenario.storyboard */; };
 		6193DCCE251B6201009B8011 /* RUMTASScreen1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCCD251B6201009B8011 /* RUMTASScreen1ViewController.swift */; };
 		6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6193DCE0251B692C009B8011 /* RUMTASTableViewController.swift */; };
@@ -510,6 +511,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 61B7885325C180CB002675B5;
 			remoteInfo = DatadogCrashReporting;
+		};
+		618F9845265BC486009959F8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6199362A265BA958009D7EA8;
+			remoteInfo = E2E;
 		};
 		61993658265BB6A6009D7EA8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -850,6 +858,10 @@
 		618E136C252384D90098C6B0 /* URLSessionAutoInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionAutoInstrumentation.swift; sourceTree = "<group>"; };
 		618E13A92524B8700098C6B0 /* HTTPHeadersReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeadersReader.swift; sourceTree = "<group>"; };
 		618E13B02524B8F80098C6B0 /* TracingHTTPHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingHTTPHeaders.swift; sourceTree = "<group>"; };
+		618F9840265BC486009959F8 /* E2EInstrumentationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = E2EInstrumentationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		618F9842265BC486009959F8 /* E2EInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EInstrumentationTests.swift; sourceTree = "<group>"; };
+		618F9844265BC486009959F8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		618F984C265BC53E009959F8 /* E2EInstrumentationTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = E2EInstrumentationTests.xcconfig; sourceTree = "<group>"; };
 		6193DCA3251B5691009B8011 /* RUMTapActionScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMTapActionScenario.storyboard; sourceTree = "<group>"; };
 		6193DCCD251B6201009B8011 /* RUMTASScreen1ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASScreen1ViewController.swift; sourceTree = "<group>"; };
 		6193DCE0251B692C009B8011 /* RUMTASTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTASTableViewController.swift; sourceTree = "<group>"; };
@@ -1106,6 +1118,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		618F983D265BC486009959F8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		61993628265BA958009D7EA8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1197,6 +1216,7 @@
 				61441C0324616DE9003D8BB8 /* Example */,
 				6199362C265BA959009D7EA8 /* E2E */,
 				61993666265BBEDC009D7EA8 /* E2ETests */,
+				618F9841265BC486009959F8 /* E2EInstrumentationTests */,
 				61133B83242393DE00786299 /* Products */,
 				61133C6F2423993200786299 /* Frameworks */,
 			);
@@ -1215,6 +1235,7 @@
 				61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */,
 				6199362B265BA958009D7EA8 /* E2E.app */,
 				61993665265BBEDC009D7EA8 /* E2ETests.xctest */,
+				618F9840265BC486009959F8 /* E2EInstrumentationTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1421,6 +1442,7 @@
 				61441C9E2461AF4D003D8BB8 /* Example */,
 				61993640265BAC34009D7EA8 /* E2E */,
 				61993670265BBF19009D7EA8 /* E2ETests */,
+				618F984B265BC4C0009959F8 /* E2EInstrumentationTests */,
 			);
 			path = TargetSupport;
 			sourceTree = "<group>";
@@ -2342,6 +2364,23 @@
 			path = URLSessionAutoInstrumentation;
 			sourceTree = "<group>";
 		};
+		618F9841265BC486009959F8 /* E2EInstrumentationTests */ = {
+			isa = PBXGroup;
+			children = (
+				618F9842265BC486009959F8 /* E2EInstrumentationTests.swift */,
+			);
+			path = E2EInstrumentationTests;
+			sourceTree = "<group>";
+		};
+		618F984B265BC4C0009959F8 /* E2EInstrumentationTests */ = {
+			isa = PBXGroup;
+			children = (
+				618F9844265BC486009959F8 /* Info.plist */,
+				618F984C265BC53E009959F8 /* E2EInstrumentationTests.xcconfig */,
+			);
+			path = E2EInstrumentationTests;
+			sourceTree = "<group>";
+		};
 		6193DCA2251B5669009B8011 /* TapActionAutoInstrumentation */ = {
 			isa = PBXGroup;
 			children = (
@@ -3137,6 +3176,24 @@
 			productReference = 61441C6824619FE4003D8BB8 /* DatadogBenchmarkTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		618F983F265BC486009959F8 /* E2EInstrumentationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 618F9847265BC486009959F8 /* Build configuration list for PBXNativeTarget "E2EInstrumentationTests" */;
+			buildPhases = (
+				618F983C265BC486009959F8 /* Sources */,
+				618F983D265BC486009959F8 /* Frameworks */,
+				618F983E265BC486009959F8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				618F9846265BC486009959F8 /* PBXTargetDependency */,
+			);
+			name = E2EInstrumentationTests;
+			productName = E2EInstrumentationTests;
+			productReference = 618F9840265BC486009959F8 /* E2EInstrumentationTests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		6199362A265BA958009D7EA8 /* E2E */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6199363F265BA95A009D7EA8 /* Build configuration list for PBXNativeTarget "E2E" */;
@@ -3249,6 +3306,10 @@
 						CreatedOnToolsVersion = 11.4;
 						TestTargetID = 61441C0124616DE9003D8BB8;
 					};
+					618F983F265BC486009959F8 = {
+						CreatedOnToolsVersion = 12.5;
+						TestTargetID = 6199362A265BA958009D7EA8;
+					};
 					6199362A265BA958009D7EA8 = {
 						CreatedOnToolsVersion = 12.5;
 					};
@@ -3289,6 +3350,7 @@
 				61441C0124616DE9003D8BB8 /* Example */,
 				6199362A265BA958009D7EA8 /* E2E */,
 				61993664265BBEDC009D7EA8 /* E2ETests */,
+				618F983F265BC486009959F8 /* E2EInstrumentationTests */,
 			);
 		};
 /* End PBXProject section */
@@ -3345,6 +3407,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		61441C6624619FE4003D8BB8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		618F983E265BC486009959F8 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3920,6 +3989,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		618F983C265BC486009959F8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				618F9843265BC486009959F8 /* E2EInstrumentationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		61993627265BA958009D7EA8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3994,6 +4071,11 @@
 			isa = PBXTargetDependency;
 			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
 			targetProxy = 6170DC5225C18E57003AED5C /* PBXContainerItemProxy */;
+		};
+		618F9846265BC486009959F8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6199362A265BA958009D7EA8 /* E2E */;
+			targetProxy = 618F9845265BC486009959F8 /* PBXContainerItemProxy */;
 		};
 		61993659265BB6A6009D7EA8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4511,6 +4593,66 @@
 			};
 			name = Integration;
 		};
+		618F9848265BC486009959F8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 618F984C265BC53E009959F8 /* E2EInstrumentationTests.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/E2EInstrumentationTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Datadog.E2EInstrumentationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = E2E;
+			};
+			name = Debug;
+		};
+		618F9849265BC486009959F8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 618F984C265BC53E009959F8 /* E2EInstrumentationTests.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/E2EInstrumentationTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Datadog.E2EInstrumentationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = E2E;
+			};
+			name = Release;
+		};
+		618F984A265BC486009959F8 /* Integration */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 618F984C265BC53E009959F8 /* E2EInstrumentationTests.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/E2EInstrumentationTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Datadog.E2EInstrumentationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = E2E;
+			};
+			name = Integration;
+		};
 		6199363C265BA95A009D7EA8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 61993641265BAD2D009D7EA8 /* E2E.xcconfig */;
@@ -4986,6 +5128,16 @@
 				61441C7124619FE4003D8BB8 /* Debug */,
 				61441C7224619FE4003D8BB8 /* Release */,
 				61441C7324619FE4003D8BB8 /* Integration */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		618F9847265BC486009959F8 /* Build configuration list for PBXNativeTarget "E2EInstrumentationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				618F9848265BC486009959F8 /* Debug */,
+				618F9849265BC486009959F8 /* Release */,
+				618F984A265BC486009959F8 /* Integration */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -192,7 +192,6 @@
 		614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614E9EB2244719FA007EE3E1 /* BundleType.swift */; };
 		614ED36C260352DC00C8C519 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; };
 		614ED37C2603533D00C8C519 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; };
-		614ED37D2603533D00C8C519 /* CrashReporter.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		614ED39A260357FA00C8C519 /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; };
 		614ED39B260357FA00C8C519 /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6152C83E24BE1C91006A1679 /* HTTPServerMock in Frameworks */ = {isa = PBXBuildFile; productRef = 6152C83D24BE1C91006A1679 /* HTTPServerMock */; };
@@ -266,13 +265,15 @@
 		61993637265BA95A009D7EA8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 61993636265BA95A009D7EA8 /* Assets.xcassets */; };
 		6199363A265BA95A009D7EA8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61993638265BA95A009D7EA8 /* LaunchScreen.storyboard */; };
 		61993654265BB6A6009D7EA8 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; };
-		61993655265BB6A6009D7EA8 /* CrashReporter.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		61993656265BB6A6009D7EA8 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61993657265BB6A6009D7EA8 /* Datadog.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6199365A265BB6A6009D7EA8 /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; };
 		6199365B265BB6A6009D7EA8 /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6199365E265BB6A6009D7EA8 /* Kronos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; };
 		6199365F265BB6A6009D7EA8 /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		61993668265BBEDC009D7EA8 /* E2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61993667265BBEDC009D7EA8 /* E2ETests.swift */; };
+		61993673265BC371009D7EA8 /* Kronos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; };
+		61993674265BC371009D7EA8 /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		619E16D82577C1CB00B2516B /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16D72577C1CB00B2516B /* DataProcessor.swift */; };
 		619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16E82578E73E00B2516B /* DataMigrator.swift */; };
 		619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */; };
@@ -432,8 +433,6 @@
 		61FF416225EE5FF400CE35EC /* CrashReportingWithLoggingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF416125EE5FF400CE35EC /* CrashReportingWithLoggingIntegrationTests.swift */; };
 		61FF9A4525AC5DEA001058CC /* RUMViewIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF9A4425AC5DEA001058CC /* RUMViewIdentity.swift */; };
 		9E0542CB25F8EBBE007A3D0B /* Kronos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; };
-		9E0542D725F8EBE3007A3D0B /* Kronos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; };
-		9E0542D825F8EBE3007A3D0B /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9E26E6B924C87693000B3270 /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
 		9E307C3224C8846D0039607E /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
 		9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */; };
@@ -526,6 +525,13 @@
 			remoteGlobalIDString = 61B7885325C180CB002675B5;
 			remoteInfo = DatadogCrashReporting;
 		};
+		6199366A265BBEDC009D7EA8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6199362A265BA958009D7EA8;
+			remoteInfo = E2E;
+		};
 		61B7885E25C180CB002675B5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 61133B79242393DE00786299 /* Project object */;
@@ -556,9 +562,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				614ED37D2603533D00C8C519 /* CrashReporter.xcframework in ⚙️ Embed Framework Dependencies */,
-				9E0542D825F8EBE3007A3D0B /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */,
 				61441C4E24619498003D8BB8 /* Datadog.framework in ⚙️ Embed Framework Dependencies */,
+				61993674265BC371009D7EA8 /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */,
 				614ED39B260357FA00C8C519 /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */,
 				61570006246AAE5E00E96950 /* DatadogObjc.framework in ⚙️ Embed Framework Dependencies */,
 			);
@@ -571,7 +576,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				61993655265BB6A6009D7EA8 /* CrashReporter.xcframework in ⚙️ Embed Framework Dependencies */,
 				6199365F265BB6A6009D7EA8 /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */,
 				61993657265BB6A6009D7EA8 /* Datadog.framework in ⚙️ Embed Framework Dependencies */,
 				6199365B265BB6A6009D7EA8 /* DatadogCrashReporting.framework in ⚙️ Embed Framework Dependencies */,
@@ -857,6 +861,10 @@
 		61993639265BA95A009D7EA8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6199363B265BA95A009D7EA8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61993641265BAD2D009D7EA8 /* E2E.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = E2E.xcconfig; sourceTree = "<group>"; };
+		61993665265BBEDC009D7EA8 /* E2ETests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = E2ETests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		61993667265BBEDC009D7EA8 /* E2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2ETests.swift; sourceTree = "<group>"; };
+		61993669265BBEDC009D7EA8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		61993672265BC029009D7EA8 /* E2ETests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = E2ETests.xcconfig; sourceTree = "<group>"; };
 		619E16D72577C1CB00B2516B /* DataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProcessor.swift; sourceTree = "<group>"; };
 		619E16E82578E73E00B2516B /* DataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrator.swift; sourceTree = "<group>"; };
 		619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllDataMigrator.swift; sourceTree = "<group>"; };
@@ -1066,9 +1074,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61993673265BC371009D7EA8 /* Kronos.xcframework in Frameworks */,
 				614ED39A260357FA00C8C519 /* DatadogCrashReporting.framework in Frameworks */,
 				614ED37C2603533D00C8C519 /* CrashReporter.xcframework in Frameworks */,
-				9E0542D725F8EBE3007A3D0B /* Kronos.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1106,6 +1114,13 @@
 				6199365A265BB6A6009D7EA8 /* DatadogCrashReporting.framework in Frameworks */,
 				6199365E265BB6A6009D7EA8 /* Kronos.xcframework in Frameworks */,
 				61993654265BB6A6009D7EA8 /* CrashReporter.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		61993662265BBEDC009D7EA8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1181,6 +1196,7 @@
 				61133C07242397F200786299 /* TargetSupport */,
 				61441C0324616DE9003D8BB8 /* Example */,
 				6199362C265BA959009D7EA8 /* E2E */,
+				61993666265BBEDC009D7EA8 /* E2ETests */,
 				61133B83242393DE00786299 /* Products */,
 				61133C6F2423993200786299 /* Frameworks */,
 			);
@@ -1198,6 +1214,7 @@
 				61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */,
 				61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */,
 				6199362B265BA958009D7EA8 /* E2E.app */,
+				61993665265BBEDC009D7EA8 /* E2ETests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1403,6 +1420,7 @@
 				9EF49F1524476FBD004F2CA0 /* DatadogIntegrationTests */,
 				61441C9E2461AF4D003D8BB8 /* Example */,
 				61993640265BAC34009D7EA8 /* E2E */,
+				61993670265BBF19009D7EA8 /* E2ETests */,
 			);
 			path = TargetSupport;
 			sourceTree = "<group>";
@@ -2355,6 +2373,23 @@
 			path = E2E;
 			sourceTree = "<group>";
 		};
+		61993666265BBEDC009D7EA8 /* E2ETests */ = {
+			isa = PBXGroup;
+			children = (
+				61993667265BBEDC009D7EA8 /* E2ETests.swift */,
+			);
+			path = E2ETests;
+			sourceTree = "<group>";
+		};
+		61993670265BBF19009D7EA8 /* E2ETests */ = {
+			isa = PBXGroup;
+			children = (
+				61993669265BBEDC009D7EA8 /* Info.plist */,
+				61993672265BC029009D7EA8 /* E2ETests.xcconfig */,
+			);
+			path = E2ETests;
+			sourceTree = "<group>";
+		};
 		619E16D42577C11B00B2516B /* Writting */ = {
 			isa = PBXGroup;
 			children = (
@@ -3122,6 +3157,25 @@
 			productReference = 6199362B265BA958009D7EA8 /* E2E.app */;
 			productType = "com.apple.product-type.application";
 		};
+		61993664265BBEDC009D7EA8 /* E2ETests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6199366C265BBEDC009D7EA8 /* Build configuration list for PBXNativeTarget "E2ETests" */;
+			buildPhases = (
+				61993661265BBEDC009D7EA8 /* Sources */,
+				61993662265BBEDC009D7EA8 /* Frameworks */,
+				61993663265BBEDC009D7EA8 /* Resources */,
+				61993671265BBF8E009D7EA8 /* ⚙️ Run linter */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6199366B265BBEDC009D7EA8 /* PBXTargetDependency */,
+			);
+			name = E2ETests;
+			productName = E2ETests;
+			productReference = 61993665265BBEDC009D7EA8 /* E2ETests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		61B7885325C180CB002675B5 /* DatadogCrashReporting */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 61B7886B25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReporting" */;
@@ -3198,6 +3252,10 @@
 					6199362A265BA958009D7EA8 = {
 						CreatedOnToolsVersion = 12.5;
 					};
+					61993664265BBEDC009D7EA8 = {
+						CreatedOnToolsVersion = 12.5;
+						TestTargetID = 6199362A265BA958009D7EA8;
+					};
 					61B7885325C180CB002675B5 = {
 						CreatedOnToolsVersion = 12.3;
 						LastSwiftMigration = 1230;
@@ -3230,6 +3288,7 @@
 				61441C2924616F1D003D8BB8 /* DatadogIntegrationTests */,
 				61441C0124616DE9003D8BB8 /* Example */,
 				6199362A265BA958009D7EA8 /* E2E */,
+				61993664265BBEDC009D7EA8 /* E2ETests */,
 			);
 		};
 /* End PBXProject section */
@@ -3301,6 +3360,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		61993663265BBEDC009D7EA8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		61B7885225C180CB002675B5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3357,6 +3423,25 @@
 			showEnvVarsInLog = 0;
 		};
 		6170DC2425C18784003AED5C /* ⚙️ Run linter */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "⚙️ Run linter";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		61993671265BBF8E009D7EA8 /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3843,6 +3928,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		61993661265BBEDC009D7EA8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				61993668265BBEDC009D7EA8 /* E2ETests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		61B7885025C180CB002675B5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3911,6 +4004,11 @@
 			isa = PBXTargetDependency;
 			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
 			targetProxy = 6199365C265BB6A6009D7EA8 /* PBXContainerItemProxy */;
+		};
+		6199366B265BBEDC009D7EA8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6199362A265BA958009D7EA8 /* E2E */;
+			targetProxy = 6199366A265BBEDC009D7EA8 /* PBXContainerItemProxy */;
 		};
 		61B7885F25C180CB002675B5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4473,6 +4571,66 @@
 			};
 			name = Integration;
 		};
+		6199366D265BBEDC009D7EA8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61993672265BC029009D7EA8 /* E2ETests.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/E2ETests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Datadog.E2ETests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/E2E.app/E2E";
+			};
+			name = Debug;
+		};
+		6199366E265BBEDC009D7EA8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61993672265BC029009D7EA8 /* E2ETests.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/E2ETests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Datadog.E2ETests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/E2E.app/E2E";
+			};
+			name = Release;
+		};
+		6199366F265BBEDC009D7EA8 /* Integration */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 61993672265BC029009D7EA8 /* E2ETests.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = TargetSupport/E2ETests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Datadog.E2ETests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/E2E.app/E2E";
+			};
+			name = Integration;
+		};
 		61B7886525C180CB002675B5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 615D9E2626048EAF006DC6D1 /* DatadogCrashReporting.xcconfig */;
@@ -4838,6 +4996,16 @@
 				6199363C265BA95A009D7EA8 /* Debug */,
 				6199363D265BA95A009D7EA8 /* Release */,
 				6199363E265BA95A009D7EA8 /* Integration */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6199366C265BBEDC009D7EA8 /* Build configuration list for PBXNativeTarget "E2ETests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6199366D265BBEDC009D7EA8 /* Debug */,
+				6199366E265BBEDC009D7EA8 /* Release */,
+				6199366F265BBEDC009D7EA8 /* Integration */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6199362A265BA958009D7EA8"
+               BuildableName = "E2E.app"
+               BlueprintName = "E2E"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6199362A265BA958009D7EA8"
+            BuildableName = "E2E.app"
+            BlueprintName = "E2E"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6199362A265BA958009D7EA8"
+            BuildableName = "E2E.app"
+            BlueprintName = "E2E"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "618F983F265BC486009959F8"
+               BuildableName = "E2EInstrumentationTests.xctest"
+               BlueprintName = "E2EInstrumentationTests"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
@@ -28,26 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "61993664265BBEDC009D7EA8"
-               BuildableName = "E2ETests.xctest"
-               BlueprintName = "E2ETests"
-               ReferencedContainer = "container:Datadog.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "618F983F265BC486009959F8"
-               BuildableName = "E2EInstrumentationTests.xctest"
-               BlueprintName = "E2EInstrumentationTests"
-               ReferencedContainer = "container:Datadog.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "61993664265BBEDC009D7EA8"
+               BuildableName = "E2ETests.xctest"
+               BlueprintName = "E2ETests"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2EInstrumentationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2EInstrumentationTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "618F983F265BC486009959F8"
+               BuildableName = "E2EInstrumentationTests.xctest"
+               BlueprintName = "E2EInstrumentationTests"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2ETests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2ETests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "61993664265BBEDC009D7EA8"
+               BuildableName = "E2ETests.xctest"
+               BlueprintName = "E2ETests"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Datadog/E2E/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Datadog/E2E/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Datadog/E2E/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Datadog/E2E/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Datadog/E2E/Assets.xcassets/Contents.json
+++ b/Datadog/E2E/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Datadog/E2E/Base.lproj/LaunchScreen.storyboard
+++ b/Datadog/E2E/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Datadog/E2E/E2EAppDelegate.swift
+++ b/Datadog/E2E/E2EAppDelegate.swift
@@ -1,0 +1,14 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import UIKit
+
+@UIApplicationMain
+class E2EAppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+}

--- a/Datadog/E2E/E2EAppDelegate.swift
+++ b/Datadog/E2E/E2EAppDelegate.swift
@@ -9,6 +9,10 @@ import UIKit
 @UIApplicationMain
 class E2EAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        // TODO: RUMM-1249 remove this when we have both manual and instrumented API tests using client token and RUM app ID
+        E2EConfig.check()
+
         return true
     }
 }

--- a/Datadog/E2E/E2EAppDelegate.swift
+++ b/Datadog/E2E/E2EAppDelegate.swift
@@ -10,7 +10,6 @@ import UIKit
 class E2EAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        // TODO: RUMM-1249 remove this when we have both manual and instrumented API tests using client token and RUM app ID
         E2EConfig.check()
 
         return true

--- a/Datadog/E2E/E2EConfig.swift
+++ b/Datadog/E2E/E2EConfig.swift
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal class E2EConfig {
+    private struct InfoPlistKey {
+        static let clientToken      = "E2EDatadogClientToken"
+        static let rumApplicationID = "E2ERUMApplicationID"
+    }
+
+    private static var bundle: Bundle { Bundle(for: E2EConfig.self) }
+
+    // MARK: - Info.plist
+
+    static func readClientToken() -> String {
+        guard let clientToken = bundle.infoDictionary?[InfoPlistKey.clientToken] as? String, !clientToken.isEmpty else {
+            fatalError("""
+            ✋⛔️ Cannot read `\(InfoPlistKey.clientToken)` from `Info.plist` dictionary.
+            Update `xcconfigs/Datadog.xcconfig` with your own client token obtained on datadoghq.com.
+            You might need to run `Product > Clean Build Folder` before retrying.
+            """)
+        }
+        return clientToken
+    }
+
+    static func readRUMApplicationID() -> String {
+        guard let rumApplicationID = bundle.infoDictionary![InfoPlistKey.rumApplicationID] as? String, !rumApplicationID.isEmpty else {
+            fatalError("""
+            ✋⛔️ Cannot read `\(InfoPlistKey.rumApplicationID)` from `Info.plist` dictionary.
+            Update `xcconfigs/Datadog.xcconfig` with your own RUM application id obtained on datadoghq.com.
+            You might need to run `Product > Clean Build Folder` before retrying.
+            """)
+        }
+        return rumApplicationID
+    }
+
+    static func check() {
+        _ = readClientToken()
+        _ = readRUMApplicationID()
+    }
+}

--- a/Datadog/E2EInstrumentationTests/E2EInstrumentationTests.swift
+++ b/Datadog/E2EInstrumentationTests/E2EInstrumentationTests.swift
@@ -1,0 +1,15 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import XCTest
+
+class E2EInstrumentationTests: XCTestCase {
+    func testBasicInstrumentation() throws {
+        let app = XCUIApplication()
+        app.launch()
+        app.terminate()
+    }
+}

--- a/Datadog/E2ETests/E2ETests.swift
+++ b/Datadog/E2ETests/E2ETests.swift
@@ -1,0 +1,13 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import XCTest
+import Datadog
+
+class E2ETests: XCTestCase {
+    func testBasicAPI() throws {
+    }
+}

--- a/Datadog/TargetSupport/E2E/E2E.xcconfig
+++ b/Datadog/TargetSupport/E2E/E2E.xcconfig
@@ -1,0 +1,2 @@
+// Add common settings from Datadog.xcconfig
+#include "../xcconfigs/Datadog.xcconfig"

--- a/Datadog/TargetSupport/E2E/Info.plist
+++ b/Datadog/TargetSupport/E2E/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Datadog/TargetSupport/E2E/Info.plist
+++ b/Datadog/TargetSupport/E2E/Info.plist
@@ -45,5 +45,7 @@
 	<string>$(E2E_DATADOG_CLIENT_TOKEN)</string>
 	<key>E2ERUMApplicationID</key>
 	<string>$(E2E_RUM_APPLICATION_ID)</string>
+	<key>IsRunningOnCI</key>
+	<string>$(IS_CI)</string>
 </dict>
 </plist>

--- a/Datadog/TargetSupport/E2E/Info.plist
+++ b/Datadog/TargetSupport/E2E/Info.plist
@@ -41,5 +41,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>E2EDatadogClientToken</key>
+	<string>$(E2E_DATADOG_CLIENT_TOKEN)</string>
+	<key>E2ERUMApplicationID</key>
+	<string>$(E2E_RUM_APPLICATION_ID)</string>
 </dict>
 </plist>

--- a/Datadog/TargetSupport/E2EInstrumentationTests/E2EInstrumentationTests.xcconfig
+++ b/Datadog/TargetSupport/E2EInstrumentationTests/E2EInstrumentationTests.xcconfig
@@ -1,0 +1,2 @@
+// Add common settings from Datadog.xcconfig
+#include "../xcconfigs/Datadog.xcconfig"

--- a/Datadog/TargetSupport/E2EInstrumentationTests/Info.plist
+++ b/Datadog/TargetSupport/E2EInstrumentationTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Datadog/TargetSupport/E2ETests/E2ETests.xcconfig
+++ b/Datadog/TargetSupport/E2ETests/E2ETests.xcconfig
@@ -1,0 +1,2 @@
+// Add common settings from Datadog.xcconfig
+#include "../xcconfigs/Datadog.xcconfig"

--- a/Datadog/TargetSupport/E2ETests/Info.plist
+++ b/Datadog/TargetSupport/E2ETests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Datadog/TargetSupport/E2ETests/Info.plist
+++ b/Datadog/TargetSupport/E2ETests/Info.plist
@@ -18,5 +18,9 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>E2EDatadogClientToken</key>
+	<string>$(E2E_DATADOG_CLIENT_TOKEN)</string>
+	<key>E2ERUMApplicationID</key>
+	<string>$(E2E_RUM_APPLICATION_ID)</string>
 </dict>
 </plist>

--- a/Datadog/TargetSupport/E2ETests/Info.plist
+++ b/Datadog/TargetSupport/E2ETests/Info.plist
@@ -22,5 +22,7 @@
 	<string>$(E2E_DATADOG_CLIENT_TOKEN)</string>
 	<key>E2ERUMApplicationID</key>
 	<string>$(E2E_RUM_APPLICATION_ID)</string>
+	<key>IsRunningOnCI</key>
+	<string>$(IS_CI)</string>
 </dict>
 </plist>

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,13 @@ ONLY_ACTIVE_ARCH = YES
 endef
 export DD_SDK_BASE_XCCONFIG
 
+define DD_SDK_DATADOG_XCCONFIG
+// Datadog secrets provisioning E2E tests data for 'Mobile - Integration' org:\n
+E2E_RUM_APPLICATION_ID=${E2E_RUM_APPLICATION_ID}\n
+E2E_DATADOG_CLIENT_TOKEN=${E2E_DATADOG_CLIENT_TOKEN}\n
+endef
+export DD_SDK_DATADOG_XCCONFIG
+
 # Installs tools and dependencies with homebrew.
 # Do not call 'brew update' and instead let Bitrise use its own brew bottle mirror.
 dependencies:
@@ -37,6 +44,7 @@ dependencies:
 		@carthage bootstrap --platform iOS --use-xcframeworks
 		@echo $$DD_SDK_BASE_XCCONFIG > xcconfigs/Base.local.xcconfig;
 ifeq (${ci}, true)
+		@echo $$DD_SDK_DATADOG_XCCONFIG > xcconfigs/Datadog.local.xcconfig;
 		@echo $$DD_SDK_TESTING_XCCONFIG_CI > xcconfigs/DatadogSDKTesting.local.xcconfig;
 		@brew list gh &>/dev/null || brew install gh
 		@rm -rf instrumented-tests/DatadogSDKTesting.xcframework

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_SDK_ENABLE_INTERNAL_MONITORING DD_SDK_E
 //		 The only "problematic" dependency is `CrashReporter.xcframework` which doesn't produce\n
 //		 the `arm64-simulator` architecture when compiled from source. Its pre-build `CrashReporter.xcframework`\n
 //		 available since `1.8.0` contains the `ios-arm64_i386_x86_64-simulator` slice and should link fine in all configurations.\n
-ONLY_ACTIVE_ARCH = YES
+ONLY_ACTIVE_ARCH = YES\n
+\n
+// If running on CI (can be set empty on local machine):\n
+IS_CI=${ci}\n 
 endef
 export DD_SDK_BASE_XCCONFIG
 

--- a/xcconfigs/Datadog.xcconfig
+++ b/xcconfigs/Datadog.xcconfig
@@ -1,9 +1,15 @@
 // Include base config
 #include "Base.xcconfig"
 
+DEVELOPMENT_TEAM[sdk=iphoneos*]=// use your own Development Team
+
+// Datadog secrets for running Example app (manual tests, integration tests, benchmarks)
 RUM_APPLICATION_ID=// use your own RUM Application ID obtained on datadoghq.com
 DATADOG_CLIENT_TOKEN=// use your own Client Token, generated for RUM_APPLICATION_ID
-DEVELOPMENT_TEAM[sdk=iphoneos*]=// use your own Development Team
+
+// Datadog secrets for running E2E tests (nightly E2E tests)
+E2E_RUM_APPLICATION_ID=// use your own RUM Application ID obtained on datadoghq.com
+E2E_DATADOG_CLIENT_TOKEN=// use your own Client Token, generated for E2E_RUM_APPLICATION_ID
 
 // Overwrite with secrets
 #include? "Datadog.local.xcconfig"


### PR DESCRIPTION
### What and why?

⚙️ This PR adds setup for E2E δ tests project. It will be used to monitor data and API performance when sending events to Datadog _"Mobile - Integration"_ org.

The E2E δ tests project will use our SDK and Datadog platform to test and monitor overall consistency of data sent from our SDK. It will additionally assert temporal metrics computed from measuring API performance with APM product. It will not assert deep consistency of data nor provide instant feedback for qualifying PRs before merge, hence:
* it is an extension to our existing integration tests with Python mock server, so the `Example` app and `DatadogIntegrationTests` remain unchanged and should be still maintained and updated with tests for new features;
* it will replace benchmark tests so we can call `DatadogBenchmarkTests` target deprecated and remove it soon.


### How?

3 new targets are added to the project:

<img width="250" alt="Screenshot 2021-05-24 at 15 33 21" src="https://user-images.githubusercontent.com/2358722/119355315-69778b80-bca5-11eb-8cbf-f7dfaa3c7854.png">

* `E2ETests` - unit tests target for running manual instrumentation tests,
* `E2EInstrumentationTests` - UI tests target for running auto instrumentation tests,
* `E2E` - application target for providing unit tests host environment and UI tests instrumentation fixtures.

💡 This new setup requires calling `make dependencies` to generate necessary placeholders for secrets. After run, the `Datadog.local.xcconfig` must be filled in manually with 'Mobile - Integration' org secrets.

💡 Additional `IS_CI` `xcconfig` flag is configured to differentiate local (debug) and CI data send to 'Mobile - Integration' org. This is to not interrupt future monitors by running tests on local.

Each target is provided its own `xcconfig` configuration in existing 4-tiers configuration model:

|   	| E2E                      	| E2ETessts                	| E2EInstrumentationTests            	| Comment                                                              	|
|---	|--------------------------	|--------------------------	|------------------------------------	|----------------------------------------------------------------------	|
| ↓ 	|      `E2E.xcconfig`      	|    `E2ETests.xcconfig`   	| `E2EInstrumentationTests.xcconfig` 	| Target-specific config                                               	|
| ↓ 	|    `Datadog.xcconfig`    	|    `Datadog.xcconfig`    	|         `Datadog.xcconfig`         	| Targets-shared config (RUM App ID & CT definition)                   	|
| ↓ 	| `Datadog.local.xcconfig` 	| `Datadog.local.xcconfig` 	|      `Datadog.local.xcconfig`      	| Secrets (git-ignored, generated on CI and in dev local)              	|
| ↓ 	|   `Base.local.xcconfig`  	|   `Base.local.xcconfig`  	|        `Base.local.xcconfig`       	| Custom configuration (git-ignored, generated on CI and in dev local) 	|


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
