### PR TITLE
RUMM-1597 Add tests for matching our crash report format with PLCR text format

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -297,6 +297,7 @@
 		61993668265BBEDC009D7EA8 /* E2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61993667265BBEDC009D7EA8 /* E2ETests.swift */; };
 		61993673265BC371009D7EA8 /* Kronos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; };
 		61993674265BC371009D7EA8 /* Kronos.xcframework in ⚙️ Embed Framework Dependencies */ = {isa = PBXBuildFile; fileRef = 9E0542CA25F8EBBE007A3D0B /* Kronos.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		619A29F326E64910007D62A3 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; };
 		619E16D82577C1CB00B2516B /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16D72577C1CB00B2516B /* DataProcessor.swift */; };
 		619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16E82578E73E00B2516B /* DataMigrator.swift */; };
 		619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */; };
@@ -1226,6 +1227,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61B7885D25C180CB002675B5 /* DatadogCrashReporting.framework in Frameworks */,
+				619A29F326E64910007D62A3 /* CrashReporter.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/PLCrashReporterIntegration.swift
@@ -7,20 +7,25 @@
 import CrashReporter
 import Datadog
 
+internal extension PLCrashReporterConfig {
+    /// `PLCR` configuration used for `DatadogCrashReporting`
+    static func ddConfiguration() -> PLCrashReporterConfig {
+        return PLCrashReporterConfig(
+            // The choice of `.BSD` over `.mach` is well discussed here:
+            // https://github.com/ChatSecure/PLCrashReporter/blob/7f27b272d5ff0d6650fc41317127bb2378ed6e88/Source/CrashReporter.h#L238-L363
+            signalHandlerType: .BSD,
+            // We don't symbolicate on device. All symbolication will happen backend-side.
+            symbolicationStrategy: []
+        )
+    }
+}
+
 internal final class PLCrashReporterIntegration: ThirdPartyCrashReporter {
     private let crashReporter: PLCrashReporter
     private let builder = DDCrashReportBuilder()
 
     init() throws {
-        self.crashReporter = PLCrashReporter(
-            configuration: PLCrashReporterConfig(
-                // The choice of `.BSD` over `.mach` is well discussed here:
-                // https://github.com/ChatSecure/PLCrashReporter/blob/7f27b272d5ff0d6650fc41317127bb2378ed6e88/Source/CrashReporter.h#L238-L363
-                signalHandlerType: .BSD,
-                // We don't symbolicate on device. All symbolication will happen backend-side.
-                symbolicationStrategy: []
-            )
-        )
+        self.crashReporter = PLCrashReporter(configuration: .ddConfiguration())
         try crashReporter.enableAndReturnError()
     }
 

--- a/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
+++ b/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 @testable import Datadog
 @testable import DatadogCrashReporting
+import CrashReporter
 
 class DDCrashReportExporterTests: XCTestCase {
     private let exporter = DDCrashReportExporter()
@@ -355,5 +356,73 @@ class DDCrashReportExporterTests: XCTestCase {
         let randomFlag: Bool = .random()
         crashReport.wasTruncated = randomFlag
         XCTAssertEqual(exporter.export(crashReport).wasTruncated, randomFlag)
+    }
+
+    // MARK: - Comparing with PLCR text format
+
+    func testExportedStacksHaveTheSameFormatAndValuesAsIfTheyWereExportedFromPLCR() throws {
+        let crashReporter = PLCrashReporter(configuration: .ddConfiguration())!
+
+        // Given
+        let plCrashReport = try PLCrashReport(
+            data: try crashReporter.generateLiveReportAndReturnError()
+        )
+
+        // When
+        let exporter = DDCrashReportExporter()
+        let ddCrashReport = exporter.export(try CrashReport(from: plCrashReport))
+
+        // Then
+        let plcrTextFormat = PLCrashReportTextFormatter.stringValue(for: plCrashReport, with: PLCrashReportTextFormatiOS)!
+
+        ddCrashReport.threads.forEach { thread in
+            XCTAssertTrue(
+                plcrTextFormat.contains(thread.stack),
+                """
+                Stack:
+                ```
+                \(thread.stack)
+                ```
+
+                does not appear in PLCR text format:
+                ```
+                \(plcrTextFormat)
+                ```
+                """
+            )
+        }
+    }
+
+    func testExportedBinaryImagesHaveTheSameValuesAsIfTheyWereExportedFromPLCR() throws {
+        let crashReporter = PLCrashReporter(configuration: .ddConfiguration())!
+
+        // Given
+        let plCrashReport = try PLCrashReport(
+            data: try crashReporter.generateLiveReportAndReturnError()
+        )
+
+        // When
+        let exporter = DDCrashReportExporter()
+        let ddCrashReport = exporter.export(try CrashReport(from: plCrashReport))
+
+        // Then
+        let plcrTextFormat = PLCrashReportTextFormatter.stringValue(for: plCrashReport, with: PLCrashReportTextFormatiOS)!
+        let plcrByLines = plcrTextFormat.split(separator: "\n").reversed() // matching in reversed report is 2x faster
+
+        ddCrashReport.binaryImages.forEach { binaryImage in
+            XCTAssertTrue(
+                plcrByLines.contains { line in
+                    // PLCR uses free-form text format, e.g.:
+                    // `       0x10ce2e000 -        0x10ced9fff +Example x86_64  <aaf339bd11e1347a91fcefdce2714ad7> /.../Example.app/Example`
+                    // Instead of matching the whole line, just checking if all values appear in the line should be enough:
+                    let matchLoadAddress = line.contains(binaryImage.loadAddress)
+                    let matchMaxAddress = line.contains(binaryImage.maxAddress)
+                    let matchArchitecture = line.contains(binaryImage.architecture)
+                    let matchLibraryName = line.contains(binaryImage.libraryName)
+                    let matchUUID = line.contains(binaryImage.uuid)
+                    return matchLoadAddress && matchMaxAddress && matchArchitecture && matchLibraryName && matchUUID
+                }
+            )
+        }
     }
 }


### PR DESCRIPTION
### What and why?

🛡️ All is good, but this PR adds two more unit tests to `DatadogCrashReporting` to ensure that the arithmetic behind our unsymbolicated stack trace computation produces same results as in [`PLCrashReportTextFormatter`](https://github.com/microsoft/plcrashreporter/blob/b6a0696d2add340999c6a03fcd10cbffdfc2a73d/Source/PLCrashReportTextFormatter.m#L47-L50).

This is to further ensure reliability of our crash reports and prevent future regressions.

### How?

Two unit tests are added. Both compare values from `DDCrashReport` to values appearing in raw crash report exported from `PLCR` (to its free-form text format). I leveraged `PLCR's` `.generateLiveReportAndReturnError()` API which produces a snapshot of running process (like it would crash, but without actual crashing).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
