### PR TITLE
RUMM-1553: Add console error type to the public API

### DIFF
--- a/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
@@ -27,6 +27,7 @@ internal extension RUMInternalErrorSource {
         case .source: return .source
         case .network: return .network
         case .webview: return .webview
+        case .console: return .console
         case .logger: return .logger
         }
     }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -78,6 +78,8 @@ public enum RUMErrorSource {
     case network
     /// Error originated in a webview.
     case webview
+    /// Error originated in a web console (used by bridges).
+    case console
     /// Custom error source.
     case custom
 }
@@ -88,6 +90,7 @@ internal enum RUMInternalErrorSource {
     case network
     case webview
     case logger
+    case console
 
     init(_ errorSource: RUMErrorSource) {
         switch errorSource {
@@ -95,6 +98,7 @@ internal enum RUMInternalErrorSource {
         case .source: self = .source
         case .network: self = .network
         case .webview: self = .webview
+        case .console: self = .console
         }
     }
 }

--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -95,6 +95,8 @@ public enum DDRUMErrorSource: Int {
     case network
     /// Error originated in a webview.
     case webview
+    /// Error originated in a web console (used by bridges).
+    case console
     /// Custom error source.
     case custom
 
@@ -104,6 +106,7 @@ public enum DDRUMErrorSource: Int {
         case .network: return .network
         case .webview: return .webview
         case .custom: return .custom
+        case .console: return .console
         default: return .custom
         }
     }

--- a/Tests/DatadogTests/Datadog/RUM/DataModels/RUMDataModelsMappingTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/DataModels/RUMDataModelsMappingTests.swift
@@ -50,6 +50,7 @@ class RUMDataModelsMappingTests: XCTestCase {
             case .source: XCTAssertEqual(rumSource, .source)
             case .network: XCTAssertEqual(rumSource, .network)
             case .webview: XCTAssertEqual(rumSource, .webview)
+            case .console: XCTAssertEqual(rumSource, .console)
             case .logger: XCTAssertEqual(rumSource, .logger)
             }
         }
@@ -57,6 +58,7 @@ class RUMDataModelsMappingTests: XCTestCase {
         verifyInternalSource(.source)
         verifyInternalSource(.network)
         verifyInternalSource(.webview)
+        verifyInternalSource(.console)
         verifyInternalSource(.logger)
     }
 
@@ -87,6 +89,7 @@ class RUMInternalDataModelsMappingTests: XCTestCase {
             case .network: XCTAssertEqual(internalSource, .network)
             case .source: XCTAssertEqual(internalSource, .source)
             case .webview: XCTAssertEqual(internalSource, .webview)
+            case .console: XCTAssertEqual(internalSource, .console)
             }
         }
         // verify all known cases
@@ -94,5 +97,6 @@ class RUMInternalDataModelsMappingTests: XCTestCase {
         verifyErrorSource(.network)
         verifyErrorSource(.source)
         verifyErrorSource(.webview)
+        verifyErrorSource(.console)
     }
 }

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -80,6 +80,7 @@ class DDRUMErrorSourceTests: XCTestCase {
         XCTAssertEqual(DDRUMErrorSource.source.swiftType, .source)
         XCTAssertEqual(DDRUMErrorSource.network.swiftType, .network)
         XCTAssertEqual(DDRUMErrorSource.webview.swiftType, .webview)
+        XCTAssertEqual(DDRUMErrorSource.console.swiftType, .console)
         XCTAssertEqual(DDRUMErrorSource.custom.swiftType, .custom)
     }
 }

--- a/api-surface-objc
+++ b/api-surface-objc
@@ -1,4 +1,6 @@
-public class DDNSURLSessionDelegate: DDURLSessionDelegate
+ public var ddURLSessionDelegate: DDURLSessionDelegate
+ override public init()
+ public init(additionalFirstPartyHosts: Set<String>)
 public class DDTrackingConsent: NSObject
  public static func granted() -> DDTrackingConsent
  public static func notGranted() -> DDTrackingConsent
@@ -14,15 +16,27 @@ public class DDDatadog: NSObject
  public static func setUserInfo(id: String? = nil, name: String? = nil, email: String? = nil, extraInfo: [String: Any] = [:])
  public static func setTrackingConsent(consent: DDTrackingConsent)
 public class DDEndpoint: NSObject
+ public static func us1() -> DDEndpoint
+ public static func us3() -> DDEndpoint
+ public static func eu1() -> DDEndpoint
+ public static func us1_fed() -> DDEndpoint
  public static func eu() -> DDEndpoint
  public static func us() -> DDEndpoint
  public static func gov() -> DDEndpoint
 public class DDLogsEndpoint: NSObject
+ public static func us1() -> DDLogsEndpoint
+ public static func us3() -> DDLogsEndpoint
+ public static func eu1() -> DDLogsEndpoint
+ public static func us1_fed() -> DDLogsEndpoint
  public static func eu() -> DDLogsEndpoint
  public static func us() -> DDLogsEndpoint
  public static func gov() -> DDLogsEndpoint
  public static func custom(url: String) -> DDLogsEndpoint
 public class DDTracesEndpoint: NSObject
+ public static func us1() -> DDTracesEndpoint
+ public static func us3() -> DDTracesEndpoint
+ public static func eu1() -> DDTracesEndpoint
+ public static func us1_fed() -> DDTracesEndpoint
  public static func eu() -> DDTracesEndpoint
  public static func us() -> DDTracesEndpoint
  public static func gov() -> DDTracesEndpoint
@@ -57,12 +71,15 @@ public class DDConfigurationBuilder: NSObject
  public func trackUIKitRUMViews()
  public func trackUIKitRUMViews(using predicate: DDUIKitRUMViewsPredicate)
  public func trackUIKitActions()
+ public func trackUIKitRUMActions()
+ public func trackUIKitRUMActions(using predicate: DDUIKitRUMUserActionsPredicate)
  public func setRUMViewEventMapper(_ mapper: @escaping (DDRUMViewEvent) -> DDRUMViewEvent)
  public func setRUMResourceEventMapper(_ mapper: @escaping (DDRUMResourceEvent) -> DDRUMResourceEvent?)
  public func setRUMActionEventMapper(_ mapper: @escaping (DDRUMActionEvent) -> DDRUMActionEvent?)
  public func setRUMErrorEventMapper(_ mapper: @escaping (DDRUMErrorEvent) -> DDRUMErrorEvent?)
  public func set(batchSize: DDBatchSize)
  public func set(uploadFrequency: DDUploadFrequency)
+ public func set(additionalConfiguration: [String: Any])
  public func build() -> DDConfiguration
 public class DDGlobal: NSObject
  @objc public static var sharedTracer = DatadogObjc.DDTracer(swiftTracer: Datadog.Global.sharedTracer)
@@ -140,6 +157,7 @@ public class DDRUMViewEvent: NSObject
  @objc public var dd: DDRUMViewEventDD
  @objc public var application: DDRUMViewEventApplication
  @objc public var connectivity: DDRUMViewEventRUMConnectivity?
+ @objc public var context: DDRUMViewEventRUMEventAttributes?
  @objc public var date: NSNumber
  @objc public var service: String?
  @objc public var session: DDRUMViewEventSession
@@ -172,6 +190,8 @@ public enum DDRUMViewEventRUMConnectivityStatus: Int
  case connected
  case notConnected
  case maybe
+public class DDRUMViewEventRUMEventAttributes: NSObject
+ @objc public var contextInfo: [String: Any]
 public class DDRUMViewEventSession: NSObject
  @objc public var hasReplay: NSNumber?
  @objc public var id: String
@@ -183,8 +203,11 @@ public class DDRUMViewEventRUMUser: NSObject
  @objc public var email: String?
  @objc public var id: String?
  @objc public var name: String?
+ @objc public var usrInfo: [String: Any]
 public class DDRUMViewEventView: NSObject
  @objc public var action: DDRUMViewEventViewAction
+ @objc public var cpuTicksCount: NSNumber?
+ @objc public var cpuTicksPerSecond: NSNumber?
  @objc public var crash: DDRUMViewEventViewCrash?
  @objc public var cumulativeLayoutShift: NSNumber?
  @objc public var customTimings: [String: NSNumber]?
@@ -196,14 +219,19 @@ public class DDRUMViewEventView: NSObject
  @objc public var firstInputDelay: NSNumber?
  @objc public var firstInputTime: NSNumber?
  @objc public var id: String
+ @objc public var inForegroundPeriods: [DDRUMViewEventViewInForegroundPeriods]?
  @objc public var isActive: NSNumber?
  @objc public var largestContentfulPaint: NSNumber?
  @objc public var loadEvent: NSNumber?
  @objc public var loadingTime: NSNumber?
  @objc public var loadingType: DDRUMViewEventViewLoadingType
  @objc public var longTask: DDRUMViewEventViewLongTask?
+ @objc public var memoryAverage: NSNumber?
+ @objc public var memoryMax: NSNumber?
  @objc public var name: String?
  @objc public var referrer: String?
+ @objc public var refreshRateAverage: NSNumber?
+ @objc public var refreshRateMin: NSNumber?
  @objc public var resource: DDRUMViewEventViewResource
  @objc public var timeSpent: NSNumber
  @objc public var url: String
@@ -213,6 +241,9 @@ public class DDRUMViewEventViewCrash: NSObject
  @objc public var count: NSNumber
 public class DDRUMViewEventViewError: NSObject
  @objc public var count: NSNumber
+public class DDRUMViewEventViewInForegroundPeriods: NSObject
+ @objc public var duration: NSNumber
+ @objc public var start: NSNumber
 public enum DDRUMViewEventViewLoadingType: Int
  case none
  case initialLoad
@@ -232,6 +263,7 @@ public class DDRUMResourceEvent: NSObject
  @objc public var action: DDRUMResourceEventAction?
  @objc public var application: DDRUMResourceEventApplication
  @objc public var connectivity: DDRUMResourceEventRUMConnectivity?
+ @objc public var context: DDRUMResourceEventRUMEventAttributes?
  @objc public var date: NSNumber
  @objc public var resource: DDRUMResourceEventResource
  @objc public var service: String?
@@ -268,6 +300,8 @@ public enum DDRUMResourceEventRUMConnectivityStatus: Int
  case connected
  case notConnected
  case maybe
+public class DDRUMResourceEventRUMEventAttributes: NSObject
+ @objc public var contextInfo: [String: Any]
 public class DDRUMResourceEventResource: NSObject
  @objc public var connect: DDRUMResourceEventResourceConnect?
  @objc public var dns: DDRUMResourceEventResourceDNS?
@@ -351,6 +385,7 @@ public class DDRUMResourceEventRUMUser: NSObject
  @objc public var email: String?
  @objc public var id: String?
  @objc public var name: String?
+ @objc public var usrInfo: [String: Any]
 public class DDRUMResourceEventView: NSObject
  @objc public var id: String
  @objc public var name: String?
@@ -361,6 +396,7 @@ public class DDRUMActionEvent: NSObject
  @objc public var action: DDRUMActionEventAction
  @objc public var application: DDRUMActionEventApplication
  @objc public var connectivity: DDRUMActionEventRUMConnectivity?
+ @objc public var context: DDRUMActionEventRUMEventAttributes?
  @objc public var date: NSNumber
  @objc public var service: String?
  @objc public var session: DDRUMActionEventSession
@@ -419,6 +455,8 @@ public enum DDRUMActionEventRUMConnectivityStatus: Int
  case connected
  case notConnected
  case maybe
+public class DDRUMActionEventRUMEventAttributes: NSObject
+ @objc public var contextInfo: [String: Any]
 public class DDRUMActionEventSession: NSObject
  @objc public var hasReplay: NSNumber?
  @objc public var id: String
@@ -430,8 +468,10 @@ public class DDRUMActionEventRUMUser: NSObject
  @objc public var email: String?
  @objc public var id: String?
  @objc public var name: String?
+ @objc public var usrInfo: [String: Any]
 public class DDRUMActionEventView: NSObject
  @objc public var id: String
+ @objc public var inForeground: NSNumber?
  @objc public var name: String?
  @objc public var referrer: String?
  @objc public var url: String
@@ -440,6 +480,7 @@ public class DDRUMErrorEvent: NSObject
  @objc public var action: DDRUMErrorEventAction?
  @objc public var application: DDRUMErrorEventApplication
  @objc public var connectivity: DDRUMErrorEventRUMConnectivity?
+ @objc public var context: DDRUMErrorEventRUMEventAttributes?
  @objc public var date: NSNumber
  @objc public var error: DDRUMErrorEventError
  @objc public var service: String?
@@ -474,7 +515,10 @@ public enum DDRUMErrorEventRUMConnectivityStatus: Int
  case connected
  case notConnected
  case maybe
+public class DDRUMErrorEventRUMEventAttributes: NSObject
+ @objc public var contextInfo: [String: Any]
 public class DDRUMErrorEventError: NSObject
+ @objc public var id: String?
  @objc public var isCrash: NSNumber?
  @objc public var message: String
  @objc public var resource: DDRUMErrorEventErrorResource?
@@ -532,8 +576,10 @@ public class DDRUMErrorEventRUMUser: NSObject
  @objc public var email: String?
  @objc public var id: String?
  @objc public var name: String?
+ @objc public var usrInfo: [String: Any]
 public class DDRUMErrorEventView: NSObject
  @objc public var id: String
+ @objc public var inForeground: NSNumber?
  @objc public var name: String?
  @objc public var referrer: String?
  @objc public var url: String
@@ -543,10 +589,17 @@ public class DDRUMView: NSObject
  public init(name: String, attributes: [String: Any])
 public protocol DDUIKitRUMViewsPredicate: AnyObject
  func rumView(for viewController: UIViewController) -> DDRUMView?
+public class DDRUMAction: NSObject
+ @objc public var name: String
+ @objc public var attributes: [String: Any]
+ public init(name: String, attributes: [String: Any])
+public protocol DDUIKitRUMUserActionsPredicate: AnyObject
+ func rumAction(targetView: UIView) -> DDRUMAction?
 public enum DDRUMErrorSource: Int
  case source
  case network
  case webview
+ case console
  case custom
 public enum DDRUMUserActionType: Int
  case tap

--- a/api-surface-swift
+++ b/api-surface-swift
@@ -4,9 +4,51 @@ public enum TrackingConsent
  case granted
  case notGranted
  case pending
+public struct CarrierInfo: Equatable
+ public enum RadioAccessTechnology: String, Codable, CaseIterable
+  case GPRS
+  case Edge
+  case WCDMA
+  case HSDPA
+  case HSUPA
+  case CDMA1x
+  case CDMAEVDORev0
+  case CDMAEVDORevA
+  case CDMAEVDORevB
+  case eHRPD
+  case LTE
+  case unknown
+ public let carrierName: String?
+ public let carrierISOCountryCode: String?
+ public let carrierAllowsVOIP: Bool
+ public let radioAccessTechnology: RadioAccessTechnology
+public struct NetworkConnectionInfo: Equatable
+ public enum Reachability: String, Codable, CaseIterable
+  case yes
+  case maybe
+  case no
+ public enum Interface: String, Codable, CaseIterable
+  case wifi
+  case wiredEthernet
+  case cellular
+  case loopback
+  case other
+ public let reachability: Reachability
+ public let availableInterfaces: [Interface]?
+ public let supportsIPv4: Bool?
+ public let supportsIPv6: Bool?
+ public let isExpensive: Bool?
+ public let isConstrained: Bool?
 public class DDCrashReport: NSObject
- public init(date: Date?,type: String,message: String,stackTrace: String,context: Data?)
-public protocol DDCrashReportingPluginType: class
+ public struct Thread: Encodable
+  public init(name: String,stack: String,crashed: Bool,state: String?)
+ public struct BinaryImage: Encodable
+  public init(libraryName: String,uuid: String,architecture: String,isSystemLibrary: Bool,loadAddress: String,maxAddress: String)
+ public struct Meta: Encodable
+  public init(incidentIdentifier: String?,processName: String?,parentProcess: String?,path: String?,codeType: String?,exceptionType: String?,exceptionCodes: String?)
+ public var diagnosticInfo: [String: Encodable] = [:]
+ public init(date: Date?,type: String,message: String,stack: String,threads: [Thread],binaryImages: [BinaryImage],meta: Meta,wasTruncated: Bool,context: Data?)
+public protocol DDCrashReportingPluginType: AnyObject
  func readPendingCrashReport(completion: (DDCrashReport?) -> Bool)
  func inject(context: Data)
 public class DDRUMMonitor
@@ -38,9 +80,10 @@ public class Datadog
  public static func initialize(appContext: AppContext, configuration: Configuration)
  public static func initialize(appContext: AppContext,trackingConsent: TrackingConsent,configuration: Configuration)
  public static var verbosityLevel: LogLevel? = nil
- public static var debugRUM: Bool = false
+ public static var debugRUM = false
  public static func setUserInfo(id: String? = nil,name: String? = nil,email: String? = nil,extraInfo: [AttributeKey: AttributeValue] = [:])
  public static func set(trackingConsent: TrackingConsent)
+ public static func flushAndDeinitialize()
  public struct Configuration
   public enum BatchSize
    case small
@@ -51,20 +94,36 @@ public class Datadog
    case average
    case rare
   public enum DatadogEndpoint
-   case us
-   case eu
-   case gov
+   case us1
+   case us3
+   case eu1
+   case us1_fed
+   public static let us: DatadogEndpoint = .us1
+   public static let eu: DatadogEndpoint = .eu1
+   public static let gov: DatadogEndpoint = .us1_fed
   public enum LogsEndpoint
+   case us1
+   case us3
+   case eu1
+   case us1_fed
    case us
    case eu
    case gov
    case custom(url: String)
   public enum TracesEndpoint
+   case us1
+   case us3
+   case eu1
+   case us1_fed
    case us
    case eu
    case gov
    case custom(url: String)
   public enum RUMEndpoint
+   case us1
+   case us3
+   case eu1
+   case us1_fed
    case us
    case eu
    case gov
@@ -83,20 +142,25 @@ public class Datadog
    public func set(tracedHosts: Set<String>) -> Builder
    public func track(firstPartyHosts: Set<String>) -> Builder
    public func trackURLSession(firstPartyHosts: Set<String> = []) -> Builder
+   public func setSpanEventMapper(_ mapper: @escaping (SpanEvent) -> SpanEvent) -> Builder
    public func enableRUM(_ enabled: Bool) -> Builder
    public func set(rumEndpoint: RUMEndpoint) -> Builder
    public func set(rumSessionsSamplingRate: Float) -> Builder
    public func trackUIKitRUMViews(using predicate: UIKitRUMViewsPredicate = DefaultUIKitRUMViewsPredicate()) -> Builder
    public func trackUIKitActions(_ enabled: Bool = true) -> Builder
+   public func trackUIKitRUMActions(using predicate: UIKitRUMUserActionsPredicate = DefaultUIKitRUMUserActionsPredicate()) -> Builder
    public func setRUMViewEventMapper(_ mapper: @escaping (RUMViewEvent) -> RUMViewEvent) -> Builder
    public func setRUMResourceEventMapper(_ mapper: @escaping (RUMResourceEvent) -> RUMResourceEvent?) -> Builder
    public func setRUMActionEventMapper(_ mapper: @escaping (RUMActionEvent) -> RUMActionEvent?) -> Builder
    public func setRUMErrorEventMapper(_ mapper: @escaping (RUMErrorEvent) -> RUMErrorEvent?) -> Builder
+   public func setRUMResourceAttributesProvider(_ provider: @escaping (URLRequest, URLResponse?, Data?, Error?) -> [AttributeKey: AttributeValue]?) -> Builder
+   public func trackBackgroundEvents(_ enabled: Bool = true) -> Builder
    public func enableCrashReporting(using crashReportingPlugin: DDCrashReportingPluginType) -> Builder
    public func enableInternalMonitoring(clientToken: String) -> Builder
    public func set(serviceName: String) -> Builder
    public func set(batchSize: BatchSize) -> Builder
    public func set(uploadFrequency: UploadFrequency) -> Builder
+   public func set(additionalConfiguration: [String: Any]) -> Builder
    public func build() -> Configuration
 public typealias DDGlobal = Global
 public struct Global
@@ -207,6 +271,15 @@ public protocol OTTracer
 public extension OTTracer
  func startSpan(operationName: String,childOf parent: OTSpanContext? = nil,tags: [String: Encodable]? = nil,startTime: Date? = nil) -> OTSpan
  func startRootSpan(operationName: String,tags: [String: Encodable]? = nil,startTime: Date? = nil) -> OTSpan
+public struct RUMAction
+ public var name: String
+ public var attributes: [AttributeKey: AttributeValue]
+ public init(name: String, attributes: [AttributeKey: AttributeValue] = [:])
+public protocol UIKitRUMUserActionsPredicate
+ func rumAction(targetView: UIView) -> RUMAction?
+public struct DefaultUIKitRUMUserActionsPredicate: UIKitRUMUserActionsPredicate
+ public init ()
+ public func rumAction(targetView: UIView) -> RUMAction?
 public struct RUMView
  public var name: String
  public var path: String?
@@ -222,6 +295,7 @@ public struct RUMViewEvent: RUMDataModel
  public let dd: DD
  public let application: Application
  public let connectivity: RUMConnectivity?
+ public let context: RUMEventAttributes?
  public let date: Int64
  public let service: String?
  public let session: Session
@@ -242,6 +316,8 @@ public struct RUMViewEvent: RUMDataModel
    case synthetics = "synthetics"
  public struct View: Codable
   public let action: Action
+  public let cpuTicksCount: Double?
+  public let cpuTicksPerSecond: Double?
   public let crash: Crash?
   public let cumulativeLayoutShift: Double?
   public let customTimings: [String: Int64]?
@@ -253,14 +329,19 @@ public struct RUMViewEvent: RUMDataModel
   public let firstInputDelay: Int64?
   public let firstInputTime: Int64?
   public let id: String
+  public let inForegroundPeriods: [InForegroundPeriods]?
   public let isActive: Bool?
   public let largestContentfulPaint: Int64?
   public let loadEvent: Int64?
   public let loadingTime: Int64?
   public let loadingType: LoadingType?
   public let longTask: LongTask?
+  public let memoryAverage: Double?
+  public let memoryMax: Double?
   public var name: String?
   public var referrer: String?
+  public let refreshRateAverage: Double?
+  public let refreshRateMin: Double?
   public let resource: Resource
   public let timeSpent: Int64
   public var url: String
@@ -270,6 +351,9 @@ public struct RUMViewEvent: RUMDataModel
    public let count: Int64
   public struct Error: Codable
    public let count: Int64
+  public struct InForegroundPeriods: Codable
+   public let duration: Int64
+   public let start: Int64
   public enum LoadingType: String, Codable
    case initialLoad = "initial_load"
    case routeChange = "route_change"
@@ -288,6 +372,7 @@ public struct RUMResourceEvent: RUMDataModel
  public let action: Action?
  public let application: Application
  public let connectivity: RUMConnectivity?
+ public let context: RUMEventAttributes?
  public let date: Int64
  public var resource: Resource
  public let service: String?
@@ -383,6 +468,7 @@ public struct RUMActionEvent: RUMDataModel
  public var action: Action
  public let application: Application
  public let connectivity: RUMConnectivity?
+ public let context: RUMEventAttributes?
  public let date: Int64
  public let service: String?
  public let session: Session
@@ -429,6 +515,7 @@ public struct RUMActionEvent: RUMDataModel
    case synthetics = "synthetics"
  public struct View: Codable
   public let id: String
+  public let inForeground: Bool?
   public var name: String?
   public var referrer: String?
   public var url: String
@@ -437,6 +524,7 @@ public struct RUMErrorEvent: RUMDataModel
  public let action: Action?
  public let application: Application
  public let connectivity: RUMConnectivity?
+ public let context: RUMEventAttributes?
  public let date: Int64
  public var error: Error
  public let service: String?
@@ -451,6 +539,7 @@ public struct RUMErrorEvent: RUMDataModel
  public struct Application: Codable
   public let id: String
  public struct Error: Codable
+  public let id: String?
   public let isCrash: Bool?
   public var message: String
   public var resource: Resource?
@@ -498,6 +587,7 @@ public struct RUMErrorEvent: RUMDataModel
    case synthetics = "synthetics"
  public struct View: Codable
   public let id: String
+  public let inForeground: Bool?
   public var name: String?
   public var referrer: String?
   public var url: String
@@ -522,10 +612,17 @@ public struct RUMConnectivity: Codable
   case connected = "connected"
   case notConnected = "not_connected"
   case maybe = "maybe"
+public struct RUMEventAttributes: Codable
+ public let contextInfo: [String: Codable]
+ public func encode(to encoder: Encoder) throws
+ public init(from decoder: Decoder) throws
 public struct RUMUser: Codable
  public let email: String?
  public let id: String?
  public let name: String?
+ public let usrInfo: [String: Codable]
+ public func encode(to encoder: Encoder) throws
+ public init(from decoder: Decoder) throws
 public enum RUMMethod: String, Codable
  case post = "POST"
  case get = "GET"
@@ -543,6 +640,7 @@ public enum RUMErrorSource
  case source
  case network
  case webview
+ case console
  case custom
 public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber
  public static func initialize() -> DDRUMMonitor
@@ -568,6 +666,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber
  override public func addUserAction(type: RUMUserActionType, name: String, attributes: [AttributeKey: AttributeValue])
  override public func addAttribute(forKey key: AttributeKey, value: AttributeValue)
  override public func removeAttribute(forKey key: AttributeKey)
+ public func flush()
 public struct DDTags
  public static let resource = "resource.name"
 public typealias DDTracer = Tracer
@@ -588,11 +687,35 @@ public class HTTPHeadersWriter: OTHTTPHeadersWriter
  public init()
  public private(set) var tracePropagationHTTPHeaders: [String: String] = [:]
  public func inject(spanContext: OTSpanContext)
+public struct SpanEvent: Encodable
+ public var operationName: String
+ public let serviceName: String
+ public var resource: String
+ public let startTime: Date
+ public let duration: TimeInterval
+ public let isError: Bool
+ public let tracerVersion: String
+ public let applicationVersion: String
+ public let networkConnectionInfo: NetworkConnectionInfo?
+ public let mobileCarrierInfo: CarrierInfo?
+ public struct UserInfo
+  public let id: String?
+  public let name: String?
+  public let email: String?
+  public var extraInfo: [String: String]
+ public var userInfo: UserInfo
+ public var tags: [String: String]
+ public func encode(to encoder: Encoder) throws
+public protocol __URLSessionDelegateProviding: URLSessionDelegate
+ var ddURLSessionDelegate: DDURLSessionDelegate
+ public var ddURLSessionDelegate: DDURLSessionDelegate
  override public init()
  public init(additionalFirstPartyHosts: Set<String>)
+ public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data)
 public class URLSessionInterceptor: URLSessionInterceptorType
  public static var shared: URLSessionInterceptor?
  public func modify(request: URLRequest, session: URLSession? = nil) -> URLRequest
  public func taskCreated(task: URLSessionTask, session: URLSession? = nil)
  public func taskMetricsCollected(task: URLSessionTask, metrics: URLSessionTaskMetrics)
+ public func taskReceivedData(task: URLSessionTask, data: Data)
  public func taskCompleted(task: URLSessionTask, error: Error?)


### PR DESCRIPTION
### What and why?

This change adds additional `.console` type to the public API. It exists internally, but is not exposed publicly. This type is needed for the errors reported from the bridges, to be consistent with Android SDK.

### How?

Just additional field in the `RUMErrorSource` enum. Also this change updates `api-surface` files, this wasn't done in a while.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
