### PR TITLE
RUMM-1421 Use XHR by default instead of Unknown for RUM Resources

### DIFF
--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -54,10 +54,10 @@ internal extension RUMResourceType {
             case ("font", _): self = .font
             case ("text", "css"): self = .css
             case ("text", "javascript"): self = .js
-            default: self = .other
+            default: self = .xhr
             }
         } else {
-            self = .other
+            self = .xhr
         }
     }
 }
@@ -464,7 +464,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
             resourceKind = RUMResourceType(response: response)
             statusCode = response.statusCode
         } else {
-            resourceKind = .other
+            resourceKind = .xhr
         }
 
         process(

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1356,9 +1356,9 @@ class RUMResourceKindTests: XCTestCase {
         )
     }
 
-    func testWhenInitializingFromHTTPURLResponse_itDefaultsToOther() {
+    func testWhenInitializingFromHTTPURLResponse_itDefaultsToXhr() {
         XCTAssertEqual(
-            RUMResourceType(response: .mockWith(mimeType: "unknown/type")), .other
+            RUMResourceType(response: .mockWith(mimeType: "unknown/type")), .xhr
         )
     }
 }


### PR DESCRIPTION
## What does this PR do?

Use XHR by default instead of Unknown for RUM Resources

## Motivation

When we are unable to detect the resource type, we're going to use XHR by default instead of unknown to ensure the resource can have a backend trace attached to it.