### PR TITLE
Use preferred isEmpty checks

### DIFF
--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -58,7 +58,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
             }
 
             let blockersForUpload = self.uploadConditions.blockersForUpload()
-            let isSystemReady = blockersForUpload.count == 0
+            let isSystemReady = blockersForUpload.isEmpty
             let nextBatch = isSystemReady ? self.fileReader.readNextBatch() : nil
             if let batch = nextBatch {
                 userLogger.debug("⏳ (\(self.featureName)) Uploading batch...")

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -30,7 +30,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
         self.reader = storage.reader
         self.queue = (storage.writer as! ConsentAwareDataWriter).queue
 
-        XCTAssertTrue(try directory.files().count == 0)
+        XCTAssertTrue(try directory.files().isEmpty)
     }
 
     override func tearDown() {

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -30,7 +30,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
         self.reader = storage.reader
         self.queue = (storage.writer as! ConsentAwareDataWriter).queue
 
-        XCTAssertTrue(try directory.files().count == 0)
+        XCTAssertTrue(try directory.files().isEmpty)
     }
 
     override func tearDown() {

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -30,7 +30,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
         self.reader = storage.reader
         self.queue = (storage.writer as! ConsentAwareDataWriter).queue
 
-        XCTAssertTrue(try directory.files().count == 0)
+        XCTAssertTrue(try directory.files().isEmpty)
     }
 
     override func tearDown() {

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadConditionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadConditionsTests.swift
@@ -122,7 +122,7 @@ class DataUploadConditionsTests: XCTestCase {
         line: UInt = #line
     ) {
         let conditions = DataUploadConditions(batteryStatus: battery, networkConnectionInfo: network)
-        let canPerformUpload = conditions.blockersForUpload().count == 0
+        let canPerformUpload = conditions.blockersForUpload().isEmpty
         XCTAssertEqual(
             value,
             canPerformUpload,

--- a/Tests/DatadogTests/Helpers/EquatableInTests.swift
+++ b/Tests/DatadogTests/Helpers/EquatableInTests.swift
@@ -32,8 +32,8 @@ private func equalsAny(lhs: Any, rhs: Any) -> Bool {
         return false // different number of children
     }
 
-    if lhsMirror.children.count == 0, rhsMirror.children.count == 0 {
-        return String(describing: lhs) == String(describing: rhs) // plain values, comopare debug strings
+    if lhsMirror.children.isEmpty, rhsMirror.children.isEmpty {
+        return String(describing: lhs) == String(describing: rhs) // plain values, compare debug strings
     }
 
     switch (lhsMirror.displayStyle, rhsMirror.displayStyle) {


### PR DESCRIPTION
### What and why?

Use preferred way of checking emptiness with `Collection`'s `isEmpty` property, as it has a complexity of O(1).

### How?

By replacing `.count == 0` checks with `.isEmpty`.
