### PR TITLE
RUMM-1467 Update dogfooding script for recent changes in other repos

### DIFF
--- a/tools/dogfooding/src/package_resolved.py
+++ b/tools/dogfooding/src/package_resolved.py
@@ -64,11 +64,11 @@ class PackageResolvedFile:
         diff = old_state.items() ^ new_state.items()
 
         if len(diff) > 0:
-            print(f'✏️️ Updated "{package_name}":')
+            print(f'✏️️ Updated "{package_name}" in {self.path}:')
             print(f'    → old: {old_state}')
             print(f'    → new: {new_state}')
         else:
-            print(f'✏️️ "{package_name}" is up-to-date')
+            print(f'✏️️ "{package_name}" is up-to-date in {self.path}')
 
     def add_dependency(self, package_name: str, repository_url: str, branch: str, revision: str, version):
         """
@@ -105,7 +105,7 @@ class PackageResolvedFile:
 
         pins.insert(index, new_pin)
 
-        print(f'✏️️ Added "{package_name}" at index {index}:')
+        print(f'✏️️ Added "{package_name}" at index {index} in {self.path}:')
         print(f'    → branch: {branch}')
         print(f'    → revision: {revision}')
         print(f'    → version: {version}')


### PR DESCRIPTION
### What and why?

⚙️ This PR updates dogfooding script for recent changes made in Datadog iOS app repo. Now the repo uses code-generated `.package.resolved` file, instead of one managed by Xcode.

### How?

Just changed the `paths` logic in `dogfooding.py`. Now it is able to modify multiple `Package.resolved` files as that's the setup currently used in mobile app repo.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
