### PR TITLE
RUMM-1276 VitalCPUReader is implemented

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -457,6 +457,8 @@
 		9E68FB55244707FD0013A8AA /* ObjcExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E68FB53244707FD0013A8AA /* ObjcExceptionHandler.m */; };
 		9E68FB56244707FD0013A8AA /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9E989A4225F640D100235FC3 /* AppStateListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E989A4125F640D100235FC3 /* AppStateListenerTests.swift */; };
+		9EC8B5DA2668197B000F7529 /* VitalCPUReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC8B5D92668197B000F7529 /* VitalCPUReader.swift */; };
+		9EC8B5EE2668E4DB000F7529 /* VitalCPUReaderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC8B5ED2668E4DB000F7529 /* VitalCPUReaderTest.swift */; };
 		9ED6A6B425F2901800CB2E29 /* AppStateListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */; };
 		9EE5AD8226205B82001E699E /* DDNSURLSessionDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE5AD8126205B82001E699E /* DDNSURLSessionDelegateTests.swift */; };
 		9EEA4871258B76A100EBDA9D /* Global+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEA4870258B76A100EBDA9D /* Global+objc.swift */; };
@@ -1068,6 +1070,8 @@
 		9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjcExceptionHandler.h; sourceTree = "<group>"; };
 		9E989A4125F640D100235FC3 /* AppStateListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateListenerTests.swift; sourceTree = "<group>"; };
 		9E9EB37624468CE90002C80B /* Datadog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Datadog.modulemap; sourceTree = "<group>"; };
+		9EC8B5D92668197B000F7529 /* VitalCPUReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalCPUReader.swift; sourceTree = "<group>"; };
+		9EC8B5ED2668E4DB000F7529 /* VitalCPUReaderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalCPUReaderTest.swift; sourceTree = "<group>"; };
 		9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateListener.swift; sourceTree = "<group>"; };
 		9EE5AD8126205B82001E699E /* DDNSURLSessionDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNSURLSessionDelegateTests.swift; sourceTree = "<group>"; };
 		9EEA4870258B76A100EBDA9D /* Global+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Global+objc.swift"; sourceTree = "<group>"; };
@@ -3059,6 +3063,7 @@
 		B3FC3C0426526EE900DEED9E /* RUMVitals */ = {
 			isa = PBXGroup;
 			children = (
+				9EC8B5D92668197B000F7529 /* VitalCPUReader.swift */,
 				B3BBBCB0265E71C600943419 /* VitalMemoryReader.swift */,
 				B3BBBCB1265E71C600943419 /* VitalReader.swift */,
 				B3FC3C0626526EFF00DEED9E /* VitalInfo.swift */,
@@ -3071,6 +3076,7 @@
 		B3FC3C1226526F4100DEED9E /* RUMVitals */ = {
 			isa = PBXGroup;
 			children = (
+				9EC8B5ED2668E4DB000F7529 /* VitalCPUReaderTest.swift */,
 				B3BBBCBB265E71D100943419 /* VitalMemoryReaderTest.swift */,
 				B3FC3C3B2653A97700DEED9E /* VitalObserverTest.swift */,
 			);
@@ -3685,6 +3691,7 @@
 				6161247925CA9CA6009901BE /* CrashReporter.swift in Sources */,
 				61133BE62423979B00786299 /* LogSanitizer.swift in Sources */,
 				615F197C25B5A64B00BE14B5 /* UIKitExtensions.swift in Sources */,
+				9EC8B5DA2668197B000F7529 /* VitalCPUReader.swift in Sources */,
 				614D812C24E3EA15004C9C5D /* Feature.swift in Sources */,
 				613E792F2577B0F900DFCC17 /* Reader.swift in Sources */,
 				61B0385A2527247000518F3C /* DDURLSessionDelegate.swift in Sources */,
@@ -3908,6 +3915,7 @@
 				61B0387B252724AB00518F3C /* URLSessionTracingHandlerTests.swift in Sources */,
 				611529AE25E3E429004F740E /* ValuePublisherTests.swift in Sources */,
 				61133C4D2423990D00786299 /* CoreTelephonyMocks.swift in Sources */,
+				9EC8B5EE2668E4DB000F7529 /* VitalCPUReaderTest.swift in Sources */,
 				6115299725E3BEF9004F740E /* UIKitExtensionsTests.swift in Sources */,
 				614B0A4D24EBD71500A2A780 /* RUMUserInfoProviderTests.swift in Sources */,
 				9EF963E82537556300235F98 /* DDURLSessionDelegateAsSuperclassTests.swift in Sources */,

--- a/Sources/Datadog/RUM/RUMVitals/VitalCPUReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalCPUReader.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// A class reading the CPU ticks (_1 second = 600 ticks_) since the start of the process.
+internal class VitalCPUReader: VitalReader {
+    /// host_cpu_load_info_count is 4 (tested in iOS 14.4)
+    private static let host_cpu_load_info_count = MemoryLayout<host_cpu_load_info>.stride / MemoryLayout<integer_t>.stride
+
+    func readVitalData() -> Double? {
+        // it must be set to host_cpu_load_info_count_size >= host_cpu_load_info_count
+        // implementation: https://github.com/opensource-apple/xnu/blob/master/osfmk/kern/host.c#L425
+        var host_cpu_load_info_count_size = mach_msg_type_number_t(Self.host_cpu_load_info_count)
+        var cpuLoadInfo = host_cpu_load_info()
+        let result = withUnsafeMutablePointer(to: &cpuLoadInfo) { cpuLoadInfoPtr in
+            cpuLoadInfoPtr.withMemoryRebound(
+                to: integer_t.self,
+                capacity: Self.host_cpu_load_info_count
+            ) { integerPtr in
+                host_statistics(
+                    mach_host_self(),
+                    HOST_CPU_LOAD_INFO,
+                    integerPtr,
+                    &host_cpu_load_info_count_size
+                )
+            }
+        }
+        if result != KERN_SUCCESS {
+            return nil
+        }
+
+        /*
+         https://github.com/opensource-apple/xnu/blob/master/osfmk/mach/machine.h#L76
+         // machine.h (tested in iOS 14.4)
+         #define CPU_STATE_USER          0
+         #define CPU_STATE_SYSTEM        1
+         #define CPU_STATE_IDLE          2
+         #define CPU_STATE_NICE          3
+         */
+        let userTicks = cpuLoadInfo.cpu_ticks.0
+        // systemTicks is always 0 (tested in iOS 14.4)
+        let systemTicks = cpuLoadInfo.cpu_ticks.1
+
+        /*
+         cpu_ticks returns UInt32.
+         Double type has enough precision within the range of UInt32;
+         therefore even at the worst-case, precision isn't lost during this conversion below.
+         */
+        return Double(userTicks + systemTicks)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalCPUReaderTest.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalCPUReaderTest.swift
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class VitalCPUReaderTest: XCTestCase {
+    let cpuReader = VitalCPUReader()
+
+    func testWhenCPUUnderHeavyLoad() throws {
+        let lowLoadAverage = try averageCPUTicks {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        let highLoadAverage = try averageCPUTicks {
+            var bigFloatingPoint = Double.greatestFiniteMagnitude
+            for _ in 0...1_000 {
+                bigFloatingPoint.formSquareRoot()
+            }
+        }
+
+        // TODO: RUMM-1276 highLoadAverage sometimes becomes 0.0,
+        // PR will stay as draft until fixing this
+        XCTAssertGreaterThan(highLoadAverage, lowLoadAverage)
+    }
+
+    private func averageCPUTicks(with block: () -> Void) throws -> Double {
+        let startDate = Date()
+
+        let startCPUTicks = try XCTUnwrap(cpuReader.readVitalData())
+        block()
+        let endCPUTicks = try XCTUnwrap(cpuReader.readVitalData())
+        let duration = Date().timeIntervalSince(startDate)
+
+        let averageCPUTicks = (endCPUTicks - startCPUTicks) / duration
+
+        return averageCPUTicks
+    }
+}


### PR DESCRIPTION
### What and why?

`VitalCPUReader` is implemented in order to measure CPU utilization of the app.

### How?

`host_statistics(...)` method with `HOST_CPU_LOAD_INFO` parameter returns CPU utilization data from the kernel.
This low-level API requires working with pointers and type conversions; however
1. there is no higher level API to get such information
2. as this is the kernel, hopefully it's likely that they don't change often.

### TODO

- [x] ~`testWhenCPUUnderHeavyLoad` test case fails quite often, this must be fixed first~ kernel fails to report too small intervals, for loop counts increased.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
