### PR TITLE
RUMM-1609 Invoke Kronos from a single thread

### DIFF
--- a/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
+++ b/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
@@ -11,20 +11,28 @@ import Kronos
 internal protocol ServerDateProvider {
     /// Start the clock synchronisation with NTP server.
     /// Calls the `completion` by passing it the server time when the synchronization succeeds or`nil` if it fails.
-    func synchronize(with ntpPool: String, completion: @escaping (Date?) -> Void)
+    func synchronize(with pool: String, completion: @escaping (Date?) -> Void)
     /// Returns the server time or `nil` if not yet determined.
     /// This time gets more precise while synchronization is pending.
     func currentDate() -> Date?
 }
 
 internal class NTPServerDateProvider: ServerDateProvider {
-    func synchronize(with ntpPool: String, completion: @escaping (Date?) -> Void) {
-        Clock.sync(from: ntpPool, completion: { serverTime, _ in
-            completion(serverTime)
-        })
+    /// Queue used for invoking Kronos clock.
+    private let queue = DispatchQueue(
+        label: "com.datadoghq.date-provider",
+        target: .global(qos: .userInteractive)
+    )
+
+    func synchronize(with pool: String, completion: @escaping (Date?) -> Void) {
+        queue.async {
+            Clock.sync(from: pool, completion: { serverTime, _ in
+                completion(serverTime)
+            })
+        }
     }
 
     func currentDate() -> Date? {
-        return Clock.now
+        queue.sync { Clock.now }
     }
 }


### PR DESCRIPTION
### What and why?

As per [this issue comment](https://github.com/MobileNativeFoundation/Kronos/issues/85#issuecomment-822664766), `Clock.now` and `.sync` from Kronos are expected to be called from the same thread.

Fix #588 

### How?

Invoke Kronos from a dedicated `DispatchQueue`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
