### PR TITLE
RUMM-1469 Fix: CI for fork PRs

### DIFF
--- a/dependency-manager-tests/carthage/Cartfile.src
+++ b/dependency-manager-tests/carthage/Cartfile.src
@@ -1,1 +1,1 @@
-github "DataDog/dd-sdk-ios" "REMOTE_GIT_REFERENCE"
+github "GIT_REMOTE" "GIT_REFERENCE"

--- a/dependency-manager-tests/carthage/Makefile
+++ b/dependency-manager-tests/carthage/Makefile
@@ -6,9 +6,16 @@ ifneq (${BITRISE_GIT_TAG},)
 	GIT_REFERENCE := ${BITRISE_GIT_TAG}
 endif
 
+GIT_REMOTE := "DataDog/dd-sdk-ios"
+ifneq (${BITRISEIO_PULL_REQUEST_REPOSITORY_URL},)
+	GIT_REMOTE := ${BITRISEIO_PULL_REQUEST_REPOSITORY_URL}
+endif
+
 test:
 		@echo "⚙️  Configuring CTProject with remote branch: '${GIT_REFERENCE}'..."
-		@sed "s|REMOTE_GIT_REFERENCE|${GIT_REFERENCE}|g" Cartfile.src > Cartfile
+		
+		@sed "s|GIT_REFERENCE|${GIT_REFERENCE}|g" Cartfile.src | \
+		sed "s|GIT_REMOTE|${GIT_REMOTE}|g" > Cartfile
 		@rm -rf Carthage/
 		@echo "🧪 Run 'carthage update'"
 		@carthage update --platform iOS --use-xcframeworks

--- a/dependency-manager-tests/cocoapods/Makefile
+++ b/dependency-manager-tests/cocoapods/Makefile
@@ -6,9 +6,15 @@ ifneq (${BITRISE_GIT_TAG},)
 	GIT_REFERENCE := "tag=\>\'${BITRISE_GIT_TAG}\'"
 endif
 
+GIT_REMOTE := "https://github.com/DataDog/dd-sdk-ios.git"
+ifneq (${BITRISEIO_PULL_REQUEST_REPOSITORY_URL},)
+	GIT_REMOTE := ${BITRISEIO_PULL_REQUEST_REPOSITORY_URL}
+endif
+
 test:
 		@echo "⚙️  Configuring CPProject with remote branch: '${GIT_REFERENCE}'..."
-		@sed "s|REMOTE_GIT_REFERENCE|${GIT_REFERENCE}|g" Podfile.src > Podfile
+		@sed "s|GIT_REFERENCE|${GIT_REFERENCE}|g" Podfile.src | \
+		sed "s|GIT_REMOTE|${GIT_REMOTE}|g" > Podfile
 		@rm -rf Pods/
 		pod update
 		@echo "👌 'pod update' OK"

--- a/dependency-manager-tests/cocoapods/Podfile.src
+++ b/dependency-manager-tests/cocoapods/Podfile.src
@@ -1,9 +1,9 @@
 platform :ios, '13.0'
 
 abstract_target 'Common' do
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :REMOTE_GIT_REFERENCE
-  pod 'DatadogSDKAlamofireExtension', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :REMOTE_GIT_REFERENCE
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios.git', :REMOTE_GIT_REFERENCE
+  pod 'DatadogSDK', :git => 'GIT_REMOTE', :GIT_REFERENCE
+  pod 'DatadogSDKAlamofireExtension', :git => 'GIT_REMOTE', :GIT_REFERENCE
+  pod 'DatadogSDKCrashReporting', :git => 'GIT_REMOTE', :GIT_REFERENCE
   pod 'Alamofire'
 
   target 'CPProjectUseFrameworks' do

--- a/dependency-manager-tests/spm/Makefile
+++ b/dependency-manager-tests/spm/Makefile
@@ -6,11 +6,17 @@ ifneq (${BITRISE_GIT_TAG},)
 	GIT_REFERENCE := ${BITRISE_GIT_TAG}
 endif
 
+GIT_REMOTE := "https://github.com/DataDog/dd-sdk-ios"
+ifneq (${BITRISEIO_PULL_REQUEST_REPOSITORY_URL},)
+	GIT_REMOTE := ${BITRISEIO_PULL_REQUEST_REPOSITORY_URL}
+endif
+
 test:
 		@echo "⚙️  Configuring SPMProject with remote branch: '${GIT_REFERENCE}'..."
 		@rm -rf SPMProject.xcodeproj
 		@cp -r SPMProject.xcodeproj.src SPMProject.xcodeproj
-		@sed "s|REMOTE_GIT_REFERENCE|${GIT_REFERENCE}|g" SPMProject.xcodeproj.src/project.pbxproj > SPMProject.xcodeproj/project.pbxproj
+		@sed "s|GIT_REFERENCE|${GIT_REFERENCE}|g" SPMProject.xcodeproj.src/project.pbxproj | \
+		sed "s|GIT_REMOTE|${GIT_REMOTE}|g" > SPMProject.xcodeproj/project.pbxproj
 		@echo "OK 👌"
 
 create-src-from-xcodeproj:

--- a/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
+++ b/dependency-manager-tests/spm/SPMProject.xcodeproj.src/project.pbxproj
@@ -678,9 +678,9 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		9E73373E26B0123500917C24 /* XCRemoteSwiftPackageReference "dd-sdk-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/DataDog/dd-sdk-ios/";
+			repositoryURL = "GIT_REMOTE";
 			requirement = {
-				branch = REMOTE_GIT_REFERENCE;
+				branch = GIT_REFERENCE;
 				kind = branch;
 			};
 		};


### PR DESCRIPTION
### What and why?

As an open-source project, we sometimes receive PRs from other forks.
We'd like to run our CI for those contributions in the same way as we do for regular PRs.

### How?

Our `dependency-manager-tests` had their repo URL hardcoded, now this value comes from Bitrise, [`$BITRISEIO_PULL_REQUEST_REPOSITORY_URL`](https://devcenter.bitrise.io/builds/available-environment-variables/).

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
