### PR TITLE
RUMM-728: Add a warning when event is received, but there is no active view scope

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -118,7 +118,17 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         }
 
         // Propagate command
-        viewScopes = manage(childScopes: viewScopes, byPropagatingCommand: command)
+        if !viewScopes.isEmpty {
+            viewScopes = manage(childScopes: viewScopes, byPropagatingCommand: command)
+        } else {
+            userLogger.warn(
+                """
+                \(String(describing: command)) was detected, but no view is active. To track views automatically, try calling the
+                DatadogConfiguration.Builder.trackUIKitRUMViews() method. You can also track views manually using
+                the RumMonitor.startView() and RumMonitor.stopView() methods.
+                """
+            )
+        }
 
         return true
     }


### PR DESCRIPTION
### What and why?

Mirror of the change https://github.com/DataDog/dd-sdk-android/pull/375 done in Android SDK before: it adds a warning if there is no view scope active when any event other than events which create view scopes is received.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
