### PR TITLE
RUMM-1614 Upgrade PLCR to `1.10.0`

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "lyft/Kronos" ~> 4.2
-github "microsoft/plcrashreporter" == 1.8.1
+github "microsoft/plcrashreporter" == 1.10.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "lyft/Kronos" ~> 4.2
-github "microsoft/plcrashreporter" == 1.10.0
+github "microsoft/plcrashreporter" ~> 1.10.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "lyft/Kronos" "4.2.1"
-github "microsoft/plcrashreporter" "1.8.1"
+github "microsoft/plcrashreporter" "1.10.0"

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
   s.dependency 'DatadogSDK', '1.7.0-beta4'
-  s.dependency 'PLCrashReporter', '~> 1.8.1'
+  s.dependency 'PLCrashReporter', '~> 1.10.0'
 end

--- a/DatadogSDKCrashReporting.podspec.src
+++ b/DatadogSDKCrashReporting.podspec.src
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
   s.dependency 'DatadogSDK', '__DATADOG_VERSION__'
-  s.dependency 'PLCrashReporter', '~> 1.8.1'
+  s.dependency 'PLCrashReporter', '~> 1.10.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Kronos", url: "https://github.com/lyft/Kronos.git", from: "4.2.1"),
-        .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.8.1"),
+        .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.10.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
### What and why?

📦 This PR upgrades PLCR dependency version to `1.10.0`.

The `1.10.0` version was very much awaited, as it is meant to solve our problem with `DDCR.podspec` distribution.

### How?

Upgraded PLCR version in `Package.swift` (for SPM), `Cartfile` (for Carthage) and `DDCR.podspec` (for Cocoapods).

I also tested that `DDCR.podspec` passes `pod spec lint`:
```
$ pod spec lint --allow-warnings --verbose DatadogSDKCrashReporting.podspec

DatadogSDKCrashReporting.podspec passed validation.
```

Later I will check if `DDCR` compiles on M1 laptop.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Check if `dd-sdk-ios` compiles on M1 laptop
