### PR TITLE
RUMM-1434 read resource span_id and trace_id from attributes

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -112,6 +112,10 @@ internal class RUMResourceScope: RUMScope {
         let resourceDuration: TimeInterval
         let size: Int64?
 
+        // Check trace attributes
+        let traceId = (attributes.removeValue(forKey: "_dd.trace_id") as? String) ?? spanContext?.traceID
+        let spanId = (attributes.removeValue(forKey: "_dd.span_id") as? String) ?? spanContext?.spanID
+
         /// Metrics values take precedence over other values.
         if let metrics = resourceMetrics {
             resourceStartTime = metrics.fetch.start
@@ -126,8 +130,8 @@ internal class RUMResourceScope: RUMScope {
 
         let eventData = RUMResourceEvent(
             dd: .init(
-                spanId: spanContext?.spanID,
-                traceId: spanContext?.traceID
+                spanId: spanId,
+                traceId: traceId
             ),
             action: context.activeUserActionID.flatMap { rumUUID in
                 .init(id: rumUUID.toRUMDataFormat)


### PR DESCRIPTION
### What and why?

Cross platform sdks will generate the resource's span_id and trace_id on their side and forward the attributes as `_dd.span_id` and `_dd.trace_id` respectively. This PR reads those value and store them in the relevant place.


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
