### PR TITLE
RUMM-1384: Specify min OS supported version in the RUM docs

### DIFF
--- a/docs/rum_collection.md
+++ b/docs/rum_collection.md
@@ -6,6 +6,8 @@ Send [Real User Monitoring data][1] to Datadog from your iOS applications with [
 * Understand which resources are the slowest.
 * Analyze errors by OS and device type.
 
+**Minimum iOS version**: Datadog SDK for iOS supports iOS v11+.
+
 ## Setup
 
 1. Declare the library as a dependency, depending on your package manager. See Datadog's [Releases page][3] for the latest beta version.


### PR DESCRIPTION
### What and why?

Similar to https://github.com/DataDog/dd-sdk-android/pull/615, this change specifies min OS supported version in the RUM docs.