### PR TITLE
RUMM-1492: Fix `isSystemImage` detection

### DIFF
--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReport.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReport.swift
@@ -241,8 +241,12 @@ extension BinaryImageInfo {
 
         self.uuid = imageUUID
         self.imageName = URL(string: imagePath)?.lastPathComponent
-        // NOTE: RUMM-1492 refer to JIRA ticket or `CrashReportTests.swift` to see imagePath examples
-        self.isSystemImage = !imagePath.contains("/Bundle/Application/") || imagePath.contains("/Contents/Developer/Platforms/")
+
+        #if targetEnvironment(simulator)
+        self.isSystemImage = Self.isPathSystemImageInSimulator(imagePath)
+        #else
+        self.isSystemImage = Self.isPathSystemImageInDevice(imagePath)
+        #endif
 
         if let codeType = imageInfo.codeType {
             self.codeType = CodeType(from: codeType)
@@ -253,6 +257,17 @@ extension BinaryImageInfo {
 
         self.imageBaseAddress = imageInfo.imageBaseAddress
         self.imageSize = imageInfo.imageSize
+    }
+
+    static func isPathSystemImageInSimulator(_ path: String) -> Bool {
+        // in simulator, example system image path: ~/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/...
+        return path.contains("/Contents/Developer/Platforms/")
+    }
+
+    static func isPathSystemImageInDevice(_ path: String) -> Bool {
+        // in device, example user image path: .../containers/Bundle/Application/0000/Example.app/Frameworks/...
+        let isUserImage = path.contains("/Bundle/Application/")
+        return !isUserImage
     }
 }
 


### PR DESCRIPTION
### What and why?

`isSystemImage` is important for crash report symbolication at the backend.
However, it's a bit tricky tell system images from user images.

#### In simulator

User images can be found in
1. `MyApp.app` bundle or
2. `DerivedData` folder (which is customizable)

System images can only be found in `Xcode.app` bundle.

#### In device

System images can be found in various places, such as
1. `usr/lib/`
2. `System/Library/`
3. etc.

User images can only be found in `MyApp.app` bundle.

### How?

We implemented 2 different logic based on the platform: simulator or device.
However, we test both in our unit tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
