### PR TITLE
Prevent iOS 15 crashes by not polling isLowPowerModeEnabled

### DIFF
--- a/Sources/Datadog/Core/System/MobileDevice.swift
+++ b/Sources/Datadog/Core/System/MobileDevice.swift
@@ -54,6 +54,7 @@ internal class MobileDevice {
 
     convenience init(uiDevice: UIDevice, processInfo: ProcessInfo) {
         let wasBatteryMonitoringEnabled = uiDevice.isBatteryMonitoringEnabled
+        let lowPowerModeMonitor = LowPowerModeMonitor(processInfo)
         self.init(
             model: uiDevice.model,
             osName: uiDevice.systemName,
@@ -64,12 +65,12 @@ internal class MobileDevice {
                 return BatteryStatus(
                     state: MobileDevice.toBatteryState(uiDevice.batteryState),
                     level: uiDevice.batteryLevel,
-                    isLowPowerModeEnabled: processInfo.isLowPowerModeEnabled
+                    isLowPowerModeEnabled: lowPowerModeMonitor.isLowPowerModeEnabled
                 )
             }
         )
     }
-
+    
     /// Returns current mobile device  if `UIDevice` is available on this platform.
     /// On other platforms returns `nil`.
     static var current: MobileDevice {
@@ -96,6 +97,32 @@ internal class MobileDevice {
         case .charging:     return .charging
         case .full:         return .full
         @unknown default:   return.unknown
+        }
+    }
+}
+
+private class LowPowerModeMonitor {
+    
+    var isLowPowerModeEnabled = false
+    private var powerStateDidChangeObserver: Any?
+    
+    init(_ processInfo: ProcessInfo) {
+        isLowPowerModeEnabled = processInfo.isLowPowerModeEnabled
+        powerStateDidChangeObserver = NotificationCenter
+            .default
+            .addObserver(forName: .NSProcessInfoPowerStateDidChange,
+                         object: nil,
+                         queue: .main) { [weak self] notification in
+                guard let processInfo = notification.object as? ProcessInfo else {
+                    return
+                }
+                self?.isLowPowerModeEnabled = processInfo.isLowPowerModeEnabled
+            }
+    }
+    
+    deinit {
+        if let observer = powerStateDidChangeObserver {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 }

--- a/Sources/Datadog/Core/System/MobileDevice.swift
+++ b/Sources/Datadog/Core/System/MobileDevice.swift
@@ -70,7 +70,6 @@ internal class MobileDevice {
             }
         )
     }
-    
     /// Returns current mobile device  if `UIDevice` is available on this platform.
     /// On other platforms returns `nil`.
     static var current: MobileDevice {
@@ -102,29 +101,26 @@ internal class MobileDevice {
 }
 
 private final class LowPowerModeMonitor {
-    
     var isLowPowerModeEnabled: Bool {
         publisher.currentValue
     }
-    
     private var publisher: ValuePublisher<Bool>
     private var powerStateDidChangeObserver: Any?
-    
     init(_ processInfo: ProcessInfo) {
         publisher = ValuePublisher(initialValue: processInfo.isLowPowerModeEnabled)
-        
         powerStateDidChangeObserver = NotificationCenter
             .default
-            .addObserver(forName: .NSProcessInfoPowerStateDidChange,
-                         object: nil,
-                         queue: .main) { [weak self] notification in
+            .addObserver(
+                forName: .NSProcessInfoPowerStateDidChange,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
                 guard let processInfo = notification.object as? ProcessInfo else {
                     return
                 }
                 self?.publisher.publishAsync(processInfo.isLowPowerModeEnabled)
             }
     }
-    
     deinit {
         if let observer = powerStateDidChangeObserver {
             NotificationCenter.default.removeObserver(observer)

--- a/Sources/Datadog/Core/System/MobileDevice.swift
+++ b/Sources/Datadog/Core/System/MobileDevice.swift
@@ -101,13 +101,18 @@ internal class MobileDevice {
     }
 }
 
-private class LowPowerModeMonitor {
+private final class LowPowerModeMonitor {
     
-    var isLowPowerModeEnabled = false
+    var isLowPowerModeEnabled: Bool {
+        publisher.currentValue
+    }
+    
+    private var publisher: ValuePublisher<Bool>
     private var powerStateDidChangeObserver: Any?
     
     init(_ processInfo: ProcessInfo) {
-        isLowPowerModeEnabled = processInfo.isLowPowerModeEnabled
+        publisher = ValuePublisher(initialValue: processInfo.isLowPowerModeEnabled)
+        
         powerStateDidChangeObserver = NotificationCenter
             .default
             .addObserver(forName: .NSProcessInfoPowerStateDidChange,
@@ -116,7 +121,7 @@ private class LowPowerModeMonitor {
                 guard let processInfo = notification.object as? ProcessInfo else {
                     return
                 }
-                self?.isLowPowerModeEnabled = processInfo.isLowPowerModeEnabled
+                self?.publisher.publishAsync(processInfo.isLowPowerModeEnabled)
             }
     }
     


### PR DESCRIPTION
### What and why?

As described in #609, iOS 15 has introduced a race condition around `ProcessInfo.isLowPowerModeEnabled`:

The conditions under which this can occur are:

1. Register to observer: `NSProcessInfoPowerStateDidChangeNotification`
2. In the observation block, query `ProcessInfo.isLowPowerModeEnabled`
3. Later on another piece of code calls `ProcessInfo.isLowPowerModeEnabled`
4. _Sometimes_ that will trigger a change in the power state which will be broadcast to observers before returning
5. The code in (2) is called which re-enters `isLowPowerModeEnabled`
6. Thread deadlock over an `os_unfair_lock` occurs and the app crashes

### How?

We introduce a `LowPowerModeMonitor` which:

1. Listens to `NSProcessInfoPowerStateDidChangeNotification`
2. On any updates it queries `ProcessInfo.isLowPowerModeEnabled` and caches the return value

`MobileDevice` retains an instance of this in the local scope and queries it instead of `ProcessInfo` locally.

This prevents us from constantly polling for new values and thus takes us out of the call stack for re-entry.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference

### Notes

This is a change in the implementation details rather than behaviour, so I've not added any additional tests
