### PR TITLE
RUMM-1548 Fix compiler warnings in unit tests + fix deprecated endpoints

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -3397,7 +3397,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = Datadog;
 				TargetAttributes = {
 					61133B81242393DE00786299 = {

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1230"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -570,6 +570,7 @@ extension Datadog {
             /// Until this option is enabled, automatic tracking of `UIEvents` is disabled and no swizzling is installed on the `UIApplication` class.
             ///
             /// - Parameter predicate: predicate deciding if a given action should be recorded and which allows to give custom name and to add custom attributes to the RUM Action.
+            /// Defaults to `DefaultUIKitRUMUserActionsPredicate` instance.
             public func trackUIKitRUMActions(using predicate: UIKitRUMUserActionsPredicate = DefaultUIKitRUMUserActionsPredicate()) -> Builder {
                 configuration.rumUIKitUserActionsPredicate = predicate
                 return self

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -51,15 +51,15 @@ extension Datadog {
             /// US based servers.
             /// Sends data to [app.datadoghq.com](https://app.datadoghq.com/).
             @available(*, deprecated, message: "Renamed to us1")
-            case us
+            public static let us: DatadogEndpoint = .us1
             /// Europe based servers.
             /// Sends data to [app.datadoghq.eu](https://app.datadoghq.eu/).
             @available(*, deprecated, message: "Renamed to eu1")
-            case eu
+            public static let eu: DatadogEndpoint = .eu1
             /// Gov servers.
             /// Sends data to [app.ddog-gov.com](https://app.ddog-gov.com/).
             @available(*, deprecated, message: "Renamed to us1_fed")
-            case gov
+            public static let gov: DatadogEndpoint = .us1_fed
 
             internal var logsEndpoint: LogsEndpoint {
                 switch self {
@@ -67,9 +67,6 @@ extension Datadog {
                 case .us3: return .us3
                 case .eu1: return .eu1
                 case .us1_fed: return .us1_fed
-                case .us: return .us
-                case .eu: return .eu
-                case .gov: return .gov
                 }
             }
 
@@ -79,9 +76,6 @@ extension Datadog {
                 case .us3: return .us3
                 case .eu1: return .eu1
                 case .us1_fed: return .us1_fed
-                case .us: return .us
-                case .eu: return .eu
-                case .gov: return .gov
                 }
             }
 
@@ -91,9 +85,6 @@ extension Datadog {
                 case .us3: return .us3
                 case .eu1: return .eu1
                 case .us1_fed: return .us1_fed
-                case .us: return .us
-                case .eu: return .eu
-                case .gov: return .gov
                 }
             }
         }
@@ -126,13 +117,10 @@ extension Datadog {
 
             internal var url: String {
                 switch self {
-                case .us1: return "https://logs.browser-intake-datadoghq.com/v1/input/"
+                case .us1, .us: return "https://logs.browser-intake-datadoghq.com/v1/input/"
                 case .us3: return "https://logs.browser-intake-us3-datadoghq.com/v1/input/"
-                case .eu1: return "https://mobile-http-intake.logs.datadoghq.eu/v1/input/"
-                case .us1_fed: return "https://logs.browser-intake-ddog-gov.com/v1/input/"
-                case .us: return "https://mobile-http-intake.logs.datadoghq.com/v1/input/"
-                case .eu: return "https://mobile-http-intake.logs.datadoghq.eu/v1/input/"
-                case .gov: return "https://logs.browser-intake-ddog-gov.com/v1/input/"
+                case .eu1, .eu: return "https://mobile-http-intake.logs.datadoghq.eu/v1/input/"
+                case .us1_fed, .gov: return "https://logs.browser-intake-ddog-gov.com/v1/input/"
                 case let .custom(url: url): return url
                 }
             }
@@ -166,13 +154,10 @@ extension Datadog {
 
             internal var url: String {
                 switch self {
-                case .us1: return "https://trace.browser-intake-datadoghq.com/v1/input/"
+                case .us1, .us: return "https://trace.browser-intake-datadoghq.com/v1/input/"
                 case .us3: return "https://trace.browser-intake-us3-datadoghq.com/v1/input/"
-                case .eu1: return "https:/public-trace-http-intake.logs.datadoghq.eu/v1/input/"
-                case .us1_fed: return "https://trace.browser-intake-ddog-gov.com/v1/input/"
-                case .us: return "https://public-trace-http-intake.logs.datadoghq.com/v1/input/"
-                case .eu: return "https://public-trace-http-intake.logs.datadoghq.eu/v1/input/"
-                case .gov: return "https://trace.browser-intake-ddog-gov.com/v1/input/"
+                case .eu1, .eu: return "https:/public-trace-http-intake.logs.datadoghq.eu/v1/input/"
+                case .us1_fed, .gov: return "https://trace.browser-intake-ddog-gov.com/v1/input/"
                 case let .custom(url: url): return url
                 }
             }
@@ -206,13 +191,10 @@ extension Datadog {
 
             internal var url: String {
                 switch self {
-                case .us1: return "https://rum.browser-intake-datadoghq.com/v1/input/"
+                case .us1, .us: return "https://rum.browser-intake-datadoghq.com/v1/input/"
                 case .us3: return "https://rum.browser-intake-us3-datadoghq.com/v1/input/"
-                case .eu1: return "https://rum-http-intake.logs.datadoghq.eu/v1/input/"
-                case .us1_fed: return "https://rum.browser-intake-ddog-gov.com/v1/input/"
-                case .us: return "https://rum-http-intake.logs.datadoghq.com/v1/input/"
-                case .eu: return "https://rum-http-intake.logs.datadoghq.eu/v1/input/"
-                case .gov: return "https://rum.browser-intake-ddog-gov.com/v1/input/"
+                case .eu1, .eu: return "https://rum-http-intake.logs.datadoghq.eu/v1/input/"
+                case .us1_fed, .gov: return "https://rum.browser-intake-ddog-gov.com/v1/input/"
                 case let .custom(url: url): return url
                 }
             }

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -30,13 +30,13 @@ public class DDEndpoint: NSObject {
     public static func us1_fed() -> DDEndpoint { .init(sdkEndpoint: .us1_fed) }
 
     @objc
-    public static func eu() -> DDEndpoint { .init(sdkEndpoint: .eu) }
+    public static func eu() -> DDEndpoint { .init(sdkEndpoint: .eu1) }
 
     @objc
-    public static func us() -> DDEndpoint { .init(sdkEndpoint: .us) }
+    public static func us() -> DDEndpoint { .init(sdkEndpoint: .us1) }
 
     @objc
-    public static func gov() -> DDEndpoint { .init(sdkEndpoint: .gov) }
+    public static func gov() -> DDEndpoint { .init(sdkEndpoint: .us1_fed) }
 }
 
 @objc

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -137,6 +137,8 @@ class FeaturesConfigurationTests: XCTestCase {
             )
         }
 
+        typealias DeprecatedEndpoints = Deprecated<Datadog.Configuration.DatadogEndpoint>
+
         XCTAssertEqual(
             try configuration(datadogEndpoint: .us1).logging?.uploadURLWithClientToken.absoluteString,
             "https://logs.browser-intake-datadoghq.com/v1/input/" + clientToken
@@ -154,15 +156,15 @@ class FeaturesConfigurationTests: XCTestCase {
             "https://logs.browser-intake-ddog-gov.com/v1/input/" + clientToken
         )
         XCTAssertEqual(
-            try configuration(datadogEndpoint: .us).logging?.uploadURLWithClientToken.absoluteString,
-            "https://mobile-http-intake.logs.datadoghq.com/v1/input/" + clientToken
+            try configuration(datadogEndpoint: DeprecatedEndpoints.us).logging?.uploadURLWithClientToken.absoluteString,
+            "https://logs.browser-intake-datadoghq.com/v1/input/" + clientToken
         )
         XCTAssertEqual(
-            try configuration(datadogEndpoint: .eu).logging?.uploadURLWithClientToken.absoluteString,
+            try configuration(datadogEndpoint: DeprecatedEndpoints.eu).logging?.uploadURLWithClientToken.absoluteString,
             "https://mobile-http-intake.logs.datadoghq.eu/v1/input/" + clientToken
         )
         XCTAssertEqual(
-            try configuration(datadogEndpoint: .gov).logging?.uploadURLWithClientToken.absoluteString,
+            try configuration(datadogEndpoint: DeprecatedEndpoints.gov).logging?.uploadURLWithClientToken.absoluteString,
             "https://logs.browser-intake-ddog-gov.com/v1/input/" + clientToken
         )
 
@@ -183,15 +185,15 @@ class FeaturesConfigurationTests: XCTestCase {
             "https://trace.browser-intake-ddog-gov.com/v1/input/" + clientToken
         )
         XCTAssertEqual(
-            try configuration(datadogEndpoint: .us).tracing?.uploadURLWithClientToken.absoluteString,
-            "https://public-trace-http-intake.logs.datadoghq.com/v1/input/" + clientToken
+            try configuration(datadogEndpoint: DeprecatedEndpoints.us).tracing?.uploadURLWithClientToken.absoluteString,
+            "https://trace.browser-intake-datadoghq.com/v1/input/" + clientToken
         )
         XCTAssertEqual(
-            try configuration(datadogEndpoint: .eu).tracing?.uploadURLWithClientToken.absoluteString,
-            "https://public-trace-http-intake.logs.datadoghq.eu/v1/input/" + clientToken
+            try configuration(datadogEndpoint: DeprecatedEndpoints.eu).tracing?.uploadURLWithClientToken.absoluteString,
+            "https:/public-trace-http-intake.logs.datadoghq.eu/v1/input/" + clientToken
         )
         XCTAssertEqual(
-            try configuration(datadogEndpoint: .gov).tracing?.uploadURLWithClientToken.absoluteString,
+            try configuration(datadogEndpoint: DeprecatedEndpoints.gov).tracing?.uploadURLWithClientToken.absoluteString,
             "https://trace.browser-intake-ddog-gov.com/v1/input/" + clientToken
         )
 
@@ -212,15 +214,15 @@ class FeaturesConfigurationTests: XCTestCase {
             "https://rum.browser-intake-ddog-gov.com/v1/input/" + clientToken
         )
         XCTAssertEqual(
-            try configuration(datadogEndpoint: .us).rum?.uploadURLWithClientToken.absoluteString,
-            "https://rum-http-intake.logs.datadoghq.com/v1/input/" + clientToken
+            try configuration(datadogEndpoint: DeprecatedEndpoints.us).rum?.uploadURLWithClientToken.absoluteString,
+            "https://rum.browser-intake-datadoghq.com/v1/input/" + clientToken
         )
         XCTAssertEqual(
-            try configuration(datadogEndpoint: .eu).rum?.uploadURLWithClientToken.absoluteString,
+            try configuration(datadogEndpoint: DeprecatedEndpoints.eu).rum?.uploadURLWithClientToken.absoluteString,
             "https://rum-http-intake.logs.datadoghq.eu/v1/input/" + clientToken
         )
         XCTAssertEqual(
-            try configuration(datadogEndpoint: .gov).rum?.uploadURLWithClientToken.absoluteString,
+            try configuration(datadogEndpoint: DeprecatedEndpoints.gov).rum?.uploadURLWithClientToken.absoluteString,
             "https://rum.browser-intake-ddog-gov.com/v1/input/" + clientToken
         )
 
@@ -760,4 +762,21 @@ class FeaturesConfigurationTests: XCTestCase {
             appContext: .mockAny()
         )
     }
+}
+
+// MARK: - Deprecation Helpers
+
+/// An assistant protocol to shim the deprecated APIs and call them with no compiler warning.
+private protocol DeprecatedDatadogEndpoints {
+    static var us: Self { get }
+    static var eu: Self { get }
+    static var gov: Self { get }
+}
+extension Datadog.Configuration.DatadogEndpoint: DeprecatedDatadogEndpoints {}
+
+/// An assistant shim to access `Datadog.Configuration.DatadogEndpoint` deprecated APIs with no warning.
+private struct Deprecated<T: DeprecatedDatadogEndpoints> {
+    static var us: T { T.us }
+    static var eu: T { T.eu }
+    static var gov: T { T.gov }
 }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -402,12 +402,6 @@ class DatadogTests: XCTestCase {
     }
 }
 
-/// An assistant protocol to shim the deprecated APIs and call them with no compiler warning.
-private protocol DatadogDeprecatedAPIs {
-    static func initialize(appContext: AppContext, configuration: Datadog.Configuration)
-}
-extension Datadog: DatadogDeprecatedAPIs {}
-
 class AppContextTests: XCTestCase {
     func testBundleType() {
         let iOSAppBundle: Bundle = .mockWith(bundlePath: "mock.app")
@@ -446,3 +440,11 @@ class AppContextTests: XCTestCase {
         )
     }
 }
+
+// MARK: - Deprecation Helpers
+
+/// An assistant protocol to shim the deprecated APIs and call them with no compiler warning.
+private protocol DatadogDeprecatedAPIs {
+    static func initialize(appContext: AppContext, configuration: Datadog.Configuration)
+}
+extension Datadog: DatadogDeprecatedAPIs {}

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -207,26 +207,26 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
         }
 
-        verify(configuration: rumBuilder.trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock()).build()) {
+        verify(configuration: rumBuilder.trackUIKitRUMViews().build()) {
             XCTAssertTrue(RUMFeature.isEnabled)
             XCTAssertNotNil(RUMAutoInstrumentation.instance?.views)
             XCTAssertNil(RUMAutoInstrumentation.instance?.userActions)
         }
         verify(
-            configuration: rumBuilder.enableRUM(false).trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock()).build()
+            configuration: rumBuilder.enableRUM(false).trackUIKitRUMViews().build()
         ) {
             XCTAssertFalse(RUMFeature.isEnabled)
             XCTAssertNil(RUMAutoInstrumentation.instance?.views)
             XCTAssertNil(RUMAutoInstrumentation.instance?.userActions)
         }
 
-        verify(configuration: rumBuilder.trackUIKitActions(true).build()) {
+        verify(configuration: rumBuilder.trackUIKitRUMActions().build()) {
             XCTAssertTrue(RUMFeature.isEnabled)
             XCTAssertNil(RUMAutoInstrumentation.instance?.views)
             XCTAssertNotNil(RUMAutoInstrumentation.instance?.userActions)
         }
         verify(
-            configuration: rumBuilder.enableRUM(false).trackUIKitActions(true).build()
+            configuration: rumBuilder.enableRUM(false).trackUIKitRUMActions().build()
         ) {
             XCTAssertFalse(RUMFeature.isEnabled)
             XCTAssertNil(RUMAutoInstrumentation.instance?.views)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -115,7 +115,7 @@ extension BundleType: CaseIterable {
 
 extension Datadog.Configuration.DatadogEndpoint {
     static func mockRandom() -> Self {
-        return [.us1, .us3, .eu1, .us1_fed, .us, .eu, .gov].randomElement()!
+        return [.us1, .us3, .eu1, .us1_fed].randomElement()!
     }
 }
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1187,7 +1187,7 @@ class RUMMonitorTests: XCTestCase {
                 .builderUsing(rumApplicationID: .mockAny(), clientToken: .mockAny(), environment: .mockAny())
                 .trackURLSession(firstPartyHosts: [.mockAny()])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock(result: .init(name: .mockAny())))
-                .trackUIKitActions(true)
+                .trackUIKitRUMActions()
                 .build()
         )
 

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -260,8 +260,14 @@ class DDConfigurationTests: XCTestCase {
     func testDeprecatedTrackUIActions() {
         let objcBuilder = DDConfiguration.builder(clientToken: "abc-123", environment: "tests")
 
-        objcBuilder.trackUIKitActions()
+        (objcBuilder as DDConfigurationBuilderDeprecatedAPIs).trackUIKitActions()
 
         XCTAssertTrue(objcBuilder.build().sdkConfiguration.rumUIKitUserActionsPredicate is DefaultUIKitRUMUserActionsPredicate)
     }
 }
+
+/// An assistant protocol to shim the deprecated APIs and call them with no compiler warning.
+private protocol DDConfigurationBuilderDeprecatedAPIs {
+    func trackUIKitActions()
+}
+extension DDConfigurationBuilder: DDConfigurationBuilderDeprecatedAPIs {}

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -104,13 +104,13 @@ class DDConfigurationTests: XCTestCase {
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.datadogEndpoint, .us1_fed)
 
         objcBuilder.set(endpoint: .eu())
-        XCTAssertEqual(objcBuilder.build().sdkConfiguration.datadogEndpoint, .eu)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.datadogEndpoint, .eu1)
 
         objcBuilder.set(endpoint: .us())
-        XCTAssertEqual(objcBuilder.build().sdkConfiguration.datadogEndpoint, .us)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.datadogEndpoint, .us1)
 
         objcBuilder.set(endpoint: .gov())
-        XCTAssertEqual(objcBuilder.build().sdkConfiguration.datadogEndpoint, .gov)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.datadogEndpoint, .us1_fed)
 
         let customLogsEndpoint = URL(string: "https://api.example.com/v1/logs")!
         objcBuilder.set(customLogsEndpoint: customLogsEndpoint)


### PR DESCRIPTION
### What and why?

🧽 This PR fixes compiler warnings emitted when building unit tests and changes deprecated Logs + Trace URLs to recommended values. It also elevates warnings policy to **treat them as errors on CI**.

This is to ensure that we always have `0` build-time issues and that nothing breaking can slip into project unnoticed:

<img width="369" alt="Screenshot 2021-08-09 at 12 05 49" src="https://user-images.githubusercontent.com/2358722/128690477-284f3758-9a5a-4bb2-a606-42c50ffc5d33.png">


### How?

First, I fixed existing warnings around using deprecated APIs in tests. This was done by referencing those APIs more dynamically - either with deprecation interface or through generic shim. Alternatively, we could remove those APIs from tests as they are meant deprecated, but I think we should still have them tested although deprecated (in fact, I spotted one missing improvement for Logs + Traces deprecated URLs thanks to having those tests).

Second, I've run recommended project update for Xcode 12.5 without selecting any recommended options:

<img width="489" alt="Screenshot 2021-08-09 at 11 17 24" src="https://user-images.githubusercontent.com/2358722/128691064-b8cea518-221f-48f7-88fe-f9606e77c12e.png">

as both seem irrelevant. We can't do firsts as we're targeting iOS 11 on purpose. Second seems to [cause some issues in not-that-old Cocoapods versions](https://github.com/CocoaPods/CocoaPods/issues/9902).

Last, as it's another time when we clean up compiler warnings, I propose an improvement: to treat them as errors on CI. This way we can still keep pace in local development, but must ensure warnings are resolved before merging to the main branch.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
