### PR TITLE
RUMM-1420 Set internal(set) accessor to readonly additionalProperties

### DIFF
--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -20,7 +20,7 @@ public struct RUMViewEvent: RUMDataModel {
     public let connectivity: RUMConnectivity?
 
     /// User provided context
-    public let context: RUMEventAttributes?
+    public internal(set) var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -35,7 +35,7 @@ public struct RUMViewEvent: RUMDataModel {
     public let type: String = "view"
 
     /// User properties
-    public let usr: RUMUser?
+    public internal(set) var usr: RUMUser?
 
     /// View properties
     public var view: View
@@ -339,7 +339,7 @@ public struct RUMResourceEvent: RUMDataModel {
     public let connectivity: RUMConnectivity?
 
     /// User provided context
-    public let context: RUMEventAttributes?
+    public internal(set) var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -357,7 +357,7 @@ public struct RUMResourceEvent: RUMDataModel {
     public let type: String = "resource"
 
     /// User properties
-    public let usr: RUMUser?
+    public internal(set) var usr: RUMUser?
 
     /// View properties
     public var view: View
@@ -693,7 +693,7 @@ public struct RUMActionEvent: RUMDataModel {
     public let connectivity: RUMConnectivity?
 
     /// User provided context
-    public let context: RUMEventAttributes?
+    public internal(set) var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -708,7 +708,7 @@ public struct RUMActionEvent: RUMDataModel {
     public let type: String = "action"
 
     /// User properties
-    public let usr: RUMUser?
+    public internal(set) var usr: RUMUser?
 
     /// View properties
     public var view: View
@@ -932,7 +932,7 @@ public struct RUMErrorEvent: RUMDataModel {
     public let connectivity: RUMConnectivity?
 
     /// User provided context
-    public let context: RUMEventAttributes?
+    public internal(set) var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
     public let date: Int64
@@ -950,7 +950,7 @@ public struct RUMErrorEvent: RUMDataModel {
     public let type: String = "error"
 
     /// User properties
-    public let usr: RUMUser?
+    public internal(set) var usr: RUMUser?
 
     /// View properties
     public var view: View
@@ -1241,7 +1241,7 @@ public struct RUMConnectivity: Codable {
 
 /// User provided context
 public struct RUMEventAttributes: Codable {
-    public let contextInfo: [String: Codable]
+    public internal(set) var contextInfo: [String: Codable]
 
     struct DynamicCodingKey: CodingKey {
         var stringValue: String
@@ -1287,7 +1287,7 @@ public struct RUMUser: Codable {
     /// Name of the user
     public let name: String?
 
-    public let usrInfo: [String: Codable]
+    public internal(set) var usrInfo: [String: Codable]
 
     enum StaticCodingKeys: String, CodingKey {
         case email = "email"

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -54,10 +54,13 @@ internal struct SwiftEnum: SwiftType {
 
 internal struct SwiftStruct: SwiftType {
     struct Property: SwiftType {
+
+        /// Mutability levels of a property.
+        /// From the lowest `immutable` to the highest `mutable`.
         enum Mutability: Int {
-           case immutable
-           case mutableInternally
-           case mutable
+            case immutable
+            case mutableInternally
+            case mutable
         }
 
         enum CodingKey {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -54,6 +54,12 @@ internal struct SwiftEnum: SwiftType {
 
 internal struct SwiftStruct: SwiftType {
     struct Property: SwiftType {
+        enum Mutability: Int {
+           case immutable
+           case mutableInternally
+           case mutable
+        }
+
         enum CodingKey {
             /// Static coding key with fixed value.
             case `static`(value: String)
@@ -72,7 +78,7 @@ internal struct SwiftStruct: SwiftType {
         var comment: String?
         var type: SwiftType
         var isOptional: Bool
-        var isMutable: Bool
+        var mutability: Mutability
         var defaultValue: SwiftPropertyDefaultValue?
         var codingKey: CodingKey
     }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -54,7 +54,6 @@ internal struct SwiftEnum: SwiftType {
 
 internal struct SwiftStruct: SwiftType {
     struct Property: SwiftType {
-
         /// Mutability levels of a property.
         /// From the lowest `immutable` to the highest `mutable`.
         enum Mutability: Int {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -241,19 +241,20 @@ internal class ObjcInteropPrinter: BasePrinter {
         let objcPropertyName = swiftProperty.name
         let objcEnumName = objcTypeNamesPrefix + nestedObjcEnum.objcTypeName
 
-        if swiftProperty.mutability == .mutable {
-            writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
-            indentRight()
-                writeLine("set { root.swiftModel.\(propertyWrapper.keyPath) = newValue.toSwift }")
-                writeLine("get { .init(swift: root.swiftModel.\(propertyWrapper.keyPath)) }")
-            indentLeft()
-            writeLine("}")
-        } else {
-            writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
-            indentRight()
-                writeLine(".init(swift: root.swiftModel.\(propertyWrapper.keyPath))")
-            indentLeft()
-            writeLine("}")
+        switch swiftProperty.mutability {
+           case .mutable:
+                writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
+                indentRight()
+                    writeLine("set { root.swiftModel.\(propertyWrapper.keyPath) = newValue.toSwift }")
+                    writeLine("get { .init(swift: root.swiftModel.\(propertyWrapper.keyPath)) }")
+                indentLeft()
+                writeLine("}")
+           case .immutable, .mutableInternally:
+                writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
+                indentRight()
+                    writeLine(".init(swift: root.swiftModel.\(propertyWrapper.keyPath))")
+                indentLeft()
+                writeLine("}")
         }
     }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -241,7 +241,7 @@ internal class ObjcInteropPrinter: BasePrinter {
         let objcPropertyName = swiftProperty.name
         let objcEnumName = objcTypeNamesPrefix + nestedObjcEnum.objcTypeName
 
-        if swiftProperty.isMutable {
+        if swiftProperty.mutability == .mutable {
             writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
             indentRight()
                 writeLine("set { root.swiftModel.\(propertyWrapper.keyPath) = newValue.toSwift }")
@@ -273,7 +273,7 @@ internal class ObjcInteropPrinter: BasePrinter {
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcEnumName = objcTypeNamesPrefix + nestedObjcEnumArray.objcTypeName
 
-        guard swiftProperty.isMutable == false else {
+        if swiftProperty.mutability == .mutable {
             throw Exception.unimplemented("Generating setter for `ObjcInteropEnumArray` is not supported: \(swiftProperty.type).")
         }
 
@@ -298,7 +298,7 @@ internal class ObjcInteropPrinter: BasePrinter {
         let objcPropertyOptionality = swiftProperty.isOptional ? "?" : ""
         let objcClassName = objcTypeNamesPrefix + nestedObjcClass.objcTypeName
 
-        guard swiftProperty.isMutable == false else {
+        if swiftProperty.mutability == .mutable {
             throw Exception.unimplemented("Generating setter for `ObjcInteropNestedClass` is not supported: \(swiftProperty.type).")
         }
 
@@ -313,7 +313,7 @@ internal class ObjcInteropPrinter: BasePrinter {
         let swiftProperty = propertyWrapper.bridgedSwiftProperty
 
         if let swiftDictionary = swiftProperty.type as? SwiftDictionary, swiftDictionary.value is SwiftPrimitive<SwiftCodable> {
-            guard !swiftProperty.isMutable else {
+            if swiftProperty.mutability == .mutable {
                 throw Exception.unimplemented(
                     "Generating ObjcInterop for mutable `[Swift: Codable]` is not supported."
                 )
@@ -327,7 +327,7 @@ internal class ObjcInteropPrinter: BasePrinter {
             asObjcCast + objcPropertyOptionality
         } ?? ""
 
-        if swiftProperty.isMutable {
+        if swiftProperty.mutability == .mutable {
             // Generate getter and setter for the managed value, e.g.:
             // ```
             // @objc public var propertyX: String? {

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/ObjcInteropPrinter.swift
@@ -242,19 +242,19 @@ internal class ObjcInteropPrinter: BasePrinter {
         let objcEnumName = objcTypeNamesPrefix + nestedObjcEnum.objcTypeName
 
         switch swiftProperty.mutability {
-           case .mutable:
-                writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
-                indentRight()
-                    writeLine("set { root.swiftModel.\(propertyWrapper.keyPath) = newValue.toSwift }")
-                    writeLine("get { .init(swift: root.swiftModel.\(propertyWrapper.keyPath)) }")
-                indentLeft()
-                writeLine("}")
-           case .immutable, .mutableInternally:
-                writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
-                indentRight()
-                    writeLine(".init(swift: root.swiftModel.\(propertyWrapper.keyPath))")
-                indentLeft()
-                writeLine("}")
+        case .mutable:
+            writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
+            indentRight()
+                writeLine("set { root.swiftModel.\(propertyWrapper.keyPath) = newValue.toSwift }")
+                writeLine("get { .init(swift: root.swiftModel.\(propertyWrapper.keyPath)) }")
+            indentLeft()
+            writeLine("}")
+        case .immutable, .mutableInternally:
+            writeLine("@objc public var \(objcPropertyName): \(objcEnumName) {")
+            indentRight()
+                writeLine(".init(swift: root.swiftModel.\(propertyWrapper.keyPath))")
+            indentLeft()
+            writeLine("}")
         }
     }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
@@ -57,7 +57,7 @@ public class SwiftPrinter: BasePrinter {
             switch property.mutability {
             case .mutable: kind = "var"
             case .mutableInternally: kind = "internal(set) var"
-            default: kind = "let"
+            case .immutable: kind = "let"
             }
             let name = property.name
             let type = try typeDeclaration(property.type)

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
@@ -53,7 +53,12 @@ public class SwiftPrinter: BasePrinter {
     private func printPropertiesList(_ properties: [SwiftStruct.Property]) throws {
         try properties.enumerated().forEach { index, property in
             let accessLevel = "public"
-            let kind = property.isMutable ? "var" : "let"
+            let kind: String
+            switch property.mutability {
+            case .mutable: kind = "var"
+            case .mutableInternally: kind = "internal(set) var"
+            default: kind = "let"
+            }
             let name = property.name
             let type = try typeDeclaration(property.type)
             let optionality = property.isOptional ? "?" : ""

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -87,7 +87,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                 comment: "Description of Bar's `property1`.",
                                 type: SwiftPrimitive<String>(),
                                 isOptional: true,
-                                isMutable: false,
+                                mutability: .immutable,
                                 defaultValue: nil,
                                 codingKey: .static(value: "property1")
                             ),
@@ -96,7 +96,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                 comment: "Description of Bar's `property2`.",
                                 type: SwiftPrimitive<String>(),
                                 isOptional: false,
-                                isMutable: true,
+                                mutability: .mutable,
                                 defaultValue: nil,
                                 codingKey: .static(value: "property2")
                             )
@@ -104,7 +104,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: true,
-                    isMutable: true, // should be mutable as at least one of the `Bar's` properties is mutable
+                    mutability: .mutable, // should be mutable as at least one of the `Bar's` properties is mutable
                     defaultValue: nil,
                     codingKey: .static(value: "bar")
                 ),
@@ -123,7 +123,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: false,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
                     codingKey: .static(value: "property1")
                 ),
@@ -144,7 +144,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         )
                     ),
                     isOptional: true,
-                    isMutable: true,
+                    mutability: .mutable,
                     defaultValue: nil,
                     codingKey: .static(value: "property2")
                 )
@@ -193,7 +193,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                     comment: "Description of a property with nested additional Int properties.",
                     type: SwiftDictionary(value: SwiftPrimitive<Int>()),
                     isOptional: true,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "propertyWithAdditionalIntProperties")
                 )
@@ -251,7 +251,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                     value: SwiftPrimitive<SwiftCodable>()
                                 ),
                                 isOptional: false,
-                                isMutable: false,
+                                mutability: .mutableInternally,
                                 defaultValue: nil,
                                 codingKey: .dynamic
                             )
@@ -259,7 +259,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: true,
-                    isMutable: false,
+                    mutability: .mutableInternally,
                     defaultValue: nil,
                     codingKey: .static(value: "propertyWithAdditionalAnyProperties")
                 )
@@ -323,7 +323,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                 comment: "Description of Foo.bar's `bazz`.",
                                 type: SwiftPrimitive<String>(),
                                 isOptional: true,
-                                isMutable: false,
+                                mutability: .immutable,
                                 defaultValue: nil,
                                 codingKey: .static(value: "bazz")
                             ),
@@ -334,7 +334,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                     value: SwiftPrimitive<SwiftCodable>()
                                 ),
                                 isOptional: false,
-                                isMutable: false,
+                                mutability: .mutableInternally,
                                 defaultValue: nil,
                                 codingKey: .dynamic
                             ),
@@ -342,7 +342,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: true,
-                    isMutable: false,
+                    mutability: .mutableInternally,
                     defaultValue: nil,
                     codingKey: .static(value: "bar")
                 )
@@ -423,7 +423,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                         value: SwiftPrimitive<Int>()
                     ),
                     isOptional: false,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "propertyWithAdditionalProperties")
                 )

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/SwiftTypeTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/SwiftTypeTests.swift
@@ -1,0 +1,21 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-2020 Datadog, Inc.
+*/
+
+import XCTest
+@testable import RUMModelsGeneratorCore
+
+final class SwiftTypeTests: XCTestCase {
+    func testSwiftStructProperty_mutabilityLevelOrder() {
+        let immutable = SwiftStruct.Property.Mutability.immutable.rawValue
+        let mutableInternally = SwiftStruct.Property.Mutability.mutableInternally.rawValue
+        let mutable = SwiftStruct.Property.Mutability.mutable.rawValue
+
+        // The level order of property mutability must always be
+        // .immutable < .mutableInternally < .mutable
+        XCTAssertTrue(immutable < mutableInternally)
+        XCTAssertTrue(mutableInternally < mutable)
+    }
+}

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
@@ -35,25 +35,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableString",
                     type: SwiftPrimitive<String>(),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableString",
                     type: SwiftPrimitive<String>(),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableString",
                     type: SwiftPrimitive<String>(),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableString",
                     type: SwiftPrimitive<String>(),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -118,25 +118,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableInt",
                     type: SwiftPrimitive<Int>(),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableInt",
                     type: SwiftPrimitive<Int>(),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableInt",
                     type: SwiftPrimitive<Int>(),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableInt",
                     type: SwiftPrimitive<Int>(),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -201,25 +201,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableInt64",
                     type: SwiftPrimitive<Int64>(),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableInt64",
                     type: SwiftPrimitive<Int64>(),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableInt",
                     type: SwiftPrimitive<Int64>(),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableInt64",
                     type: SwiftPrimitive<Int64>(),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -284,25 +284,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableDouble",
                     type: SwiftPrimitive<Double>(),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableDouble",
                     type: SwiftPrimitive<Double>(),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableDouble",
                     type: SwiftPrimitive<Double>(),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableDouble",
                     type: SwiftPrimitive<Double>(),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -367,25 +367,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableBool",
                     type: SwiftPrimitive<Bool>(),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableBool",
                     type: SwiftPrimitive<Bool>(),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableBool",
                     type: SwiftPrimitive<Bool>(),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableBool",
                     type: SwiftPrimitive<Bool>(),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -463,25 +463,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableEnum",
                     type: mockEnumeration(named: "Enumeration1"),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableEnum",
                     type: mockEnumeration(named: "Enumeration2"),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableEnum",
                     type: mockEnumeration(named: "Enumeration3"),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableEnum",
                     type: mockEnumeration(named: "Enumeration4"),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -670,25 +670,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableStrings",
                     type: SwiftArray(element: SwiftPrimitive<String>()),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableStrings",
                     type: SwiftArray(element: SwiftPrimitive<String>()),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableStrings",
                     type: SwiftArray(element: SwiftPrimitive<String>()),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableStrings",
                     type: SwiftArray(element: SwiftPrimitive<String>()),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -753,25 +753,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableInt64s",
                     type: SwiftArray(element: SwiftPrimitive<Int64>()),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableInt64s",
                     type: SwiftArray(element: SwiftPrimitive<Int64>()),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableInt64s",
                     type: SwiftArray(element: SwiftPrimitive<Int64>()),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableInt64s",
                     type: SwiftArray(element: SwiftPrimitive<Int64>()),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -849,13 +849,13 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableEnums",
                     type: SwiftArray(element: mockEnumeration(named: "Options1")),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableEnums",
                     type: SwiftArray(element: mockEnumeration(named: "Options2")),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
             ],
             conformance: []
@@ -969,7 +969,7 @@ final class ObjcInteropPrinterTests: XCTestCase {
                         comment: nil,
                         type: SwiftPrimitive<String>(),
                         isOptional: false,
-                        isMutable: false,
+                        mutability: .immutable,
                         defaultValue: nil,
                         codingKey: .static(value: "property")
                     )
@@ -986,13 +986,13 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableStructs",
                     type: SwiftArray(element: mockStruct(named: "Bar")),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableStructs",
                     type: SwiftArray(element: mockStruct(named: "Bizz")),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
             ],
             conformance: []
@@ -1081,25 +1081,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableStrings",
                     type: SwiftDictionary(value: SwiftPrimitive<String>()),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableStrings",
                     type: SwiftDictionary(value: SwiftPrimitive<String>()),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableStrings",
                     type: SwiftDictionary(value: SwiftPrimitive<String>()),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableStrings",
                     type: SwiftDictionary(value: SwiftPrimitive<String>()),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -1164,25 +1164,25 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableInt64s",
                     type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableInt64s",
                     type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "mutableInt64s",
                     type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalMutableInt64s",
                     type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -1247,13 +1247,13 @@ final class ObjcInteropPrinterTests: XCTestCase {
                     propertyName: "immutableCodables",
                     type: SwiftDictionary(value: SwiftPrimitive<SwiftCodable>()),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableCodables",
                     type: SwiftDictionary(value: SwiftPrimitive<SwiftCodable>()),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
             ],
             conformance: []
@@ -1308,15 +1308,15 @@ final class ObjcInteropPrinterTests: XCTestCase {
                         name: "MutableBar",
                         comment: nil,
                         properties: [
-                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: false),
-                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: false),
-                            .mock(propertyName: "mutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: true),
-                            .mock(propertyName: "optionalMutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: true),
+                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, mutability: .immutable),
+                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, mutability: .immutable),
+                            .mock(propertyName: "mutableString", type: SwiftPrimitive<String>(), isOptional: false, mutability: .mutable),
+                            .mock(propertyName: "optionalMutableString", type: SwiftPrimitive<String>(), isOptional: true, mutability: .mutable),
                         ],
                         conformance: []
                     ),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "immutableBar",
@@ -1324,13 +1324,13 @@ final class ObjcInteropPrinterTests: XCTestCase {
                         name: "ImmutableBar",
                         comment: nil,
                         properties: [
-                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: false),
-                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: false),
+                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, mutability: .immutable),
+                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, mutability: .immutable),
                         ],
                         conformance: []
                     ),
                     isOptional: false,
-                    isMutable: false
+                    mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalMutableBar",
@@ -1338,13 +1338,13 @@ final class ObjcInteropPrinterTests: XCTestCase {
                         name: "OptionalMutableBar",
                         comment: nil,
                         properties: [
-                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: false),
-                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: false),
+                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, mutability: .immutable),
+                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, mutability: .immutable),
                         ],
                         conformance: []
                     ),
                     isOptional: true,
-                    isMutable: true
+                    mutability: .mutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableBar",
@@ -1352,13 +1352,13 @@ final class ObjcInteropPrinterTests: XCTestCase {
                         name: "OptionalImmutableBar",
                         comment: nil,
                         properties: [
-                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, isMutable: false),
-                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, isMutable: false),
+                            .mock(propertyName: "immutableString", type: SwiftPrimitive<String>(), isOptional: false, mutability: .immutable),
+                            .mock(propertyName: "optionalImmutableString", type: SwiftPrimitive<String>(), isOptional: true, mutability: .immutable),
                         ],
                         conformance: []
                     ),
                     isOptional: true,
-                    isMutable: false
+                    mutability: .immutable
                 ),
             ],
             conformance: []
@@ -1542,13 +1542,13 @@ final class ObjcInteropPrinterTests: XCTestCase {
                                     conformance: []
                                 ),
                                 isOptional: false,
-                                isMutable: true
+                                mutability: .mutable
                             ),
                         ],
                         conformance: []
                     ),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -1648,19 +1648,19 @@ final class ObjcInteropPrinterTests: XCTestCase {
                                 propertyName: "sharedStruct",
                                 type: SwiftTypeReference(referencedTypeName: "SharedStruct"),
                                 isOptional: false,
-                                isMutable: true
+                                mutability: .mutable
                             ),
                             .mock(
                                 propertyName: "sharedEnumeration",
                                 type: SwiftTypeReference(referencedTypeName: "SharedEnum"),
                                 isOptional: false,
-                                isMutable: true
+                                mutability: .mutable
                             ),
                         ],
                         conformance: []
                     ),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -1680,19 +1680,19 @@ final class ObjcInteropPrinterTests: XCTestCase {
                                 propertyName: "sharedStruct",
                                 type: SwiftTypeReference(referencedTypeName: "SharedStruct"),
                                 isOptional: false,
-                                isMutable: true
+                                mutability: .mutable
                             ),
                             .mock(
                                 propertyName: "sharedEnumeration",
                                 type: SwiftTypeReference(referencedTypeName: "SharedEnum"),
                                 isOptional: false,
-                                isMutable: true
+                                mutability: .mutable
                             ),
                         ],
                         conformance: []
                     ),
                     isOptional: false,
-                    isMutable: true
+                    mutability: .mutable
                 ),
             ],
             conformance: []
@@ -1702,7 +1702,7 @@ final class ObjcInteropPrinterTests: XCTestCase {
             name: "SharedStruct",
             comment: nil,
             properties: [
-                .mock(propertyName: "integer", type: SwiftPrimitive<Int>(), isOptional: true, isMutable: true)
+                .mock(propertyName: "integer", type: SwiftPrimitive<Int>(), isOptional: true, mutability: .mutable)
             ],
             conformance: []
         )
@@ -1904,14 +1904,14 @@ extension SwiftStruct.Property {
         propertyName: String,
         type: SwiftType,
         isOptional: Bool,
-        isMutable: Bool
+        mutability: SwiftStruct.Property.Mutability
     ) -> SwiftStruct.Property {
         return SwiftStruct.Property(
             name: propertyName,
             comment: nil,
             type: type,
             isOptional: isOptional,
-            isMutable: isMutable,
+            mutability: mutability,
             defaultValue: nil,
             codingKey: .static(value: propertyName)
         )

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -25,7 +25,7 @@ final class SwiftPrinterTests: XCTestCase {
                                 comment: "Description of Bar's `property1`.",
                                 type: SwiftPrimitive<String>(),
                                 isOptional: true,
-                                isMutable: false,
+                                mutability: .immutable,
                                 defaultValue: nil,
                                 codingKey: .static(value: "property1")
                             ),
@@ -34,7 +34,7 @@ final class SwiftPrinterTests: XCTestCase {
                                 comment: "Description of Bar's `property2`.",
                                 type: SwiftPrimitive<String>(),
                                 isOptional: false,
-                                isMutable: true,
+                                mutability: .mutable,
                                 defaultValue: nil,
                                 codingKey: .static(value: "property2")
                             )
@@ -42,7 +42,7 @@ final class SwiftPrinterTests: XCTestCase {
                         conformance: [codableProtocol]
                     ),
                     isOptional: true,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "bar")
                 ),
@@ -61,7 +61,7 @@ final class SwiftPrinterTests: XCTestCase {
                         conformance: [codableProtocol]
                     ),
                     isOptional: false,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
                     codingKey: .static(value: "bizz")
                 ),
@@ -82,7 +82,7 @@ final class SwiftPrinterTests: XCTestCase {
                         )
                     ),
                     isOptional: true,
-                    isMutable: true,
+                    mutability: .mutable,
                     defaultValue: nil,
                     codingKey: .static(value: "buzz")
                 ),
@@ -91,7 +91,7 @@ final class SwiftPrinterTests: XCTestCase {
                     comment: "Description of FooBar's `propertiesByNames`.",
                     type: SwiftDictionary(value: SwiftPrimitive<String>()),
                     isOptional: true,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "propertiesByNames")
                 )
@@ -215,7 +215,7 @@ final class SwiftPrinterTests: XCTestCase {
                     comment: nil,
                     type: SwiftPrimitive<String>(),
                     isOptional: false,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "property_1")
                 ),
@@ -226,7 +226,7 @@ final class SwiftPrinterTests: XCTestCase {
                         value: SwiftPrimitive<Int>()
                     ),
                     isOptional: false,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "property_2")
                 )
@@ -267,7 +267,7 @@ final class SwiftPrinterTests: XCTestCase {
                         value: SwiftPrimitive<SwiftCodable>()
                     ),
                     isOptional: false,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .dynamic
                 )
@@ -331,7 +331,7 @@ final class SwiftPrinterTests: XCTestCase {
                     comment: nil,
                     type: SwiftPrimitive<Int>(),
                     isOptional: false,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "property_1")
                 ),
@@ -342,7 +342,7 @@ final class SwiftPrinterTests: XCTestCase {
                         value: SwiftPrimitive<SwiftCodable>()
                     ),
                     isOptional: false,
-                    isMutable: false,
+                    mutability: .mutableInternally,
                     defaultValue: nil,
                     codingKey: .dynamic
                 ),
@@ -351,7 +351,7 @@ final class SwiftPrinterTests: XCTestCase {
                     comment: nil,
                     type: SwiftPrimitive<Bool>(),
                     isOptional: true,
-                    isMutable: true,
+                    mutability: .mutable,
                     defaultValue: nil,
                     codingKey: .static(value: "property_2")
                 )
@@ -367,7 +367,7 @@ final class SwiftPrinterTests: XCTestCase {
         public struct Foo: Codable {
             public let property1: Int
 
-            public let context: [String: Codable]
+            public internal(set) var context: [String: Codable]
 
             public var property2: Bool?
 

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUM/RUMSwiftTypeTransformerTests.swift
@@ -25,7 +25,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                                 comment: "Description of Bar's `property1`.",
                                 type: SwiftPrimitive<String>(),
                                 isOptional: true,
-                                isMutable: false,
+                                mutability: .immutable,
                                 defaultValue: nil,
                                 codingKey: .static(value: "property1")
                             ),
@@ -34,7 +34,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                                 comment: "Description of Bar's `property2`.",
                                 type: SwiftPrimitive<String>(),
                                 isOptional: false,
-                                isMutable: true,
+                                mutability: .mutable,
                                 defaultValue: nil,
                                 codingKey: .static(value: "property2")
                             )
@@ -42,7 +42,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: true,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "bar")
                 ),
@@ -61,7 +61,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: false,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
                     codingKey: .static(value: "property1")
                 ),
@@ -82,7 +82,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         )
                     ),
                     isOptional: true,
-                    isMutable: true,
+                    mutability: .mutable,
                     defaultValue: nil,
                     codingKey: .static(value: "property2")
                 ),
@@ -91,7 +91,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                     comment: "Description of Foobar's `propertiesByNames`",
                     type: SwiftDictionary(value: SwiftPrimitive<Int>()),
                     isOptional: true,
-                    isMutable: true,
+                    mutability: .mutable,
                     defaultValue: nil,
                     codingKey: .static(value: "propertiesByNames")
                 )
@@ -118,7 +118,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                                     comment: "Description of Bar's `property1`.",
                                     type: SwiftPrimitive<String>(),
                                     isOptional: true,
-                                    isMutable: false,
+                                    mutability: .immutable,
                                     defaultValue: nil,
                                     codingKey: .static(value: "property1")
                                 ),
@@ -127,7 +127,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                                     comment: "Description of Bar's `property2`.",
                                     type: SwiftPrimitive<String>(),
                                     isOptional: false,
-                                    isMutable: true,
+                                    mutability: .mutable,
                                     defaultValue: nil,
                                     codingKey: .static(value: "property2")
                                 )
@@ -135,7 +135,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                             conformance: [codableProtocol]
                         ),
                         isOptional: true,
-                        isMutable: false,
+                        mutability: .immutable,
                         defaultValue: nil,
                         codingKey: .static(value: "bar")
                     ),
@@ -154,7 +154,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                             conformance: [codableProtocol]
                         ),
                         isOptional: false,
-                        isMutable: false,
+                        mutability: .immutable,
                         defaultValue: SwiftEnum.Case(label: "case2", rawValue: .string(value: "case2")),
                         codingKey: .static(value: "property1")
                     ),
@@ -175,7 +175,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                             )
                         ),
                         isOptional: true,
-                        isMutable: true,
+                        mutability: .mutable,
                         defaultValue: nil,
                         codingKey: .static(value: "property2")
                     ),
@@ -184,7 +184,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         comment: "Description of Foobar's `propertiesByNames`",
                         type: SwiftDictionary(value: SwiftPrimitive<Int64>()),
                         isOptional: true,
-                        isMutable: true,
+                        mutability: .mutable,
                         defaultValue: nil,
                         codingKey: .static(value: "propertiesByNames")
                     )
@@ -211,7 +211,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: true,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "connectivity")
                 ),
@@ -225,7 +225,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: true,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "usr")
                 ),
@@ -239,7 +239,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         conformance: []
                     ),
                     isOptional: true,
-                    isMutable: false,
+                    mutability: .immutable,
                     defaultValue: nil,
                     codingKey: .static(value: "method")
                 )
@@ -259,7 +259,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         comment: nil,
                         type: SwiftTypeReference(referencedTypeName: "RUMConnectivity"),
                         isOptional: true,
-                        isMutable: false,
+                        mutability: .immutable,
                         defaultValue: nil,
                         codingKey: .static(value: "connectivity")
                     ),
@@ -268,7 +268,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         comment: nil,
                         type: SwiftTypeReference(referencedTypeName: "RUMUser"),
                         isOptional: true,
-                        isMutable: false,
+                        mutability: .immutable,
                         defaultValue: nil,
                         codingKey: .static(value: "usr")
                     ),
@@ -277,7 +277,7 @@ final class RUMSwiftTypeTransformerTests: XCTestCase {
                         comment: nil,
                         type: SwiftTypeReference(referencedTypeName: "RUMMethod"),
                         isOptional: true,
-                        isMutable: false,
+                        mutability: .immutable,
                         defaultValue: nil,
                         codingKey: .static(value: "method")
                     )


### PR DESCRIPTION
### What and why?

As part of applying new RUM event schema, we need to add internal mutation capabilities to rum event models in order to sanitise custom attributes. The `rum-models-generator` tool was creating immutable models which prevented from sanitising the `usr` and `context` additional properties. 

### How?

The `rum-models-generator` now support 3 levels of property mutability:
```swift
enum Mutability: Int {
    case immutable
    case mutableInternally
    case mutable
 }
```
The `mutableInternally`  will be applied to read-only models with `additionalProperties` set to `true`. The generated models will then have an accessor level of `public internal(set) var` in a transitive way.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
