### PR TITLE
RUMM-1373 Fix flaky unit tests

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -266,6 +266,8 @@
 		617CD0DD24CEDDD300B0B557 /* RUMUserActionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */; };
 		617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617CEB382456BC3A00AD4669 /* TracingUUID.swift */; };
 		6182374325D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6182374225D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift */; };
+		6184751526EFCF1300C7C9C5 /* DatadogTestsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6184751426EFCF1300C7C9C5 /* DatadogTestsObserver.swift */; };
+		6184751826EFD03400C7C9C5 /* DatadogTestsObserverLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 6184751726EFD03400C7C9C5 /* DatadogTestsObserverLoader.m */; };
 		618715F724DC0CDE00FC0F69 /* RUMCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */; };
 		618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */; };
 		618715FC24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715FB24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift */; };
@@ -898,6 +900,8 @@
 		617CD0DC24CEDDD300B0B557 /* RUMUserActionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUserActionScopeTests.swift; sourceTree = "<group>"; };
 		617CEB382456BC3A00AD4669 /* TracingUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingUUID.swift; sourceTree = "<group>"; };
 		6182374225D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingWithRUMIntegrationTests.swift; sourceTree = "<group>"; };
+		6184751426EFCF1300C7C9C5 /* DatadogTestsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogTestsObserver.swift; sourceTree = "<group>"; };
+		6184751726EFD03400C7C9C5 /* DatadogTestsObserverLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatadogTestsObserverLoader.m; sourceTree = "<group>"; };
 		6185EB0F25FA94A700B43E2E /* Base.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.local.xcconfig; sourceTree = "<group>"; };
 		618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommandTests.swift; sourceTree = "<group>"; };
 		618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMapping.swift; sourceTree = "<group>"; };
@@ -1558,6 +1562,7 @@
 		61133C122423990D00786299 /* DatadogTests */ = {
 			isa = PBXGroup;
 			children = (
+				6184751626EFD01600C7C9C5 /* TestsObserver */,
 				61133C182423990D00786299 /* Datadog */,
 				61133C132423990D00786299 /* DatadogObjc */,
 				61C3637E2436163400C4D4E6 /* DatadogPrivate */,
@@ -2427,6 +2432,15 @@
 				61FF416125EE5FF400CE35EC /* CrashReportingWithLoggingIntegrationTests.swift */,
 			);
 			path = CrashReporting;
+			sourceTree = "<group>";
+		};
+		6184751626EFD01600C7C9C5 /* TestsObserver */ = {
+			isa = PBXGroup;
+			children = (
+				6184751426EFCF1300C7C9C5 /* DatadogTestsObserver.swift */,
+				6184751726EFD03400C7C9C5 /* DatadogTestsObserverLoader.m */,
+			);
+			path = TestsObserver;
 			sourceTree = "<group>";
 		};
 		618715FA24DC5EE700FC0F69 /* DataModels */ = {
@@ -3955,6 +3969,7 @@
 				613F23F1252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,
 				61B03879252724AB00518F3C /* URLSessionInterceptorTests.swift in Sources */,
 				61C363802436164B00C4D4E6 /* ObjcExceptionHandlerTests.swift in Sources */,
+				6184751526EFCF1300C7C9C5 /* DatadogTestsObserver.swift in Sources */,
 				61133C602423990D00786299 /* RequestBuilderTests.swift in Sources */,
 				61133C572423990D00786299 /* FileReaderTests.swift in Sources */,
 				D2F1B81326D8DA68009F3293 /* DDNoopRUMMonitorTests.swift in Sources */,
@@ -4055,6 +4070,7 @@
 				61133C532423990D00786299 /* MobileDeviceTests.swift in Sources */,
 				61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */,
 				61B5E42926DFB60A000B0A5F /* DDConfiguration+apiTests.m in Sources */,
+				6184751826EFD03400C7C9C5 /* DatadogTestsObserverLoader.m in Sources */,
 				61345613244756E300E7DA6B /* PerformancePresetTests.swift in Sources */,
 				616A9CD22535D38200DB83CF /* UIKitHierarchyInspectorTests.swift in Sources */,
 			);

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
@@ -77,6 +77,11 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
+            key = "DD_DISABLE_NETWORK_INSTRUMENTATION"
+            value = "$(DD_DISABLE_NETWORK_INSTRUMENTATION)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "SRCROOT"
             value = "$(SRCROOT)"
             isEnabled = "YES">

--- a/Sources/Datadog/Core/PerformancePreset.swift
+++ b/Sources/Datadog/Core/PerformancePreset.swift
@@ -34,13 +34,10 @@ internal protocol StoragePerformancePreset {
 }
 
 internal protocol UploadPerformancePreset {
-    /// First upload delay (in seconds).
-    /// It is used as a base value until no more files eligible for upload are found - then `defaultUploadDelay` is used as a new base.
-    var initialUploadDelay: TimeInterval { get }
-    /// Default uploads interval (in seconds).
-    /// At runtime, the upload interval ranges from `minUploadDelay` to `maxUploadDelay` depending
+    /// Initial upload delay (in seconds).
+    /// At runtime, the upload interval starts with `initialUploadDelay` and then ranges from `minUploadDelay` to `maxUploadDelay` depending
     /// on delivery success or failure.
-    var defaultUploadDelay: TimeInterval { get }
+    var initialUploadDelay: TimeInterval { get }
     /// Mininum  interval of data upload (in seconds).
     var minUploadDelay: TimeInterval { get }
     /// Maximum interval of data upload (in seconds).
@@ -64,7 +61,6 @@ internal struct PerformancePreset: Equatable, StoragePerformancePreset, UploadPe
     // MARK: - UploadPerformancePreset
 
     let initialUploadDelay: TimeInterval
-    let defaultUploadDelay: TimeInterval
     let minUploadDelay: TimeInterval
     let maxUploadDelay: TimeInterval
     let uploadDelayChangeRate: Double
@@ -139,7 +135,6 @@ internal extension PerformancePreset {
         self.maxObjectsInFile = 500
         self.maxObjectSize = 256 * 1_024 // 256KB
         self.initialUploadDelay = minUploadDelay * uploadDelayFactors.initial
-        self.defaultUploadDelay = minUploadDelay * uploadDelayFactors.default
         self.minUploadDelay = minUploadDelay * uploadDelayFactors.min
         self.maxUploadDelay = minUploadDelay * uploadDelayFactors.max
         self.uploadDelayChangeRate = uploadDelayFactors.changeRate

--- a/Sources/Datadog/Core/Swizzling/MethodSwizzler.swift
+++ b/Sources/Datadog/Core/Swizzling/MethodSwizzler.swift
@@ -66,6 +66,10 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
             let newImp: IMP = imp_implementationWithBlock(newImpBlock)
 
             set(newIMP: newImp, for: foundMethod)
+
+            #if DD_SDK_COMPILED_FOR_TESTING
+            activeSwizzlingNames.append(foundMethod.swizzlingName)
+            #endif
         }
     }
 
@@ -76,6 +80,8 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
             let originalTypedIMP = originalImplementation(of: foundMethod)
             let originalIMP: IMP = unsafeBitCast(originalTypedIMP, to: IMP.self)
             method_setImplementation(foundMethod.method, originalIMP)
+
+            activeSwizzlingNames.removeAll { $0 == foundMethod.swizzlingName }
         }
     }
 #endif
@@ -114,3 +120,12 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
         method_setImplementation(found.method, newIMP)
     }
 }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+extension MethodSwizzler.FoundMethod {
+    var swizzlingName: String { "\(klass).\(method_getName(method))" }
+}
+
+/// The list of active swizzlings to ensure integrity in unit tests.
+internal var activeSwizzlingNames: [String] = []
+#endif

--- a/Sources/Datadog/Core/Upload/DataUploadDelay.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadDelay.swift
@@ -14,15 +14,12 @@ internal protocol Delay {
 
 /// Mutable interval used for periodic data uploads.
 internal struct DataUploadDelay: Delay {
-    private let defaultDelay: TimeInterval
     private let minDelay: TimeInterval
     private let maxDelay: TimeInterval
     private let changeRate: Double
-
     private var delay: TimeInterval
 
     init(performance: UploadPerformancePreset) {
-        self.defaultDelay = performance.defaultUploadDelay
         self.minDelay = performance.minUploadDelay
         self.maxDelay = performance.maxUploadDelay
         self.changeRate = performance.uploadDelayChangeRate

--- a/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
@@ -26,7 +26,6 @@ class PerformancePresetTests: XCTestCase {
 
         let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSApp)
         XCTAssertEqual(frequentUploadAnyBatch.initialUploadDelay, 5.0)
-        XCTAssertEqual(frequentUploadAnyBatch.defaultUploadDelay, 5.0)
         XCTAssertEqual(frequentUploadAnyBatch.minUploadDelay, 1.0)
         XCTAssertEqual(frequentUploadAnyBatch.maxUploadDelay, 10.0)
         XCTAssertEqual(frequentUploadAnyBatch.uploadDelayChangeRate, 0.1)
@@ -34,7 +33,6 @@ class PerformancePresetTests: XCTestCase {
 
         let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSApp)
         XCTAssertEqual(averageUploadAnyBatch.initialUploadDelay, 25.0)
-        XCTAssertEqual(averageUploadAnyBatch.defaultUploadDelay, 25.0)
         XCTAssertEqual(averageUploadAnyBatch.minUploadDelay, 5.0)
         XCTAssertEqual(averageUploadAnyBatch.maxUploadDelay, 50.0)
         XCTAssertEqual(averageUploadAnyBatch.uploadDelayChangeRate, 0.1)
@@ -42,7 +40,6 @@ class PerformancePresetTests: XCTestCase {
 
         let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSApp)
         XCTAssertEqual(rareUploadAnyBatch.initialUploadDelay, 50.0)
-        XCTAssertEqual(rareUploadAnyBatch.defaultUploadDelay, 50.0)
         XCTAssertEqual(rareUploadAnyBatch.minUploadDelay, 10.0)
         XCTAssertEqual(rareUploadAnyBatch.maxUploadDelay, 100.0)
         XCTAssertEqual(rareUploadAnyBatch.uploadDelayChangeRate, 0.1)
@@ -67,7 +64,6 @@ class PerformancePresetTests: XCTestCase {
 
         let frequentUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .frequent, bundleType: .iOSAppExtension)
         XCTAssertEqual(frequentUploadAnyBatch.initialUploadDelay, 0.25)
-        XCTAssertEqual(frequentUploadAnyBatch.defaultUploadDelay, 1.5)
         XCTAssertEqual(frequentUploadAnyBatch.minUploadDelay, 0.5)
         XCTAssertEqual(frequentUploadAnyBatch.maxUploadDelay, 2.5)
         XCTAssertEqual(frequentUploadAnyBatch.uploadDelayChangeRate, 0.5)
@@ -75,7 +71,6 @@ class PerformancePresetTests: XCTestCase {
 
         let averageUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .average, bundleType: .iOSAppExtension)
         XCTAssertEqual(averageUploadAnyBatch.initialUploadDelay, 0.5)
-        XCTAssertEqual(averageUploadAnyBatch.defaultUploadDelay, 3.0)
         XCTAssertEqual(averageUploadAnyBatch.minUploadDelay, 1.0)
         XCTAssertEqual(averageUploadAnyBatch.maxUploadDelay, 5.0)
         XCTAssertEqual(averageUploadAnyBatch.uploadDelayChangeRate, 0.5)
@@ -83,7 +78,6 @@ class PerformancePresetTests: XCTestCase {
 
         let rareUploadAnyBatch = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .rare, bundleType: .iOSAppExtension)
         XCTAssertEqual(rareUploadAnyBatch.initialUploadDelay, 2.5)
-        XCTAssertEqual(rareUploadAnyBatch.defaultUploadDelay, 15.0)
         XCTAssertEqual(rareUploadAnyBatch.minUploadDelay, 5.0)
         XCTAssertEqual(rareUploadAnyBatch.maxUploadDelay, 25.0)
         XCTAssertEqual(rareUploadAnyBatch.uploadDelayChangeRate, 0.5)

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadDelayTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadDelayTests.swift
@@ -10,7 +10,6 @@ import XCTest
 class DataUploadDelayTests: XCTestCase {
     private let mockPerformance = UploadPerformanceMock(
         initialUploadDelay: 3,
-        defaultUploadDelay: 5,
         minUploadDelay: 1,
         maxUploadDelay: 20,
         uploadDelayChangeRate: 0.1

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -86,7 +86,7 @@ class DataUploadWorkerTests: XCTestCase {
             fileReader: reader,
             dataUploader: mockDataUploader,
             uploadConditions: .alwaysUpload(),
-            delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
+            delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: .mockAny()
         )
 
@@ -101,7 +101,9 @@ class DataUploadWorkerTests: XCTestCase {
         let startUploadExpectation = self.expectation(description: "Upload has started")
 
         var mockDataUploader = DataUploaderMock(uploadStatus: .mockWith(needsRetry: true))
-        mockDataUploader.onUpload = { startUploadExpectation.fulfill() }
+        mockDataUploader.onUpload = {
+            startUploadExpectation.fulfill()
+        }
 
         // Given
         writer.write(value: ["key": "value"])
@@ -113,7 +115,7 @@ class DataUploadWorkerTests: XCTestCase {
             fileReader: reader,
             dataUploader: mockDataUploader,
             uploadConditions: .alwaysUpload(),
-            delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuick),
+            delay: DataUploadDelay(performance: UploadPerformanceMock.veryQuickInitialUpload),
             featureName: .mockAny()
         )
 

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -101,9 +101,7 @@ class DataUploadWorkerTests: XCTestCase {
         let startUploadExpectation = self.expectation(description: "Upload has started")
 
         var mockDataUploader = DataUploaderMock(uploadStatus: .mockWith(needsRetry: true))
-        mockDataUploader.onUpload = {
-            startUploadExpectation.fulfill()
-        }
+        mockDataUploader.onUpload = { startUploadExpectation.fulfill() }
 
         // Given
         writer.write(value: ["key": "value"])

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -74,12 +74,12 @@ class RUMIntegrationsTests: XCTestCase {
 class RUMErrorsIntegrationTests: XCTestCase {
     private let integration = RUMErrorsIntegration()
 
-    override class func setUp() {
+    override func setUp() {
         super.setUp()
         temporaryFeatureDirectories.create()
     }
 
-    override class func tearDown() {
+    override func tearDown() {
         super.tearDown()
         temporaryFeatureDirectories.delete()
     }

--- a/Tests/DatadogTests/Datadog/GlobalTests.swift
+++ b/Tests/DatadogTests/Datadog/GlobalTests.swift
@@ -16,6 +16,10 @@ class GlobalTests: XCTestCase {
         XCTAssertTrue(Global.rum is DDNoopRUMMonitor)
     }
 
+    func testWhenCrashReportingIsNotEnabled_thenCrashReporterIsNotSet() {
+        XCTAssertNil(Global.crashReporter)
+    }
+
     func testDDGlobalIsGlobalTypealias() {
         XCTAssertTrue(DDGlobal.self == Global.self)
     }

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -13,6 +13,8 @@ class LoggerBuilderTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        temporaryFeatureDirectories.create()
+
         LoggingFeature.instance = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
@@ -32,6 +34,7 @@ class LoggerBuilderTests: XCTestCase {
 
     override func tearDown() {
         LoggingFeature.instance?.deinitialize()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -96,7 +96,6 @@ class LoggingFeatureTests: XCTestCase {
                     ),
                     uploadPerformance: UploadPerformanceMock(
                         initialUploadDelay: 0.5, // wait enough until spans are written,
-                        defaultUploadDelay: 1,
                         minUploadDelay: 1,
                         maxUploadDelay: 1,
                         uploadDelayChangeRate: 0

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -373,25 +373,31 @@ struct StoragePerformanceMock: StoragePerformancePreset {
 
 struct UploadPerformanceMock: UploadPerformancePreset {
     let initialUploadDelay: TimeInterval
-    let defaultUploadDelay: TimeInterval
     let minUploadDelay: TimeInterval
     let maxUploadDelay: TimeInterval
     let uploadDelayChangeRate: Double
 
     static let noOp = UploadPerformanceMock(
         initialUploadDelay: .distantFuture,
-        defaultUploadDelay: .distantFuture,
         minUploadDelay: .distantFuture,
         maxUploadDelay: .distantFuture,
         uploadDelayChangeRate: 0
     )
 
+    /// Optimized for performing very fast uploads in unit tests.
     static let veryQuick = UploadPerformanceMock(
         initialUploadDelay: 0.05,
-        defaultUploadDelay: 0.05,
         minUploadDelay: 0.05,
         maxUploadDelay: 0.05,
         uploadDelayChangeRate: 0
+    )
+
+    /// Optimized for performing very fast first upload and then changing to unrealistically long intervals.
+    static let veryQuickInitialUpload = UploadPerformanceMock(
+        initialUploadDelay: 0.05,
+        minUploadDelay: 60,
+        maxUploadDelay: 60,
+        uploadDelayChangeRate: 60 / 0.05
     )
 }
 
@@ -406,7 +412,6 @@ extension PerformancePreset {
             maxObjectsInFile: storage.maxObjectsInFile,
             maxObjectSize: storage.maxObjectSize,
             initialUploadDelay: upload.initialUploadDelay,
-            defaultUploadDelay: upload.defaultUploadDelay,
             minUploadDelay: upload.minUploadDelay,
             maxUploadDelay: upload.maxUploadDelay,
             uploadDelayChangeRate: upload.uploadDelayChangeRate

--- a/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/ServerMock.swift
@@ -231,6 +231,6 @@ class ServerMock {
         let uploadPerformanceForTests = UploadPerformanceMock.veryQuick
         // Set the timeout to 40 times more than expected.
         // In `RUMM-311` we observed 0.66% of flakiness for 150 test runs on CI with arbitrary value of `20`.
-        return uploadPerformanceForTests.defaultUploadDelay * Double(numberOfRequestsMade) * 40
+        return uploadPerformanceForTests.initialUploadDelay * Double(numberOfRequestsMade) * 40
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -105,7 +105,6 @@ class RUMFeatureTests: XCTestCase {
                     ),
                     uploadPerformance: UploadPerformanceMock(
                         initialUploadDelay: 0.5, // wait enough until spans are written,
-                        defaultUploadDelay: 1,
                         minUploadDelay: 1,
                         maxUploadDelay: 1,
                         uploadDelayChangeRate: 0

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -85,8 +85,12 @@ class RUMSessionScopeTests: XCTestCase {
 
         let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date(), backgroundEventTrackingEnabled: true)
 
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
+
         let logOutput = LogOutputMock()
         userLogger = .mockWith(logOutput: logOutput)
+
         _ = scope.process(command: RUMStartResourceCommand.mockWith(resourceKey: "/resource/1", time: currentTime))
 
         XCTAssertEqual(scope.viewScopes.count, 1)
@@ -102,8 +106,12 @@ class RUMSessionScopeTests: XCTestCase {
 
         let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date(), backgroundEventTrackingEnabled: true)
 
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
+
         let logOutput = LogOutputMock()
         userLogger = .mockWith(logOutput: logOutput)
+
         _ = scope.process(command: RUMStartUserActionCommand.mockWith(time: currentTime))
 
         XCTAssertEqual(scope.viewScopes.count, 1)
@@ -119,8 +127,12 @@ class RUMSessionScopeTests: XCTestCase {
 
         let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date(), backgroundEventTrackingEnabled: true)
 
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
+
         let logOutput = LogOutputMock()
         userLogger = .mockWith(logOutput: logOutput)
+
         _ = scope.process(command: RUMAddUserActionCommand.mockWith(time: currentTime))
 
         XCTAssertEqual(scope.viewScopes.count, 1)
@@ -200,8 +212,12 @@ class RUMSessionScopeTests: XCTestCase {
         let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date(), backgroundEventTrackingEnabled: .mockAny())
         XCTAssertEqual(scope.viewScopes.count, 0)
 
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
+
         let logOutput = LogOutputMock()
         userLogger = .mockWith(logOutput: logOutput)
+
         let command = generateRandomNotValidStartCommand()
 
         // When

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -436,6 +436,9 @@ class RUMViewScopeTests: XCTestCase {
             startTime: Date()
         )
 
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
+
         let logOutput = LogOutputMock()
         userLogger = .mockWith(logOutput: logOutput)
 
@@ -492,6 +495,9 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: currentTime
         )
+
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
 
         let logOutput = LogOutputMock()
         userLogger = .mockWith(logOutput: logOutput)
@@ -731,6 +737,9 @@ class RUMViewScopeTests: XCTestCase {
         // Given
         XCTAssertTrue(scope.isActiveView)
         XCTAssertEqual(scope.customTimings.count, 0)
+
+        let previousUserLogger = userLogger
+        defer { userLogger = previousUserLogger }
 
         let logOutput = LogOutputMock()
         userLogger = .mockWith(logOutput: logOutput)

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -12,6 +12,9 @@ class RUMMonitorConfigurationTests: XCTestCase {
     private let carrierInfoProvider: CarrierInfoProviderMock = .mockAny()
 
     func testRUMMonitorConfiguration() throws {
+        temporaryFeatureDirectories.create()
+        defer { temporaryFeatureDirectories.delete() }
+
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -801,6 +801,7 @@ class RUMMonitorTests: XCTestCase {
             expectation.fulfill()
         }
 
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         RUMFeature.instance = .mockWith(
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
@@ -808,12 +809,14 @@ class RUMMonitorTests: XCTestCase {
                 onSessionStart: onSessionStart
             )
         )
-
         defer { RUMFeature.instance?.deinitialize() }
 
         let monitor = RUMMonitor.initialize()
         monitor.startView(viewController: mockView)
+
         waitForExpectations(timeout: 0.5)
+
+        _ = server.waitAndReturnRequests(count: keepAllSessions ? 1 : 0)
     }
 
     // MARK: - RUM Events Dates Correction

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -13,6 +13,8 @@ class TracerConfigurationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        temporaryFeatureDirectories.create()
+
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
@@ -32,6 +34,7 @@ class TracerConfigurationTests: XCTestCase {
 
     override func tearDown() {
         TracingFeature.instance?.deinitialize()
+        temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -97,7 +97,6 @@ class TracingFeatureTests: XCTestCase {
                     ),
                     uploadPerformance: UploadPerformanceMock(
                         initialUploadDelay: 0.5, // wait enough until spans are written,
-                        defaultUploadDelay: 1,
                         minUploadDelay: 1,
                         maxUploadDelay: 1,
                         uploadDelayChangeRate: 0

--- a/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -56,14 +56,16 @@
     [monitor startViewWithKey:@"" name:nil attributes:@{}];
     [monitor stopViewWithKey:@"" attributes:@{}];
     [monitor addErrorWithMessage:@"" source:DDRUMErrorSourceCustom stack:nil attributes:@{}];
-    [monitor addErrorWithError:[NSError new] source:DDRUMErrorSourceNetwork attributes:@{}];
+    [monitor addErrorWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:-100 userInfo:nil]
+                        source:DDRUMErrorSourceNetwork attributes:@{}];
     [monitor startResourceLoadingWithResourceKey:@"" request:[NSURLRequest new] attributes:@{}];
     [monitor startResourceLoadingWithResourceKey:@"" url:[NSURL new] attributes:@{}];
     [monitor startResourceLoadingWithResourceKey:@"" httpMethod:DDRUMMethodGet urlString:@"" attributes:@{}];
     [monitor addResourceMetricsWithResourceKey:@"" metrics:[NSURLSessionTaskMetrics new] attributes:@{}];
     [monitor stopResourceLoadingWithResourceKey:@"" response:[NSURLResponse new] size:nil attributes:@{}];
     [monitor stopResourceLoadingWithResourceKey:@"" statusCode:nil kind:DDRUMResourceTypeOther size:nil attributes:@{}];
-    [monitor stopResourceLoadingWithErrorWithResourceKey:@"" error:[NSError new] response:nil attributes:@{}];
+    [monitor stopResourceLoadingWithErrorWithResourceKey:@""
+                                                   error:[NSError errorWithDomain:NSURLErrorDomain code:-99 userInfo:nil] response:nil attributes:@{}];
     [monitor stopResourceLoadingWithErrorWithResourceKey:@"" errorMessage:@"" response:nil attributes:@{}];
     [monitor startUserActionWithType:DDRUMUserActionTypeSwipe name:@"" attributes:@{}];
     [monitor stopUserActionWithType:DDRUMUserActionTypeSwipe name:nil attributes:@{}];

--- a/Tests/DatadogTests/Helpers/TestsDirectory.swift
+++ b/Tests/DatadogTests/Helpers/TestsDirectory.swift
@@ -46,6 +46,11 @@ extension Directory {
         }
     }
 
+    /// Checks if directory exists.
+    func exists() -> Bool {
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
     func createMockFiles(count: Int, prefix: String = "file") {
         (0..<count).forEach { index in
             _ = try! createFile(named: "\(prefix)\(index)")

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -1,0 +1,164 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+/// Observes unit tests execution and performs integrity checks after each test to ensure that the global state is unaltered.
+internal class DatadogTestsObserver: NSObject, XCTestObservation {
+    @objc
+    static func startObserving() {
+        let observer = DatadogTestsObserver()
+        XCTestObservationCenter.shared.addTestObserver(observer)
+    }
+
+    // MARK: - Checking Tests Integrity
+
+    /// A list of checks ensuring global state integrity before and after each tests.
+    private let checks: [TestIntegrityCheck] = [
+        .init(
+            assert: { Datadog.instance == nil },
+            problem: "`Datadog` must not be initialized.",
+            solution: """
+            Make sure `Datadog.flushAndDeinitialize()` is called before the end of test that uses `Datadog.initialize()`.
+            """
+        ),
+        .init(
+            assert: {
+                Global.sharedTracer is DDNoopTracer
+                    && Global.rum is DDNoopRUMMonitor
+                    && Global.crashReporter == nil
+            },
+            problem: "All Global components must use no-op implementations.",
+            solution: """
+            Make sure each Global component is reset to its default implementation before the end of test that mocks it:
+            ```
+            Global.sharedTracer = DDNoopGlobals.tracer
+            Global.rum = DDNoopRUMMonitor()
+            Global.crashReporter = nil
+            ```
+            """
+        ),
+        .init(
+            assert: {
+                LoggingFeature.instance == nil
+                    && TracingFeature.instance == nil
+                    && RUMFeature.instance == nil
+                    && CrashReportingFeature.instance == nil
+                    && InternalMonitoringFeature.instance == nil
+            },
+            problem: "All features not be initialized.",
+            solution: """
+            Make sure `{Feature}.instance?.deinitialize()` is called before the end of test that uses `{Feature}.instance` mock.
+            """
+        ),
+        .init(
+            assert: {
+                RUMAutoInstrumentation.instance == nil && URLSessionAutoInstrumentation.instance == nil
+            },
+            problem: "All auto-instrumentation features not be initialized.",
+            solution: """
+            Make sure `{AutoInstrumentationFeature}.instance?.deinitialize()` is called before the end of test that
+            uses `{AutoInstrumentationFeature}.instance` mock.
+            """
+        ),
+        .init(
+            assert: { activeSwizzlingNames.isEmpty },
+            problem: "No swizzling must be applied.",
+            solution: """
+            Make sure all applied swizzling are reset by the end of test with `unswizzle()`.
+
+            `DatadogTestsObserver` found \(activeSwizzlingNames.count) leaked swizzlings:
+            \(activeSwizzlingNames.joined(separator: ", "))
+            """
+        ),
+        .init(
+            assert: { userLogger.logBuilder == nil && userLogger.logOutput == nil },
+            problem: "`userLogger` must use no-op implementation.",
+            solution: """
+            Make sure the `userLogger` is captured before test and reset to the previous implementation after, e.g.:
+
+            ```
+            let previousUserLogger = userLogger
+            defer { userLogger = previousUserLogger }
+            ```
+            """
+        ),
+        .init(
+            assert: { ServerMock.activeInstance == nil },
+            problem: "`ServerMock` must not be active.",
+            solution: """
+            Make sure that test waits for `ServerMock` completion at the end:
+
+            ```
+            let server = ServerMock(...)
+
+            // ... testing
+
+            server.wait<...>(...) // <-- after return, no reference to `server` will exist as it processed all callbacks and got be safely deallocated
+            ```
+            """
+        ),
+        .init(
+            assert: {
+                temporaryFeatureDirectories.authorized.exists() == false
+                    && temporaryFeatureDirectories.unauthorized.exists() == false
+            },
+            problem: "`temporaryFeatureDirectories` must not exist.",
+            solution: """
+            Make sure that `temporaryFeatureDirectories` is unifromly managed in every test by using:
+            ```
+            // Before test:
+            temporaryFeatureDirectories.create()
+
+            // After test:
+            temporaryFeatureDirectories.delete()
+            ```
+            """
+        )
+    ]
+
+    func testCaseDidFinish(_ testCase: XCTestCase) {
+        performIntegrityChecks(after: testCase)
+    }
+
+    private func performIntegrityChecks(after testCase: XCTestCase) {
+        let failedChecks = checks.filter { $0.assert() == false }
+
+        if !failedChecks.isEmpty {
+            var message = """
+            🐶✋ `DatadogTests` integrity check failure.
+
+            `DatadogTestsObserver` found that `\(testCase.name)` breaks \(failedChecks.count) integrity rule(s) which
+            must be fulfilled before and after each unit test:
+            """
+            failedChecks.forEach { check in
+                message += """
+                \n⚠️ ---- \(check.problem) ----
+                🔎 \(check.solution())
+                """
+            }
+
+            message += "\n"
+            preconditionFailure(message)
+        }
+    }
+}
+
+private struct TestIntegrityCheck {
+    /// If this assertion evaluates to `false`, the integrity issue is raised.
+    let assert: () -> Bool
+    /// What is the assertion about?
+    let problem: StaticString
+    /// How to fix it if it fails?
+    let solution: () -> String
+
+    init(assert: @escaping () -> Bool, problem: StaticString, solution: @escaping @autoclosure () -> String) {
+        self.assert = assert
+        self.problem = problem
+        self.solution = solution
+    }
+}

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -8,6 +8,7 @@ import XCTest
 @testable import Datadog
 
 /// Observes unit tests execution and performs integrity checks after each test to ensure that the global state is unaltered.
+@objc
 internal class DatadogTestsObserver: NSObject, XCTestObservation {
     @objc
     static func startObserving() {

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -50,7 +50,7 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
                     && CrashReportingFeature.instance == nil
                     && InternalMonitoringFeature.instance == nil
             },
-            problem: "All features not be initialized.",
+            problem: "All features must not be initialized.",
             solution: """
             Make sure `{Feature}.instance?.deinitialize()` is called before the end of test that uses `{Feature}.instance` mock.
             """
@@ -59,7 +59,7 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
             assert: {
                 RUMAutoInstrumentation.instance == nil && URLSessionAutoInstrumentation.instance == nil
             },
-            problem: "All auto-instrumentation features not be initialized.",
+            problem: "All auto-instrumentation features must not be initialized.",
             solution: """
             Make sure `{AutoInstrumentationFeature}.instance?.deinitialize()` is called before the end of test that
             uses `{AutoInstrumentationFeature}.instance` mock.

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserverLoader.m
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserverLoader.m
@@ -6,15 +6,10 @@
 
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
+#import "DatadogTests-Swift.h"
 
 /// This code runs when the `DatadogTests` bundle is loaded into memory and tests start.
 /// Reference: https://developer.apple.com/documentation/objectivec/nsobject/1418815-load
 __attribute__((constructor)) static void initialize_FrameworkLoadHandler() {
-    Class testsObserverClass = objc_getClass("DatadogTests.DatadogTestsObserver");
-    SEL startObservingSelector = NSSelectorFromString(@"startObserving");
-    NSMethodSignature *methodSignature = [testsObserverClass methodSignatureForSelector:startObservingSelector];
-    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:methodSignature];
-    [invocation setTarget:testsObserverClass];
-    [invocation setSelector:startObservingSelector];
-    [invocation invoke];
+    [DatadogTestsObserver startObserving];
 }

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserverLoader.m
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserverLoader.m
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+/// This code runs when the `DatadogTests` bundle is loaded into memory and tests start.
+/// Reference: https://developer.apple.com/documentation/objectivec/nsobject/1418815-load
+__attribute__((constructor)) static void initialize_FrameworkLoadHandler() {
+    Class testsObserverClass = objc_getClass("DatadogTests.DatadogTestsObserver");
+    SEL startObservingSelector = NSSelectorFromString(@"startObserving");
+    NSMethodSignature *methodSignature = [testsObserverClass methodSignatureForSelector:startObservingSelector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:methodSignature];
+    [invocation setTarget:testsObserverClass];
+    [invocation setSelector:startObservingSelector];
+    [invocation invoke];
+}

--- a/tools/nightly-unit-tests/bitrise.yml.src
+++ b/tools/nightly-unit-tests/bitrise.yml.src
@@ -29,6 +29,14 @@ workflows:
             set -e
             make dependencies ci=${CI}
 
+            # Patch for `dd-sdk-swift-testing` to disable network instrumentation which
+            # is causing some URLSession-related tests failures on iOS 11.x and 12.x.
+            #
+            # This issue is already reported to otel-swift:
+            # https://github.com/open-telemetry/opentelemetry-swift/issues/229
+            # and this patch can be removed after the fix is available in `dd-sdk-swift-testing`.
+            echo "DD_DISABLE_NETWORK_INSTRUMENTATION=1" >> xcconfigs/DatadogSDKTesting.local.xcconfig
+
   _run_unit_tests:
     steps:
     - script@1.1.6:


### PR DESCRIPTION
### What and why?

⚙️ This PR solves flakiness in unit tests. It should make both **PRs integration** and **nightly unit test** more stable.

As some of the flakiness came from not managing the global state properly, I also added a new component: `DatadogTestsObserver`. It runs integrity check after each test, ensuring that known aspects of global state are met. This tool was already helpful in spotting several issues fixed in this PR. It should also help contributing to the SDK codebase as no more known issues will get into the main branch unnoticed in code review.

**Note:** This PR doesn't solve UI tests flakiness (integration tests). This can be a next goal in the backlog.

### How?

I addressed all top 10 failures (`346`) reported to CI App from `master` branch in last 1 month:
<img width="1450" alt="Screenshot 2021-09-13 at 18 58 20" src="https://user-images.githubusercontent.com/2358722/133257749-0d0bda98-ce44-4058-aaec-355ae5e6809d.png">

#### 🐞 First `308` failures were coming from our nightly CI jobs:
* `run_nightly_unit_tests_on_macOS_bigsur`;
* and `run_nightly_unit_tests_on_macOS_catalina `.

**Fix:** It mainly corresponded to `URLSession` swizzling and `DDURLSessionDelegate` tests failing on iOS versions prior to iOS 13 (`12.x` and `11.x`). The problem is not on our side, instead [`dd-swift-testing`](https://github.com/DataDog/dd-sdk-swift-testing) network instrumentation seems to handle `URLSession` swizzlings and `URLSessionDelegate` incorrectly.

I reported the issue to `opentelemetry-swift` https://github.com/open-telemetry/opentelemetry-swift/issues/229 and until it is fixed, I disabled network instrumentation for `dd-swift-testing` with `DD_DISABLE_NETWORK_INSTRUMENTATION=1` ENV in nightly jobs.

#### 🐞 `22` failures in `testWhenMemoryConsumptionGrows`
corresponded to using too optimistic value for asserting allocated memory. The `XCTest` process itself was allocating similar amount of memory to what was asserted, making it fail randomly.

**Fix:** I increased the size of asserted memory and added additional logic for measuring the allocation several times and asserting its `mean` value.

#### 🐞 `11` failures in `testWhenSDKIsNotInitialized_itUsesNoOpUserLogger`
corresponded to not cleaning up global state (notably: `userLogger`) in multiple tests.

**Fix:** I ensured that global `userLogger` is managed correctly by adding check to `DatadogTestsObserver`. Other checks unrevealed even more issues, which are also fixed.

#### 🐞 `5` issues in `testStartingViewCreatesNewSession`
corresponded to bad usage of `RUMFeature.mockWith()`. This API needs to be used together with `ServerMock` to ensure that no requests are leaked asynchronously after test completion.

**Fix:** Added `ServerMock` to this test.

#### 🐞 Last, I also fixed `testGivenDataToUpload_whenUploadFinishesAndNeedsToBeRetried_thenDataIsPreserved`
in `DataUploadWorkerTests`, which was failing due to race condition between fulfilling test expectation and scheduling next upload in a very short `0.05s` interval.

**Fix:** I added smarter performance preset for this kind of tests, where only initial upload is scheduled in `0.05s` and all next uploads are scheduled in `60s`, which is enough time to cancel the uploader work upon test completion.

---

To fix less popular failures (not classified in top 10), we need more data in CI app, as some of them should be gone with the fixes I described above ☝️.

This PR can be reviewed commit by commit - each tackles different issue.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
