### PR TITLE
RUMM-1530 Add Datadog.isInitialized variable

### DIFF
--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -104,7 +104,7 @@ public class Datadog {
 
     /// Returns `true` if the Datadog SDK is already initialized, `false` otherwise.
     public static var isInitialized: Bool {
-        instance != nil
+        return instance != nil
     }
 
     /// Sets current user information.

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -102,6 +102,11 @@ public class Datadog {
         }
     }
 
+    /// Returns `true` if the Datadog SDK is already initialized, `false` otherwise.
+    public static var isInitialized: Bool {
+        instance != nil
+    }
+
     /// Sets current user information.
     /// Those will be added to logs, traces and RUM events automatically.
     /// - Parameters:

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -18,7 +18,7 @@ class DatadogTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        XCTAssertNil(Datadog.instance)
+        XCTAssertFalse(Datadog.isInitialized)
         printFunction = PrintFunctionMock()
         consolePrint = printFunction.print
     }
@@ -26,7 +26,7 @@ class DatadogTests: XCTestCase {
     override func tearDown() {
         consolePrint = { print($0) }
         printFunction = nil
-        XCTAssertNil(Datadog.instance)
+        XCTAssertFalse(Datadog.isInitialized)
         super.tearDown()
     }
 
@@ -38,7 +38,7 @@ class DatadogTests: XCTestCase {
             trackingConsent: .mockRandom(),
             configuration: defaultBuilder.build()
         )
-        XCTAssertNotNil(Datadog.instance)
+        XCTAssertTrue(Datadog.isInitialized)
         Datadog.flushAndDeinitialize()
     }
 
@@ -48,7 +48,7 @@ class DatadogTests: XCTestCase {
             trackingConsent: .mockRandom(),
             configuration: rumBuilder.build()
         )
-        XCTAssertNotNil(Datadog.instance)
+        XCTAssertTrue(Datadog.isInitialized)
         Datadog.flushAndDeinitialize()
     }
 
@@ -67,7 +67,7 @@ class DatadogTests: XCTestCase {
             printFunction.printedMessage,
             "🔥 Datadog SDK usage error: `clientToken` cannot be empty."
         )
-        XCTAssertNil(Datadog.instance)
+        XCTAssertFalse(Datadog.isInitialized)
     }
 
     func testGivenValidConfiguration_whenInitializedMoreThanOnce_itPrintsError() {


### PR DESCRIPTION
### What and why?

The public interface lacks a way of checking the SDK initialized state.

### How?

A static variable `isInitialized` of the `Datadog` configuration class checks the internal `instance` availability.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
