### PR TITLE
RUMM-1420  `additionalProperties` as [String: Encodable]

### DIFF
--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -1241,7 +1241,7 @@ public struct RUMConnectivity: Codable {
 
 /// User provided context
 public struct RUMEventAttributes: Codable {
-    public internal(set) var contextInfo: [String: Codable]
+    public internal(set) var contextInfo: [String: Encodable]
 
     struct DynamicCodingKey: CodingKey {
         var stringValue: String
@@ -1287,7 +1287,7 @@ public struct RUMUser: Codable {
     /// Name of the user
     public let name: String?
 
-    public internal(set) var usrInfo: [String: Codable]
+    public internal(set) var usrInfo: [String: Encodable]
 
     enum StaticCodingKeys: String, CodingKey {
         case email = "email"

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/ObjcInteropType.swift
@@ -149,10 +149,10 @@ internal class ObjcInteropNSString: ObjcInteropType {
 }
 
 internal class ObjcInteropAny: ObjcInteropType {
-    let swiftCodable: SwiftPrimitive<SwiftCodable>
+    let swiftType: SwiftPrimitiveNoObjcInteropType
 
-    init(swiftCodable: SwiftPrimitive<SwiftCodable>) {
-        self.swiftCodable = swiftCodable
+    init(swiftType: SwiftPrimitiveNoObjcInteropType) {
+        self.swiftType = swiftType
     }
 }
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/ObjcInterop/SwiftToObjcInteropTypeTransformer.swift
@@ -143,13 +143,15 @@ internal class SwiftToObjcInteropTypeTransformer {
 
     private func objcInteropType(for swiftType: SwiftType) throws -> ObjcInteropType {
         switch swiftType {
-        case _ as SwiftPrimitive<Bool>,
-             _ as SwiftPrimitive<Double>,
-             _ as SwiftPrimitive<Int>,
-             _ as SwiftPrimitive<Int64>:
+        case is SwiftPrimitive<Bool>,
+             is SwiftPrimitive<Double>,
+             is SwiftPrimitive<Int>,
+             is SwiftPrimitive<Int64>:
             return ObjcInteropNSNumber(swiftType: swiftType)
-        case let swiftCodable as SwiftPrimitive<SwiftCodable>:
-            return ObjcInteropAny(swiftCodable: swiftCodable)
+        case let swiftCodable as SwiftCodable:
+            return ObjcInteropAny(swiftType: swiftCodable)
+        case let swiftEncodable as SwiftEncodable:
+            return ObjcInteropAny(swiftType: swiftEncodable)
         case let swiftString as SwiftPrimitive<String>:
             return ObjcInteropNSString(swiftString: swiftString)
         case let swiftArray as SwiftArray:

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -87,7 +87,7 @@ internal class JSONToSwiftTypeTransformer {
                         name: additionalPropertyName,
                         comment: additionalProperties.comment,
                         type: SwiftDictionary(
-                            value: SwiftPrimitive<SwiftCodable>()
+                            value: SwiftEncodable()
                         ),
                         isOptional: false,
                         mutability: mutability,

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/SwiftType.swift
@@ -15,6 +15,8 @@ internal protocol SwiftPrimitiveType: SwiftType {}
 internal protocol SwiftPrimitiveValue {}
 /// An allowed default value of Swift property.
 internal protocol SwiftPropertyDefaultValue {}
+/// An allowed value of Swift with no obj-c interoperability.
+internal protocol SwiftPrimitiveNoObjcInteropType: SwiftPrimitiveType {}
 
 extension Bool: SwiftPrimitiveValue, SwiftPropertyDefaultValue {}
 extension Int: SwiftPrimitiveValue, SwiftPropertyDefaultValue {}
@@ -23,7 +25,10 @@ extension String: SwiftPrimitiveValue, SwiftPropertyDefaultValue {}
 extension Double: SwiftPrimitiveValue, SwiftPropertyDefaultValue {}
 
 /// Represents `Swift.Codable` - we need to define utility type because it cannot be declared as `extension` to `Codable`.
-internal struct SwiftCodable: SwiftPrimitiveValue, SwiftPropertyDefaultValue {}
+internal struct SwiftCodable: SwiftPrimitiveNoObjcInteropType {}
+
+/// Represents `Swift.Encodable` - we need to define utility type because it cannot be declared as `extension` to `Encodable`.
+internal struct SwiftEncodable: SwiftPrimitiveNoObjcInteropType {}
 
 internal struct SwiftPrimitive<T: SwiftPrimitiveValue>: SwiftPrimitiveType {}
 

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Printing/SwiftPrinter.swift
@@ -324,18 +324,20 @@ public class SwiftPrinter: BasePrinter {
 
     private func typeDeclaration(_ type: SwiftType) throws -> String {
         switch type {
-        case _ as SwiftPrimitive<Bool>:
+        case is SwiftPrimitive<Bool>:
             return "Bool"
-        case _ as SwiftPrimitive<Double>:
+        case is SwiftPrimitive<Double>:
             return "Double"
-        case _ as SwiftPrimitive<Int>:
+        case is SwiftPrimitive<Int>:
             return "Int"
-        case _ as SwiftPrimitive<Int64>:
+        case is SwiftPrimitive<Int64>:
             return "Int64"
-        case _ as SwiftPrimitive<String>:
+        case is SwiftPrimitive<String>:
             return "String"
-        case _ as SwiftPrimitive<SwiftCodable>:
+        case is SwiftCodable:
             return "Codable"
+        case is SwiftEncodable:
+            return "Encodable"
         case let swiftArray as SwiftArray:
             return "[\(try typeDeclaration(swiftArray.element))]"
         case let swiftDictionary as SwiftDictionary:

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -248,7 +248,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                 name: "propertyWithAdditionalAnyPropertiesInfo",
                                 comment: nil,
                                 type: SwiftDictionary(
-                                    value: SwiftPrimitive<SwiftCodable>()
+                                    value: SwiftEncodable()
                                 ),
                                 isOptional: false,
                                 mutability: .mutableInternally,
@@ -331,7 +331,7 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
                                 name: "barInfo",
                                 comment: "Additional properties of `bar`.",
                                 type: SwiftDictionary(
-                                    value: SwiftPrimitive<SwiftCodable>()
+                                    value: SwiftEncodable()
                                 ),
                                 isOptional: false,
                                 mutability: .mutableInternally,

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
@@ -1245,13 +1245,13 @@ final class ObjcInteropPrinterTests: XCTestCase {
             properties: [
                 .mock(
                     propertyName: "immutableCodables",
-                    type: SwiftDictionary(value: SwiftPrimitive<SwiftCodable>()),
+                    type: SwiftDictionary(value: SwiftCodable()),
                     isOptional: false,
                     mutability: .immutable
                 ),
                 .mock(
                     propertyName: "optionalImmutableCodables",
-                    type: SwiftDictionary(value: SwiftPrimitive<SwiftCodable>()),
+                    type: SwiftDictionary(value: SwiftCodable()),
                     isOptional: true,
                     mutability: .immutable
                 ),

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/SwiftPrinterTests.swift
@@ -264,7 +264,7 @@ final class SwiftPrinterTests: XCTestCase {
                     name: "context",
                     comment: nil,
                     type: SwiftDictionary(
-                        value: SwiftPrimitive<SwiftCodable>()
+                        value: SwiftCodable()
                     ),
                     isOptional: false,
                     mutability: .immutable,
@@ -339,7 +339,7 @@ final class SwiftPrinterTests: XCTestCase {
                     name: "context",
                     comment: nil,
                     type: SwiftDictionary(
-                        value: SwiftPrimitive<SwiftCodable>()
+                        value: SwiftEncodable()
                     ),
                     isOptional: false,
                     mutability: .mutableInternally,
@@ -367,7 +367,7 @@ final class SwiftPrinterTests: XCTestCase {
         public struct Foo: Codable {
             public let property1: Int
 
-            public internal(set) var context: [String: Codable]
+            public internal(set) var context: [String: Encodable]
 
             public var property2: Bool?
 


### PR DESCRIPTION
### What and why?

RUM models additional properties needs to be set as `[String: Encodable]` to match the public API definition.

### How?

The codegen `rum-models-generator` now adds addition properties with type `[String: Encodable]`.

A new protocol `SwiftPrimitiveNoObjcInteropType` has been added to prevent the objc interface from being generated, both `SwiftCodable` and `SwiftEncodable` now complies to the protocol.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
