### PR TITLE
RUMM-1374 Fix deprecation and lint warnings in Xcode 12.5

### DIFF
--- a/Sources/Datadog/Core/System/AppStateListener.swift
+++ b/Sources/Datadog/Core/System/AppStateListener.swift
@@ -83,7 +83,7 @@ internal struct AppStateHistory: Equatable {
     }
 }
 
-internal protocol AppStateListening: class {
+internal protocol AppStateListening: AnyObject {
     var history: AppStateHistory { get }
 }
 

--- a/Sources/Datadog/Core/System/Time/DateCorrector.swift
+++ b/Sources/Datadog/Core/System/Time/DateCorrector.swift
@@ -36,7 +36,6 @@ internal class DateCorrector: DateCorrectorType {
     init(deviceDateProvider: DateProvider, serverDateProvider: ServerDateProvider) {
         self.deviceDateProvider = deviceDateProvider
         self.serverDateProvider = serverDateProvider
-        // swiftlint:disable trailing_closure
         serverDateProvider.synchronize(
             with: DateCorrector.datadogNTPServers.randomElement()!, // swiftlint:disable:this force_unwrapping
             completion: { serverTime in
@@ -59,7 +58,6 @@ internal class DateCorrector: DateCorrectorType {
                 }
             }
         )
-        // swiftlint:enable trailing_closure
     }
 
     var currentCorrection: DateCorrection {

--- a/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
+++ b/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
@@ -19,11 +19,9 @@ internal protocol ServerDateProvider {
 
 internal class NTPServerDateProvider: ServerDateProvider {
     func synchronize(with ntpPool: String, completion: @escaping (Date?) -> Void) {
-        // swiftlint:disable trailing_closure multiline_arguments_brackets
         Clock.sync(from: ntpPool, completion: { serverTime, _ in
             completion(serverTime)
         })
-        // swiftlint:enable trailing_closure multiline_arguments_brackets
     }
 
     func currentDate() -> Date? {

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// An interface for writing and reading  the `CrashContext`
-internal protocol CrashContextProviderType: class {
+internal protocol CrashContextProviderType: AnyObject {
     /// Returns current `CrashContext` value.
     var currentCrashContext: CrashContext { get }
     /// Notifies on `CrashContext` change.

--- a/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
+++ b/Sources/Datadog/CrashReporting/DDCrashReportingPluginType.swift
@@ -48,7 +48,7 @@ public class DDCrashReport: NSObject {
 ///
 /// The SDK calls each API on a background thread and succeeding calls are synchronized.
 @objc
-public protocol DDCrashReportingPluginType: class {
+public protocol DDCrashReportingPluginType: AnyObject {
     /// Reads unprocessed crash report if available.
     /// - Parameter completion: the completion block called with the value of `DDCrashReport` if a crash report is available
     /// or with `nil` otherwise. The value returned by the receiver should indicate if the crash report was processed correctly (`true`)

--- a/Sources/Datadog/RUM/AutoInstrumentation/Actions/UIKitRUMUserActionsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Actions/UIKitRUMUserActionsHandler.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-internal protocol UIKitRUMUserActionsHandlerType: class {
+internal protocol UIKitRUMUserActionsHandlerType: AnyObject {
     func subscribe(commandsSubscriber: RUMCommandSubscriber)
     func notify_sendEvent(application: UIApplication, event: UIEvent)
 }

--- a/Sources/Datadog/RUM/AutoInstrumentation/RUMCommandSubscriber.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/RUMCommandSubscriber.swift
@@ -6,6 +6,6 @@
 
 import Foundation
 
-internal protocol RUMCommandSubscriber: class {
+internal protocol RUMCommandSubscriber: AnyObject {
     func process(command: RUMCommand)
 }

--- a/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/Views/UIKitRUMViewsHandler.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-internal protocol UIKitRUMViewsHandlerType: class {
+internal protocol UIKitRUMViewsHandlerType: AnyObject {
     func subscribe(commandsSubscriber: RUMCommandSubscriber)
     /// Gets called on `super.viewDidAppear()`.
     func notify_viewDidAppear(viewController: UIViewController, animated: Bool)

--- a/Sources/Datadog/RUM/RUMContext/RUMContextProvider.swift
+++ b/Sources/Datadog/RUM/RUMContext/RUMContextProvider.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal protocol RUMContextProvider: class {
+internal protocol RUMContextProvider: AnyObject {
     /// The RUM context local to this provider.
     var context: RUMContext { get }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMScope.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal protocol RUMScope: class {
+internal protocol RUMScope: AnyObject {
     /// Processes given command. Returns:
     /// * `true` if the scope should be kept open.
     /// * `false` if the scope should be closed.

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -207,7 +207,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     }
 
     private func startContinuousUserAction(on command: RUMStartUserActionCommand) {
-        // swiftlint:disable trailing_closure
         userActionScope = RUMUserActionScope(
             parent: self,
             dependencies: dependencies,
@@ -222,11 +221,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 self?.needsViewUpdate = true
             }
         )
-        // swiftlint:enable trailing_closure
     }
 
     private func addDiscreteUserAction(on command: RUMAddUserActionCommand) {
-        // swiftlint:disable trailing_closure
         userActionScope = RUMUserActionScope(
             parent: self,
             dependencies: dependencies,
@@ -241,7 +238,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 self?.needsViewUpdate = true
             }
         )
-        // swiftlint:enable trailing_closure
     }
 
     // MARK: - Sending RUM Events

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -15,7 +15,7 @@ internal protocol URLSessionInterceptionHandler {
 }
 
 /// An interface for processing `URLSession` task interceptions.
-internal protocol URLSessionInterceptorType: class {
+internal protocol URLSessionInterceptorType: AnyObject {
     func modify(request: URLRequest, session: URLSession?) -> URLRequest
     func taskCreated(task: URLSessionTask, session: URLSession?)
     func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics)

--- a/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
@@ -13,7 +13,6 @@ private extension ExampleApplication {
     }
 }
 
-// swiftlint:disable trailing_closure
 class CrashReportingWithLoggingScenarioTests: IntegrationTests, LoggingCommonAsserts {
     /// Launches the app, taps "Call fatalError()" button (leading to crash), then restarts the app
     /// to have the crash report uploaded to logging endpoint.
@@ -87,4 +86,3 @@ class CrashReportingWithLoggingScenarioTests: IntegrationTests, LoggingCommonAss
         crashLog.assertLoggerName(equals: "crash-reporter")
     }
 }
-// swiftlint:enable trailing_closure

--- a/Tests/DatadogIntegrationTests/Scenarios/Logging/LoggingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/Logging/LoggingScenarioTests.swift
@@ -7,7 +7,6 @@
 import HTTPServerMock
 import XCTest
 
-// swiftlint:disable trailing_closure
 class LoggingScenarioTests: IntegrationTests, LoggingCommonAsserts {
     func testLoggingScenario() throws {
         let loggingServerSession = server.obtainUniqueRecordingSession()
@@ -108,4 +107,3 @@ class LoggingScenarioTests: IntegrationTests, LoggingCommonAsserts {
         }
     }
 }
-// swiftlint:enable trailing_closure

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -107,11 +107,9 @@ class LoggerTests: XCTestCase {
         logger.info("message 3")
 
         let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 3)
-        // swiftlint:disable trailing_closure
         logMatchers[0].assertDate(matches: { $0 == Date.mockDecember15th2019At10AMUTC() })
         logMatchers[1].assertDate(matches: { $0 == Date.mockDecember15th2019At10AMUTC(addingTimeInterval: 1) })
         logMatchers[2].assertDate(matches: { $0 == Date.mockDecember15th2019At10AMUTC(addingTimeInterval: 2) })
-        // swiftlint:enable trailing_closure
     }
 
     func testSendingLogsWithDifferentLevels() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -461,7 +461,6 @@ class RUMResourceScopeTests: XCTestCase {
         var onResourceEventSentCalled = false
         var onErrorEventSentCalled = false
         // Given
-        // swiftlint:disable trailing_closure
         let scope1 = RUMResourceScope.mockWith(
             context: context,
             dependencies: dependencies,
@@ -495,7 +494,6 @@ class RUMResourceScopeTests: XCTestCase {
                 onErrorEventSentCalled = true
             }
         )
-        // swiftlint:enable trailing_closure
 
         // When
         XCTAssertFalse(

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -363,7 +363,6 @@ class RUMUserActionScopeTests: XCTestCase {
     func testGivenUserActionScopeWithEventSentCallback_whenSuccessfullySendingEvent_thenCallbackIsCalled() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         var callbackCalled = false
-        // swiftlint:disable trailing_closure
         let scope = RUMUserActionScope.mockWith(
             parent: parent,
             dependencies: dependencies,
@@ -377,7 +376,6 @@ class RUMUserActionScopeTests: XCTestCase {
                 callbackCalled = true
             }
         )
-        // swiftlint:enable trailing_closure
 
         XCTAssertFalse(
             scope.process(

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -848,7 +848,6 @@ class RUMViewScopeTests: XCTestCase {
     }
 
     func testGivenViewScopeWithDroppingEventsMapper_whenProcessingApplicationStartAction_thenNoEventIsSent() throws {
-        // swiftlint:disable trailing_closure
         let eventBuilder = RUMEventBuilder(
             userInfoProvider: UserInfoProvider.mockAny(),
             eventsMapper: RUMEventsMapper.mockWith(
@@ -857,7 +856,6 @@ class RUMViewScopeTests: XCTestCase {
                 }
             )
         )
-        // swiftlint:enable trailing_closure
         let dependencies: RUMScopeDependencies = .mockWith(eventBuilder: eventBuilder, eventOutput: output)
 
         let scope = RUMViewScope(

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -56,7 +56,6 @@ only_rules: # we enable lint rules explicitly - only the ones listed below are a
   - statement_position
   - switch_case_alignment
   - syntactic_sugar
-  - trailing_closure
   - trailing_newline
   - trailing_semicolon
   - trailing_whitespace

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -50,7 +50,6 @@ only_rules: # we enable lint rules explicitly - only the ones listed below are a
   - statement_position
   - switch_case_alignment
   - syntactic_sugar
-  - trailing_closure
   - trailing_newline
   - trailing_semicolon
   - trailing_whitespace


### PR DESCRIPTION
### What and why?

📦 This PR solves warnings which pop up when compiling with Xcode 12.5.

### How?

There were 2 kinds of warnings:
* compiler: `Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead`
* linter: `Trailing Closure Violation: Trailing closure syntax should be used whenever possible`

The compiler warning is fixed by updating to recommended `AnyObject` declaration.

The linter issue is not new, but it only starter being visible after upgrading to Xcode 12.5 (see [this SwiftLint GH Issue](https://github.com/realm/SwiftLint/issues/3592)). It is only emitted from tests code (38 warnings), due to our partial mocking convention:
* e.g. this doesn't lint according to `trailing_closure` rule:
```swift
let builder: SpanEventBuilder = .mockWith(
    eventsMapper: { span in
        var mutableSpan = span
        mutableSpan.tags = .mockRandom()
        return mutableSpan
    }
)
```
* and would need to be changed to this to leverage trailing closure syntax:
```swift
let builder: SpanEventBuilder = .mockWith { span in
    var mutableSpan = span
    mutableSpan.tags = .mockRandom()
    return mutableSpan
}
```

I consider code update a bad idea - it erases its readability. If we refactor to the enforced solution, there's no way to read the purpose of the closure just from the `mockWith` name.

Hence, linter warnings are solved by removing `trailing_closure` rule from our SwiftLint definition. I also removed 12  exclusions to this rule defined in the production code, which further proves that this rule is not compatible with our code style.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
