### PR TITLE
RUMM-1381 Add internal API to send buffered data before deinitializing SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,11 @@ endef
 export DD_SDK_TESTING_XCCONFIG_CI
 
 define DD_SDK_BASE_XCCONFIG
-// To enable Internal Monitoring APIs:\n
-SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_SDK_ENABLE_INTERNAL_MONITORING DD_SDK_ENABLE_EXPERIMENTAL_APIS\n
+// Active compilation conditions - only enabled on local machine:\n
+// - DD_SDK_ENABLE_INTERNAL_MONITORING - enables Internal Monitoring APIs\n
+// - DD_SDK_ENABLE_EXPERIMENTAL_APIS - enables APIs which are not available in released version of the SDK\n
+// - DD_SDK_COMPILED_FOR_TESTING - conditions the SDK code compiled for testing\n
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_SDK_ENABLE_INTERNAL_MONITORING DD_SDK_ENABLE_EXPERIMENTAL_APIS DD_SDK_COMPILED_FOR_TESTING\n
 \n
 // To build only active architecture for all configurations.\n
 // TODO: RUMM-1200 We can perhaps remove this fix when carthage supports pre-build xcframeworks.\n

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -40,7 +40,7 @@ internal struct FeatureStorage {
 
     /// An arbitrary `Writer` which always writes data to authorized folder.
     /// Should be only used by components which implement their own consideration of the `TrackingConsent` value
-    /// associated with data written.
+    /// associated with data written (e.g. crash reporting integration which saves the consent value along with the crash report).
     let arbitraryAuthorizedWriter: Writer
 
     init(
@@ -120,6 +120,19 @@ internal struct FeatureStorage {
         self.reader = reader
         self.arbitraryAuthorizedWriter = arbitraryAuthorizedWriter
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    /// Flushes all async write operations.
+    ///
+    /// This method is executed synchronously. After return, the storage feature has no more
+    /// pending asynchronous write operations so all its data is ready for upload.
+    func flush() {
+        let consentAwareDataWriter = writer as? ConsentAwareDataWriter
+        let arbitraryDataWriter = arbitraryAuthorizedWriter as? ArbitraryDataWriter
+        let readWriteQueue = consentAwareDataWriter?.readWriteQueue ?? arbitraryDataWriter?.readWriteQueue
+        readWriteQueue?.sync {}
+    }
+#endif
 }
 
 internal struct FeatureUpload {
@@ -166,4 +179,18 @@ internal struct FeatureUpload {
     init(uploader: DataUploadWorkerType) {
         self.uploader = uploader
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    /// Flushes all authorised data and tears down the upload stack.
+    /// - It flushes all data stored in authorized files by performing their arbitrary upload (without retrying).
+    /// - It completes all pending asynchronous work in upload worker and cancels its next schedules.
+    ///
+    /// This method is executed synchronously. After return, the upload feature has no more
+    /// pending asynchronous operations and all its authorized data should be considered uploaded.
+    func flushAndTearDown() {
+        let dataUploadWorker = uploader as? DataUploadWorker
+        dataUploadWorker?.cancelSynchronously()
+        dataUploadWorker?.flushSynchronously()
+    }
+#endif
 }

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -34,14 +34,14 @@ internal struct FeaturesCommonDependencies {
 internal struct FeatureStorage {
     /// Writes data to files. This `Writer` takes current value of the `TrackingConsent` into consideration
     /// to decided if the data should be written to authorized or unauthorized folder.
-    let writer: Writer
+    let writer: AsyncWriter
     /// Reads data from files in authorized folder.
-    let reader: Reader
+    let reader: SyncReader
 
     /// An arbitrary `Writer` which always writes data to authorized folder.
     /// Should be only used by components which implement their own consideration of the `TrackingConsent` value
     /// associated with data written (e.g. crash reporting integration which saves the consent value along with the crash report).
-    let arbitraryAuthorizedWriter: Writer
+    let arbitraryAuthorizedWriter: AsyncWriter
 
     init(
         featureName: String,
@@ -115,22 +115,23 @@ internal struct FeatureStorage {
         )
     }
 
-    init(writer: Writer, reader: Reader, arbitraryAuthorizedWriter: Writer) {
+    init(writer: AsyncWriter, reader: SyncReader, arbitraryAuthorizedWriter: AsyncWriter) {
         self.writer = writer
         self.reader = reader
         self.arbitraryAuthorizedWriter = arbitraryAuthorizedWriter
     }
 
 #if DD_SDK_COMPILED_FOR_TESTING
-    /// Flushes all async write operations.
+    /// Flushes all async write operations and tears down the storage stack.
+    /// - It completes all async writes by synchronously saving data to authorized files.
+    /// - It cancels the storage by preventing all future write operations and marking all authorised files as "ready for upload".
     ///
     /// This method is executed synchronously. After return, the storage feature has no more
     /// pending asynchronous write operations so all its data is ready for upload.
-    func flush() {
-        let consentAwareDataWriter = writer as? ConsentAwareDataWriter
-        let arbitraryDataWriter = arbitraryAuthorizedWriter as? ArbitraryDataWriter
-        let readWriteQueue = consentAwareDataWriter?.readWriteQueue ?? arbitraryDataWriter?.readWriteQueue
-        readWriteQueue?.sync {}
+    func flushAndTearDown() {
+        writer.flushAndCancelSynchronously()
+        arbitraryAuthorizedWriter.flushAndCancelSynchronously()
+        reader.markAllFilesAsReadable()
     }
 #endif
 }
@@ -182,15 +183,14 @@ internal struct FeatureUpload {
 
 #if DD_SDK_COMPILED_FOR_TESTING
     /// Flushes all authorised data and tears down the upload stack.
-    /// - It flushes all data stored in authorized files by performing their arbitrary upload (without retrying).
     /// - It completes all pending asynchronous work in upload worker and cancels its next schedules.
+    /// - It flushes all data stored in authorized files by performing their arbitrary upload (without retrying).
     ///
     /// This method is executed synchronously. After return, the upload feature has no more
     /// pending asynchronous operations and all its authorized data should be considered uploaded.
     func flushAndTearDown() {
-        let dataUploadWorker = uploader as? DataUploadWorker
-        dataUploadWorker?.cancelSynchronously()
-        dataUploadWorker?.flushSynchronously()
+        uploader.cancelSynchronously()
+        uploader.flushSynchronously()
     }
 #endif
 }

--- a/Sources/Datadog/Core/Persistence/FilesOrchestrator.swift
+++ b/Sources/Datadog/Core/Persistence/FilesOrchestrator.swift
@@ -101,6 +101,12 @@ internal class FilesOrchestrator {
                 return nil
             }
 
+            #if DD_SDK_COMPILED_FOR_TESTING
+            if ignoreFilesAgeWhenReading {
+                return oldestFile
+            }
+            #endif
+
             let oldestFileAge = dateProvider.currentDate().timeIntervalSince(creationDate)
             let fileIsOldEnough = oldestFileAge >= performance.minFileAgeForRead
 
@@ -118,6 +124,11 @@ internal class FilesOrchestrator {
             internalMonitor?.sdkLogger.error("Failed to delete file", error: error)
         }
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    /// If files age should be ignored for obtaining `ReadableFile`.
+    var ignoreFilesAgeWhenReading = false
+#endif
 
     // MARK: - Directory size management
 

--- a/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
@@ -11,7 +11,7 @@ internal final class FileReader: Reader {
     /// Data reading format.
     private let dataFormat: DataFormat
     /// Orchestrator producing reference to readable file.
-    private let orchestrator: FilesOrchestrator
+    internal let orchestrator: FilesOrchestrator
     private let internalMonitor: InternalMonitor?
 
     /// Files marked as read.

--- a/Sources/Datadog/Core/Persistence/Reading/Reader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/Reader.swift
@@ -17,3 +17,13 @@ internal protocol Reader {
     func readNextBatch() -> Batch?
     func markBatchAsRead(_ batch: Batch)
 }
+
+/// Reader performing reads synchronously on a given queue.
+internal protocol SyncReader: Reader {
+    /// Queue used for synchronous reads.
+    var queue: DispatchQueue { get }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func markAllFilesAsReadable()
+#endif
+}

--- a/Sources/Datadog/Core/Persistence/Writting/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/FileWriter.swift
@@ -11,7 +11,7 @@ internal final class FileWriter: Writer {
     /// Data writing format.
     private let dataFormat: DataFormat
     /// Orchestrator producing reference to writable file.
-    private let orchestrator: FilesOrchestrator
+    internal let orchestrator: FilesOrchestrator
     /// JSON encoder used to encode data.
     private let jsonEncoder: JSONEncoder
     private let internalMonitor: InternalMonitor?

--- a/Sources/Datadog/Core/Persistence/Writting/Writer.swift
+++ b/Sources/Datadog/Core/Persistence/Writting/Writer.swift
@@ -10,3 +10,13 @@ import Foundation
 internal protocol Writer {
     func write<T: Encodable>(value: T)
 }
+
+/// Writer performing writes asynchronously on a given queue.
+internal protocol AsyncWriter: Writer {
+    /// Queue used for asynchronous writes.
+    var queue: DispatchQueue { get }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func flushAndCancelSynchronously()
+#endif
+}

--- a/Sources/Datadog/Core/Swizzling/MethodSwizzler.swift
+++ b/Sources/Datadog/Core/Swizzling/MethodSwizzler.swift
@@ -69,6 +69,17 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
         }
     }
 
+#if DD_SDK_COMPILED_FOR_TESTING
+    /// Removes swizzling and resets the method to its original implementation.
+    func unswizzle() {
+        for foundMethod in swizzledMethods {
+            let originalTypedIMP = originalImplementation(of: foundMethod)
+            let originalIMP: IMP = unsafeBitCast(originalTypedIMP, to: IMP.self)
+            method_setImplementation(foundMethod.method, originalIMP)
+        }
+    }
+#endif
+
     // MARK: - Private methods
 
     @discardableResult

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -49,6 +49,14 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
         let uploadWork = DispatchWorkItem { [weak self] in
             guard let self = self else {
+                #if DD_SDK_COMPILED_FOR_TESTING
+                assertionFailure(
+                    """
+                    All asynchronous work must be stopped before deallocating `DataUploadWorker` in tests.
+                    This is to prevent flakiness by ensuring clean state before and after each test.
+                    """
+                )
+                #endif
                 return
             }
 

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -29,6 +29,9 @@ internal class DataUploadWorker: DataUploadWorkerType {
     /// Delay used to schedule consecutive uploads.
     private var delay: Delay
 
+    /// Upload work scheduled by this worker.
+    private var uploadWork: DispatchWorkItem?
+
     init(
         queue: DispatchQueue,
         fileReader: Reader,
@@ -44,11 +47,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
         self.delay = delay
         self.featureName = featureName
 
-        scheduleNextUpload(after: self.delay.current)
-    }
-
-    private func scheduleNextUpload(after delay: TimeInterval) {
-        queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+        let uploadWork = DispatchWorkItem { [weak self] in
             guard let self = self else {
                 return
             }
@@ -81,7 +80,45 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
             self.scheduleNextUpload(after: self.delay.current)
         }
+
+        self.uploadWork = uploadWork
+
+        scheduleNextUpload(after: self.delay.current)
     }
+
+    private func scheduleNextUpload(after delay: TimeInterval) {
+        guard let work = uploadWork else {
+            return
+        }
+
+        queue.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    /// Sends all unsent data synchronously.
+    /// - It performs arbiitrary upload (without checking upload condition and without re-transmitting failed uploads).
+    func flushSynchronously() {
+        queue.sync {
+            while let nextBatch = self.fileReader.readNextBatch() {
+                _ = self.dataUploader.upload(data: nextBatch.data)
+                self.fileReader.markBatchAsRead(nextBatch)
+            }
+        }
+    }
+
+    /// Cancels scheduled uploads and stops scheduling next ones.
+    /// - It does not affect the upload that has already begun.
+    /// - It blocks the caller thread if called in the middle of upload execution.
+    func cancelSynchronously() {
+        queue.sync {
+            // This cancellation must be performed on the `queue` to ensure that it is not called
+            // in the middle of a `DispatchWorkItem` execution - otherwise, as the pending block would be
+            // fully executed, it will schedule another upload by calling `nextScheduledWork(after:)` at the end.
+            self.uploadWork?.cancel()
+            self.uploadWork = nil
+        }
+    }
+#endif
 }
 
 extension DataUploadConditions.Blocker: CustomStringConvertible {

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -7,7 +7,12 @@
 import Foundation
 
 /// Abstracts the `DataUploadWorker`, so we can have no-op uploader in tests.
-internal protocol DataUploadWorkerType {}
+internal protocol DataUploadWorkerType {
+#if DD_SDK_COMPILED_FOR_TESTING
+    func flushSynchronously()
+    func cancelSynchronously()
+#endif
+}
 
 internal class DataUploadWorker: DataUploadWorkerType {
     /// Queue to execute uploads.
@@ -96,7 +101,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
 #if DD_SDK_COMPILED_FOR_TESTING
     /// Sends all unsent data synchronously.
-    /// - It performs arbiitrary upload (without checking upload condition and without re-transmitting failed uploads).
+    /// - It performs arbitrary upload (without checking upload condition and without re-transmitting failed uploads).
     func flushSynchronously() {
         queue.sync {
             while let nextBatch = self.fileReader.readNextBatch() {

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -49,14 +49,6 @@ internal class DataUploadWorker: DataUploadWorkerType {
 
         let uploadWork = DispatchWorkItem { [weak self] in
             guard let self = self else {
-                #if DD_SDK_COMPILED_FOR_TESTING
-                assertionFailure(
-                    """
-                    All asynchronous work must be stopped before deallocating `DataUploadWorker` in tests.
-                    This is to prevent flakiness by ensuring clean state before and after each test.
-                    """
-                )
-                #endif
                 return
             }
 

--- a/Sources/Datadog/Core/Upload/HTTPClient.swift
+++ b/Sources/Datadog/Core/Upload/HTTPClient.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Client for sending requests over HTTP.
-internal final class HTTPClient {
+internal class HTTPClient {
     private let session: URLSession
 
     convenience init() {

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -42,4 +42,10 @@ internal final class CrashReportingFeature {
         self.carrierInfoProvider = commonDependencies.carrierInfoProvider
         self.rumViewEventProvider = ValuePublisher(initialValue: nil)
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func deinitialize() {
+        CrashReportingFeature.instance = nil
+    }
+#endif
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -289,9 +289,12 @@ public class Datadog {
     }
 
 #if DD_SDK_COMPILED_FOR_TESTING
-    /// Deinitializes the SDK by tearing down all running feature and ensuring clean state for
-    /// next initialization. This is highly experimental API and only supported in tests.
-    static func deinitialize() {
+    /// Flushes all authorised data for each feature, tears down and deinitializes the SDK.
+    /// - It flushes all data authorised for each feature by performing its arbitrary upload (without retrying).
+    /// - It completes all pending asynchronous work in each feature.
+    ///
+    /// This is highly experimental API and only supported in tests.
+    public static func flushAndDeinitialize() {
         assert(Datadog.instance != nil, "SDK must be first initialized.")
 
         // Reset internal loggers:

--- a/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
+++ b/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
@@ -144,7 +144,7 @@ internal final class InternalMonitoringFeature {
 
 #if DD_SDK_COMPILED_FOR_TESTING
     func deinitialize() {
-        logsStorage.flush()
+        logsStorage.flushAndTearDown()
         logsUpload.flushAndTearDown()
         InternalMonitoringFeature.instance = nil
     }

--- a/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
+++ b/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
@@ -141,4 +141,12 @@ internal final class InternalMonitoringFeature {
 
         self.monitor = InternalMonitor(sdkLogger: internalLogger)
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func deinitialize() {
+        logsStorage.flush()
+        logsUpload.flushAndTearDown()
+        InternalMonitoringFeature.instance = nil
+    }
+#endif
 }

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -141,7 +141,7 @@ internal final class LoggingFeature {
 
 #if DD_SDK_COMPILED_FOR_TESTING
     func deinitialize() {
-        storage.flush()
+        storage.flushAndTearDown()
         upload.flushAndTearDown()
         LoggingFeature.instance = nil
     }

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -138,4 +138,12 @@ internal final class LoggingFeature {
         self.storage = storage
         self.upload = upload
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func deinitialize() {
+        storage.flush()
+        upload.flushAndTearDown()
+        LoggingFeature.instance = nil
+    }
+#endif
 }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Actions/UIApplicationSwizzler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Actions/UIApplicationSwizzler.swift
@@ -17,6 +17,12 @@ internal class UIApplicationSwizzler {
         sendEvent.swizzle()
     }
 
+#if DD_SDK_COMPILED_FOR_TESTING
+    func unswizzle() {
+        sendEvent.unswizzle()
+    }
+#endif
+
     // MARK: - Swizzlings
 
     /// Swizzles the `UIApplication.sendEvent(_:)`

--- a/Sources/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentation.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentation.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// RUM Auto Instrumentation feature.
-internal class RUMAutoInstrumentation {
+internal final class RUMAutoInstrumentation {
     static var instance: RUMAutoInstrumentation?
 
     /// RUM Views auto instrumentation.
@@ -85,4 +85,10 @@ internal class RUMAutoInstrumentation {
         views?.handler.subscribe(commandsSubscriber: commandSubscriber)
         userActions?.handler.subscribe(commandsSubscriber: commandSubscriber)
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func deinitialize() {
+        RUMAutoInstrumentation.instance = nil
+    }
+#endif
 }

--- a/Sources/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentation.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentation.swift
@@ -87,7 +87,10 @@ internal final class RUMAutoInstrumentation {
     }
 
 #if DD_SDK_COMPILED_FOR_TESTING
+    /// Removes RUM instrumentation swizzlings and deinitializes this component.
     func deinitialize() {
+        views?.swizzler.unswizzle()
+        userActions?.swizzler.unswizzle()
         RUMAutoInstrumentation.instance = nil
     }
 #endif

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzler.swift
@@ -20,6 +20,13 @@ internal class UIViewControllerSwizzler {
         viewDidDisappear.swizzle()
     }
 
+#if DD_SDK_COMPILED_FOR_TESTING
+    func unswizzle() {
+        viewDidAppear.unswizzle()
+        viewDidDisappear.unswizzle()
+    }
+#endif
+
     // MARK: - Swizzlings
 
     /// Swizzles the `UIViewController.viewDidAppear()`

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -164,7 +164,7 @@ internal final class RUMFeature {
 
 #if DD_SDK_COMPILED_FOR_TESTING
     func deinitialize() {
-        storage.flush()
+        storage.flushAndTearDown()
         upload.flushAndTearDown()
         RUMFeature.instance = nil
     }

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -161,4 +161,12 @@ internal final class RUMFeature {
         self.storage = storage
         self.upload = upload
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func deinitialize() {
+        storage.flush()
+        upload.flushAndTearDown()
+        RUMFeature.instance = nil
+    }
+#endif
 }

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -153,4 +153,12 @@ internal final class TracingFeature {
         self.storage = storage
         self.upload = upload
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func deinitialize() {
+        storage.flush()
+        upload.flushAndTearDown()
+        TracingFeature.instance = nil
+    }
+#endif
 }

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -156,7 +156,7 @@ internal final class TracingFeature {
 
 #if DD_SDK_COMPILED_FOR_TESTING
     func deinitialize() {
-        storage.flush()
+        storage.flushAndTearDown()
         upload.flushAndTearDown()
         TracingFeature.instance = nil
     }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// `URLSession` Auto Instrumentation feature.
-internal class URLSessionAutoInstrumentation {
+internal final class URLSessionAutoInstrumentation {
     static var instance: URLSessionAutoInstrumentation?
 
     let swizzler: URLSessionSwizzler
@@ -48,4 +48,10 @@ internal class URLSessionAutoInstrumentation {
         let rumResourceHandler = interceptor.handler as? URLSessionRUMResourcesHandler
         rumResourceHandler?.subscribe(commandsSubscriber: commandSubscriber)
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func deinitialize() {
+        URLSessionAutoInstrumentation.instance = nil
+    }
+#endif
 }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
@@ -50,7 +50,9 @@ internal final class URLSessionAutoInstrumentation {
     }
 
 #if DD_SDK_COMPILED_FOR_TESTING
+    /// Removes `URLSession` swizzling and deinitializes this component.
     func deinitialize() {
+        swizzler.unswizzle()
         URLSessionAutoInstrumentation.instance = nil
     }
 #endif

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
@@ -39,6 +39,15 @@ internal class URLSessionSwizzler {
         dataTaskWithURL?.swizzle()
     }
 
+#if DD_SDK_COMPILED_FOR_TESTING
+    func unswizzle() {
+        dataTaskWithURLRequestAndCompletion.unswizzle()
+        dataTaskWithURLRequest.unswizzle()
+        dataTaskWithURLAndCompletion?.unswizzle()
+        dataTaskWithURL?.unswizzle()
+    }
+#endif
+
     // MARK: - Swizzlings
 
     typealias CompletionHandler = (Data?, URLResponse?, Error?) -> Void

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -28,7 +28,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
         )
         self.writer = storage.writer
         self.reader = storage.reader
-        self.queue = (storage.writer as! ConsentAwareDataWriter).readWriteQueue
+        self.queue = (storage.writer as! ConsentAwareDataWriter).queue
 
         XCTAssertTrue(try directory.files().count == 0)
     }

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -28,7 +28,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
         )
         self.writer = storage.writer
         self.reader = storage.reader
-        self.queue = (storage.writer as! ConsentAwareDataWriter).readWriteQueue
+        self.queue = (storage.writer as! ConsentAwareDataWriter).queue
 
         XCTAssertTrue(try directory.files().count == 0)
     }

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -28,7 +28,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
         )
         self.writer = storage.writer
         self.reader = storage.reader
-        self.queue = (storage.writer as! ConsentAwareDataWriter).readWriteQueue
+        self.queue = (storage.writer as! ConsentAwareDataWriter).queue
 
         XCTAssertTrue(try directory.files().count == 0)
     }

--- a/Tests/DatadogTests/Datadog/Core/Swizzling/MethodSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Swizzling/MethodSwizzlerTests.swift
@@ -7,16 +7,6 @@
 import XCTest
 @testable import Datadog
 
-extension MethodSwizzler {
-    func unswizzle() {
-        for foundMethod in swizzledMethods {
-            let originalTypedIMP = originalImplementation(of: foundMethod)
-            let originalIMP: IMP = unsafeBitCast(originalTypedIMP, to: IMP.self)
-            method_setImplementation(foundMethod.method, originalIMP)
-        }
-    }
-}
-
 @objc
 private class EmptySubclass: BaseClass { }
 

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -35,7 +35,7 @@ class DataUploadWorkerTests: XCTestCase {
         super.tearDown()
     }
 
-    func testItUploadsAllData() throws {
+    func testItUploadsAllData() {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
@@ -69,7 +69,7 @@ class DataUploadWorkerTests: XCTestCase {
         XCTAssertEqual(try temporaryDirectory.files().count, 0)
     }
 
-    func testWhenThereIsNoBatch_thenIntervalIncreases() throws {
+    func testWhenThereIsNoBatch_thenIntervalIncreases() {
         let delayChangeExpectation = expectation(description: "Upload delay is increased")
         let mockDelay = MockDelay { command in
             if case .increase = command {
@@ -103,7 +103,7 @@ class DataUploadWorkerTests: XCTestCase {
         worker.cancelSynchronously()
     }
 
-    func testWhenBatchFails_thenIntervalIncreases() throws {
+    func testWhenBatchFails_thenIntervalIncreases() {
         let delayChangeExpectation = expectation(description: "Upload delay is increased")
         let mockDelay = MockDelay { command in
             if case .increase = command {
@@ -137,7 +137,7 @@ class DataUploadWorkerTests: XCTestCase {
         worker.cancelSynchronously()
     }
 
-    func testWhenBatchSucceeds_thenIntervalDecreases() throws {
+    func testWhenBatchSucceeds_thenIntervalDecreases() {
         let delayChangeExpectation = expectation(description: "Upload delay is decreased")
         let mockDelay = MockDelay { command in
             if case .decrease = command {
@@ -171,7 +171,7 @@ class DataUploadWorkerTests: XCTestCase {
         worker.cancelSynchronously()
     }
 
-    func testWhenCancelled_itPerformsNoMoreUploads() throws {
+    func testWhenCancelled_itPerformsNoMoreUploads() {
         // Given
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -39,7 +39,7 @@ class DataUploadWorkerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
 
@@ -85,7 +85,7 @@ class DataUploadWorkerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let worker = DataUploadWorker(
@@ -119,7 +119,7 @@ class DataUploadWorkerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 500)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let worker = DataUploadWorker(
@@ -153,7 +153,7 @@ class DataUploadWorkerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let worker = DataUploadWorker(
@@ -176,7 +176,7 @@ class DataUploadWorkerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let worker = DataUploadWorker(
@@ -201,7 +201,7 @@ class DataUploadWorkerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let worker = DataUploadWorker(

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -42,152 +42,212 @@ class DataUploadWorkerTests: XCTestCase {
             httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
-        // Write 3 files
+
+        // Given
         writer.write(value: ["k1": "v1"])
         writer.write(value: ["k2": "v2"])
         writer.write(value: ["k3": "v3"])
-        // Start logs uploader
-        try withExtendedLifetime(
-            DataUploadWorker(
-                queue: uploaderQueue,
-                fileReader: reader,
-                dataUploader: dataUploader,
-                uploadConditions: DataUploadConditions.alwaysUpload(),
-                delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
-                featureName: .mockAny()
-            )
-        ) {
-            let recordedRequests = server.waitAndReturnRequests(count: 3)
-            XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k1":"v1"}]"#.utf8Data })
-            XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k2":"v2"}]"#.utf8Data })
-            XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k3":"v3"}]"#.utf8Data })
 
-            uploaderQueue.sync {} // wait until last "process upload" operation completes (to make sure "delete file" was requested)
+        // When
+        let worker = DataUploadWorker(
+            queue: uploaderQueue,
+            fileReader: reader,
+            dataUploader: dataUploader,
+            uploadConditions: DataUploadConditions.alwaysUpload(),
+            delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
+            featureName: .mockAny()
+        )
 
-            XCTAssertEqual(try temporaryDirectory.files().count, 0)
-        }
+        // Then
+        let recordedRequests = server.waitAndReturnRequests(count: 3)
+        XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k1":"v1"}]"#.utf8Data })
+        XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k2":"v2"}]"#.utf8Data })
+        XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k3":"v3"}]"#.utf8Data })
+
+        worker.cancelSynchronously()
+
+        XCTAssertEqual(try temporaryDirectory.files().count, 0)
     }
 
-    // swiftlint:disable multiline_arguments_brackets
     func testWhenThereIsNoBatch_thenIntervalIncreases() throws {
-        let expectation = XCTestExpectation(description: "high expectation")
+        let delayChangeExpectation = expectation(description: "Upload delay is increased")
         let mockDelay = MockDelay { command in
             if case .increase = command {
-                expectation.fulfill()
+                delayChangeExpectation.fulfill()
             } else {
                 XCTFail("Wrong command is sent!")
             }
         }
+
+        // When
+        XCTAssertEqual(try temporaryDirectory.files().count, 0)
+
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
             httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
-        // Start logs uploader
-        withExtendedLifetime([
-            ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200))),
-            DataUploadWorker(
-                queue: uploaderQueue,
-                fileReader: reader,
-                dataUploader: dataUploader,
-                uploadConditions: DataUploadConditions.neverUpload(),
-                delay: mockDelay,
-                featureName: .mockAny()
-            )
-        ]) {
-            self.wait(for: [expectation], timeout: (mockDelay.current + 0.1) * 1.5)
-        }
+        let worker = DataUploadWorker(
+            queue: uploaderQueue,
+            fileReader: reader,
+            dataUploader: dataUploader,
+            uploadConditions: DataUploadConditions.neverUpload(),
+            delay: mockDelay,
+            featureName: .mockAny()
+        )
+
+        // Then
+        server.waitFor(requestsCompletion: 0)
+        waitForExpectations(timeout: 1, handler: nil)
+        worker.cancelSynchronously()
     }
 
     func testWhenBatchFails_thenIntervalIncreases() throws {
-        let expectation = XCTestExpectation(description: "high expectation")
+        let delayChangeExpectation = expectation(description: "Upload delay is increased")
         let mockDelay = MockDelay { command in
             if case .increase = command {
-                expectation.fulfill()
+                delayChangeExpectation.fulfill()
             } else {
                 XCTFail("Wrong command is sent!")
             }
         }
+
+        // When
+        writer.write(value: ["k1": "v1"])
+
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 500)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
             httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
-        // Write some content
-        writer.write(value: ["k1": "v1"])
-        // Start logs uploader
-        withExtendedLifetime([
-            ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 500))),
-            DataUploadWorker(
-                queue: uploaderQueue,
-                fileReader: reader,
-                dataUploader: dataUploader,
-                uploadConditions: DataUploadConditions.alwaysUpload(),
-                delay: mockDelay,
-                featureName: .mockAny()
-            )
-        ]) {
-            self.wait(for: [expectation], timeout: 1.5)
-        }
+        let worker = DataUploadWorker(
+            queue: uploaderQueue,
+            fileReader: reader,
+            dataUploader: dataUploader,
+            uploadConditions: DataUploadConditions.alwaysUpload(),
+            delay: mockDelay,
+            featureName: .mockAny()
+        )
+
+        // Then
+        server.waitFor(requestsCompletion: 1)
+        waitForExpectations(timeout: 1, handler: nil)
+        worker.cancelSynchronously()
     }
 
     func testWhenBatchSucceeds_thenIntervalDecreases() throws {
-        let expectation = XCTestExpectation(description: "low expectation")
+        let delayChangeExpectation = expectation(description: "Upload delay is decreased")
         let mockDelay = MockDelay { command in
             if case .decrease = command {
-                expectation.fulfill()
+                delayChangeExpectation.fulfill()
             } else {
                 XCTFail("Wrong command is sent!")
             }
         }
+
+        // When
+        writer.write(value: ["k1": "v1"])
+
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let dataUploader = DataUploader(
             urlProvider: .mockAny(),
             httpClient: HTTPClient(session: .serverMockURLSession),
             httpHeaders: .mockAny()
         )
-        // Write some content
-        writer.write(value: ["k1": "v1"])
-        // Start logs uploader
-        withExtendedLifetime([
-            ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200))),
-            DataUploadWorker(
-                queue: uploaderQueue,
-                fileReader: reader,
-                dataUploader: dataUploader,
-                uploadConditions: DataUploadConditions.alwaysUpload(),
-                delay: mockDelay,
-                featureName: .mockAny()
-            )
-        ]) {
-            self.wait(for: [expectation], timeout: 1.5)
-        }
+        let worker = DataUploadWorker(
+            queue: uploaderQueue,
+            fileReader: reader,
+            dataUploader: dataUploader,
+            uploadConditions: DataUploadConditions.alwaysUpload(),
+            delay: mockDelay,
+            featureName: .mockAny()
+        )
+
+        // Then
+        server.waitFor(requestsCompletion: 1)
+        waitForExpectations(timeout: 2, handler: nil)
+        worker.cancelSynchronously()
     }
-    // swiftlint:enable multiline_arguments_brackets
+
+    func testWhenCancelled_itPerformsNoMoreUploads() throws {
+        // Given
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        let dataUploader = DataUploader(
+            urlProvider: .mockAny(),
+            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpHeaders: .mockAny()
+        )
+        let worker = DataUploadWorker(
+            queue: uploaderQueue,
+            fileReader: reader,
+            dataUploader: dataUploader,
+            uploadConditions: DataUploadConditions.neverUpload(),
+            delay: MockDelay(),
+            featureName: .mockAny()
+        )
+
+        // When
+        worker.cancelSynchronously()
+
+        // Then
+        writer.write(value: ["k1": "v1"])
+
+        server.waitFor(requestsCompletion: 0)
+    }
+
+    func testItFlushesAllData() {
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        let dataUploader = DataUploader(
+            urlProvider: .mockAny(),
+            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpHeaders: .mockAny()
+        )
+        let worker = DataUploadWorker(
+            queue: uploaderQueue,
+            fileReader: reader,
+            dataUploader: dataUploader,
+            uploadConditions: DataUploadConditions.alwaysUpload(),
+            delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
+            featureName: .mockAny()
+        )
+
+        // Given
+        writer.write(value: ["k1": "v1"])
+        writer.write(value: ["k2": "v2"])
+        writer.write(value: ["k3": "v3"])
+
+        // When
+        worker.flushSynchronously()
+
+        // Then
+        XCTAssertEqual(try temporaryDirectory.files().count, 0)
+
+        let recordedRequests = server.waitAndReturnRequests(count: 3)
+        XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k1":"v1"}]"#.utf8Data })
+        XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k2":"v2"}]"#.utf8Data })
+        XCTAssertTrue(recordedRequests.contains { $0.httpBody == #"[{"k3":"v3"}]"#.utf8Data })
+
+        worker.cancelSynchronously()
+    }
 }
 
 struct MockDelay: Delay {
     enum Command {
         case increase, decrease
     }
-    // NOTE: RUMM-737 private only doesn't compile due to "private initializer is inaccessible", probably a bug in Swift
-    private(set) var didReceiveCommand = false
-    let callback: (Command) -> Void
 
-    let current: TimeInterval = 0
+    var callback: ((Command) -> Void)?
+    let current: TimeInterval = 0.1
 
     mutating func decrease() {
-        if didReceiveCommand {
-            return
-        }
-        didReceiveCommand = true
-        callback(.decrease)
+        callback?(.decrease)
+        callback = nil
     }
     mutating func increase() {
-        if didReceiveCommand {
-            return
-        }
-        didReceiveCommand = true
-        callback(.increase)
+        callback?(.increase)
+        callback = nil
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploaderTests.swift
@@ -51,7 +51,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -64,7 +64,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 300)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -77,7 +77,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 400)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -90,7 +90,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 403)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -103,7 +103,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 500)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -117,7 +117,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .failure(error: mockError))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())
@@ -130,7 +130,7 @@ class DataUploaderTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: -1)))
         let uploader = DataUploader(
             urlProvider: .mockAny(),
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: HTTPClient(session: server.getInterceptedURLSession()),
             httpHeaders: .mockAny()
         )
         let status = uploader.upload(data: .mockAny())

--- a/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
@@ -11,7 +11,7 @@ class HTTPClientTests: XCTestCase {
     func testWhenRequestIsDelivered_itReturnsHTTPResponse() {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let expectation = self.expectation(description: "receive response")
-        let client = HTTPClient(session: .serverMockURLSession)
+        let client = HTTPClient(session: server.getInterceptedURLSession())
 
         client.send(request: .mockAny()) { result in
             switch result {
@@ -31,7 +31,7 @@ class HTTPClientTests: XCTestCase {
         let mockError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "no internet connection"])
         let server = ServerMock(delivery: .failure(error: mockError))
         let expectation = self.expectation(description: "receive response")
-        let client = HTTPClient(session: .serverMockURLSession)
+        let client = HTTPClient(session: server.getInterceptedURLSession())
 
         client.send(request: .mockAny()) { result in
             switch result {

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -32,27 +32,27 @@ class DatadogTests: XCTestCase {
 
     // MARK: - Initializing with different configurations
 
-    func testGivenDefaultConfiguration_itCanBeInitialized() throws {
+    func testGivenDefaultConfiguration_itCanBeInitialized() {
         Datadog.initialize(
             appContext: .mockAny(),
             trackingConsent: .mockRandom(),
             configuration: defaultBuilder.build()
         )
         XCTAssertNotNil(Datadog.instance)
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
-    func testGivenDefaultRUMConfiguration_itCanBeInitialized() throws {
+    func testGivenDefaultRUMConfiguration_itCanBeInitialized() {
         Datadog.initialize(
             appContext: .mockAny(),
             trackingConsent: .mockRandom(),
             configuration: rumBuilder.build()
         )
         XCTAssertNotNil(Datadog.instance)
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
-    func testGivenInvalidConfiguration_itPrintsError() throws {
+    func testGivenInvalidConfiguration_itPrintsError() {
         let invalidConiguration = Datadog.Configuration
             .builderUsing(clientToken: "", environment: "tests")
             .build()
@@ -70,7 +70,7 @@ class DatadogTests: XCTestCase {
         XCTAssertNil(Datadog.instance)
     }
 
-    func testGivenValidConfiguration_whenInitializedMoreThanOnce_itPrintsError() throws {
+    func testGivenValidConfiguration_whenInitializedMoreThanOnce_itPrintsError() {
         Datadog.initialize(
             appContext: .mockAny(),
             trackingConsent: .mockRandom(),
@@ -87,13 +87,13 @@ class DatadogTests: XCTestCase {
             "🔥 Datadog SDK usage error: SDK is already initialized."
         )
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     // MARK: - Toggling features
 
-    func testEnablingAndDisablingFeatures() throws {
-        func verify(configuration: Datadog.Configuration, verificationBlock: () -> Void) throws {
+    func testEnablingAndDisablingFeatures() {
+        func verify(configuration: Datadog.Configuration, verificationBlock: () -> Void) {
             Datadog.initialize(
                 appContext: .mockAny(),
                 trackingConsent: .mockRandom(),
@@ -103,7 +103,7 @@ class DatadogTests: XCTestCase {
 
             RUMAutoInstrumentation.instance?.views?.swizzler.unswizzle()
             URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
-            try Datadog.deinitializeOrThrow()
+            Datadog.deinitialize()
         }
 
         defer {
@@ -111,7 +111,7 @@ class DatadogTests: XCTestCase {
             URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
         }
 
-        try verify(configuration: defaultBuilder.build()) {
+        verify(configuration: defaultBuilder.build()) {
             // verify features:
             XCTAssertTrue(LoggingFeature.isEnabled)
             XCTAssertTrue(TracingFeature.isEnabled)
@@ -123,7 +123,7 @@ class DatadogTests: XCTestCase {
             // verify integrations:
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
         }
-        try verify(configuration: rumBuilder.build()) {
+        verify(configuration: rumBuilder.build()) {
             // verify features:
             XCTAssertTrue(LoggingFeature.isEnabled)
             XCTAssertTrue(TracingFeature.isEnabled)
@@ -136,7 +136,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
         }
 
-        try verify(configuration: defaultBuilder.enableLogging(false).build()) {
+        verify(configuration: defaultBuilder.enableLogging(false).build()) {
             // verify features:
             XCTAssertFalse(LoggingFeature.isEnabled)
             XCTAssertTrue(TracingFeature.isEnabled)
@@ -148,7 +148,7 @@ class DatadogTests: XCTestCase {
             // verify integrations:
             XCTAssertNil(TracingFeature.instance?.loggingFeatureAdapter)
         }
-        try verify(configuration: rumBuilder.enableLogging(false).build()) {
+        verify(configuration: rumBuilder.enableLogging(false).build()) {
             // verify features:
             XCTAssertFalse(LoggingFeature.isEnabled)
             XCTAssertTrue(TracingFeature.isEnabled)
@@ -161,7 +161,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(TracingFeature.instance?.loggingFeatureAdapter)
         }
 
-        try verify(configuration: defaultBuilder.enableTracing(false).build()) {
+        verify(configuration: defaultBuilder.enableTracing(false).build()) {
             // verify features:
             XCTAssertTrue(LoggingFeature.isEnabled)
             XCTAssertFalse(TracingFeature.isEnabled)
@@ -171,7 +171,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             XCTAssertNil(InternalMonitoringFeature.instance)
         }
-        try verify(configuration: rumBuilder.enableTracing(false).build()) {
+        verify(configuration: rumBuilder.enableTracing(false).build()) {
             // verify features:
             XCTAssertTrue(LoggingFeature.isEnabled)
             XCTAssertFalse(TracingFeature.isEnabled)
@@ -182,7 +182,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(InternalMonitoringFeature.instance)
         }
 
-        try verify(configuration: defaultBuilder.enableRUM(true).build()) {
+        verify(configuration: defaultBuilder.enableRUM(true).build()) {
             // verify features:
             XCTAssertTrue(LoggingFeature.isEnabled)
             XCTAssertTrue(TracingFeature.isEnabled)
@@ -194,7 +194,7 @@ class DatadogTests: XCTestCase {
             // verify integrations:
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
         }
-        try verify(configuration: rumBuilder.enableRUM(false).build()) {
+        verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
             XCTAssertTrue(LoggingFeature.isEnabled)
             XCTAssertTrue(TracingFeature.isEnabled)
@@ -207,12 +207,12 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
         }
 
-        try verify(configuration: rumBuilder.trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock()).build()) {
+        verify(configuration: rumBuilder.trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock()).build()) {
             XCTAssertTrue(RUMFeature.isEnabled)
             XCTAssertNotNil(RUMAutoInstrumentation.instance?.views)
             XCTAssertNil(RUMAutoInstrumentation.instance?.userActions)
         }
-        try verify(
+        verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock()).build()
         ) {
             XCTAssertFalse(RUMFeature.isEnabled)
@@ -220,12 +220,12 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(RUMAutoInstrumentation.instance?.userActions)
         }
 
-        try verify(configuration: rumBuilder.trackUIKitActions(true).build()) {
+        verify(configuration: rumBuilder.trackUIKitActions(true).build()) {
             XCTAssertTrue(RUMFeature.isEnabled)
             XCTAssertNil(RUMAutoInstrumentation.instance?.views)
             XCTAssertNotNil(RUMAutoInstrumentation.instance?.userActions)
         }
-        try verify(
+        verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitActions(true).build()
         ) {
             XCTAssertFalse(RUMFeature.isEnabled)
@@ -233,14 +233,14 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(RUMAutoInstrumentation.instance?.userActions)
         }
 
-        try verify(configuration: defaultBuilder.trackURLSession(firstPartyHosts: ["example.com"]).build()) {
+        verify(configuration: defaultBuilder.trackURLSession(firstPartyHosts: ["example.com"]).build()) {
             XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
         }
-        try verify(configuration: defaultBuilder.trackURLSession().build()) {
+        verify(configuration: defaultBuilder.trackURLSession().build()) {
             XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
         }
 
-        try verify(
+        verify(
             configuration: rumBuilder
                 .enableLogging(true)
                 .enableRUM(false)
@@ -255,7 +255,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(InternalMonitoringFeature.instance)
         }
 
-        try verify(
+        verify(
             configuration: rumBuilder
                 .enableLogging(false)
                 .enableRUM(true)
@@ -270,7 +270,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(InternalMonitoringFeature.instance)
         }
 
-        try verify(
+        verify(
             configuration: rumBuilder
                 .enableLogging(true)
                 .enableRUM(true)
@@ -285,7 +285,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(InternalMonitoringFeature.instance)
         }
 
-        try verify(
+        verify(
             configuration: rumBuilder
                 .enableLogging(false)
                 .enableRUM(false)
@@ -300,7 +300,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(InternalMonitoringFeature.instance)
         }
 
-        try verify(
+        verify(
             configuration: rumBuilder
                 .enableLogging(.random())
                 .enableTracing(.random())
@@ -314,7 +314,7 @@ class DatadogTests: XCTestCase {
                 "When client token for internal monitoring is set, the Internal Monitoring feature should be enabled"
             )
         }
-        try verify(
+        verify(
             configuration: rumBuilder
                 .enableLogging(.random())
                 .enableTracing(.random())
@@ -331,7 +331,7 @@ class DatadogTests: XCTestCase {
 
     // MARK: - Global Values
 
-    func testTrackingConsent() throws {
+    func testTrackingConsent() {
         let initialConsent: TrackingConsent = .mockRandom()
         let nextConsent: TrackingConsent = .mockRandom()
 
@@ -347,10 +347,10 @@ class DatadogTests: XCTestCase {
 
         XCTAssertEqual(Datadog.instance?.consentProvider.currentValue, nextConsent)
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
-    func testUserInfo() throws {
+    func testUserInfo() {
         Datadog.initialize(
             appContext: .mockAny(),
             trackingConsent: .mockRandom(),
@@ -375,7 +375,7 @@ class DatadogTests: XCTestCase {
         XCTAssertEqual(Datadog.instance?.userInfoProvider.value.email, "foo@bar.com")
         XCTAssertEqual(Datadog.instance?.userInfoProvider.value.extraInfo as? [String: Int], ["abc": 123])
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     func testDefaultVerbosityLevel() {
@@ -386,7 +386,7 @@ class DatadogTests: XCTestCase {
         XCTAssertFalse(Datadog.debugRUM)
     }
 
-    func testDeprecatedAPIs() throws {
+    func testDeprecatedAPIs() {
         (Datadog.self as DatadogDeprecatedAPIs.Type).initialize(
             appContext: .mockAny(),
             configuration: defaultBuilder.build()
@@ -398,7 +398,7 @@ class DatadogTests: XCTestCase {
             "When using deprecated Datadog initialization API the consent should be set to `.granted`"
         )
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 }
 
@@ -416,12 +416,12 @@ class AppContextTests: XCTestCase {
         XCTAssertEqual(AppContext(mainBundle: iOSAppExtensionBundle).bundleType, .iOSAppExtension)
     }
 
-    func testBundleIdentifier() throws {
+    func testBundleIdentifier() {
         XCTAssertEqual(AppContext(mainBundle: .mockWith(bundleIdentifier: "com.abc.app")).bundleIdentifier, "com.abc.app")
         XCTAssertNil(AppContext(mainBundle: .mockWith(bundleIdentifier: nil)).bundleIdentifier)
     }
 
-    func testBundleVersion() throws {
+    func testBundleVersion() {
         XCTAssertEqual(
             AppContext(mainBundle: .mockWith(CFBundleVersion: "1.0", CFBundleShortVersionString: "1.0.0")).bundleVersion,
             "1.0.0"
@@ -439,7 +439,7 @@ class AppContextTests: XCTestCase {
         )
     }
 
-    func testBundleName() throws {
+    func testBundleName() {
         XCTAssertEqual(
             AppContext(mainBundle: .mockWith(bundlePath: .mockAny(), CFBundleExecutable: "FooApp")).bundleName,
             "FooApp"

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -39,7 +39,7 @@ class DatadogTests: XCTestCase {
             configuration: defaultBuilder.build()
         )
         XCTAssertNotNil(Datadog.instance)
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testGivenDefaultRUMConfiguration_itCanBeInitialized() {
@@ -49,7 +49,7 @@ class DatadogTests: XCTestCase {
             configuration: rumBuilder.build()
         )
         XCTAssertNotNil(Datadog.instance)
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testGivenInvalidConfiguration_itPrintsError() {
@@ -87,7 +87,7 @@ class DatadogTests: XCTestCase {
             "🔥 Datadog SDK usage error: SDK is already initialized."
         )
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     // MARK: - Toggling features
@@ -103,7 +103,7 @@ class DatadogTests: XCTestCase {
 
             RUMAutoInstrumentation.instance?.views?.swizzler.unswizzle()
             URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
-            Datadog.deinitialize()
+            Datadog.flushAndDeinitialize()
         }
 
         defer {
@@ -347,7 +347,7 @@ class DatadogTests: XCTestCase {
 
         XCTAssertEqual(Datadog.instance?.consentProvider.currentValue, nextConsent)
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testUserInfo() {
@@ -375,7 +375,7 @@ class DatadogTests: XCTestCase {
         XCTAssertEqual(Datadog.instance?.userInfoProvider.value.email, "foo@bar.com")
         XCTAssertEqual(Datadog.instance?.userInfoProvider.value.extraInfo as? [String: Int], ["abc": 123])
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testDefaultVerbosityLevel() {
@@ -398,7 +398,7 @@ class DatadogTests: XCTestCase {
             "When using deprecated Datadog initialization API the consent should be set to `.granted`"
         )
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 }
 

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -12,7 +12,7 @@ class RUMIntegrationsTests: XCTestCase {
 
     func testGivenRUMMonitorRegistered_itProvidesRUMContextAttributes() throws {
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         // given
         Global.rum = RUMMonitor.initialize()
@@ -43,7 +43,7 @@ class RUMIntegrationsTests: XCTestCase {
             configuration: .mockWith(sessionSamplingRate: 0.0),
             commonDependencies: .mockAny()
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         // given
         Global.rum = RUMMonitor.initialize()
@@ -58,7 +58,7 @@ class RUMIntegrationsTests: XCTestCase {
 
     func testWhenRUMMonitorIsNotRegistered_itReturnsNil() throws {
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         // when
         XCTAssertTrue(Global.rum is DDNoopRUMMonitor)
@@ -83,7 +83,7 @@ class RUMErrorsIntegrationTests: XCTestCase {
 
     func testGivenRUMMonitorRegistered_whenAddingErrorMessage_itSendsRUMErrorForCurrentView() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         // given
         Global.rum = RUMMonitor.initialize()

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -11,7 +11,7 @@ class RUMWithCrashContextIntegrationTests: XCTestCase {
     func testWhenCrashReportingIsEnabled_itUpdatesCrashContextWithLastRUMView() throws {
         // When
         CrashReportingFeature.instance = .mockNoOp()
-        defer { CrashReportingFeature.instance = nil }
+        defer { CrashReportingFeature.instance?.deinitialize() }
 
         // Then
         let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration())

--- a/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
@@ -39,7 +39,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
                 mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1")
             )
         )
-        defer { InternalMonitoringFeature.instance = nil }
+        defer { InternalMonitoringFeature.instance?.deinitialize() }
 
         let sdkLogger = try XCTUnwrap(InternalMonitoringFeature.instance?.monitor.sdkLogger)
         sdkLogger.debug("message")
@@ -71,7 +71,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
                 dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
             )
         )
-        defer { InternalMonitoringFeature.instance = nil }
+        defer { InternalMonitoringFeature.instance?.deinitialize() }
 
         let sdkLogger = try XCTUnwrap(InternalMonitoringFeature.instance?.monitor.sdkLogger)
         sdkLogger.error("internal error message")

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -31,7 +31,7 @@ class LoggerBuilderTests: XCTestCase {
     }
 
     override func tearDown() {
-        LoggingFeature.instance = nil
+        LoggingFeature.instance?.deinitialize()
         super.tearDown()
     }
 
@@ -62,7 +62,7 @@ class LoggerBuilderTests: XCTestCase {
 
     func testDefaultLoggerWithRUMEnabled() throws {
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let logger1 = Logger.builder.build()
         XCTAssertNotNil(logger1.rumContextIntegration)
@@ -73,7 +73,7 @@ class LoggerBuilderTests: XCTestCase {
 
     func testDefaultLoggerWithTracingEnabled() throws {
         TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let logger1 = Logger.builder.build()
         XCTAssertNotNil(logger1.activeSpanIntegration)
@@ -84,10 +84,10 @@ class LoggerBuilderTests: XCTestCase {
 
     func testCustomizedLogger() throws {
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder
             .set(serviceName: "custom-service-name")

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -40,7 +40,7 @@ class LoggerTests: XCTestCase {
                 dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
         logger.debug("message")
@@ -63,7 +63,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingLogWithCustomizedLogger() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder
             .set(serviceName: "custom-service-name")
@@ -99,7 +99,7 @@ class LoggerTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC(), advancingBySeconds: 1)
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
         logger.info("message 1")
@@ -116,7 +116,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingLogsWithDifferentLevels() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
         logger.debug("message")
@@ -139,7 +139,7 @@ class LoggerTests: XCTestCase {
 
     func testLoggingError() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         struct TestError: Error {
             var description = "Test description"
@@ -170,7 +170,7 @@ class LoggerTests: XCTestCase {
             userInfoProvider: UserInfoProvider(),
             launchTimeProvider: LaunchTimeProviderMock()
         )
-        defer { Datadog.instance = nil }
+        defer { Datadog.deinitialize() }
 
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,
@@ -178,7 +178,7 @@ class LoggerTests: XCTestCase {
                 userInfoProvider: Datadog.instance!.userInfoProvider
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
         logger.debug("message with no user info")
@@ -230,7 +230,7 @@ class LoggerTests: XCTestCase {
                 carrierInfoProvider: carrierInfoProvider
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder
             .sendNetworkInfo(true)
@@ -271,7 +271,7 @@ class LoggerTests: XCTestCase {
                 networkConnectionInfoProvider: networkConnectionInfoProvider
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder
             .sendNetworkInfo(true)
@@ -325,7 +325,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingLoggerAttributesOfDifferentEncodableValues() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
 
@@ -389,7 +389,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingMessageAttributes() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
 
@@ -421,7 +421,7 @@ class LoggerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
 
@@ -466,7 +466,7 @@ class LoggerTests: XCTestCase {
                 )
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
         logger.debug("message")
@@ -484,7 +484,7 @@ class LoggerTests: XCTestCase {
                 )
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
         logger.debug("message")
@@ -499,10 +499,10 @@ class LoggerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         // given
         let logger = Logger.builder.build()
@@ -534,10 +534,10 @@ class LoggerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }
@@ -567,10 +567,10 @@ class LoggerTests: XCTestCase {
 
     func testWhenSendingErrorOrCriticalLogs_itCreatesRUMErrorForCurrentView() throws {
         LoggingFeature.instance = .mockNoOp()
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         // given
         let logger = Logger.builder.build()
@@ -607,10 +607,10 @@ class LoggerTests: XCTestCase {
 
     func testGivenBundlingWithTraceEnabledAndTracerRegistered_whenSendingLog_itContainsActiveSpanAttributes() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         // given
         let logger = Logger.builder.build()
@@ -639,10 +639,10 @@ class LoggerTests: XCTestCase {
 
     func testGivenBundlingWithTraceEnabledButTracerNotRegistered_whenSendingLog_itPrintsWarning() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }
@@ -673,13 +673,13 @@ class LoggerTests: XCTestCase {
 
     func testGivenBundlingWithTraceEnabledAndTracerRegisteredAndEnvironmentContext_whenSendingLog_itContainsEnvironmentContextAttributes() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         setenv("x-datadog-trace-id", "111111", 1)
         setenv("x-datadog-parent-id", "222222", 1)
 
         TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         // given
         let logger = Logger.builder.build()
@@ -730,7 +730,7 @@ class LoggerTests: XCTestCase {
                 dateCorrector: DateCorrectorMock(correctionOffset: serverTimeDifference)
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
         logger.debug("message")
@@ -752,7 +752,7 @@ class LoggerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(consentProvider: consentProvider)
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
 
@@ -777,7 +777,7 @@ class LoggerTests: XCTestCase {
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         LoggingFeature.instance = .mockNoOp()
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder
             .sendLogsToDatadog(false)
@@ -827,7 +827,7 @@ class LoggerTests: XCTestCase {
         XCTAssertNil(logger.logOutput)
     }
 
-    func testGivenLoggingFeatureDisabled_whenInitializingLogger_itPrintsError() throws {
+    func testGivenLoggingFeatureDisabled_whenInitializingLogger_itPrintsError() {
         let printFunction = PrintFunctionMock()
         consolePrint = printFunction.print
         defer { consolePrint = { print($0) } }
@@ -852,7 +852,7 @@ class LoggerTests: XCTestCase {
         XCTAssertNil(logger.logBuilder)
         XCTAssertNil(logger.logOutput)
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     func testDDLoggerIsLoggerTypealias() {

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -170,7 +170,7 @@ class LoggerTests: XCTestCase {
             userInfoProvider: UserInfoProvider(),
             launchTimeProvider: LaunchTimeProviderMock()
         )
-        defer { Datadog.deinitialize() }
+        defer { Datadog.flushAndDeinitialize() }
 
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,
@@ -852,7 +852,7 @@ class LoggerTests: XCTestCase {
         XCTAssertNil(logger.logBuilder)
         XCTAssertNil(logger.logOutput)
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testDDLoggerIsLoggerTypealias() {

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -39,7 +39,7 @@ class LoggingFeatureTests: XCTestCase {
                 mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1")
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
         logger.debug("message")
@@ -78,7 +78,7 @@ class LoggingFeatureTests: XCTestCase {
                 )
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let logger = Logger.builder.build()
         logger.debug("log 1")

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -505,16 +505,23 @@ class FileWriterMock: Writer {
     }
 }
 
-class NoOpFileWriter: Writer {
+class NoOpFileWriter: AsyncWriter {
+    var queue: DispatchQueue { DispatchQueue(label: .mockRandom()) }
     func write<T>(value: T) where T: Encodable {}
+    func flushAndCancelSynchronously() {}
 }
 
-class NoOpFileReader: Reader {
+class NoOpFileReader: SyncReader {
+    var queue: DispatchQueue { DispatchQueue(label: .mockRandom()) }
     func readNextBatch() -> Batch? { return nil }
     func markBatchAsRead(_ batch: Batch) {}
+    func markAllFilesAsReadable() {}
 }
 
-class NoOpDataUploadWorker: DataUploadWorkerType {}
+class NoOpDataUploadWorker: DataUploadWorkerType {
+    func flushSynchronously() {}
+    func cancelSynchronously() {}
+}
 
 extension DataFormat {
     static func mockAny() -> DataFormat {

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -434,10 +434,31 @@ extension FeaturesCommonDependencies {
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny(),
         launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock()
     ) -> FeaturesCommonDependencies {
+        let httpClient: HTTPClient
+
+        if let activeServer = ServerMock.activeInstance {
+            httpClient = HTTPClient(session: activeServer.getInterceptedURLSession())
+        } else {
+            class AssertedHTTPClient: HTTPClient {
+                // swiftlint:disable:next unavailable_function
+                override func send(request: URLRequest, completion: @escaping (Result<HTTPURLResponse, Error>) -> Void) {
+                    preconditionFailure(
+                        """
+                        ⚠️ Request to \(request.url?.absoluteString ?? "null") was sent but there is no `ServerMock` instance set up for its interception.
+                        All unit tests must be configured to either send data to mocked `FeatureStorage` (`XYZFeature.mockByRecordingXYZ(...)`)
+                        or use `ServerMock` instance and `serverMock.getInterceptedURLSession()` for requests interception.
+                        """
+                    )
+                }
+            }
+
+            httpClient = AssertedHTTPClient()
+        }
+
         return FeaturesCommonDependencies(
             consentProvider: consentProvider,
             performance: performance,
-            httpClient: HTTPClient(session: .serverMockURLSession),
+            httpClient: httpClient,
             mobileDevice: mobileDevice,
             dateProvider: dateProvider,
             dateCorrector: dateCorrector,

--- a/Tests/DatadogTests/Datadog/Mocks/InternalMonitoringFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/InternalMonitoringFeatureMocks.swift
@@ -36,7 +36,7 @@ extension InternalMonitoringFeature {
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
             )
         )
-
+        fullFeature.deinitialize()
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.logsStorage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:

--- a/Tests/DatadogTests/Datadog/Mocks/InternalMonitoringFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/InternalMonitoringFeatureMocks.swift
@@ -36,11 +36,12 @@ extension InternalMonitoringFeature {
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
             )
         )
-        fullFeature.deinitialize()
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.logsStorage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:
         let mockedUpload = FeatureUpload(uploader: uploadWorker)
+        // Tear down the original upload
+        fullFeature.logsUpload.flushAndTearDown()
         return InternalMonitoringFeature(
             storage: observedStorage,
             upload: mockedUpload,

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -42,6 +42,7 @@ extension LoggingFeature {
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
             )
         )
+        fullFeature.deinitialize()
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -42,11 +42,12 @@ extension LoggingFeature {
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
             )
         )
-        fullFeature.deinitialize()
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:
         let mockedUpload = FeatureUpload(uploader: uploadWorker)
+        // Tear down the original upload
+        fullFeature.upload.flushAndTearDown()
         return LoggingFeature(
             storage: observedStorage,
             upload: mockedUpload,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -44,6 +44,7 @@ extension RUMFeature {
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
             )
         )
+        fullFeature.deinitialize()
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -44,11 +44,12 @@ extension RUMFeature {
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`
             )
         )
-        fullFeature.deinitialize()
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:
         let mockedUpload = FeatureUpload(uploader: uploadWorker)
+        // Tear down the original upload
+        fullFeature.upload.flushAndTearDown()
         return RUMFeature(
             eventsMapper: fullFeature.eventsMapper,
             storage: observedStorage,

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -56,6 +56,7 @@ extension TracingFeature {
             loggingFeature: loggingFeature,
             tracingUUIDGenerator: tracingUUIDGenerator
         )
+        fullFeature.deinitialize()
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -56,11 +56,12 @@ extension TracingFeature {
             loggingFeature: loggingFeature,
             tracingUUIDGenerator: tracingUUIDGenerator
         )
-        fullFeature.deinitialize()
         let uploadWorker = DataUploadWorkerMock()
         let observedStorage = uploadWorker.observe(featureStorage: fullFeature.storage)
         // Replace by mocking the `FeatureUpload` and observing the `FatureStorage`:
         let mockedUpload = FeatureUpload(uploader: uploadWorker)
+        // Tear down the original upload
+        fullFeature.upload.flushAndTearDown()
         return TracingFeature(
             storage: observedStorage,
             upload: mockedUpload,

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Actions/UIApplicationSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Actions/UIApplicationSwizzlerTests.swift
@@ -7,12 +7,6 @@
 import XCTest
 @testable import Datadog
 
-extension UIApplicationSwizzler {
-    func unswizzle() {
-        sendEvent.unswizzle()
-    }
-}
-
 class UIApplicationSwizzlerTests: XCTestCase {
     private let handler = UIKitRUMUserActionsHandlerMock()
     private lazy var swizzler = try! UIApplicationSwizzler(handler: handler)

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentationTests.swift
@@ -23,7 +23,7 @@ class RUMAutoInstrumentationTests: XCTestCase {
     func testGivenRUMViewsAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsViewsHandler() throws {
         // Given
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         RUMAutoInstrumentation.instance = RUMAutoInstrumentation(
             configuration: .init(
@@ -32,7 +32,7 @@ class RUMAutoInstrumentationTests: XCTestCase {
             ),
             dateProvider: SystemDateProvider()
         )
-        defer { RUMAutoInstrumentation.instance = nil }
+        defer { RUMAutoInstrumentation.instance?.deinitialize() }
 
         // When
         Global.rum = RUMMonitor.initialize()
@@ -46,7 +46,7 @@ class RUMAutoInstrumentationTests: XCTestCase {
     func testGivenRUMUserActionsAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsUserActionsHandler() throws {
         // Given
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         RUMAutoInstrumentation.instance = RUMAutoInstrumentation(
             configuration: .init(
@@ -55,7 +55,7 @@ class RUMAutoInstrumentationTests: XCTestCase {
             ),
             dateProvider: SystemDateProvider()
         )
-        defer { RUMAutoInstrumentation.instance = nil }
+        defer { RUMAutoInstrumentation.instance?.deinitialize() }
 
         // When
         Global.rum = RUMMonitor.initialize()
@@ -70,7 +70,7 @@ class RUMAutoInstrumentationTests: XCTestCase {
     func testWhenAllRUMAutoInstrumentationsDisabled_itDoesNotCreateInstrumentationComponents() throws {
         // Given
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         /// This configuration is not allowed by `FeaturesConfiguration` logic. We test it for sanity.
         let notAllowedConfiguration = FeaturesConfiguration.RUM.AutoInstrumentation(
@@ -82,7 +82,7 @@ class RUMAutoInstrumentationTests: XCTestCase {
             configuration: notAllowedConfiguration,
             dateProvider: SystemDateProvider()
         )
-        defer { RUMAutoInstrumentation.instance = nil }
+        defer { RUMAutoInstrumentation.instance?.deinitialize() }
 
         // Then
         XCTAssertNil(RUMAutoInstrumentation.instance?.views)

--- a/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/AutoInstrumentation/Views/UIViewControllerSwizzlerTests.swift
@@ -22,13 +22,6 @@ private class ViewControllerMock: UIViewController {
     }
 }
 
-extension UIViewControllerSwizzler {
-    func unswizzle() {
-        viewDidAppear.unswizzle()
-        viewDidDisappear.unswizzle()
-    }
-}
-
 class UIViewControllerSwizzlerTests: XCTestCase {
     private let handler = UIKitRUMViewsHandlerMock()
     private lazy var swizzler = try! UIViewControllerSwizzler(handler: handler)

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -41,7 +41,7 @@ class RUMFeatureTests: XCTestCase {
                 mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1")
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
 
@@ -87,7 +87,7 @@ class RUMFeatureTests: XCTestCase {
                 )
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let fileWriter = try XCTUnwrap(RUMFeature.instance?.storage.writer)
         fileWriter.write(value: RUMDataModelMock(attribute: "1st event"))

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -28,7 +28,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
                 carrierInfoProvider: carrierInfoProvider
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize().dd
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -33,7 +33,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: dateProvider
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -67,7 +67,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: dateProvider
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -89,7 +89,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingImageResourceWithRequest() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -123,7 +123,7 @@ class RUMMonitorTests: XCTestCase {
         }
 
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -158,7 +158,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingXHRResourceWithRequestWithExternalMetrics() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -226,7 +226,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingResourceWithURL() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -247,7 +247,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingResourceWithURLString() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -274,7 +274,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -305,7 +305,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingResources_whileScrolling() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -368,7 +368,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0.01)
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -433,7 +433,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -483,7 +483,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingLoadingResourcesFromTheFirstView_thenStartingAnotherViewWhichAlsoLoadsResources() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -555,7 +555,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
 
@@ -599,7 +599,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
 
@@ -648,7 +648,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
 
@@ -686,7 +686,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testSendingAttributes() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let view1 = createMockView(viewControllerClassName: "FirstViewController")
         let view2 = createMockView(viewControllerClassName: "SecondViewController")
@@ -729,7 +729,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testWhenViewIsStarted_attributesCanBeAddedOrUpdatedButNotRemoved() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
 
@@ -767,7 +767,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         setGlobalAttributes(of: monitor)
@@ -803,7 +803,7 @@ class RUMMonitorTests: XCTestCase {
                 dateCorrector: DateCorrectorMock(correctionOffset: serverTimeDifference)
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
 
@@ -862,7 +862,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
 
@@ -928,7 +928,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
 
@@ -967,7 +967,7 @@ class RUMMonitorTests: XCTestCase {
                 errorEventMapper: { _ in nil }
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
 
@@ -1012,10 +1012,10 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         CrashReportingFeature.instance = .mockNoOp()
-        defer { CrashReportingFeature.instance = nil }
+        defer { CrashReportingFeature.instance?.deinitialize() }
 
         // Given
         Global.crashReporter = CrashReporter(crashReportingFeature: CrashReportingFeature.instance!)
@@ -1048,7 +1048,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         let view = mockView
@@ -1098,7 +1098,7 @@ class RUMMonitorTests: XCTestCase {
         XCTAssertTrue(monitor is DDNoopRUMMonitor)
     }
 
-    func testGivenRUMFeatureDisabled_whenInitializingRUMMonitor_itPrintsError() throws {
+    func testGivenRUMFeatureDisabled_whenInitializingRUMMonitor_itPrintsError() {
         let printFunction = PrintFunctionMock()
         consolePrint = printFunction.print
         defer { consolePrint = { print($0) } }
@@ -1120,10 +1120,10 @@ class RUMMonitorTests: XCTestCase {
         )
         XCTAssertTrue(monitor is DDNoopRUMMonitor)
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
-    func testGivenRUMMonitorInitialized_whenInitializingAnotherTime_itPrintsError() throws {
+    func testGivenRUMMonitorInitialized_whenInitializingAnotherTime_itPrintsError() {
         let printFunction = PrintFunctionMock()
         consolePrint = printFunction.print
         defer { consolePrint = { print($0) } }
@@ -1148,10 +1148,10 @@ class RUMMonitorTests: XCTestCase {
             """
         )
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
-    func testGivenRUMMonitorInitialized_whenTogglingDatadogDebugRUM_itTogglesRUMDebugging() throws {
+    func testGivenRUMMonitorInitialized_whenTogglingDatadogDebugRUM_itTogglesRUMDebugging() {
         // given
         Datadog.initialize(
             appContext: .mockAny(),
@@ -1177,7 +1177,7 @@ class RUMMonitorTests: XCTestCase {
             XCTAssertNil(monitor.debugging)
         }
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     func testGivenRUMAutoInstrumentationEnabled_whenRUMMonitorIsNotRegistered_itPrintsWarningsOnEachEvent() throws {
@@ -1244,14 +1244,14 @@ class RUMMonitorTests: XCTestCase {
         RUMAutoInstrumentation.instance?.views?.swizzler.unswizzle()
         RUMAutoInstrumentation.instance?.userActions?.swizzler.unswizzle()
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     // MARK: - Internal attributes
 
     func testHandlingInternalTimestampAttribute() throws {
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         var mockCommand = RUMCommandMock()
         mockCommand.attributes = [

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1120,7 +1120,7 @@ class RUMMonitorTests: XCTestCase {
         )
         XCTAssertTrue(monitor is DDNoopRUMMonitor)
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testGivenRUMMonitorInitialized_whenInitializingAnotherTime_itPrintsError() {
@@ -1148,7 +1148,7 @@ class RUMMonitorTests: XCTestCase {
             """
         )
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testGivenRUMMonitorInitialized_whenTogglingDatadogDebugRUM_itTogglesRUMDebugging() {
@@ -1177,7 +1177,7 @@ class RUMMonitorTests: XCTestCase {
             XCTAssertNil(monitor.debugging)
         }
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testGivenRUMAutoInstrumentationEnabled_whenRUMMonitorIsNotRegistered_itPrintsWarningsOnEachEvent() throws {
@@ -1244,7 +1244,7 @@ class RUMMonitorTests: XCTestCase {
         RUMAutoInstrumentation.instance?.views?.swizzler.unswizzle()
         RUMAutoInstrumentation.instance?.userActions?.swizzler.unswizzle()
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     // MARK: - Internal attributes

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -31,7 +31,7 @@ class TracerConfigurationTests: XCTestCase {
     }
 
     override func tearDown() {
-        TracingFeature.instance = nil
+        TracingFeature.instance?.deinitialize()
         super.tearDown()
     }
 
@@ -66,7 +66,7 @@ class TracerConfigurationTests: XCTestCase {
 
     func testDefaultTracerWithRUMEnabled() {
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let tracer1 = Tracer.initialize(configuration: .init()).dd
         XCTAssertNotNil(tracer1.rumContextIntegration)

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -42,7 +42,7 @@ class TracerTests: XCTestCase {
             ),
             tracingUUIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1)
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init())
 
@@ -78,7 +78,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithCustomizedTracer() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(
             configuration: .init(
@@ -108,7 +108,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithGlobalTags() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(
             configuration: .init(
@@ -134,7 +134,7 @@ class TracerTests: XCTestCase {
 
     func testSendingCustomizedSpan() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
 
@@ -162,7 +162,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithParentAndBaggageItems() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
 
@@ -222,7 +222,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithActiveSpanAsAParent() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
         let queue1 = DispatchQueue(label: "\(#function)-queue1")
@@ -254,7 +254,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpansWithNoParent() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
         let queue = DispatchQueue(label: "\(#function)-queue")
@@ -283,7 +283,7 @@ class TracerTests: XCTestCase {
 
     func testStartingRootActiveSpanInAsynchronousJobs() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init())
         let queue = DispatchQueue(label: "\(#function)")
@@ -320,7 +320,7 @@ class TracerTests: XCTestCase {
             userInfoProvider: UserInfoProvider(),
             launchTimeProvider: LaunchTimeProviderMock()
         )
-        defer { Datadog.instance = nil }
+        defer { Datadog.deinitialize() }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -328,7 +328,7 @@ class TracerTests: XCTestCase {
                 userInfoProvider: Datadog.instance!.userInfoProvider
             )
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
 
@@ -386,7 +386,7 @@ class TracerTests: XCTestCase {
                 carrierInfoProvider: carrierInfoProvider
             )
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(
             configuration: .init(sendNetworkInfo: true)
@@ -432,7 +432,7 @@ class TracerTests: XCTestCase {
                 networkConnectionInfoProvider: networkConnectionInfoProvider
             )
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(
             configuration: .init(sendNetworkInfo: true)
@@ -497,7 +497,7 @@ class TracerTests: XCTestCase {
                 )
             )
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
 
@@ -516,7 +516,7 @@ class TracerTests: XCTestCase {
                 )
             )
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
 
@@ -529,7 +529,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanTagsOfDifferentEncodableValues() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
 
@@ -604,7 +604,7 @@ class TracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -613,7 +613,7 @@ class TracerTests: XCTestCase {
             ),
             loggingFeature: LoggingFeature.instance!
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init())
 
@@ -648,7 +648,7 @@ class TracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -657,7 +657,7 @@ class TracerTests: XCTestCase {
             ),
             loggingFeature: LoggingFeature.instance!
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init())
 
@@ -684,7 +684,7 @@ class TracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -693,7 +693,7 @@ class TracerTests: XCTestCase {
             ),
             loggingFeature: LoggingFeature.instance!
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init())
 
@@ -726,7 +726,7 @@ class TracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -735,7 +735,7 @@ class TracerTests: XCTestCase {
             ),
             loggingFeature: LoggingFeature.instance!
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init())
 
@@ -760,10 +760,10 @@ class TracerTests: XCTestCase {
 
     func testGivenBundlingWithRUMEnabledAndRUMMonitorRegistered_whenSendingSpan_itContainsCurrentRUMContext() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         // given
         let tracer = Tracer.initialize(configuration: .init()).dd
@@ -787,10 +787,10 @@ class TracerTests: XCTestCase {
 
     func testGivenBundlingWithRUMEnabledButRUMMonitorNotRegistered_whenSendingSpan_itPrintsWarning() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }
@@ -869,7 +869,7 @@ class TracerTests: XCTestCase {
                 dateCorrector: DateCorrectorMock(correctionOffset: serverTimeDifference)
             )
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init())
 
@@ -900,7 +900,7 @@ class TracerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(consentProvider: consentProvider)
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
 
@@ -930,7 +930,7 @@ class TracerTests: XCTestCase {
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
         TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init())
         var spans: [DDSpan] = []
@@ -988,7 +988,7 @@ class TracerTests: XCTestCase {
         XCTAssertTrue(tracer is DDNoopTracer)
     }
 
-    func testGivenTracingFeatureDisabled_whenInitializingTracer_itPrintsError() throws {
+    func testGivenTracingFeatureDisabled_whenInitializingTracer_itPrintsError() {
         let printFunction = PrintFunctionMock()
         consolePrint = printFunction.print
         defer { consolePrint = { print($0) } }
@@ -1012,10 +1012,10 @@ class TracerTests: XCTestCase {
         )
         XCTAssertTrue(tracer is DDNoopTracer)
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
-    func testGivenLoggingFeatureDisabled_whenSendingLogFromSpan_itPrintsWarning() throws {
+    func testGivenLoggingFeatureDisabled_whenSendingLogFromSpan_itPrintsWarning() {
         // given
         Datadog.initialize(
             appContext: .mockAny(),
@@ -1038,10 +1038,10 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(output.recordedLog?.status, .warn)
         XCTAssertEqual(output.recordedLog?.message, "The log for span \"foo\" will not be send, because the Logging feature is disabled.")
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
-    func testGivenTracerInitialized_whenInitializingAnotherTime_itPrintsError() throws {
+    func testGivenTracerInitialized_whenInitializingAnotherTime_itPrintsError() {
         let printFunction = PrintFunctionMock()
         consolePrint = printFunction.print
         defer { consolePrint = { print($0) } }
@@ -1066,7 +1066,7 @@ class TracerTests: XCTestCase {
             """
         )
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     func testGivenOnlyTracingAutoInstrumentationEnabled_whenTracerIsNotRegistered_itPrintsWarningsOnEachFirstPartyRequest() throws {
@@ -1101,14 +1101,14 @@ class TracerTests: XCTestCase {
 
         URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     // MARK: - Environment Context
 
     func testSendingSpansWithNoDirectParentAndEnvironmentContext() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         setenv("x-datadog-trace-id", "111111", 1)
         setenv("x-datadog-parent-id", "222222", 1)
@@ -1145,7 +1145,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithActiveSpanAsAParentAndEnvironmentContext() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         setenv("x-datadog-trace-id", "111111", 1)
         setenv("x-datadog-parent-id", "222222", 1)

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -320,7 +320,7 @@ class TracerTests: XCTestCase {
             userInfoProvider: UserInfoProvider(),
             launchTimeProvider: LaunchTimeProviderMock()
         )
-        defer { Datadog.deinitialize() }
+        defer { Datadog.flushAndDeinitialize() }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -1012,7 +1012,7 @@ class TracerTests: XCTestCase {
         )
         XCTAssertTrue(tracer is DDNoopTracer)
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testGivenLoggingFeatureDisabled_whenSendingLogFromSpan_itPrintsWarning() {
@@ -1038,7 +1038,7 @@ class TracerTests: XCTestCase {
         XCTAssertEqual(output.recordedLog?.status, .warn)
         XCTAssertEqual(output.recordedLog?.message, "The log for span \"foo\" will not be send, because the Logging feature is disabled.")
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testGivenTracerInitialized_whenInitializingAnotherTime_itPrintsError() {
@@ -1066,7 +1066,7 @@ class TracerTests: XCTestCase {
             """
         )
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testGivenOnlyTracingAutoInstrumentationEnabled_whenTracerIsNotRegistered_itPrintsWarningsOnEachFirstPartyRequest() throws {
@@ -1101,7 +1101,7 @@ class TracerTests: XCTestCase {
 
         URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     // MARK: - Environment Context

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -38,7 +38,7 @@ class TracingFeatureTests: XCTestCase {
                 mobileDevice: .mockWith(model: "iPhone", osName: "iOS", osVersion: "13.3.1")
             )
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
 
@@ -79,7 +79,7 @@ class TracingFeatureTests: XCTestCase {
                 )
             )
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let tracer = Tracer.initialize(configuration: .init()).dd
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
@@ -20,7 +20,7 @@ class DDURLSessionDelegateTests: XCTestCase {
     }
 
     override func tearDown() {
-        URLSessionAutoInstrumentation.instance = nil
+        URLSessionAutoInstrumentation.instance?.deinitialize()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
@@ -37,7 +37,7 @@ class DDURLSessionDelegateTests: XCTestCase {
         interceptor.onTaskMetricsCollected = { _, _ in notifyTaskMetricsCollected.fulfill() }
 
         // Given
-        let session = URLSession.createServerMockURLSession(delegate: delegate)
+        let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
         let task = session.dataTask(with: URL.mockAny())
@@ -59,7 +59,7 @@ class DDURLSessionDelegateTests: XCTestCase {
         interceptor.onTaskMetricsCollected = { _, _ in notifyTaskMetricsCollected.fulfill() }
 
         // Given
-        let session = URLSession.createServerMockURLSession(delegate: delegate)
+        let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
         let task = session.dataTask(with: URLRequest.mockAny())
@@ -90,7 +90,7 @@ class DDURLSessionDelegateTests: XCTestCase {
         let dateBeforeAnyRequests = Date()
 
         // Given
-        let session = URLSession.createServerMockURLSession(delegate: delegate)
+        let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
         let taskWithURL = session.dataTask(with: URL.mockAny())
@@ -137,7 +137,7 @@ class DDURLSessionDelegateTests: XCTestCase {
         let dateBeforeAnyRequests = Date()
 
         // Given
-        let session = URLSession.createServerMockURLSession(delegate: delegate)
+        let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
         let taskWithURL = session.dataTask(with: URL.mockAny())

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
@@ -29,7 +29,7 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
         )
         defer {
             URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
-            URLSessionAutoInstrumentation.instance = nil
+            URLSessionAutoInstrumentation.instance?.deinitialize()
         }
 
         // Then
@@ -39,7 +39,7 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
     func testGivenURLSessionAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsResourcesHandler() throws {
         // Given
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
             configuration: .mockAny(),
@@ -48,7 +48,7 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
         )
         defer {
             URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
-            URLSessionAutoInstrumentation.instance = nil
+            URLSessionAutoInstrumentation.instance?.deinitialize()
         }
 
         // When

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -36,7 +36,7 @@ class URLSessionSwizzlerTests: XCTestCase {
 
     override func tearDown() {
         URLSessionAutoInstrumentation.instance?.disable() // unswizzle `URLSession`
-        URLSessionAutoInstrumentation.instance = nil
+        URLSessionAutoInstrumentation.instance?.deinitialize()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -7,21 +7,6 @@
 import XCTest
 @testable import Datadog
 
-extension URLSessionSwizzler {
-    func unswizzle() {
-        dataTaskWithURLRequestAndCompletion.unswizzle()
-        dataTaskWithURLRequest.unswizzle()
-        dataTaskWithURLAndCompletion?.unswizzle()
-        dataTaskWithURL?.unswizzle()
-    }
-}
-
-extension URLSessionAutoInstrumentation {
-    func disable() {
-        swizzler.unswizzle()
-    }
-}
-
 class URLSessionSwizzlerTests: XCTestCase {
     private let interceptor = URLSessionInterceptorMock()
 
@@ -35,8 +20,7 @@ class URLSessionSwizzlerTests: XCTestCase {
     }
 
     override func tearDown() {
-        URLSessionAutoInstrumentation.instance?.disable() // unswizzle `URLSession`
-        URLSessionAutoInstrumentation.instance?.deinitialize()
+        URLSessionAutoInstrumentation.instance?.deinitialize() // unswizzle & deinit
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -24,10 +24,6 @@ class URLSessionSwizzlerTests: XCTestCase {
         super.tearDown()
     }
 
-    private func interceptedSession() -> URLSession {
-        return .createServerMockURLSession(delegate: DDURLSessionDelegate())
-    }
-
     // MARK: - Interception Flow
 
     func testGivenURLSessionWithDDURLSessionDelegate_whenUsingTaskWithURLRequestAndCompletion_itNotifiesCreationAndCompletionAndModifiesTheRequest() throws {
@@ -54,7 +50,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
-        let session = interceptedSession()
+        let session = server.getInterceptedURLSession(delegate: DDURLSessionDelegate())
 
         // When
         let task = session.dataTask(with: URLRequest(url: .mockRandom())) { _, _, _ in
@@ -96,7 +92,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
-        let session = interceptedSession()
+        let session = server.getInterceptedURLSession(delegate: DDURLSessionDelegate())
 
         // When
         let task = session.dataTask(with: URL.mockRandom()) { _, _, _ in
@@ -138,7 +134,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
-        let session = interceptedSession()
+        let session = server.getInterceptedURLSession(delegate: DDURLSessionDelegate())
 
         // When
         let task = session.dataTask(with: URLRequest(url: .mockAny()))
@@ -172,7 +168,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
-        let session = interceptedSession()
+        let session = server.getInterceptedURLSession(delegate: DDURLSessionDelegate())
 
         // When
         let task = session.dataTask(with: URL.mockRandom())
@@ -200,7 +196,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         interceptor.onTaskCompleted = { _, _ in notifyTaskCompleted.fulfill() }
 
         // Given
-        let nsSession = NSURLSessionBridge(interceptedSession())!
+        let nsSession = NSURLSessionBridge(server.getInterceptedURLSession(delegate: DDURLSessionDelegate()))!
 
         // When
         let task1 = nsSession.dataTask(with: URL.mockRandom(), completionHandler: nil)!
@@ -257,7 +253,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         let expectedResponse: HTTPURLResponse = .mockResponseWith(statusCode: 200)
         let expectedData: Data = .mockRandom()
         let server = ServerMock(delivery: .success(response: expectedResponse, data: expectedData))
-        let session = interceptedSession()
+        let session = server.getInterceptedURLSession(delegate: DDURLSessionDelegate())
 
         // When
         let taskWithURLRequestAndCompletion = session.dataTask(with: URLRequest(url: .mockAny())) { data, response, error in
@@ -324,7 +320,7 @@ class URLSessionSwizzlerTests: XCTestCase {
         // Given
         let expectedError = NSError(domain: "network", code: 999, userInfo: [NSLocalizedDescriptionKey: "some error"])
         let server = ServerMock(delivery: .failure(error: expectedError))
-        let session = interceptedSession()
+        let session = server.getInterceptedURLSession(delegate: DDURLSessionDelegate())
 
         // When
         let taskWithURLRequestAndCompletion = session.dataTask(with: URLRequest(url: .mockAny())) { data, response, error in

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -23,7 +23,7 @@ class InternalLoggersTests: XCTestCase {
         XCTAssertNil(userLogger.logOutput)
     }
 
-    func testGivenDefaultSDKConfiguration_whenInitialized_itUsesWorkingUserLogger() throws {
+    func testGivenDefaultSDKConfiguration_whenInitialized_itUsesWorkingUserLogger() {
         let defaultSDKConfiguration = Datadog.Configuration.builderUsing(clientToken: "abc", environment: "test").build()
         Datadog.initialize(
             appContext: .mockAny(),
@@ -31,17 +31,17 @@ class InternalLoggersTests: XCTestCase {
             configuration: defaultSDKConfiguration
         )
         XCTAssertTrue((userLogger.logOutput as? ConditionalLogOutput)?.conditionedOutput is LogConsoleOutput)
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
-    func testGivenLoggingFeatureDisabled_whenSDKisInitialized_itUsesWorkingUserLogger() throws {
+    func testGivenLoggingFeatureDisabled_whenSDKisInitialized_itUsesWorkingUserLogger() {
         Datadog.initialize(
             appContext: .mockAny(),
             trackingConsent: .mockRandom(),
             configuration: .mockWith(loggingEnabled: false)
         )
         XCTAssertTrue((userLogger.logOutput as? ConditionalLogOutput)?.conditionedOutput is LogConsoleOutput)
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     func testUserLoggerPrintsMessagesAboveGivenVerbosityLevel() {

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -31,7 +31,7 @@ class InternalLoggersTests: XCTestCase {
             configuration: defaultSDKConfiguration
         )
         XCTAssertTrue((userLogger.logOutput as? ConditionalLogOutput)?.conditionedOutput is LogConsoleOutput)
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testGivenLoggingFeatureDisabled_whenSDKisInitialized_itUsesWorkingUserLogger() {
@@ -41,7 +41,7 @@ class InternalLoggersTests: XCTestCase {
             configuration: .mockWith(loggingEnabled: false)
         )
         XCTAssertTrue((userLogger.logOutput as? ConditionalLogOutput)?.conditionedOutput is LogConsoleOutput)
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     func testUserLoggerPrintsMessagesAboveGivenVerbosityLevel() {

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -26,7 +26,7 @@ class DDDatadogTests: XCTestCase {
 
     // MARK: - Initializing with configuration
 
-    func testItFowardsInitializationToSwift() throws {
+    func testItFowardsInitializationToSwift() {
         let configBuilder = DDConfiguration.builder(clientToken: "abcefghi", environment: "tests")
         configBuilder.trackURLSession(firstPartyHosts: ["example.com"])
 
@@ -42,12 +42,12 @@ class DDDatadogTests: XCTestCase {
         XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
 
         URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     // MARK: - Changing Tracking Consent
 
-    func testItForwardsTrackingConsentToSwift() throws {
+    func testItForwardsTrackingConsentToSwift() {
         let initialConsent = randomConsent()
         let nextConsent = randomConsent()
 
@@ -63,7 +63,7 @@ class DDDatadogTests: XCTestCase {
 
         XCTAssertEqual(Datadog.instance?.consentProvider.currentValue, nextConsent.swift)
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     // MARK: - Setting user info
@@ -100,7 +100,7 @@ class DDDatadogTests: XCTestCase {
         XCTAssertNil(userInfo.value.email)
         XCTAssertTrue(userInfo.value.extraInfo.isEmpty)
 
-        try Datadog.deinitializeOrThrow()
+        Datadog.deinitialize()
     }
 
     // MARK: - Changing SDK verbosity level

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -42,7 +42,7 @@ class DDDatadogTests: XCTestCase {
         XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
 
         URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     // MARK: - Changing Tracking Consent
@@ -63,7 +63,7 @@ class DDDatadogTests: XCTestCase {
 
         XCTAssertEqual(Datadog.instance?.consentProvider.currentValue, nextConsent.swift)
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     // MARK: - Setting user info
@@ -100,7 +100,7 @@ class DDDatadogTests: XCTestCase {
         XCTAssertNil(userInfo.value.email)
         XCTAssertTrue(userInfo.value.extraInfo.isEmpty)
 
-        Datadog.deinitialize()
+        Datadog.flushAndDeinitialize()
     }
 
     // MARK: - Changing SDK verbosity level

--- a/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
@@ -24,7 +24,7 @@ class DDGlobalTests: XCTestCase {
 
     func testWhenTracerIsSet_itSetsSwiftImplementation() {
         TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.sharedTracer,
@@ -51,7 +51,7 @@ class DDGlobalTests: XCTestCase {
 
     func testWhenRUMMonitorIsSet_itSetsSwiftImplementation() {
         RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.rum,

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -25,7 +25,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingLogsWithDifferentLevels() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let objcLogger = DDLogger.builder().build()
 
@@ -47,7 +47,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingNSError() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let objcLogger = DDLogger.builder().build()
 
@@ -79,7 +79,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingMessageAttributes() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let objcLogger = DDLogger.builder().build()
 
@@ -104,7 +104,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingLoggerAttributes() throws {
         LoggingFeature.instance = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let objcLogger = DDLogger.builder().build()
 
@@ -144,7 +144,7 @@ class DDLoggerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "test"))
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         let objcLogger = DDLogger.builder().build()
 

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -96,7 +96,7 @@ class DDRUMMonitorTests: XCTestCase {
 
     func testSendingViewEvents() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let objcRUMMonitor = DatadogObjc.DDRUMMonitor()
         let mockView = createMockView(viewControllerClassName: "FirstViewController")
@@ -131,7 +131,7 @@ class DDRUMMonitorTests: XCTestCase {
 
     func testSendingViewEventsWithTiming() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let objcRUMMonitor = DatadogObjc.DDRUMMonitor()
 
@@ -160,7 +160,7 @@ class DDRUMMonitorTests: XCTestCase {
         }
 
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let objcRUMMonitor = DatadogObjc.DDRUMMonitor()
 
@@ -213,7 +213,7 @@ class DDRUMMonitorTests: XCTestCase {
 
     func testSendingErrorEvents() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let objcRUMMonitor = DatadogObjc.DDRUMMonitor()
 
@@ -281,7 +281,7 @@ class DDRUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let objcRUMMonitor = DatadogObjc.DDRUMMonitor()
 
@@ -315,7 +315,7 @@ class DDRUMMonitorTests: XCTestCase {
 
     func testSendingGlobalAttributes() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance = nil }
+        defer { RUMFeature.instance?.deinitialize() }
 
         let objcRUMMonitor = DatadogObjc.DDRUMMonitor()
         objcRUMMonitor.addAttribute(forKey: "global-attribute1", value: "foo1")

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -23,7 +23,7 @@ class DDTracerTests: XCTestCase {
 
     func testSendingCustomizedSpans() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration()).dd!
 
@@ -120,7 +120,7 @@ class DDTracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -129,7 +129,7 @@ class DDTracerTests: XCTestCase {
             ),
             loggingFeature: LoggingFeature.instance!
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
 
@@ -153,7 +153,7 @@ class DDTracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -162,7 +162,7 @@ class DDTracerTests: XCTestCase {
             ),
             loggingFeature: LoggingFeature.instance!
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
 
@@ -189,7 +189,7 @@ class DDTracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance = nil }
+        defer { LoggingFeature.instance?.deinitialize() }
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -198,7 +198,7 @@ class DDTracerTests: XCTestCase {
             ),
             loggingFeature: LoggingFeature.instance!
         )
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
 
@@ -260,7 +260,7 @@ class DDTracerTests: XCTestCase {
 
     func testsWhenTagsDictionaryContainsInvalidKeys_thenThosesTagsAreDropped() throws {
         TracingFeature.instance = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        defer { TracingFeature.instance = nil }
+        defer { TracingFeature.instance?.deinitialize() }
 
         // Given
         let objcTracer = DDTracer(configuration: DDTracerConfiguration()).dd!

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -73,6 +73,14 @@ custom_rules:
       - comment
     message: "All TODOs must be followed by JIRA reference, for example: \"TODO: RUMM-123\""
     severity: error
+  unmanaged_deallocation: # prevents from unmanaged singletons deallocation with `.instance = nil`
+    name: "Unmanaged singleton deallocation: `.instance = nil`"
+    regex: '.instance = nil'
+    excluded_match_kinds: 
+      - comment
+      - doccomment
+    message: "All singletons must provide an explicit deinitialization API (e.g. `deinitialize()`) to reset its state and tear down all asynchronous work."
+    severity: error
 
 included:
   - ../../Tests


### PR DESCRIPTION
### What and why?

⚙️ This PR adds an internal API to flush all authorised data and deinitialize the SDK:
```swift
#if DD_SDK_COMPILED_FOR_TESTING

public static func flushAndDeinitialize() { /* ... */ }

#endif
```

It executes synchronously, so upon return it guarantees that:
* the SDK instance is destroyed,
* all asynchronous work is completed in `storage` and `upload` stacks,
* all authorised data is uploaded arbitrarily (without retrying on failure).

This API is required for E2E δ project (#496) and will be used in `E2ETests` module for tearing down the SDK in each unit test.

### How?

This is highly experimental API, so it is conditioned by `DD_SDK_COMPILED_FOR_TESTING` compiler flag and is not planned for visibility in public releases. This flag needs to be defined in `Base.local.xcconfig` - requires `make dependencies`.

The implementation of `flushAndDeinitialize()` executes (synchronously) a chain of commands for deinitializing all active components in each feature. This chain is mirroring the components' initialization chain:

**Initialization chain - on `Datadog.initialize()`:**
* for each feature (Logging, Tracing, RUM):
   * initialize `FeatureStorage`
   * initialize `FeatureUpload`
      * start upload worker
* for each instrumentation (`UIViewController`, `UIApplication`, `URLSession`):
   * swizzle instrumented APIs

**Deinitialization chain - on `Datadog. flushAndDeinitialize()`:**
* for each feature (Logging, Tracing, RUM):
   * deinitialize `FeatureStorage`
      * wait for pending async writes completion
   * deinitialize `FeatureUpload`
      * cancel upload worker
      * upload unsent authorised data
* for each instrumentation (`UIViewController`, `UIApplication`, `URLSession`):
   * unswizzle instrumented APIs

---

Given this more strict control over features deinitialization, I also replaced all arbitrary deallocations (`.instance = nil`) with the new explicit APIs (`.instance.deinitialize()`). This revealed the source of recent tests flakiness that we observe on CI and in local. To further fix this flakiness, I improved the implementation of `ServerMock`, so it's also more strict and explicit.

The `ServerMock` instance which we create in unit tests intercepts the `URLSession` by installing `URLProtocol`. The problem is that we don't control the initialization of `URLProtocol` subclass - it is performed behind the scene. This is why the `ServerMockProtocol` implementation needs to obtain `ServerMock` reference through static global `.activeServer`.

We had an issue in few tests, where the `.activeServer` reference was leaked from one test to another, causing some asynchronous request completions to be reported to the new instance. I've fixed that by:
* repairing that tests,
* ensuring that `ServerMockProtocol` always captures the right  instance of `ServerMock` (tests will fail otherwise).

This should solve some of the existing flakiness and help us adding new tests by controlling their consistency. For verification, I've run unit tests 40 times on CI without observing any failure 🏆.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
