### PR TITLE
RUMM-1668 Associate Logs and Traces with RUM Action

### DIFF
--- a/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
@@ -15,6 +15,7 @@ internal struct RUMContextIntegration {
         static let applicationID = "application_id"
         static let sessionID = "session_id"
         static let viewID = "view.id"
+        static let actionID = "user_action.id"
     }
 
     /// Returns attributes describing the current RUM context or `nil`if global `RUMMonitor` is not registered.
@@ -31,6 +32,7 @@ internal struct RUMContextIntegration {
             Attributes.applicationID: rumContext.rumApplicationID,
             Attributes.sessionID: rumContext.sessionID.rawValue.uuidString.lowercased(),
             Attributes.viewID: rumContext.activeViewID?.rawValue.uuidString.lowercased(),
+            Attributes.actionID: rumContext.activeUserActionID?.rawValue.uuidString.lowercased(),
         ]
     }
 }

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -17,18 +17,20 @@ class RUMIntegrationsTests: XCTestCase {
         // given
         Global.rum = RUMMonitor.initialize()
         Global.rum.startView(viewController: mockView)
+        Global.rum.startUserAction(type: .tap, name: .mockAny())
         defer { Global.rum = DDNoopRUMMonitor() }
 
         // then
         let attributes = try XCTUnwrap(integration.currentRUMContextAttributes)
 
-        XCTAssertEqual(attributes.count, 3)
+        XCTAssertEqual(attributes.count, 4)
         XCTAssertEqual(
             attributes["application_id"] as? String,
             try XCTUnwrap(RUMFeature.instance?.configuration.applicationID)
         )
         XCTAssertValidRumUUID(attributes["session_id"] as? String)
         XCTAssertValidRumUUID(attributes["view.id"] as? String)
+        XCTAssertValidRumUUID(attributes["user_action.id"] as? String)
     }
 
     func testGivenRUMMonitorRegistered_whenSessionIsSampled_itProvidesEmptyRUMContextAttributes() throws {

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -506,6 +506,7 @@ class LoggerTests: XCTestCase {
         let logger = Logger.builder.build()
         Global.rum = RUMMonitor.initialize()
         Global.rum.startView(viewController: mockView)
+        Global.rum.startUserAction(type: .tap, name: .mockAny())
         defer { Global.rum = DDNoopRUMMonitor() }
 
         // when
@@ -523,6 +524,10 @@ class LoggerTests: XCTestCase {
         )
         logMatcher.assertValue(
             forKeyPath: RUMContextIntegration.Attributes.viewID,
+            isTypeOf: String.self
+        )
+        logMatcher.assertValue(
+            forKeyPath: RUMContextIntegration.Attributes.actionID,
             isTypeOf: String.self
         )
     }
@@ -561,6 +566,7 @@ class LoggerTests: XCTestCase {
         logMatcher.assertNoValue(forKeyPath: RUMContextIntegration.Attributes.applicationID)
         logMatcher.assertNoValue(forKeyPath: RUMContextIntegration.Attributes.sessionID)
         logMatcher.assertNoValue(forKeyPath: RUMContextIntegration.Attributes.viewID)
+        logMatcher.assertNoValue(forKeyPath: RUMContextIntegration.Attributes.actionID)
     }
 
     func testWhenSendingErrorOrCriticalLogs_itCreatesRUMErrorForCurrentView() throws {


### PR DESCRIPTION
### What and why?

Add User Action id to shared context with Logs and Traces.

### How?

Based on [browser-sdk/#352](https://github.com/DataDog/browser-sdk/pull/352), the shared context with Logs and Traces integration now includes the `user_action.id` if an active User Action ID is present.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
