### PR TITLE
Update to version 0.8.1 of testing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: dependencies xcodeproj-httpservermock templates
 
 # The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
-DD_SDK_SWIFT_TESTING_VERSION = 0.8.0
+DD_SDK_SWIFT_TESTING_VERSION = 0.8.1
 
 define DD_SDK_TESTING_XCCONFIG_CI
 FRAMEWORK_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n


### PR DESCRIPTION
### What and why?

Update to version 0.8.1 of testing framework. It solves an issue with tests that could be reported as child of another tests and were not correctly reported in the dashboard

### How?

Changed version in the makefile
