### PR TITLE
RUMM-1085: Add a warning when action is dropped when another action is still active

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -146,6 +146,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         case let command as RUMStartUserActionCommand where isActiveView:
             if userActionScope == nil {
                 startContinuousUserAction(on: command)
+            } else {
+                reportActionDropped(type: command.actionType, name: command.name)
             }
         case let command as RUMAddUserActionCommand where isActiveView:
             if userActionScope == nil {
@@ -153,6 +155,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             } else if command.actionType == .custom {
                 // still let it go, just instantly without any dependencies
                 sendDiscreteCustomUserAction(on: command)
+            } else {
+                reportActionDropped(type: command.actionType, name: command.name)
             }
 
         // Error command
@@ -260,6 +264,14 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                                     actionType: .custom,
                                     name: nil
             )
+        )
+    }
+
+    private func reportActionDropped(type: RUMUserActionType, name: String) {
+        userLogger.warn(
+            """
+            RUM Action '\(type)' on '\(name)' was dropped, because another action is still active for the same view.
+            """
         )
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -433,6 +433,10 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: Date()
         )
+
+        let logOutput = LogOutputMock()
+        userLogger = .mockWith(logOutput: logOutput)
+
         XCTAssertTrue(
             scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
         )
@@ -445,10 +449,17 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertNotNil(scope.userActionScope)
         XCTAssertEqual(scope.userActionScope?.name, actionName)
 
+        let secondAction = RUMStartUserActionCommand.mockWith(actionType: .swipe, name: .mockRandom())
         XCTAssertTrue(
-            scope.process(command: RUMStartUserActionCommand.mockWith(actionType: .swipe, name: .mockRandom()))
+            scope.process(command: secondAction)
         )
         XCTAssertEqual(scope.userActionScope?.name, actionName, "View should ignore the next (only non-custom) UA if one is pending.")
+        XCTAssertEqual(
+            logOutput.recordedLog?.message,
+            """
+            RUM Action '\(secondAction.actionType)' on '\(secondAction.name)' was dropped, because another action is still active for the same view.
+            """
+        )
 
         XCTAssertTrue(
             scope.process(command: RUMAddUserActionCommand.mockWith(actionType: .custom, name: .mockRandom()))
@@ -479,6 +490,10 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime
         )
+
+        let logOutput = LogOutputMock()
+        userLogger = .mockWith(logOutput: logOutput)
+
         XCTAssertTrue(
             scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: mockView))
         )
@@ -493,10 +508,17 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertNotNil(scope.userActionScope)
         XCTAssertEqual(scope.userActionScope?.name, actionName)
 
+        let secondAction = RUMAddUserActionCommand.mockWith(time: currentTime, actionType: .tap, name: .mockRandom())
         XCTAssertTrue(
-            scope.process(command: RUMAddUserActionCommand.mockWith(time: currentTime, actionType: .tap, name: .mockRandom()))
+            scope.process(command: secondAction)
         )
         XCTAssertEqual(scope.userActionScope?.name, actionName, "View should ignore the next (only non-custom) UA if one is pending.")
+        XCTAssertEqual(
+            logOutput.recordedLog?.message,
+            """
+            RUM Action '\(secondAction.actionType)' on '\(secondAction.name)' was dropped, because another action is still active for the same view.
+            """
+        )
 
         XCTAssertTrue(
             scope.process(command: RUMAddUserActionCommand.mockWith(actionType: .custom, name: .mockRandom()))


### PR DESCRIPTION
### What and why?

Mirror of the change https://github.com/DataDog/dd-sdk-android/pull/503 done for Android SDK earlier. This change add a warning if action is dropped when another action is still active in the given view scope.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
