### PR TITLE
RUMM-1575 Set `Proxy-Authorization` header with proxy configuration

### DIFF
--- a/Sources/Datadog/Core/Upload/HTTPClient.swift
+++ b/Sources/Datadog/Core/Upload/HTTPClient.swift
@@ -18,8 +18,16 @@ internal class HTTPClient {
         configuration.urlCache = nil
         configuration.connectionProxyDictionary = proxyConfiguration
 
-        // TODO: RUMM-123 Optimize `URLSessionConfiguration` for good traffic performance
-        // and move session configuration constants to `PerformancePreset`.
+        // URLSession does not set the `Proxy-Authorization` header automatically when using a proxy
+        // configuration. We manually set the HTTP basic authentication header.
+        if
+            let user = proxyConfiguration?[kCFProxyUsernameKey] as? String,
+            let password = proxyConfiguration?[kCFProxyPasswordKey] as? String
+        {
+            let authorization = basicHTTPAuthentication(username: user, password: password)
+            configuration.httpAdditionalHeaders = ["Proxy-Authorization": authorization]
+        }
+
         self.init(session: URLSession(configuration: configuration))
     }
 
@@ -38,6 +46,17 @@ internal class HTTPClient {
 /// An error returned if `URLSession` response state is inconsistent (like no data, no response and no error).
 /// The code execution in `URLSessionTransport` should never reach its initialization.
 internal struct URLSessionTransportInconsistencyException: Error {}
+
+/// Returns a `Basic` `Authorization` header using the `username` and `password` provided.
+///
+/// - Parameters:
+///   - username: The username of the header.
+///   - password: The password of the header.
+/// - Returns: The HTTP Basic authentication header value
+private func basicHTTPAuthentication(username: String, password: String) -> String {
+    let credential = Data("\(username):\(password)".utf8).base64EncodedString()
+    return "Basic \(credential)"
+}
 
 /// As `URLSession` returns 3-values-tuple for request execution, this function applies consistency constraints and turns
 /// it into only two possible states of `HTTPTransportResult`.

--- a/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/HTTPClientTests.swift
@@ -64,5 +64,9 @@ class HTTPClientTests: XCTestCase {
         XCTAssertEqual(actualProxy[kCFNetworkProxiesHTTPProxy] as? String, "www.example.com")
         XCTAssertEqual(actualProxy[kCFProxyUsernameKey] as? String, "proxyuser")
         XCTAssertEqual(actualProxy[kCFProxyPasswordKey] as? String, "proxypass")
+        XCTAssertEqual(
+            client.session.configuration.httpAdditionalHeaders?["Proxy-Authorization"] as? String,
+            "Basic cHJveHl1c2VyOnByb3h5cGFzcw==" // Base64.encode(proxyuser:proxypass)
+        )
     }
 }


### PR DESCRIPTION
### What and why?

URLSession does not set the `Proxy-Authorization` header automatically when using a proxy configuration. We have to manually set the HTTP basic authentication header.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
