### PR TITLE
RUMM-1243 Fix crash context deserialization if it contains `null` value

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		6112B11425C84E7900B37771 /* CrashReportingIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6112B11325C84E7900B37771 /* CrashReportingIntegration.swift */; };
 		61133B8C242393DE00786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
 		61133B93242393DE00786299 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		61133BCA2423979B00786299 /* EncodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* EncodableValue.swift */; };
+		61133BCA2423979B00786299 /* CodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* CodableValue.swift */; };
 		61133BCB2423979B00786299 /* CarrierInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA22423979B00786299 /* CarrierInfoProvider.swift */; };
 		61133BCC2423979B00786299 /* MobileDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA32423979B00786299 /* MobileDevice.swift */; };
 		61133BCD2423979B00786299 /* NetworkConnectionInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA42423979B00786299 /* NetworkConnectionInfoProvider.swift */; };
@@ -407,7 +407,7 @@
 		61E909F224A24DD3005EA2DE /* OTConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909EB24A24DD3005EA2DE /* OTConstants.swift */; };
 		61E909F324A24DD3005EA2DE /* OTSpanContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909EC24A24DD3005EA2DE /* OTSpanContext.swift */; };
 		61E909F624A32D1C005EA2DE /* GlobalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E909F524A32D1C005EA2DE /* GlobalTests.swift */; };
-		61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917CE2464270500E6C631 /* EncodableValueTests.swift */; };
+		61E917CF2464270500E6C631 /* CodableValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917CE2464270500E6C631 /* CodableValueTests.swift */; };
 		61E917D12465423600E6C631 /* TracerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D02465423600E6C631 /* TracerConfiguration.swift */; };
 		61E917D3246546BF00E6C631 /* TracerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E917D2246546BF00E6C631 /* TracerConfigurationTests.swift */; };
 		61E95D882695C00200EA3115 /* DDCrashReportExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E95D872695C00200EA3115 /* DDCrashReportExporterTests.swift */; };
@@ -435,7 +435,7 @@
 		61F3CDA72512144600C816E5 /* UIKitRUMViewsPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */; };
 		61F3CDAB25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDAA25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift */; };
 		61F3CDAD25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDAC25122C9200C816E5 /* UIKitRUMViewsHandlerTests.swift */; };
-		61F7F1DD266F9CB000F9F53B /* EncodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* EncodableValue.swift */; };
+		61F7F1DD266F9CB000F9F53B /* CodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* CodableValue.swift */; };
 		61F8CC092469295500FE2908 /* DatadogConfigurationBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8CC082469295500FE2908 /* DatadogConfigurationBuilderTests.swift */; };
 		61F9CA712512450B000A5E61 /* RUMAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA702512450B000A5E61 /* RUMAutoInstrumentationTests.swift */; };
 		61F9CA792512593A000A5E61 /* RUMNavigationControllerScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61F9CA782512593A000A5E61 /* RUMNavigationControllerScenario.storyboard */; };
@@ -647,7 +647,7 @@
 		61133B86242393DE00786299 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61133B8B242393DE00786299 /* DatadogTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		61133B92242393DE00786299 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		61133BA02423979B00786299 /* EncodableValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncodableValue.swift; sourceTree = "<group>"; };
+		61133BA02423979B00786299 /* CodableValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodableValue.swift; sourceTree = "<group>"; };
 		61133BA22423979B00786299 /* CarrierInfoProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CarrierInfoProvider.swift; sourceTree = "<group>"; };
 		61133BA32423979B00786299 /* MobileDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileDevice.swift; sourceTree = "<group>"; };
 		61133BA42423979B00786299 /* NetworkConnectionInfoProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkConnectionInfoProvider.swift; sourceTree = "<group>"; };
@@ -1033,7 +1033,7 @@
 		61E909EB24A24DD3005EA2DE /* OTConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTConstants.swift; sourceTree = "<group>"; };
 		61E909EC24A24DD3005EA2DE /* OTSpanContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTSpanContext.swift; sourceTree = "<group>"; };
 		61E909F524A32D1C005EA2DE /* GlobalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalTests.swift; sourceTree = "<group>"; };
-		61E917CE2464270500E6C631 /* EncodableValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodableValueTests.swift; sourceTree = "<group>"; };
+		61E917CE2464270500E6C631 /* CodableValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableValueTests.swift; sourceTree = "<group>"; };
 		61E917D02465423600E6C631 /* TracerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracerConfiguration.swift; sourceTree = "<group>"; };
 		61E917D2246546BF00E6C631 /* TracerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracerConfigurationTests.swift; sourceTree = "<group>"; };
 		61E95D872695C00200EA3115 /* DDCrashReportExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportExporterTests.swift; sourceTree = "<group>"; };
@@ -1367,7 +1367,7 @@
 			isa = PBXGroup;
 			children = (
 				61D447E124917F8F00649287 /* DateFormatting.swift */,
-				61133BA02423979B00786299 /* EncodableValue.swift */,
+				61133BA02423979B00786299 /* CodableValue.swift */,
 				9E58E8E024615C75008E5063 /* JSONEncoder.swift */,
 				61363D9C24D999F70084CD6F /* DDError.swift */,
 				6139CD702589FAFD007E8BB7 /* Retrying.swift */,
@@ -2857,7 +2857,7 @@
 		61E917CD246426E000E6C631 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				61E917CE2464270500E6C631 /* EncodableValueTests.swift */,
+				61E917CE2464270500E6C631 /* CodableValueTests.swift */,
 				6139CD762589FEE3007E8BB7 /* RetryingTests.swift */,
 				611529AD25E3E429004F740E /* ValuePublisherTests.swift */,
 			);
@@ -3726,7 +3726,7 @@
 				61AD4E3824531500006E34EA /* DataFormat.swift in Sources */,
 				9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */,
 				61F1878D25FA33A90022CE9A /* InternalMonitor.swift in Sources */,
-				61133BCA2423979B00786299 /* EncodableValue.swift in Sources */,
+				61133BCA2423979B00786299 /* CodableValue.swift in Sources */,
 				6139CD712589FAFD007E8BB7 /* Retrying.swift in Sources */,
 				61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */,
 				618D9DE7263AD78900A3FAD2 /* SpanEventMapper.swift in Sources */,
@@ -3902,7 +3902,7 @@
 				61EF78B7257E37D500EDCCB3 /* MoveDataMigratorTests.swift in Sources */,
 				61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */,
 				615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */,
-				61E917CF2464270500E6C631 /* EncodableValueTests.swift in Sources */,
+				61E917CF2464270500E6C631 /* CodableValueTests.swift in Sources */,
 				61133C542423990D00786299 /* NetworkConnectionInfoProviderTests.swift in Sources */,
 				616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */,
 				B3BBBCBC265E71D100943419 /* VitalMemoryReaderTests.swift in Sources */,
@@ -4093,7 +4093,7 @@
 				61B6811F25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift in Sources */,
 				61C2C20D24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift in Sources */,
 				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
-				61F7F1DD266F9CB000F9F53B /* EncodableValue.swift in Sources */,
+				61F7F1DD266F9CB000F9F53B /* CodableValue.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,
 				61441C4124617013003D8BB8 /* LoggingScenarioTests.swift in Sources */,
 				612D8F8125AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift in Sources */,

--- a/Sources/Datadog/Core/Utils/CodableValue.swift
+++ b/Sources/Datadog/Core/Utils/CodableValue.swift
@@ -6,9 +6,6 @@
 
 import Foundation
 
-internal typealias EncodableValue = CodableValue
-internal typealias DecodableValue = CodableValue
-
 /// Helper type performing type erasure of encoded JSON types.
 /// It conforms to `Encodable`, so decoded value can be further serialized into exactly the same JSON representation.
 internal struct CodableValue: Codable {

--- a/Sources/Datadog/Core/Utils/CodableValue.swift
+++ b/Sources/Datadog/Core/Utils/CodableValue.swift
@@ -6,10 +6,16 @@
 
 import Foundation
 
-/// Helper type performing type erasure of encoded JSON types.
-/// It conforms to `Encodable`, so decoded value can be further serialized into exactly the same JSON representation.
+/// `Encodable` type erasure used for encoding and decoding user attributes.
 internal struct CodableValue: Codable {
-    struct CodableNull: Encodable {}
+    /// A private representation of `null` JSON value used for decoding and encoding.
+    ///
+    /// In JSON `null` represents an absent value for an `Encodable` optional (e.g. encoding `Optional<String>.none` will produce `null`).
+    /// To decode `null` as `CodableValue`, in `init(from:)` the value of `CodableNull()` is assigned to `value: Encodable` property.
+    /// It is later recognized in `encode(to:)` to encode the `null` back into produced JSON data.
+    ///
+    /// This way, after deserializing user attributes we can encode them again without altering the original data representation.
+    private struct CodableNull: Encodable {}
 
     let value: Encodable
 

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
@@ -139,7 +139,7 @@ private struct CodableUserInfo: Codable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        let encodedExtraInfo = extraInfo.mapValues { EncodableValue($0) }
+        let encodedExtraInfo = extraInfo.mapValues { CodableValue($0) }
 
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .name)
@@ -185,8 +185,8 @@ private struct CodableRUMViewEvent: Codable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        let encodedAttributes = attributes.mapValues { EncodableValue($0) }
-        let encodedUserInfoAttributes = userInfoAttributes.mapValues { EncodableValue($0) }
+        let encodedAttributes = attributes.mapValues { CodableValue($0) }
+        let encodedUserInfoAttributes = userInfoAttributes.mapValues { CodableValue($0) }
 
         try container.encode(model, forKey: .model)
         try container.encode(encodedAttributes, forKey: .attributes)

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -155,8 +155,12 @@ internal class CrashReporter {
                 Error details: \(error)
                 """
             )
+#if DD_SDK_ENABLE_INTERNAL_MONITORING
+            let contextUTF8String = String(data: crashContextData, encoding: .utf8)
+            let attributes = ["context_utf8_string": contextUTF8String ?? "none"]
             InternalMonitoringFeature.instance?.monitor.sdkLogger
-                .error("Failed to decode crash report context", error: error)
+                .error("Failed to decode crash report context", error: error, attributes: attributes)
+#endif
             return nil
         }
     }

--- a/Sources/Datadog/Logging/Log/LogEncoder.swift
+++ b/Sources/Datadog/Logging/Log/LogEncoder.swift
@@ -156,19 +156,19 @@ internal struct LogEncoder {
         // 1. user info attributes
         try log.userInfo.extraInfo.forEach {
             let key = DynamicCodingKey("usr.\($0)")
-            try attributesContainer.encode(EncodableValue($1), forKey: key)
+            try attributesContainer.encode(CodableValue($1), forKey: key)
         }
 
         // 2. user attributes
         let encodableUserAttributes = Dictionary(
-            uniqueKeysWithValues: log.attributes.userAttributes.map { name, value in (name, EncodableValue(value)) }
+            uniqueKeysWithValues: log.attributes.userAttributes.map { name, value in (name, CodableValue(value)) }
         )
         try encodableUserAttributes.forEach { try attributesContainer.encode($0.value, forKey: DynamicCodingKey($0.key)) }
 
         // 3. internal attributes
         if let internalAttributes = log.attributes.internalAttributes {
             let encodableInternalAttributes = Dictionary(
-                uniqueKeysWithValues: internalAttributes.map { name, value in (name, EncodableValue(value)) }
+                uniqueKeysWithValues: internalAttributes.map { name, value in (name, CodableValue(value)) }
             )
             try encodableInternalAttributes.forEach { try attributesContainer.encode($0.value, forKey: DynamicCodingKey($0.key)) }
         }

--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -1164,7 +1164,7 @@ extension RUMEventAttributes {
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
         try contextInfo.forEach {
             let key = DynamicCodingKey($0)
-            try dynamicContainer.encode(EncodableValue($1), forKey: key)
+            try dynamicContainer.encode(CodableValue($1), forKey: key)
         }
     }
 
@@ -1175,7 +1175,7 @@ extension RUMEventAttributes {
         var dictionary: [String: Codable] = [:]
 
         try dynamicKeys.forEach { codingKey in
-            dictionary[codingKey.stringValue] = try dynamicContainer.decodeIfPresent(CodableValue.self, forKey: codingKey)
+            dictionary[codingKey.stringValue] = try dynamicContainer.decode(CodableValue.self, forKey: codingKey)
         }
 
         self.contextInfo = dictionary
@@ -1222,7 +1222,7 @@ extension RUMUser {
         var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
         try usrInfo.forEach {
             let key = DynamicCodingKey($0)
-            try dynamicContainer.encode(EncodableValue($1), forKey: key)
+            try dynamicContainer.encode(CodableValue($1), forKey: key)
         }
     }
 
@@ -1240,7 +1240,7 @@ extension RUMUser {
         var dictionary: [String: Codable] = [:]
 
         try dynamicKeys.forEach { codingKey in
-            dictionary[codingKey.stringValue] = try dynamicContainer.decodeIfPresent(CodableValue.self, forKey: codingKey)
+            dictionary[codingKey.stringValue] = try dynamicContainer.decode(CodableValue.self, forKey: codingKey)
         }
 
         self.usrInfo = dictionary

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -39,13 +39,13 @@ internal struct RUMEventEncoder {
         try event.attributes.forEach { attributeName, attributeValue in
             // TODO: RUMM-1463 Remove this condition once new error format is managed through `RUMDataModels`
             if attributeName == DDError.threads || attributeName == DDError.binaryImages || attributeName == DDError.meta || attributeName == DDError.wasTruncated {
-                try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey(attributeName))
+                try attributesContainer.encode(CodableValue(attributeValue), forKey: DynamicCodingKey(attributeName))
             } else {
-                try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("context.\(attributeName)"))
+                try attributesContainer.encode(CodableValue(attributeValue), forKey: DynamicCodingKey("context.\(attributeName)"))
             }
         }
         try event.userInfoAttributes.forEach { attributeName, attributeValue in
-            try attributesContainer.encode(EncodableValue(attributeValue), forKey: DynamicCodingKey("usr.\(attributeName)"))
+            try attributesContainer.encode(CodableValue(attributeValue), forKey: DynamicCodingKey("usr.\(attributeName)"))
         }
 
         // Encode `RUMDataModel`

--- a/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
@@ -102,7 +102,7 @@ internal struct SpanEventBuilder {
                 casted[key] = urlValue.absoluteString
             } else {
                 do {
-                    let encodable = EncodableValue(value)
+                    let encodable = CodableValue(value)
                     let jsonData: Data
 
                     if #available(iOS 13.0, *) {

--- a/Tests/DatadogTests/Datadog/Core/Utils/CodableValueTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Utils/CodableValueTests.swift
@@ -8,34 +8,140 @@ import XCTest
 @testable import Datadog
 
 class CodableValueTests: XCTestCase {
-    func testItEncodesDifferentEncodableValues() throws {
-        let encoder = JSONEncoder()
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
 
-        XCTAssertEqual(
-            try encoder.encode(EncodingContainer(CodableValue("string"))).utf8String,
-            #"{"value":"string"}"#
-        )
-        XCTAssertEqual(
-            try encoder.encode(EncodingContainer(CodableValue(123))).utf8String,
-            #"{"value":123}"#
-        )
-        XCTAssertEqual(
-            try encoder.encode(CodableValue(["a", "b", "c"])).utf8String,
-            #"["a","b","c"]"#
-        )
-        XCTAssertEqual(
-            try encoder.encode(
-                EncodingContainer(CodableValue(URL(string: "https://example.com/image.png")!))
-            ).utf8String,
-            #"{"value":"https:\/\/example.com\/image.png"}"#
-        )
-        struct Foo: Encodable {
-            let bar = "bar_"
-            let bizz = "bizz_"
+    /// Sample struct used to test complex `Encodable` types encoding
+    private struct Foo: Encodable, RandomMockable {
+        var bar: String
+        var bizz: Bizz
+
+        struct Bizz: Encodable {
+            var buzz: String
+            var bazz: [Int: Int]
         }
-        XCTAssertEqual(
-            try encoder.encode(CodableValue(Foo())).utf8String,
-            #"{"bar":"bar_","bizz":"bizz_"}"#
-        )
+
+        static func mockRandom() -> Foo {
+            return Foo(
+                bar: .mockRandom(),
+                bizz: .init(
+                    buzz: .mockRandom(),
+                    bazz: [1: 2, 3: 4]
+                )
+            )
+        }
+    }
+
+    func testGivenEncodableValueWrappedIntoCodableValue_whenEncoding_itProducesExpectedJSONRepresentation() throws {
+        func json<T: Encodable>(for value: T) throws -> String {
+            // Given
+            let codableValue = CodableValue(value)
+
+            // When
+            let encodedCodableValue = try encoder.encode(codableValue)
+
+            // Then
+            return encodedCodableValue.utf8String
+        }
+
+        if #available(iOS 13.0, *) {
+            XCTAssertEqual(try json(for: true), "true")
+            XCTAssertEqual(try json(for: false), "false")
+            XCTAssertEqual(try json(for: 123), "123")
+            XCTAssertEqual(try json(for: -123), "-123")
+            XCTAssertEqual(try json(for: 123.45), "123.45")
+            XCTAssertEqual(try json(for: "string"), "\"string\"")
+
+            let url = URL(string: "https://example.com/image.png")!
+            XCTAssertEqual(try json(for: url), #""https:\/\/example.com\/image.png""#)
+
+            // swiftlint:disable syntactic_sugar
+            XCTAssertEqual(try json(for: Optional<Bool>.none), "null")
+            XCTAssertEqual(try json(for: Optional<UInt64>.none), "null")
+            XCTAssertEqual(try json(for: Optional<Int>.none), "null")
+            XCTAssertEqual(try json(for: Optional<Double>.none), "null")
+            XCTAssertEqual(try json(for: Optional<String>.none), "null")
+            XCTAssertEqual(try json(for: Optional<URL>.none), "null")
+            XCTAssertEqual(try json(for: Optional<Foo>.none), "null")
+            // swiftlint:enable syntactic_sugar
+        } else {
+            XCTAssertEqual(try json(for: EncodingContainer(true)), #"{"value":true}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(false)), #"{"value":false}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(123)), #"{"value":123}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(-123)), #"{"value":-123}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(123.45)), #"{"value":123.45}"#)
+            XCTAssertEqual(try json(for: EncodingContainer("string")), #"{"value":"string"}"#)
+
+            let url = URL(string: "https://example.com/image.png")!
+            XCTAssertEqual(try json(for: EncodingContainer(url)), #"{"value":"https:\/\/example.com\/image.png"}"#)
+
+            // swiftlint:disable syntactic_sugar
+            XCTAssertEqual(try json(for: EncodingContainer(Optional<Bool>.none)), #"{"value":null}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(Optional<UInt64>.none)), #"{"value":null}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(Optional<Int>.none)), #"{"value":null}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(Optional<Double>.none)), #"{"value":null}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(Optional<String>.none)), #"{"value":null}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(Optional<URL>.none)), #"{"value":null}"#)
+            XCTAssertEqual(try json(for: EncodingContainer(Optional<Foo>.none)), #"{"value":null}"#)
+            // swiftlint:enable syntactic_sugar
+        }
+
+        XCTAssertEqual(try json(for: [true, false, true, false]), "[true,false,true,false]")
+        XCTAssertEqual(try json(for: [1, 2, 3, 4, 5]), "[1,2,3,4,5]")
+        XCTAssertEqual(try json(for: [1.5, 2.5, 3.5]), "[1.5,2.5,3.5]")
+        XCTAssertEqual(try json(for: ["foo", "bar", "fizz", "buzz"]), #"["foo","bar","fizz","buzz"]"#)
+
+        let foo = Foo(bar: "bar", bizz: .init(buzz: "buzz", bazz: [1: 2]))
+        XCTAssertEqual(try json(for: foo), #"{"bar":"bar","bizz":{"bazz":{"1":2},"buzz":"buzz"}}"#)
+        XCTAssertEqual(try json(for: [foo]), #"[{"bar":"bar","bizz":{"bazz":{"1":2},"buzz":"buzz"}}]"#)
+        XCTAssertEqual(try json(for: ["foo": foo]), #"{"foo":{"bar":"bar","bizz":{"bazz":{"1":2},"buzz":"buzz"}}}"#)
+    }
+
+    func testGivenEncodedCodableValue_whenDecoding_itPreservesValueRepresentation() throws {
+        func test<T: Encodable>(value: T) throws {
+            // Given
+            let codableValue = CodableValue(value)
+            let encodedCodableValue = try encoder.encode(codableValue)
+
+            // When
+            let decodedCodableValue = try decoder.decode(CodableValue.self, from: encodedCodableValue)
+
+            // Then
+            try AssertEncodedRepresentationsEqual(value1: codableValue, value2: decodedCodableValue)
+        }
+
+        try test(value: EncodingContainer(Bool.mockRandom()))
+        try test(value: EncodingContainer(UInt64.mockRandom()))
+        try test(value: EncodingContainer(Int.mockRandom()))
+        try test(value: EncodingContainer(Double.mockRandom()))
+        try test(value: EncodingContainer(String.mockRandom()))
+        try test(value: EncodingContainer(URL.mockRandom()))
+        try test(value: Foo.mockRandom())
+
+        // swiftlint:disable syntactic_sugar
+        try test(value: EncodingContainer(Optional<Bool>.none))
+        try test(value: EncodingContainer(Optional<UInt64>.none))
+        try test(value: EncodingContainer(Optional<Int>.none))
+        try test(value: EncodingContainer(Optional<Double>.none))
+        try test(value: EncodingContainer(Optional<String>.none))
+        try test(value: EncodingContainer(Optional<URL>.none))
+        try test(value: EncodingContainer(Optional<Foo>.none))
+        // swiftlint:enable syntactic_sugar
+
+        try test(value: [Bool].mockRandom())
+        try test(value: [UInt64].mockRandom())
+        try test(value: [Int].mockRandom())
+        try test(value: [Double].mockRandom())
+        try test(value: [String].mockRandom())
+        try test(value: [URL].mockRandom())
+        try test(value: [Foo].mockRandom())
+
+        try test(value: [AttributeKey: Bool].mockRandom())
+        try test(value: [AttributeKey: UInt64].mockRandom())
+        try test(value: [AttributeKey: Int].mockRandom())
+        try test(value: [AttributeKey: Double].mockRandom())
+        try test(value: [AttributeKey: String].mockRandom())
+        try test(value: [AttributeKey: URL].mockRandom())
+        try test(value: [AttributeKey: Foo].mockRandom())
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/Utils/CodableValueTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Utils/CodableValueTests.swift
@@ -7,25 +7,25 @@
 import XCTest
 @testable import Datadog
 
-class EncodableValueTests: XCTestCase {
+class CodableValueTests: XCTestCase {
     func testItEncodesDifferentEncodableValues() throws {
         let encoder = JSONEncoder()
 
         XCTAssertEqual(
-            try encoder.encode(EncodingContainer(EncodableValue("string"))).utf8String,
+            try encoder.encode(EncodingContainer(CodableValue("string"))).utf8String,
             #"{"value":"string"}"#
         )
         XCTAssertEqual(
-            try encoder.encode(EncodingContainer(EncodableValue(123))).utf8String,
+            try encoder.encode(EncodingContainer(CodableValue(123))).utf8String,
             #"{"value":123}"#
         )
         XCTAssertEqual(
-            try encoder.encode(EncodableValue(["a", "b", "c"])).utf8String,
+            try encoder.encode(CodableValue(["a", "b", "c"])).utf8String,
             #"["a","b","c"]"#
         )
         XCTAssertEqual(
             try encoder.encode(
-                EncodingContainer(EncodableValue(URL(string: "https://example.com/image.png")!))
+                EncodingContainer(CodableValue(URL(string: "https://example.com/image.png")!))
             ).utf8String,
             #"{"value":"https:\/\/example.com\/image.png"}"#
         )
@@ -34,7 +34,7 @@ class EncodableValueTests: XCTestCase {
             let bizz = "bizz_"
         }
         XCTAssertEqual(
-            try encoder.encode(EncodableValue(Foo())).utf8String,
+            try encoder.encode(CodableValue(Foo())).utf8String,
             #"{"bar":"bar_","bizz":"bizz_"}"#
         )
     }

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
@@ -126,8 +126,8 @@ class CrashContextTests: XCTestCase {
         line: UInt = #line
     ) throws {
         try AssertEncodedRepresentationsEqual(
-            value1: dictionary1.mapValues { EncodableValue($0) },
-            value2: dictionary2.mapValues { EncodableValue($0) }
+            value1: dictionary1.mapValues { CodableValue($0) },
+            value2: dictionary2.mapValues { CodableValue($0) }
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
@@ -101,22 +101,6 @@ class CrashContextTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Asserts that JSON representations of two `Encodable` values are equal.
-    /// This allows us testing if the information is not lost due to type erasing done in `CrashContext` serialization.
-    private func AssertEncodedRepresentationsEqual<V: Encodable>(
-        value1: V,
-        value2: V,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) throws {
-        let prettyEncoder = JSONEncoder()
-        prettyEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let encodedValue1 = try prettyEncoder.encode(value1)
-        let encodedValue2 = try prettyEncoder.encode(value2)
-
-        XCTAssertEqual(encodedValue1.utf8String, encodedValue2.utf8String, file: file, line: line)
-    }
-
     /// Asserts that JSON representations of two `[String: Encodable]` dictionaries are equal.
     /// This allows us testing if the information is not lost due to type erasing done in `CrashContext` serialization.
     private func AssertEncodedRepresentationsEqual(

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -34,8 +34,9 @@ class CrashReporterTests: XCTestCase {
 
         waitForExpectations(timeout: 0.5, handler: nil)
         XCTAssertEqual(integration.sentCrashReport, crashReport, "It should send the crash report retrieved from the `plugin`")
+        let sentCrashContext = try XCTUnwrap(integration.sentCrashContext, "It should send the crash context")
         AssertDictionariesEqual(
-            try integration.sentCrashContext!.data.toJSONObject(),
+            try sentCrashContext.data.toJSONObject(),
             try crashContext.data.toJSONObject(),
             "It should send the crash context retrieved from the `plugin`"
         )

--- a/Tests/DatadogTests/Datadog/Mocks/AttributesMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/AttributesMocks.swift
@@ -17,6 +17,21 @@ func mockRandomAttributes() -> [String: Codable] {
         }
     }
 
+    // Produces a `.none` value for optional of a random type.
+    let randomAbsentOptional: () -> Codable = [
+        // swiftlint:disable opening_brace syntactic_sugar
+        { Optional<String>.none },
+        { Optional<Int>.none },
+        { Optional<UInt64>.none },
+        { Optional<Double>.none },
+        { Optional<Bool>.none },
+        { Optional<[Int]>.none },
+        { Optional<[String: Int]>.none },
+        { Optional<URL>.none },
+        { Optional<Foo>.none },
+        // swiftlint:enable opening_brace syntactic_sugar
+    ].randomElement()!
+
     return [
         "string-attribute": String.mockRandom(),
         "int-attribute": Int.mockRandom(),
@@ -26,6 +41,7 @@ func mockRandomAttributes() -> [String: Codable] {
         "int-array-attribute": [Int].mockRandom(),
         "dictionary-attribute": [String: Int].mockRandom(),
         "url-attribute": URL.mockRandom(),
-        "encodable-struct-attribute": Foo()
+        "encodable-struct-attribute": Foo(),
+        "absent-attribute": randomAbsentOptional() // when JSON-encoding: `"absent-attribute": null`
     ]
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -877,9 +877,9 @@ extension AppStateListener {
     }
 }
 
-extension EncodableValue {
-    static func mockAny() -> EncodableValue {
-        return EncodableValue(String.mockAny())
+extension CodableValue {
+    static func mockAny() -> CodableValue {
+        return CodableValue(String.mockAny())
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -219,6 +219,12 @@ extension Int: AnyMockable, RandomMockable {
     }
 }
 
+extension Bool: RandomMockable {
+    static func mockRandom() -> Bool {
+        return .random()
+    }
+}
+
 extension Range where Bound == Int {
     static func mockRandomBetween(min: Int, max: Int) -> Range<Int> {
         let bound1: Int = .mockRandom(min: min, max: max)

--- a/Tests/DatadogTests/Helpers/Encoding.swift
+++ b/Tests/DatadogTests/Helpers/Encoding.swift
@@ -4,16 +4,10 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-@testable import Datadog
-
-extension EncodableValue: Equatable {
-    public static func == (lhs: EncodableValue, rhs: EncodableValue) -> Bool {
-        return String(describing: lhs) == String(describing: rhs)
-    }
-}
+import Foundation
 
 /// Prior to `iOS13.0`, the `JSONEncoder` supports only object or array as the root type.
-/// Hence we can't test encoding `Encodable` values directly and we need as support of this `EncodingContainer` container.
+/// Hence we can't test encoding `Encodable` values directly and we need to wrap it inside this `EncodingContainer` container.
 ///
 /// Reference: https://bugs.swift.org/browse/SR-6163
 struct EncodingContainer<Value: Encodable>: Encodable {

--- a/Tests/DatadogTests/Helpers/XCTestCase.swift
+++ b/Tests/DatadogTests/Helpers/XCTestCase.swift
@@ -123,4 +123,22 @@ extension XCTestCase {
             }
         }
     }
+
+    /// Asserts that JSON representations of two `Encodable` values are equal.
+    /// This allows us testing if the information is not lost due to type erasing done in `CrashContext` serialization.
+    func AssertEncodedRepresentationsEqual<V: Encodable>(
+        value1: V,
+        value2: V,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let prettyEncoder = JSONEncoder()
+        prettyEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let encodedValue1 = try prettyEncoder.encode(value1)
+        let encodedValue2 = try prettyEncoder.encode(value2)
+
+        let value1JSONString = encodedValue1.utf8String
+        let value2JSONString = encodedValue2.utf8String
+        XCTAssertEqual(value1JSONString, value2JSONString, file: file, line: line)
+    }
 }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
@@ -178,7 +178,7 @@ public class SwiftPrinter: BasePrinter {
                 writeLine("try \(dynamicProperty.name).forEach {") // dynamic properties are dictionaries
                 indentRight()
                     writeLine("let key = DynamicCodingKey($0)") // dictionary key is used as coding key
-                    writeLine("try dynamicContainer.encode(EncodableValue($1), forKey: key)") // encode value
+                    writeLine("try dynamicContainer.encode(CodableValue($1), forKey: key)") // encode value
                 indentLeft()
                 writeLine("}")
             }
@@ -227,7 +227,11 @@ public class SwiftPrinter: BasePrinter {
 
                 writeLine("try dynamicKeys.forEach { codingKey in")
                 indentRight()
-                writeLine("dictionary[codingKey.stringValue] = try dynamicContainer.decodeIfPresent(CodableValue.self, forKey: codingKey)")
+                // We use `dynamicContainer.decode()` instead of `dynamicContainer.decodeIfPresent()` to not lose
+                // the information of decoded `null` value. Our `CodableValue` implementation recognizes `null` and preserves
+                // it for eventual encoding. This guarantees no difference in serialized payload even if we deserialize it
+                // and encode again.
+                writeLine("dictionary[codingKey.stringValue] = try dynamicContainer.decode(CodableValue.self, forKey: codingKey)")
                 indentLeft()
                 writeLine("}")
 

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -270,7 +270,7 @@ final class SwiftPrinterTests: XCTestCase {
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
                 try context.forEach {
                     let key = DynamicCodingKey($0)
-                    try dynamicContainer.encode(EncodableValue($1), forKey: key)
+                    try dynamicContainer.encode(CodableValue($1), forKey: key)
                 }
             }
 
@@ -281,7 +281,7 @@ final class SwiftPrinterTests: XCTestCase {
                 var dictionary: [String: Codable] = [:]
 
                 try dynamicKeys.forEach { codingKey in
-                    dictionary[codingKey.stringValue] = try dynamicContainer.decodeIfPresent(CodableValue.self, forKey: codingKey)
+                    dictionary[codingKey.stringValue] = try dynamicContainer.decode(CodableValue.self, forKey: codingKey)
                 }
 
                 self.context = dictionary
@@ -368,7 +368,7 @@ final class SwiftPrinterTests: XCTestCase {
                 var dynamicContainer = encoder.container(keyedBy: DynamicCodingKey.self)
                 try context.forEach {
                     let key = DynamicCodingKey($0)
-                    try dynamicContainer.encode(EncodableValue($1), forKey: key)
+                    try dynamicContainer.encode(CodableValue($1), forKey: key)
                 }
             }
 
@@ -385,7 +385,7 @@ final class SwiftPrinterTests: XCTestCase {
                 var dictionary: [String: Codable] = [:]
 
                 try dynamicKeys.forEach { codingKey in
-                    dictionary[codingKey.stringValue] = try dynamicContainer.decodeIfPresent(CodableValue.self, forKey: codingKey)
+                    dictionary[codingKey.stringValue] = try dynamicContainer.decode(CodableValue.self, forKey: codingKey)
                 }
 
                 self.context = dictionary


### PR DESCRIPTION
### What and why?

🐞 This PR fixes a bug where `CrashContext` decoding was failing if a `null` value was written in the JSON.

Because `CrashContext` is necessary for building the `RUMError` (it must be associated with `RUMView` which is encoded as part fo the `CrashContext`), the Crash Reporting feature was failing to upload crashes that include `null` value set in last view event attributes.

### How?

Swift uses `null` to represent absent optional value in JSON payload:
```swift
let absentString: String? = nil

let jsonData = try JSONEncoder().encode(absentString)
print(String(data: jsonData, encoding: .utf8)!)

// null
```

This PR improves our `Encodable` type erasure (now called `CodableValue`) to handle `null` value. When decoding `null` it stores internal `CodableNull()` value which is later used to encode `null` back into serialized JSON. This way we guarantee that user data representation is not alerted by our read / write operations.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
