### PR TITLE
RUMM-1376 δ Add E2E tests for Logging

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */; };
+		610DE00E26613E990042763D /* PersistenceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111544725C9A88B007C84C9 /* PersistenceHelper.swift */; };
 		6111542525C992F8007C84C9 /* CrashReportingScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111542425C992F8007C84C9 /* CrashReportingScenarios.swift */; };
 		6111543625C993C2007C84C9 /* CrashReportingScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6111543525C993C2007C84C9 /* CrashReportingScenario.storyboard */; };
 		6111543F25C996A5007C84C9 /* CrashReportingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111543E25C996A5007C84C9 /* CrashReportingViewController.swift */; };
@@ -116,6 +117,11 @@
 		611F82032563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611F82022563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift */; };
 		61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */; };
 		6121627C247D220500AC5D67 /* LoggingForTracingAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */; };
+		61216B762666DDA10089DCD1 /* LoggerBuilderE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216B752666DDA10089DCD1 /* LoggerBuilderE2ETests.swift */; };
+		61216B7B2667A9AE0089DCD1 /* LoggingConfigurationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216B7A2667A9AE0089DCD1 /* LoggingConfigurationE2ETests.swift */; };
+		61216B802667C79B0089DCD1 /* LoggingTrackingConsentE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216B7F2667C79B0089DCD1 /* LoggingTrackingConsentE2ETests.swift */; };
+		61216B842667CFF70089DCD1 /* DatadogE2EHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216B7D2667BC220089DCD1 /* DatadogE2EHelpers.swift */; };
+		61216B852667CFFE0089DCD1 /* RUME2EHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61216B7826679DD20089DCD1 /* RUME2EHelpers.swift */; };
 		612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612983CC2449E62E00D4424B /* LoggingFeature.swift */; };
 		612D8F6925AEE68F000E2E09 /* RUMScrubbingScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 612D8F6825AEE68F000E2E09 /* RUMScrubbingScenario.storyboard */; };
 		612D8F6F25AEE6A7000E2E09 /* RUMScrubbingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612D8F6E25AEE6A7000E2E09 /* RUMScrubbingViewController.swift */; };
@@ -228,6 +234,9 @@
 		6167ACFD251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167ACFC251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift */; };
 		6167AD19251A27B80012B4D0 /* URLSessionScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6167AD18251A27B80012B4D0 /* URLSessionScenario.storyboard */; };
 		6167AD20251A27CC0012B4D0 /* SendFirstPartyRequestsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167AD1F251A27CC0012B4D0 /* SendFirstPartyRequestsViewController.swift */; };
+		6167C791266636B300D4CF07 /* FoundationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C202423990D00786299 /* FoundationMocks.swift */; };
+		6167C79326665D6900D4CF07 /* E2EUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167C79226665D6900D4CF07 /* E2EUtils.swift */; };
+		6167C7952666622800D4CF07 /* LoggingE2EHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167C7942666622800D4CF07 /* LoggingE2EHelpers.swift */; };
 		616A9CD22535D38200DB83CF /* UIKitHierarchyInspectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616A9CD12535D38200DB83CF /* UIKitHierarchyInspectorTests.swift */; };
 		616B6684259CAE3300968EE8 /* DDGlobalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B6683259CAE3300968EE8 /* DDGlobalTests.swift */; };
 		616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */; };
@@ -302,6 +311,7 @@
 		61B038BA2527257B00518F3C /* URLSessionAutoInstrumentationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B038B92527257B00518F3C /* URLSessionAutoInstrumentationMocks.swift */; };
 		61B038C62527259300518F3C /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B038C52527259300518F3C /* XCTestCase.swift */; };
 		61B22E5A24F3E6B700DC26D2 /* RUMDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */; };
+		61B3BD52266128D300A9BEF0 /* LoggerE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B3BD51266128D300A9BEF0 /* LoggerE2ETests.swift */; };
 		61B558CF2469561C001460D3 /* LoggerBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */; };
 		61B558D42469CDD8001460D3 /* TracingUUIDGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */; };
 		61B6811F25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B6811E25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift */; };
@@ -712,6 +722,11 @@
 		611F82022563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMViewsPredicateTests.swift; sourceTree = "<group>"; };
 		61216275247D1CD700AC5D67 /* LoggingForTracingAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapter.swift; sourceTree = "<group>"; };
 		61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingForTracingAdapterTests.swift; sourceTree = "<group>"; };
+		61216B752666DDA10089DCD1 /* LoggerBuilderE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerBuilderE2ETests.swift; sourceTree = "<group>"; };
+		61216B7826679DD20089DCD1 /* RUME2EHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUME2EHelpers.swift; sourceTree = "<group>"; };
+		61216B7A2667A9AE0089DCD1 /* LoggingConfigurationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingConfigurationE2ETests.swift; sourceTree = "<group>"; };
+		61216B7D2667BC220089DCD1 /* DatadogE2EHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogE2EHelpers.swift; sourceTree = "<group>"; };
+		61216B7F2667C79B0089DCD1 /* LoggingTrackingConsentE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingTrackingConsentE2ETests.swift; sourceTree = "<group>"; };
 		612983CC2449E62E00D4424B /* LoggingFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeature.swift; sourceTree = "<group>"; };
 		612D8F6825AEE68F000E2E09 /* RUMScrubbingScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMScrubbingScenario.storyboard; sourceTree = "<group>"; };
 		612D8F6E25AEE6A7000E2E09 /* RUMScrubbingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMScrubbingViewController.swift; sourceTree = "<group>"; };
@@ -826,6 +841,8 @@
 		6167ACFC251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingURLSessionScenarioTests.swift; sourceTree = "<group>"; };
 		6167AD18251A27B80012B4D0 /* URLSessionScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = URLSessionScenario.storyboard; sourceTree = "<group>"; };
 		6167AD1F251A27CC0012B4D0 /* SendFirstPartyRequestsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendFirstPartyRequestsViewController.swift; sourceTree = "<group>"; };
+		6167C79226665D6900D4CF07 /* E2EUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EUtils.swift; sourceTree = "<group>"; };
+		6167C7942666622800D4CF07 /* LoggingE2EHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingE2EHelpers.swift; sourceTree = "<group>"; };
 		616A9CD12535D38200DB83CF /* UIKitHierarchyInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitHierarchyInspectorTests.swift; sourceTree = "<group>"; };
 		616B6683259CAE3300968EE8 /* DDGlobalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDGlobalTests.swift; sourceTree = "<group>"; };
 		616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMMonitorTests.swift; sourceTree = "<group>"; };
@@ -903,6 +920,7 @@
 		61B038B92527257B00518F3C /* URLSessionAutoInstrumentationMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionAutoInstrumentationMocks.swift; sourceTree = "<group>"; };
 		61B038C52527259300518F3C /* XCTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTestCase.swift; sourceTree = "<group>"; };
 		61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebugging.swift; sourceTree = "<group>"; };
+		61B3BD51266128D300A9BEF0 /* LoggerE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerE2ETests.swift; sourceTree = "<group>"; };
 		61B558CE2469561C001460D3 /* LoggerBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerBuilderTests.swift; sourceTree = "<group>"; };
 		61B558D32469CDD8001460D3 /* TracingUUIDGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUIDGeneratorTests.swift; sourceTree = "<group>"; };
 		61B6811E25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingWithLoggingScenarioTests.swift; sourceTree = "<group>"; };
@@ -1772,6 +1790,16 @@
 			path = FeaturesIntegration;
 			sourceTree = "<group>";
 		};
+		61216B812667CFC90089DCD1 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				61216B7D2667BC220089DCD1 /* DatadogE2EHelpers.swift */,
+				6167C7942666622800D4CF07 /* LoggingE2EHelpers.swift */,
+				61216B7826679DD20089DCD1 /* RUME2EHelpers.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		612D8F6725AEE65F000E2E09 /* Scrubbing */ = {
 			isa = PBXGroup;
 			children = (
@@ -2425,7 +2453,10 @@
 		61993666265BBEDC009D7EA8 /* E2ETests */ = {
 			isa = PBXGroup;
 			children = (
+				61B3BD502661224800A9BEF0 /* Logging */,
 				61993667265BBEDC009D7EA8 /* E2ETests.swift */,
+				6167C79226665D6900D4CF07 /* E2EUtils.swift */,
+				61216B812667CFC90089DCD1 /* Helpers */,
 			);
 			path = E2ETests;
 			sourceTree = "<group>";
@@ -2511,6 +2542,17 @@
 				61B22E5924F3E6B700DC26D2 /* RUMDebugging.swift */,
 			);
 			path = Debugging;
+			sourceTree = "<group>";
+		};
+		61B3BD502661224800A9BEF0 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				61216B7F2667C79B0089DCD1 /* LoggingTrackingConsentE2ETests.swift */,
+				61216B7A2667A9AE0089DCD1 /* LoggingConfigurationE2ETests.swift */,
+				61B3BD51266128D300A9BEF0 /* LoggerE2ETests.swift */,
+				61216B752666DDA10089DCD1 /* LoggerBuilderE2ETests.swift */,
+			);
+			path = Logging;
 			sourceTree = "<group>";
 		};
 		61B6811D25F0E8480015B4AF /* CrashReporting */ = {
@@ -4026,8 +4068,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6167C7952666622800D4CF07 /* LoggingE2EHelpers.swift in Sources */,
+				6167C791266636B300D4CF07 /* FoundationMocks.swift in Sources */,
 				618F984F265BC905009959F8 /* E2EConfig.swift in Sources */,
+				61216B7B2667A9AE0089DCD1 /* LoggingConfigurationE2ETests.swift in Sources */,
 				61993668265BBEDC009D7EA8 /* E2ETests.swift in Sources */,
+				61216B852667CFFE0089DCD1 /* RUME2EHelpers.swift in Sources */,
+				61216B762666DDA10089DCD1 /* LoggerBuilderE2ETests.swift in Sources */,
+				61B3BD52266128D300A9BEF0 /* LoggerE2ETests.swift in Sources */,
+				61216B842667CFF70089DCD1 /* DatadogE2EHelpers.swift in Sources */,
+				6167C79326665D6900D4CF07 /* E2EUtils.swift in Sources */,
+				610DE00E26613E990042763D /* PersistenceHelper.swift in Sources */,
+				61216B802667C79B0089DCD1 /* LoggingTrackingConsentE2ETests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4685,7 +4737,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.E2E;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadog.ios.nightly;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};
@@ -4705,7 +4757,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.E2E;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadog.ios.nightly;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};
@@ -4725,7 +4777,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.E2E;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadog.ios.nightly;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};

--- a/Datadog/E2ETests/E2ETests.swift
+++ b/Datadog/E2ETests/E2ETests.swift
@@ -7,7 +7,65 @@
 import XCTest
 import Datadog
 
+
+/// A base class for all E2E test cases.
 class E2ETests: XCTestCase {
-    func testBasicAPI() throws {
+    /// If enabled, the SDK will not be initialized before each test.
+    var skipSDKInitialization = false
+
+    // MARK: - Before & After Each Test
+
+    override func setUp() {
+        super.setUp()
+        deleteAllSDKData()
+        if !skipSDKInitialization {
+            initializeSDK()
+        }
+    }
+
+    override func tearDown() {
+        sendAllDataAndDeinitializeSDK()
+        super.tearDown()
+    }
+
+    // MARK: - Measuring Performance with APM
+
+    /// Measures time of execution for given `block` - sends it as a `Span` with a given name.
+    func measure(spanName: String, _ block: () -> Void) {
+        let start = Date()
+        block()
+        let stop = Date()
+
+        Global.sharedTracer
+            .startRootSpan(operationName: spanName, startTime: start)
+            .finish(at: stop)
+    }
+
+    // MARK: - SDK Lifecycle
+
+    func initializeSDK(
+        trackingConsent: TrackingConsent = .granted,
+        configuration: Datadog.Configuration = .builderUsingE2EConfig().build()
+    ) {
+        Datadog.initialize(
+            appContext: .init(),
+            trackingConsent: trackingConsent,
+            configuration: configuration
+        )
+
+        Global.sharedTracer = Tracer.initialize(configuration: .init())
+        Global.rum = RUMMonitor.initialize()
+    }
+
+    /// Sends all collected data and deinitializes the SDK. It is executed synchronously.
+    private func sendAllDataAndDeinitializeSDK() {
+        Datadog.flushAndDeinitialize()
+    }
+
+    // MARK: - Helpers
+
+    /// Deletes persisted data for all SDK features. Ensures clean start for each test.
+    private func deleteAllSDKData() {
+        PersistenceHelpers.deleteAllSDKData()
     }
 }

--- a/Datadog/E2ETests/E2EUtils.swift
+++ b/Datadog/E2ETests/E2EUtils.swift
@@ -63,7 +63,7 @@ struct DD {
     }
 
     static func specialBoolAttribute() -> SpecialAttribute {
-        let value: Bool = .random() // asserted in monitors (`@test_special_double_attribute:(true OR false)`)
+        let value: Bool = .random() // asserted in monitors (`@test_special_bool_attribute:(true OR false)`)
         return .init(key: "test_special_bool_attribute", value: value)
     }
 

--- a/Datadog/E2ETests/E2EUtils.swift
+++ b/Datadog/E2ETests/E2EUtils.swift
@@ -1,0 +1,113 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import Datadog
+
+/// Collection of utilities for creating values for facets configured in "Mobile - Integration" org.
+struct DD {
+    /// Collection of performance span names for measuring time performance of different APIs.
+    ///
+    /// There is a performance monitor defined for each span name from this collection.
+    struct PerfSpanName {
+        /// Builds the span name by extracting it from the caller method
+        /// name (it removes `test_` prefix, `()` suffix and converts the name to lowercase).
+        static func fromCurrentMethodName(functionName: StaticString = #function) -> String {
+            return testMethodName(functionName: functionName)
+        }
+
+        // MARK: - Common
+
+        static let sdkInitialize = "sdk_initialize"
+        static let setTrackingConsent = "sdk_set_tracking_consent"
+
+        // MARK: - Logging-specific
+
+        static let loggerInitialize = "logs_logger_initialize"
+    }
+
+    // MARK: - Special Attributes
+
+    /// Special attribute added to events.
+    ///
+    /// There is a facet created for each produced **attribute key**.
+    /// Some **attribute values** contain fixed part, which is additionally asserted in monitor.
+    ///
+    /// We only test `String`, `Int`, `Double` and `Bool` attributes as these are the only ones available for facets at Datadog.
+    struct SpecialAttribute {
+        let key: String
+        let value: Encodable
+
+        fileprivate init(key: String, value: Encodable) {
+            self.key = key
+            self.value = value
+        }
+    }
+
+    static func specialStringAttribute() -> SpecialAttribute {
+        let prefix = "customAttribute" // asserted in monitors (`@test_special_string_attribute:customAttribute*`)
+        return .init(key: "test_special_string_attribute", value: prefix + .mockRandom())
+    }
+
+    static func specialIntAttribute() -> SpecialAttribute {
+        let min: Int = 11 // asserted in monitors (`@test_special_int_attribute:>11`)
+        return .init(key: "test_special_int_attribute", value: Int.mockRandom(min: min, max: .max))
+    }
+
+    static func specialDoubleAttribute() -> SpecialAttribute {
+        let min: Double = 11.0 // asserted in monitors (`@test_special_double_attribute:>11.0`)
+        return .init(key: "test_special_double_attribute", value: Double.mockRandom(min: min, max: .greatestFiniteMagnitude))
+    }
+
+    static func specialBoolAttribute() -> SpecialAttribute {
+        let value: Bool = .random() // asserted in monitors (`@test_special_double_attribute:(true OR false)`)
+        return .init(key: "test_special_bool_attribute", value: value)
+    }
+
+    // MARK: - Special Tags
+
+    /// Special tag added to events.
+    ///
+    /// There is a facet created for each produced **tag name**.
+    /// **Tag values** contain fixed part, which is additionally asserted in monitor.
+    struct SpecialTag {
+        let key: String
+        let value: String
+
+        fileprivate init(key: String, value: String) {
+            self.key = key
+            self.value = value
+        }
+    }
+
+    static func specialStringTag() -> SpecialTag {
+        let prefix = "customTag" // asserted in monitors (`@test_special_string_tag:customTag*`)
+        return .init(key: "test_special_string_tag", value: prefix + .mockRandom())
+    }
+
+    // MARK: - Logging-specific Attributes
+
+    /// Attributes added to each log event.
+    ///
+    /// Each attributes has a facet used in monitor to assert that events are actually delivered.
+    static func logAttributes(functionName: StaticString = #function) -> [AttributeKey: AttributeValue] {
+        return [
+            "test_method_name": testMethodName(functionName: functionName)
+        ]
+    }
+}
+
+/// Removes `test_` prefix, `()` suffix and converts the `functionName` to lowercase.
+///
+/// e.g. if called with `test_logs_logger_debug_log()`, it will return `logs_logger_debug_log`.
+private func testMethodName(functionName: StaticString = #function) -> String {
+    var name = "\(functionName)"
+    precondition(name.hasPrefix("test_"), "Cannot read `testMethodName` from: \(name) - it must have 'test_' prefix.")
+    precondition(name.hasSuffix("()"), "Cannot read `testMethodName` from: \(name) - it must have '()' suffix.")
+    name.removeFirst(("test_".count))
+    name.removeLast("()".count)
+    return name.lowercased()
+}

--- a/Datadog/E2ETests/Helpers/DatadogE2EHelpers.swift
+++ b/Datadog/E2ETests/Helpers/DatadogE2EHelpers.swift
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+extension Datadog.Configuration {
+    static func builderUsingE2EConfig() -> Datadog.Configuration.Builder {
+        return builderUsing(
+            rumApplicationID: E2EConfig.readRUMApplicationID(),
+            clientToken: E2EConfig.readClientToken(),
+            environment: E2EConfig.readEnv()
+        )
+    }
+}

--- a/Datadog/E2ETests/Helpers/LoggingE2EHelpers.swift
+++ b/Datadog/E2ETests/Helpers/LoggingE2EHelpers.swift
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+extension Logger {
+    func sendRandomLog(with attributes: [AttributeKey: AttributeValue]) {
+        let message: String = .mockRandom()
+        let error: Error? = Bool.random() ? ErrorMock(.mockRandom()) : nil
+
+        let allMethods = [
+            { self.debug(message, error: error, attributes: attributes) },
+            { self.info(message, error: error, attributes: attributes) },
+            { self.notice(message, error: error, attributes: attributes) },
+            { self.warn(message, error: error, attributes: attributes) },
+            { self.error(message, error: error, attributes: attributes) },
+            { self.critical(message, error: error, attributes: attributes) },
+        ]
+
+        let randomMethod = allMethods.randomElement()!
+        randomMethod()
+    }
+}
+
+extension Logger.Builder.ConsoleLogFormat {
+    static func random() -> Logger.Builder.ConsoleLogFormat {
+        let allFormats: [Logger.Builder.ConsoleLogFormat] = [
+            .json,
+            .jsonWith(prefix: .mockRandom()),
+            .short,
+            .shortWith(prefix: .mockRandom())
+        ]
+
+        return allFormats.randomElement()!
+    }
+}

--- a/Datadog/E2ETests/Helpers/RUME2EHelpers.swift
+++ b/Datadog/E2ETests/Helpers/RUME2EHelpers.swift
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+extension DDRUMMonitor {
+    var dd: RUMMonitor { self as! RUMMonitor }
+}

--- a/Datadog/E2ETests/Logging/LoggerBuilderE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggerBuilderE2ETests.swift
@@ -1,0 +1,148 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+class LoggerBuilderE2ETests: E2ETests {
+    private var logger: Logger!
+
+    override func tearDown() {
+        logger = nil
+        super.tearDown()
+    }
+
+    // MARK: - Enabling Options
+
+    /// - api-surface: Logger.Builder.set(serviceName: String) -> Builder
+    func test_logs_logger_builder_set_SERVICE_NAME() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.set(serviceName: "com.datadog.ios.nightly.custom").build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.Builder.set(loggerName: String) -> Builder
+    func test_logs_logger_builder_set_LOGGER_NAME() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.set(loggerName: "custom_logger_name").build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.Builder.sendNetworkInfo(_ enabled: Bool) -> Builder
+    func test_logs_logger_builder_SEND_NETWORK_INFO_enabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.sendNetworkInfo(true).build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.Builder.sendNetworkInfo(_ enabled: Bool) -> Builder
+    func test_logs_logger_builder_SEND_NETWORK_INFO_disabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.sendNetworkInfo(false).build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    // MARK: - Choosing Logs Output
+
+    /// - api-surface: Logger.Builder.sendLogsToDatadog(_ enabled: Bool) -> Builder
+    func test_logs_logger_builder_SEND_LOGS_TO_DATADOG_enabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.sendLogsToDatadog(true).build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.Builder.sendLogsToDatadog(_ enabled: Bool) -> Builder
+    func test_logs_logger_builder_SEND_LOGS_TO_DATADOG_disabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.sendLogsToDatadog(false).build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.Builder.printLogsToConsole(_ enabled: Bool, usingFormat format: ConsoleLogFormat = .short) -> Builder
+    func test_logs_logger_builder_PRINT_LOGS_TO_CONSOLE_enabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.printLogsToConsole(true, usingFormat: .random()).build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.Builder.printLogsToConsole(_ enabled: Bool, usingFormat format: ConsoleLogFormat = .short) -> Builder
+    func test_logs_logger_builder_PRINT_LOGS_TO_CONSOLE_disabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.printLogsToConsole(false, usingFormat: .random()).build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    // MARK: - Bundling With Other Features
+
+    /// - api-surface: Logger.Builder.bundleWithRUM(_ enabled: Bool) -> Builder
+    func test_logs_logger_builder_BUNDLE_WITH_RUM_enabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.bundleWithRUM(true).build()
+        }
+
+        let viewKey: String = .mockRandom()
+        Global.rum.startView(key: viewKey)
+        Global.rum.dd.flush()
+        logger.sendRandomLog(with: DD.logAttributes())
+        Global.rum.stopView(key: viewKey)
+    }
+
+    /// - api-surface: Logger.Builder.bundleWithRUM(_ enabled: Bool) -> Builder
+    func test_logs_logger_builder_BUNDLE_WITH_RUM_disabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.bundleWithRUM(false).build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+
+        let viewKey: String = .mockRandom()
+        Global.rum.startView(key: viewKey)
+        Global.rum.dd.flush()
+        logger.sendRandomLog(with: DD.logAttributes())
+        Global.rum.stopView(key: viewKey)
+    }
+
+    /// - api-surface: Logger.Builder.bundleWithTrace(_ enabled: Bool) -> Builder
+    func test_logs_logger_builder_BUNDLE_WITH_TRACE_enabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.bundleWithTrace(true).build()
+        }
+
+        let activeSpan = Global.sharedTracer
+            .startRootSpan(operationName: .mockRandom())
+            .setActive()
+        logger.sendRandomLog(with: DD.logAttributes())
+        activeSpan.finish()
+    }
+
+    /// - api-surface: Logger.Builder.bundleWithTrace(_ enabled: Bool) -> Builder
+    func test_logs_logger_builder_BUNDLE_WITH_TRACE_disabled() {
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.bundleWithTrace(false).build()
+        }
+
+        let activeSpan = Global.sharedTracer
+            .startRootSpan(operationName: .mockRandom())
+            .setActive()
+        logger.sendRandomLog(with: DD.logAttributes())
+        activeSpan.finish()
+    }
+}

--- a/Datadog/E2ETests/Logging/LoggerE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggerE2ETests.swift
@@ -1,0 +1,224 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+class LoggerE2ETests: E2ETests {
+    private var logger: Logger!
+
+    override func setUp() {
+        super.setUp()
+        logger = Logger.builder.build()
+    }
+
+    override func tearDown() {
+        logger = nil
+        super.tearDown()
+    }
+
+    // MARK: - Logging Method
+
+    /// - api-surface: Logger.debug(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_DEBUG_log() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.debug(.mockRandom(), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.debug(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_DEBUG_log_with_error() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.debug(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.info(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_INFO_log() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.info(.mockRandom(), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.info(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_INFO_log_with_error() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.info(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.notice(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_NOTICE_log() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.notice(.mockRandom(), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.notice(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_NOTICE_log_with_error() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.notice(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.warn(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_WARN_log() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.warn(.mockRandom(), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.warn(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_WARN_log_with_error() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.warn(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.error(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_ERROR_log() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.error(.mockRandom(), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.error(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_ERROR_log_with_error() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.error(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.critical(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_CRITICAL_log() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.critical(.mockRandom(), attributes: DD.logAttributes())
+        }
+    }
+
+    /// - api-surface: Logger.critical(_ message: String, error: Error? = nil, attributes: [AttributeKey: AttributeValue]? = nil)
+    func test_logs_logger_CRITICAL_log_with_error() {
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.critical(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
+        }
+    }
+
+    // MARK: - Adding Attributes
+
+    /// - api-surface: Logger.addAttribute(forKey key: AttributeKey, value: AttributeValue)
+    func test_logs_logger_add_STRING_attribute() {
+        let attribute = DD.specialStringAttribute()
+
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.addAttribute(forKey: attribute.key, value: attribute.value)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.addAttribute(forKey key: AttributeKey, value: AttributeValue)
+    func test_logs_logger_add_INT_attribute() {
+        let attribute = DD.specialIntAttribute()
+
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.addAttribute(forKey: attribute.key, value: attribute.value)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.addAttribute(forKey key: AttributeKey, value: AttributeValue)
+    func test_logs_logger_add_DOUBLE_attribute() {
+        let attribute = DD.specialDoubleAttribute()
+
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.addAttribute(forKey: attribute.key, value: attribute.value)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.addAttribute(forKey key: AttributeKey, value: AttributeValue)
+    func test_logs_logger_add_BOOL_attribute() {
+        let attribute = DD.specialBoolAttribute()
+
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.addAttribute(forKey: attribute.key, value: attribute.value)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    // MARK: - Removing Attributes
+
+    /// - api-surface: Logger.removeAttribute(forKey key: AttributeKey)
+    func test_logs_logger_remove_attribute() {
+        let possibleAttributes = [
+            DD.specialStringAttribute(),
+            DD.specialIntAttribute(),
+            DD.specialDoubleAttribute(),
+            DD.specialBoolAttribute()
+        ]
+        let randomAttribute = possibleAttributes.randomElement()!
+
+        logger.addAttribute(forKey: randomAttribute.key, value: randomAttribute.value)
+
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.removeAttribute(forKey: randomAttribute.key)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    // MARK: - Adding Tags
+
+    /// - api-surface: Logger.addTag(withKey key: String, value: String)
+    func test_logs_logger_add_tag() {
+        let tag = DD.specialStringTag()
+
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.addTag(withKey: tag.key, value: tag.value)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.add(tag: String)
+    func test_logs_logger_add_already_formatted_tag() {
+        let tag = DD.specialStringTag()
+
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.add(tag: "\(tag.key):\(tag.value)")
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    // MARK: - Removing Tags
+
+    /// - api-surface: Logger.removeTag(withKey key: String)
+    func test_logs_logger_remove_tag() {
+        let tag = DD.specialStringTag()
+        logger.addTag(withKey: tag.key, value: tag.value)
+
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.removeTag(withKey: tag.key)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Logger.remove(tag: String)
+    func test_logs_logger_remove_already_formatted_tag() {
+        let tag = DD.specialStringTag()
+        logger.add(tag: "\(tag.key):\(tag.value)")
+
+        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+            logger.remove(tag: "\(tag.key):\(tag.value)")
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+}

--- a/Datadog/E2ETests/Logging/LoggingConfigurationE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggingConfigurationE2ETests.swift
@@ -1,0 +1,64 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+import DatadogCrashReporting
+
+class LoggingConfigurationE2ETests: E2ETests {
+    private var logger: Logger!
+
+    override func setUp() {
+        skipSDKInitialization = true // we will initialize it in each test
+        super.setUp()
+    }
+
+    override func tearDown() {
+        logger = nil
+        super.tearDown()
+    }
+
+    /// - api-surface: Datadog.Configuration.Builder.enableLogging(_ enabled: Bool) -> Builder
+    func test_logs_config_feature_enabled() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(
+                trackingConsent: .granted,
+                configuration: .builderUsingE2EConfig()
+                    .enableLogging(true)
+                    .enableTracing(true)
+                    .enableRUM(true)
+                    .enableCrashReporting(using: DDCrashReportingPlugin())
+                    .build()
+            )
+        }
+
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Datadog.Configuration.Builder.enableLogging(_ enabled: Bool) -> Builder
+    func test_logs_config_feature_disabled() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(
+                trackingConsent: .granted,
+                configuration: .builderUsingE2EConfig()
+                    .enableLogging(false)
+                    .enableTracing(true)
+                    .enableRUM(true)
+                    .enableCrashReporting(using: DDCrashReportingPlugin())
+                    .build()
+            )
+        }
+
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+}

--- a/Datadog/E2ETests/Logging/LoggingTrackingConsentE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggingTrackingConsentE2ETests.swift
@@ -1,0 +1,153 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+class LoggingTrackingConsentE2ETests: E2ETests {
+    private var logger: Logger!
+
+    override func setUp() {
+        skipSDKInitialization = true // we will initialize it in each test
+        super.setUp()
+    }
+
+    override func tearDown() {
+        logger = nil
+        super.tearDown()
+    }
+
+    // MARK: - Starting With a Consent
+
+    /// - api-surface: Datadog.initialize(appContext: AppContext,trackingConsent: TrackingConsent,configuration: Configuration)
+    /// - api-surface: TrackingConsent.granted
+    func test_logs_config_consent_GRANTED() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(trackingConsent: .granted)
+        }
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Datadog.initialize(appContext: AppContext,trackingConsent: TrackingConsent,configuration: Configuration)
+    /// - api-surface: TrackingConsent.notGranted
+    func test_logs_config_consent_NOT_GRANTED() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(trackingConsent: .notGranted)
+        }
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Datadog.initialize(appContext: AppContext,trackingConsent: TrackingConsent,configuration: Configuration)
+    /// - api-surface: TrackingConsent.pending
+    func test_logs_config_consent_PENDING() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(trackingConsent: .pending)
+        }
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    // MARK: - Changing Consent
+
+    /// - api-surface: Datadog.set(trackingConsent: TrackingConsent)
+    func test_logs_config_consent_GRANTED_to_NOT_GRANTED() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(trackingConsent: .granted)
+        }
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+            Datadog.set(trackingConsent: .notGranted)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Datadog.set(trackingConsent: TrackingConsent)
+    func test_logs_config_consent_GRANTED_to_PENDING() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(trackingConsent: .granted)
+        }
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+            Datadog.set(trackingConsent: .pending)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Datadog.set(trackingConsent: TrackingConsent)
+    func test_logs_config_consent_NOT_GRANTED_to_GRANTED() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(trackingConsent: .notGranted)
+        }
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+            Datadog.set(trackingConsent: .granted)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Datadog.set(trackingConsent: TrackingConsent)
+    func test_logs_config_consent_NOT_GRANTED_to_PENDING() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(trackingConsent: .notGranted)
+        }
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+            Datadog.set(trackingConsent: .pending)
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+    }
+
+    /// - api-surface: Datadog.set(trackingConsent: TrackingConsent)
+    func test_logs_config_consent_PENDING_to_GRANTED() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(trackingConsent: .pending)
+        }
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+
+        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+            Datadog.set(trackingConsent: .granted)
+        }
+    }
+
+    /// - api-surface: Datadog.set(trackingConsent: TrackingConsent)
+    func test_logs_config_consent_PENDING_to_NOT_GRANTED() {
+        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(trackingConsent: .pending)
+        }
+        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+            logger = Logger.builder.build()
+        }
+
+        logger.sendRandomLog(with: DD.logAttributes())
+
+        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+            Datadog.set(trackingConsent: .notGranted)
+        }
+    }
+}

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -311,7 +311,9 @@ public class Datadog {
         RUMAutoInstrumentation.instance?.deinitialize()
         URLSessionAutoInstrumentation.instance?.deinitialize()
 
-        // Deinitialize Crash Reporter managed internally by the SDK
+        // Reset Globals:
+        Global.sharedTracer = DDNoopGlobals.tracer
+        Global.rum = DDNoopRUMMonitor()
         Global.crashReporter = nil
 
         // Deinitialize `Datadog`:

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -128,7 +128,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
     /// Attributes associated with every command.
     private var rumAttributes: [AttributeKey: AttributeValue] = [:]
     /// Queue for processing RUM commands off the main thread and providing current RUM context.
-    internal let queue = DispatchQueue(
+    private let queue = DispatchQueue(
         label: "com.datadoghq.rum-monitor",
         target: .global(qos: .userInteractive)
     )
@@ -625,4 +625,11 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
 
         return mutableCommand
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    /// Blocks the caller thread until (asynchronous) command processing in `RUMMonitor` is completed.
+    public func flush() {
+        queue.sync {}
+    }
+#endif
 }

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -199,7 +199,11 @@ extension Int: AnyMockable, RandomMockable {
     }
 
     static func mockRandom() -> Int {
-        return .random(in: Int.min...Int.max)
+        return mockRandom(min: .min, max: .max)
+    }
+
+    static func mockRandom(min: Int, max: Int) -> Int {
+        return .random(in: min...max)
     }
 }
 
@@ -236,7 +240,11 @@ extension Double: AnyMockable, RandomMockable {
     }
 
     static func mockRandom() -> Double {
-        return Double.random(in: 0..<Double.greatestFiniteMagnitude)
+        return mockRandom(min: 0, max: .greatestFiniteMagnitude)
+    }
+
+    static func mockRandom(min: Double, max: Double) -> Double {
+        return .random(in: min...max)
     }
 }
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -869,15 +869,15 @@ class RUMMonitorTests: XCTestCase {
         // When
         monitor.startView(viewController: mockView, name: "view in `.pending` consent changed to `.granted`")
         monitor.stopView(viewController: mockView)
-        monitor.dd.queue.sync {} // wait for processing the event in `RUMMonitor`
+        monitor.dd.flush()
         consentProvider.changeConsent(to: .granted)
         monitor.startView(viewController: mockView, name: "view in `.granted` consent")
         monitor.stopView(viewController: mockView)
-        monitor.dd.queue.sync {}
+        monitor.dd.flush()
         consentProvider.changeConsent(to: .notGranted)
         monitor.startView(viewController: mockView, name: "view in `.notGranted` consent")
         monitor.stopView(viewController: mockView)
-        monitor.dd.queue.sync {}
+        monitor.dd.flush()
         consentProvider.changeConsent(to: .granted)
         monitor.startView(viewController: mockView, name: "another view in `.granted` consent")
         monitor.stopView(viewController: mockView)
@@ -1162,20 +1162,17 @@ class RUMMonitorTests: XCTestCase {
         defer { Global.rum = DDNoopRUMMonitor() }
 
         let monitor = Global.rum.dd
-        monitor.queue.sync {
-            XCTAssertNil(monitor.debugging)
-        }
+        monitor.flush()
+        XCTAssertNil(monitor.debugging)
 
         // when & then
         Datadog.debugRUM = true
-        monitor.queue.sync {
-            XCTAssertNotNil(monitor.debugging)
-        }
+        monitor.flush()
+        XCTAssertNotNil(monitor.debugging)
 
         Datadog.debugRUM = false
-        monitor.queue.sync {
-            XCTAssertNil(monitor.debugging)
-        }
+        monitor.flush()
+        XCTAssertNil(monitor.debugging)
 
         Datadog.flushAndDeinitialize()
     }


### PR DESCRIPTION
### What and why?

📦 This PR adds E2E tests for Logging feature.

These tests will be run in nightly CI job, sending data to _"Mobile - Integration"_ org. The org will be configured with a bunch of monitors asserting events volume, consistency and performance.

### How?

`E2ETests` is a base class for all E2E tests. It performs common things:
* starting SDK,
* measuring performance,
* stopping SDK with waiting for all data upload.

`E2EUtils` is a helper structure used to produce attributes, tags and span names expected by monitors in MI org. Most of the test-monitor contracts are laid out there, which gives a good place for documenting E2E tests system in the code.


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
