### PR TITLE
RUMM-1278 RefreshRate is normalized to 0...60

### DIFF
--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -39,6 +39,8 @@ internal final class VitalInfoSampler {
 
     var refreshRate: VitalInfo {
         let info = refreshRatePublisher.currentValue
+        // NOTE: RUMM-1278 refreshRate is normalized to 0...60 range
+        // assuming 60 is the industry standard.
         return info.scaledDown(by: maximumRefreshRate / 60.0)
     }
 

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -17,6 +17,12 @@ internal protocol ContinuousVitalReader {
 }
 
 internal final class VitalInfoSampler {
+    struct Constants {
+        // We use normalized 0...60 range for refresh rate in Mobile Vitals,
+        // assuming 60 is the industry standard.
+        static let normalizedRefreshRate = 60.0
+    }
+
     private static let frequency: TimeInterval = 1.0
 
     let cpuReader: SamplingBasedVitalReader
@@ -39,9 +45,7 @@ internal final class VitalInfoSampler {
 
     var refreshRate: VitalInfo {
         let info = refreshRatePublisher.currentValue
-        // NOTE: RUMM-1278 refreshRate is normalized to 0...60 range
-        // assuming 60 is the industry standard.
-        return info.scaledDown(by: maximumRefreshRate / 60.0)
+        return info.scaledDown(by: maximumRefreshRate / Constants.normalizedRefreshRate)
     }
 
     private var timer: Timer?

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -39,7 +39,7 @@ internal final class VitalInfoSampler {
 
     var refreshRate: VitalInfo {
         let info = refreshRatePublisher.currentValue
-        return info.scaledDown(by: maximumRefreshRate)
+        return info.scaledDown(by: maximumRefreshRate / 60.0)
     }
 
     private var timer: Timer?

--- a/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
@@ -24,7 +24,7 @@ class VitalInfoSamplerTests: XCTestCase {
         mockMemoryReader.vitalData = 321.0
         mockRefreshRateReader.vitalInfo = {
             var info = VitalInfo()
-            info.addSample(666.0)
+            info.addSample(60.0)
             return info
         }()
 
@@ -38,8 +38,7 @@ class VitalInfoSamplerTests: XCTestCase {
             XCTAssertGreaterThan(sampler.cpu.sampleCount, 1)
             XCTAssertEqual(sampler.memory.meanValue, 321.0)
             XCTAssertGreaterThan(sampler.memory.sampleCount, 1)
-            let maxFPS = Double(UIScreen.main.maximumFramesPerSecond)
-            XCTAssertEqual(sampler.refreshRate.meanValue, 666.0 / maxFPS)
+            XCTAssertEqual(sampler.refreshRate.meanValue, 60.0)
         }
     }
 


### PR DESCRIPTION
### What and why?

`RefreshRate` is shown as a mobile vital in Datadog UI.
It needs to be normalized as different devices can have different maximum FPS rates.

### How?

It was normalized to 0...1, this was not consistent with other platforms.
Now it is normalized to 0...60 range, as browser and Android SDKs do.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
