### PR TITLE
RUMM-1527 Add billing attribute to all RUM events

### DIFF
--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -95,13 +95,17 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         errorEventAttributes[DDError.wasTruncated] = crashReport.wasTruncated
 
         let rumError = RUMErrorEvent(
-            dd: .init(),
+            dd: .init(
+                session: .init(plan: .plan1)
+            ),
             action: nil,
             application: .init(id: lastRUMView.application.id),
             connectivity: lastRUMView.connectivity,
             context: nil,
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds,
             error: .init(
+                handling: nil,
+                handlingStack: nil,
                 id: nil,
                 isCrash: true,
                 message: errorMessage,
@@ -136,7 +140,10 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
     private func updateRUMViewWithNewError(_ rumViewEvent: RUMEvent<RUMViewEvent>, crashDate: Date) -> RUMEvent<RUMViewEvent> {
         let original = rumViewEvent.model
         let rumView = RUMViewEvent(
-            dd: .init(documentVersion: original.dd.documentVersion + 1),
+            dd: .init(
+                documentVersion: original.dd.documentVersion + 1,
+                session: .init(plan: .plan1)
+            ),
             application: original.application,
             connectivity: original.connectivity,
             context: original.context,

--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -61,9 +61,29 @@ public struct RUMViewEvent: RUMDataModel {
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
+        /// Session-related internal properties
+        public let session: Session?
+
         enum CodingKeys: String, CodingKey {
             case documentVersion = "document_version"
             case formatVersion = "format_version"
+            case session = "session"
+        }
+
+        /// Session-related internal properties
+        public struct Session: Codable {
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public let plan: Plan
+
+            enum CodingKeys: String, CodingKey {
+                case plan = "plan"
+            }
+
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public enum Plan: Int, Codable {
+                case plan1 = 1
+                case plan2 = 2
+            }
         }
     }
 
@@ -362,6 +382,9 @@ public struct RUMResourceEvent: RUMDataModel {
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
+        /// Session-related internal properties
+        public let session: Session?
+
         /// span identifier in decimal format
         public let spanId: String?
 
@@ -370,8 +393,25 @@ public struct RUMResourceEvent: RUMDataModel {
 
         enum CodingKeys: String, CodingKey {
             case formatVersion = "format_version"
+            case session = "session"
             case spanId = "span_id"
             case traceId = "trace_id"
+        }
+
+        /// Session-related internal properties
+        public struct Session: Codable {
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public let plan: Plan
+
+            enum CodingKeys: String, CodingKey {
+                case plan = "plan"
+            }
+
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public enum Plan: Int, Codable {
+                case plan1 = 1
+                case plan2 = 2
+            }
         }
     }
 
@@ -692,8 +732,28 @@ public struct RUMActionEvent: RUMDataModel {
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
+        /// Session-related internal properties
+        public let session: Session?
+
         enum CodingKeys: String, CodingKey {
             case formatVersion = "format_version"
+            case session = "session"
+        }
+
+        /// Session-related internal properties
+        public struct Session: Codable {
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public let plan: Plan
+
+            enum CodingKeys: String, CodingKey {
+                case plan = "plan"
+            }
+
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public enum Plan: Int, Codable {
+                case plan1 = 1
+                case plan2 = 2
+            }
         }
     }
 
@@ -915,8 +975,28 @@ public struct RUMErrorEvent: RUMDataModel {
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
+        /// Session-related internal properties
+        public let session: Session?
+
         enum CodingKeys: String, CodingKey {
             case formatVersion = "format_version"
+            case session = "session"
+        }
+
+        /// Session-related internal properties
+        public struct Session: Codable {
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public let plan: Plan
+
+            enum CodingKeys: String, CodingKey {
+                case plan = "plan"
+            }
+
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public enum Plan: Int, Codable {
+                case plan1 = 1
+                case plan2 = 2
+            }
         }
     }
 
@@ -942,6 +1022,12 @@ public struct RUMErrorEvent: RUMDataModel {
 
     /// Error properties
     public struct Error: Codable {
+        /// Whether the error has been handled manually in the source code or not
+        public let handling: Handling?
+
+        /// Handling call stack
+        public let handlingStack: String?
+
         /// UUID of the error
         public let id: String?
 
@@ -964,6 +1050,8 @@ public struct RUMErrorEvent: RUMDataModel {
         public let type: String?
 
         enum CodingKeys: String, CodingKey {
+            case handling = "handling"
+            case handlingStack = "handling_stack"
             case id = "id"
             case isCrash = "is_crash"
             case message = "message"
@@ -971,6 +1059,12 @@ public struct RUMErrorEvent: RUMDataModel {
             case source = "source"
             case stack = "stack"
             case type = "type"
+        }
+
+        /// Whether the error has been handled manually in the source code or not
+        public enum Handling: String, Codable {
+            case handled = "handled"
+            case unhandled = "unhandled"
         }
 
         /// Resource properties of the error
@@ -1257,4 +1351,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/d40d93a607a2d4483c95bd000a4e8ebd96fdf1fd
+// Generated from https://github.com/DataDog/rum-events-format/tree/2ea84b56a4e0670b2d6e3e0c6a5fd27774ce4a3d

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -130,6 +130,7 @@ internal class RUMResourceScope: RUMScope {
 
         let eventData = RUMResourceEvent(
             dd: .init(
+                session: .init(plan: .plan1),
                 spanId: spanId,
                 traceId: traceId
             ),
@@ -208,7 +209,9 @@ internal class RUMResourceScope: RUMScope {
         attributes.merge(rumCommandAttributes: command.attributes)
 
         let eventData = RUMErrorEvent(
-            dd: .init(),
+            dd: .init(
+                session: .init(plan: .plan1)
+            ),
             action: context.activeUserActionID.flatMap { rumUUID in
                 .init(id: rumUUID.toRUMDataFormat)
             },
@@ -217,6 +220,8 @@ internal class RUMResourceScope: RUMScope {
             context: nil,
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
             error: .init(
+                handling: nil,
+                handlingStack: nil,
                 id: nil,
                 isCrash: false,
                 message: command.errorMessage,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -128,7 +128,9 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
         }
 
         let eventData = RUMActionEvent(
-            dd: .init(),
+            dd: .init(
+                session: .init(plan: .plan1)
+            ),
             action: .init(
                 crash: nil,
                 error: .init(count: errorsCount.toInt64),

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -287,7 +287,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
     private func sendApplicationStartAction(on command: RUMCommand) -> Bool {
         let eventData = RUMActionEvent(
-            dd: .init(),
+            dd: .init(
+                session: .init(plan: .plan1)
+            ),
             action: .init(
                 crash: nil,
                 error: nil,
@@ -332,7 +334,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let refreshRateInfo = vitalInfoSampler.refreshRate
 
         let eventData = RUMViewEvent(
-            dd: .init(documentVersion: version.toInt64),
+            dd: .init(
+                documentVersion: version.toInt64,
+                session: .init(plan: .plan1)
+            ),
             application: .init(id: context.rumApplicationID),
             connectivity: dependencies.connectivityInfoProvider.current,
             context: nil,
@@ -388,7 +393,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         attributes.merge(rumCommandAttributes: command.attributes)
 
         let eventData = RUMErrorEvent(
-            dd: .init(),
+            dd: .init(
+                session: .init(plan: .plan1)
+            ),
             action: context.activeUserActionID.flatMap { rumUUID in
                 .init(id: rumUUID.toRUMDataFormat)
             },
@@ -397,6 +404,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             context: nil,
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
             error: .init(
+                handling: nil,
+                handlingStack: nil,
                 id: nil,
                 isCrash: nil,
                 message: command.message,

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -76,6 +76,43 @@ public class DDRUMViewEventDD: NSObject {
     @objc public var formatVersion: NSNumber {
         root.swiftModel.dd.formatVersion as NSNumber
     }
+
+    @objc public var session: DDRUMViewEventDDSession? {
+        root.swiftModel.dd.session != nil ? DDRUMViewEventDDSession(root: root) : nil
+    }
+}
+
+@objc
+public class DDRUMViewEventDDSession: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var plan: DDRUMViewEventDDSessionPlan {
+        .init(swift: root.swiftModel.dd.session!.plan)
+    }
+}
+
+@objc
+public enum DDRUMViewEventDDSessionPlan: Int {
+    internal init(swift: RUMViewEvent.DD.Session.Plan) {
+        switch swift {
+        case .plan1: self = .plan1
+        case .plan2: self = .plan2
+        }
+    }
+
+    internal var toSwift: RUMViewEvent.DD.Session.Plan {
+        switch self {
+        case .plan1: return .plan1
+        case .plan2: return .plan2
+        }
+    }
+
+    case plan1
+    case plan2
 }
 
 @objc
@@ -598,6 +635,10 @@ public class DDRUMResourceEventDD: NSObject {
         root.swiftModel.dd.formatVersion as NSNumber
     }
 
+    @objc public var session: DDRUMResourceEventDDSession? {
+        root.swiftModel.dd.session != nil ? DDRUMResourceEventDDSession(root: root) : nil
+    }
+
     @objc public var spanId: String? {
         root.swiftModel.dd.spanId
     }
@@ -605,6 +646,39 @@ public class DDRUMResourceEventDD: NSObject {
     @objc public var traceId: String? {
         root.swiftModel.dd.traceId
     }
+}
+
+@objc
+public class DDRUMResourceEventDDSession: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var plan: DDRUMResourceEventDDSessionPlan {
+        .init(swift: root.swiftModel.dd.session!.plan)
+    }
+}
+
+@objc
+public enum DDRUMResourceEventDDSessionPlan: Int {
+    internal init(swift: RUMResourceEvent.DD.Session.Plan) {
+        switch swift {
+        case .plan1: self = .plan1
+        case .plan2: self = .plan2
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.DD.Session.Plan {
+        switch self {
+        case .plan1: return .plan1
+        case .plan2: return .plan2
+        }
+    }
+
+    case plan1
+    case plan2
 }
 
 @objc
@@ -1234,6 +1308,43 @@ public class DDRUMActionEventDD: NSObject {
     @objc public var formatVersion: NSNumber {
         root.swiftModel.dd.formatVersion as NSNumber
     }
+
+    @objc public var session: DDRUMActionEventDDSession? {
+        root.swiftModel.dd.session != nil ? DDRUMActionEventDDSession(root: root) : nil
+    }
+}
+
+@objc
+public class DDRUMActionEventDDSession: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var plan: DDRUMActionEventDDSessionPlan {
+        .init(swift: root.swiftModel.dd.session!.plan)
+    }
+}
+
+@objc
+public enum DDRUMActionEventDDSessionPlan: Int {
+    internal init(swift: RUMActionEvent.DD.Session.Plan) {
+        switch swift {
+        case .plan1: self = .plan1
+        case .plan2: self = .plan2
+        }
+    }
+
+    internal var toSwift: RUMActionEvent.DD.Session.Plan {
+        switch self {
+        case .plan1: return .plan1
+        case .plan2: return .plan2
+        }
+    }
+
+    case plan1
+    case plan2
 }
 
 @objc
@@ -1673,6 +1784,43 @@ public class DDRUMErrorEventDD: NSObject {
     @objc public var formatVersion: NSNumber {
         root.swiftModel.dd.formatVersion as NSNumber
     }
+
+    @objc public var session: DDRUMErrorEventDDSession? {
+        root.swiftModel.dd.session != nil ? DDRUMErrorEventDDSession(root: root) : nil
+    }
+}
+
+@objc
+public class DDRUMErrorEventDDSession: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var plan: DDRUMErrorEventDDSessionPlan {
+        .init(swift: root.swiftModel.dd.session!.plan)
+    }
+}
+
+@objc
+public enum DDRUMErrorEventDDSessionPlan: Int {
+    internal init(swift: RUMErrorEvent.DD.Session.Plan) {
+        switch swift {
+        case .plan1: self = .plan1
+        case .plan2: self = .plan2
+        }
+    }
+
+    internal var toSwift: RUMErrorEvent.DD.Session.Plan {
+        switch self {
+        case .plan1: return .plan1
+        case .plan2: return .plan2
+        }
+    }
+
+    case plan1
+    case plan2
 }
 
 @objc
@@ -1824,6 +1972,14 @@ public class DDRUMErrorEventError: NSObject {
         self.root = root
     }
 
+    @objc public var handling: DDRUMErrorEventErrorHandling {
+        .init(swift: root.swiftModel.error.handling)
+    }
+
+    @objc public var handlingStack: String? {
+        root.swiftModel.error.handlingStack
+    }
+
     @objc public var id: String? {
         root.swiftModel.error.id
     }
@@ -1853,6 +2009,29 @@ public class DDRUMErrorEventError: NSObject {
     @objc public var type: String? {
         root.swiftModel.error.type
     }
+}
+
+@objc
+public enum DDRUMErrorEventErrorHandling: Int {
+    internal init(swift: RUMErrorEvent.Error.Handling?) {
+        switch swift {
+        case nil: self = .none
+        case .handled?: self = .handled
+        case .unhandled?: self = .unhandled
+        }
+    }
+
+    internal var toSwift: RUMErrorEvent.Error.Handling? {
+        switch self {
+        case .none: return nil
+        case .handled: return .handled
+        case .unhandled: return .unhandled
+        }
+    }
+
+    case none
+    case handled
+    case unhandled
 }
 
 @objc
@@ -2128,4 +2307,4 @@ public class DDRUMErrorEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/d40d93a607a2d4483c95bd000a4e8ebd96fdf1fd
+// Generated from https://github.com/DataDog/rum-events-format/tree/2ea84b56a4e0670b2d6e3e0c6a5fd27774ce4a3d

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -159,6 +159,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
             crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds,
             "The `RUMViewEvent` sent must include crash date corrected by current correction offset."
         )
+        XCTAssertEqual(sendRUMViewEvent.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
     func testWhenSendingRUMErrorEvent_itIncludesCrashInformation() throws {
@@ -243,6 +244,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
             2: stack-trace line 2
             """
         )
+        XCTAssertEqual(sendRUMErrorEvent.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
         XCTAssertEqual(sendRUMEvent.attributes[DDError.threads] as? [DDCrashReport.Thread], crashReport.threads)
         XCTAssertEqual(sendRUMEvent.attributes[DDError.binaryImages] as? [DDCrashReport.BinaryImage], crashReport.binaryImages)
         XCTAssertEqual(sendRUMEvent.attributes[DDError.meta] as? DDCrashReport.Meta, crashReport.meta)

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -53,7 +53,10 @@ extension RUMEventAttributes: RandomMockable {
 extension RUMViewEvent {
     static func mockRandom() -> RUMViewEvent {
         return RUMViewEvent(
-            dd: .init(documentVersion: .mockRandom()),
+            dd: .init(
+                documentVersion: .mockRandom(),
+                session: .init(plan: .plan1)
+            ),
             application: .init(id: .mockRandom()),
             connectivity: .mockRandom(),
             context: .mockRandom(),
@@ -110,6 +113,7 @@ extension RUMResourceEvent {
     static func mockRandom() -> RUMResourceEvent {
         return RUMResourceEvent(
             dd: .init(
+                session: .init(plan: .plan1),
                 spanId: .mockRandom(),
                 traceId: .mockRandom()
             ),
@@ -157,7 +161,9 @@ extension RUMResourceEvent {
 extension RUMActionEvent {
     static func mockRandom() -> RUMActionEvent {
         return RUMActionEvent(
-            dd: .init(),
+            dd: .init(
+                session: .init(plan: .plan1)
+            ),
             action: .init(
                 crash: .init(count: .mockRandom()),
                 error: .init(count: .mockRandom()),
@@ -192,13 +198,17 @@ extension RUMActionEvent {
 extension RUMErrorEvent {
     static func mockRandom() -> RUMErrorEvent {
         return RUMErrorEvent(
-            dd: .init(),
+            dd: .init(
+                session: .init(plan: .plan1)
+            ),
             action: .init(id: .mockRandom()),
             application: .init(id: .mockRandom()),
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
             error: .init(
+                handling: nil,
+                handlingStack: nil,
                 id: .mockRandom(),
                 isCrash: .random(),
                 message: .mockRandom(),

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -97,6 +97,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
         XCTAssertEqual(event.model.dd.traceId, "100")
         XCTAssertEqual(event.model.dd.spanId, "200")
+        XCTAssertEqual(event.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
     func testGivenStartedResource_whenResourceLoadingEnds_itSendsResourceEventWithCustomSpanAndTraceId() throws {
@@ -213,6 +214,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.error.resource?.url, "https://foo.com/resource/1")
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), context.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
     func testGivenStartedResource_whenResourceReceivesMetricsBeforeItEnds_itUsesMetricValuesInSentResourceEvent() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -57,6 +57,7 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertEqual(recordedActionEvents.count, 1)
         let recordedAction = try XCTUnwrap(recordedActionEvents.last)
         XCTAssertEqual(recordedAction.model.action.type.rawValue, String(describing: mockUserActionCmd.actionType))
+        XCTAssertEqual(recordedAction.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
     // MARK: - Continuous User Action

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -92,6 +92,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertValidRumUUID(event.model.action.id)
         XCTAssertEqual(event.model.action.type, .applicationStart)
         XCTAssertEqual(event.model.action.loadingTime, 2_000_000_000) // 2e+9 ns
+        XCTAssertEqual(event.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
     func testWhenInitialViewIsStarted_itSendsViewUpdateEvent() throws {
@@ -129,6 +130,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)
         XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
     func testWhenViewIsStarted_itSendsViewUpdateEvent() throws {
@@ -581,6 +583,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertNil(error.model.error.resource)
         XCTAssertNil(error.model.action)
         XCTAssertEqual(error.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(error.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
 
         let viewUpdate = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)
         XCTAssertEqual(viewUpdate.model.view.error.count, 1)

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
@@ -81,7 +81,7 @@ internal class JSONSchema: Decodable {
             // If data in this `decoder` cannot be represented as keyed container, perhaps it encodes
             // a single value. Check known schema values:
             do {
-                if decoder.codingPath.last as! JSONSchema.CodingKeys == .additionalProperties { // swiftlint:disable:this force_cast
+                if decoder.codingPath.last as? JSONSchema.CodingKeys == .additionalProperties {
                     // Handle `additionalProperties: true | false`
                     let singleValueContainer = try decoder.singleValueContainer()
                     let hasAdditionalProperties = try singleValueContainer.decode(Bool.self)
@@ -113,6 +113,22 @@ internal class JSONSchema: Decodable {
 
     // MARK: - Schema attributes
 
+    enum EnumValue: Decodable, Equatable {
+        case string(String)
+        case integer(Int)
+
+        init(from decoder: Decoder) throws {
+            let singleValueContainer = try decoder.singleValueContainer()
+            if let string = try? singleValueContainer.decode(String.self) {
+                self = .string(string)
+            } else if let integer = try? singleValueContainer.decode(Int.self) {
+                self = .integer(integer)
+            } else {
+                throw Exception.unimplemented("Trying to decode `EnumValue` but its none of supported values.")
+            }
+        }
+    }
+
     private(set) var id: String?
     private(set) var title: String?
     private(set) var description: String?
@@ -120,7 +136,7 @@ internal class JSONSchema: Decodable {
     private(set) var additionalProperties: JSONSchema?
     private(set) var required: [String]?
     private(set) var type: SchemaType?
-    private(set) var `enum`: [String]?
+    private(set) var `enum`: [EnumValue]?
     private(set) var const: SchemaConstant?
     private(set) var items: JSONSchema?
     private(set) var readOnly: Bool?

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
@@ -71,13 +71,13 @@ internal class JSONSchema: Decodable {
             self.additionalProperties = try keyedContainer.decodeIfPresent(JSONSchema.self, forKey: .additionalProperties)
             self.required = try keyedContainer.decodeIfPresent([String].self, forKey: .required)
             self.type = try keyedContainer.decodeIfPresent(SchemaType.self, forKey: .type)
-            self.enum = try keyedContainer.decodeIfPresent([String].self, forKey: .enum)
+            self.enum = try keyedContainer.decodeIfPresent([EnumValue].self, forKey: .enum)
             self.const = try keyedContainer.decodeIfPresent(SchemaConstant.self, forKey: .const)
             self.items = try keyedContainer.decodeIfPresent(JSONSchema.self, forKey: .items)
             self.readOnly = try keyedContainer.decodeIfPresent(Bool.self, forKey: .readOnly)
             self.ref = try keyedContainer.decodeIfPresent(String.self, forKey: .ref)
             self.allOf = try keyedContainer.decodeIfPresent([JSONSchema].self, forKey: .allOf)
-        } catch let keyedContainerError {
+        } catch let keyedContainerError as DecodingError {
             // If data in this `decoder` cannot be represented as keyed container, perhaps it encodes
             // a single value. Check known schema values:
             do {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchemaToJSONTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchemaToJSONTypeTransformer.swift
@@ -42,7 +42,11 @@ internal class JSONSchemaToJSONTypeTransformer {
         case .array:
             return try transformSchemaToArray(schema, named: name)
         case .boolean, .integer, .number:
-            return try transformSchemaToPrimitive(schema)
+            if schema.enum != nil {
+                return try transformSchemaToEnumeration(schema, named: name)
+            } else {
+                return try transformSchemaToPrimitive(schema)
+            }
         case .string:
             if schema.enum != nil {
                 return try transformSchemaToEnumeration(schema, named: name)
@@ -89,6 +93,12 @@ internal class JSONSchemaToJSONTypeTransformer {
             comment: schema.description,
             values: try schema.enum
                 .unwrapOrThrow(.inconsistency("`JSONEnumeration` schema must define `enum`."))
+                .map { schemaValue in
+                    switch schemaValue {
+                    case .string(let value): return .string(value: value)
+                    case .integer(let value): return .integer(value: value)
+                    }
+                }
         )
     }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONType.swift
@@ -23,9 +23,14 @@ internal struct JSONArray: JSONType {
 }
 
 internal struct JSONEnumeration: JSONType {
+    enum Value {
+        case string(value: String)
+        case integer(value: Int)
+    }
+
     let name: String
     let comment: String?
-    let values: [String]
+    let values: [Value]
 }
 
 internal struct JSONObject: JSONType {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -59,7 +59,12 @@ internal class JSONToSwiftTypeTransformer {
             name: jsonEnumeration.name,
             comment: jsonEnumeration.comment,
             cases: jsonEnumeration.values.map { value in
-                SwiftEnum.Case(label: value, rawValue: value)
+                switch value {
+                case .string(let value):
+                    return SwiftEnum.Case(label: value, rawValue: .string(value: value))
+                case .integer(let value):
+                    return SwiftEnum.Case(label: "\(jsonEnumeration.name)\(value)", rawValue: .integer(value: value))
+                }
             },
             conformance: []
         )
@@ -111,7 +116,7 @@ internal class JSONToSwiftTypeTransformer {
                         return intValue
                     case .string(let stringValue):
                         if objectProperty.type is JSONEnumeration {
-                            return SwiftEnum.Case(label: stringValue, rawValue: stringValue)
+                            return SwiftEnum.Case(label: stringValue, rawValue: .string(value: stringValue))
                         } else {
                             return stringValue
                         }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -38,8 +38,12 @@ internal struct SwiftDictionary: SwiftType {
 
 internal struct SwiftEnum: SwiftType {
     struct Case: SwiftType, SwiftPropertyDefaultValue {
+        enum RawValue {
+            case string(value: String)
+            case integer(value: Int)
+        }
         var label: String
-        var rawValue: String
+        var rawValue: RawValue
     }
 
     var name: String

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaReaderTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaReaderTests.swift
@@ -16,15 +16,21 @@ final class JSONSchemaReaderTests: XCTestCase {
             "title": "Schema title",
             "description": "Schema description.",
             "properties": {
-                "property1": {
+                "stringEnumProperty": {
                     "type": "string",
-                    "description": "Description of `property1`.",
+                    "description": "Description of `stringEnumProperty`.",
                     "enum": ["case1", "case2", "case3", "case4"],
                     "const": "case2"
                 },
-                "property2": {
+                "integerEnumProperty": {
+                    "type": "number",
+                    "description": "Description of `integerEnumProperty`.",
+                    "enum": [1, 2, 3, 4],
+                    "const": 3
+                },
+                "arrayProperty": {
                     "type": "array",
-                    "description": "Description of `property2`.",
+                    "description": "Description of `arrayProperty`.",
                     "items": {
                         "type": "string",
                         "enum": ["option1", "option2", "option3", "option4"]
@@ -60,27 +66,33 @@ final class JSONSchemaReaderTests: XCTestCase {
         XCTAssertEqual(schema.title, "Schema title")
         XCTAssertEqual(schema.description, "Schema description.")
 
-        XCTAssertEqual(schema.properties?.count, 3)
+        XCTAssertEqual(schema.properties?.count, 4)
 
-        let property1 = try XCTUnwrap(schema.properties?["property1"])
+        let property1 = try XCTUnwrap(schema.properties?["stringEnumProperty"])
         XCTAssertEqual(property1.type, .string)
-        XCTAssertEqual(property1.description, "Description of `property1`.")
-        XCTAssertEqual(property1.enum, ["case1", "case2", "case3", "case4"])
+        XCTAssertEqual(property1.description, "Description of `stringEnumProperty`.")
+        XCTAssertEqual(property1.enum, [.string("case1"), .string("case2"), .string("case3"), .string("case4")])
         XCTAssertEqual(property1.const!.value, .string(value: "case2"))
 
-        let property2 = try XCTUnwrap(schema.properties?["property2"])
-        XCTAssertEqual(property2.type, .array)
-        XCTAssertEqual(property2.description, "Description of `property2`.")
-        XCTAssertEqual(property2.items?.type, .string)
-        XCTAssertEqual(property2.items?.enum, ["option1", "option2", "option3", "option4"])
-        XCTAssertTrue(property2.readOnly == false)
+        let property2 = try XCTUnwrap(schema.properties?["integerEnumProperty"])
+        XCTAssertEqual(property2.type, .number)
+        XCTAssertEqual(property2.description, "Description of `integerEnumProperty`.")
+        XCTAssertEqual(property2.enum, [.integer(1), .integer(2), .integer(3), .integer(4)])
+        XCTAssertEqual(property2.const!.value, .integer(value: 3))
 
-        let property3 = try XCTUnwrap(schema.properties?["propertyWithAdditionalProperties"])
-        XCTAssertEqual(property3.type, .object)
-        XCTAssertEqual(property3.description, "Description of a property with nested additional properties.")
-        XCTAssertEqual(property3.additionalProperties?.type, .integer)
-        XCTAssertEqual(property3.additionalProperties?.readOnly, true)
-        XCTAssertTrue(property3.readOnly == true)
+        let property3 = try XCTUnwrap(schema.properties?["arrayProperty"])
+        XCTAssertEqual(property3.type, .array)
+        XCTAssertEqual(property3.description, "Description of `arrayProperty`.")
+        XCTAssertEqual(property3.items?.type, .string)
+        XCTAssertEqual(property3.items?.enum, [.string("option1"), .string("option2"), .string("option3"), .string("option4")])
+        XCTAssertTrue(property3.readOnly == false)
+
+        let property4 = try XCTUnwrap(schema.properties?["propertyWithAdditionalProperties"])
+        XCTAssertEqual(property4.type, .object)
+        XCTAssertEqual(property4.description, "Description of a property with nested additional properties.")
+        XCTAssertEqual(property4.additionalProperties?.type, .integer)
+        XCTAssertEqual(property4.additionalProperties?.readOnly, true)
+        XCTAssertTrue(property4.readOnly == true)
 
         XCTAssertEqual(schema.additionalProperties?.type, .string)
         XCTAssertEqual(schema.additionalProperties?.description, "Additional properties of main schema.")

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
@@ -60,15 +60,21 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                 { "$ref": "referenced-schema2.json" },
                 {
                     "properties": {
-                        "property1": {
+                        "stringEnumProperty": {
                             "type": "string",
-                            "description": "Description of Foo's `property1`.",
+                            "description": "Description of Foo's `stringEnumProperty`.",
                             "enum": ["case1", "case2", "case3", "case4"],
                             "const": "case2"
                         },
-                        "property2": {
+                        "integerEnumProperty": {
+                            "type": "number",
+                            "description": "Description of Foo's `integerEnumProperty`.",
+                            "enum": [1, 2, 3, 4],
+                            "const": 3
+                        },
+                        "arrayProperty": {
                             "type": "array",
-                            "description": "Description of Foo's `property2`.",
+                            "description": "Description of Foo's `arrayProperty`.",
                             "items": {
                                 "type": "string",
                                 "enum": ["option1", "option2", "option3", "option4"]
@@ -91,7 +97,7 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                         "description": "Additional properties of Foo.",
                         "readOnly": true
                     },
-                    "required": ["property1"],
+                    "required": ["stringEnumProperty"],
                 }
             ]
         }
@@ -131,25 +137,37 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
                     isReadOnly: true
                 ),
                 JSONObject.Property(
-                    name: "property1",
-                    comment: "Description of Foo's `property1`.",
+                    name: "stringEnumProperty",
+                    comment: "Description of Foo's `stringEnumProperty`.",
                     type: JSONEnumeration(
-                        name: "property1",
-                        comment: "Description of Foo's `property1`.",
-                        values: ["case1", "case2", "case3", "case4"]
+                        name: "stringEnumProperty",
+                        comment: "Description of Foo's `stringEnumProperty`.",
+                        values: [.string(value: "case1"), .string(value: "case2"), .string(value: "case3"), .string(value: "case4")]
                     ),
                     defaultValue: JSONObject.Property.DefaultValue.string(value: "case2"),
                     isRequired: true,
                     isReadOnly: true
                 ),
                 JSONObject.Property(
-                    name: "property2",
-                    comment: "Description of Foo's `property2`.",
+                    name: "integerEnumProperty",
+                    comment: "Description of Foo's `integerEnumProperty`.",
+                    type: JSONEnumeration(
+                        name: "integerEnumProperty",
+                        comment: "Description of Foo's `integerEnumProperty`.",
+                        values: [.integer(value: 1), .integer(value: 2), .integer(value: 3), .integer(value: 4)]
+                    ),
+                    defaultValue: JSONObject.Property.DefaultValue.integer(value: 3),
+                    isRequired: false,
+                    isReadOnly: true
+                ),
+                JSONObject.Property(
+                    name: "arrayProperty",
+                    comment: "Description of Foo's `arrayProperty`.",
                     type: JSONArray(
                         element: JSONEnumeration(
-                            name: "property2",
+                            name: "arrayProperty",
                             comment: nil,
-                            values: ["option1", "option2", "option3", "option4"]
+                            values: [.string(value: "option1"), .string(value: "option2"), .string(value: "option3"), .string(value: "option4")]
                         )
                     ),
                     defaultValue: nil,

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -48,7 +48,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                     type: JSONEnumeration(
                         name: "property1",
                         comment: "Description of Foo's `property1`.",
-                        values: ["case1", "case2", "case3", "case4"]
+                        values: [.string(value: "case1"), .string(value: "case2"), .string(value: "case3"), .string(value: "case4")]
                     ),
                     defaultValue: JSONObject.Property.DefaultValue.string(value: "case2"),
                     isRequired: true,
@@ -61,7 +61,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         element: JSONEnumeration(
                             name: "property2",
                             comment: nil,
-                            values: ["option1", "option2", "option3", "option4"]
+                            values: [.string(value: "option1"), .string(value: "option2"), .string(value: "option3"), .string(value: "option4")]
                         )
                     ),
                     defaultValue: nil,
@@ -115,16 +115,16 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         name: "property1",
                         comment: "Description of Foo's `property1`.",
                         cases: [
-                            SwiftEnum.Case(label: "case1", rawValue: "case1"),
-                            SwiftEnum.Case(label: "case2", rawValue: "case2"),
-                            SwiftEnum.Case(label: "case3", rawValue: "case3"),
-                            SwiftEnum.Case(label: "case4", rawValue: "case4"),
+                            SwiftEnum.Case(label: "case1", rawValue: .string(value: "case1")),
+                            SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
+                            SwiftEnum.Case(label: "case3", rawValue: .string(value: "case3")),
+                            SwiftEnum.Case(label: "case4", rawValue: .string(value: "case4")),
                         ],
                         conformance: []
                     ),
                     isOptional: false,
                     isMutable: false,
-                    defaultValue: SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                    defaultValue: SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
                     codingKey: .static(value: "property1")
                 ),
                 SwiftStruct.Property(
@@ -135,10 +135,10 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                             name: "property2",
                             comment: nil,
                             cases: [
-                                SwiftEnum.Case(label: "option1", rawValue: "option1"),
-                                SwiftEnum.Case(label: "option2", rawValue: "option2"),
-                                SwiftEnum.Case(label: "option3", rawValue: "option3"),
-                                SwiftEnum.Case(label: "option4", rawValue: "option4"),
+                                SwiftEnum.Case(label: "option1", rawValue: .string(value: "option1")),
+                                SwiftEnum.Case(label: "option2", rawValue: .string(value: "option2")),
+                                SwiftEnum.Case(label: "option3", rawValue: .string(value: "option3")),
+                                SwiftEnum.Case(label: "option4", rawValue: .string(value: "option4")),
                             ],
                             conformance: []
                         )

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
@@ -447,9 +447,9 @@ final class ObjcInteropPrinterTests: XCTestCase {
                 name: name,
                 comment: nil,
                 cases: [
-                    SwiftEnum.Case(label: "case1", rawValue: "case1"),
-                    SwiftEnum.Case(label: "case2", rawValue: "case2"),
-                    SwiftEnum.Case(label: "case3", rawValue: "case3"),
+                    SwiftEnum.Case(label: "case1", rawValue: .string(value: "case1")),
+                    SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
+                    SwiftEnum.Case(label: "case3", rawValue: .string(value: "case3")),
                 ],
                 conformance: []
             )
@@ -833,9 +833,9 @@ final class ObjcInteropPrinterTests: XCTestCase {
                 name: name,
                 comment: nil,
                 cases: [
-                    SwiftEnum.Case(label: "option1", rawValue: "option1"),
-                    SwiftEnum.Case(label: "option2", rawValue: "option2"),
-                    SwiftEnum.Case(label: "option3", rawValue: "option3"),
+                    SwiftEnum.Case(label: "option1", rawValue: .string(value: "option1")),
+                    SwiftEnum.Case(label: "option2", rawValue: .string(value: "option2")),
+                    SwiftEnum.Case(label: "option3", rawValue: .string(value: "option3")),
                 ],
                 conformance: []
             )
@@ -1535,9 +1535,9 @@ final class ObjcInteropPrinterTests: XCTestCase {
                                     name: "Enumeration",
                                     comment: nil,
                                     cases: [
-                                        SwiftEnum.Case(label: "case1", rawValue: "case1"),
-                                        SwiftEnum.Case(label: "case2", rawValue: "case2"),
-                                        SwiftEnum.Case(label: "case3", rawValue: "case3"),
+                                        SwiftEnum.Case(label: "case1", rawValue: .string(value: "case1")),
+                                        SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
+                                        SwiftEnum.Case(label: "case3", rawValue: .string(value: "case3")),
                                     ],
                                     conformance: []
                                 ),
@@ -1711,9 +1711,9 @@ final class ObjcInteropPrinterTests: XCTestCase {
             name: "SharedEnum",
             comment: nil,
             cases: [
-                SwiftEnum.Case(label: "case1", rawValue: "case1"),
-                SwiftEnum.Case(label: "case2", rawValue: "case2"),
-                SwiftEnum.Case(label: "case3", rawValue: "case3"),
+                SwiftEnum.Case(label: "case1", rawValue: .string(value: "case1")),
+                SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
+                SwiftEnum.Case(label: "case3", rawValue: .string(value: "case3")),
             ],
             conformance: []
         )

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -53,16 +53,16 @@ final class SwiftPrinterTests: XCTestCase {
                         name: "Bizz",
                         comment: "Description of FooBar's `bizz`.",
                         cases: [
-                            SwiftEnum.Case(label: "case1", rawValue: "case 1"),
-                            SwiftEnum.Case(label: "case2", rawValue: "case 2"),
-                            SwiftEnum.Case(label: "case3", rawValue: "case 3"),
-                            SwiftEnum.Case(label: "case4", rawValue: "case 4"),
+                            SwiftEnum.Case(label: "case1", rawValue: .string(value: "case 1")),
+                            SwiftEnum.Case(label: "case2", rawValue: .string(value: "case 2")),
+                            SwiftEnum.Case(label: "case3", rawValue: .string(value: "case 3")),
+                            SwiftEnum.Case(label: "case4", rawValue: .string(value: "case 4")),
                         ],
                         conformance: [codableProtocol]
                     ),
                     isOptional: false,
                     isMutable: false,
-                    defaultValue: SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                    defaultValue: SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
                     codingKey: .static(value: "bizz")
                 ),
                 SwiftStruct.Property(
@@ -73,10 +73,10 @@ final class SwiftPrinterTests: XCTestCase {
                             name: "Buzz",
                             comment: nil,
                             cases: [
-                                SwiftEnum.Case(label: "option1", rawValue: "option-1"),
-                                SwiftEnum.Case(label: "option2", rawValue: "option-2"),
-                                SwiftEnum.Case(label: "option3", rawValue: "option-3"),
-                                SwiftEnum.Case(label: "option4", rawValue: "option-4"),
+                                SwiftEnum.Case(label: "option1", rawValue: .string(value: "option-1")),
+                                SwiftEnum.Case(label: "option2", rawValue: .string(value: "option-2")),
+                                SwiftEnum.Case(label: "option3", rawValue: .string(value: "option-3")),
+                                SwiftEnum.Case(label: "option4", rawValue: .string(value: "option-4")),
                             ],
                             conformance: [codableProtocol]
                         )
@@ -99,19 +99,8 @@ final class SwiftPrinterTests: XCTestCase {
             conformance: [SwiftProtocol(name: "RUMDataModel", conformance: [codableProtocol])]
         )
 
-        let `enum` = SwiftEnum(
-            name: "BizzBuzz",
-            comment: nil,
-            cases: [
-                SwiftEnum.Case(label: "case1", rawValue: "case 1"),
-                SwiftEnum.Case(label: "case2", rawValue: "case 2"),
-                SwiftEnum.Case(label: "case3", rawValue: "case 3"),
-            ],
-            conformance: [codableProtocol]
-        )
-
         let printer = SwiftPrinter()
-        let actual = try printer.print(swiftTypes: [`struct`, `enum`])
+        let actual = try printer.print(swiftTypes: [`struct`])
 
         let expected = """
 
@@ -166,10 +155,49 @@ final class SwiftPrinterTests: XCTestCase {
             }
         }
 
+        """
+
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testPrintingSwiftEnum() throws {
+        let enumWithStringRawValue = SwiftEnum(
+            name: "BizzBuzz",
+            comment: nil,
+            cases: [
+                SwiftEnum.Case(label: "case1", rawValue: .string(value: "case 1")),
+                SwiftEnum.Case(label: "case2", rawValue: .string(value: "case 2")),
+                SwiftEnum.Case(label: "case3", rawValue: .string(value: "case 3")),
+            ],
+            conformance: [codableProtocol]
+        )
+
+        let enumWithIntegerRawValue = SwiftEnum(
+            name: "FizzBazz",
+            comment: nil,
+            cases: [
+                SwiftEnum.Case(label: "value1", rawValue: .integer(value: 1)),
+                SwiftEnum.Case(label: "value2", rawValue: .integer(value: 2)),
+                SwiftEnum.Case(label: "value3", rawValue: .integer(value: 3)),
+            ],
+            conformance: [codableProtocol]
+        )
+
+        let printer = SwiftPrinter()
+        let actual = try printer.print(swiftTypes: [enumWithStringRawValue, enumWithIntegerRawValue])
+
+        let expected = """
+
         public enum BizzBuzz: String, Codable {
             case case1 = "case 1"
             case case2 = "case 2"
             case case3 = "case 3"
+        }
+
+        public enum FizzBazz: Int, Codable {
+            case value1 = 1
+            case value2 = 2
+            case value3 = 3
         }
 
         """

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
@@ -53,16 +53,16 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         name: "property1",
                         comment: "Description of FooBar's `property1`.",
                         cases: [
-                            SwiftEnum.Case(label: "case 1", rawValue: "case 1"),
-                            SwiftEnum.Case(label: "case 2", rawValue: "case 2"),
-                            SwiftEnum.Case(label: "case 3", rawValue: "case 3"),
-                            SwiftEnum.Case(label: "case 4", rawValue: "case 4"),
+                            SwiftEnum.Case(label: "case 1", rawValue: .string(value: "case 1")),
+                            SwiftEnum.Case(label: "case 2", rawValue: .string(value: "case 2")),
+                            SwiftEnum.Case(label: "case 3", rawValue: .string(value: "case 3")),
+                            SwiftEnum.Case(label: "case 4", rawValue: .string(value: "case 4")),
                         ],
                         conformance: []
                     ),
                     isOptional: false,
                     isMutable: false,
-                    defaultValue: SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                    defaultValue: SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
                     codingKey: .static(value: "property1")
                 ),
                 SwiftStruct.Property(
@@ -73,10 +73,10 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                             name: "property2",
                             comment: nil,
                             cases: [
-                                SwiftEnum.Case(label: "option-1", rawValue: "option-1"),
-                                SwiftEnum.Case(label: "option-2", rawValue: "option-2"),
-                                SwiftEnum.Case(label: "option-3", rawValue: "option-3"),
-                                SwiftEnum.Case(label: "option-4", rawValue: "option-4"),
+                                SwiftEnum.Case(label: "option-1", rawValue: .string(value: "option-1")),
+                                SwiftEnum.Case(label: "option-2", rawValue: .string(value: "option-2")),
+                                SwiftEnum.Case(label: "option-3", rawValue: .string(value: "option-3")),
+                                SwiftEnum.Case(label: "option-4", rawValue: .string(value: "option-4")),
                             ],
                             conformance: []
                         )
@@ -146,16 +146,16 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                             name: "Property1",
                             comment: "Description of FooBar's `property1`.",
                             cases: [
-                                SwiftEnum.Case(label: "case1", rawValue: "case 1"),
-                                SwiftEnum.Case(label: "case2", rawValue: "case 2"),
-                                SwiftEnum.Case(label: "case3", rawValue: "case 3"),
-                                SwiftEnum.Case(label: "case4", rawValue: "case 4"),
+                                SwiftEnum.Case(label: "case1", rawValue: .string(value: "case 1")),
+                                SwiftEnum.Case(label: "case2", rawValue: .string(value: "case 2")),
+                                SwiftEnum.Case(label: "case3", rawValue: .string(value: "case 3")),
+                                SwiftEnum.Case(label: "case4", rawValue: .string(value: "case 4")),
                             ],
                             conformance: [codableProtocol]
                         ),
                         isOptional: false,
                         isMutable: false,
-                        defaultValue: SwiftEnum.Case(label: "case2", rawValue: "case2"),
+                        defaultValue: SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
                         codingKey: .static(value: "property1")
                     ),
                     SwiftStruct.Property(
@@ -166,10 +166,10 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                                 name: "Property2",
                                 comment: nil,
                                 cases: [
-                                    SwiftEnum.Case(label: "option1", rawValue: "option-1"),
-                                    SwiftEnum.Case(label: "option2", rawValue: "option-2"),
-                                    SwiftEnum.Case(label: "option3", rawValue: "option-3"),
-                                    SwiftEnum.Case(label: "option4", rawValue: "option-4"),
+                                    SwiftEnum.Case(label: "option1", rawValue: .string(value: "option-1")),
+                                    SwiftEnum.Case(label: "option2", rawValue: .string(value: "option-2")),
+                                    SwiftEnum.Case(label: "option3", rawValue: .string(value: "option-3")),
+                                    SwiftEnum.Case(label: "option4", rawValue: .string(value: "option-4")),
                                 ],
                                 conformance: [codableProtocol]
                             )


### PR DESCRIPTION
### What and why?

📦 This PR adds billing information to RUM events - all must use plan `1`. It updates `RUMDataModels` (both Swift and Objc)  to recent schemas and configures `.plan1` value for all events send from the SDK.

### How?

Billing information was [earlier added to rum-events schema](https://github.com/DataDog/rum-events-format/blob/2ea84b56a4e0670b2d6e3e0c6a5fd27774ce4a3d/schemas/_common-schema.json#L171-L182):
```json
        "session": {
          "type": "object",
          "description": "Session-related internal properties",
          "required": ["plan"],
          "properties": {
            "plan": {
              "type": "number",
              "description": "Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan",
              "enum": [1, 2]
            }
          }
        }
```

It uses a new semantic: _enum with numeric values_, so I had to update the `rum-models-generator` to support it. It was quite simple, as enums support was already implemented and it only required introducing `EnumValue` concept at the bottom of generation pipeline (in `JSONSchema`):
```swift
enum EnumValue: Decodable, Equatable {
   case string(String)
   case integer(Int)
}
```
and updating each next step of the pipeline (swift schema, swift printer etc.) to support it.



---

Also, to receive better errors from `rum-models-generator`, I added some more inspection code for `DecodingError`. Now it prints much better information when generator hits unsupported / unimplemented thing:
```swift
// old:
🛑 Decoding [CodingKeys(stringValue: "properties", intValue: nil), _JSONKey(stringValue: "session", intValue: nil), CodingKeys(stringValue: "properties", intValue: nil), _JSONKey(stringValue: "plan", intValue: nil)] is not supported in `JSONSchema.init(from:)`.

// new:
🔎 Pretty error: 
→ Type String could not be decoded because it did not match the type of what was found in the encoded payload.
→ In Context:
    → coding path: properties → session → properties → plan → enum → 0
    → underlyingError: nil
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
