### PR TITLE
RUMM-1057: Sanitize custom timings

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -320,7 +320,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 cpuTicksPerSecond: nil,
                 crash: nil,
                 cumulativeLayoutShift: nil,
-                customTimings: customTimings,
+                customTimings: customTimings.reduce(into: [:]) { acc, element in
+                    acc[sanitizeCustomTimingName(customTiming: element.key)] = element.value
+                },
                 domComplete: nil,
                 domContentLoaded: nil,
                 domInteractive: nil,
@@ -394,5 +396,19 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             return true
         }
         return false
+    }
+
+    private func sanitizeCustomTimingName(customTiming: String) -> String {
+        let sanitized = customTiming.replacingOccurrences(of: "[^a-zA-Z0-9_.@$-]", with: "_", options: .regularExpression)
+
+        if customTiming != sanitized {
+            userLogger.warn(
+                """
+                Custom timing '\(customTiming)' was modified to '\(sanitized)' to match Datadog constraints.
+                """
+            )
+        }
+
+        return sanitized
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -775,12 +775,14 @@ class RUMMonitorTests: XCTestCase {
         monitor.startView(viewController: mockView)
         monitor.addTiming(name: "timing1")
         monitor.addTiming(name: "timing2")
+        monitor.addTiming(name: "timing3_.@$-()&+=Д")
 
         let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
         verifyGlobalAttributes(in: rumEventMatchers)
         let lastViewUpdate = try rumEventMatchers.lastRUMEvent(ofType: RUMViewEvent.self)
         XCTAssertEqual(try lastViewUpdate.timing(named: "timing1"), 1_000_000_000)
         XCTAssertEqual(try lastViewUpdate.timing(named: "timing2"), 2_000_000_000)
+        XCTAssertEqual(try lastViewUpdate.timing(named: "timing3_.@$-______"), 3_000_000_000)
     }
 
     // MARK: - RUM Events Dates Correction


### PR DESCRIPTION
### What and why?

Follow-up on https://github.com/DataDog/dd-sdk-android/pull/504 - the same sanitization of custom timings, but in iOS SDK.

### How?

This change adds sanitization of names in `custom_timings` per defined characters set.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
