### PR TITLE
RUMM-1588 + RUMM-1610 Update E2E test monitors to new metric format

### DIFF
--- a/Datadog/E2ETests/E2ETests.swift
+++ b/Datadog/E2ETests/E2ETests.swift
@@ -31,6 +31,7 @@ class E2ETests: XCTestCase {
 
     /// - common performance monitor - measures `Datadog.initialize(...)` performance:
     /// ```apm
+    /// $feature = core
     /// $monitor_id = sdk_initialize_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - sdk_initialize: has a high average execution time"
     /// $monitor_query = "avg(last_1d):avg:trace.sdk_initialize{env:instrumentation,resource_name:sdk_initialize,service:com.datadog.ios.nightly} > 0.016"

--- a/Datadog/E2ETests/E2ETests.swift
+++ b/Datadog/E2ETests/E2ETests.swift
@@ -34,21 +34,21 @@ class E2ETests: XCTestCase {
     /// $feature = core
     /// $monitor_id = sdk_initialize_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - sdk_initialize: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):avg:trace.sdk_initialize{env:instrumentation,resource_name:sdk_initialize,service:com.datadog.ios.nightly} > 0.016"
+    /// $monitor_query = "avg(last_1d):avg:trace.perf_measure{env:instrumentation,resource_name:sdk_initialize,service:com.datadog.ios.nightly} > 0.016"
     /// $monitor_threshold = 0.016
     /// ```
 
     // MARK: - Measuring Performance with APM
 
-    /// Measures time of execution for given `block` - sends it as a `Span` with a given name.
-    func measure(spanName: String, _ block: () -> Void) {
+    /// Measures time of execution for given `block` - sends it as a `"perf_measure"` `Span` with a given resource name.
+    func measure(resourceName: String, _ block: () -> Void) {
         let start = Date()
         block()
         let stop = Date()
 
-        Global.sharedTracer
-            .startRootSpan(operationName: spanName, startTime: start)
-            .finish(at: stop)
+        let performanceSpan = Global.sharedTracer.startRootSpan(operationName: "perf_measure", startTime: start)
+        performanceSpan.setTag(key: DDTags.resource, value: resourceName)
+        performanceSpan.finish(at: stop)
     }
 
     // MARK: - SDK Lifecycle

--- a/Datadog/E2ETests/Logging/LoggerBuilderE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggerBuilderE2ETests.swift
@@ -18,6 +18,7 @@ class LoggerBuilderE2ETests: E2ETests {
 
     /// - common performance monitor - measures `Logger.builder.build()` performance:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_initialize_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_initialize: has a high average execution time"
     /// $monitor_query = "avg(last_1d):avg:trace.logs_logger_initialize{env:instrumentation,resource_name:logs_logger_initialize,service:com.datadog.ios.nightly} > 0.016"

--- a/Datadog/E2ETests/Logging/LoggerBuilderE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggerBuilderE2ETests.swift
@@ -21,7 +21,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_initialize_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_initialize: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):avg:trace.logs_logger_initialize{env:instrumentation,resource_name:logs_logger_initialize,service:com.datadog.ios.nightly} > 0.016"
+    /// $monitor_query = "avg(last_1d):avg:trace.perf_measure{env:instrumentation,resource_name:logs_logger_initialize,service:com.datadog.ios.nightly} > 0.016"
     /// $monitor_threshold = 0.016
     /// ```
 
@@ -36,7 +36,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly.custom @test_method_name:logs_logger_builder_set_service_name\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_logger_builder_set_SERVICE_NAME() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.set(serviceName: "com.datadog.ios.nightly.custom").build()
         }
 
@@ -52,7 +52,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_logger_builder_set_logger_name @logger.name:custom_logger_name\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_logger_builder_set_LOGGER_NAME() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.set(loggerName: "custom_logger_name").build()
         }
 
@@ -68,7 +68,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_logger_builder_send_network_info_enabled @network.client.reachability:*\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_logger_builder_SEND_NETWORK_INFO_enabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.sendNetworkInfo(true).build()
         }
 
@@ -86,7 +86,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_logger_builder_SEND_NETWORK_INFO_disabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.sendNetworkInfo(false).build()
         }
 
@@ -104,7 +104,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_logger_builder_send_logs_to_datadog_enabled\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_logger_builder_SEND_LOGS_TO_DATADOG_enabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.sendLogsToDatadog(true).build()
         }
 
@@ -122,7 +122,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_logger_builder_SEND_LOGS_TO_DATADOG_disabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.sendLogsToDatadog(false).build()
         }
 
@@ -138,7 +138,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_logger_builder_print_logs_to_console_enabled\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_logger_builder_PRINT_LOGS_TO_CONSOLE_enabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.printLogsToConsole(true, usingFormat: .random()).build()
         }
 
@@ -154,7 +154,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_logger_builder_print_logs_to_console_disabled\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_logger_builder_PRINT_LOGS_TO_CONSOLE_disabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.printLogsToConsole(false, usingFormat: .random()).build()
         }
 
@@ -172,7 +172,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_logger_builder_bundle_with_rum_enabled @application_id:* @session_id:*\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_logger_builder_BUNDLE_WITH_RUM_enabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.bundleWithRUM(true).build()
         }
 
@@ -194,7 +194,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_logger_builder_BUNDLE_WITH_RUM_disabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.bundleWithRUM(false).build()
         }
 
@@ -216,7 +216,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_logger_builder_bundle_with_trace_enabled\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_logger_builder_BUNDLE_WITH_TRACE_enabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.bundleWithTrace(true).build()
         }
 
@@ -236,7 +236,7 @@ class LoggerBuilderE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_logger_builder_bundle_with_trace_disabled\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_logger_builder_BUNDLE_WITH_TRACE_disabled() {
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.bundleWithTrace(false).build()
         }
 

--- a/Datadog/E2ETests/Logging/LoggerE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggerE2ETests.swift
@@ -35,10 +35,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_debug_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_debug_log: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_debug_log{env:instrumentation,resource_name:logs_logger_debug_log,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_debug_log,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_DEBUG_log() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.debug(.mockRandom(), attributes: DD.logAttributes())
         }
     }
@@ -57,10 +57,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_debug_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_debug_log_with_error: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_debug_log_with_error{env:instrumentation,resource_name:logs_logger_debug_log_with_error*,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_debug_log_with_error*,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_DEBUG_log_with_error() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.debug(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
         }
     }
@@ -79,10 +79,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_info_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_info_log: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_info_log{env:instrumentation,resource_name:logs_logger_info_log,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_info_log,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_INFO_log() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.info(.mockRandom(), attributes: DD.logAttributes())
         }
     }
@@ -101,10 +101,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_info_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_info_log_with_error: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_info_log_with_error{env:instrumentation,resource_name:logs_logger_info_log_with_error,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_info_log_with_error,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_INFO_log_with_error() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.info(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
         }
     }
@@ -123,10 +123,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_notice_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_notice_log: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_notice_log{env:instrumentation,resource_name:logs_logger_notice_log,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_notice_log,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_NOTICE_log() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.notice(.mockRandom(), attributes: DD.logAttributes())
         }
     }
@@ -145,10 +145,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_notice_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_notice_log_with_error: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_notice_log_with_error{env:instrumentation,resource_name:logs_logger_notice_log_with_error,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_notice_log_with_error,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_NOTICE_log_with_error() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.notice(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
         }
     }
@@ -167,10 +167,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_warn_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_warn_log: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_warn_log{env:instrumentation,resource_name:logs_logger_warn_log,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_warn_log,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_WARN_log() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.warn(.mockRandom(), attributes: DD.logAttributes())
         }
     }
@@ -189,10 +189,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_warn_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_warn_log_with_error: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_warn_log_with_error{env:instrumentation,resource_name:logs_logger_warn_log_with_error,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_warn_log_with_error,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_WARN_log_with_error() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.warn(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
         }
     }
@@ -211,10 +211,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_error_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_error_log: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_error_log{env:instrumentation,resource_name:logs_logger_error_log,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_error_log,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_ERROR_log() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.error(.mockRandom(), attributes: DD.logAttributes())
         }
     }
@@ -233,10 +233,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_error_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_error_log_with_error: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_error_log_with_error{env:instrumentation,resource_name:logs_logger_error_log_with_error,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_error_log_with_error,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_ERROR_log_with_error() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.error(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
         }
     }
@@ -255,10 +255,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_critical_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_critical_log: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_critical_log{env:instrumentation,resource_name:logs_logger_critical_log,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_critical_log,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_CRITICAL_log() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.critical(.mockRandom(), attributes: DD.logAttributes())
         }
     }
@@ -277,10 +277,10 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_critical_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_critical_log_with_error: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_critical_log_with_error{env:instrumentation,resource_name:logs_logger_critical_log_with_error,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_critical_log_with_error,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_CRITICAL_log_with_error() {
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.critical(.mockRandom(), error: ErrorMock(.mockRandom()), attributes: DD.logAttributes())
         }
     }
@@ -301,12 +301,12 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_add_string_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_string_attribute: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_string_attribute{env:instrumentation,resource_name:logs_logger_add_string_attribute,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_add_string_attribute,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_add_STRING_attribute() {
         let attribute = DD.specialStringAttribute()
 
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.addAttribute(forKey: attribute.key, value: attribute.value)
         }
 
@@ -327,12 +327,12 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_add_int_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_int_attribute: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_int_attribute{env:instrumentation,resource_name:logs_logger_add_int_attribute,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_add_int_attribute,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_add_INT_attribute() {
         let attribute = DD.specialIntAttribute()
 
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.addAttribute(forKey: attribute.key, value: attribute.value)
         }
 
@@ -353,12 +353,12 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_add_double_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_double_attribute: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_double_attribute{env:instrumentation,resource_name:logs_logger_add_double_attribute,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_add_double_attribute,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_add_DOUBLE_attribute() {
         let attribute = DD.specialDoubleAttribute()
 
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.addAttribute(forKey: attribute.key, value: attribute.value)
         }
 
@@ -379,12 +379,12 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_add_bool_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_bool_attribute: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_bool_attribute{env:instrumentation,resource_name:logs_logger_add_bool_attribute,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_add_bool_attribute,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_add_BOOL_attribute() {
         let attribute = DD.specialBoolAttribute()
 
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.addAttribute(forKey: attribute.key, value: attribute.value)
         }
 
@@ -407,7 +407,7 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_remove_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_remove_attribute: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_remove_attribute{env:instrumentation,resource_name:logs_logger_remove_attribute,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_remove_attribute,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_remove_attribute() {
         let possibleAttributes = [
@@ -420,7 +420,7 @@ class LoggerE2ETests: E2ETests {
 
         logger.addAttribute(forKey: randomAttribute.key, value: randomAttribute.value)
 
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.removeAttribute(forKey: randomAttribute.key)
         }
 
@@ -443,12 +443,12 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_add_tag_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_tag: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_tag{env:instrumentation,resource_name:logs_logger_add_tag,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_add_tag,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_add_tag() {
         let tag = DD.specialTag()
 
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.addTag(withKey: tag.key, value: tag.value)
         }
 
@@ -469,12 +469,12 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_add_already_formatted_tag_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_already_formatted_tag: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_already_formatted_tag{env:instrumentation,resource_name:logs_logger_add_already_formatted_tag,service:com.datadog.ios.nightly} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:logs_logger_add_already_formatted_tag,service:com.datadog.ios.nightly} > 0.024"
     /// ```
     func test_logs_logger_add_already_formatted_tag() {
         let tag = DD.specialTag()
 
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.add(tag: "\(tag.key):\(tag.value)")
         }
 
@@ -497,13 +497,13 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_remove_tag_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_remove_tag: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_remove_tag{env:instrumentation,service:com.datadog.ios.nightly,resource_name:logs_logger_remove_tag} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,service:com.datadog.ios.nightly,resource_name:logs_logger_remove_tag} > 0.024"
     /// ```
     func test_logs_logger_remove_tag() {
         let tag = DD.specialTag()
         logger.addTag(withKey: tag.key, value: tag.value)
 
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.removeTag(withKey: tag.key)
         }
 
@@ -524,13 +524,13 @@ class LoggerE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = logs_logger_remove_already_formatted_tag_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_remove_already_formatted_tag: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_remove_already_formatted_tag{env:instrumentation,service:com.datadog.ios.nightly,resource_name:logs_logger_remove_already_formatted_tag} > 0.024"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,service:com.datadog.ios.nightly,resource_name:logs_logger_remove_already_formatted_tag} > 0.024"
     /// ```
     func test_logs_logger_remove_already_formatted_tag() {
         let tag = DD.specialTag()
         logger.add(tag: "\(tag.key):\(tag.value)")
 
-        measure(spanName: DD.PerfSpanName.fromCurrentMethodName()) {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
             logger.remove(tag: "\(tag.key):\(tag.value)")
         }
 

--- a/Datadog/E2ETests/Logging/LoggerE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggerE2ETests.swift
@@ -32,6 +32,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_debug_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_debug_log: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_debug_log{env:instrumentation,resource_name:logs_logger_debug_log,service:com.datadog.ios.nightly} > 0.024"
@@ -53,6 +54,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_debug_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_debug_log_with_error: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_debug_log_with_error{env:instrumentation,resource_name:logs_logger_debug_log_with_error*,service:com.datadog.ios.nightly} > 0.024"
@@ -74,6 +76,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_info_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_info_log: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_info_log{env:instrumentation,resource_name:logs_logger_info_log,service:com.datadog.ios.nightly} > 0.024"
@@ -95,6 +98,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_info_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_info_log_with_error: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_info_log_with_error{env:instrumentation,resource_name:logs_logger_info_log_with_error,service:com.datadog.ios.nightly} > 0.024"
@@ -116,6 +120,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_notice_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_notice_log: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_notice_log{env:instrumentation,resource_name:logs_logger_notice_log,service:com.datadog.ios.nightly} > 0.024"
@@ -137,6 +142,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_notice_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_notice_log_with_error: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_notice_log_with_error{env:instrumentation,resource_name:logs_logger_notice_log_with_error,service:com.datadog.ios.nightly} > 0.024"
@@ -158,6 +164,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_warn_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_warn_log: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_warn_log{env:instrumentation,resource_name:logs_logger_warn_log,service:com.datadog.ios.nightly} > 0.024"
@@ -179,6 +186,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_warn_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_warn_log_with_error: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_warn_log_with_error{env:instrumentation,resource_name:logs_logger_warn_log_with_error,service:com.datadog.ios.nightly} > 0.024"
@@ -200,6 +208,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_error_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_error_log: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_error_log{env:instrumentation,resource_name:logs_logger_error_log,service:com.datadog.ios.nightly} > 0.024"
@@ -221,6 +230,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_error_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_error_log_with_error: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_error_log_with_error{env:instrumentation,resource_name:logs_logger_error_log_with_error,service:com.datadog.ios.nightly} > 0.024"
@@ -242,6 +252,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_critical_log_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_critical_log: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_critical_log{env:instrumentation,resource_name:logs_logger_critical_log,service:com.datadog.ios.nightly} > 0.024"
@@ -263,6 +274,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_critical_log_with_error_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_critical_log_with_error: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_critical_log_with_error{env:instrumentation,resource_name:logs_logger_critical_log_with_error,service:com.datadog.ios.nightly} > 0.024"
@@ -286,6 +298,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_add_string_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_string_attribute: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_string_attribute{env:instrumentation,resource_name:logs_logger_add_string_attribute,service:com.datadog.ios.nightly} > 0.024"
@@ -311,6 +324,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_add_int_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_int_attribute: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_int_attribute{env:instrumentation,resource_name:logs_logger_add_int_attribute,service:com.datadog.ios.nightly} > 0.024"
@@ -336,6 +350,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_add_double_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_double_attribute: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_double_attribute{env:instrumentation,resource_name:logs_logger_add_double_attribute,service:com.datadog.ios.nightly} > 0.024"
@@ -361,6 +376,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_add_bool_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_bool_attribute: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_bool_attribute{env:instrumentation,resource_name:logs_logger_add_bool_attribute,service:com.datadog.ios.nightly} > 0.024"
@@ -388,6 +404,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_remove_attribute_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_remove_attribute: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_remove_attribute{env:instrumentation,resource_name:logs_logger_remove_attribute,service:com.datadog.ios.nightly} > 0.024"
@@ -423,6 +440,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_add_tag_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_tag: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_tag{env:instrumentation,resource_name:logs_logger_add_tag,service:com.datadog.ios.nightly} > 0.024"
@@ -448,6 +466,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_add_already_formatted_tag_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_add_already_formatted_tag: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_add_already_formatted_tag{env:instrumentation,resource_name:logs_logger_add_already_formatted_tag,service:com.datadog.ios.nightly} > 0.024"
@@ -475,6 +494,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_remove_tag_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_remove_tag: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_remove_tag{env:instrumentation,service:com.datadog.ios.nightly,resource_name:logs_logger_remove_tag} > 0.024"
@@ -501,6 +521,7 @@ class LoggerE2ETests: E2ETests {
     ///
     /// - performance monitor:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = logs_logger_remove_already_formatted_tag_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - logs_logger_remove_already_formatted_tag: has a high average execution time"
     /// $monitor_query = "avg(last_1d):p50:trace.logs_logger_remove_already_formatted_tag{env:instrumentation,service:com.datadog.ios.nightly,resource_name:logs_logger_remove_already_formatted_tag} > 0.024"

--- a/Datadog/E2ETests/Logging/LoggingConfigurationE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggingConfigurationE2ETests.swift
@@ -29,7 +29,7 @@ class LoggingConfigurationE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_config_feature_enabled\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_config_feature_enabled() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(
                 trackingConsent: .granted,
                 configuration: Datadog.Configuration.builderUsingE2EConfig()
@@ -41,7 +41,7 @@ class LoggingConfigurationE2ETests: E2ETests {
             )
         }
 
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
 
@@ -59,7 +59,7 @@ class LoggingConfigurationE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_config_feature_disabled() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(
                 trackingConsent: .granted,
                 configuration: Datadog.Configuration.builderUsingE2EConfig()
@@ -71,7 +71,7 @@ class LoggingConfigurationE2ETests: E2ETests {
             )
         }
 
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
 

--- a/Datadog/E2ETests/Logging/LoggingTrackingConsentE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggingTrackingConsentE2ETests.swift
@@ -23,6 +23,7 @@ class LoggingTrackingConsentE2ETests: E2ETests {
 
     /// - common performance monitor - measures `Datadog.set(trackingConsent:)` performance:
     /// ```apm
+    /// $feature = logs
     /// $monitor_id = sdk_set_tracking_consent_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - sdk_set_tracking_consent: has a high average execution time"
     /// $monitor_query = "avg(last_1d):avg:trace.sdk_set_tracking_consent{env:instrumentation,resource_name:sdk_set_tracking_consent,service:com.datadog.ios.nightly} > 0.016"

--- a/Datadog/E2ETests/Logging/LoggingTrackingConsentE2ETests.swift
+++ b/Datadog/E2ETests/Logging/LoggingTrackingConsentE2ETests.swift
@@ -26,7 +26,7 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $feature = logs
     /// $monitor_id = sdk_set_tracking_consent_performance
     /// $monitor_name = "[RUM] [iOS] Nightly Performance - sdk_set_tracking_consent: has a high average execution time"
-    /// $monitor_query = "avg(last_1d):avg:trace.sdk_set_tracking_consent{env:instrumentation,resource_name:sdk_set_tracking_consent,service:com.datadog.ios.nightly} > 0.016"
+    /// $monitor_query = "avg(last_1d):avg:trace.perf_measure{env:instrumentation,resource_name:sdk_set_tracking_consent,service:com.datadog.ios.nightly} > 0.016"
     /// $monitor_threshold = 0.016
     /// ```
 
@@ -42,10 +42,10 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_config_consent_granted\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_config_consent_GRANTED() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(trackingConsent: .granted)
         }
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
         logger.sendRandomLog(with: DD.logAttributes())
@@ -63,10 +63,10 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_config_consent_NOT_GRANTED() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(trackingConsent: .notGranted)
         }
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
         logger.sendRandomLog(with: DD.logAttributes())
@@ -84,10 +84,10 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_config_consent_PENDING() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(trackingConsent: .pending)
         }
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
         logger.sendRandomLog(with: DD.logAttributes())
@@ -106,13 +106,13 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_config_consent_GRANTED_to_NOT_GRANTED() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(trackingConsent: .granted)
         }
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
-        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+        measure(resourceName: DD.PerfSpanName.setTrackingConsent) {
             Datadog.set(trackingConsent: .notGranted)
         }
 
@@ -130,13 +130,13 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_config_consent_GRANTED_to_PENDING() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(trackingConsent: .granted)
         }
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
-        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+        measure(resourceName: DD.PerfSpanName.setTrackingConsent) {
             Datadog.set(trackingConsent: .pending)
         }
 
@@ -152,13 +152,13 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_config_consent_not_granted_to_granted\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_config_consent_NOT_GRANTED_to_GRANTED() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(trackingConsent: .notGranted)
         }
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
-        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+        measure(resourceName: DD.PerfSpanName.setTrackingConsent) {
             Datadog.set(trackingConsent: .granted)
         }
 
@@ -176,13 +176,13 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_config_consent_NOT_GRANTED_to_PENDING() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(trackingConsent: .notGranted)
         }
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
-        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+        measure(resourceName: DD.PerfSpanName.setTrackingConsent) {
             Datadog.set(trackingConsent: .pending)
         }
 
@@ -198,16 +198,16 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:logs_config_consent_pending_to_granted\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
     /// ```
     func test_logs_config_consent_PENDING_to_GRANTED() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(trackingConsent: .pending)
         }
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
 
         logger.sendRandomLog(with: DD.logAttributes())
 
-        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+        measure(resourceName: DD.PerfSpanName.setTrackingConsent) {
             Datadog.set(trackingConsent: .granted)
         }
     }
@@ -223,16 +223,16 @@ class LoggingTrackingConsentE2ETests: E2ETests {
     /// $notify_no_data = false
     /// ```
     func test_logs_config_consent_PENDING_to_NOT_GRANTED() {
-        measure(spanName: DD.PerfSpanName.sdkInitialize) {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
             initializeSDK(trackingConsent: .pending)
         }
-        measure(spanName: DD.PerfSpanName.loggerInitialize) {
+        measure(resourceName: DD.PerfSpanName.loggerInitialize) {
             logger = Logger.builder.build()
         }
 
         logger.sendRandomLog(with: DD.logAttributes())
 
-        measure(spanName: DD.PerfSpanName.setTrackingConsent) {
+        measure(resourceName: DD.PerfSpanName.setTrackingConsent) {
             Datadog.set(trackingConsent: .notGranted)
         }
     }

--- a/tools/nightly-e2e-tests/monitors-gen/templates/monitor-apm.tf.src
+++ b/tools/nightly-e2e-tests/monitors-gen/templates/monitor-apm.tf.src
@@ -1,7 +1,7 @@
 resource "datadog_monitor" ${{monitor_id}} {
   name               = ${{monitor_name}}
   type               = "query alert"
-  tags               = ["service:com.datadog.ios.nightly", "env:instrumentation", "team:rumm", "source:ios", ]
+  tags               = ["service:com.datadog.ios.nightly", "env:instrumentation", "team:rumm", "source:ios", "feature:${{feature}}", "monitor:performance"]
   message            = <<EOT
 @maciek.grzybowski@datadoghq.com
 @mert.buran@datadoghq.com

--- a/tools/nightly-e2e-tests/monitors-gen/templates/monitor-apm.tf.src
+++ b/tools/nightly-e2e-tests/monitors-gen/templates/monitor-apm.tf.src
@@ -5,6 +5,12 @@ resource "datadog_monitor" ${{monitor_id}} {
   message            = <<EOT
 @maciek.grzybowski@datadoghq.com
 @mert.buran@datadoghq.com
+@maxime.epain@datadoghq.com
+
+## E2E test code:
+```
+## MONITOR_CODE ##
+```
 EOT
   escalation_message = <<EOT
 <nil>

--- a/tools/nightly-e2e-tests/monitors-gen/templates/monitor-logs.tf.src
+++ b/tools/nightly-e2e-tests/monitors-gen/templates/monitor-logs.tf.src
@@ -1,7 +1,7 @@
 resource "datadog_monitor" ${{monitor_id}} {
   name               = ${{monitor_name}}
   type               = "log alert"
-  tags               = ["service:com.datadog.ios.nightly", "env:instrumentation", "team:rumm", "source:ios", ]
+  tags               = ["service:com.datadog.ios.nightly", "env:instrumentation", "team:rumm", "source:ios", "feature:logs", "monitor:behavior"]
   message            = <<EOT
 @maciek.grzybowski@datadoghq.com
 @mert.buran@datadoghq.com

--- a/tools/nightly-e2e-tests/monitors-gen/templates/monitor-logs.tf.src
+++ b/tools/nightly-e2e-tests/monitors-gen/templates/monitor-logs.tf.src
@@ -5,6 +5,12 @@ resource "datadog_monitor" ${{monitor_id}} {
   message            = <<EOT
 @maciek.grzybowski@datadoghq.com
 @mert.buran@datadoghq.com
+@maxime.epain@datadoghq.com
+
+## E2E test code:
+```
+## MONITOR_CODE ##
+```
 EOT
   escalation_message = <<EOT
 <nil>

--- a/tools/nightly-e2e-tests/src/main_tf_renderer.py
+++ b/tools/nightly-e2e-tests/src/main_tf_renderer.py
@@ -73,6 +73,7 @@ class MonitorTemplate:
         result = ''
         result += self.template_content
         result = MonitorTemplate.render_template_variables(template=result, monitor=monitor)
+        result = MonitorTemplate.render_monitor_code(template=result, monitor=monitor)
         return result
 
     @staticmethod
@@ -131,3 +132,10 @@ class MonitorTemplate:
                     )
 
         return '\n'.join(rendered_lines)
+
+    @staticmethod
+    def render_monitor_code(template: str, monitor: MonitorConfiguration) -> str:
+        """
+        Replaces '## MONITOR_CODE ##' anchor in the template with the code associated to this monitor.
+        """
+        return template.replace("## MONITOR_CODE ##", monitor.code)

--- a/tools/nightly-e2e-tests/src/test_file_parser.py
+++ b/tools/nightly-e2e-tests/src/test_file_parser.py
@@ -25,6 +25,7 @@ class MonitorConfiguration:
     type: str  # a type of monitor (allowed values: 'apm' | 'logs'), used to select monitor template
     variables: [MonitorVariable]  # list of monitor variables
     code_reference: CodeReference
+    code: str = ''  # monitor code (monitor definition from comment and the entire test method declaration)
 
 
 @dataclass
@@ -32,6 +33,7 @@ class TestMethod:
     method_name: str  # the name of this test method
     monitors: [MonitorConfiguration]  # monitors defined in method comment
     code_reference: CodeReference
+    code: str  # the entire test method declaration code
 
 
 @dataclass()
@@ -47,38 +49,64 @@ def read_test_file(path: str):
     """
     with open(path, 'r') as file:
         comment_regex = r'^[\t ]*(\/\/\/.*)'  # e.g. '    /// Sample comment'
-        method_signature_regex = r'^[\s ]+func (test\w*)\(\)( throws)? {'  # e.g. '    func test_sample() throws {'
+        method_signature_regex = r'^[\t ]+func (test\w*)\(\)( throws)? {'  # e.g. '    func test_sample() throws {'
 
         test_methods: [TestMethod] = []
         independent_monitors: [MonitorConfiguration] = []
-        comment_lines_buffer: [(int, str)] = []
+        comment_lines_buffer: [(int, str, str)] = []  # (line number, comment with no indent, original line)
 
-        for line_no, line_text in enumerate(file.readlines()):
+        lines_in_file = file.readlines()
+
+        for line_no, line_text in enumerate(lines_in_file):
             if comment_match := re.match(comment_regex, line_text):  # matched comment `///`
-                comment_lines_buffer.append((line_no, comment_match.groups()[0]))
+                comment_lines_buffer.append((line_no, comment_match.groups()[0], line_text))
 
             elif method_signature_match := re.match(method_signature_regex, line_text):  # matched test method signature
                 method_name = method_signature_match.groups()[0]
-                method = TestMethod(
-                    method_name=method_name,
-                    monitors=read_monitor_configuration(
+
+                method_code_reference = CodeReference(
+                    file_path=path,
+                    line_no=line_no + 1,
+                    line_text=line_text
+                )
+
+                with linter_context(code_reference=method_code_reference):
+                    method_monitors = read_monitors_configuration(  # read monitors defined in this method comment
                         comment_lines=comment_lines_buffer,
                         file_path=path
-                    ),
-                    code_reference=CodeReference(
-                        file_path=path,
-                        line_no=line_no + 1,
-                        line_text=line_text
                     )
-                )
+                    method_code = read_method_body(  # read method body
+                        lines_in_file=lines_in_file,
+                        method_signature_line_no=line_no
+                    )
+
+                    # Link code declaration to each monitor in this test method:
+                    for method_monitor in method_monitors:
+                        comment_lines = list(map(lambda buffered_line: buffered_line[2], comment_lines_buffer))
+                        method_monitor.code = ''.join(comment_lines) + method_code
+
+                    method = TestMethod(
+                        method_name=method_name,
+                        monitors=method_monitors,
+                        code_reference=method_code_reference,
+                        code=method_code
+                    )
+
                 test_methods.append(method)
                 comment_lines_buffer = []
             else:  # matched some other line in the file
-                # Check if buffered comments define any additional monitors:
-                additional_monitors = read_monitor_configuration(
+                # Check if buffered comments define any additional monitors (independent monitors defined
+                # in the test file, but not linked to any test method):
+                additional_monitors = read_monitors_configuration(
                     comment_lines=comment_lines_buffer,
                     file_path=path
                 )
+
+                # Link code declaration to each additional monitor:
+                for additional_monitor in additional_monitors:
+                    comment_lines = list(map(lambda buffered_line: buffered_line[2], comment_lines_buffer))
+                    additional_monitor.code = ''.join(comment_lines)
+
                 # Add to the list of independent monitors for this file:
                 independent_monitors += additional_monitors
 
@@ -93,11 +121,11 @@ def read_test_file(path: str):
             return None
 
 
-def read_monitor_configuration(comment_lines: [(int, str)], file_path: str) -> [MonitorConfiguration]:
+def read_monitors_configuration(comment_lines: [(int, str, str)], file_path: str) -> [MonitorConfiguration]:
     """
-    Parses method comment lines and produces one or more `MonitorConfiguration` objects.
+    Parses comment lines and returns zero to many `MonitorConfiguration` objects.
 
-    The expected method comment has following structure:
+    The expected monitor comment has following structure:
 
     /// ... anything before
     /// ```logs
@@ -113,7 +141,7 @@ def read_monitor_configuration(comment_lines: [(int, str)], file_path: str) -> [
     The "```" token indicates the beginning and end of the monitor definition. There can be more than one
     monitor defined in each comment.
 
-    :return: returns list of `MonitorConfiguration` objects (0 to many) recognized in the method comment.
+    :return: returns list of `MonitorConfiguration` objects (0 to many) recognized in the comment.
     """
     monitor_region_start_regex = r'^\/\/\/[\s ]+```([a-zA-Z0-9]+)[\s ]*$'  # e.g. '/// ```apm'
     monitor_region_end_regex = r'^\/\/\/[\s ]+```[\s ]*$'  # e.g. '/// ```'
@@ -124,7 +152,7 @@ def read_monitor_configuration(comment_lines: [(int, str)], file_path: str) -> [
     monitors: [MonitorConfiguration] = []
     variables_buffer: [MonitorVariable] = []
 
-    for line_no, line_text in comment_lines:
+    for line_no, line_text, _ in comment_lines:
         comment_line_code_reference = CodeReference(
             file_path=file_path,
             line_no=(line_no + 1),
@@ -198,3 +226,36 @@ def read_variable(line_text: str, comment_line_code_reference: CodeReference):
         with linter_context(code_reference=comment_line_code_reference):
             Linter.shared.emit_error('Incorrect variable definitions - variable must follow `$name = value` syntax.')
             return None
+
+
+def read_method_body(lines_in_file: [str], method_signature_line_no: int) -> str:
+    """
+    Parses method body.
+
+    It starts from `method_signature_line` and accepts lines until all opening brackets "{" are matched
+    with enclosing "}" brackets.
+
+    :return: the body of test method, including its signature and enclosing `}` bracket.
+    """
+
+    method_body = ''
+    line_no = method_signature_line_no
+    brackets_matched = 0
+
+    while line_no < len(lines_in_file):
+        line_text = lines_in_file[line_no]
+        brackets_matched += line_text.count('{')
+        brackets_matched -= line_text.count('}')
+
+        method_body += line_text
+
+        if brackets_matched == 0:
+            break
+        else:
+            line_no += 1
+
+    if line_no == (len(lines_in_file) - 1):
+        Linter.shared.emit_warning('E2E monitors parser cannot read this method body. Make sure that all opening'
+                                   ' brackets "{" are matched with their closing bracket "}".')
+
+    return method_body

--- a/tools/nightly-e2e-tests/tests/test_parsing_test_file.py
+++ b/tools/nightly-e2e-tests/tests/test_parsing_test_file.py
@@ -55,9 +55,21 @@ class TestFileTestCase(unittest.TestCase):
                                 )
                             ],
                             code_reference=CodeReference(
-                            file_path=file.name,
-                            line_no=3,
-                            line_text='/// ```'
+                                file_path=file.name,
+                                line_no=3,
+                                line_text='/// ```'
+                            ),
+                            code='\n'.join(
+                                [
+                                    '        /// Monitor definition assigned to the test method:',
+                                    '        /// ```apm',
+                                    '        /// $foo = <foo value>',
+                                    '        /// $bar = <bar value>',
+                                    '        /// ```',
+                                    '        func test_method_name() {',
+                                    '        }',
+                                    ''
+                                ]
                             )
                         )
                     ],
@@ -65,6 +77,13 @@ class TestFileTestCase(unittest.TestCase):
                         file_path=file.name,
                         line_no=7,
                         line_text='        func test_method_name() {\n'
+                    ),
+                    code='\n'.join(
+                        [
+                            '        func test_method_name() {',
+                            '        }',
+                            ''
+                        ]
                     )
                 )
             ],
@@ -116,6 +135,16 @@ class TestFileTestCase(unittest.TestCase):
                         file_path=file.name,
                         line_no=4,
                         line_text='/// ```'
+                    ),
+                    code='\n'.join(
+                        [
+                            '            /// Monitor definition not assigned to any test method:',
+                            '            /// ```apm',
+                            '            /// $foo = <foo value>',
+                            '            /// $bar = <bar value>',
+                            '            /// ```',
+                            ''
+                        ]
                     )
                 )
             ]

--- a/tools/nightly-e2e-tests/tests/test_rendering_monitor_template.py
+++ b/tools/nightly-e2e-tests/tests/test_rendering_monitor_template.py
@@ -110,9 +110,41 @@ class MonitorTemplateTestCase(unittest.TestCase):
             message='Variable $argument_with_no_default is required, but not defined for this monitor.'
         )
 
+    def test_it_renders_monitor_code(self):
+        template = MonitorTemplate(
+            '''
+            some text before
+            ## MONITOR_CODE ##
+            some text after
+            '''
+        )
+
+        monitor_code = random_multiline_string(length=256)
+
+        monitor = MonitorConfiguration(
+            type='',
+            variables=[],
+            code_reference=any_code_reference(),
+            code=monitor_code
+        )
+
+        rendered_template = template.render(monitor=monitor)
+        expected_template = f'''
+            some text before
+            {monitor_code}
+            some text after
+            '''
+
+        self.assertEqual(expected_template, rendered_template)
+
 
 def random_string(length: int = 32):
     characters_set = string.ascii_letters + string.digits + string.punctuation + ' \t'
+    return ''.join((random.choice(characters_set) for i in range(length)))
+
+
+def random_multiline_string(length: int = 32):
+    characters_set = string.ascii_letters + string.digits + string.punctuation + ' \t' + '\n'
     return ''.join((random.choice(characters_set) for i in range(length)))
 
 


### PR DESCRIPTION
### What and why?

⚙️ This PR updates our E2E test monitors to new format:
* it adds `feature` tag (`logs` | `trace` | `rum` | `core`) to each monitor;
* it adds `monitor:behavior` tag to all monitors asserting data;
* it adds `monitor:performance` tag to all monitors asserting performance;
* from now on, all performance spans use `"perf_measure"` span with test method sent as a resource name.

It also adds a bonus for troubleshooting, now each monitor renders its corresponding E2E test code in monitor UI, e.g.:

<img width="1340" alt="Screenshot 2021-09-21 at 16 55 30" src="https://user-images.githubusercontent.com/2358722/134194629-e2916e93-607e-42fa-ad7f-4b990f9ff6a2.png">

This helps understanding each monitor, especially if it expects "data" or "no data".

### How?

* I added `${{feature}}` variable to monitors template - it has no default value, so linter will emit an error if not specified.
* Both `monitor:behaviour` and `monitor:performance` tags are hardcoded in each template.
* I updated code to differentiate `resource_name` for each span and use common `operation_name`.

Code rendering is done through template system. Code is parsed while reading monitors from test files.

I regenerated all monitors by first deleting them, and then running `terraform apply`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
