### PR TITLE
RUMM-954: Update docs, track() option vs trackURLSession()

### DIFF
--- a/docs/rum_collection.md
+++ b/docs/rum_collection.md
@@ -144,7 +144,7 @@ To enable RUM resources tracking, use the `.track(firstPartyHosts:)` option when
 ```swift
 Datadog.Configuration
    .builderUsing(...)
-   .track(firstPartyHosts: ["your.domain.com"])
+   .trackURLSession(firstPartyHosts: ["your.domain.com"])
    .build()
 
 Global.rum = RUMMonitor.initialize()


### PR DESCRIPTION
### What and why?

RUMM-954 changed an option, and missed an instance in the docs.

Following [the docs to implement my RUM autoinstrumentation](https://docs.datadoghq.com/real_user_monitoring/ios/?tab=cocoapods#auto-instrumentation), we hit:

> 'track(firstPartyHosts:)' is deprecated: This option is replaced by `trackURLSession(firstPartyHosts:)`. Refer to the new API comment for important details.

Seems the option was changed in [RUMM-954](https://github.com/DataDog/dd-sdk-ios/commit/2caea0b5e0ead46dc99995f499c3a25bbe655eb6#diff-43cd34cced2c4dbcc1402f5ed1e770728fcc4a107d97527a795152908711d7ee), back in January.

### How?

Docs-only.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration) [N/A? -ecv]
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
