### PR TITLE
Update License to be recognised by Github 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a


### PR DESCRIPTION
### What and why?

For now the License is not recognised by Github License detection, nor the Swift Package Index [page](https://swiftpackageindex.com/DataDog/dd-sdk-ios)
