### PR TITLE
RUMM-1605 Use Native resource type instead of XHR

### DIFF
--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -27,11 +27,11 @@ internal extension RUMResourceType {
     /// - Parameters:
     ///   - request: the `URLRequest` for the resource.
     init?(request: URLRequest) {
-        let xhrHTTPMethods: Set<String> = ["POST", "PUT", "DELETE"]
+        let nativeHTTPMethods: Set<String> = ["POST", "PUT", "DELETE"]
 
         if let requestMethod = request.httpMethod?.uppercased(),
-           xhrHTTPMethods.contains(requestMethod) {
-            self = .xhr
+            nativeHTTPMethods.contains(requestMethod) {
+            self = .native
         } else {
             return nil
         }
@@ -54,10 +54,10 @@ internal extension RUMResourceType {
             case ("font", _): self = .font
             case ("text", "css"): self = .css
             case ("text", "javascript"): self = .js
-            default: self = .xhr
+            default: self = .native
             }
         } else {
-            self = .xhr
+            self = .native
         }
     }
 }

--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -144,6 +144,7 @@ public enum DDRUMResourceType: Int {
     case js
     case media
     case other
+    case native
 
     internal var swiftType: RUMResourceType {
         switch self {
@@ -156,6 +157,7 @@ public enum DDRUMResourceType: Int {
         case .font: return .font
         case .js: return .js
         case .media: return .media
+        case .native: return .native
         default: return .other
         }
     }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -143,7 +143,7 @@ extension RUMResourceEvent: RandomMockable {
                 size: .mockRandom(),
                 ssl: .init(duration: .mockRandom(), start: .mockRandom()),
                 statusCode: .mockRandom(),
-                type: [.xhr, .fetch, .image].randomElement()!,
+                type: [.native, .image].randomElement()!,
                 url: .mockRandom()
             ),
             service: .mockRandom(),

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -379,13 +379,14 @@ extension URLResponse {
 
     static func mockWith(
         statusCode: Int = 200,
-        mimeType: String = "application/json"
+        mimeType: String? = "application/json"
     ) -> HTTPURLResponse {
+        let headers: [String: String] = (mimeType == nil) ? [:] : ["Content-Type": "\(mimeType!)"]
         return HTTPURLResponse(
             url: .mockAny(),
             statusCode: statusCode,
             httpVersion: nil,
-            headerFields: ["Content-Type": "\(mimeType)"]
+            headerFields: headers
         )!
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -356,7 +356,7 @@ class RUMResourceScopeTests: XCTestCase {
     }
 
     func testGivenResourceStartedWithKindBasedOnRequest_whenLoadingEndsWithDifferentKind_itSendsTheKindBasedOnRequest() throws {
-        let kinds: [RUMResourceType] = [.image, .xhr, .beacon, .css, .document, .fetch, .font, .js, .media, .other]
+        let kinds: [RUMResourceType] = [.image, .xhr, .beacon, .css, .document, .fetch, .font, .js, .media, .other, .native]
         let kindBasedOnRequest = kinds.randomElement()!
         let kindBasedOnResponse = kinds.randomElement()!
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -117,7 +117,7 @@ class RUMMonitorTests: XCTestCase {
         }
     }
 
-    func testStartingView_thenLoadingXHRResourceWithRequestWithMetrics() throws {
+    func testStartingView_thenLoadingNativeResourceWithRequestWithMetrics() throws {
         guard #available(iOS 13, *) else {
             return // `URLSessionTaskMetrics` mocking doesn't work prior to iOS 13.0
         }
@@ -149,14 +149,14 @@ class RUMMonitorTests: XCTestCase {
 
         let session = try XCTUnwrap(try RUMSessionMatcher.groupMatchersBySessions(rumEventMatchers).first)
         let resourceEvent = session.viewVisits[0].resourceEvents[0]
-        XCTAssertEqual(resourceEvent.resource.type, .xhr, "POST Resources should always have the `.xhr` kind")
+        XCTAssertEqual(resourceEvent.resource.type, .native, "POST Resources should always have the `.native` kind")
         XCTAssertEqual(resourceEvent.resource.statusCode, 200)
         XCTAssertEqual(resourceEvent.resource.duration, 4_000_000_000)
         XCTAssertEqual(resourceEvent.resource.dns!.start, 1_000_000_000)
         XCTAssertEqual(resourceEvent.resource.dns!.duration, 2_000_000_000)
     }
 
-    func testStartingView_thenLoadingXHRResourceWithRequestWithExternalMetrics() throws {
+    func testStartingView_thenLoadingNativeResourceWithRequestWithExternalMetrics() throws {
         RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
         defer { RUMFeature.instance?.deinitialize() }
 
@@ -200,7 +200,7 @@ class RUMMonitorTests: XCTestCase {
 
         let session = try XCTUnwrap(try RUMSessionMatcher.groupMatchersBySessions(rumEventMatchers).first)
         let resourceEvent = session.viewVisits[0].resourceEvents[0]
-        XCTAssertEqual(resourceEvent.resource.type, .xhr, "POST Resources should always have the `.xhr` kind")
+        XCTAssertEqual(resourceEvent.resource.type, .native, "POST Resources should always have the `.native` kind")
         XCTAssertEqual(resourceEvent.resource.statusCode, 200)
 
         XCTAssertEqual(resourceEvent.resource.duration, 12_000_000_000)
@@ -1373,15 +1373,15 @@ class RUMResourceKindTests: XCTestCase {
         }
     }
 
-    func testWhenInitializedWithPOSTorPUTorDELETErequest_itReturnsXHR() {
+    func testWhenInitialized_itDefaultsToNative() {
         XCTAssertEqual(
-            RUMResourceType(request: .mockWith(httpMethod: "POST".randomcased())), .xhr
+            RUMResourceType(request: .mockWith(httpMethod: "POST".randomcased())), .native
         )
         XCTAssertEqual(
-            RUMResourceType(request: .mockWith(httpMethod: "PUT".randomcased())), .xhr
+            RUMResourceType(request: .mockWith(httpMethod: "PUT".randomcased())), .native
         )
         XCTAssertEqual(
-            RUMResourceType(request: .mockWith(httpMethod: "DELETE".randomcased())), .xhr
+            RUMResourceType(request: .mockWith(httpMethod: "DELETE".randomcased())), .native
         )
     }
 
@@ -1397,9 +1397,15 @@ class RUMResourceKindTests: XCTestCase {
         )
     }
 
-    func testWhenInitializingFromHTTPURLResponse_itDefaultsToXhr() {
+    func testWhenInitializingFromHTTPURLResponseWithUnknownType_itDefaultsToNative() {
         XCTAssertEqual(
-            RUMResourceType(response: .mockWith(mimeType: "unknown/type")), .xhr
+            RUMResourceType(response: .mockWith(mimeType: "unknown/type")), .native
+        )
+    }
+
+    func testWhenInitializingFromHTTPURLResponseWithNoType_itDefaultsToNative() {
+        XCTAssertEqual(
+            RUMResourceType(response: .mockWith(mimeType: nil)), .native
         )
     }
 }

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -97,6 +97,7 @@ class DDRUMResourceKindTests: XCTestCase {
         XCTAssertEqual(DDRUMResourceType.js.swiftType, .js)
         XCTAssertEqual(DDRUMResourceType.media.swiftType, .media)
         XCTAssertEqual(DDRUMResourceType.other.swiftType, .other)
+        XCTAssertEqual(DDRUMResourceType.native.swiftType, .native)
     }
 }
 

--- a/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
+++ b/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDRUMMonitor+apiTests.m
@@ -41,6 +41,7 @@
 - (void)testDDRUMResourceTypeAPI {
     DDRUMResourceTypeImage; DDRUMResourceTypeXhr; DDRUMResourceTypeBeacon; DDRUMResourceTypeCss; DDRUMResourceTypeDocument;
     DDRUMResourceTypeFetch; DDRUMResourceTypeFont; DDRUMResourceTypeJs; DDRUMResourceTypeMedia; DDRUMResourceTypeOther;
+    DDRUMResourceTypeNative;
 }
 
 - (void)testDDRUMMethodAPI {


### PR DESCRIPTION
### What and why?

Use `native` resource type instead of `xhr`. The latter was used as a legacy based on the Browser RUM SDK, but we need something more relevant for mobile apps.