### PR TITLE
Add support for DatadogSDKTesting to DatadogCrashReportingTests

### DIFF
--- a/Datadog/TargetSupport/DatadogCrashReportingTests/DatadogCrashReportingTests.xcconfig
+++ b/Datadog/TargetSupport/DatadogCrashReportingTests/DatadogCrashReportingTests.xcconfig
@@ -1,11 +1,7 @@
 // Add common settings from Datadog.xcconfig
 #include "../xcconfigs/Datadog.xcconfig"
 
-// Add DatadogSDKTesting instrumentation (if available in current environment)
-//#include "../xcconfigs/DatadogSDKTesting.local.xcconfig"
-//
-// Note: The 'DatadogSDKTesting' instrumentation is temporarily disabled as it causes issues in 'DatadogCrashReportingTests'.
-//       Both 'DatadogSDKTesting' and 'DatadogCrashReporting' link PLCR dependency statically, resulting with these runtime warnings:
+// Both 'DatadogSDKTesting' and 'DatadogCrashReporting' link PLCR dependency statically, resulting with these runtime warnings:
 //
 //       """
 //       objc[50310]: Class PLCrashReportThreadInfo is implemented in both
@@ -15,5 +11,11 @@
 //       One of the two will be used. Which one is undefined.
 //       """
 //
-//       Because some mocks in 'DatadogCrashReportingTests' use PLCR type's subclassing, their runtime cast with 'as? <PLCR_TYPE>' fails
-//       resulting with tests failures. Until a workaround or a better solution is found, this instrumentation must be disabled.
+//       Because some mocks in 'DatadogCrashReportingTests' use PLCR type's subclassing, their runtime cast with 'as? <PLCR_TYPE>' could fail depending in which library is found first
+// We force 'DatadogCrashReporting' to be linked before linking 'DatadogSDKTesting' so PLCR symbols are found in that library.
+OTHER_LDFLAGS= $(inherited) -framework DatadogCrashReporting
+
+// Add DatadogSDKTesting instrumentation (if available in current environment)
+ #include "../xcconfigs/DatadogSDKTesting.local.xcconfig"
+
+

--- a/Datadog/TargetSupport/DatadogCrashReportingTests/DatadogCrashReportingTests.xcconfig
+++ b/Datadog/TargetSupport/DatadogCrashReportingTests/DatadogCrashReportingTests.xcconfig
@@ -16,6 +16,6 @@
 OTHER_LDFLAGS= $(inherited) -framework DatadogCrashReporting
 
 // Add DatadogSDKTesting instrumentation (if available in current environment)
- #include "../xcconfigs/DatadogSDKTesting.local.xcconfig"
+ #include? "../xcconfigs/DatadogSDKTesting.local.xcconfig"
 
 


### PR DESCRIPTION
### What and why?
`PLCrashReporter` symbols are duplicated both in `DatadogCrashReporting` and `DatadogSDKTesting`, this was producing, apart from warnings, that `PLCR`symbols were found in the `DatadogSDKTesting` framework which made the test fail. The reason for that is because `DatadogSDKTesting` framework was being linked first, as its liking was configured in the `.xcconfig` file and the `DatadogCrashReporting` linking was added later in the Build phase.

### How?

We add the linking with the `DatadogCrashReporting` framework before the linking with `DatadogSDKTesting`, which makes the linker find its symbols as expected

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
