### PR TITLE
RUMM-1086 LongTaskObserver implemented

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -473,6 +473,7 @@
 		9E26E6B924C87693000B3270 /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
 		9E2EF44F2694FA14008A7DAE /* VitalInfoSamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2EF44E2694FA14008A7DAE /* VitalInfoSamplerTests.swift */; };
 		9E307C3224C8846D0039607E /* RUMDataModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E26E6B824C87693000B3270 /* RUMDataModels.swift */; };
+		9E359F4E26CD518D001E25E9 /* LongTaskObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E359F4D26CD518D001E25E9 /* LongTaskObserver.swift */; };
 		9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */; };
 		9E544A4F24753C6E00E83072 /* MethodSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */; };
 		9E544A5124753DDE00E83072 /* MethodSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */; };
@@ -485,6 +486,9 @@
 		9E989A4225F640D100235FC3 /* AppStateListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E989A4125F640D100235FC3 /* AppStateListenerTests.swift */; };
 		9E9973F1268DF69500D8059B /* VitalInfoSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9973F0268DF69500D8059B /* VitalInfoSampler.swift */; };
 		9EA3CA6926775A3500B16871 /* VitalRefreshRateReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA3CA6826775A3500B16871 /* VitalRefreshRateReader.swift */; };
+		9EC2835A26CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC2835926CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift */; };
+		9EC2835E26CFF57A00FACF1C /* RUMMobileVitalsScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9EC2835D26CFF57A00FACF1C /* RUMMobileVitalsScenario.storyboard */; };
+		9EC2836026CFF59400FACF1C /* RUMMobileVitalsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC2835F26CFF59400FACF1C /* RUMMobileVitalsViewController.swift */; };
 		9EC8B5DA2668197B000F7529 /* VitalCPUReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC8B5D92668197B000F7529 /* VitalCPUReader.swift */; };
 		9EC8B5EE2668E4DB000F7529 /* VitalCPUReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC8B5ED2668E4DB000F7529 /* VitalCPUReaderTests.swift */; };
 		9ED6A6B425F2901800CB2E29 /* AppStateListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */; };
@@ -1108,6 +1112,7 @@
 		9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Kronos.xcframework; path = ../Carthage/Build/Kronos.xcframework; sourceTree = "<group>"; };
 		9E26E6B824C87693000B3270 /* RUMDataModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMDataModels.swift; sourceTree = "<group>"; };
 		9E2EF44E2694FA14008A7DAE /* VitalInfoSamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalInfoSamplerTests.swift; sourceTree = "<group>"; };
+		9E359F4D26CD518D001E25E9 /* LongTaskObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongTaskObserver.swift; sourceTree = "<group>"; };
 		9E36D92124373EA700BFBDB7 /* SwiftExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftExtensionsTests.swift; sourceTree = "<group>"; };
 		9E544A4E24753C6E00E83072 /* MethodSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzler.swift; sourceTree = "<group>"; };
 		9E544A5024753DDE00E83072 /* MethodSwizzlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzlerTests.swift; sourceTree = "<group>"; };
@@ -1121,6 +1126,9 @@
 		9E9973F0268DF69500D8059B /* VitalInfoSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalInfoSampler.swift; sourceTree = "<group>"; };
 		9E9EB37624468CE90002C80B /* Datadog.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Datadog.modulemap; sourceTree = "<group>"; };
 		9EA3CA6826775A3500B16871 /* VitalRefreshRateReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalRefreshRateReader.swift; sourceTree = "<group>"; };
+		9EC2835926CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMobileVitalsScenarioTests.swift; sourceTree = "<group>"; };
+		9EC2835D26CFF57A00FACF1C /* RUMMobileVitalsScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMMobileVitalsScenario.storyboard; sourceTree = "<group>"; };
+		9EC2835F26CFF59400FACF1C /* RUMMobileVitalsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMobileVitalsViewController.swift; sourceTree = "<group>"; };
 		9EC8B5D92668197B000F7529 /* VitalCPUReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalCPUReader.swift; sourceTree = "<group>"; };
 		9EC8B5ED2668E4DB000F7529 /* VitalCPUReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalCPUReaderTests.swift; sourceTree = "<group>"; };
 		9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateListener.swift; sourceTree = "<group>"; };
@@ -1942,6 +1950,7 @@
 		61337036250F84F100236D58 /* RUM */ = {
 			isa = PBXGroup;
 			children = (
+				9EC2835C26CFF56B00FACF1C /* MobileVitals */,
 				61D50C532580EF41006038A3 /* RUMScenarios.swift */,
 				61337037250F84FD00236D58 /* ManualInstrumentation */,
 				61F9CA7725125918000A5E61 /* NavigationControllerAutoInstrumentation */,
@@ -2330,6 +2339,7 @@
 				61F3CDA1251118DD00C816E5 /* Views */,
 				6141014D251A578D00E3C2D9 /* Actions */,
 				6157FA5C252767B3009A8A3B /* Resources */,
+				9E06058F26EF904200F5F935 /* LongTasks */,
 			);
 			path = AutoInstrumentation;
 			sourceTree = "<group>";
@@ -3024,6 +3034,7 @@
 				61163C49252E03D6007DD5BF /* RUMModalViewsScenarioTests.swift */,
 				6164AF2D252C9C51000D78C4 /* RUMResourcesScenarioTests.swift */,
 				612D8F8025AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift */,
+				9EC2835926CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -3119,6 +3130,14 @@
 			path = RUMEventOutputs;
 			sourceTree = "<group>";
 		};
+		9E06058F26EF904200F5F935 /* LongTasks */ = {
+			isa = PBXGroup;
+			children = (
+				9E359F4D26CD518D001E25E9 /* LongTaskObserver.swift */,
+			);
+			path = LongTasks;
+			sourceTree = "<group>";
+		};
 		9E47010324471027000073A4 /* include */ = {
 			isa = PBXGroup;
 			children = (
@@ -3153,6 +3172,15 @@
 			);
 			name = _Datadog_Private;
 			path = ../Sources/_Datadog_Private;
+			sourceTree = "<group>";
+		};
+		9EC2835C26CFF56B00FACF1C /* MobileVitals */ = {
+			isa = PBXGroup;
+			children = (
+				9EC2835D26CFF57A00FACF1C /* RUMMobileVitalsScenario.storyboard */,
+				9EC2835F26CFF59400FACF1C /* RUMMobileVitalsViewController.swift */,
+			);
+			path = MobileVitals;
 			sourceTree = "<group>";
 		};
 		9EF49F1524476FBD004F2CA0 /* DatadogIntegrationTests */ = {
@@ -3562,6 +3590,7 @@
 				6137E649252DD88D00720485 /* RUMModalViewsAutoInstrumentationScenario.storyboard in Resources */,
 				61441C0C24616DE9003D8BB8 /* Main.storyboard in Resources */,
 				615AAC36251E353700C89EE9 /* RUMTabBarAutoInstrumentationScenario.storyboard in Resources */,
+				9EC2835E26CFF57A00FACF1C /* RUMMobileVitalsScenario.storyboard in Resources */,
 				6167AD19251A27B80012B4D0 /* URLSessionScenario.storyboard in Resources */,
 				61F9CA792512593A000A5E61 /* RUMNavigationControllerScenario.storyboard in Resources */,
 				61337035250F84BF00236D58 /* TracingManualInstrumentationScenario.storyboard in Resources */,
@@ -3850,6 +3879,7 @@
 				61C3E63724BF191F008053F2 /* RUMScope.swift in Sources */,
 				61133BE52423979B00786299 /* LogBuilder.swift in Sources */,
 				61133BD42423979B00786299 /* FileReader.swift in Sources */,
+				9E359F4E26CD518D001E25E9 /* LongTaskObserver.swift in Sources */,
 				61C5A88A24509A0C00DA608C /* SpanFileOutput.swift in Sources */,
 				61C3E63524BF1794008053F2 /* Attributes.swift in Sources */,
 				61133BD32423979B00786299 /* File.swift in Sources */,
@@ -4124,6 +4154,7 @@
 				61E5333824B84EE2003D6C4E /* DebugRUMViewController.swift in Sources */,
 				615C3155251C9D7A0018781C /* RUMTASVariousUIControllsViewController.swift in Sources */,
 				61441C9D2461A796003D8BB8 /* AppConfiguration.swift in Sources */,
+				9EC2836026CFF59400FACF1C /* RUMMobileVitalsViewController.swift in Sources */,
 				6164AF06252C9004000D78C4 /* ObjcSendFirstPartyRequestsViewController.m in Sources */,
 				6167AD20251A27CC0012B4D0 /* SendFirstPartyRequestsViewController.swift in Sources */,
 				6193DCE8251B9AB1009B8011 /* RUMTASCollectionViewController.swift in Sources */,
@@ -4156,6 +4187,7 @@
 				61B9ED212462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift in Sources */,
 				61B6811F25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift in Sources */,
 				61C2C20D24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift in Sources */,
+				9EC2835A26CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift in Sources */,
 				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61F7F1DD266F9CB000F9F53B /* CodableValue.swift in Sources */,
 				61B9ED1F2461E57700C0DCFF /* UITestsHelpers.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -58,6 +58,11 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "DD_TEST_SCENARIO_CLASS_NAME"
+            value = "RUMMobileVitalsScenario"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_TEST_SCENARIO_CLASS_NAME"
             value = "TracingManualInstrumentationScenario"
             isEnabled = "NO">
          </EnvironmentVariable>

--- a/Datadog/Example/Scenarios/RUM/MobileVitals/RUMMobileVitalsScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/MobileVitals/RUMMobileVitalsScenario.storyboard
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Mobile Vitals View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" customClass="RUMMobileVitalsViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ca2-aW-xR8">
+                                <rect key="frame" x="143" y="423" width="128" height="60"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SSx-AL-9bb">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="30"/>
+                                        <state key="normal" title="No-op"/>
+                                        <connections>
+                                            <action selector="noOpButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="aqU-RG-zDa"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jCt-PH-psR">
+                                        <rect key="frame" x="0.0" y="30" width="128" height="30"/>
+                                        <state key="normal" title="Block Main Thread"/>
+                                        <connections>
+                                            <action selector="blockMainThreadButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="CCI-ts-9al"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ca2-aW-xR8" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="WMO-TA-5tP"/>
+                            <constraint firstItem="ca2-aW-xR8" firstAttribute="centerY" secondItem="vDu-zF-Fre" secondAttribute="centerY" id="YHh-T6-UK3"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="28" y="75"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Datadog/Example/Scenarios/RUM/MobileVitals/RUMMobileVitalsViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/MobileVitals/RUMMobileVitalsViewController.swift
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+final class RUMMobileVitalsViewController: UIViewController {
+
+    @IBAction func noOpButtonTapped(_ sender: Any) {
+        print("No-op button tapped... Sending view update...")
+    }
+
+    @IBAction func blockMainThreadButtonTapped(_ sender: Any) {
+        print("❌ Blocking main thread at \(Date())...")
+        let startDate = Date()
+        var i = 1
+        while true {
+            i += 1
+            if Date().timeIntervalSince(startDate) > 3.0 {
+                print("✅ Main thread is unblocked!")
+                break
+            }
+        }
+    }
+
+}

--- a/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
+++ b/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
@@ -129,7 +129,7 @@ final class RUMMobileVitalsScenario: TestScenario {
         _ = builder
             .trackUIKitRUMViews()
             .trackUIKitRUMActions()
-            .trackLongTasks()
+            .trackLongTasks(threshold: 2.5)
             .enableLogging(false)
             .enableTracing(false)
     }

--- a/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
+++ b/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
@@ -121,6 +121,20 @@ final class RUMTapActionScenario: TestScenario {
     }
 }
 
+/// Scenario which uses RUM only. Blocks the main thread and expects to have non-zero MobileVitals values
+final class RUMMobileVitalsScenario: TestScenario {
+    static var storyboardName: String = "RUMMobileVitalsScenario"
+
+    func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder
+            .trackUIKitRUMViews()
+            .trackUIKitRUMActions()
+            .trackLongTasks()
+            .enableLogging(false)
+            .enableTracing(false)
+    }
+}
+
 /// Scenario which uses RUM and Tracing auto instrumentation features to track bunch of network requests
 /// sent with `URLSession` from two VCs. The first VC calls first party resources, the second one calls third parties.
 final class RUMURLSessionResourcesScenario: URLSessionBaseScenario, TestScenario {

--- a/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
+++ b/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
@@ -129,7 +129,7 @@ final class RUMMobileVitalsScenario: TestScenario {
         _ = builder
             .trackUIKitRUMViews()
             .trackUIKitRUMActions()
-            .trackLongTasks(threshold: 2.5)
+            .trackRUMLongTasks(threshold: 2.5)
             .enableLogging(false)
             .enableTracing(false)
     }

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -39,6 +39,7 @@ internal struct FeaturesConfiguration {
         struct AutoInstrumentation {
             let uiKitRUMViewsPredicate: UIKitRUMViewsPredicate?
             let uiKitRUMUserActionsPredicate: UIKitRUMUserActionsPredicate?
+            let longTaskThreshold: TimeInterval?
         }
 
         let common: Common
@@ -50,6 +51,7 @@ internal struct FeaturesConfiguration {
         let resourceEventMapper: RUMResourceEventMapper?
         let actionEventMapper: RUMActionEventMapper?
         let errorEventMapper: RUMErrorEventMapper?
+        let longTaskEventMapper: RUMLongTaskEventMapper?
         /// RUM auto instrumentation configuration, `nil` if not enabled.
         let autoInstrumentation: AutoInstrumentation?
         let backgroundEventTrackingEnabled: Bool
@@ -182,10 +184,13 @@ extension FeaturesConfiguration {
         if configuration.rumEnabled {
             var autoInstrumentation: RUM.AutoInstrumentation?
 
-            if configuration.rumUIKitViewsPredicate != nil || configuration.rumUIKitUserActionsPredicate != nil {
+            if configuration.rumUIKitViewsPredicate != nil ||
+                configuration.rumUIKitUserActionsPredicate != nil ||
+                configuration.rumLongTaskDurationThreshold != nil {
                 autoInstrumentation = RUM.AutoInstrumentation(
                     uiKitRUMViewsPredicate: configuration.rumUIKitViewsPredicate,
-                    uiKitRUMUserActionsPredicate: configuration.rumUIKitUserActionsPredicate
+                    uiKitRUMUserActionsPredicate: configuration.rumUIKitUserActionsPredicate,
+                    longTaskThreshold: configuration.rumLongTaskDurationThreshold
                 )
             }
 
@@ -200,6 +205,7 @@ extension FeaturesConfiguration {
                     resourceEventMapper: configuration.rumResourceEventMapper,
                     actionEventMapper: configuration.rumActionEventMapper,
                     errorEventMapper: configuration.rumErrorEventMapper,
+                    longTaskEventMapper: configuration.rumLongTaskEventMapper,
                     autoInstrumentation: autoInstrumentation,
                     backgroundEventTrackingEnabled: configuration.rumBackgroundEventTrackingEnabled,
                     onSessionStart: configuration.rumSessionsListener

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -599,7 +599,7 @@ extension Datadog {
             /// Enable long operations on the main thread to be tracked automatically.
             /// Any long running operation on the main thread will appear as Long Tasks in Datadog RUM Explorer.
             /// - Parameter threshold: the threshold in seconds above which a task running on the Main thread is considered as a long task (default 0.1 second)
-            public func trackLongTasks(threshold: TimeInterval = 0.1) -> Builder {
+            public func trackRUMLongTasks(threshold: TimeInterval = 0.1) -> Builder {
                 configuration.rumLongTaskDurationThreshold = threshold
                 return self
             }

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -254,10 +254,12 @@ extension Datadog {
         private(set) var rumSessionsListener: RUMSessionListener?
         private(set) var rumUIKitViewsPredicate: UIKitRUMViewsPredicate?
         private(set) var rumUIKitUserActionsPredicate: UIKitRUMUserActionsPredicate?
+        private(set) var rumLongTaskDurationThreshold: TimeInterval?
         private(set) var rumViewEventMapper: RUMViewEventMapper?
         private(set) var rumResourceEventMapper: RUMResourceEventMapper?
         private(set) var rumActionEventMapper: RUMActionEventMapper?
         private(set) var rumErrorEventMapper: RUMErrorEventMapper?
+        private(set) var rumLongTaskEventMapper: RUMLongTaskEventMapper?
         private(set) var rumResourceAttributesProvider: URLSessionRUMAttributesProvider?
         private(set) var rumBackgroundEventTrackingEnabled: Bool
         private(set) var batchSize: BatchSize
@@ -594,6 +596,14 @@ extension Datadog {
                 return self
             }
 
+            /// Enable long operations on the main thread to be tracked automatically.
+            /// Any long running operation on the main thread will appear as Long Tasks in Datadog RUM Explorer.
+            /// - Parameter threshold: the threshold in seconds above which a task running on the Main thread is considered as a long task (default 0.1 second)
+            public func trackLongTasks(threshold: TimeInterval = 0.1) -> Builder {
+                configuration.rumLongTaskDurationThreshold = threshold
+                return self
+            }
+
             /// Sets the custom mapper for `RUMViewEvent`. This can be used to modify RUM View events before they are send to Datadog.
             /// - Parameter mapper: the closure taking `RUMViewEvent` as input and expecting `RUMViewEvent` as output.
             /// The implementation should obtain a mutable version of the `RUMViewEvent`, modify it and return it.
@@ -630,6 +640,15 @@ extension Datadog {
             /// with dropping the RUM Error event entirely, so it won't be send to Datadog.
             public func setRUMErrorEventMapper(_ mapper: @escaping (RUMErrorEvent) -> RUMErrorEvent?) -> Builder {
                 configuration.rumErrorEventMapper = mapper
+                return self
+            }
+
+            /// Sets the custom mapper for `RUMLongTaskEvent`. This can be used to modify RUM Long Task events before they are send to Datadog.
+            /// - Parameter mapper: the closure taking `RUMLongTaskEvent` as input and expecting `RUMLongTaskEvent` or `nil` as output.
+            /// The implementation should obtain a mutable version of the `RUMLongTaskEvent`, modify it and return. Returning `nil` will result
+            /// with dropping the RUM Long Task event entirely, so it won't be send to Datadog.
+            public func setRUMLongTaskEventMapper(_ mapper: @escaping (RUMLongTaskEvent) -> RUMLongTaskEvent?) -> Builder {
+                configuration.rumLongTaskEventMapper = mapper
                 return self
             }
 

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -120,6 +120,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 id: lastRUMView.session.id,
                 type: .user
             ),
+            synthetics: nil,
             usr: lastRUMView.usr,
             view: .init(
                 id: lastRUMView.view.id,
@@ -149,6 +150,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds,
             service: original.service,
             session: original.session,
+            synthetics: nil,
             usr: original.usr,
             view: .init(
                 action: original.view.action,
@@ -164,9 +166,11 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 firstContentfulPaint: original.view.firstContentfulPaint,
                 firstInputDelay: original.view.firstInputDelay,
                 firstInputTime: original.view.firstInputTime,
+                frozenFrame: nil,
                 id: original.view.id,
                 inForegroundPeriods: original.view.inForegroundPeriods,
                 isActive: false,
+                isSlowRendered: nil,
                 largestContentfulPaint: original.view.largestContentfulPaint,
                 loadEvent: original.view.loadEvent,
                 loadingTime: original.view.loadingTime,

--- a/Sources/Datadog/RUM/AutoInstrumentation/LongTasks/LongTaskObserver.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/LongTasks/LongTaskObserver.swift
@@ -7,8 +7,8 @@
 import Foundation
 
 internal class LongTaskObserver {
-    let longTaskDurationThreshold: TimeInterval
-    let dateProvider: DateProvider
+    private let longTaskDurationThreshold: TimeInterval
+    private let dateProvider: DateProvider
 
     private var observer_begin: CFRunLoopObserver?
     private var observer_end: CFRunLoopObserver?

--- a/Sources/Datadog/RUM/AutoInstrumentation/LongTasks/LongTaskObserver.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/LongTasks/LongTaskObserver.swift
@@ -1,0 +1,83 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal class LongTaskObserver {
+    let longTaskDurationThreshold: TimeInterval
+    let dateProvider: DateProvider
+
+    private var observer_begin: CFRunLoopObserver?
+    private var observer_end: CFRunLoopObserver?
+    private var lastActivity: (kind: CFRunLoopActivity, date: Date)?
+
+    weak var subscriber: RUMCommandSubscriber?
+    func subscribe(commandsSubscriber: RUMCommandSubscriber) {
+        self.subscriber = commandsSubscriber
+    }
+
+    init(threshold: TimeInterval, dateProvider: DateProvider) {
+        self.longTaskDurationThreshold = threshold
+        self.dateProvider = dateProvider
+
+        let activites_begin: [CFRunLoopActivity] = [
+            .entry,
+            .afterWaiting,
+            .beforeSources,
+            .beforeTimers
+        ]
+        observer_begin = CFRunLoopObserverCreateWithHandler(
+            kCFAllocatorDefault,
+            CFRunLoopActivity(activites_begin).rawValue,
+            true,
+            CFIndex.min
+        ) { [weak self] block_obs, block_act in
+            guard let strongSelf = self else {
+                return
+            }
+            let now = strongSelf.dateProvider.currentDate()
+            strongSelf.processActivity(block_act, at: now)
+            strongSelf.lastActivity = (kind: block_act, date: now)
+        }
+
+        let activites_end: [CFRunLoopActivity] = [.beforeWaiting, .exit]
+        observer_end = CFRunLoopObserverCreateWithHandler(
+            kCFAllocatorDefault,
+            CFRunLoopActivity(activites_end).rawValue,
+            true,
+            CFIndex.max
+        ) { [weak self] block_obs, block_act in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.processActivity(block_act, at: strongSelf.dateProvider.currentDate())
+            strongSelf.lastActivity = nil
+        }
+    }
+
+    func start() {
+        CFRunLoopAddObserver(RunLoop.main.getCFRunLoop(), observer_begin, .commonModes)
+        CFRunLoopAddObserver(RunLoop.main.getCFRunLoop(), observer_end, .commonModes)
+    }
+
+    deinit {
+        CFRunLoopRemoveObserver(RunLoop.main.getCFRunLoop(), observer_begin, .commonModes)
+        CFRunLoopRemoveObserver(RunLoop.main.getCFRunLoop(), observer_end, .commonModes)
+    }
+
+    private func processActivity(_ activity: CFRunLoopActivity, at date: Date) {
+        if let last = self.lastActivity,
+           date.timeIntervalSince(last.date) > self.longTaskDurationThreshold {
+            let duration = date.timeIntervalSince(last.date)
+            let longTaskCommand = RUMAddLongTaskCommand(
+                time: date,
+                attributes: [:],
+                duration: duration
+            )
+            subscriber?.process(command: longTaskCommand)
+        }
+    }
+}

--- a/Sources/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentation.swift
+++ b/Sources/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentation.swift
@@ -50,6 +50,8 @@ internal final class RUMAutoInstrumentation {
     let views: Views?
     /// RUM User Actions auto instrumentation, `nil` if not enabled.
     let userActions: UserActions?
+    /// RUM Long Tasks auto instrumentation, `nil` if not enabled.
+    let longTasks: LongTaskObserver?
 
     // MARK: - Initialization
 
@@ -68,6 +70,12 @@ internal final class RUMAutoInstrumentation {
             } else {
                 userActions = nil
             }
+
+            if let threshold = configuration.longTaskThreshold {
+                longTasks = LongTaskObserver(threshold: threshold, dateProvider: dateProvider)
+            } else {
+                longTasks = nil
+            }
         } catch {
             consolePrint(
                 "🔥 Datadog SDK error: RUM automatic tracking can't be set up due to error: \(error)"
@@ -79,11 +87,13 @@ internal final class RUMAutoInstrumentation {
     func enable() {
         views?.enable()
         userActions?.enable()
+        longTasks?.start()
     }
 
     func subscribe(commandSubscriber: RUMCommandSubscriber) {
         views?.handler.subscribe(commandsSubscriber: commandSubscriber)
         userActions?.handler.subscribe(commandsSubscriber: commandSubscriber)
+        longTasks?.subscribe(commandsSubscriber: commandSubscriber)
     }
 
 #if DD_SDK_COMPILED_FOR_TESTING

--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -31,6 +31,9 @@ public struct RUMViewEvent: RUMDataModel {
     /// Session properties
     public let session: Session
 
+    /// Synthetics properties
+    public let synthetics: Synthetics?
+
     /// RUM event type
     public let type: String = "view"
 
@@ -48,6 +51,7 @@ public struct RUMViewEvent: RUMDataModel {
         case date = "date"
         case service = "service"
         case session = "session"
+        case synthetics = "synthetics"
         case type = "type"
         case usr = "usr"
         case view = "view"
@@ -121,6 +125,20 @@ public struct RUMViewEvent: RUMDataModel {
         }
     }
 
+    /// Synthetics properties
+    public struct Synthetics: Codable {
+        /// The identifier of the current Synthetics test results
+        public let resultId: String
+
+        /// The identifier of the current Synthetics test
+        public let testId: String
+
+        enum CodingKeys: String, CodingKey {
+            case resultId = "result_id"
+            case testId = "test_id"
+        }
+    }
+
     /// View properties
     public struct View: Codable {
         /// Properties of the actions of the view
@@ -162,6 +180,9 @@ public struct RUMViewEvent: RUMDataModel {
         /// Duration in ns to the first input
         public let firstInputTime: Int64?
 
+        /// Properties of the frozen frames of the view
+        public let frozenFrame: FrozenFrame?
+
         /// UUID of the view
         public let id: String
 
@@ -170,6 +191,9 @@ public struct RUMViewEvent: RUMDataModel {
 
         /// Whether the View corresponding to this event is considered active
         public let isActive: Bool?
+
+        /// Whether the View had a low average refresh rate
+        public let isSlowRendered: Bool?
 
         /// Duration in ns to the largest contentful paint
         public let largestContentfulPaint: Int64?
@@ -227,9 +251,11 @@ public struct RUMViewEvent: RUMDataModel {
             case firstContentfulPaint = "first_contentful_paint"
             case firstInputDelay = "first_input_delay"
             case firstInputTime = "first_input_time"
+            case frozenFrame = "frozen_frame"
             case id = "id"
             case inForegroundPeriods = "in_foreground_periods"
             case isActive = "is_active"
+            case isSlowRendered = "is_slow_rendered"
             case largestContentfulPaint = "largest_contentful_paint"
             case loadEvent = "load_event"
             case loadingTime = "loading_time"
@@ -269,6 +295,16 @@ public struct RUMViewEvent: RUMDataModel {
         /// Properties of the errors of the view
         public struct Error: Codable {
             /// Number of errors that occurred on the view
+            public let count: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case count = "count"
+            }
+        }
+
+        /// Properties of the frozen frames of the view
+        public struct FrozenFrame: Codable {
+            /// Number of frozen frames that occurred on the view
             public let count: Int64
 
             enum CodingKeys: String, CodingKey {
@@ -353,6 +389,9 @@ public struct RUMResourceEvent: RUMDataModel {
     /// Session properties
     public let session: Session
 
+    /// Synthetics properties
+    public let synthetics: Synthetics?
+
     /// RUM event type
     public let type: String = "resource"
 
@@ -372,6 +411,7 @@ public struct RUMResourceEvent: RUMDataModel {
         case resource = "resource"
         case service = "service"
         case session = "session"
+        case synthetics = "synthetics"
         case type = "type"
         case usr = "usr"
         case view = "view"
@@ -628,6 +668,7 @@ public struct RUMResourceEvent: RUMDataModel {
             case font = "font"
             case media = "media"
             case other = "other"
+            case native = "native"
         }
     }
 
@@ -652,6 +693,20 @@ public struct RUMResourceEvent: RUMDataModel {
         public enum SessionType: String, Codable {
             case user = "user"
             case synthetics = "synthetics"
+        }
+    }
+
+    /// Synthetics properties
+    public struct Synthetics: Codable {
+        /// The identifier of the current Synthetics test results
+        public let resultId: String
+
+        /// The identifier of the current Synthetics test
+        public let testId: String
+
+        enum CodingKeys: String, CodingKey {
+            case resultId = "result_id"
+            case testId = "test_id"
         }
     }
 
@@ -704,6 +759,9 @@ public struct RUMActionEvent: RUMDataModel {
     /// Session properties
     public let session: Session
 
+    /// Synthetics properties
+    public let synthetics: Synthetics?
+
     /// RUM event type
     public let type: String = "action"
 
@@ -722,6 +780,7 @@ public struct RUMActionEvent: RUMDataModel {
         case date = "date"
         case service = "service"
         case session = "session"
+        case synthetics = "synthetics"
         case type = "type"
         case usr = "usr"
         case view = "view"
@@ -890,6 +949,20 @@ public struct RUMActionEvent: RUMDataModel {
         }
     }
 
+    /// Synthetics properties
+    public struct Synthetics: Codable {
+        /// The identifier of the current Synthetics test results
+        public let resultId: String
+
+        /// The identifier of the current Synthetics test
+        public let testId: String
+
+        enum CodingKeys: String, CodingKey {
+            case resultId = "result_id"
+            case testId = "test_id"
+        }
+    }
+
     /// View properties
     public struct View: Codable {
         /// UUID of the view
@@ -946,6 +1019,9 @@ public struct RUMErrorEvent: RUMDataModel {
     /// Session properties
     public let session: Session
 
+    /// Synthetics properties
+    public let synthetics: Synthetics?
+
     /// RUM event type
     public let type: String = "error"
 
@@ -965,6 +1041,7 @@ public struct RUMErrorEvent: RUMDataModel {
         case error = "error"
         case service = "service"
         case session = "session"
+        case synthetics = "synthetics"
         case type = "type"
         case usr = "usr"
         case view = "view"
@@ -1161,6 +1238,20 @@ public struct RUMErrorEvent: RUMDataModel {
         }
     }
 
+    /// Synthetics properties
+    public struct Synthetics: Codable {
+        /// The identifier of the current Synthetics test results
+        public let resultId: String
+
+        /// The identifier of the current Synthetics test
+        public let testId: String
+
+        enum CodingKeys: String, CodingKey {
+            case resultId = "result_id"
+            case testId = "test_id"
+        }
+    }
+
     /// View properties
     public struct View: Codable {
         /// UUID of the view
@@ -1181,6 +1272,192 @@ public struct RUMErrorEvent: RUMDataModel {
         enum CodingKeys: String, CodingKey {
             case id = "id"
             case inForeground = "in_foreground"
+            case name = "name"
+            case referrer = "referrer"
+            case url = "url"
+        }
+    }
+}
+
+/// Schema of all properties of a Long Task event
+public struct RUMLongTaskEvent: RUMDataModel {
+    /// Internal properties
+    public let dd: DD
+
+    /// Action properties
+    public let action: Action?
+
+    /// Application properties
+    public let application: Application
+
+    /// Device connectivity properties
+    public let connectivity: RUMConnectivity?
+
+    /// User provided context
+    public internal(set) var context: RUMEventAttributes?
+
+    /// Start of the event in ms from epoch
+    public let date: Int64
+
+    /// Long Task properties
+    public let longTask: LongTask
+
+    /// The service name for this application
+    public let service: String?
+
+    /// Session properties
+    public let session: Session
+
+    /// Synthetics properties
+    public let synthetics: Synthetics?
+
+    /// RUM event type
+    public let type: String = "long_task"
+
+    /// User properties
+    public internal(set) var usr: RUMUser?
+
+    /// View properties
+    public var view: View
+
+    enum CodingKeys: String, CodingKey {
+        case dd = "_dd"
+        case action = "action"
+        case application = "application"
+        case connectivity = "connectivity"
+        case context = "context"
+        case date = "date"
+        case longTask = "long_task"
+        case service = "service"
+        case session = "session"
+        case synthetics = "synthetics"
+        case type = "type"
+        case usr = "usr"
+        case view = "view"
+    }
+
+    /// Internal properties
+    public struct DD: Codable {
+        /// Version of the RUM event format
+        public let formatVersion: Int64 = 2
+
+        /// Session-related internal properties
+        public let session: Session?
+
+        enum CodingKeys: String, CodingKey {
+            case formatVersion = "format_version"
+            case session = "session"
+        }
+
+        /// Session-related internal properties
+        public struct Session: Codable {
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public let plan: Plan
+
+            enum CodingKeys: String, CodingKey {
+                case plan = "plan"
+            }
+
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public enum Plan: Int, Codable {
+                case plan1 = 1
+                case plan2 = 2
+            }
+        }
+    }
+
+    /// Action properties
+    public struct Action: Codable {
+        /// UUID of the action
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Application properties
+    public struct Application: Codable {
+        /// UUID of the application
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Long Task properties
+    public struct LongTask: Codable {
+        /// Duration in ns of the long task
+        public let duration: Int64
+
+        /// UUID of the long task
+        public let id: String?
+
+        /// Whether this long task is considered a frozen frame
+        public let isFrozenFrame: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case duration = "duration"
+            case id = "id"
+            case isFrozenFrame = "is_frozen_frame"
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// Whether this session has a replay
+        public let hasReplay: Bool?
+
+        /// UUID of the session
+        public let id: String
+
+        /// Type of the session
+        public let type: SessionType
+
+        enum CodingKeys: String, CodingKey {
+            case hasReplay = "has_replay"
+            case id = "id"
+            case type = "type"
+        }
+
+        /// Type of the session
+        public enum SessionType: String, Codable {
+            case user = "user"
+            case synthetics = "synthetics"
+        }
+    }
+
+    /// Synthetics properties
+    public struct Synthetics: Codable {
+        /// The identifier of the current Synthetics test results
+        public let resultId: String
+
+        /// The identifier of the current Synthetics test
+        public let testId: String
+
+        enum CodingKeys: String, CodingKey {
+            case resultId = "result_id"
+            case testId = "test_id"
+        }
+    }
+
+    /// View properties
+    public struct View: Codable {
+        /// UUID of the view
+        public let id: String
+
+        /// User defined name of the view
+        public var name: String?
+
+        /// URL that linked to the initial view of the page
+        public var referrer: String?
+
+        /// URL of the view
+        public var url: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
             case name = "name"
             case referrer = "referrer"
             case url = "url"
@@ -1351,4 +1628,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/2ea84b56a4e0670b2d6e3e0c6a5fd27774ce4a3d
+// Generated from https://github.com/DataDog/rum-events-format/tree/cdf9a70e6be9cfec5e9524c58abfe79a9fea1f64

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -69,3 +69,5 @@ extension RUMActionEvent: RUMSanitizableEvent {}
 extension RUMResourceEvent: RUMSanitizableEvent {}
 
 extension RUMErrorEvent: RUMSanitizableEvent {}
+
+extension RUMLongTaskEvent: RUMSanitizableEvent {}

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -37,9 +37,9 @@ internal final class RUMFeature {
     let carrierInfoProvider: CarrierInfoProviderType
     let launchTimeProvider: LaunchTimeProviderType
 
-    let vitalCPUReader: SamplingBasedVitalReader // VitalCPUReader
-    let vitalMemoryReader: SamplingBasedVitalReader // VitalMemoryReader
-    let vitalRefreshRateReader: ContinuousVitalReader // VitalRefreshRateReader
+    let vitalCPUReader: SamplingBasedVitalReader
+    let vitalMemoryReader: SamplingBasedVitalReader
+    let vitalRefreshRateReader: ContinuousVitalReader
 
     let onSessionStart: RUMSessionListener?
 
@@ -124,6 +124,7 @@ internal final class RUMFeature {
             errorEventMapper: configuration.errorEventMapper,
             resourceEventMapper: configuration.resourceEventMapper,
             actionEventMapper: configuration.actionEventMapper,
+            longTaskEventMapper: configuration.longTaskEventMapper,
             internalMonitor: internalMonitor
         )
         let storage = RUMFeature.createStorage(
@@ -180,7 +181,6 @@ internal final class RUMFeature {
         self.vitalCPUReader = vitalCPUReader
         self.vitalMemoryReader = vitalMemoryReader
         self.vitalRefreshRateReader = vitalRefreshRateReader
-
         self.onSessionStart = onSessionStart
     }
 

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -256,3 +256,12 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     let actionType: RUMUserActionType
     let name: String
 }
+
+// MARK: - RUM Long Task related commands
+
+internal struct RUMAddLongTaskCommand: RUMCommand {
+    var time: Date
+    var attributes: [AttributeKey: AttributeValue]
+
+    let duration: TimeInterval
+}

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -189,6 +189,7 @@ internal class RUMResourceScope: RUMScope {
             ),
             service: nil,
             session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
+            synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             view: .init(
                 id: context.activeViewID.orNull.toRUMDataFormat,
@@ -237,6 +238,7 @@ internal class RUMResourceScope: RUMScope {
             ),
             service: nil,
             session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
+            synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             view: .init(
                 id: context.activeViewID.orNull.toRUMDataFormat,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -10,6 +10,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     struct Constants {
         static let backgroundViewURL = "com/datadog/background/view"
         static let backgroundViewName = "Background"
+
+        static let frozenFrameThresholdInNs = (0.07).toInt64Nanoseconds // 70ms
+        static let slowRenderingThresholdFPS = 55.0
     }
 
     // MARK: - Child Scopes
@@ -55,6 +58,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     private var resourcesCount: UInt = 0
     /// Number of Errors tracked by this View.
     private var errorsCount: UInt = 0
+    /// Number of Long Tasks tracked by this View.
+    private var longTasksCount: Int64 = 0
+    /// Number of Frozen Frames tracked by this View.
+    private var frozenFramesCount: Int64 = 0
 
     /// Current version of this View to use for RUM `documentVersion`.
     private var version: UInt = 0
@@ -174,6 +181,19 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 needsViewUpdate = true
             } else {
                 errorsCount -= 1
+            }
+
+        case let command as RUMAddLongTaskCommand where isActiveView:
+            longTasksCount += 1
+            if command.duration.toInt64Nanoseconds > Constants.frozenFrameThresholdInNs {
+                frozenFramesCount += 1
+            }
+
+            if sendLongTaskEvent(on: command) {
+                needsViewUpdate = true
+            } else {
+                longTasksCount -= 1
+                frozenFramesCount -= 1
             }
 
         default:
@@ -306,6 +326,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
             service: nil,
             session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
+            synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             view: .init(
                 id: viewUUID.toRUMDataFormat,
@@ -332,6 +353,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let cpuInfo = vitalInfoSampler.cpu
         let memoryInfo = vitalInfoSampler.memory
         let refreshRateInfo = vitalInfoSampler.refreshRate
+        let isSlowRendered = refreshRateInfo.meanValue.flatMap { $0 < Constants.slowRenderingThresholdFPS }
 
         let eventData = RUMViewEvent(
             dd: .init(
@@ -344,6 +366,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
             service: nil,
             session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
+            synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             view: .init(
                 action: .init(count: actionsCount.toInt64),
@@ -361,14 +384,16 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 firstContentfulPaint: nil,
                 firstInputDelay: nil,
                 firstInputTime: nil,
+                frozenFrame: .init(count: frozenFramesCount),
                 id: viewUUID.toRUMDataFormat,
                 inForegroundPeriods: nil,
                 isActive: isActiveView,
+                isSlowRendered: isSlowRendered,
                 largestContentfulPaint: nil,
                 loadEvent: nil,
                 loadingTime: nil,
                 loadingType: nil,
-                longTask: nil,
+                longTask: .init(count: longTasksCount),
                 memoryAverage: memoryInfo.meanValue,
                 memoryMax: memoryInfo.maxValue,
                 name: viewName,
@@ -416,10 +441,44 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ),
             service: nil,
             session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
+            synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             view: .init(
                 id: context.activeViewID.orNull.toRUMDataFormat,
                 inForeground: nil,
+                name: context.activeViewName,
+                referrer: nil,
+                url: context.activeViewPath ?? ""
+            )
+        )
+
+        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData) {
+            dependencies.eventOutput.write(rumEvent: event)
+            return true
+        }
+        return false
+    }
+
+    private func sendLongTaskEvent(on command: RUMAddLongTaskCommand) -> Bool {
+        attributes.merge(rumCommandAttributes: command.attributes)
+
+        let taskDurationInNs = command.duration.toInt64Nanoseconds
+        let isFrozenFrame = taskDurationInNs > Constants.frozenFrameThresholdInNs
+
+        let eventData = RUMLongTaskEvent(
+            dd: .init(session: .init(plan: .plan1)),
+            action: context.activeUserActionID.flatMap { RUMLongTaskEvent.Action(id: $0.toRUMDataFormat) },
+            application: .init(id: context.rumApplicationID),
+            connectivity: dependencies.connectivityInfoProvider.current,
+            context: .init(contextInfo: attributes),
+            date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
+            longTask: .init(duration: taskDurationInNs, id: nil, isFrozenFrame: isFrozenFrame),
+            service: nil,
+            session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
+            synthetics: nil,
+            usr: dependencies.userInfoProvider.current,
+            view: .init(
+                id: context.activeViewID.orNull.toRUMDataFormat,
                 name: context.activeViewName,
                 referrer: nil,
                 url: context.activeViewPath ?? ""

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -184,16 +184,13 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             }
 
         case let command as RUMAddLongTaskCommand where isActiveView:
-            longTasksCount += 1
-            if command.duration.toInt64Nanoseconds > Constants.frozenFrameThresholdInNs {
-                frozenFramesCount += 1
-            }
-
             if sendLongTaskEvent(on: command) {
+                longTasksCount += 1
+                if command.duration.toInt64Nanoseconds > Constants.frozenFrameThresholdInNs {
+                    frozenFramesCount += 1
+                }
+
                 needsViewUpdate = true
-            } else {
-                longTasksCount -= 1
-                frozenFramesCount -= 1
             }
 
         default:

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -52,7 +52,9 @@ internal final class VitalInfoSampler {
         maximumRefreshRate: Double = Double(UIScreen.main.maximumFramesPerSecond)
     ) {
         self.cpuReader = cpuReader
+
         self.memoryReader = memoryReader
+
         self.refreshRateReader = refreshRateReader
         self.refreshRateReader.register(self.refreshRatePublisher)
         self.maximumRefreshRate = maximumRefreshRate

--- a/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
+++ b/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
@@ -10,6 +10,7 @@ internal typealias RUMViewEventMapper = (RUMViewEvent) -> RUMViewEvent
 internal typealias RUMErrorEventMapper = (RUMErrorEvent) -> RUMErrorEvent?
 internal typealias RUMResourceEventMapper = (RUMResourceEvent) -> RUMResourceEvent?
 internal typealias RUMActionEventMapper = (RUMActionEvent) -> RUMActionEvent?
+internal typealias RUMLongTaskEventMapper = (RUMLongTaskEvent) -> RUMLongTaskEvent?
 
 /// The `EventMapper` for RUM events.
 internal struct RUMEventsMapper {
@@ -17,6 +18,7 @@ internal struct RUMEventsMapper {
     let errorEventMapper: RUMErrorEventMapper?
     let resourceEventMapper: RUMResourceEventMapper?
     let actionEventMapper: RUMActionEventMapper?
+    let longTaskEventMapper: RUMLongTaskEventMapper?
     var internalMonitor: InternalMonitor? = nil
 
     // MARK: - EventMapper
@@ -33,6 +35,8 @@ internal struct RUMEventsMapper {
             return map(rumEvent: resourceEvent, using: resourceEventMapper) as? T
         case let actionEvent as RUMEvent<RUMActionEvent>:
             return map(rumEvent: actionEvent, using: actionEventMapper) as? T
+        case let longTaskEvent as RUMEvent<RUMLongTaskEvent>:
+            return map(rumEvent: longTaskEvent, using: longTaskEventMapper) as? T
         default:
             internalMonitor?.sdkLogger.critical("No `RUMEventMapper` is registered for \(type(of: event))")
             return event

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -293,6 +293,16 @@ public class DDConfigurationBuilder: NSObject {
     }
 
     @objc
+    public func trackRUMLongTasks() {
+        _ = sdkBuilder.trackRUMLongTasks()
+    }
+
+    @objc
+    public func trackRUMLongTasks(threshold: TimeInterval) {
+        _ = sdkBuilder.trackRUMLongTasks(threshold: threshold)
+    }
+
+    @objc
     public func setRUMViewEventMapper(_ mapper: @escaping (DDRUMViewEvent) -> DDRUMViewEvent) {
         _ = sdkBuilder.setRUMViewEventMapper { swiftEvent in
             let objcEvent = DDRUMViewEvent(swiftModel: swiftEvent)
@@ -320,6 +330,14 @@ public class DDConfigurationBuilder: NSObject {
     public func setRUMErrorEventMapper(_ mapper: @escaping (DDRUMErrorEvent) -> DDRUMErrorEvent?) {
         _ = sdkBuilder.setRUMErrorEventMapper { swiftEvent in
             let objcEvent = DDRUMErrorEvent(swiftModel: swiftEvent)
+            return mapper(objcEvent)?.swiftModel
+        }
+    }
+
+    @objc
+    public func setRUMLongTaskEventMapper(_ mapper: @escaping (DDRUMLongTaskEvent) -> DDRUMLongTaskEvent?) {
+        _ = sdkBuilder.setRUMLongTaskEventMapper { swiftEvent in
+            let objcEvent = DDRUMLongTaskEvent(swiftModel: swiftEvent)
             return mapper(objcEvent)?.swiftModel
         }
     }

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -48,6 +48,10 @@ public class DDRUMViewEvent: NSObject {
         DDRUMViewEventSession(root: root)
     }
 
+    @objc public var synthetics: DDRUMViewEventSynthetics? {
+        root.swiftModel.synthetics != nil ? DDRUMViewEventSynthetics(root: root) : nil
+    }
+
     @objc public var type: String {
         root.swiftModel.type
     }
@@ -285,6 +289,23 @@ public enum DDRUMViewEventSessionSessionType: Int {
 }
 
 @objc
+public class DDRUMViewEventSynthetics: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var resultId: String {
+        root.swiftModel.synthetics!.resultId
+    }
+
+    @objc public var testId: String {
+        root.swiftModel.synthetics!.testId
+    }
+}
+
+@objc
 public class DDRUMViewEventRUMUser: NSObject {
     internal let root: DDRUMViewEvent
 
@@ -369,6 +390,10 @@ public class DDRUMViewEventView: NSObject {
         root.swiftModel.view.firstInputTime as NSNumber?
     }
 
+    @objc public var frozenFrame: DDRUMViewEventViewFrozenFrame? {
+        root.swiftModel.view.frozenFrame != nil ? DDRUMViewEventViewFrozenFrame(root: root) : nil
+    }
+
     @objc public var id: String {
         root.swiftModel.view.id
     }
@@ -379,6 +404,10 @@ public class DDRUMViewEventView: NSObject {
 
     @objc public var isActive: NSNumber? {
         root.swiftModel.view.isActive as NSNumber?
+    }
+
+    @objc public var isSlowRendered: NSNumber? {
+        root.swiftModel.view.isSlowRendered as NSNumber?
     }
 
     @objc public var largestContentfulPaint: NSNumber? {
@@ -477,6 +506,19 @@ public class DDRUMViewEventViewError: NSObject {
 
     @objc public var count: NSNumber {
         root.swiftModel.view.error.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewFrozenFrame: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.frozenFrame!.count as NSNumber
     }
 }
 
@@ -608,6 +650,10 @@ public class DDRUMResourceEvent: NSObject {
 
     @objc public var session: DDRUMResourceEventSession {
         DDRUMResourceEventSession(root: root)
+    }
+
+    @objc public var synthetics: DDRUMResourceEventSynthetics? {
+        root.swiftModel.synthetics != nil ? DDRUMResourceEventSynthetics(root: root) : nil
     }
 
     @objc public var type: String {
@@ -1119,6 +1165,7 @@ public enum DDRUMResourceEventResourceResourceType: Int {
         case .font: self = .font
         case .media: self = .media
         case .other: self = .other
+        case .native: self = .native
         }
     }
 
@@ -1134,6 +1181,7 @@ public enum DDRUMResourceEventResourceResourceType: Int {
         case .font: return .font
         case .media: return .media
         case .other: return .other
+        case .native: return .native
         }
     }
 
@@ -1147,6 +1195,7 @@ public enum DDRUMResourceEventResourceResourceType: Int {
     case font
     case media
     case other
+    case native
 }
 
 @objc
@@ -1188,6 +1237,23 @@ public enum DDRUMResourceEventSessionSessionType: Int {
 
     case user
     case synthetics
+}
+
+@objc
+public class DDRUMResourceEventSynthetics: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var resultId: String {
+        root.swiftModel.synthetics!.resultId
+    }
+
+    @objc public var testId: String {
+        root.swiftModel.synthetics!.testId
+    }
 }
 
 @objc
@@ -1282,6 +1348,10 @@ public class DDRUMActionEvent: NSObject {
 
     @objc public var session: DDRUMActionEventSession {
         DDRUMActionEventSession(root: root)
+    }
+
+    @objc public var synthetics: DDRUMActionEventSynthetics? {
+        root.swiftModel.synthetics != nil ? DDRUMActionEventSynthetics(root: root) : nil
     }
 
     @objc public var type: String {
@@ -1659,6 +1729,23 @@ public enum DDRUMActionEventSessionSessionType: Int {
 }
 
 @objc
+public class DDRUMActionEventSynthetics: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var resultId: String {
+        root.swiftModel.synthetics!.resultId
+    }
+
+    @objc public var testId: String {
+        root.swiftModel.synthetics!.testId
+    }
+}
+
+@objc
 public class DDRUMActionEventRUMUser: NSObject {
     internal let root: DDRUMActionEvent
 
@@ -1758,6 +1845,10 @@ public class DDRUMErrorEvent: NSObject {
 
     @objc public var session: DDRUMErrorEventSession {
         DDRUMErrorEventSession(root: root)
+    }
+
+    @objc public var synthetics: DDRUMErrorEventSynthetics? {
+        root.swiftModel.synthetics != nil ? DDRUMErrorEventSynthetics(root: root) : nil
     }
 
     @objc public var type: String {
@@ -2249,6 +2340,23 @@ public enum DDRUMErrorEventSessionSessionType: Int {
 }
 
 @objc
+public class DDRUMErrorEventSynthetics: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var resultId: String {
+        root.swiftModel.synthetics!.resultId
+    }
+
+    @objc public var testId: String {
+        root.swiftModel.synthetics!.testId
+    }
+}
+
+@objc
 public class DDRUMErrorEventRUMUser: NSObject {
     internal let root: DDRUMErrorEvent
 
@@ -2305,6 +2413,391 @@ public class DDRUMErrorEventView: NSObject {
     }
 }
 
+@objc
+public class DDRUMLongTaskEvent: NSObject {
+    internal var swiftModel: RUMLongTaskEvent
+    internal var root: DDRUMLongTaskEvent { self }
+
+    internal init(swiftModel: RUMLongTaskEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var dd: DDRUMLongTaskEventDD {
+        DDRUMLongTaskEventDD(root: root)
+    }
+
+    @objc public var action: DDRUMLongTaskEventAction? {
+        root.swiftModel.action != nil ? DDRUMLongTaskEventAction(root: root) : nil
+    }
+
+    @objc public var application: DDRUMLongTaskEventApplication {
+        DDRUMLongTaskEventApplication(root: root)
+    }
+
+    @objc public var connectivity: DDRUMLongTaskEventRUMConnectivity? {
+        root.swiftModel.connectivity != nil ? DDRUMLongTaskEventRUMConnectivity(root: root) : nil
+    }
+
+    @objc public var context: DDRUMLongTaskEventRUMEventAttributes? {
+        root.swiftModel.context != nil ? DDRUMLongTaskEventRUMEventAttributes(root: root) : nil
+    }
+
+    @objc public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    @objc public var longTask: DDRUMLongTaskEventLongTask {
+        DDRUMLongTaskEventLongTask(root: root)
+    }
+
+    @objc public var service: String? {
+        root.swiftModel.service
+    }
+
+    @objc public var session: DDRUMLongTaskEventSession {
+        DDRUMLongTaskEventSession(root: root)
+    }
+
+    @objc public var synthetics: DDRUMLongTaskEventSynthetics? {
+        root.swiftModel.synthetics != nil ? DDRUMLongTaskEventSynthetics(root: root) : nil
+    }
+
+    @objc public var type: String {
+        root.swiftModel.type
+    }
+
+    @objc public var usr: DDRUMLongTaskEventRUMUser? {
+        root.swiftModel.usr != nil ? DDRUMLongTaskEventRUMUser(root: root) : nil
+    }
+
+    @objc public var view: DDRUMLongTaskEventView {
+        DDRUMLongTaskEventView(root: root)
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventDD: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+
+    @objc public var session: DDRUMLongTaskEventDDSession? {
+        root.swiftModel.dd.session != nil ? DDRUMLongTaskEventDDSession(root: root) : nil
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventDDSession: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var plan: DDRUMLongTaskEventDDSessionPlan {
+        .init(swift: root.swiftModel.dd.session!.plan)
+    }
+}
+
+@objc
+public enum DDRUMLongTaskEventDDSessionPlan: Int {
+    internal init(swift: RUMLongTaskEvent.DD.Session.Plan) {
+        switch swift {
+        case .plan1: self = .plan1
+        case .plan2: self = .plan2
+        }
+    }
+
+    internal var toSwift: RUMLongTaskEvent.DD.Session.Plan {
+        switch self {
+        case .plan1: return .plan1
+        case .plan2: return .plan2
+        }
+    }
+
+    case plan1
+    case plan2
+}
+
+@objc
+public class DDRUMLongTaskEventAction: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.action!.id
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventApplication: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventRUMConnectivity: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var cellular: DDRUMLongTaskEventRUMConnectivityCellular? {
+        root.swiftModel.connectivity!.cellular != nil ? DDRUMLongTaskEventRUMConnectivityCellular(root: root) : nil
+    }
+
+    @objc public var interfaces: [Int] {
+        root.swiftModel.connectivity!.interfaces.map { DDRUMLongTaskEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    }
+
+    @objc public var status: DDRUMLongTaskEventRUMConnectivityStatus {
+        .init(swift: root.swiftModel.connectivity!.status)
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventRUMConnectivityCellular: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var carrierName: String? {
+        root.swiftModel.connectivity!.cellular!.carrierName
+    }
+
+    @objc public var technology: String? {
+        root.swiftModel.connectivity!.cellular!.technology
+    }
+}
+
+@objc
+public enum DDRUMLongTaskEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces) {
+        switch swift {
+        case .bluetooth: self = .bluetooth
+        case .cellular: self = .cellular
+        case .ethernet: self = .ethernet
+        case .wifi: self = .wifi
+        case .wimax: self = .wimax
+        case .mixed: self = .mixed
+        case .other: self = .other
+        case .unknown: self = .unknown
+        case .none: self = .none
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces {
+        switch self {
+        case .bluetooth: return .bluetooth
+        case .cellular: return .cellular
+        case .ethernet: return .ethernet
+        case .wifi: return .wifi
+        case .wimax: return .wimax
+        case .mixed: return .mixed
+        case .other: return .other
+        case .unknown: return .unknown
+        case .none: return .none
+        }
+    }
+
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case none
+}
+
+@objc
+public enum DDRUMLongTaskEventRUMConnectivityStatus: Int {
+    internal init(swift: RUMConnectivity.Status) {
+        switch swift {
+        case .connected: self = .connected
+        case .notConnected: self = .notConnected
+        case .maybe: self = .maybe
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Status {
+        switch self {
+        case .connected: return .connected
+        case .notConnected: return .notConnected
+        case .maybe: return .maybe
+        }
+    }
+
+    case connected
+    case notConnected
+    case maybe
+}
+
+@objc
+public class DDRUMLongTaskEventRUMEventAttributes: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var contextInfo: [String: Any] {
+        root.swiftModel.context!.contextInfo
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventLongTask: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.longTask.duration as NSNumber
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.longTask.id
+    }
+
+    @objc public var isFrozenFrame: NSNumber? {
+        root.swiftModel.longTask.isFrozenFrame as NSNumber?
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventSession: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var hasReplay: NSNumber? {
+        root.swiftModel.session.hasReplay as NSNumber?
+    }
+
+    @objc public var id: String {
+        root.swiftModel.session.id
+    }
+
+    @objc public var type: DDRUMLongTaskEventSessionSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc
+public enum DDRUMLongTaskEventSessionSessionType: Int {
+    internal init(swift: RUMLongTaskEvent.Session.SessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        }
+    }
+
+    internal var toSwift: RUMLongTaskEvent.Session.SessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        }
+    }
+
+    case user
+    case synthetics
+}
+
+@objc
+public class DDRUMLongTaskEventSynthetics: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var resultId: String {
+        root.swiftModel.synthetics!.resultId
+    }
+
+    @objc public var testId: String {
+        root.swiftModel.synthetics!.testId
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventRUMUser: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var email: String? {
+        root.swiftModel.usr!.email
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.usr!.id
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.usr!.name
+    }
+
+    @objc public var usrInfo: [String: Any] {
+        root.swiftModel.usr!.usrInfo
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventView: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.view.id
+    }
+
+    @objc public var name: String? {
+        set { root.swiftModel.view.name = newValue }
+        get { root.swiftModel.view.name }
+    }
+
+    @objc public var referrer: String? {
+        set { root.swiftModel.view.referrer = newValue }
+        get { root.swiftModel.view.referrer }
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.view.url = newValue }
+        get { root.swiftModel.view.url }
+    }
+}
+
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/2ea84b56a4e0670b2d6e3e0c6a5fd27774ce4a3d
+// Generated from https://github.com/DataDog/rum-events-format/tree/cdf9a70e6be9cfec5e9524c58abfe79a9fea1f64

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMMobileVitalsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMMobileVitalsScenarioTests.swift
@@ -1,0 +1,64 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import HTTPServerMock
+import XCTest
+
+private extension ExampleApplication {
+    func tapNoOpButton() {
+        buttons["No-op"].tap()
+    }
+
+    func tapBlockMainThreadButton() {
+        buttons["Block Main Thread"].tap()
+    }
+}
+
+class RUMMobileVitalsScenarioTests: IntegrationTests, RUMCommonAsserts {
+    func testRUMMobileVitalsScenario() throws {
+        // Server session recording RUM events send to `HTTPServerMock`.
+        let rumServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenarioClassName: "RUMMobileVitalsScenario",
+            serverConfiguration: HTTPServerMockConfiguration(
+                rumEndpoint: rumServerSession.recordingURL
+            )
+        )
+
+        // Wait for the app to settle down for 3 second
+        Thread.sleep(forTimeInterval: 3.0)
+
+        app.tapNoOpButton()
+        app.tapBlockMainThreadButton()
+        app.tapNoOpButton()
+
+        // Get RUM Sessions with expected number of View visits
+        let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            let visitCount = try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count
+            return visitCount == 1
+        }
+
+        assertRUM(requests: recordedRUMRequests)
+
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
+
+        XCTAssertEqual(session.viewVisits[0].viewEvents.count, 2)
+        let event1 = session.viewVisits[0].viewEvents[0].view
+        let event2 = session.viewVisits[0].viewEvents[1].view
+
+        let longTask1 = try XCTUnwrap(event1.longTask)
+        let longTask2 = try XCTUnwrap(event2.longTask)
+        XCTAssertEqual(longTask1.count + 1, longTask2.count)
+
+        let cpuTicksPerSec2 = try XCTUnwrap(event2.cpuTicksPerSecond)
+        XCTAssertGreaterThan(cpuTicksPerSec2, 0.0)
+
+        let fps2 = try XCTUnwrap(event2.refreshRateAverage)
+        XCTAssertGreaterThan(fps2, 0.0)
+    }
+}

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -48,10 +48,12 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertNil(configuration.rumSessionsListener)
             XCTAssertNil(configuration.rumUIKitViewsPredicate)
             XCTAssertNil(configuration.rumUIKitUserActionsPredicate)
+            XCTAssertNil(configuration.rumLongTaskDurationThreshold)
             XCTAssertNil(configuration.rumViewEventMapper)
             XCTAssertNil(configuration.rumResourceEventMapper)
             XCTAssertNil(configuration.rumActionEventMapper)
             XCTAssertNil(configuration.rumErrorEventMapper)
+            XCTAssertNil(configuration.rumLongTaskEventMapper)
             XCTAssertNil(configuration.rumResourceAttributesProvider)
             XCTAssertEqual(configuration.batchSize, .medium)
             XCTAssertEqual(configuration.uploadFrequency, .average)
@@ -65,6 +67,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
         let mockRUMErrorEvent: RUMErrorEvent = .mockRandom()
         let mockRUMResourceEvent: RUMResourceEvent = .mockRandom()
         let mockRUMActionEvent: RUMActionEvent = .mockRandom()
+        let mockRUMLongTaskEvent: RUMLongTaskEvent = .mockRandom()
         let mockCrashReportingPlugin = CrashReportingPluginMock()
 
         func customized(_ builder: Datadog.Configuration.Builder) -> Datadog.Configuration.Builder {
@@ -84,11 +87,13 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .trackURLSession(firstPartyHosts: ["example.com"])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock())
                 .trackUIKitRUMActions(using: UIKitRUMUserActionsPredicateMock())
+                .trackLongTasks(threshold: 100.0)
                 .trackBackgroundEvents(false)
                 .setRUMViewEventMapper { _ in mockRUMViewEvent }
                 .setRUMErrorEventMapper { _ in mockRUMErrorEvent }
                 .setRUMResourceEventMapper { _ in mockRUMResourceEvent }
                 .setRUMActionEventMapper { _ in mockRUMActionEvent }
+                .setRUMLongTaskEventMapper { _ in mockRUMLongTaskEvent }
                 .setRUMResourceAttributesProvider { _, _, _, _ in ["foo": "bar"] }
                 .set(batchSize: .small)
                 .set(uploadFrequency: .frequent)
@@ -138,11 +143,13 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertNotNil(configuration.rumSessionsListener)
             XCTAssertTrue(configuration.rumUIKitViewsPredicate is UIKitRUMViewsPredicateMock)
             XCTAssertTrue(configuration.rumUIKitUserActionsPredicate is UIKitRUMUserActionsPredicateMock)
+            XCTAssertEqual(configuration.rumLongTaskDurationThreshold, 100.0)
             XCTAssertEqual(configuration.spanEventMapper?(.mockRandom()), mockSpanEvent)
             XCTAssertEqual(configuration.rumViewEventMapper?(.mockRandom()), mockRUMViewEvent)
             XCTAssertEqual(configuration.rumResourceEventMapper?(.mockRandom()), mockRUMResourceEvent)
             XCTAssertEqual(configuration.rumActionEventMapper?(.mockRandom()), mockRUMActionEvent)
             XCTAssertEqual(configuration.rumErrorEventMapper?(.mockRandom()), mockRUMErrorEvent)
+            XCTAssertEqual(configuration.rumLongTaskEventMapper?(.mockRandom()), mockRUMLongTaskEvent)
             XCTAssertEqual(configuration.rumResourceAttributesProvider?(.mockAny(), nil, nil, nil) as? [String: String], ["foo": "bar"])
             XCTAssertFalse(configuration.rumBackgroundEventTrackingEnabled)
             XCTAssertEqual(configuration.batchSize, .small)

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -87,7 +87,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .trackURLSession(firstPartyHosts: ["example.com"])
                 .trackUIKitRUMViews(using: UIKitRUMViewsPredicateMock())
                 .trackUIKitRUMActions(using: UIKitRUMUserActionsPredicateMock())
-                .trackLongTasks(threshold: 100.0)
+                .trackRUMLongTasks(threshold: 100.0)
                 .trackBackgroundEvents(false)
                 .setRUMViewEventMapper { _ in mockRUMViewEvent }
                 .setRUMErrorEventMapper { _ in mockRUMErrorEvent }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -232,6 +232,7 @@ extension FeaturesConfiguration.RUM {
         resourceEventMapper: RUMResourceEventMapper? = nil,
         actionEventMapper: RUMActionEventMapper? = nil,
         errorEventMapper: RUMErrorEventMapper? = nil,
+        longTaskEventMapper: RUMLongTaskEventMapper? = nil,
         autoInstrumentation: FeaturesConfiguration.RUM.AutoInstrumentation? = nil,
         backgroundEventTrackingEnabled: Bool = false,
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListerner()
@@ -246,6 +247,7 @@ extension FeaturesConfiguration.RUM {
             resourceEventMapper: resourceEventMapper,
             actionEventMapper: actionEventMapper,
             errorEventMapper: errorEventMapper,
+            longTaskEventMapper: longTaskEventMapper,
             autoInstrumentation: autoInstrumentation,
             backgroundEventTrackingEnabled: backgroundEventTrackingEnabled,
             onSessionStart: onSessionStart

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -12,6 +12,7 @@ extension RUMViewEvent: EquatableInTests {}
 extension RUMResourceEvent: EquatableInTests {}
 extension RUMActionEvent: EquatableInTests {}
 extension RUMErrorEvent: EquatableInTests {}
+extension RUMLongTaskEvent: EquatableInTests {}
 extension RUMEvent: EquatableInTests {}
 
 extension RUMUser {
@@ -67,6 +68,7 @@ extension RUMViewEvent: RandomMockable {
                 id: .mockRandom(),
                 type: .user
             ),
+            synthetics: nil,
             usr: .mockRandom(),
             view: .init(
                 action: .init(count: .mockRandom()),
@@ -82,6 +84,7 @@ extension RUMViewEvent: RandomMockable {
                 firstContentfulPaint: .mockRandom(),
                 firstInputDelay: .mockRandom(),
                 firstInputTime: .mockRandom(),
+                frozenFrame: .init(count: .mockRandom()),
                 id: .mockRandom(),
                 inForegroundPeriods: [
                     .init(
@@ -90,6 +93,7 @@ extension RUMViewEvent: RandomMockable {
                     )
                 ],
                 isActive: .random(),
+                isSlowRendered: .mockRandom(),
                 largestContentfulPaint: .mockRandom(),
                 loadEvent: .mockRandom(),
                 loadingTime: .mockRandom(),
@@ -148,6 +152,7 @@ extension RUMResourceEvent: RandomMockable {
                 id: .mockRandom(),
                 type: .user
             ),
+            synthetics: nil,
             usr: .mockRandom(),
             view: .init(
                 id: .mockRandom(),
@@ -184,6 +189,7 @@ extension RUMActionEvent: RandomMockable {
                 id: .mockRandom(),
                 type: .user
             ),
+            synthetics: nil,
             usr: .mockRandom(),
             view: .init(
                 id: .mockRandom(),
@@ -232,6 +238,7 @@ extension RUMErrorEvent: RandomMockable {
                 id: .mockRandom(),
                 type: .user
             ),
+            synthetics: nil,
             usr: .mockRandom(),
             view: .init(
                 id: .mockRandom(),
@@ -239,6 +246,25 @@ extension RUMErrorEvent: RandomMockable {
                 referrer: .mockRandom(),
                 url: .mockRandom()
             )
+        )
+    }
+}
+
+extension RUMLongTaskEvent: RandomMockable {
+    static func mockRandom() -> RUMLongTaskEvent {
+        return RUMLongTaskEvent(
+            dd: .init(session: .init(plan: .plan1)),
+            action: .init(id: .mockRandom()),
+            application: .init(id: .mockRandom()),
+            connectivity: .mockRandom(),
+            context: .mockRandom(),
+            date: .mockRandom(),
+            longTask: .init(duration: .mockRandom(), id: .mockRandom(), isFrozenFrame: .mockRandom()),
+            service: .mockRandom(),
+            session: .init(hasReplay: false, id: .mockRandom(), type: .user),
+            synthetics: nil,
+            usr: .mockRandom(),
+            view: .init(id: .mockRandom(), name: .mockRandom(), referrer: .mockRandom(), url: .mockRandom())
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -137,13 +137,15 @@ extension RUMEventsMapper {
         viewEventMapper: RUMViewEventMapper? = nil,
         errorEventMapper: RUMErrorEventMapper? = nil,
         resourceEventMapper: RUMResourceEventMapper? = nil,
-        actionEventMapper: RUMActionEventMapper? = nil
+        actionEventMapper: RUMActionEventMapper? = nil,
+        longTaskEventMapper: RUMLongTaskEventMapper? = nil
     ) -> RUMEventsMapper {
         return RUMEventsMapper(
             viewEventMapper: viewEventMapper,
             errorEventMapper: errorEventMapper,
             resourceEventMapper: resourceEventMapper,
-            actionEventMapper: actionEventMapper
+            actionEventMapper: actionEventMapper,
+            longTaskEventMapper: longTaskEventMapper
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
@@ -12,6 +12,7 @@ class RUMEventSanitizerTests: XCTestCase {
     private let resourceEvent: RUMResourceEvent = .mockRandom()
     private let actionEvent: RUMActionEvent = .mockRandom()
     private let errorEvent: RUMErrorEvent = .mockRandom()
+    private let longTaskEvent: RUMLongTaskEvent = .mockRandom()
 
     func testWhenAttributeNameExceeds10NestedLevels_itIsEscapedByUnderscore() {
         func test<Event>(event: Event) where Event: RUMSanitizableEvent {
@@ -81,6 +82,7 @@ class RUMEventSanitizerTests: XCTestCase {
         test(event: resourceEvent)
         test(event: actionEvent)
         test(event: errorEvent)
+        test(event: longTaskEvent)
     }
 
     func testWhenNumberOfAttributesExceedsLimit_itDropsExtraOnes() {
@@ -121,6 +123,7 @@ class RUMEventSanitizerTests: XCTestCase {
         test(event: resourceEvent)
         test(event: actionEvent)
         test(event: errorEvent)
+        test(event: longTaskEvent)
     }
 
     // MARK: - Private

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -359,6 +359,40 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertEqual(event.model.action.error?.count, 1)
     }
 
+    // MARK: - Long task actions
+
+    func testWhileDiscreteUserActionIsActive_itCountsLongTasks() throws {
+        var currentTime = Date()
+        let scope = RUMUserActionScope.mockWith(
+            parent: parent,
+            dependencies: dependencies,
+            name: .mockAny(),
+            actionType: .scroll,
+            attributes: [:],
+            startTime: currentTime,
+            dateCorrection: .zero,
+            isContinuous: false
+        )
+
+        currentTime.addTimeInterval(0.05)
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddLongTaskCommand(time: currentTime, attributes: [:], duration: 1.0)
+            )
+        )
+
+        currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration)
+
+        XCTAssertFalse(
+            scope.process(command: RUMCommandMock(time: currentTime)),
+            "Discrete User Action should complete as it reached the timeout duration"
+        )
+
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMActionEvent>.self).last)
+        XCTAssertEqual(event.model.action.longTask?.count, 1)
+    }
+
     // MARK: - Events sending callbacks
 
     func testGivenUserActionScopeWithEventSentCallback_whenSuccessfullySendingEvent_thenCallbackIsCalled() throws {

--- a/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
@@ -21,6 +21,9 @@ class RUMEventsMapperTests: XCTestCase {
         let originalActionEvent: RUMActionEvent = .mockRandom()
         let modifiedActionEvent: RUMActionEvent = .mockRandom()
 
+        let originalLongTaskEvent: RUMLongTaskEvent = .mockRandom()
+        let modifiedLongTaskEvent: RUMLongTaskEvent = .mockRandom()
+
         // Given
         let mapper = RUMEventsMapper(
             viewEventMapper: { viewEvent in
@@ -38,6 +41,10 @@ class RUMEventsMapperTests: XCTestCase {
             actionEventMapper: { actionEvent in
                 XCTAssertEqual(actionEvent, originalActionEvent, "Mapper should be called with the original event.")
                 return modifiedActionEvent
+            },
+            longTaskEventMapper: { longTaskEvent in
+                XCTAssertEqual(longTaskEvent, originalLongTaskEvent, "Mapper should be called with the original event.")
+                return modifiedLongTaskEvent
             }
         )
 
@@ -46,18 +53,21 @@ class RUMEventsMapperTests: XCTestCase {
         let mappedErrorEvent = mapper.map(event: RUMEvent(model: originalErrorEvent))?.model
         let mappedResourceEvent = mapper.map(event: RUMEvent(model: originalResourceEvent))?.model
         let mappedActionEvent = mapper.map(event: RUMEvent(model: originalActionEvent))?.model
+        let mappedLongTaskEvent = mapper.map(event: RUMEvent(model: originalLongTaskEvent))?.model
 
         // Then
         XCTAssertEqual(try XCTUnwrap(mappedViewEvent), modifiedViewEvent, "Mapper should return modified event.")
         XCTAssertEqual(try XCTUnwrap(mappedErrorEvent), modifiedErrorEvent, "Mapper should return modified event.")
         XCTAssertEqual(try XCTUnwrap(mappedResourceEvent), modifiedResourceEvent, "Mapper should return modified event.")
         XCTAssertEqual(try XCTUnwrap(mappedActionEvent), modifiedActionEvent, "Mapper should return modified event.")
+        XCTAssertEqual(try XCTUnwrap(mappedLongTaskEvent), modifiedLongTaskEvent, "Mapper should return modified event.")
     }
 
     func testGivenMappersEnabled_whenDroppingEvents_itReturnsNil() {
         let originalErrorEvent: RUMErrorEvent = .mockRandom()
         let originalResourceEvent: RUMResourceEvent = .mockRandom()
         let originalActionEvent: RUMActionEvent = .mockRandom()
+        let originalLongTaskEvent: RUMLongTaskEvent = .mockRandom()
 
         // Given
         let mapper = RUMEventsMapper(
@@ -73,6 +83,10 @@ class RUMEventsMapperTests: XCTestCase {
             actionEventMapper: { actionEvent in
                 XCTAssertEqual(actionEvent, originalActionEvent, "Mapper should be called with the original event.")
                 return nil
+            },
+            longTaskEventMapper: { longTaskEvent in
+                XCTAssertEqual(longTaskEvent, originalLongTaskEvent, "Mapper should be called with the original event.")
+                return nil
             }
         )
 
@@ -80,11 +94,13 @@ class RUMEventsMapperTests: XCTestCase {
         let mappedErrorEvent = mapper.map(event: RUMEvent(model: originalErrorEvent))?.model
         let mappedResourceEvent = mapper.map(event: RUMEvent(model: originalResourceEvent))?.model
         let mappedActionEvent = mapper.map(event: RUMEvent(model: originalActionEvent))?.model
+        let mappedLongTaskEvent = mapper.map(event: RUMEvent(model: originalLongTaskEvent))?.model
 
         // Then
         XCTAssertNil(mappedErrorEvent, "Mapper should return nil.")
         XCTAssertNil(mappedResourceEvent, "Mapper should return nil.")
         XCTAssertNil(mappedActionEvent, "Mapper should return nil.")
+        XCTAssertNil(mappedLongTaskEvent, "Mapper should return nil.")
     }
 
     func testGivenMappersDisabled_whenMappingEvents_itReturnsTheirOriginalRepresentation() throws {
@@ -92,13 +108,15 @@ class RUMEventsMapperTests: XCTestCase {
         let originalErrorEvent: RUMErrorEvent = .mockRandom()
         let originalResourceEvent: RUMResourceEvent = .mockRandom()
         let originalActionEvent: RUMActionEvent = .mockRandom()
+        let originalLongTaskEvent: RUMLongTaskEvent = .mockRandom()
 
         // Given
         let mapper = RUMEventsMapper(
             viewEventMapper: nil,
             errorEventMapper: nil,
             resourceEventMapper: nil,
-            actionEventMapper: nil
+            actionEventMapper: nil,
+            longTaskEventMapper: nil
         )
 
         // When
@@ -106,12 +124,14 @@ class RUMEventsMapperTests: XCTestCase {
         let mappedErrorEvent = mapper.map(event: RUMEvent(model: originalErrorEvent))?.model
         let mappedResourceEvent = mapper.map(event: RUMEvent(model: originalResourceEvent))?.model
         let mappedActionEvent = mapper.map(event: RUMEvent(model: originalActionEvent))?.model
+        let mappedLongTaskEvent = mapper.map(event: RUMEvent(model: originalLongTaskEvent))?.model
 
         // Then
         XCTAssertEqual(try XCTUnwrap(mappedViewEvent), originalViewEvent, "Mapper should return the original event.")
         XCTAssertEqual(try XCTUnwrap(mappedErrorEvent), originalErrorEvent, "Mapper should return the original event.")
         XCTAssertEqual(try XCTUnwrap(mappedResourceEvent), originalResourceEvent, "Mapper should return the original event.")
         XCTAssertEqual(try XCTUnwrap(mappedActionEvent), originalActionEvent, "Mapper should return the original event.")
+        XCTAssertEqual(try XCTUnwrap(mappedLongTaskEvent), originalLongTaskEvent, "Mapper should return the original event.")
     }
 
     func testGivenUnrecognizedEvent_whenMapping_itReturnsItsOriginalImplementation() throws {
@@ -127,7 +147,8 @@ class RUMEventsMapperTests: XCTestCase {
             viewEventMapper: nil,
             errorEventMapper: { _ in nil },
             resourceEventMapper: { _ in nil },
-            actionEventMapper: { _ in nil }
+            actionEventMapper: { _ in nil },
+            longTaskEventMapper: { _ in nil }
         )
 
         let mappedEvent = try XCTUnwrap(mapper.map(event: originalEvent))

--- a/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
+++ b/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
@@ -92,6 +92,8 @@
         viewEvent.view.url = @"";
         return viewEvent;
     }];
+    [builder trackRUMLongTasks];
+    [builder trackRUMLongTasksWithThreshold:10.0];
     [builder setRUMResourceEventMapper:^DDRUMResourceEvent * _Nullable(DDRUMResourceEvent * _Nonnull resourceEvent) {
         resourceEvent.resource.url = @"";
         return resourceEvent;
@@ -100,6 +102,9 @@
         return nil;
     }];
     [builder setRUMErrorEventMapper:^DDRUMErrorEvent * _Nullable(DDRUMErrorEvent * _Nonnull errorEvent) {
+        return nil;
+    }];
+    [builder setRUMLongTaskEventMapper:^DDRUMLongTaskEvent * _Nullable(DDRUMLongTaskEvent * _Nonnull longTaskEvent) {
         return nil;
     }];
     [builder setWithBatchSize:DDBatchSizeMedium];

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -68,6 +68,9 @@ internal class RUMSessionMatcher {
 
         /// `RUMError` events tracked during this visit.
         fileprivate(set) var errorEvents: [RUMErrorEvent] = []
+
+        /// `RUMLongTask` events tracked during this visit.
+        fileprivate(set) var longTaskEvents: [RUMLongTaskEvent] = []
     }
 
     /// An array of view visits tracked during this RUM Session.
@@ -177,6 +180,16 @@ internal class RUMSessionMatcher {
         try errorEvents.forEach { rumEvent in
             if let visit = visitsByViewID[rumEvent.view.id] {
                 visit.errorEvents.append(rumEvent)
+            } else {
+                throw RUMSessionConsistencyException(
+                    description: "Cannot link RUM Event: \(rumEvent) to `RUMSessionMatcher.ViewVisit` by `view.id`."
+                )
+            }
+        }
+
+        try longTaskEvents.forEach { rumEvent in
+            if let visit = visitsByViewID[rumEvent.view.id] {
+                visit.longTaskEvents.append(rumEvent)
             } else {
                 throw RUMSessionConsistencyException(
                     description: "Cannot link RUM Event: \(rumEvent) to `RUMSessionMatcher.ViewVisit` by `view.id`."

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -78,6 +78,7 @@ internal class RUMSessionMatcher {
     let actionEventMatchers: [RUMEventMatcher]
     let resourceEventMatchers: [RUMEventMatcher]
     let errorEventMatchers: [RUMEventMatcher]
+    let longTaskEventMatchers: [RUMEventMatcher]
 
     private init(sessionEventMatchers: [RUMEventMatcher]) throws {
         // Sort events so they follow increasing time order
@@ -97,6 +98,7 @@ internal class RUMSessionMatcher {
         self.actionEventMatchers = eventsMatchersByType["action"] ?? []
         self.resourceEventMatchers = eventsMatchersByType["resource"] ?? []
         self.errorEventMatchers = eventsMatchersByType["error"] ?? []
+        self.longTaskEventMatchers = eventsMatchersByType["long_task"] ?? []
 
         let viewEvents: [RUMViewEvent] = try viewEventMatchers.map { matcher in try matcher.model() }
 
@@ -109,11 +111,15 @@ internal class RUMSessionMatcher {
         let errorEvents: [RUMErrorEvent] = try errorEventMatchers
             .map { matcher in try matcher.model() }
 
+        let longTaskEvents: [RUMLongTaskEvent] = try longTaskEventMatchers
+            .map { matcher in try matcher.model() }
+
         // Validate each group of events individually
         try validate(rumViewEvents: viewEvents)
         try validate(rumActionEvents: actionEvents)
         try validate(rumResourceEvents: resourceEvents)
         try validate(rumErrorEvents: errorEvents)
+        try validate(rumLongTaskEvents: longTaskEvents)
 
         // Group RUMView events into ViewVisits:
         let uniqueViewIDs = Set(viewEvents.map { $0.view.id })
@@ -265,6 +271,17 @@ private func validate(rumErrorEvents: [RUMErrorEvent]) throws {
         if errorEvent.dd.session?.plan != .plan1 {
             throw RUMSessionConsistencyException(
                 description: "All RUM events must use session plan `1` (RUM Lite). Bad error event: \(errorEvent)"
+            )
+        }
+    }
+}
+
+private func validate(rumLongTaskEvents: [RUMLongTaskEvent]) throws {
+    // All error events must use `session.plan` "lite"
+    try rumLongTaskEvents.forEach { longTaskEvent in
+        if longTaskEvent.dd.session?.plan != .plan1 {
+            throw RUMSessionConsistencyException(
+                description: "All RUM events must use session plan `1` (RUM Lite). Bad long task event: \(longTaskEvent)"
             )
         }
     }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUMModelsGenerator.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUMModelsGenerator.swift
@@ -58,7 +58,8 @@ public class RUMModelsGenerator {
             schemaFiles.viewSchema,
             schemaFiles.resourceSchema,
             schemaFiles.actionSchema,
-            schemaFiles.errorSchema
+            schemaFiles.errorSchema,
+            schemaFiles.longTaskSchema,
         ]
 
         // Read ambiguous JSON schemas from `*.json` files


### PR DESCRIPTION
### What and why?

Long Tasks are events that occur when the main thread is blocked for more than the given threshold.
This event can show our users whether their apps block the main thread longer than needed and if so, how and when.

### How?

`RunLoopObserver`s added to `RunLoop.main`: they observe the intervals between run loop activites and report long intervals.
These observers act similarly to [view and user action tracking](https://github.com/DataDog/dd-sdk-ios/blob/master/Sources/Datadog/RUM/AutoInstrumentation/RUMAutoInstrumentation.swift).

### TODO

- [x] Add ObjC APIs

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
