### PR TITLE
Send nithgly unit tests Slack notification to different channels

### DIFF
--- a/tools/nightly-unit-tests/bitrise.yml.src
+++ b/tools/nightly-unit-tests/bitrise.yml.src
@@ -68,7 +68,8 @@ workflows:
     - slack:
         run_if: '{{(getenv "DD_SKIP_SLACK") | eq ""}}'
         inputs:
-        - channel: '#dd-sdk-ios'
+        - channel: '#mobile-ci-ios'
+        - channel_on_error: '#dd-sdk-ios'
         - fields: |-
             macOS|## <MACOS VERSION> ##
             Commit|${GIT_CLONE_COMMIT_HASH}


### PR DESCRIPTION
### What and why?

📦 As flakiness was finally addressed in our unit tests (#592), we can relax the observability of nightly jobs. With this change, successful jobs will be notified to utility channel and only failures will be reported to the main one.

### How?

Using [`channel_on_error`](https://github.com/bitrise-steplib/steps-slack-message/blob/fed002637189e15384c61e71a9dcd71b75200b4a/step.yml#L93) option.

### Review checklist

~- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)~
~- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference~
