### PR TITLE
RUMM-1140 δ Configure CI for running E2E tests nightly

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2EInstrumentationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2EInstrumentationTests.xcscheme
@@ -34,6 +34,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6199362A265BA958009D7EA8"
+            BuildableName = "E2E.app"
+            BlueprintName = "E2E"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -41,6 +51,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6199362A265BA958009D7EA8"
+            BuildableName = "E2E.app"
+            BlueprintName = "E2E"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2ETests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2ETests.xcscheme
@@ -34,6 +34,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6199362A265BA958009D7EA8"
+            BuildableName = "E2E.app"
+            BlueprintName = "E2E"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -41,6 +51,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6199362A265BA958009D7EA8"
+            BuildableName = "E2E.app"
+            BlueprintName = "E2E"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,6 +19,13 @@ workflows:
   push_to_dogfooding:
     after_run:
     - create_dogfooding_pr
+    - _notify_failure_on_slack
+
+  run_nightly_e2e_tests:
+    after_run:
+    - _make_dependencies
+    - run_e2e_tests
+    - _notify_failure_on_slack
 
   _make_dependencies:
     description: |-
@@ -37,6 +44,27 @@ workflows:
         Uploads artifacts to associate them with build log on Bitrise.io.
     steps:
     - deploy-to-bitrise-io: {}
+
+  _notify_failure_on_slack:
+    description: |-
+        Notifies any (previous) workflow failure on Slack.
+        Should be used to notify failures for workflows which do not report back to GitHub check.
+    steps:
+    - slack:
+        is_always_run: true
+        run_if: .IsBuildFailed
+        inputs:
+        - channel: '#dd-sdk-ios'
+        - buttons: |-
+            See Bitrise log|${BITRISE_BUILD_URL}
+        - pretext: |-
+            ⚠️ Bitrise build failed.
+        - color_on_error: '#FF0000'
+        - author_name: ''
+        - message: ''
+        - message_on_error: ''
+        - icon_url: 'https://avatars.githubusercontent.com/t/3555052?s=128&v=4'
+        - webhook_url: '${SLACK_INCOMING_WEBHOOK_MOBILE_CI}'
 
   run_linter:
     description: |-
@@ -237,3 +265,21 @@ workflows:
             set -e
             make dogfood ci=${CI}
 
+  run_e2e_tests:
+    description: |-
+        Runs E2E tests on iOS Simulator.
+    steps:
+    - xcode-test:
+        title: Run E2E tests for manual instrumentation APIs - iOS Simulator
+        inputs:
+        - scheme: E2ETests
+        - simulator_device: iPhone 11
+        - project_path: Datadog.xcworkspace
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/E2E-tests.html"
+    - xcode-test:
+        title: Run E2E tests for auto instrumentation APIs - iOS Simulator
+        inputs:
+        - scheme: E2EInstrumentationTests
+        - simulator_device: iPhone 11
+        - project_path: Datadog.xcworkspace
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/E2E-instrumentation-tests.html"


### PR DESCRIPTION
### What and why?

⚙️ This PR configures CI for running E2E tests (#496) nightly.

### How?

It adds `run_e2e_tests` workflow definition to `bitrise.yml`. Secrets and trigger are set up on Bitrise. After merging, I will configure necessary Bitrise schedule to run this workflow every night at a certain hour.

Additionally, I added `_notify_failure_on_slack` workflow which sends notification to our iOS Slack chanel upon certain workflow failure. It can be used to notify failure for workflows which are not asserted by GitHub PR checks (now: nightly E2E tests + dogfooding, later: release).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
