### PR TITLE
RUMM-1373 Do not run `DatadogTests` integrity checks if test fails

### DIFF
--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -123,7 +123,9 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
     ]
 
     func testCaseDidFinish(_ testCase: XCTestCase) {
-        performIntegrityChecks(after: testCase)
+        if testCase.testRun?.hasSucceeded == true {
+            performIntegrityChecks(after: testCase)
+        }
     }
 
     private func performIntegrityChecks(after testCase: XCTestCase) {


### PR DESCRIPTION
### What and why?

📦 This PR adds small, but convenient improvement to `DatadogTestsObserver` introduced in #592. Now, it will run integrity checks only if the test succeeds. 

Running checks for failed tests, might result with making the failure information unreadable, whereas it is more important than the integrity check result.  Given this test:
```swift
func testFoo() {
   RUMFeature.instance = .mockNoOp() // breaking integrity rule, as it is never reset to `nil`
   XCTAssertEqual(2, 3)
}
```
the outcome was:
```
error: -[DatadogTests.GlobalTests testFoo] : XCTAssertEqual failed: ("2") is not equal to ("3")
Fatal error: 🐶✋ `DatadogTests` integrity check failure.

`DatadogTestsObserver` found that `-[FooTests testFoo]` breaks 1 integrity rule(s) which
must be fulfilled before and after each unit test:
⚠️ ---- All features must not be initialized. ----
🔎 Make sure `{Feature}.instance?.deinitialize()` is called before the end of test that uses `{Feature}.instance` mock.
```
but what really maters in the first place is only this:
```
error: -[DatadogTests.GlobalTests testFoo] : XCTAssertEqual failed: ("2") is not equal to ("3")
```
We found the original behaviour very annoying and interrupting when debugging `dd-swift-testing` issue with @nachoBonafonte.

### How?

Added condition on `testCase.testRun.hasSucceeded`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
