### PR TITLE
RUMM-1467 Remove deprecation warnings when compiling the SDK code

### DIFF
--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -114,15 +114,12 @@ extension Datadog {
             case us1_fed
             /// US based servers.
             /// Sends logs to [app.datadoghq.com](https://app.datadoghq.com/).
-            @available(*, deprecated, message: "Renamed to us1")
             case us
             /// Europe based servers.
             /// Sends logs to [app.datadoghq.eu](https://app.datadoghq.eu/).
-            @available(*, deprecated, message: "Renamed to eu1")
             case eu
             /// Gov servers.
             /// Sends logs to [app.ddog-gov.com](https://app.ddog-gov.com/).
-            @available(*, deprecated, message: "Renamed to us1_fed")
             case gov
             /// User-defined server.
             case custom(url: String)
@@ -157,15 +154,12 @@ extension Datadog {
             case us1_fed
             /// US based servers.
             /// Sends traces to [app.datadoghq.com](https://app.datadoghq.com/).
-            @available(*, deprecated, message: "Renamed to us1")
             case us
             /// Europe based servers.
             /// Sends traces to [app.datadoghq.eu](https://app.datadoghq.eu/).
-            @available(*, deprecated, message: "Renamed to eu1")
             case eu
             /// Gov servers.
             /// Sends traces to [app.ddog-gov.com](https://app.ddog-gov.com/).
-            @available(*, deprecated, message: "Renamed to us1_fed")
             case gov
             /// User-defined server.
             case custom(url: String)
@@ -200,15 +194,12 @@ extension Datadog {
             case us1_fed
             /// US based servers.
             /// Sends RUM events to [app.datadoghq.com](https://app.datadoghq.com/).
-            @available(*, deprecated, message: "Renamed to us1")
             case us
             /// Europe based servers.
             /// Sends RUM events to [app.datadoghq.eu](https://app.datadoghq.eu/).
-            @available(*, deprecated, message: "Renamed to eu1")
             case eu
             /// Gov servers.
             /// Sends RUM events to [app.ddog-gov.com](https://app.ddog-gov.com/).
-            @available(*, deprecated, message: "Renamed to us1_fed")
             case gov
             /// User-defined server.
             case custom(url: String)


### PR DESCRIPTION
### What and why?

🧽 This PR cleans up compiler warnings which pop up when compiling the SDK:

<img width="209" alt="Screenshot 2021-08-02 at 12 39 33" src="https://user-images.githubusercontent.com/2358722/127850018-189acfe7-b175-4dc7-ac8f-339813558429.png">

These warnings appear to any user linking the SDK to their project. Their presence is misleading - the user is not using any deprecated API, instead we do it internally in the SDK code. Because the user can't do anything to dismiss it, I'm fixing it in this PR by removing deprecation annotation in these APIs. This operation is safe as explained below.

### How?

These warnings were introduced in https://github.com/DataDog/dd-sdk-ios/pull/523 by marking legacy cases as _deprecated_ in 3 enums:
```swift
public enum LogsEndpoint {
   // ...
}
public enum TracesEndpoint {
   // ...
}
public enum RUMEndpoint {
   // ...
}
```

This isn't required, as those endpoints can only be used in these 3 legacy APIs which (if called) will already emit the deprecation warning:
```swift
@available(*, deprecated, message: "This option is replaced by `set(endpoint:)`. Refer to the new API comment for details.")
public func set(logsEndpoint: LogsEndpoint) -> Builder { /* ... */ }

@available(*, deprecated, message: "This option is replaced by `set(endpoint:)`. Refer to the new API comment for details.")
public func set(tracesEndpoint: TracesEndpoint) -> Builder { /* ... */ }

@available(*, deprecated, message: "This option is replaced by `set(endpoint:)`. Refer to the new API comment for details.")
public func set(rumEndpoint: RUMEndpoint) -> Builder { /* ... */ }
```

All these APIs are already replaced with a single `set(endpoint:)` which receives `DatadogEndpoint` enum.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
