### PR TITLE
RUMM-1625 Do not run nightly tests below iOS 11.0.0

### DIFF
--- a/tools/nightly-unit-tests/generate_bitrise_yml.py
+++ b/tools/nightly-unit-tests/generate_bitrise_yml.py
@@ -53,7 +53,6 @@ def dump_environment(simulators: Simulators, runtimes: Runtimes, devices: Device
     print_devices(devices=devices.all)
 
 
-
 def generate_bitrise_yml(test_plan: TestPlan, dry_run: bool):
     """
     Generates `bitrise.yml` file for given Test Plan.

--- a/tools/nightly-unit-tests/generate_bitrise_yml.py
+++ b/tools/nightly-unit-tests/generate_bitrise_yml.py
@@ -23,6 +23,37 @@ from src.test_plan import TestPlan, TestPlanStep
 from src.semver import Version
 
 
+def get_environment() -> (Simulators, Runtimes, Devices):
+    """
+    Uses `xcversion simulators` and `xcrun simctl` CLIs to load available
+    simulators, runtimes and devices.
+    """
+    simulators = Simulators(
+        xcversion_simulators_output=shell_output('xcversion simulators')
+    )
+    runtimes = Runtimes(
+        xcrun_simctl_list_runtimes_json_output=shell_output('xcrun simctl list runtimes --json')
+    )
+    devices = Devices(
+        runtimes=runtimes,
+        xcrun_simctl_list_devices_json_output=shell_output('xcrun simctl list devices --json')
+    )
+    return simulators, runtimes, devices
+
+
+def dump_environment(simulators: Simulators, runtimes: Runtimes, devices: Devices):
+    """
+    Prints log listing all available simulators, runtimes and devices.
+    """
+    print('\n⚙️ All simulators:')
+    print_simulators(simulators=simulators.all)
+    print('\n⚙️ All runtimes:')
+    print_runtimes(runtimes=runtimes.all)
+    print('\n⚙️ All devices:')
+    print_devices(devices=devices.all)
+
+
+
 def generate_bitrise_yml(test_plan: TestPlan, dry_run: bool):
     """
     Generates `bitrise.yml` file for given Test Plan.
@@ -55,22 +86,8 @@ def generate_bitrise_yml(test_plan: TestPlan, dry_run: bool):
             print(f' → installed {simulator.os_name} {simulator.os_version} Simulator, in: {minutes_elapsed}')
 
     # After installing new simulators, load list of available devices:
-    simulators = Simulators(
-        xcversion_simulators_output=shell_output('xcversion simulators')
-    )
-    runtimes = Runtimes(
-        xcrun_simctl_list_runtimes_json_output=shell_output('xcrun simctl list runtimes --json')
-    )
-    devices = Devices(
-        runtimes=runtimes,
-        xcrun_simctl_list_devices_json_output=shell_output('xcrun simctl list devices --json')
-    )
-    print('\n⚙️ App simulators:')
-    print_simulators(simulators=simulators.all)
-    print('\n⚙️ All runtimes:')
-    print_runtimes(runtimes=runtimes.all)
-    print('\n⚙️ All devices:')
-    print_devices(devices=devices.all)
+    simulators, runtimes, devices = get_environment()
+    dump_environment(simulators=simulators, runtimes=runtimes, devices=devices)
 
     # Generate `bitrise.yml`
     print('\n⚙️ Creating `bitrise.yml`:')
@@ -189,6 +206,9 @@ if __name__ == "__main__":
         print('-' * 60)
         traceback.print_exc(file=sys.stdout)
         print('-' * 60)
+        print('Environment dump:')
+        simulators, runtimes, devices = get_environment()
+        dump_environment(simulators=simulators, runtimes=runtimes, devices=devices)
         sys.exit(1)
 
     sys.exit(0)

--- a/tools/nightly-unit-tests/src/semver.py
+++ b/tools/nightly-unit-tests/src/semver.py
@@ -44,3 +44,6 @@ class Version:
                     return True
 
         return False
+
+    def is_newer_than_or_equal(self, other_version: 'Version'):
+        return self.is_newer_than(other_version=other_version) or self == other_version

--- a/tools/nightly-unit-tests/src/test_plan.py
+++ b/tools/nightly-unit-tests/src/test_plan.py
@@ -6,6 +6,7 @@
 
 import random
 from src.simulators_parser import Simulator
+from src.semver import Version
 
 # An estimated duration of installing simulator on Bitrise.
 # It includes ~3-5min margin over measured duration.
@@ -18,6 +19,9 @@ UNIT_TESTS_EXECUTION_TIME_IN_MINUTES = 10
 # The maximum time of running a build in Bitrise.
 # It includes ~10min margin for set-up and tear-down jobs.
 BITRISE_TIMEOUT_IN_MINUTES = 80
+
+# The minimal supported iOS version for running unit tests.
+MIN_SUPPORTED_IOS_VERSION = Version.parse('11.0.0')
 
 
 class TestPlanStep:
@@ -62,6 +66,8 @@ class TestPlan:
         :return: a `TestPlan` object
         """
         possible_steps = list(map(lambda s: TestPlanStep(simulator=s), simulators))
+        possible_steps = list(filter(lambda step: is_using_supported_ios_version(step), possible_steps))
+
         planned_steps: [TestPlanStep] = []
 
         random.shuffle(possible_steps)
@@ -90,3 +96,7 @@ def total_duration_in_minutes(steps: [TestPlanStep]):
     for step in steps:
         total += step.estimated_duration_in_minutes
     return total
+
+
+def is_using_supported_ios_version(step: TestPlanStep) -> bool:
+    return step.simulator.os_version.is_newer_than_or_equal(MIN_SUPPORTED_IOS_VERSION)

--- a/tools/nightly-unit-tests/tests/test_semver.py
+++ b/tools/nightly-unit-tests/tests/test_semver.py
@@ -1,0 +1,26 @@
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-2020 Datadog, Inc.
+# -----------------------------------------------------------
+
+import unittest
+from src.semver import Version
+
+
+class VersionTestCase(unittest.TestCase):
+    def test_parsing(self):
+        self.assertEqual(Version.parse('10.0.3'), Version(major=10, minor=0, patch=3))
+        self.assertEqual(Version.parse('11.4'), Version(major=11, minor=4, patch=0))
+        self.assertEqual(Version.parse('12'), Version(major=12, minor=0, patch=0))
+
+    def test_comparing(self):
+        self.assertTrue(Version.parse('14.0.0').is_newer_than(Version.parse('13.1.2')))
+        self.assertTrue(Version.parse('14.1.1').is_newer_than(Version.parse('14.1.0')))
+        self.assertTrue(Version.parse('14.2.3').is_newer_than(Version.parse('14.2.2')))
+        self.assertFalse(Version.parse('14.0.3').is_newer_than(Version.parse('15.0.2')))
+        self.assertFalse(Version.parse('14.0.3').is_newer_than(Version.parse('14.1.0')))
+        self.assertFalse(Version.parse('14.0.3').is_newer_than(Version.parse('14.0.4')))
+        self.assertFalse(Version.parse('14.0.3').is_newer_than(Version.parse('14.0.3')))
+        self.assertTrue(Version.parse('14.0.3').is_newer_than_or_equal(Version.parse('14.0.3')))
+        self.assertFalse(Version.parse('14.0.2').is_newer_than_or_equal(Version.parse('14.0.3')))


### PR DESCRIPTION
### What and why?

🐞 This PR fixes an issue in nightly tests automation, where sometimes it was trying to run unit tests on `iOS 10.x`.

### How?

Our nightly tests automation looks at all installed and available for installation Simulators in host environment (CI machine). Then it picks few Simulators (randomly) and runs tests (if Simulator is pre-installed) or installs the Simulator and then runs tests. Because `iOS 10.x` simulator can be installed on macOS Catalina, it was sometimes picked by our automation.

I added `MIN_SUPPORTED_IOS_VERSION` variable to filter out unsupported versions from test plan.

Also, I added `dump_environment()` function to print more information about the Simulators, Runtimes and Devices when automation fails. This should be handy for debugging issues like [iOS 15.0 Simulator not being visible by `xcode-install`](https://github.com/xcpretty/xcode-install/issues/444).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
