### PR TITLE
RUMM-1420 Remove attributes and userInfoAttributes property from RUMEvent

### DIFF
--- a/Sources/Datadog/Core/Utils/ValuePublisher.swift
+++ b/Sources/Datadog/Core/Utils/ValuePublisher.swift
@@ -19,7 +19,7 @@ internal protocol ValueObserver: AnyObject {
 }
 
 /// Manages the `Value` in a thread safe manner and notifies subscribed `ValueObservers` on its change.
-internal class ValuePublisher<Value> {
+internal final class ValuePublisher<Value> {
     /// Type erasure for `ValueObserver` type.
     private struct AnyObserver<ObservedValue> {
         let notifyValueChanged: (ObservedValue, ObservedValue) -> Void

--- a/Sources/Datadog/Core/Utils/ValuePublisher.swift
+++ b/Sources/Datadog/Core/Utils/ValuePublisher.swift
@@ -48,7 +48,7 @@ internal class ValuePublisher<Value> {
         }
     }
 
-    init(initialValue: Value) {
+    required init(initialValue: Value) {
         self.unsafeValue = initialValue
         self.unsafeObservers = []
     }

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
@@ -150,47 +150,35 @@ private struct CodableUserInfo: Codable {
 
 private struct CodableRUMViewEvent: Codable {
     private let model: RUMViewEvent
-    private let attributes: [String: Encodable]
-    private let userInfoAttributes: [String: Encodable]
+    private let errorAttributes: [AttributeKey: AttributeValue]?
 
     init(from managedValue: RUMEvent<RUMViewEvent>) {
         self.model = managedValue.model
-        self.attributes = managedValue.attributes
-        self.userInfoAttributes = managedValue.userInfoAttributes
+        self.errorAttributes = managedValue.errorAttributes
     }
 
     var managedValue: RUMEvent<RUMViewEvent> {
-        return .init(
-            model: model,
-            attributes: attributes,
-            userInfoAttributes: userInfoAttributes
-        )
+        return .init(model: model, errorAttributes: errorAttributes)
     }
 
     // MARK: - Codable
 
     enum CodingKeys: String, CodingKey {
         case model = "mdl"
-        case attributes = "att"
-        case userInfoAttributes = "uia"
+        case errorAttributes = "ea"
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-
         self.model = try container.decode(RUMViewEvent.self, forKey: .model)
-        self.attributes = try container.decode([String: CodableValue].self, forKey: .attributes)
-        self.userInfoAttributes = try container.decode([String: CodableValue].self, forKey: .userInfoAttributes)
+        self.errorAttributes = try container.decodeIfPresent([String: CodableValue].self, forKey: .errorAttributes)
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        let encodedAttributes = attributes.mapValues { CodableValue($0) }
-        let encodedUserInfoAttributes = userInfoAttributes.mapValues { CodableValue($0) }
-
         try container.encode(model, forKey: .model)
-        try container.encode(encodedAttributes, forKey: .attributes)
-        try container.encode(encodedUserInfoAttributes, forKey: .userInfoAttributes)
+        let error = errorAttributes?.mapValues { CodableValue($0) }
+        try container.encode(error, forKey: .errorAttributes)
     }
 }
 

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
@@ -150,35 +150,29 @@ private struct CodableUserInfo: Codable {
 
 private struct CodableRUMViewEvent: Codable {
     private let model: RUMViewEvent
-    private let errorAttributes: [AttributeKey: AttributeValue]?
 
     init(from managedValue: RUMEvent<RUMViewEvent>) {
         self.model = managedValue.model
-        self.errorAttributes = managedValue.errorAttributes
     }
 
     var managedValue: RUMEvent<RUMViewEvent> {
-        return .init(model: model, errorAttributes: errorAttributes)
+        return .init(model: model)
     }
 
     // MARK: - Codable
 
     enum CodingKeys: String, CodingKey {
         case model = "mdl"
-        case errorAttributes = "ea"
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.model = try container.decode(RUMViewEvent.self, forKey: .model)
-        self.errorAttributes = try container.decodeIfPresent([String: CodableValue].self, forKey: .errorAttributes)
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(model, forKey: .model)
-        let error = errorAttributes?.mapValues { CodableValue($0) }
-        try container.encode(error, forKey: .errorAttributes)
     }
 }
 

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -88,11 +88,11 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         let errorMessage = crashReport.message
         let errorStackTrace = crashReport.stack
 
-        var errorEventAttributes = lastRUMViewEvent.attributes
-        errorEventAttributes[DDError.threads] = crashReport.threads
-        errorEventAttributes[DDError.binaryImages] = crashReport.binaryImages
-        errorEventAttributes[DDError.meta] = crashReport.meta
-        errorEventAttributes[DDError.wasTruncated] = crashReport.wasTruncated
+        var errorAttributes = lastRUMViewEvent.errorAttributes ?? [:]
+        errorAttributes[DDError.threads] = crashReport.threads
+        errorAttributes[DDError.binaryImages] = crashReport.binaryImages
+        errorAttributes[DDError.meta] = crashReport.meta
+        errorAttributes[DDError.wasTruncated] = crashReport.wasTruncated
 
         let rumError = RUMErrorEvent(
             dd: .init(
@@ -131,8 +131,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
 
         return RUMEvent(
             model: rumError,
-            attributes: errorEventAttributes,
-            userInfoAttributes: lastRUMViewEvent.userInfoAttributes
+            errorAttributes: errorAttributes
         )
     }
 
@@ -185,10 +184,6 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             )
         )
 
-        return RUMEvent(
-            model: rumView,
-            attributes: rumViewEvent.attributes,
-            userInfoAttributes: rumViewEvent.userInfoAttributes
-        )
+        return RUMEvent(model: rumView)
     }
 }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -7,14 +7,9 @@
 import Foundation
 
 internal class RUMEventBuilder {
-    let userInfoProvider: UserInfoProvider
     let eventsMapper: RUMEventsMapper
 
-    init(
-        userInfoProvider: UserInfoProvider,
-        eventsMapper: RUMEventsMapper
-    ) {
-        self.userInfoProvider = userInfoProvider
+    init(eventsMapper: RUMEventsMapper) {
         self.eventsMapper = eventsMapper
     }
 
@@ -26,10 +21,6 @@ internal class RUMEventBuilder {
 
         if !attributes.isEmpty {
             model.context = RUMEventAttributes(contextInfo: attributes)
-        }
-
-        if !userInfoProvider.value.extraInfo.isEmpty {
-            model.usr = RUMUser(email: model.usr?.email, id: model.usr?.id, name: model.usr?.name, usrInfo: userInfoProvider.value.extraInfo)
         }
 
         let event = RUMEvent(model: model)

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -13,18 +13,8 @@ internal class RUMEventBuilder {
         self.eventsMapper = eventsMapper
     }
 
-    func createRUMEvent<DM: RUMDataModel>(
-        with model: DM,
-        attributes: [String: Encodable]
-    ) -> RUMEvent<DM>? {
-        var model = model
-
-        if !attributes.isEmpty {
-            model.context = RUMEventAttributes(contextInfo: attributes)
-        }
-
+    func createRUMEvent<DM: RUMDataModel>(with model: DM) -> RUMEvent<DM>? {
         let event = RUMEvent(model: model)
-        let mappedEvent = eventsMapper.map(event: event)
-        return mappedEvent
+        return eventsMapper.map(event: event)
     }
 }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -22,11 +22,17 @@ internal class RUMEventBuilder {
         with model: DM,
         attributes: [String: Encodable]
     ) -> RUMEvent<DM>? {
-        let event = RUMEvent(
-            model: model,
-            attributes: attributes,
-            userInfoAttributes: userInfoProvider.value.extraInfo
-        )
+        var model = model
+
+        if !attributes.isEmpty {
+            model.context = RUMEventAttributes(contextInfo: attributes)
+        }
+
+        if !userInfoProvider.value.extraInfo.isEmpty {
+            model.usr = RUMUser(email: model.usr?.email, id: model.usr?.id, name: model.usr?.name, usrInfo: userInfoProvider.value.extraInfo)
+        }
+
+        let event = RUMEvent(model: model)
         let mappedEvent = eventsMapper.map(event: event)
         return mappedEvent
     }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -8,13 +8,13 @@ import Foundation
 
 /// `Encodable` representation of RUM event.
 /// Mutable properties are subject of sanitization or data scrubbing.
-/// /// TODO: RUMM-1463 Remove `errorAttributes` property once new error format is managed through `RUMDataModels`
 /// TODO: RUMM-1584 - Remove `RUMEvent` container.
 internal struct RUMEvent<DM>: Encodable where DM: RUMDataModel, DM: RUMSanitizableEvent {
     /// The actual RUM event model created by `RUMMonitor`
     var model: DM
 
-    /// Error attributes.
+    /// Error attributes. Only set when `DM == RUMErrorEvent` and error describes a crash.
+    /// Can be entirely removed when RUMM-1463 is resolved and error values are part of the `RUMErrorEvent`.
     let errorAttributes: [String: Encodable]?
 
     /// Creates a RUM Event object object based on the given sanitizable model.

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventEncoder.swift
@@ -8,22 +8,41 @@ import Foundation
 
 /// `Encodable` representation of RUM event.
 /// Mutable properties are subject of sanitization or data scrubbing.
-internal struct RUMEvent<DM: RUMDataModel>: Encodable {
+/// /// TODO: RUMM-1463 Remove `errorAttributes` property once new error format is managed through `RUMDataModels`
+/// TODO: RUMM-1584 - Remove `RUMEvent` container.
+internal struct RUMEvent<DM>: Encodable where DM: RUMDataModel, DM: RUMSanitizableEvent {
     /// The actual RUM event model created by `RUMMonitor`
     var model: DM
 
-    /// Custom attributes set by the user
-    var attributes: [String: Encodable]
-    var userInfoAttributes: [String: Encodable]
+    /// Error attributes.
+    let errorAttributes: [String: Encodable]?
+
+    /// Creates a RUM Event object object based on the given sanitizable model.
+    ///
+    /// The error attributes keys must be prefixed by `error.*`.
+    ///
+    /// - Parameters:
+    ///   - model: The sanitizable event model.
+    ///   - errorAttributes: The optional error attributes.
+    init(model: DM, errorAttributes: [String: Encodable]? = nil) {
+        self.model = model
+        self.errorAttributes = errorAttributes
+    }
 
     func encode(to encoder: Encoder) throws {
-        let sanitizedEvent = RUMEventSanitizer().sanitize(event: self)
-        try RUMEventEncoder().encode(sanitizedEvent, to: encoder)
-    }
-}
+        // Encode attributes
+        var container = encoder.container(keyedBy: DynamicCodingKey.self)
 
-/// Encodes `RUMEvent` to given encoder.
-internal struct RUMEventEncoder {
+        // TODO: RUMM-1463 Remove this `errorAttributes` property once new error format is managed through `RUMDataModels`
+        try errorAttributes?.forEach { attribute in
+            try container.encode(CodableValue(attribute.value), forKey: DynamicCodingKey(attribute.key))
+        }
+
+        // Encode the sanitized `RUMDataModel`.
+        let sanitizedModel = RUMEventSanitizer().sanitize(event: model)
+        try sanitizedModel.encode(to: encoder)
+    }
+
     /// Coding keys for dynamic `RUMEvent` attributes specified by user.
     private struct DynamicCodingKey: CodingKey {
         var stringValue: String
@@ -32,23 +51,21 @@ internal struct RUMEventEncoder {
         init?(intValue: Int) { return nil }
         init(_ string: String) { self.stringValue = string }
     }
-
-    func encode<DM: RUMDataModel>(_ event: RUMEvent<DM>, to encoder: Encoder) throws {
-        // Encode attributes
-        var attributesContainer = encoder.container(keyedBy: DynamicCodingKey.self)
-        try event.attributes.forEach { attributeName, attributeValue in
-            // TODO: RUMM-1463 Remove this condition once new error format is managed through `RUMDataModels`
-            if attributeName == DDError.threads || attributeName == DDError.binaryImages || attributeName == DDError.meta || attributeName == DDError.wasTruncated {
-                try attributesContainer.encode(CodableValue(attributeValue), forKey: DynamicCodingKey(attributeName))
-            } else {
-                try attributesContainer.encode(CodableValue(attributeValue), forKey: DynamicCodingKey("context.\(attributeName)"))
-            }
-        }
-        try event.userInfoAttributes.forEach { attributeName, attributeValue in
-            try attributesContainer.encode(CodableValue(attributeValue), forKey: DynamicCodingKey("usr.\(attributeName)"))
-        }
-
-        // Encode `RUMDataModel`
-        try event.model.encode(to: encoder)
-    }
 }
+
+/// Constraint on RUM event types that require sanitization before encoding.
+internal protocol RUMSanitizableEvent {
+    /// Mutable user property.
+    var usr: RUMUser? { get set }
+
+    /// Mutable event contect.
+    var context: RUMEventAttributes? { get set }
+}
+
+extension RUMViewEvent: RUMSanitizableEvent {}
+
+extension RUMActionEvent: RUMSanitizableEvent {}
+
+extension RUMResourceEvent: RUMSanitizableEvent {}
+
+extension RUMErrorEvent: RUMSanitizableEvent {}

--- a/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
@@ -12,17 +12,18 @@ internal struct RUMUserInfoProvider {
     let userInfoProvider: UserInfoProvider
 
     var current: RUMUser? {
-        let userInfo = userInfoProvider.value
+        let user = userInfoProvider.value
 
-        if userInfo.id == nil && userInfo.name == nil && userInfo.email == nil {
+        // Returns nil if UserInfo has no data
+        if user.id == nil, user.name == nil, user.email == nil, user.extraInfo.isEmpty {
             return nil
-        } else {
-            return RUMUser(
-                email: userInfo.email,
-                id: userInfo.id,
-                name: userInfo.name,
-                usrInfo: [:]
-            )
         }
+
+        return RUMUser(
+            email: user.email,
+            id: user.id,
+            name: user.name,
+            usrInfo: user.extraInfo
+        )
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -139,7 +139,7 @@ internal class RUMResourceScope: RUMScope {
             },
             application: .init(id: context.rumApplicationID),
             connectivity: dependencies.connectivityInfoProvider.current,
-            context: nil,
+            context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: resourceStartTime).timeIntervalSince1970.toInt64Milliseconds,
             resource: .init(
                 connect: resourceMetrics?.connect.flatMap { metric in
@@ -198,7 +198,7 @@ internal class RUMResourceScope: RUMScope {
             )
         )
 
-        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes) {
+        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData) {
             dependencies.eventOutput.write(rumEvent: event)
             return true
         }
@@ -217,7 +217,7 @@ internal class RUMResourceScope: RUMScope {
             },
             application: .init(id: context.rumApplicationID),
             connectivity: dependencies.connectivityInfoProvider.current,
-            context: nil,
+            context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
             error: .init(
                 handling: nil,
@@ -247,7 +247,7 @@ internal class RUMResourceScope: RUMScope {
             )
         )
 
-        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes) {
+        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData) {
             dependencies.eventOutput.write(rumEvent: event)
             return true
         }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -143,7 +143,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             ),
             application: .init(id: context.rumApplicationID),
             connectivity: dependencies.connectivityInfoProvider.current,
-            context: nil,
+            context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: actionStartTime).timeIntervalSince1970.toInt64Milliseconds,
             service: nil,
             session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
@@ -157,7 +157,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             )
         )
 
-        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes) {
+        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData) {
             dependencies.eventOutput.write(rumEvent: event)
             return true
         }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -302,7 +302,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ),
             application: .init(id: context.rumApplicationID),
             connectivity: dependencies.connectivityInfoProvider.current,
-            context: nil,
+            context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
             service: nil,
             session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
@@ -316,7 +316,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             )
         )
 
-        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: command.attributes) {
+        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData) {
             dependencies.eventOutput.write(rumEvent: event)
             return true
         }
@@ -340,7 +340,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ),
             application: .init(id: context.rumApplicationID),
             connectivity: dependencies.connectivityInfoProvider.current,
-            context: nil,
+            context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
             service: nil,
             session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
@@ -381,7 +381,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             )
         )
 
-        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes) {
+        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData) {
             dependencies.eventOutput.write(rumEvent: event)
             crashContextIntegration?.update(lastRUMViewEvent: event)
         } else {
@@ -401,7 +401,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             },
             application: .init(id: context.rumApplicationID),
             connectivity: dependencies.connectivityInfoProvider.current,
-            context: nil,
+            context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
             error: .init(
                 handling: nil,
@@ -426,7 +426,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             )
         )
 
-        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData, attributes: attributes) {
+        if let event = dependencies.eventBuilder.createRUMEvent(with: eventData) {
             dependencies.eventOutput.write(rumEvent: event)
             return true
         }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -180,7 +180,6 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                         carrierInfoProvider: rumFeature.carrierInfoProvider
                     ),
                     eventBuilder: RUMEventBuilder(
-                        userInfoProvider: rumFeature.userInfoProvider,
                         eventsMapper: rumFeature.eventsMapper
                     ),
                     eventOutput: RUMEventFileOutput(

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -43,7 +43,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
     }
 
     func testWrittingRUMEventsOnDisc() throws {
-        let event = createRandomizedRUMEvent()
+        let event = RUMEvent(model: RUMViewEvent.mockRandom())
 
         measure {
             writer.write(value: event)
@@ -53,7 +53,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
 
     func testReadingRUMEventsFromDisc() throws {
         while try directory.files().count < 10 { // `measureMetrics {}` is fired 10 times so 10 batch files are required
-            writer.write(value: createRandomizedRUMEvent())
+            writer.write(value: RUMEvent(model: RUMViewEvent.mockRandom()))
             queue.sync {} // wait to complete async write
         }
 
@@ -71,15 +71,5 @@ class RUMStorageBenchmarkTests: XCTestCase {
                 reader.markBatchAsRead(batch)
             }
         }
-    }
-
-    // MARK: - Helpers
-
-    private func createRandomizedRUMEvent() -> RUMEvent<RUMViewEvent> {
-        return RUMEvent(
-            model: .mockRandom(),
-            attributes: mockRandomAttributes(),
-            userInfoAttributes: mockRandomAttributes()
-        )
     }
 }

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -23,7 +23,7 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: .mockAny(),
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
             carrierInfoProvider: CarrierInfoProviderMock.mockAny(),
-            rumViewEventProvider: .mockAny()
+            rumViewEventProvider: .mockRandom()
         )
 
         let initialContext = crashContextProvider.currentCrashContext
@@ -46,7 +46,7 @@ class CrashContextProviderTests: XCTestCase {
 
     func testWhenRUMWithCrashContextIntegrationIsUpdated_thenCrashContextProviderNotifiesNewContext() {
         let expectation = self.expectation(description: "Notify new crash context")
-        let randomRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandomWith(model: RUMViewEvent.mockRandom())
+        let randomRUMViewEvent: RUMEvent<RUMViewEvent> = RUMEvent(model: RUMViewEvent.mockRandom())
 
         let rumViewEventProvider = ValuePublisher<RUMEvent<RUMViewEvent>?>(initialValue: randomRUMViewEvent)
         let crashContextProvider = CrashContextProvider(
@@ -89,7 +89,7 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
             carrierInfoProvider: CarrierInfoProviderMock.mockAny(),
-            rumViewEventProvider: .mockAny()
+            rumViewEventProvider: .mockRandom()
         )
 
         let initialContext = crashContextProvider.currentCrashContext
@@ -121,7 +121,7 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: .mockAny(),
             networkConnectionInfoProvider: mainProvider,
             carrierInfoProvider: CarrierInfoProviderMock.mockAny(),
-            rumViewEventProvider: .mockAny()
+            rumViewEventProvider: .mockRandom()
         )
 
         let initialContext = crashContextProvider.currentCrashContext
@@ -154,7 +154,7 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: .mockAny(),
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
             carrierInfoProvider: mainProvider,
-            rumViewEventProvider: .mockAny()
+            rumViewEventProvider: .mockRandom()
         )
 
         let initialContext = crashContextProvider.currentCrashContext
@@ -178,7 +178,7 @@ class CrashContextProviderTests: XCTestCase {
 
     func testWhenContextIsWrittenAndReadFromDifferentThreads_itRunsAllOperationsSafely() {
         let consentProvider: ConsentProvider = .mockAny()
-        let rumViewEventProvider: ValuePublisher<RUMEvent<RUMViewEvent>?> = .mockAny()
+        let rumViewEventProvider: ValuePublisher<RUMEvent<RUMViewEvent>?> = .mockRandom()
         let userInfoProvider: UserInfoProvider = .mockAny()
         let networkInfoWrappedProvider = NetworkConnectionInfoProviderMock(networkConnectionInfo: .mockRandom())
         let networkInfoMainProvider = NetworkConnectionInfoProvider(wrappedProvider: networkInfoWrappedProvider)
@@ -190,7 +190,7 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkInfoMainProvider,
             carrierInfoProvider: carrierInfoMainProvider,
-            rumViewEventProvider: .mockAny()
+            rumViewEventProvider: .mockRandom()
         )
 
         withExtendedLifetime(provider) {
@@ -208,7 +208,7 @@ class CrashContextProviderTests: XCTestCase {
                         carrierInfoWrappedProvider.set(current: .mockRandom())
                         _ = carrierInfoMainProvider.current
                     },
-                    { rumViewEventProvider.publishSyncOrAsync(.mockRandomWith(model: RUMViewEvent.mockRandom())) },
+                    { rumViewEventProvider.publishSyncOrAsync(.mockRandom()) },
                 ],
                 iterations: 50
             )

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
@@ -28,9 +28,7 @@ class CrashContextTests: XCTestCase {
 
     func testGivenContextWithLastRUMViewEventSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
         let randomRUMViewEvent = RUMEvent(
-            model: RUMViewEvent.mockRandom(),
-            attributes: mockRandomAttributes(),
-            userInfoAttributes: mockRandomAttributes()
+            model: RUMViewEvent.mockRandom()
         )
 
         // Given

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
@@ -71,7 +71,7 @@ class CrashReportingWithLoggingIntegrationTests: XCTestCase {
         )
         let crashContext: CrashContext = .mockWith(
             lastUserInfo: Bool.random() ? .mockRandom() : .empty,
-            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom()),
+            lastRUMViewEvent: .mockRandom(),
             lastNetworkConnectionInfo: .mockRandom(),
             lastCarrierInfo: .mockRandom()
         )

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -22,7 +22,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
+            lastRUMViewEvent: .mockRandom()
         )
 
         // When
@@ -49,7 +49,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
+            lastRUMViewEvent: .mockRandom()
         )
 
         // When
@@ -70,7 +70,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(date: .mockDecember15th2019At10AMUTC())
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: [.pending, .notGranted].randomElement()!,
-            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom())
+            lastRUMViewEvent: .mockRandom()
         )
 
         // When
@@ -198,7 +198,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         )
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: .mockRandomWith(model: lastRUMViewEvent)
+            lastRUMViewEvent: RUMEvent(model: lastRUMViewEvent)
         )
 
         // When

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -115,7 +115,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: .mockRandomWith(model: lastRUMViewEvent)
+            lastRUMViewEvent: RUMEvent(model: lastRUMViewEvent)
         )
 
         // When
@@ -245,9 +245,9 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
             """
         )
         XCTAssertEqual(sendRUMErrorEvent.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
-        XCTAssertEqual(sendRUMEvent.attributes[DDError.threads] as? [DDCrashReport.Thread], crashReport.threads)
-        XCTAssertEqual(sendRUMEvent.attributes[DDError.binaryImages] as? [DDCrashReport.BinaryImage], crashReport.binaryImages)
-        XCTAssertEqual(sendRUMEvent.attributes[DDError.meta] as? DDCrashReport.Meta, crashReport.meta)
-        XCTAssertEqual(sendRUMEvent.attributes[DDError.wasTruncated] as? Bool, crashReport.wasTruncated)
+        XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.threads] as? [DDCrashReport.Thread], crashReport.threads)
+        XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.binaryImages] as? [DDCrashReport.BinaryImage], crashReport.binaryImages)
+        XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.meta] as? DDCrashReport.Meta, crashReport.meta)
+        XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.wasTruncated] as? Bool, crashReport.wasTruncated)
     }
 }

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -15,7 +15,7 @@ class RUMWithCrashContextIntegrationTests: XCTestCase {
 
         // Then
         let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration())
-        let randomRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandomWith(model: RUMViewEvent.mockRandom())
+        let randomRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandom()
         rumWithCrashContextIntegration.update(lastRUMViewEvent: randomRUMViewEvent)
 
         XCTAssertEqual(CrashReportingFeature.instance?.rumViewEventProvider.currentValue, randomRUMViewEvent)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -957,9 +957,15 @@ extension CodableValue {
     }
 }
 
-extension ValuePublisher where Value: AnyMockable {
-    static func mockAny() -> ValuePublisher {
+extension ValuePublisher: AnyMockable where Value: AnyMockable {
+    static func mockAny() -> Self {
         return .init(initialValue: .mockAny())
+    }
+}
+
+extension ValuePublisher: RandomMockable where Value: RandomMockable {
+    static func mockRandom() -> Self {
+        return .init(initialValue: .mockRandom())
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -105,7 +105,7 @@ extension CrashContext {
         return CrashContext(
             lastTrackingConsent: .mockRandom(),
             lastUserInfo: .mockRandom(),
-            lastRUMViewEvent: .mockRandomWith(model: RUMViewEvent.mockRandom()),
+            lastRUMViewEvent: .mockRandom(),
             lastNetworkConnectionInfo: .mockRandom(),
             lastCarrierInfo: .mockRandom()
         )

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -38,7 +38,7 @@ extension RUMConnectivity {
     }
 }
 
-extension RUMMethod {
+extension RUMMethod: RandomMockable {
     static func mockRandom() -> RUMMethod {
         return [.post, .get, .head, .put, .delete, .patch].randomElement()!
     }
@@ -50,7 +50,7 @@ extension RUMEventAttributes: RandomMockable {
     }
 }
 
-extension RUMViewEvent {
+extension RUMViewEvent: RandomMockable {
     static func mockRandom() -> RUMViewEvent {
         return RUMViewEvent(
             dd: .init(
@@ -109,7 +109,7 @@ extension RUMViewEvent {
     }
 }
 
-extension RUMResourceEvent {
+extension RUMResourceEvent: RandomMockable {
     static func mockRandom() -> RUMResourceEvent {
         return RUMResourceEvent(
             dd: .init(
@@ -158,7 +158,7 @@ extension RUMResourceEvent {
     }
 }
 
-extension RUMActionEvent {
+extension RUMActionEvent: RandomMockable {
     static func mockRandom() -> RUMActionEvent {
         return RUMActionEvent(
             dd: .init(
@@ -195,7 +195,7 @@ extension RUMActionEvent {
     }
 }
 
-extension RUMErrorEvent {
+extension RUMErrorEvent: RandomMockable {
     static func mockRandom() -> RUMErrorEvent {
         return RUMErrorEvent(
             dd: .init(

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -96,30 +96,15 @@ struct RUMDataModelMock: RUMDataModel, RUMSanitizableEvent, EquatableInTests {
 
 // MARK: - Component Mocks
 
-extension RUMEvent: AnyMockable where DM == RUMViewEvent {
-    static func mockAny() -> RUMEvent<RUMViewEvent> {
-        return RUMEvent(model: RUMViewEvent.mockRandom())
+extension RUMEvent: AnyMockable where DM: AnyMockable {
+    static func mockAny() -> RUMEvent<DM> {
+        return RUMEvent(model: .mockAny())
     }
 }
 
-extension RUMEvent {
-    static func mockRandomWith<DM: RUMDataModel>(model: DM) -> RUMEvent<DM> {
-        func randomAttributes(prefixed prefix: String) -> [String: Encodable] {
-            var attributes: [String: String] = [:]
-            (0..<10).forEach { index in attributes["\(prefix)\(index)"] = "value\(index)" }
-            return attributes
-        }
-
-        var model = model
-        model.context = RUMEventAttributes(contextInfo: randomAttributes(prefixed: "event-attribute"))
-        model.usr = RUMUser(
-            email: model.usr?.email,
-            id: model.usr?.id,
-            name: model.usr?.name,
-            usrInfo: randomAttributes(prefixed: "user-attribute")
-        )
-
-        return RUMEvent<DM>(model: model)
+extension RUMEvent: RandomMockable where DM: RandomMockable {
+    static func mockRandom() -> RUMEvent<DM> {
+        return RUMEvent(model: .mockRandom())
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -110,7 +110,7 @@ extension RUMEvent: RandomMockable where DM: RandomMockable {
 
 extension RUMEventBuilder {
     static func mockAny() -> RUMEventBuilder {
-        return RUMEventBuilder(userInfoProvider: UserInfoProvider.mockAny(), eventsMapper: RUMEventsMapper.mockNoOp())
+        return RUMEventBuilder(eventsMapper: .mockNoOp())
     }
 }
 
@@ -393,7 +393,7 @@ extension RUMScopeDependencies {
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock(networkConnectionInfo: nil),
             carrierInfoProvider: CarrierInfoProviderMock(carrierInfo: nil)
         ),
-        eventBuilder: RUMEventBuilder = RUMEventBuilder(userInfoProvider: UserInfoProvider.mockAny(), eventsMapper: RUMEventsMapper.mockNoOp()),
+        eventBuilder: RUMEventBuilder = RUMEventBuilder(eventsMapper: .mockNoOp()),
         eventOutput: RUMEventOutput = RUMEventOutputMock(),
         rumUUIDGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
         dateCorrector: DateCorrectorType = DateCorrectorMock()

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -65,6 +65,12 @@ extension Optional: AnyMockable where Wrapped: AnyMockable {
     }
 }
 
+extension Optional: RandomMockable where Wrapped: RandomMockable {
+    static func mockRandom() -> Self {
+        return .some(.mockRandom())
+    }
+}
+
 extension Array where Element == Data {
     /// Returns chunks of mocked data. Accumulative size of all chunks equals `totalSize`.
     static func mockChunksOf(totalSize: UInt64, maxChunkSize: UInt64) -> [Data] {

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
@@ -9,12 +9,7 @@ import XCTest
 
 class RUMEventBuilderTests: XCTestCase {
     func testItBuildsRUMEvent() throws {
-        let builder = RUMEventBuilder(
-            userInfoProvider: .mockWith(
-                userInfo: .init(id: nil, name: nil, email: nil, extraInfo: ["bazz": "buzz"])
-            ),
-            eventsMapper: .mockNoOp()
-        )
+        let builder = RUMEventBuilder(eventsMapper: .mockNoOp())
 
         let event = try XCTUnwrap(
             builder.createRUMEvent(
@@ -26,12 +21,10 @@ class RUMEventBuilderTests: XCTestCase {
         XCTAssertEqual(event.model.attribute, "foo")
         XCTAssertEqual((event.model.context?.contextInfo as? [String: String])?["foo"], "bar")
         XCTAssertEqual((event.model.context?.contextInfo as? [String: String])?["fizz"], "buzz")
-        XCTAssertEqual((event.model.usr?.usrInfo as? [String: String])?["bazz"], "buzz")
     }
 
     func testGivenEventBuilderWithEventMapper_whenEventIsModified_itBuildsModifiedEvent() throws {
         let builder = RUMEventBuilder(
-            userInfoProvider: .mockAny(),
             eventsMapper: .mockWith(
                 viewEventMapper: { viewEvent in
                     return RUMViewEvent.mockRandom()
@@ -50,7 +43,6 @@ class RUMEventBuilderTests: XCTestCase {
 
     func testGivenEventBuilderWithEventMapper_whenEventIsDropped_itBuildsNoEvent() {
         let builder = RUMEventBuilder(
-            userInfoProvider: .mockAny(),
             eventsMapper: .mockWith(
                 resourceEventMapper: { event in
                     return nil
@@ -66,7 +58,6 @@ class RUMEventBuilderTests: XCTestCase {
 
     func testGivenEventBuilderWithNoEventMapper_whenBuildingAnEvent_itBuildsEventWithOriginalModel() throws {
         let builder = RUMEventBuilder(
-            userInfoProvider: .mockAny(),
             eventsMapper: .mockWith(
                 resourceEventMapper: { event in
                     return event

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
@@ -9,7 +9,13 @@ import XCTest
 
 class RUMEventBuilderTests: XCTestCase {
     func testItBuildsRUMEvent() throws {
-        let builder = RUMEventBuilder(userInfoProvider: .mockAny(), eventsMapper: .mockNoOp())
+        let builder = RUMEventBuilder(
+            userInfoProvider: .mockWith(
+                userInfo: .init(id: nil, name: nil, email: nil, extraInfo: ["bazz": "buzz"])
+            ),
+            eventsMapper: .mockNoOp()
+        )
+
         let event = try XCTUnwrap(
             builder.createRUMEvent(
                 with: RUMDataModelMock(attribute: "foo"),
@@ -20,6 +26,7 @@ class RUMEventBuilderTests: XCTestCase {
         XCTAssertEqual(event.model.attribute, "foo")
         XCTAssertEqual((event.model.context?.contextInfo as? [String: String])?["foo"], "bar")
         XCTAssertEqual((event.model.context?.contextInfo as? [String: String])?["fizz"], "buzz")
+        XCTAssertEqual((event.model.usr?.usrInfo as? [String: String])?["bazz"], "buzz")
     }
 
     func testGivenEventBuilderWithEventMapper_whenEventIsModified_itBuildsModifiedEvent() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
@@ -8,21 +8,6 @@ import XCTest
 @testable import Datadog
 
 class RUMEventBuilderTests: XCTestCase {
-    func testItBuildsRUMEvent() throws {
-        let builder = RUMEventBuilder(eventsMapper: .mockNoOp())
-
-        let event = try XCTUnwrap(
-            builder.createRUMEvent(
-                with: RUMDataModelMock(attribute: "foo"),
-                attributes: ["foo": "bar", "fizz": "buzz"]
-            )
-        )
-
-        XCTAssertEqual(event.model.attribute, "foo")
-        XCTAssertEqual((event.model.context?.contextInfo as? [String: String])?["foo"], "bar")
-        XCTAssertEqual((event.model.context?.contextInfo as? [String: String])?["fizz"], "buzz")
-    }
-
     func testGivenEventBuilderWithEventMapper_whenEventIsModified_itBuildsModifiedEvent() throws {
         let builder = RUMEventBuilder(
             eventsMapper: .mockWith(
@@ -33,10 +18,7 @@ class RUMEventBuilderTests: XCTestCase {
         )
         let originalEventModel = RUMViewEvent.mockRandom()
         let event = try XCTUnwrap(
-            builder.createRUMEvent(
-                with: RUMViewEvent.mockRandom(),
-                attributes: ["foo": "bar", "fizz": "buzz"]
-            )
+            builder.createRUMEvent(with: RUMViewEvent.mockRandom())
         )
         XCTAssertNotEqual(event.model, originalEventModel)
     }
@@ -49,10 +31,7 @@ class RUMEventBuilderTests: XCTestCase {
                 }
             )
         )
-        let event = builder.createRUMEvent(
-            with: RUMResourceEvent.mockRandom(),
-            attributes: [:]
-        )
+        let event = builder.createRUMEvent(with: RUMResourceEvent.mockRandom())
         XCTAssertNil(event)
     }
 
@@ -66,10 +45,7 @@ class RUMEventBuilderTests: XCTestCase {
         )
         let originalEventModel = RUMResourceEvent.mockRandom()
         let event = try XCTUnwrap(
-            builder.createRUMEvent(
-                with: originalEventModel,
-                attributes: [:]
-            )
+            builder.createRUMEvent(with: originalEventModel)
         )
         XCTAssertEqual(event.model, originalEventModel)
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
@@ -18,8 +18,8 @@ class RUMEventBuilderTests: XCTestCase {
         )
 
         XCTAssertEqual(event.model.attribute, "foo")
-        XCTAssertEqual((event.attributes as? [String: String])?["foo"], "bar")
-        XCTAssertEqual((event.attributes as? [String: String])?["fizz"], "buzz")
+        XCTAssertEqual((event.model.context?.contextInfo as? [String: String])?["foo"], "bar")
+        XCTAssertEqual((event.model.context?.contextInfo as? [String: String])?["fizz"], "buzz")
     }
 
     func testGivenEventBuilderWithEventMapper_whenEventIsModified_itBuildsModifiedEvent() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
@@ -113,8 +113,8 @@ class RUMEventSanitizerTests: XCTestCase {
             remaining -= expectedSanitizedAttrs
 
             XCTAssertGreaterThanOrEqual(remaining, 0)
-            XCTAssertEqual(sanitized.usr?.usrInfo.count, expectedSanitizedUserInfo, "If number of attributes needs to be limited, `userInfoAttributes` are removed second")
-            XCTAssertEqual(sanitized.context?.contextInfo.count, expectedSanitizedAttrs, "If number of attributes needs to be limited, `attributes` are removed first.")
+            XCTAssertEqual(sanitized.usr?.usrInfo.count, expectedSanitizedUserInfo, "If number of attributes needs to be limited, `usrInfo` are removed second")
+            XCTAssertEqual(sanitized.context?.contextInfo.count, expectedSanitizedAttrs, "If number of attributes needs to be limited, `contextInfo` are removed first.")
         }
 
         test(event: viewEvent)

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventSanitizerTests.swift
@@ -14,78 +14,77 @@ class RUMEventSanitizerTests: XCTestCase {
     private let errorEvent: RUMErrorEvent = .mockRandom()
 
     func testWhenAttributeNameExceeds10NestedLevels_itIsEscapedByUnderscore() {
-        func test<DM: RUMDataModel>(model: DM) {
-            let event = RUMEvent<DM>(
-                model: model,
-                attributes: [
-                    "attribute-one": mockValue(),
-                    "attribute-one.two": mockValue(),
-                    "attribute-one.two.three": mockValue(),
-                    "attribute-one.two.three.four": mockValue(),
-                    "attribute-one.two.three.four.five": mockValue(),
-                    "attribute-one.two.three.four.five.six": mockValue(),
-                    "attribute-one.two.three.four.five.six.seven": mockValue(),
-                    "attribute-one.two.three.four.five.six.seven.eight": mockValue(),
-                    "attribute-one.two.three.four.five.six.seven.eight.nine": mockValue(),
-                    "attribute-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
-                    "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
-                    "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
-                ],
-                userInfoAttributes: [
-                    "user-info-one": mockValue(),
-                    "user-info-one.two": mockValue(),
-                    "user-info-one.two.three": mockValue(),
-                    "user-info-one.two.three.four": mockValue(),
-                    "user-info-one.two.three.four.five": mockValue(),
-                    "user-info-one.two.three.four.five.six": mockValue(),
-                    "user-info-one.two.three.four.five.six.seven": mockValue(),
-                    "user-info-one.two.three.four.five.six.seven.eight": mockValue(),
-                    "user-info-one.two.three.four.five.six.seven.eight.nine": mockValue(),
-                    "user-info-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
-                    "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
-                    "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
-                ]
-            )
+        func test<Event>(event: Event) where Event: RUMSanitizableEvent {
+            var event = event
+            event.context?.contextInfo = [
+                "attribute-one": mockValue(),
+                "attribute-one.two": mockValue(),
+                "attribute-one.two.three": mockValue(),
+                "attribute-one.two.three.four": mockValue(),
+                "attribute-one.two.three.four.five": mockValue(),
+                "attribute-one.two.three.four.five.six": mockValue(),
+                "attribute-one.two.three.four.five.six.seven": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+                "attribute-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+            ]
+
+            event.usr?.usrInfo = [
+                "user-info-one": mockValue(),
+                "user-info-one.two": mockValue(),
+                "user-info-one.two.three": mockValue(),
+                "user-info-one.two.three.four": mockValue(),
+                "user-info-one.two.three.four.five": mockValue(),
+                "user-info-one.two.three.four.five.six": mockValue(),
+                "user-info-one.two.three.four.five.six.seven": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight.nine": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight.nine.ten": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven": mockValue(),
+                "user-info-one.two.three.four.five.six.seven.eight.nine.ten.eleven.twelve": mockValue(),
+            ]
 
             // When
             let sanitized = RUMEventSanitizer().sanitize(event: event)
 
             // Then
-            XCTAssertEqual(sanitized.attributes.count, 12)
-            XCTAssertNotNil(sanitized.attributes["attribute-one"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight.nine_ten"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
-            XCTAssertNotNil(sanitized.attributes["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
+            XCTAssertEqual(sanitized.context?.contextInfo.count, 12)
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
+            XCTAssertNotNil(sanitized.context?.contextInfo["attribute-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
 
-            XCTAssertEqual(sanitized.userInfoAttributes.count, 12)
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight.nine_ten"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
-            XCTAssertNotNil(sanitized.userInfoAttributes["user-info-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
+            XCTAssertEqual(sanitized.usr?.usrInfo.count, 12)
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two.three"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two.three.four"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two.three.four.five"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two.three.four.five.six"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two.three.four.five.six.seven"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two.three.four.five.six.seven.eight"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two.three.four.five.six.seven.eight.nine_ten"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two.three.four.five.six.seven.eight.nine_ten_eleven"])
+            XCTAssertNotNil(sanitized.usr?.usrInfo["user-info-one.two.three.four.five.six.seven.eight.nine_ten_eleven_twelve"])
         }
 
-        test(model: viewEvent)
-        test(model: resourceEvent)
-        test(model: actionEvent)
-        test(model: errorEvent)
+        test(event: viewEvent)
+        test(event: resourceEvent)
+        test(event: actionEvent)
+        test(event: errorEvent)
     }
 
     func testWhenNumberOfAttributesExceedsLimit_itDropsExtraOnes() {
-        func test<DM: RUMDataModel>(model: DM) {
+        func test<Event>(event: Event) where Event: RUMSanitizableEvent {
             let oneHalfOfTheLimit = Int(Double(AttributesSanitizer.Constraints.maxNumberOfAttributes) * 0.5)
             let twiceTheLimit = AttributesSanitizer.Constraints.maxNumberOfAttributes * 2
 
@@ -99,31 +98,29 @@ class RUMEventSanitizerTests: XCTestCase {
                 ("user-info-\(index)", mockValue())
             }
 
-            let event = RUMEvent<DM>(
-                model: model,
-                attributes: Dictionary(uniqueKeysWithValues: mockAttributes),
-                userInfoAttributes: Dictionary(uniqueKeysWithValues: mockUserInfoAttributes)
-            )
+            var event = event
+            event.context?.contextInfo = Dictionary(uniqueKeysWithValues: mockAttributes)
+            event.usr?.usrInfo = Dictionary(uniqueKeysWithValues: mockUserInfoAttributes)
 
             // When
             let sanitized = RUMEventSanitizer().sanitize(event: event)
 
             // Then
             var remaining = AttributesSanitizer.Constraints.maxNumberOfAttributes
-            let expectedSanitizedUserInfo = min(sanitized.userInfoAttributes.count, remaining)
+            let expectedSanitizedUserInfo = min(sanitized.usr!.usrInfo.count , remaining)
             remaining -= expectedSanitizedUserInfo
-            let expectedSanitizedAttrs = min(sanitized.attributes.count, remaining)
+            let expectedSanitizedAttrs = min(sanitized.context!.contextInfo.count, remaining)
             remaining -= expectedSanitizedAttrs
 
             XCTAssertGreaterThanOrEqual(remaining, 0)
-            XCTAssertEqual(sanitized.userInfoAttributes.count, expectedSanitizedUserInfo, "If number of attributes needs to be limited, `userInfoAttributes` are removed second")
-            XCTAssertEqual(sanitized.attributes.count, expectedSanitizedAttrs, "If number of attributes needs to be limited, `attributes` are removed first.")
+            XCTAssertEqual(sanitized.usr?.usrInfo.count, expectedSanitizedUserInfo, "If number of attributes needs to be limited, `userInfoAttributes` are removed second")
+            XCTAssertEqual(sanitized.context?.contextInfo.count, expectedSanitizedAttrs, "If number of attributes needs to be limited, `attributes` are removed first.")
         }
 
-        test(model: viewEvent)
-        test(model: resourceEvent)
-        test(model: actionEvent)
-        test(model: errorEvent)
+        test(event: viewEvent)
+        test(event: resourceEvent)
+        test(event: actionEvent)
+        test(event: errorEvent)
     }
 
     // MARK: - Private

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
@@ -31,7 +31,6 @@ class RUMUserInfoProviderTests: XCTestCase {
 
         let extraInfo: [String: Encodable] = mockRandomAttributes()
         userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com", extraInfo: extraInfo)
-        // TODO: RUMM-1420 Encode user `extraInfo` info as RUMUser `usrInfo`
         XCTAssertEqual(rumUserInfoProvider.current, RUMUser(email: "foo@bar.com", id: "abc-123", name: "Foo", usrInfo: extraInfo))
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
@@ -29,8 +29,9 @@ class RUMUserInfoProviderTests: XCTestCase {
         userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com", extraInfo: [:])
         XCTAssertEqual(rumUserInfoProvider.current, RUMUser(email: "foo@bar.com", id: "abc-123", name: "Foo", usrInfo: [:]))
 
-        userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com", extraInfo: mockRandomAttributes())
+        let extraInfo: [String: Encodable] =  mockRandomAttributes()
+        userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com", extraInfo: extraInfo)
         // TODO: RUMM-1420 Encode user `extraInfo` info as RUMUser `usrInfo`
-        XCTAssertEqual(rumUserInfoProvider.current, RUMUser(email: "foo@bar.com", id: "abc-123", name: "Foo", usrInfo: [:]))
+        XCTAssertEqual(rumUserInfoProvider.current, RUMUser(email: "foo@bar.com", id: "abc-123", name: "Foo", usrInfo: extraInfo))
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMUserInfoProviderTests.swift
@@ -29,7 +29,7 @@ class RUMUserInfoProviderTests: XCTestCase {
         userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com", extraInfo: [:])
         XCTAssertEqual(rumUserInfoProvider.current, RUMUser(email: "foo@bar.com", id: "abc-123", name: "Foo", usrInfo: [:]))
 
-        let extraInfo: [String: Encodable] =  mockRandomAttributes()
+        let extraInfo: [String: Encodable] = mockRandomAttributes()
         userInfoProvider.value = UserInfo(id: "abc-123", name: "Foo", email: "foo@bar.com", extraInfo: extraInfo)
         // TODO: RUMM-1420 Encode user `extraInfo` info as RUMUser `usrInfo`
         XCTAssertEqual(rumUserInfoProvider.current, RUMUser(email: "foo@bar.com", id: "abc-123", name: "Foo", usrInfo: extraInfo))

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -37,8 +37,8 @@ class RUMEventFileOutputTests: XCTestCase {
 
         let dataModel1 = RUMDataModelMock(attribute: "foo", context: RUMEventAttributes(contextInfo: ["custom.attribute": "value"]))
         let dataModel2 = RUMDataModelMock(attribute: "bar")
-        let event1 = try XCTUnwrap(builder.createRUMEvent(with: dataModel1, attributes: ["custom.attribute": "value"]))
-        let event2 = try XCTUnwrap(builder.createRUMEvent(with: dataModel2, attributes: [:]))
+        let event1 = try XCTUnwrap(builder.createRUMEvent(with: dataModel1))
+        let event2 = try XCTUnwrap(builder.createRUMEvent(with: dataModel2))
 
         output.write(rumEvent: event1)
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -35,7 +35,7 @@ class RUMEventFileOutputTests: XCTestCase {
             )
         )
 
-        let dataModel1 = RUMDataModelMock(attribute: "foo")
+        let dataModel1 = RUMDataModelMock(attribute: "foo", context: RUMEventAttributes(contextInfo: ["custom.attribute": "value"]))
         let dataModel2 = RUMDataModelMock(attribute: "bar")
         let event1 = try XCTUnwrap(builder.createRUMEvent(with: dataModel1, attributes: ["custom.attribute": "value"]))
         let event2 = try XCTUnwrap(builder.createRUMEvent(with: dataModel2, attributes: [:]))
@@ -49,7 +49,9 @@ class RUMEventFileOutputTests: XCTestCase {
         let event1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())
         let event1Data = try temporaryDirectory.file(named: event1FileName).read()
         let event1Matcher = try RUMEventMatcher.fromJSONObjectData(event1Data)
-        XCTAssertEqual(try event1Matcher.model(), dataModel1)
+
+        let expectedDatamodel1 = RUMDataModelMock(attribute: "foo", context: RUMEventAttributes(contextInfo: ["custom.attribute": CodableValue("value")]))
+        XCTAssertEqual(try event1Matcher.model(), expectedDatamodel1)
 
         let event2FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
         let event2Data = try temporaryDirectory.file(named: event2FileName).read()
@@ -62,7 +64,9 @@ class RUMEventFileOutputTests: XCTestCase {
             jsonString: """
             {
                 "attribute": "foo",
-                "context.custom.attribute": "value"
+                "context": {
+                    "custom.attribute": "value"
+                }
             }
             """
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -20,7 +20,7 @@ class RUMEventFileOutputTests: XCTestCase {
 
     func testItWritesRUMEventToFileAsJSON() throws {
         let fileCreationDateProvider = RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC())
-        let builder = RUMEventBuilder(userInfoProvider: .mockAny(), eventsMapper: .mockNoOp())
+        let builder = RUMEventBuilder(eventsMapper: .mockNoOp())
         let output = RUMEventFileOutput(
             fileWriter: FileWriter(
                 dataFormat: RUMFeature.dataFormat,

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -94,7 +94,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertNil(event.model.resource.firstByte)
         XCTAssertNil(event.model.resource.download)
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), context.activeUserActionID?.toRUMDataFormat)
-        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.model.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(event.model.dd.traceId, "100")
         XCTAssertEqual(event.model.dd.spanId, "200")
         XCTAssertEqual(event.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
@@ -158,7 +158,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertNil(event.model.resource.firstByte)
         XCTAssertNil(event.model.resource.download)
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), context.activeUserActionID?.toRUMDataFormat)
-        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.model.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(event.model.dd.traceId, "100")
         XCTAssertEqual(event.model.dd.spanId, "200")
     }
@@ -213,7 +213,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.error.resource?.statusCode, 500)
         XCTAssertEqual(event.model.error.resource?.url, "https://foo.com/resource/1")
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), context.activeUserActionID?.toRUMDataFormat)
-        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.model.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(event.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
@@ -320,7 +320,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.resource.download?.start, 9_000_000_000)
         XCTAssertEqual(event.model.resource.download?.duration, 1_000_000_000)
         XCTAssertEqual(try XCTUnwrap(event.model.action?.id), context.activeUserActionID?.toRUMDataFormat)
-        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.model.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertNil(event.model.dd.traceId)
         XCTAssertNil(event.model.dd.spanId)
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -593,7 +593,6 @@ class RUMResourceScopeTests: XCTestCase {
 
         // Given
         let eventBuilder = RUMEventBuilder(
-            userInfoProvider: UserInfoProvider.mockAny(),
             eventsMapper: RUMEventsMapper.mockWith(
                 errorEventMapper: { event in
                     nil

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -101,7 +101,7 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertEqual(event.model.action.loadingTime, 1_000_000_000)
         XCTAssertEqual(event.model.action.resource?.count, 0)
         XCTAssertEqual(event.model.action.error?.count, 0)
-        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.model.context?.contextInfo as? [String: String], ["foo": "bar"])
     }
 
     func testWhenContinuousUserActionExpires_itSendsActionEvent() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -396,8 +396,7 @@ class RUMUserActionScopeTests: XCTestCase {
     func testGivenUserActionScopeWithEventSentCallback_whenBypassingSendingEvent_thenCallbackIsNotCalled() {
         // swiftlint:disable trailing_closure
         let eventBuilder = RUMEventBuilder(
-            userInfoProvider: UserInfoProvider.mockAny(),
-            eventsMapper: RUMEventsMapper.mockWith(
+            eventsMapper: .mockWith(
                 actionEventMapper: { event in
                     nil
                 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -848,8 +848,7 @@ class RUMViewScopeTests: XCTestCase {
         // - discards `RUMErrorEvent` for `RUMAddCurrentViewErrorCommand`
         // - discards `RUMResourceEvent` from `RUMStartResourceCommand` /resource/1
         let eventBuilder = RUMEventBuilder(
-            userInfoProvider: UserInfoProvider.mockAny(),
-            eventsMapper: RUMEventsMapper.mockWith(
+            eventsMapper: .mockWith(
                 errorEventMapper: { event in
                     nil
                 },
@@ -935,8 +934,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testGivenViewScopeWithDroppingEventsMapper_whenProcessingApplicationStartAction_thenNoEventIsSent() throws {
         let eventBuilder = RUMEventBuilder(
-            userInfoProvider: UserInfoProvider.mockAny(),
-            eventsMapper: RUMEventsMapper.mockWith(
+            eventsMapper: .mockWith(
                 actionEventMapper: { event in
                     nil
                 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -129,7 +129,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.error.count, 0)
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)
-        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.model.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(event.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
@@ -167,7 +167,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.error.count, 0)
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)
-        XCTAssertEqual(event.attributes as? [String: String], ["foo": "bar 2", "fizz": "buzz"])
+        XCTAssertEqual(event.model.context?.contextInfo as? [String: String], ["foo": "bar 2", "fizz": "buzz"])
     }
 
     func testWhenViewIsStopped_itSendsViewUpdateEvent_andEndsTheScope() throws {
@@ -217,7 +217,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.error.count, 0)
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 2)
-        XCTAssertTrue(event.attributes.isEmpty)
+        XCTAssertNil(event.model.context)
     }
 
     func testWhenAnotherViewIsStarted_itEndsTheScope() throws {
@@ -582,7 +582,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertNil(error.model.error.isCrash)
         XCTAssertNil(error.model.error.resource)
         XCTAssertNil(error.model.action)
-        XCTAssertEqual(error.attributes as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(error.model.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(error.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
 
         let viewUpdate = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -178,7 +178,7 @@ class RUMViewScopeTests: XCTestCase {
             identity: mockView,
             path: "UIViewController",
             name: "ViewName",
-            attributes: [:],
+            attributes: ["foo": "bar"],
             customTimings: [:],
             startTime: currentTime
         )
@@ -217,7 +217,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.error.count, 0)
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 2)
-        XCTAssertNil(event.model.context)
+        XCTAssertEqual(event.model.context?.contextInfo as? [String: String], ["foo": "bar"])
     }
 
     func testWhenAnotherViewIsStarted_itEndsTheScope() throws {

--- a/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
@@ -42,49 +42,16 @@ class RUMEventsMapperTests: XCTestCase {
         )
 
         // When
-        let mappedViewEvent = mapper.map(event: RUMEvent<RUMViewEvent>.mockWith(model: originalViewEvent))?.model
-        let mappedErrorEvent = mapper.map(event: RUMEvent<RUMErrorEvent>.mockWith(model: originalErrorEvent))?.model
-        let mappedResourceEvent = mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: originalResourceEvent))?.model
-        let mappedActionEvent = mapper.map(event: RUMEvent<RUMActionEvent>.mockWith(model: originalActionEvent))?.model
+        let mappedViewEvent = mapper.map(event: RUMEvent(model: originalViewEvent))?.model
+        let mappedErrorEvent = mapper.map(event: RUMEvent(model: originalErrorEvent))?.model
+        let mappedResourceEvent = mapper.map(event: RUMEvent(model: originalResourceEvent))?.model
+        let mappedActionEvent = mapper.map(event: RUMEvent(model: originalActionEvent))?.model
 
         // Then
         XCTAssertEqual(try XCTUnwrap(mappedViewEvent), modifiedViewEvent, "Mapper should return modified event.")
         XCTAssertEqual(try XCTUnwrap(mappedErrorEvent), modifiedErrorEvent, "Mapper should return modified event.")
         XCTAssertEqual(try XCTUnwrap(mappedResourceEvent), modifiedResourceEvent, "Mapper should return modified event.")
         XCTAssertEqual(try XCTUnwrap(mappedActionEvent), modifiedActionEvent, "Mapper should return modified event.")
-    }
-
-    func testGivenMappersEnabled_whenModifyingEvents_itDoesNotModifyCustomAttributes() throws {
-        // Given
-        let mapper = RUMEventsMapper(
-            viewEventMapper: { _ in .mockRandom() },
-            errorEventMapper: { _ in .mockRandom() },
-            resourceEventMapper: { _ in .mockRandom() },
-            actionEventMapper: { _ in .mockRandom() }
-        )
-
-        // When
-        let rumEvent1: RUMEvent<RUMViewEvent> = .mockRandomWith(model: .mockRandom())
-        let rumEvent2: RUMEvent<RUMErrorEvent> = .mockRandomWith(model: .mockRandom())
-        let rumEvent3: RUMEvent<RUMResourceEvent> = .mockRandomWith(model: .mockRandom())
-        let rumEvent4: RUMEvent<RUMActionEvent> = .mockRandomWith(model: .mockRandom())
-        let mappedRUMEvent1 = try XCTUnwrap(mapper.map(event: rumEvent1))
-        let mappedRUMEvent2 = try XCTUnwrap(mapper.map(event: rumEvent2))
-        let mappedRUMEvent3 = try XCTUnwrap(mapper.map(event: rumEvent3))
-        let mappedRUMEvent4 = try XCTUnwrap(mapper.map(event: rumEvent4))
-
-        // Then
-        XCTAssertEqual(rumEvent1.attributes as! [String: String], mappedRUMEvent1.attributes as! [String: String])
-        XCTAssertEqual(rumEvent1.userInfoAttributes as! [String: String], mappedRUMEvent1.userInfoAttributes as! [String: String])
-
-        XCTAssertEqual(rumEvent2.attributes as! [String: String], mappedRUMEvent2.attributes as! [String: String])
-        XCTAssertEqual(rumEvent2.userInfoAttributes as! [String: String], mappedRUMEvent2.userInfoAttributes as! [String: String])
-
-        XCTAssertEqual(rumEvent3.attributes as! [String: String], mappedRUMEvent3.attributes as! [String: String])
-        XCTAssertEqual(rumEvent3.userInfoAttributes as! [String: String], mappedRUMEvent3.userInfoAttributes as! [String: String])
-
-        XCTAssertEqual(rumEvent4.attributes as! [String: String], mappedRUMEvent4.attributes as! [String: String])
-        XCTAssertEqual(rumEvent4.userInfoAttributes as! [String: String], mappedRUMEvent4.userInfoAttributes as! [String: String])
     }
 
     func testGivenMappersEnabled_whenDroppingEvents_itReturnsNil() {
@@ -110,9 +77,9 @@ class RUMEventsMapperTests: XCTestCase {
         )
 
         // When
-        let mappedErrorEvent = mapper.map(event: RUMEvent<RUMErrorEvent>.mockWith(model: originalErrorEvent))?.model
-        let mappedResourceEvent = mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: originalResourceEvent))?.model
-        let mappedActionEvent = mapper.map(event: RUMEvent<RUMActionEvent>.mockWith(model: originalActionEvent))?.model
+        let mappedErrorEvent = mapper.map(event: RUMEvent(model: originalErrorEvent))?.model
+        let mappedResourceEvent = mapper.map(event: RUMEvent(model: originalResourceEvent))?.model
+        let mappedActionEvent = mapper.map(event: RUMEvent(model: originalActionEvent))?.model
 
         // Then
         XCTAssertNil(mappedErrorEvent, "Mapper should return nil.")
@@ -135,10 +102,10 @@ class RUMEventsMapperTests: XCTestCase {
         )
 
         // When
-        let mappedViewEvent = mapper.map(event: RUMEvent<RUMViewEvent>.mockWith(model: originalViewEvent))?.model
-        let mappedErrorEvent = mapper.map(event: RUMEvent<RUMErrorEvent>.mockWith(model: originalErrorEvent))?.model
-        let mappedResourceEvent = mapper.map(event: RUMEvent<RUMResourceEvent>.mockWith(model: originalResourceEvent))?.model
-        let mappedActionEvent = mapper.map(event: RUMEvent<RUMActionEvent>.mockWith(model: originalActionEvent))?.model
+        let mappedViewEvent = mapper.map(event: RUMEvent(model: originalViewEvent))?.model
+        let mappedErrorEvent = mapper.map(event: RUMEvent(model: originalErrorEvent))?.model
+        let mappedResourceEvent = mapper.map(event: RUMEvent(model: originalResourceEvent))?.model
+        let mappedActionEvent = mapper.map(event: RUMEvent(model: originalActionEvent))?.model
 
         // Then
         XCTAssertEqual(try XCTUnwrap(mappedViewEvent), originalViewEvent, "Mapper should return the original event.")


### PR DESCRIPTION
### What and why?

The RUM events schema now support `additionalProperties` in `usr` and `context` fields. Therefor, `RUMEvent`'s properties `attributes` and `userInfoAttributes` are no longer required.

### How?

#### RUM Event Sanitization

The `RUMSanitizableEvent` protocol is a type constraint on events that require sanitisation by enforcing mutation on `usr` and `context` properties.

#### RUM Event

Error attributes were previously included in the  `RUMEvent`'s `attributes` and then separated during encoding. A new `errorAttributes` property has been added until error are added to the schema.

The `userInfoProvider` property has been removed from the `RUMEventBuilder` as the `usr` is now part of the model and will be populated by the `RUMViewScope`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
