### PR TITLE
RUMM-1544 Fix: `RefreshRateReader` doesn't read while scrolling UI

### DIFF
--- a/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
@@ -76,7 +76,8 @@ internal class VitalRefreshRateReader: ContinuousVitalReader {
         }
 
         displayLink = CADisplayLink(target: self, selector: #selector(displayTick(link:)))
-        displayLink?.add(to: .main, forMode: .default)
+        // NOTE: RUMM-1544 `.default` mode doesn't get fired while scrolling the UI, `.common` does.
+        displayLink?.add(to: .main, forMode: .common)
     }
 
     private func stop() {


### PR DESCRIPTION
### What and why?

`VitalRefreshRateReader` doesn't get updated while any tracking event, such as scrolling, is ongoing.
This results in reading too low FPS rates whereas UI is performing fine.

### How?

`CADisplayLink` is added to `RunLoop.main` in `.common` mode.
`.common` contains `.tracking` mode which is active while events like scrolling are ingoing.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
