### PR TITLE
RUMM-1544 RunLoop is used in common mode only

### DIFF
--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -67,7 +67,7 @@ internal final class VitalInfoSampler {
         // NOTE: RUMM-1280 based on my running Example app
         // non-main run loops don't fire the timer.
         // Although i can't catch this in unit tests
-        RunLoop.main.add(timer, forMode: .default)
+        RunLoop.main.add(timer, forMode: .common)
         self.timer = timer
     }
 


### PR DESCRIPTION
### What and why?

`VitalInfoSampler` samples vital info, such as CPU, RAM and FPS, with a timer.
However, the timer is added to main `RunLoop` with `default` mode. For example, when `RunLoop` goes into `tracking` mode when the user scrolls a view then timer stops firing during the scroll.

### How?

`common` mode is used to solve this issue.
Similar to https://github.com/DataDog/dd-sdk-ios/pull/554

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
