### PR TITLE
DatadogSDKCrashReporting.podspec added

### DIFF
--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+    "Mert Buran" => "mert.buran@datadoghq.com"
   }
 
   s.swift_version      = '5.1'

--- a/DatadogSDK.podspec.src
+++ b/DatadogSDK.podspec.src
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+    "Mert Buran" => "mert.buran@datadoghq.com"
   }
 
   s.swift_version      = '5.1'

--- a/DatadogSDKAlamofireExtension.podspec
+++ b/DatadogSDKAlamofireExtension.podspec
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+    "Mert Buran" => "mert.buran@datadoghq.com"
   }
 
   s.swift_version      = '5.1'

--- a/DatadogSDKAlamofireExtension.podspec.src
+++ b/DatadogSDKAlamofireExtension.podspec.src
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+    "Mert Buran" => "mert.buran@datadoghq.com"
   }
 
   s.swift_version      = '5.1'

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+    "Mert Buran" => "mert.buran@datadoghq.com"
   }
 
   s.swift_version      = '5.1'

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name         = "DatadogSDKCrashReporting"
+  s.module_name  = "DatadogCrashReporting"
+  s.version      = "1.7.0-beta2"
+  s.summary      = "Official Datadog Crash Reporting SDK for iOS."
+  
+  s.homepage     = "https://www.datadoghq.com"
+  s.social_media_url   = "https://twitter.com/datadoghq"
+
+  s.license            = { :type => "Apache", :file => 'LICENSE' }
+  s.authors            = { 
+    "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
+    "Mert Buran" => "mert.buran@datadoghq.com",
+    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+  }
+
+  s.swift_version      = '5.1'
+  s.ios.deployment_target = '11.0'
+
+  s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
+
+  s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
+  s.dependency 'DatadogSDK', '1.7.0-beta2'
+  s.dependency 'PLCrashReporter'
+end

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
   s.dependency 'DatadogSDK', '1.7.0-beta2'
-  s.dependency 'PLCrashReporter'
+  s.dependency 'PLCrashReporter', '~> 1.8.1'
 end

--- a/DatadogSDKCrashReporting.podspec.src
+++ b/DatadogSDKCrashReporting.podspec.src
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name         = "DatadogSDKCrashReporting"
+  s.module_name  = "DatadogCrashReporting"
+  s.version      = "__DATADOG_VERSION__"
+  s.summary      = "Official Datadog Crash Reporting SDK for iOS."
+  
+  s.homepage     = "https://www.datadoghq.com"
+  s.social_media_url   = "https://twitter.com/datadoghq"
+
+  s.license            = { :type => "Apache", :file => 'LICENSE' }
+  s.authors            = { 
+    "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
+    "Mert Buran" => "mert.buran@datadoghq.com",
+    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+  }
+
+  s.swift_version      = '5.1'
+  s.ios.deployment_target = '11.0'
+
+  s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
+
+  s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
+  s.dependency 'DatadogSDK', '__DATADOG_VERSION__'
+  s.dependency 'PLCrashReporter'
+end

--- a/DatadogSDKCrashReporting.podspec.src
+++ b/DatadogSDKCrashReporting.podspec.src
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+    "Mert Buran" => "mert.buran@datadoghq.com"
   }
 
   s.swift_version      = '5.1'

--- a/DatadogSDKCrashReporting.podspec.src
+++ b/DatadogSDKCrashReporting.podspec.src
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
   s.dependency 'DatadogSDK', '__DATADOG_VERSION__'
-  s.dependency 'PLCrashReporter'
+  s.dependency 'PLCrashReporter', '~> 1.8.1'
 end

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+    "Mert Buran" => "mert.buran@datadoghq.com"
   }
 
   s.swift_version      = '5.1'

--- a/DatadogSDKObjc.podspec.src
+++ b/DatadogSDKObjc.podspec.src
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Alexandre Costanza" => "alexandre.costanza@datadoghq.com"
+    "Mert Buran" => "mert.buran@datadoghq.com"
   }
 
   s.swift_version      = '5.1'

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ bump:
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDK.podspec.src > DatadogSDK.podspec; \
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKObjc.podspec.src > DatadogSDKObjc.podspec; \
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKAlamofireExtension.podspec.src > DatadogSDKAlamofireExtension.podspec; \
+		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKCrashReporting.podspec.src > DatadogSDKCrashReporting.podspec; \
 		git add . ; \
 		git commit -m "Bumped version to $$version"; \
 		echo Bumped version to $$version

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3296A07406DE5BB45CA9083E /* libPods-CPProject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E6C42F30EE6D862365BD49E /* libPods-CPProject.a */; };
 		61C363932436318E00C4D4E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363922436318E00C4D4E6 /* AppDelegate.swift */; };
 		61C363952436318E00C4D4E6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363942436318E00C4D4E6 /* SceneDelegate.swift */; };
 		61C363972436318E00C4D4E6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363962436318E00C4D4E6 /* ViewController.swift */; };
@@ -14,7 +15,8 @@
 		61C3639F2436319000C4D4E6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61C3639D2436319000C4D4E6 /* LaunchScreen.storyboard */; };
 		61C363AA2436319000C4D4E6 /* CPProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363A92436319000C4D4E6 /* CPProjectUITests.swift */; };
 		61C364552437568300C4D4E6 /* CPProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C364542437568300C4D4E6 /* CPProjectTests.swift */; };
-		BFBE2FE9FE6CA40F0A6B154A /* Pods_CPProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A18949628C7A45A21789F71F /* Pods_CPProject.framework */; };
+		6E7B73B9F4D7E8A58B086155 /* libPods-CPProjectTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 31E926F4C533D0D1360D5687 /* libPods-CPProjectTests.a */; };
+		8EEE3FE79BFAEBCA3A64D389 /* libPods-CPProjectUITests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 61C1E052B846F0F98C23CAD8 /* libPods-CPProjectUITests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,7 +37,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2E6C42F30EE6D862365BD49E /* libPods-CPProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CPProject.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		31E926F4C533D0D1360D5687 /* libPods-CPProjectTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CPProjectTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5ACCCE7D06C5874130D7D6D4 /* Pods-CPProjectUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectUITests.debug.xcconfig"; path = "Target Support Files/Pods-CPProjectUITests/Pods-CPProjectUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		5AD49F84C2EA2EE5CB99586F /* Pods-CPProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject.debug.xcconfig"; path = "Target Support Files/Pods-CPProject/Pods-CPProject.debug.xcconfig"; sourceTree = "<group>"; };
+		61C1E052B846F0F98C23CAD8 /* libPods-CPProjectUITests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CPProjectUITests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61C3638F2436318E00C4D4E6 /* CPProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CPProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		61C363922436318E00C4D4E6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61C363942436318E00C4D4E6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -51,8 +57,10 @@
 		61C364562437568300C4D4E6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61ED26E42461D29E00752D66 /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		61ED26E52461D29E00752D66 /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
-		A18949628C7A45A21789F71F /* Pods_CPProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9E33ADFE7E2CECC33A07A795 /* Pods-CPProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-CPProjectTests/Pods-CPProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
+		A9A539012CEB94D3DDBEEFAF /* Pods-CPProjectUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectUITests.release.xcconfig"; path = "Target Support Files/Pods-CPProjectUITests/Pods-CPProjectUITests.release.xcconfig"; sourceTree = "<group>"; };
 		C7DE97263B77DC87F0FC27F0 /* Pods-CPProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject.release.xcconfig"; path = "Target Support Files/Pods-CPProject/Pods-CPProject.release.xcconfig"; sourceTree = "<group>"; };
+		E4221836EB9A6AB7B55FCA4E /* Pods-CPProjectTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectTests.release.xcconfig"; path = "Target Support Files/Pods-CPProjectTests/Pods-CPProjectTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,7 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFBE2FE9FE6CA40F0A6B154A /* Pods_CPProject.framework in Frameworks */,
+				3296A07406DE5BB45CA9083E /* libPods-CPProject.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -68,6 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8EEE3FE79BFAEBCA3A64D389 /* libPods-CPProjectUITests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -75,6 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6E7B73B9F4D7E8A58B086155 /* libPods-CPProjectTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,6 +96,10 @@
 			children = (
 				5AD49F84C2EA2EE5CB99586F /* Pods-CPProject.debug.xcconfig */,
 				C7DE97263B77DC87F0FC27F0 /* Pods-CPProject.release.xcconfig */,
+				9E33ADFE7E2CECC33A07A795 /* Pods-CPProjectTests.debug.xcconfig */,
+				E4221836EB9A6AB7B55FCA4E /* Pods-CPProjectTests.release.xcconfig */,
+				5ACCCE7D06C5874130D7D6D4 /* Pods-CPProjectUITests.debug.xcconfig */,
+				A9A539012CEB94D3DDBEEFAF /* Pods-CPProjectUITests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -157,7 +171,9 @@
 		A0508E6A3FA3F45E84391D24 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A18949628C7A45A21789F71F /* Pods_CPProject.framework */,
+				2E6C42F30EE6D862365BD49E /* libPods-CPProject.a */,
+				31E926F4C533D0D1360D5687 /* libPods-CPProjectTests.a */,
+				61C1E052B846F0F98C23CAD8 /* libPods-CPProjectUITests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -173,7 +189,6 @@
 				61C3638B2436318E00C4D4E6 /* Sources */,
 				61C3638C2436318E00C4D4E6 /* Frameworks */,
 				61C3638D2436318E00C4D4E6 /* Resources */,
-				E9D5FEEB347D68D026118CC9 /* [CP] Embed Pods Frameworks */,
 				61C3645E24376AEF00C4D4E6 /* ⚙️ Run linter */,
 			);
 			buildRules = (
@@ -189,6 +204,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 61C363B12436319000C4D4E6 /* Build configuration list for PBXNativeTarget "CPProjectUITests" */;
 			buildPhases = (
+				46BAFB96F3CF8A0594FB8A8D /* [CP] Check Pods Manifest.lock */,
 				61C363A12436319000C4D4E6 /* Sources */,
 				61C363A22436319000C4D4E6 /* Frameworks */,
 				61C363A32436319000C4D4E6 /* Resources */,
@@ -207,6 +223,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 61C3645B2437568300C4D4E6 /* Build configuration list for PBXNativeTarget "CPProjectTests" */;
 			buildPhases = (
+				E0C0BFBDF1EBCFBACB1B053D /* [CP] Check Pods Manifest.lock */,
 				61C3644E2437568300C4D4E6 /* Sources */,
 				61C3644F2437568300C4D4E6 /* Frameworks */,
 				61C364502437568300C4D4E6 /* Resources */,
@@ -291,6 +308,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		46BAFB96F3CF8A0594FB8A8D /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-CPProjectUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		61C3645E24376AEF00C4D4E6 /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -332,21 +371,26 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E9D5FEEB347D68D026118CC9 /* [CP] Embed Pods Frameworks */ = {
+		E0C0BFBDF1EBCFBACB1B053D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-CPProject/Pods-CPProject-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-CPProject/Pods-CPProject-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-CPProjectTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CPProject/Pods-CPProject-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -577,6 +621,7 @@
 		};
 		61C363B22436319000C4D4E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5ACCCE7D06C5874130D7D6D4 /* Pods-CPProjectUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
@@ -600,6 +645,7 @@
 		};
 		61C363B32436319000C4D4E6 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A9A539012CEB94D3DDBEEFAF /* Pods-CPProjectUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
@@ -623,6 +669,7 @@
 		};
 		61C364592437568300C4D4E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9E33ADFE7E2CECC33A07A795 /* Pods-CPProjectTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
@@ -646,6 +693,7 @@
 		};
 		61C3645A2437568300C4D4E6 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E4221836EB9A6AB7B55FCA4E /* Pods-CPProjectTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3296A07406DE5BB45CA9083E /* libPods-CPProject.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2E6C42F30EE6D862365BD49E /* libPods-CPProject.a */; };
 		61C363932436318E00C4D4E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363922436318E00C4D4E6 /* AppDelegate.swift */; };
 		61C363952436318E00C4D4E6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363942436318E00C4D4E6 /* SceneDelegate.swift */; };
 		61C363972436318E00C4D4E6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363962436318E00C4D4E6 /* ViewController.swift */; };
@@ -15,8 +14,9 @@
 		61C3639F2436319000C4D4E6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61C3639D2436319000C4D4E6 /* LaunchScreen.storyboard */; };
 		61C363AA2436319000C4D4E6 /* CPProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363A92436319000C4D4E6 /* CPProjectUITests.swift */; };
 		61C364552437568300C4D4E6 /* CPProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C364542437568300C4D4E6 /* CPProjectTests.swift */; };
-		6E7B73B9F4D7E8A58B086155 /* libPods-CPProjectTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 31E926F4C533D0D1360D5687 /* libPods-CPProjectTests.a */; };
-		8EEE3FE79BFAEBCA3A64D389 /* libPods-CPProjectUITests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 61C1E052B846F0F98C23CAD8 /* libPods-CPProjectUITests.a */; };
+		6A041621927324C2E4FD0D67 /* Pods_CPProjectTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F729D663C57D967288C4441 /* Pods_CPProjectTests.framework */; };
+		7EFE9B5530413599C43DEF11 /* Pods_CPProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 394ABB8D53A46EFC06232B89 /* Pods_CPProject.framework */; };
+		8F6691C65EDD79FE49759F08 /* Pods_CPProjectUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABCC79B30B45CB378F4351A5 /* Pods_CPProjectUITests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,11 +37,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		2E6C42F30EE6D862365BD49E /* libPods-CPProject.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CPProject.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		31E926F4C533D0D1360D5687 /* libPods-CPProjectTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CPProjectTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2F729D663C57D967288C4441 /* Pods_CPProjectTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProjectTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		394ABB8D53A46EFC06232B89 /* Pods_CPProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5ACCCE7D06C5874130D7D6D4 /* Pods-CPProjectUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectUITests.debug.xcconfig"; path = "Target Support Files/Pods-CPProjectUITests/Pods-CPProjectUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		5AD49F84C2EA2EE5CB99586F /* Pods-CPProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject.debug.xcconfig"; path = "Target Support Files/Pods-CPProject/Pods-CPProject.debug.xcconfig"; sourceTree = "<group>"; };
-		61C1E052B846F0F98C23CAD8 /* libPods-CPProjectUITests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CPProjectUITests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61C3638F2436318E00C4D4E6 /* CPProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CPProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		61C363922436318E00C4D4E6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61C363942436318E00C4D4E6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -59,6 +58,7 @@
 		61ED26E52461D29E00752D66 /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
 		9E33ADFE7E2CECC33A07A795 /* Pods-CPProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-CPProjectTests/Pods-CPProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A9A539012CEB94D3DDBEEFAF /* Pods-CPProjectUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectUITests.release.xcconfig"; path = "Target Support Files/Pods-CPProjectUITests/Pods-CPProjectUITests.release.xcconfig"; sourceTree = "<group>"; };
+		ABCC79B30B45CB378F4351A5 /* Pods_CPProjectUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProjectUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7DE97263B77DC87F0FC27F0 /* Pods-CPProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject.release.xcconfig"; path = "Target Support Files/Pods-CPProject/Pods-CPProject.release.xcconfig"; sourceTree = "<group>"; };
 		E4221836EB9A6AB7B55FCA4E /* Pods-CPProjectTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectTests.release.xcconfig"; path = "Target Support Files/Pods-CPProjectTests/Pods-CPProjectTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -68,7 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3296A07406DE5BB45CA9083E /* libPods-CPProject.a in Frameworks */,
+				7EFE9B5530413599C43DEF11 /* Pods_CPProject.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,7 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8EEE3FE79BFAEBCA3A64D389 /* libPods-CPProjectUITests.a in Frameworks */,
+				8F6691C65EDD79FE49759F08 /* Pods_CPProjectUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,7 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6E7B73B9F4D7E8A58B086155 /* libPods-CPProjectTests.a in Frameworks */,
+				6A041621927324C2E4FD0D67 /* Pods_CPProjectTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -171,9 +171,9 @@
 		A0508E6A3FA3F45E84391D24 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				2E6C42F30EE6D862365BD49E /* libPods-CPProject.a */,
-				31E926F4C533D0D1360D5687 /* libPods-CPProjectTests.a */,
-				61C1E052B846F0F98C23CAD8 /* libPods-CPProjectUITests.a */,
+				394ABB8D53A46EFC06232B89 /* Pods_CPProject.framework */,
+				2F729D663C57D967288C4441 /* Pods_CPProjectTests.framework */,
+				ABCC79B30B45CB378F4351A5 /* Pods_CPProjectUITests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -190,6 +190,7 @@
 				61C3638C2436318E00C4D4E6 /* Frameworks */,
 				61C3638D2436318E00C4D4E6 /* Resources */,
 				61C3645E24376AEF00C4D4E6 /* ⚙️ Run linter */,
+				1D03F40EC3476C946BC0FE93 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -308,6 +309,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1D03F40EC3476C946BC0FE93 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CPProject/Pods-CPProject-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CPProject/Pods-CPProject-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CPProject/Pods-CPProject-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		46BAFB96F3CF8A0594FB8A8D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/cocoapods/CPProject.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		531C3FE9C2034D6CA1287A2B /* Pods_CPProject_CPProjectTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E0EA15A59822C848CE2682 /* Pods_CPProject_CPProjectTests.framework */; };
 		61C363932436318E00C4D4E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363922436318E00C4D4E6 /* AppDelegate.swift */; };
 		61C363952436318E00C4D4E6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363942436318E00C4D4E6 /* SceneDelegate.swift */; };
 		61C363972436318E00C4D4E6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363962436318E00C4D4E6 /* ViewController.swift */; };
@@ -14,9 +15,8 @@
 		61C3639F2436319000C4D4E6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61C3639D2436319000C4D4E6 /* LaunchScreen.storyboard */; };
 		61C363AA2436319000C4D4E6 /* CPProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C363A92436319000C4D4E6 /* CPProjectUITests.swift */; };
 		61C364552437568300C4D4E6 /* CPProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C364542437568300C4D4E6 /* CPProjectTests.swift */; };
-		6A041621927324C2E4FD0D67 /* Pods_CPProjectTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F729D663C57D967288C4441 /* Pods_CPProjectTests.framework */; };
 		7EFE9B5530413599C43DEF11 /* Pods_CPProject.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 394ABB8D53A46EFC06232B89 /* Pods_CPProject.framework */; };
-		8F6691C65EDD79FE49759F08 /* Pods_CPProjectUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABCC79B30B45CB378F4351A5 /* Pods_CPProjectUITests.framework */; };
+		8051FF40D3D1CDD4E547A094 /* Pods_CPProject_CPProjectUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16AA6425CE83208EBE1AEF5B /* Pods_CPProject_CPProjectUITests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,7 +37,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		2F729D663C57D967288C4441 /* Pods_CPProjectTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProjectTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		023E9F71B1FFBEAF47AD599B /* Pods-CPProject-CPProjectUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject-CPProjectUITests.debug.xcconfig"; path = "Target Support Files/Pods-CPProject-CPProjectUITests/Pods-CPProject-CPProjectUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		0D9B145559078D7130D6AA72 /* Pods-CPProject-CPProjectTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject-CPProjectTests.release.xcconfig"; path = "Target Support Files/Pods-CPProject-CPProjectTests/Pods-CPProject-CPProjectTests.release.xcconfig"; sourceTree = "<group>"; };
+		16AA6425CE83208EBE1AEF5B /* Pods_CPProject_CPProjectUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProject_CPProjectUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		394ABB8D53A46EFC06232B89 /* Pods_CPProject.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProject.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5ACCCE7D06C5874130D7D6D4 /* Pods-CPProjectUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectUITests.debug.xcconfig"; path = "Target Support Files/Pods-CPProjectUITests/Pods-CPProjectUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		5AD49F84C2EA2EE5CB99586F /* Pods-CPProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject.debug.xcconfig"; path = "Target Support Files/Pods-CPProject/Pods-CPProject.debug.xcconfig"; sourceTree = "<group>"; };
@@ -56,11 +58,13 @@
 		61C364562437568300C4D4E6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61ED26E42461D29E00752D66 /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		61ED26E52461D29E00752D66 /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
+		6C29934101A436B996950B9C /* Pods-CPProject-CPProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject-CPProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-CPProject-CPProjectTests/Pods-CPProject-CPProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
+		93E0EA15A59822C848CE2682 /* Pods_CPProject_CPProjectTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProject_CPProjectTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E33ADFE7E2CECC33A07A795 /* Pods-CPProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectTests.debug.xcconfig"; path = "Target Support Files/Pods-CPProjectTests/Pods-CPProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A9A539012CEB94D3DDBEEFAF /* Pods-CPProjectUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectUITests.release.xcconfig"; path = "Target Support Files/Pods-CPProjectUITests/Pods-CPProjectUITests.release.xcconfig"; sourceTree = "<group>"; };
-		ABCC79B30B45CB378F4351A5 /* Pods_CPProjectUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CPProjectUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7DE97263B77DC87F0FC27F0 /* Pods-CPProject.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject.release.xcconfig"; path = "Target Support Files/Pods-CPProject/Pods-CPProject.release.xcconfig"; sourceTree = "<group>"; };
 		E4221836EB9A6AB7B55FCA4E /* Pods-CPProjectTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProjectTests.release.xcconfig"; path = "Target Support Files/Pods-CPProjectTests/Pods-CPProjectTests.release.xcconfig"; sourceTree = "<group>"; };
+		EB80E12EA30834731C20BC88 /* Pods-CPProject-CPProjectUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPProject-CPProjectUITests.release.xcconfig"; path = "Target Support Files/Pods-CPProject-CPProjectUITests/Pods-CPProject-CPProjectUITests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,7 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8F6691C65EDD79FE49759F08 /* Pods_CPProjectUITests.framework in Frameworks */,
+				8051FF40D3D1CDD4E547A094 /* Pods_CPProject_CPProjectUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,7 +88,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A041621927324C2E4FD0D67 /* Pods_CPProjectTests.framework in Frameworks */,
+				531C3FE9C2034D6CA1287A2B /* Pods_CPProject_CPProjectTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,6 +104,10 @@
 				E4221836EB9A6AB7B55FCA4E /* Pods-CPProjectTests.release.xcconfig */,
 				5ACCCE7D06C5874130D7D6D4 /* Pods-CPProjectUITests.debug.xcconfig */,
 				A9A539012CEB94D3DDBEEFAF /* Pods-CPProjectUITests.release.xcconfig */,
+				6C29934101A436B996950B9C /* Pods-CPProject-CPProjectTests.debug.xcconfig */,
+				0D9B145559078D7130D6AA72 /* Pods-CPProject-CPProjectTests.release.xcconfig */,
+				023E9F71B1FFBEAF47AD599B /* Pods-CPProject-CPProjectUITests.debug.xcconfig */,
+				EB80E12EA30834731C20BC88 /* Pods-CPProject-CPProjectUITests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -172,8 +180,8 @@
 			isa = PBXGroup;
 			children = (
 				394ABB8D53A46EFC06232B89 /* Pods_CPProject.framework */,
-				2F729D663C57D967288C4441 /* Pods_CPProjectTests.framework */,
-				ABCC79B30B45CB378F4351A5 /* Pods_CPProjectUITests.framework */,
+				93E0EA15A59822C848CE2682 /* Pods_CPProject_CPProjectTests.framework */,
+				16AA6425CE83208EBE1AEF5B /* Pods_CPProject_CPProjectUITests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -209,6 +217,7 @@
 				61C363A12436319000C4D4E6 /* Sources */,
 				61C363A22436319000C4D4E6 /* Frameworks */,
 				61C363A32436319000C4D4E6 /* Resources */,
+				567E049B7EEB3FF26416E3A0 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -228,6 +237,7 @@
 				61C3644E2437568300C4D4E6 /* Sources */,
 				61C3644F2437568300C4D4E6 /* Frameworks */,
 				61C364502437568300C4D4E6 /* Resources */,
+				D8E080EFA5BC75427C8EA6A2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -341,11 +351,28 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-CPProjectUITests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-CPProject-CPProjectUITests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		567E049B7EEB3FF26416E3A0 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CPProject-CPProjectUITests/Pods-CPProject-CPProjectUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CPProject-CPProjectUITests/Pods-CPProject-CPProjectUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CPProject-CPProjectUITests/Pods-CPProject-CPProjectUITests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		61C3645E24376AEF00C4D4E6 /* ⚙️ Run linter */ = {
@@ -389,6 +416,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		D8E080EFA5BC75427C8EA6A2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CPProject-CPProjectTests/Pods-CPProject-CPProjectTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-CPProject-CPProjectTests/Pods-CPProject-CPProjectTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CPProject-CPProjectTests/Pods-CPProject-CPProjectTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		E0C0BFBDF1EBCFBACB1B053D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -404,7 +448,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-CPProjectTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-CPProject-CPProjectTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -639,7 +683,7 @@
 		};
 		61C363B22436319000C4D4E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5ACCCE7D06C5874130D7D6D4 /* Pods-CPProjectUITests.debug.xcconfig */;
+			baseConfigurationReference = 023E9F71B1FFBEAF47AD599B /* Pods-CPProject-CPProjectUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
@@ -663,7 +707,7 @@
 		};
 		61C363B32436319000C4D4E6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A9A539012CEB94D3DDBEEFAF /* Pods-CPProjectUITests.release.xcconfig */;
+			baseConfigurationReference = EB80E12EA30834731C20BC88 /* Pods-CPProject-CPProjectUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
@@ -687,7 +731,7 @@
 		};
 		61C364592437568300C4D4E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E33ADFE7E2CECC33A07A795 /* Pods-CPProjectTests.debug.xcconfig */;
+			baseConfigurationReference = 6C29934101A436B996950B9C /* Pods-CPProject-CPProjectTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
@@ -711,7 +755,7 @@
 		};
 		61C3645A2437568300C4D4E6 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E4221836EB9A6AB7B55FCA4E /* Pods-CPProjectTests.release.xcconfig */;
+			baseConfigurationReference = 0D9B145559078D7130D6AA72 /* Pods-CPProject-CPProjectTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";

--- a/dependency-manager-tests/cocoapods/CPProject/ViewController.swift
+++ b/dependency-manager-tests/cocoapods/CPProject/ViewController.swift
@@ -7,6 +7,7 @@
 import UIKit
 import Datadog
 import DatadogAlamofireExtension
+import DatadogCrashReporting
 import Alamofire
 
 internal class ViewController: UIViewController {
@@ -20,6 +21,7 @@ internal class ViewController: UIViewController {
             trackingConsent: .pending,
             configuration: Datadog.Configuration
                 .builderUsing(clientToken: "abc", environment: "tests")
+                .enableCrashReporting(using: DDCrashReportingPlugin())
                 .build()
         )
 

--- a/dependency-manager-tests/cocoapods/Makefile
+++ b/dependency-manager-tests/cocoapods/Makefile
@@ -10,5 +10,5 @@ test:
 		@echo "⚙️  Configuring CPProject with remote branch: '${GIT_REFERENCE}'..."
 		@sed "s|REMOTE_GIT_REFERENCE|${GIT_REFERENCE}|g" Podfile.src > Podfile
 		@rm -rf Pods/
-		pod install
+		pod update
 		@echo "OK 👌"

--- a/dependency-manager-tests/cocoapods/Makefile
+++ b/dependency-manager-tests/cocoapods/Makefile
@@ -10,5 +10,5 @@ test:
 		@echo "⚙️  Configuring CPProject with remote branch: '${GIT_REFERENCE}'..."
 		@sed "s|REMOTE_GIT_REFERENCE|${GIT_REFERENCE}|g" Podfile.src > Podfile
 		@rm -rf Pods/
-		pod update
+		pod install
 		@echo "OK 👌"

--- a/dependency-manager-tests/cocoapods/Podfile.src
+++ b/dependency-manager-tests/cocoapods/Podfile.src
@@ -3,6 +3,7 @@ platform :ios, '12.0'
 target 'CPProject' do
   pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :REMOTE_GIT_REFERENCE
   pod 'DatadogSDKAlamofireExtension', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :REMOTE_GIT_REFERENCE
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :REMOTE_GIT_REFERENCE
   pod 'Alamofire'
 
   target 'CPProjectTests' do

--- a/dependency-manager-tests/cocoapods/Podfile.src
+++ b/dependency-manager-tests/cocoapods/Podfile.src
@@ -1,5 +1,7 @@
 platform :ios, '12.0'
 
+use_frameworks!
+
 target 'CPProject' do
   pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :REMOTE_GIT_REFERENCE
   pod 'DatadogSDKAlamofireExtension', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :REMOTE_GIT_REFERENCE
@@ -11,5 +13,19 @@ target 'CPProject' do
   end
   target 'CPProjectUITests' do
     inherit! :search_paths
+  end
+end
+
+static_frameworks = ['DatadogSDKCrashReporting']
+pre_install do |installer|
+  installer.pod_targets.each do |pod|
+    if static_frameworks.include?(pod.name)
+      def pod.static_framework?;
+        true
+      end
+      def pod.build_type;
+        Pod::BuildType.static_library
+      end
+    end
   end
 end

--- a/dependency-manager-tests/cocoapods/Podfile.src
+++ b/dependency-manager-tests/cocoapods/Podfile.src
@@ -9,14 +9,14 @@ target 'CPProject' do
   pod 'Alamofire'
 
   target 'CPProjectTests' do
-    inherit! :search_paths
+    inherit! :complete
   end
   target 'CPProjectUITests' do
-    inherit! :search_paths
+    inherit! :complete
   end
 end
 
-static_frameworks = ['DatadogSDKCrashReporting']
+static_frameworks = ['DatadogSDKCrashReporting','PLCrashReporter']
 pre_install do |installer|
   installer.pod_targets.each do |pod|
     if static_frameworks.include?(pod.name)

--- a/tools/distribution/push_podspecs.sh
+++ b/tools/distribution/push_podspecs.sh
@@ -16,6 +16,15 @@ while [[ $alamofireRetVal -ne 0 ]] ; do
    	alamofireRetVal=$? ;
 done
 
+crashReportingRetVal=1
+while [[ $crashReportingRetVal -ne 0 ]] ; do
+	sleep 30s ;
+	pod repo update ;
+    pod spec lint --allow-warnings DatadogSDKCrashReporting.podspec ;
+   	crashReportingRetVal=$? ;
+done
+
 pod trunk me
 pod trunk push --allow-warnings DatadogSDKObjc.podspec
 pod trunk push --allow-warnings DatadogSDKAlamofireExtension.podspec
+pod trunk push --allow-warnings DatadogSDKCrashReporting.podspec

--- a/tools/distribution/push_podspecs.sh
+++ b/tools/distribution/push_podspecs.sh
@@ -18,10 +18,10 @@ done
 
 crashReportingRetVal=1
 while [[ $crashReportingRetVal -ne 0 ]] ; do
-	sleep 30s ;
-	pod repo update ;
-    pod spec lint --allow-warnings DatadogSDKCrashReporting.podspec ;
-   	crashReportingRetVal=$? ;
+   sleep 30s ;
+   pod repo update ;
+   pod spec lint --allow-warnings DatadogSDKCrashReporting.podspec ;
+   crashReportingRetVal=$? ;
 done
 
 pod trunk me


### PR DESCRIPTION
### What and why?

`DatadogSDK` was using a custom `modulemap` and therefore Cocoapods was enforcing `use_frameworks!` when you have `DatadogSDK` pod.
On the other hand, `PLCrashReporter` needs to be statically linked and these 2 limitations were contradicting.
As a result, `DatadogCrashReporting` didn't support Cocoapods in the first place.

### How?

Since `DatadogSDK` doesn't require `use_frameworks!` anymore, we simply added `DatadogSDKCrashReporting.podspec` and it works.

⚠️  Please note that `PLCrashReporter` still needs to linked statically, so you can't use `use_frameworks!` with `DatadogSDKCrashReporting` pod.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
