### PR TITLE
RUMM-1350 let customer set up a Proxy for data upload

### DIFF
--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -19,6 +19,7 @@ internal struct FeaturesConfiguration {
         let environment: String
         let performance: PerformancePreset
         let source: String
+        let proxyConfiguration: [AnyHashable: Any]?
     }
 
     struct Logging {
@@ -156,7 +157,8 @@ extension FeaturesConfiguration {
                 uploadFrequency: configuration.uploadFrequency,
                 bundleType: appContext.bundleType
             ),
-            source: source
+            source: source,
+            proxyConfiguration: configuration.proxyConfiguration
         )
 
         if configuration.loggingEnabled {

--- a/Sources/Datadog/Core/Upload/HTTPClient.swift
+++ b/Sources/Datadog/Core/Upload/HTTPClient.swift
@@ -8,14 +8,16 @@ import Foundation
 
 /// Client for sending requests over HTTP.
 internal class HTTPClient {
-    private let session: URLSession
+    internal let session: URLSession
 
-    convenience init() {
+    convenience init(proxyConfiguration: [AnyHashable: Any]? = nil) {
         let configuration: URLSessionConfiguration = .ephemeral
         // NOTE: RUMM-610 Default behaviour of `.ephemeral` session is to cache requests.
         // To not leak requests memory (including their `.httpBody` which may be significant)
         // we explicitly opt-out from using cache. This cannot be achieved using `.requestCachePolicy`.
         configuration.urlCache = nil
+        configuration.connectionProxyDictionary = proxyConfiguration
+
         // TODO: RUMM-123 Optimize `URLSessionConfiguration` for good traffic performance
         // and move session configuration constants to `PerformancePreset`.
         self.init(session: URLSession(configuration: configuration))

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -187,7 +187,7 @@ public class Datadog {
         let commonDependencies = FeaturesCommonDependencies(
             consentProvider: consentProvider,
             performance: configuration.common.performance,
-            httpClient: HTTPClient(),
+            httpClient: HTTPClient(proxyConfiguration: configuration.common.proxyConfiguration),
             mobileDevice: MobileDevice.current,
             dateProvider: dateProvider,
             dateCorrector: dateCorrector,

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -244,6 +244,7 @@ extension Datadog {
         private(set) var batchSize: BatchSize
         private(set) var uploadFrequency: UploadFrequency
         private(set) var additionalConfiguration: [String: Any]
+        private(set) var proxyConfiguration: [AnyHashable: Any]?
 
         /// The client token autorizing internal monitoring data to be sent to Datadog org.
         private(set) var internalMonitoringClientToken: String?
@@ -316,6 +317,7 @@ extension Datadog {
                     batchSize: .medium,
                     uploadFrequency: .average,
                     additionalConfiguration: [:],
+                    proxyConfiguration: nil,
                     internalMonitoringClientToken: nil
                 )
             }
@@ -689,6 +691,14 @@ extension Datadog {
             /// - Parameter uploadFrequency: `.average` by default.
             public func set(uploadFrequency: UploadFrequency) -> Builder {
                 configuration.uploadFrequency = uploadFrequency
+                return self
+            }
+
+            /// Sets proxy configuration attributes.
+            /// This can be used to a enable a custom proxy for uploading tracked data to Datadog's intake.
+            /// - Parameter proxyConfiguration: `nil` by default.
+            public func set(proxyConfiguration: [AnyHashable: Any]?) -> Builder {
+                configuration.proxyConfiguration = proxyConfiguration
                 return self
             }
 

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -332,6 +332,11 @@ public class DDConfigurationBuilder: NSObject {
     }
 
     @objc
+    public func set(proxyConfiguration: [AnyHashable: Any]) {
+        _ = sdkBuilder.set(proxyConfiguration: proxyConfiguration)
+    }
+
+    @objc
     public func build() -> DDConfiguration {
         return DDConfiguration(sdkConfiguration: sdkBuilder.build())
     }

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -253,19 +253,19 @@ class FeaturesConfigurationTests: XCTestCase {
 
     func testCustomProxy() throws {
         let proxyConfiguration: [AnyHashable: Any] = [
-            kCFNetworkProxiesHTTPEnable as AnyHashable: true,
-            kCFNetworkProxiesHTTPPort as AnyHashable: 123,
-            kCFNetworkProxiesHTTPProxy as AnyHashable: "www.example.com",
-            kCFProxyUsernameKey as AnyHashable: "proxyuser",
-            kCFProxyPasswordKey as AnyHashable: "proxypass",
+            kCFNetworkProxiesHTTPEnable: true,
+            kCFNetworkProxiesHTTPPort: 123,
+            kCFNetworkProxiesHTTPProxy: "www.example.com",
+            kCFProxyUsernameKey: "proxyuser",
+            kCFProxyPasswordKey: "proxypass",
         ]
         let configuration = try createConfiguration(proxyConfiguration: proxyConfiguration)
 
-        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFNetworkProxiesHTTPEnable as AnyHashable] as? Bool, true)
-        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFNetworkProxiesHTTPPort as AnyHashable] as? Int, 123)
-        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFNetworkProxiesHTTPProxy as AnyHashable] as? String, "www.example.com")
-        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFProxyUsernameKey as AnyHashable] as? String, "proxyuser")
-        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFProxyPasswordKey as AnyHashable] as? String, "proxypass")
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFNetworkProxiesHTTPEnable] as? Bool, true)
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFNetworkProxiesHTTPPort] as? Int, 123)
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFNetworkProxiesHTTPProxy] as? String, "www.example.com")
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFProxyUsernameKey] as? String, "proxyuser")
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFProxyPasswordKey] as? String, "proxypass")
     }
 
     // MARK: - Logging Configuration Tests

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -251,6 +251,23 @@ class FeaturesConfigurationTests: XCTestCase {
         )
     }
 
+    func testCustomProxy() throws {
+        let proxyConfiguration: [AnyHashable: Any] = [
+            kCFNetworkProxiesHTTPEnable as AnyHashable: true,
+            kCFNetworkProxiesHTTPPort as AnyHashable: 123,
+            kCFNetworkProxiesHTTPProxy as AnyHashable: "www.example.com",
+            kCFProxyUsernameKey as AnyHashable: "proxyuser",
+            kCFProxyPasswordKey as AnyHashable: "proxypass",
+        ]
+        let configuration = try createConfiguration(proxyConfiguration: proxyConfiguration)
+
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFNetworkProxiesHTTPEnable as AnyHashable] as? Bool, true)
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFNetworkProxiesHTTPPort as AnyHashable] as? Int, 123)
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFNetworkProxiesHTTPProxy as AnyHashable] as? String, "www.example.com")
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFProxyUsernameKey as AnyHashable] as? String, "proxyuser")
+        XCTAssertEqual(configuration.common.proxyConfiguration?[kCFProxyPasswordKey as AnyHashable] as? String, "proxypass")
+    }
+
     // MARK: - Logging Configuration Tests
 
     func testWhenLoggingIsDisabled() throws {
@@ -752,7 +769,8 @@ class FeaturesConfigurationTests: XCTestCase {
         customRUMEndpoint: URL? = nil,
         logsEndpoint: Datadog.Configuration.LogsEndpoint = .us1,
         tracesEndpoint: Datadog.Configuration.TracesEndpoint = .us1,
-        rumEndpoint: Datadog.Configuration.RUMEndpoint = .us1
+        rumEndpoint: Datadog.Configuration.RUMEndpoint = .us1,
+        proxyConfiguration: [AnyHashable: Any]? = nil
     ) throws -> FeaturesConfiguration {
         return try FeaturesConfiguration(
             configuration: .mockWith(
@@ -766,7 +784,8 @@ class FeaturesConfigurationTests: XCTestCase {
                 customRUMEndpoint: customRUMEndpoint,
                 logsEndpoint: logsEndpoint,
                 tracesEndpoint: tracesEndpoint,
-                rumEndpoint: rumEndpoint
+                rumEndpoint: rumEndpoint,
+                proxyConfiguration: proxyConfiguration
             ),
             appContext: .mockAny()
         )

--- a/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
@@ -46,4 +46,23 @@ class HTTPClientTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
         server.waitFor(requestsCompletion: 1)
     }
+
+    func testWhenProxyConfigurationIsSet_itUsesProxyConfiguration() {
+        let proxyConfiguration: [AnyHashable: Any] = [
+            kCFNetworkProxiesHTTPEnable as AnyHashable: true,
+            kCFNetworkProxiesHTTPPort as AnyHashable: 123,
+            kCFNetworkProxiesHTTPProxy as AnyHashable: "www.example.com",
+            kCFProxyUsernameKey as AnyHashable: "proxyuser",
+            kCFProxyPasswordKey as AnyHashable: "proxypass",
+        ]
+
+        let client = HTTPClient(proxyConfiguration: proxyConfiguration)
+
+        let actualProxy: [AnyHashable: Any] = client.session.configuration.connectionProxyDictionary!
+        XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPEnable as AnyHashable] as? Bool, true)
+        XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPPort as AnyHashable] as? Int, 123)
+        XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPProxy as AnyHashable] as? String, "www.example.com")
+        XCTAssertEqual(actualProxy[kCFProxyUsernameKey as AnyHashable] as? String, "proxyuser")
+        XCTAssertEqual(actualProxy[kCFProxyPasswordKey as AnyHashable] as? String, "proxypass")
+    }
 }

--- a/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
@@ -49,20 +49,20 @@ class HTTPClientTests: XCTestCase {
 
     func testWhenProxyConfigurationIsSet_itUsesProxyConfiguration() {
         let proxyConfiguration: [AnyHashable: Any] = [
-            kCFNetworkProxiesHTTPEnable as AnyHashable: true,
-            kCFNetworkProxiesHTTPPort as AnyHashable: 123,
-            kCFNetworkProxiesHTTPProxy as AnyHashable: "www.example.com",
-            kCFProxyUsernameKey as AnyHashable: "proxyuser",
-            kCFProxyPasswordKey as AnyHashable: "proxypass",
+            kCFNetworkProxiesHTTPEnable: true,
+            kCFNetworkProxiesHTTPPort: 123,
+            kCFNetworkProxiesHTTPProxy: "www.example.com",
+            kCFProxyUsernameKey: "proxyuser",
+            kCFProxyPasswordKey: "proxypass",
         ]
 
         let client = HTTPClient(proxyConfiguration: proxyConfiguration)
 
         let actualProxy: [AnyHashable: Any] = client.session.configuration.connectionProxyDictionary!
-        XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPEnable as AnyHashable] as? Bool, true)
-        XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPPort as AnyHashable] as? Int, 123)
-        XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPProxy as AnyHashable] as? String, "www.example.com")
-        XCTAssertEqual(actualProxy[kCFProxyUsernameKey as AnyHashable] as? String, "proxyuser")
-        XCTAssertEqual(actualProxy[kCFProxyPasswordKey as AnyHashable] as? String, "proxypass")
+        XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPEnable] as? Bool, true)
+        XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPPort] as? Int, 123)
+        XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPProxy] as? String, "www.example.com")
+        XCTAssertEqual(actualProxy[kCFProxyUsernameKey] as? String, "proxyuser")
+        XCTAssertEqual(actualProxy[kCFProxyPasswordKey] as? String, "proxypass")
     }
 }

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -92,11 +92,11 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .set(uploadFrequency: .frequent)
                 .set(additionalConfiguration: ["foo": 42, "bar": "something"])
                 .set(proxyConfiguration: [
-                    kCFNetworkProxiesHTTPEnable as AnyHashable: true,
-                    kCFNetworkProxiesHTTPPort as AnyHashable: 123,
-                    kCFNetworkProxiesHTTPProxy as AnyHashable: "www.example.com",
-                    kCFProxyUsernameKey as AnyHashable: "proxyuser",
-                    kCFProxyPasswordKey as AnyHashable: "proxypass",
+                    kCFNetworkProxiesHTTPEnable: true,
+                    kCFNetworkProxiesHTTPPort: 123,
+                    kCFNetworkProxiesHTTPProxy: "www.example.com",
+                    kCFProxyUsernameKey: "proxyuser",
+                    kCFProxyPasswordKey: "proxypass",
                 ])
 
             return builder
@@ -146,11 +146,11 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.uploadFrequency, .frequent)
             XCTAssertEqual(configuration.additionalConfiguration["foo"] as? Int, 42)
             XCTAssertEqual(configuration.additionalConfiguration["bar"] as? String, "something")
-            XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPEnable as AnyHashable] as? Bool, true)
-            XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPPort as AnyHashable] as? Int, 123)
-            XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPProxy as AnyHashable] as? String, "www.example.com")
-            XCTAssertEqual(configuration.proxyConfiguration?[kCFProxyUsernameKey as AnyHashable] as? String, "proxyuser")
-            XCTAssertEqual(configuration.proxyConfiguration?[kCFProxyPasswordKey as AnyHashable] as? String, "proxypass")
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPEnable] as? Bool, true)
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPPort] as? Int, 123)
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPProxy] as? String, "www.example.com")
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFProxyUsernameKey] as? String, "proxyuser")
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFProxyPasswordKey] as? String, "proxypass")
         }
 
         XCTAssertTrue(rumConfigurationWithDefaultValues.rumUIKitViewsPredicate is DefaultUIKitRUMViewsPredicate)

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -91,6 +91,13 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .set(batchSize: .small)
                 .set(uploadFrequency: .frequent)
                 .set(additionalConfiguration: ["foo": 42, "bar": "something"])
+                .set(proxyConfiguration: [
+                    kCFNetworkProxiesHTTPEnable as AnyHashable: true,
+                    kCFNetworkProxiesHTTPPort as AnyHashable: 123,
+                    kCFNetworkProxiesHTTPProxy as AnyHashable: "www.example.com",
+                    kCFProxyUsernameKey as AnyHashable: "proxyuser",
+                    kCFProxyPasswordKey as AnyHashable: "proxypass",
+                ])
 
             return builder
         }
@@ -139,6 +146,11 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.uploadFrequency, .frequent)
             XCTAssertEqual(configuration.additionalConfiguration["foo"] as? Int, 42)
             XCTAssertEqual(configuration.additionalConfiguration["bar"] as? String, "something")
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPEnable as AnyHashable] as? Bool, true)
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPPort as AnyHashable] as? Int, 123)
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPProxy as AnyHashable] as? String, "www.example.com")
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFProxyUsernameKey as AnyHashable] as? String, "proxyuser")
+            XCTAssertEqual(configuration.proxyConfiguration?[kCFProxyPasswordKey as AnyHashable] as? String, "proxypass")
         }
 
         XCTAssertTrue(rumConfigurationWithDefaultValues.rumUIKitViewsPredicate is DefaultUIKitRUMViewsPredicate)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -57,6 +57,7 @@ extension Datadog.Configuration {
         batchSize: BatchSize = .medium,
         uploadFrequency: UploadFrequency = .average,
         additionalConfiguration: [String: Any] = [:],
+        proxyConfiguration: [AnyHashable: Any]? = nil,
         internalMonitoringClientToken: String? = nil
     ) -> Datadog.Configuration {
         return Datadog.Configuration(
@@ -84,6 +85,7 @@ extension Datadog.Configuration {
             batchSize: batchSize,
             uploadFrequency: uploadFrequency,
             additionalConfiguration: additionalConfiguration,
+            proxyConfiguration: proxyConfiguration,
             internalMonitoringClientToken: internalMonitoringClientToken
         )
     }
@@ -171,7 +173,8 @@ extension FeaturesConfiguration.Common {
         serviceName: String = .mockAny(),
         environment: String = .mockAny(),
         performance: PerformancePreset = .init(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
-        source: String = .mockAny()
+        source: String = .mockAny(),
+        proxyConfiguration: [AnyHashable: Any]? = nil
     ) -> Self {
         return .init(
             applicationName: applicationName,
@@ -180,7 +183,8 @@ extension FeaturesConfiguration.Common {
             serviceName: serviceName,
             environment: environment,
             performance: performance,
-            source: source
+            source: source,
+            proxyConfiguration: proxyConfiguration
         )
     }
 }

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -180,6 +180,13 @@ class DDConfigurationTests: XCTestCase {
         objcBuilder.set(additionalConfiguration: ["foo": 42, "bar": "something"])
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.additionalConfiguration["foo"] as? Int, 42)
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.additionalConfiguration["bar"] as? String, "something")
+
+        objcBuilder.set(proxyConfiguration: [kCFNetworkProxiesHTTPEnable as AnyHashable: true, kCFNetworkProxiesHTTPPort as AnyHashable: 123, kCFNetworkProxiesHTTPProxy as AnyHashable: "www.example.com", kCFProxyUsernameKey as AnyHashable: "proxyuser", kCFProxyPasswordKey as AnyHashable: "proxypass" ])
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPEnable as AnyHashable] as? Bool, true)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPPort as AnyHashable] as? Int, 123)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPProxy as AnyHashable] as? String, "www.example.com")
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFProxyUsernameKey as AnyHashable] as? String, "proxyuser")
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFProxyPasswordKey as AnyHashable] as? String, "proxypass")
     }
 
     func testScrubbingRUMEvents() {

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -181,12 +181,12 @@ class DDConfigurationTests: XCTestCase {
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.additionalConfiguration["foo"] as? Int, 42)
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.additionalConfiguration["bar"] as? String, "something")
 
-        objcBuilder.set(proxyConfiguration: [kCFNetworkProxiesHTTPEnable as AnyHashable: true, kCFNetworkProxiesHTTPPort as AnyHashable: 123, kCFNetworkProxiesHTTPProxy as AnyHashable: "www.example.com", kCFProxyUsernameKey as AnyHashable: "proxyuser", kCFProxyPasswordKey as AnyHashable: "proxypass" ])
-        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPEnable as AnyHashable] as? Bool, true)
-        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPPort as AnyHashable] as? Int, 123)
-        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPProxy as AnyHashable] as? String, "www.example.com")
-        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFProxyUsernameKey as AnyHashable] as? String, "proxyuser")
-        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFProxyPasswordKey as AnyHashable] as? String, "proxypass")
+        objcBuilder.set(proxyConfiguration: [kCFNetworkProxiesHTTPEnable: true, kCFNetworkProxiesHTTPPort: 123, kCFNetworkProxiesHTTPProxy: "www.example.com", kCFProxyUsernameKey: "proxyuser", kCFProxyPasswordKey: "proxypass" ])
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPEnable] as? Bool, true)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPPort] as? Int, 123)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPProxy] as? String, "www.example.com")
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFProxyUsernameKey] as? String, "proxyuser")
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFProxyPasswordKey] as? String, "proxypass")
     }
 
     func testScrubbingRUMEvents() {

--- a/docs/rum_collection/advanced_configuration.md
+++ b/docs/rum_collection/advanced_configuration.md
@@ -198,7 +198,7 @@ You can use the following methods in `Datadog.Configuration.Builder` when creati
 
 `setSpanEventMapper(_ mapper: @escaping (SpanEvent) -> SpanEvent)`
 : Sets the data scrubbing callback for spans. This can be used to modify or drop span events before they are sent to Datadog.
- 
+
 ### Automatically track views
 
 To automatically track views (`UIViewControllers`), use the `.trackUIKitRUMViews()` option when configuring the SDK. By default, views are named with the view controller's class name. To customize it, use `.trackUIKitRUMViews(using: predicate)` and provide your own implementation of the `predicate` which conforms to `UIKitRUMViewsPredicate` protocol:
@@ -391,6 +391,27 @@ This means that even if users open your application while offline, no data is lo
 
 **Note**: The data on the disk is automatically discarded if it gets too old to ensure the SDK doesn't use too much disk space.
 
+## Configuring a custom Proxy for Datadog data upload
+
+If your app is running on devices behind a custom proxy, you can let the SDK's data uploader know about it to ensure all tracked data are uploaded with the relevant configuration. You can specify your proxy configuration (as described in the [URLSessionConfiguration.connectionProxyDictionary][12] documentation) when initializing the SDK.
+
+```swift
+Datadog.initialize(
+    // ...
+    configuration: Datadog.Configuration
+        .builderUsing(/* ... */)
+        .set(proxyConfiguration: [
+            kCFNetworkProxiesHTTPEnable: true, 
+            kCFNetworkProxiesHTTPPort: 123, 
+            kCFNetworkProxiesHTTPProxy: "www.example.com", 
+            kCFProxyUsernameKey: "proxyuser", 
+            kCFProxyPasswordKey: "proxypass" 
+        ])
+        // ...
+        .build()
+)
+```
+
 
 ## Further Reading
 
@@ -408,3 +429,4 @@ This means that even if users open your application while offline, no data is lo
 [9]: #modify-or-drop-rum-events
 [10]: https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces?tab=browserrum
 [11]: /real_user_monitoring/ios/data_collected?tab=session#default-attributes
+[12]: https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411499-connectionproxydictionary

--- a/docs/rum_collection/advanced_configuration.md
+++ b/docs/rum_collection/advanced_configuration.md
@@ -391,7 +391,7 @@ This means that even if users open your application while offline, no data is lo
 
 **Note**: The data on the disk is automatically discarded if it gets too old to ensure the SDK doesn't use too much disk space.
 
-## Configuring a custom Proxy for Datadog data upload
+## Configuring a custom proxy for Datadog data upload
 
 If your app is running on devices behind a custom proxy, you can let the SDK's data uploader know about it to ensure all tracked data are uploaded with the relevant configuration. You can specify your proxy configuration (as described in the [URLSessionConfiguration.connectionProxyDictionary][12] documentation) when initializing the SDK.
 


### PR DESCRIPTION
### What and why?

Let a customer setup a custom Proxy for data intake. 

### How?

A new method let's the customer provide the proxy configuration dictionary that will be forwarded to the HttpClient to create the `URLSession`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
