### PR TITLE
RUMM-1265 Correctly handle RUM events when app in background

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -105,6 +105,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         switch command {
         case let command as RUMStartViewCommand:
             startView(on: command)
+        case is RUMStartResourceCommand, is RUMAddUserActionCommand, is RUMStartUserActionCommand:
+            handleOrphanStartCommand(command: command)
         default:
             break
         }
@@ -132,7 +134,23 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         )
     }
 
-    // MARK: - Private
+    // MARK: - Private    
+    private func handleOrphanStartCommand(command: RUMCommand) {
+        if viewScopes.isEmpty {
+            viewScopes.append(
+                RUMViewScope(
+                    parent: self,
+                    dependencies: dependencies,
+                    identity: RUMViewScope.Constants.backgroundViewURL,
+                    path: RUMViewScope.Constants.backgroundViewURL,
+                    name: RUMViewScope.Constants.backgroundViewName,
+                    attributes: command.attributes,
+                    customTimings: [:],
+                    startTime: command.time
+                )
+            )
+        }
+    }
 
     private func timedOutOrExpired(currentTime: Date) -> Bool {
         let timeElapsedSinceLastInteraction = currentTime.timeIntervalSince(lastInteractionTime)

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -7,6 +7,11 @@
 import Foundation
 
 internal class RUMViewScope: RUMScope, RUMContextProvider {
+    struct Constants {
+        static let backgroundViewURL = "com/datadog/background/view"
+        static let backgroundViewName = "Background"
+    }
+
     // MARK: - Child Scopes
 
     /// Active Resource scopes, keyed by .resourceKey.
@@ -33,7 +38,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     /// The name of this View, used as the `VIEW NAME` in RUM Explorer.
     let viewName: String
     /// The start time of this View.
-    private let viewStartTime: Date
+    let viewStartTime: Date
     /// Date correction to server time.
     private let dateCorrection: DateCorrection
     /// Tells if this View is the active one.
@@ -129,7 +134,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         case let command as RUMStopViewCommand where identity.equals(command.identity):
             isActiveView = false
             needsViewUpdate = true
-
         case let command as RUMAddViewTimingCommand where isActiveView:
             customTimings[command.timingName] = command.time.timeIntervalSince(viewStartTime).toInt64Nanoseconds
             needsViewUpdate = true

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -8,6 +8,8 @@ import XCTest
 @testable import Datadog
 
 class RUMSessionScopeTests: XCTestCase {
+    // MARK: - Unit Tests
+
     func testDefaultContext() {
         let parent: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: .mockAny())
@@ -77,6 +79,66 @@ class RUMSessionScopeTests: XCTestCase {
         XCTAssertEqual(scope.viewScopes.count, 0)
     }
 
+    func testWhenNoViewScope_andReceivedStartResourceCommand_itCreatesNewViewScope() {
+        let parent = RUMContextProviderMock()
+        let currentTime = Date()
+
+        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date())
+
+        _ = scope.process(command: RUMStartResourceCommand.mockWith(resourceKey: "/resource/1", time: currentTime))
+
+        XCTAssertEqual(scope.viewScopes.count,1)
+        XCTAssertEqual(scope.viewScopes[0].viewStartTime, currentTime)
+        XCTAssertEqual(scope.viewScopes[0].viewName, RUMViewScope.Constants.backgroundViewName)
+        XCTAssertEqual(scope.viewScopes[0].viewPath, RUMViewScope.Constants.backgroundViewURL)
+    }
+
+    func testWhenNoViewScope_andReceivedStartActionCommand_itCreatesNewViewScope() {
+        let parent = RUMContextProviderMock()
+        let currentTime = Date()
+
+        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date())
+
+        _ = scope.process(command: RUMStartUserActionCommand.mockWith(time: currentTime))
+
+        XCTAssertEqual(scope.viewScopes.count,1)
+        XCTAssertEqual(scope.viewScopes[0].viewStartTime, currentTime)
+        XCTAssertEqual(scope.viewScopes[0].viewName, RUMViewScope.Constants.backgroundViewName)
+        XCTAssertEqual(scope.viewScopes[0].viewPath, RUMViewScope.Constants.backgroundViewURL)
+    }
+
+    func testWhenNoViewScope_andReceivedAddUserActionCommand_itCreatesNewViewScope() {
+        let parent = RUMContextProviderMock()
+        let currentTime = Date()
+
+        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date())
+
+        _ = scope.process(command: RUMAddUserActionCommand.mockWith(time: currentTime))
+
+        XCTAssertEqual(scope.viewScopes.count,1)
+        XCTAssertEqual(scope.viewScopes[0].viewStartTime, currentTime)
+        XCTAssertEqual(scope.viewScopes[0].viewName, RUMViewScope.Constants.backgroundViewName)
+        XCTAssertEqual(scope.viewScopes[0].viewPath, RUMViewScope.Constants.backgroundViewURL)
+    }
+
+    func testWhenActiveViewScope_andReceivingStartCommand_itDoesNotCreateNewViewScope() {
+        let parent = RUMContextProviderMock()
+        let currentTime = Date()
+
+        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date())
+        _ = scope.process(command: generateRandomNotValidStartCommand())
+        _ = scope.process(command: RUMAddUserActionCommand.mockWith(time: currentTime))
+        XCTAssertEqual(scope.viewScopes.count, 1)
+    }
+
+    func testWhenNoActiveViewScope_andReceivingNotValidStartCommand_itDoesNotCreateNewViewScope() {
+        let parent = RUMContextProviderMock()
+
+        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date())
+        _ = scope.process(command: generateRandomNotValidStartCommand())
+        XCTAssertEqual(scope.viewScopes.count, 0)
+    }
+
     func testWhenSessionIsSampled_itDoesNotCreateViewScopes() {
         let parent = RUMContextProviderMock()
 
@@ -87,5 +149,15 @@ class RUMSessionScopeTests: XCTestCase {
             "Sampled session should be kept until it expires or reaches the timeout."
         )
         XCTAssertEqual(scope.viewScopes.count, 0)
+    }
+
+    // MARK: - Private
+
+    private func generateRandomValidStartCommand() -> RUMCommand {
+       return [RUMStartUserActionCommand.mockAny(), RUMStartResourceCommand.mockAny(), RUMAddUserActionCommand.mockAny()].randomElement()!
+    }
+
+    private func generateRandomNotValidStartCommand() -> RUMCommand {
+        return [RUMStopViewCommand.mockAny(), RUMStopResourceCommand.mockAny(), RUMStopUserActionCommand.mockAny(), RUMAddCurrentViewErrorCommand.mockWithErrorObject()].randomElement()!
     }
 }


### PR DESCRIPTION
### What and why?

Currently if the application is not in foreground (there is no active View scope), any resource or action event will be ignored as there is no active `View` on which to attach it.
In this **PR** we are adding a change in the way we handle the received commands in the `RUMSessionScope` in order to be able to record RUM events while the application is in background.

### How?

We are introducing the concept of `RUM background View scope` which by definition is a normal View scope with predefined `name` and `url`. Once the `RUMSessionScope` needs to handle a `RUMStartAction` or `RUMStartResource` command and there is no active `RUMViewScope`, instead of ignoring the command as before it will automatically create a special `RUMViewScope` on which the received resource or action will be attached. For more information please check: [RUM Background events RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/1385267440/RFC+-+Background+Mobile+Events)

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
