### PR TITLE
RUMM-1492 isSystemImage property was wrong in simulator

### DIFF
--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReport.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReport.swift
@@ -241,7 +241,8 @@ extension BinaryImageInfo {
 
         self.uuid = imageUUID
         self.imageName = URL(string: imagePath)?.lastPathComponent
-        self.isSystemImage = !imagePath.contains("/Bundle/Application/")
+        // NOTE: RUMM-1492 refer to JIRA ticket or `CrashReportTests.swift` to see imagePath examples
+        self.isSystemImage = !imagePath.contains("/Bundle/Application/") || imagePath.contains("/Contents/Developer/Platforms/")
 
         if let codeType = imageInfo.codeType {
             self.codeType = CodeType(from: codeType)

--- a/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/CrashReportTests.swift
+++ b/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/CrashReportTests.swift
@@ -220,8 +220,20 @@ class CrashReportTests: XCTestCase {
         }
 
         // Given
-        let systemImagePath: URL = .mockRandomPath()
-        let userImagePath: URL = .mockRandomPath(containing: ["Bundle", "Application"])
+        let systemImagePathString = [
+            "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+            "/usr/lib/system/libdyld.dylib",
+            "/Users/john.appleseed/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+        ].randomElement()!
+        let systemImagePath = URL(string: systemImagePathString)!
+
+        let userImagePathString = [
+            "/private/var/containers/Bundle/Application/0000/Example.app/Example",
+            "/private/var/containers/Bundle/Application/0000/Example.app/Frameworks/DatadogCrashReporting.framework/DatadogCrashReporting",
+            "/Users/john.appleseed/Library/Developer/CoreSimulator/Devices/0000/data/Containers/Bundle/Application/0000/Example.app/Example",
+            "/Users/john.appleseed/Library/Developer/Xcode/DerivedData/Datadog-abcd/Build/Products/Release-iphonesimulator/DatadogCrashReporting.framework/DatadogCrashReporting"
+        ].randomElement()!
+        let userImagePath = URL(string: userImagePathString)!
 
         let mockSystemImage = mock(with: systemImagePath)
         let mockUserImage = mock(with: userImagePath)
@@ -233,14 +245,14 @@ class CrashReportTests: XCTestCase {
         // Then
         XCTAssertEqual(systemBinaryImageInfo.uuid, mockSystemImage.mockImageUUID)
         XCTAssertEqual(systemBinaryImageInfo.imageName, systemImagePath.lastPathComponent)
-        XCTAssertTrue(systemBinaryImageInfo.isSystemImage)
+        XCTAssertTrue(systemBinaryImageInfo.isSystemImage, "\(systemImagePath) is a system image")
         XCTAssertEqual(systemBinaryImageInfo.imageBaseAddress, mockSystemImage.mockImageBaseAddress)
         XCTAssertEqual(systemBinaryImageInfo.imageSize, mockSystemImage.mockImageSize)
         XCTAssertEqual(systemBinaryImageInfo.codeType?.architectureName, "x86_64")
 
         XCTAssertEqual(userBinaryImageInfo.uuid, mockUserImage.mockImageUUID)
         XCTAssertEqual(userBinaryImageInfo.imageName, userImagePath.lastPathComponent)
-        XCTAssertFalse(userBinaryImageInfo.isSystemImage)
+        XCTAssertFalse(userBinaryImageInfo.isSystemImage, "\(userImagePath) is a user image")
         XCTAssertEqual(userBinaryImageInfo.imageBaseAddress, mockUserImage.mockImageBaseAddress)
         XCTAssertEqual(userBinaryImageInfo.imageSize, mockUserImage.mockImageSize)
         XCTAssertEqual(userBinaryImageInfo.codeType?.architectureName, "x86_64")


### PR DESCRIPTION
### What and why?

`isSystemImage` property was set by searching for `/Bundle/Application/` in the image paths.
This works well when running the app in devices where image paths can be like the followings:
```
// binaries in the App bundle:
/private/var/containers/Bundle/Application/00...00/Example.app/Example
/private/var/containers/Bundle/Application/00...00/Example.app/Frameworks/DatadogCrashReporting.framework/DatadogCrashReporting

// binaries coming from iOS
/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore
/usr/lib/system/libdyld.dylib
/usr/lib/system/libsystem_kernel.dylib
/usr/lib/system/libsystem_c.dylib
```

However, this check gives wrong results when running in iOS simulator where non-system images do not have to be in the App bundle:
```
// non-system binary
~/Library/Developer/Xcode/DerivedData/Datadog-abcd/Build/Products/Release-iphonesimulator/DatadogCrashReporting.framework/DatadogCrashReporting

// binaries coming from iOS
'~/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
```

### How?

As seen in the examples above, non-system binaries come from `Derived Data` path which is customizable and system binaries come from `{Xcode.app path}/Contents/Developer/Platforms` which is at least fixed.

Therefore I added `Contents/Developer/Platforms` sub-path to our `isSystemImage` detection logic.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
