### PR TITLE
RUMM-1609 Use NTP server offset

### DIFF
--- a/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
+++ b/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
@@ -10,21 +10,41 @@ import Kronos
 /// Abstract the monotonic clock synchronized with the server using NTP.
 internal protocol ServerDateProvider {
     /// Start the clock synchronisation with NTP server.
-    /// Calls the `completion` by passing it the server time when the synchronization succeeds or`nil` if it fails.
-    func synchronize(with ntpPool: String, completion: @escaping (Date?) -> Void)
-    /// Returns the server time or `nil` if not yet determined.
-    /// This time gets more precise while synchronization is pending.
-    func currentDate() -> Date?
+    /// Calls the `completion` by passing it the server time offset when the synchronization succeeds or`nil` if it fails.
+    func synchronize(with pool: String, completion: @escaping (TimeInterval?) -> Void)
+    /// Returns the server time offset or `nil` if not yet determined.
+    /// This offset gets more precise while synchronization is pending.
+    var offset: TimeInterval? { get }
 }
 
 internal class NTPServerDateProvider: ServerDateProvider {
-    func synchronize(with ntpPool: String, completion: @escaping (Date?) -> Void) {
-        Clock.sync(from: ntpPool, completion: { serverTime, _ in
-            completion(serverTime)
-        })
+    /// Server offset publisher.
+    private let publisher: ValuePublisher<TimeInterval?> = ValuePublisher(initialValue: nil)
+
+    /// Returns the server time offset or `nil` if not yet determined.
+    /// This offset gets more precise while synchronization is pending.
+    var offset: TimeInterval? {
+        return publisher.currentValue
     }
 
-    func currentDate() -> Date? {
-        return Clock.now
+    func synchronize(with pool: String, completion: @escaping (TimeInterval?) -> Void) {
+        // Kronos only notifies for the first and last samples.
+        // In case, the last sample does not return an offset, we calculate the offset
+        // from `Clock.now`.
+        Clock.sync(
+            from: pool,
+            first: { _, offset in
+                self.publisher.publishAsync(offset)
+            },
+            completion: { now, offset in
+                if let offset = offset {
+                    self.publisher.publishAsync(offset)
+                } else if let now = now {
+                    self.publisher.publishAsync(now.timeIntervalSinceNow)
+                }
+
+                completion(self.publisher.currentValue)
+            }
+        )
     }
 }

--- a/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
+++ b/Sources/Datadog/Core/System/Time/ServerDateProvider.swift
@@ -47,5 +47,9 @@ internal class NTPServerDateProvider: ServerDateProvider {
                 completion(self?.publisher.currentValue)
             }
         )
+
+        // `Kronos.sync` first loads the previous state from the `UserDefaults` if any.
+        // We can invoke `Clock.now` to retrieve the stored offset.
+        publisher.publishAsync(Clock.now?.timeIntervalSinceNow)
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -119,7 +119,7 @@ extension Date: AnyMockable {
     }
 
     static func mockRandomInThePast() -> Date {
-        return Date(timeIntervalSinceReferenceDate: TimeInterval.random(in: 0..<Date().timeIntervalSinceReferenceDate))
+        return Date(timeIntervalSinceReferenceDate: TimeInterval.mockRandomInThePast())
     }
 
     static func mockSpecificUTCGregorianDate(year: Int, month: Int, day: Int, hour: Int, minute: Int = 0, second: Int = 0) -> Date {
@@ -286,7 +286,7 @@ extension Float: AnyMockable {
 }
 
 extension Double: AnyMockable, RandomMockable {
-    static func mockAny() -> Float {
+    static func mockAny() -> Double {
         return 0
     }
 
@@ -300,11 +300,11 @@ extension Double: AnyMockable, RandomMockable {
 }
 
 extension TimeInterval {
-    static func mockAny() -> TimeInterval {
-        return 0
-    }
-
     static let distantFuture = TimeInterval(integerLiteral: .max)
+
+    static func mockRandomInThePast() -> TimeInterval {
+        return random(in: 0..<Date().timeIntervalSinceReferenceDate)
+    }
 }
 
 struct ErrorMock: Error, CustomStringConvertible {


### PR DESCRIPTION
### What and why?

The Kronos `Clock.now` property is not thread safe and should always be invoked from the main thread, this change would have a large impact on our codebase. As an alternative, we can rely on the server time offset we get from `Clock.sync`: The `Clock.now` is in fact used by `DateCorrector` to actually compute the server offset.

Below a quick benchmark of the computed offset previously used and the server offset applied by this PR:
|Previous Computed Offset|Server Offset|
|---|---|
|**0.0537**11891174316406|**0.0537**5981330871582|
|**0.0476**3531684875488|**0.0476**7334461212158|
|**0.0457**2319984436035|**0.0457**66234397888184|
|**0.081**27260208129883|**0.081**31551742553711|
|**0.051**30136013031006|**0.051**299452781677246|
|**0.0388**5924816131592|**0.0388**74030113220215|

> Note that `Kronos.Clock.now` has a [sub-second precision](https://github.com/MobileNativeFoundation/Kronos/blob/master/Sources/TimeFreeze.swift#L69) which is reflected in the above tests.

Fix #588

### How?

The `ServerDateProvider` will now provide an `offset` time interval and its concrete implementation `NTPServerDateProvider` will retrieve that value from `Kronos.Clock.sync`.

`Clock.sync` callback is invoked on the main thread, so we  are now using a `ValuePublisher` to safely access the server time offset. 

⚠️  `Clock.sync` only notifies the first and last samples, so we are losing the intermediate offsets!

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
