### PR TITLE
RUMM-1377 Add E2E tests for Tracing APIs

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		618715F724DC0CDE00FC0F69 /* RUMCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */; };
 		618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */; };
 		618715FC24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715FB24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift */; };
+		6187A53926FCBE240015D94A /* TracerE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6187A53826FCBE240015D94A /* TracerE2ETests.swift */; };
 		618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618C365E248E85B400520CDE /* DateFormattingTests.swift */; };
 		618D9DE7263AD78900A3FAD2 /* SpanEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618D9DE6263AD78900A3FAD2 /* SpanEventMapper.swift */; };
 		618DCFD724C7265300589570 /* RUMUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618DCFD624C7265300589570 /* RUMUUID.swift */; };
@@ -912,6 +913,7 @@
 		618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommandTests.swift; sourceTree = "<group>"; };
 		618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMapping.swift; sourceTree = "<group>"; };
 		618715FB24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMappingTests.swift; sourceTree = "<group>"; };
+		6187A53826FCBE240015D94A /* TracerE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracerE2ETests.swift; sourceTree = "<group>"; };
 		618C365E248E85B400520CDE /* DateFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingTests.swift; sourceTree = "<group>"; };
 		618D9DE6263AD78900A3FAD2 /* SpanEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanEventMapper.swift; sourceTree = "<group>"; };
 		618DCFD624C7265300589570 /* RUMUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMUUID.swift; sourceTree = "<group>"; };
@@ -2466,6 +2468,14 @@
 			path = DataModels;
 			sourceTree = "<group>";
 		};
+		6187A53726FCBDD00015D94A /* Tracing */ = {
+			isa = PBXGroup;
+			children = (
+				6187A53826FCBE240015D94A /* TracerE2ETests.swift */,
+			);
+			path = Tracing;
+			sourceTree = "<group>";
+		};
 		618C365D248E858200520CDE /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -2557,6 +2567,7 @@
 			isa = PBXGroup;
 			children = (
 				61B3BD502661224800A9BEF0 /* Logging */,
+				6187A53726FCBDD00015D94A /* Tracing */,
 				61993667265BBEDC009D7EA8 /* E2ETests.swift */,
 				6167C79226665D6900D4CF07 /* E2EUtils.swift */,
 				61216B812667CFC90089DCD1 /* Helpers */,
@@ -4264,6 +4275,7 @@
 				6167C791266636B300D4CF07 /* FoundationMocks.swift in Sources */,
 				618F984F265BC905009959F8 /* E2EConfig.swift in Sources */,
 				61216B7B2667A9AE0089DCD1 /* LoggingConfigurationE2ETests.swift in Sources */,
+				6187A53926FCBE240015D94A /* TracerE2ETests.swift in Sources */,
 				61993668265BBEDC009D7EA8 /* E2ETests.swift in Sources */,
 				61216B852667CFFE0089DCD1 /* RUME2EHelpers.swift in Sources */,
 				61216B762666DDA10089DCD1 /* LoggerBuilderE2ETests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		6182374325D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6182374225D3DFD5006A375B /* CrashReportingWithRUMIntegrationTests.swift */; };
 		6184751526EFCF1300C7C9C5 /* DatadogTestsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6184751426EFCF1300C7C9C5 /* DatadogTestsObserver.swift */; };
 		6184751826EFD03400C7C9C5 /* DatadogTestsObserverLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 6184751726EFD03400C7C9C5 /* DatadogTestsObserverLoader.m */; };
+		6185F4AE26FE1956001A7641 /* SpanE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6185F4AD26FE1956001A7641 /* SpanE2ETests.swift */; };
 		618715F724DC0CDE00FC0F69 /* RUMCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */; };
 		618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */; };
 		618715FC24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618715FB24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift */; };
@@ -910,6 +911,7 @@
 		6184751426EFCF1300C7C9C5 /* DatadogTestsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogTestsObserver.swift; sourceTree = "<group>"; };
 		6184751726EFD03400C7C9C5 /* DatadogTestsObserverLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatadogTestsObserverLoader.m; sourceTree = "<group>"; };
 		6185EB0F25FA94A700B43E2E /* Base.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.local.xcconfig; sourceTree = "<group>"; };
+		6185F4AD26FE1956001A7641 /* SpanE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanE2ETests.swift; sourceTree = "<group>"; };
 		618715F624DC0CDE00FC0F69 /* RUMCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommandTests.swift; sourceTree = "<group>"; };
 		618715F824DC13A100FC0F69 /* RUMDataModelsMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMapping.swift; sourceTree = "<group>"; };
 		618715FB24DC5F0800FC0F69 /* RUMDataModelsMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelsMappingTests.swift; sourceTree = "<group>"; };
@@ -2472,6 +2474,7 @@
 			isa = PBXGroup;
 			children = (
 				6187A53826FCBE240015D94A /* TracerE2ETests.swift */,
+				6185F4AD26FE1956001A7641 /* SpanE2ETests.swift */,
 			);
 			path = Tracing;
 			sourceTree = "<group>";
@@ -4283,6 +4286,7 @@
 				61216B842667CFF70089DCD1 /* DatadogE2EHelpers.swift in Sources */,
 				6167C79326665D6900D4CF07 /* E2EUtils.swift in Sources */,
 				610DE00E26613E990042763D /* PersistenceHelper.swift in Sources */,
+				6185F4AE26FE1956001A7641 /* SpanE2ETests.swift in Sources */,
 				61216B802667C79B0089DCD1 /* LoggingTrackingConsentE2ETests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		61441C982461A649003D8BB8 /* DebugTracingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C932461A649003D8BB8 /* DebugTracingViewController.swift */; };
 		61441C992461A649003D8BB8 /* DebugLoggingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C942461A649003D8BB8 /* DebugLoggingViewController.swift */; };
 		61441C9D2461A796003D8BB8 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C9C2461A796003D8BB8 /* AppConfiguration.swift */; };
+		6147E3B3270486920092BC9F /* TracingConfigurationE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6147E3B2270486920092BC9F /* TracingConfigurationE2ETests.swift */; };
 		614872772485067300E3EBDB /* SpanTagsReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614872762485067300E3EBDB /* SpanTagsReducer.swift */; };
 		61494CB124C839460082C633 /* RUMResourceScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB024C839460082C633 /* RUMResourceScope.swift */; };
 		61494CB524C864680082C633 /* RUMResourceScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61494CB424C864680082C633 /* RUMResourceScopeTests.swift */; };
@@ -826,6 +827,7 @@
 		61441C932461A649003D8BB8 /* DebugTracingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugTracingViewController.swift; sourceTree = "<group>"; };
 		61441C942461A649003D8BB8 /* DebugLoggingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugLoggingViewController.swift; sourceTree = "<group>"; };
 		61441C9C2461A796003D8BB8 /* AppConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
+		6147E3B2270486920092BC9F /* TracingConfigurationE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingConfigurationE2ETests.swift; sourceTree = "<group>"; };
 		614872762485067300E3EBDB /* SpanTagsReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanTagsReducer.swift; sourceTree = "<group>"; };
 		61494CB024C839460082C633 /* RUMResourceScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceScope.swift; sourceTree = "<group>"; };
 		61494CB424C864680082C633 /* RUMResourceScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMResourceScopeTests.swift; sourceTree = "<group>"; };
@@ -2473,6 +2475,7 @@
 		6187A53726FCBDD00015D94A /* Tracing */ = {
 			isa = PBXGroup;
 			children = (
+				6147E3B2270486920092BC9F /* TracingConfigurationE2ETests.swift */,
 				6187A53826FCBE240015D94A /* TracerE2ETests.swift */,
 				6185F4AD26FE1956001A7641 /* SpanE2ETests.swift */,
 			);
@@ -4286,6 +4289,7 @@
 				61216B842667CFF70089DCD1 /* DatadogE2EHelpers.swift in Sources */,
 				6167C79326665D6900D4CF07 /* E2EUtils.swift in Sources */,
 				610DE00E26613E990042763D /* PersistenceHelper.swift in Sources */,
+				6147E3B3270486920092BC9F /* TracingConfigurationE2ETests.swift in Sources */,
 				6185F4AE26FE1956001A7641 /* SpanE2ETests.swift in Sources */,
 				61216B802667C79B0089DCD1 /* LoggingTrackingConsentE2ETests.swift in Sources */,
 			);

--- a/Datadog/E2ETests/Tracing/SpanE2ETests.swift
+++ b/Datadog/E2ETests/Tracing/SpanE2ETests.swift
@@ -1,0 +1,181 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+class SpanE2ETests: E2ETests {
+    /// - api-surface: OTSpan.setOperationName(_ operationName: String)
+    ///
+    /// - data monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_set_operation_name_data
+    /// $monitor_name = "[RUM] [iOS] Nightly - trace_span_set_operation_name: number of hits is below expected value"
+    /// $monitor_query = "sum(last_1d):avg:trace.trace_span_set_operation_name.hits{service:com.datadog.ios.nightly,env:instrumentation}.as_count() < 1"
+    /// $monitor_threshold = 1
+    /// ```
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_set_operation_name_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_span_set_operation_name: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_span_set_operation_name,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_span_set_operation_name() {
+        let span = Global.sharedTracer.startSpan(operationName: .mockRandom())
+        let knownOperationName = "trace_span_set_operation_name_new_operation_name" // asserted in monitor
+
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            span.setOperationName(knownOperationName)
+        }
+
+        span.finish()
+    }
+
+    /// - api-surface: OTSpan.setTag(key: String, value: Encodable)
+    ///
+    /// - data monitor: (it uses `ios_trace_span_set_tag` metric defined in "APM > Generate Metrics > Custom Span Metrics")
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_set_tag_data
+    /// $monitor_name = "[RUM] [iOS] Nightly - trace_span_set_tag: number of hits is below expected value"
+    /// $monitor_query = "sum(last_1d):avg:ios_trace_span_set_tag.hits_with_proper_payload{*}.as_count() < 1"
+    /// $monitor_threshold = 1
+    /// ```
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_set_tag_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_span_set_tag: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_span_set_tag,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_span_set_tag() {
+        let span = Global.sharedTracer.startSpan(operationName: "ios_trace_span_set_tag")
+        let knownTag = DD.specialTag()
+
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            span.setTag(key: knownTag.key, value: knownTag.value)
+        }
+
+        span.finish()
+    }
+
+    /// - api-surface: OTSpan.setBaggageItem(key: String, value: String)
+    ///
+    /// - data monitor: (it uses `ios_trace_span_set_baggage_item` metric defined in "APM > Generate Metrics > Custom Span Metrics")
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_set_baggage_item_data
+    /// $monitor_name = "[RUM] [iOS] Nightly - trace_span_set_baggage_item: number of hits is below expected value"
+    /// $monitor_query = "sum(last_1d):avg:ios_trace_span_set_baggage_item.hits_with_proper_payload{*}.as_count() < 1"
+    /// $monitor_threshold = 1
+    /// ```
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_set_baggage_item_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_span_set_baggage_item: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_span_set_baggage_item,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_span_set_baggage_item() {
+        let span = Global.sharedTracer.startSpan(operationName: "ios_trace_span_set_baggage_item")
+        let knownTag = DD.specialTag()
+
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            span.setBaggageItem(key: knownTag.key, value: knownTag.value)
+        }
+
+        span.finish()
+    }
+
+    /// - api-surface: OTTracer.activeSpan: OTSpan?
+    ///
+    /// - data monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_set_active_data
+    /// $monitor_name = "[RUM] [iOS] Nightly - trace_span_set_active: number of hits is below expected value"
+    /// $monitor_query = "sum(last_1d):avg:trace.trace_span_set_active_measured_span.hits{service:com.datadog.ios.nightly,env:instrumentation}.as_count() < 1"
+    /// $monitor_threshold = 1
+    /// ```
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_set_active_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_span_set_active: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_span_set_active,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_span_set_active() {
+        let span = Global.sharedTracer.startSpan(operationName: "trace_span_set_active_measured_span")
+
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            span.setActive()
+        }
+
+        span.finish()
+    }
+
+    /// - api-surface: OTTracer.log(fields: [String: Encodable], timestamp: Date)
+    ///
+    /// - data monitor:
+    /// ```logs
+    /// $feature = trace
+    /// $monitor_id = trace_span_log_data
+    /// $monitor_name = "[RUM] [iOS] Nightly - trace_span_log: number of hits is below expected value"
+    /// $monitor_query = "logs(\"service:com.datadog.ios.nightly @test_method_name:trace_span_log @test_special_string_attribute:customAttribute*\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
+    /// ```
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_log_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_span_log: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_span_log,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_span_log() {
+        let span = Global.sharedTracer.startSpan(operationName: "trace_span_log_measured_span")
+        let log = DD.specialStringAttribute()
+
+        var fields = DD.logAttributes()
+        fields[log.key] = log.value
+
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            span.log(fields: fields)
+        }
+
+        span.finish()
+    }
+
+    /// - api-surface: OTTracer.finish(at time: Date)
+    ///
+    /// - data monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_finish_data
+    /// $monitor_name = "[RUM] [iOS] Nightly - trace_span_finish: number of hits is below expected value"
+    /// $monitor_query = "sum(last_1d):avg:trace.trace_span_finish_measured_span.hits{service:com.datadog.ios.nightly,env:instrumentation}.as_count() < 1"
+    /// $monitor_threshold = 1
+    /// ```
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_span_finish_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_span_finish: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_span_finish,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_span_finish() {
+        let span = Global.sharedTracer.startSpan(operationName: "trace_span_finish_measured_span")
+
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            span.finish()
+        }
+    }
+}

--- a/Datadog/E2ETests/Tracing/TracerE2ETests.swift
+++ b/Datadog/E2ETests/Tracing/TracerE2ETests.swift
@@ -1,0 +1,84 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+class TracerE2ETests: E2ETests {
+    private var tracer: OTTracer! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        tracer = Tracer.initialize(configuration: .init())
+    }
+
+    override func tearDown() {
+        tracer = nil
+        super.tearDown()
+    }
+
+    /// - api-surface: OTTracer.startSpan(operationName: String,references: [OTReference]?,tags: [String: Encodable]?,startTime: Date?) -> OTSpan
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_tracer_start_span_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_tracer_start_span: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_tracer_start_span,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_tracer_start_span() {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            _ = tracer.startSpan(operationName: .mockRandom()) // this span is never sent
+        }
+    }
+
+    /// - api-surface: OTTracer.startRootSpan(operationName: String,tags: [String: Encodable]?,startTime: Date?) -> OTSpan
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_tracer_start_root_span_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_tracer_start_root_span: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_tracer_start_root_span,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_tracer_start_root_span() {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            _ = tracer.startRootSpan(operationName: .mockRandom()) // this span is never sent
+        }
+    }
+
+    /// - api-surface: OTTracer.inject(spanContext: OTSpanContext, writer: OTFormatWriter)
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_tracer_inject_span_context_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_tracer_inject_span_context: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_tracer_inject_span_context,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_tracer_inject_span_context() {
+        let anySpan = tracer.startSpan(operationName: .mockRandom()) // this span is never sent
+        let anyWriter = HTTPHeadersWriter()
+
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            tracer.inject(spanContext: anySpan.context, writer: anyWriter)
+        }
+    }
+
+    /// - api-surface: OTTracer.activeSpan: OTSpan?
+    ///
+    /// - performance monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_tracer_active_span_performance
+    /// $monitor_name = "[RUM] [iOS] Nightly Performance - trace_tracer_active_span: has a high average execution time"
+    /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:trace_tracer_active_span,service:com.datadog.ios.nightly} > 0.024"
+    /// ```
+    func test_trace_tracer_active_span() {
+        measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
+            _ = tracer.activeSpan
+        }
+    }
+}

--- a/Datadog/E2ETests/Tracing/TracingConfigurationE2ETests.swift
+++ b/Datadog/E2ETests/Tracing/TracingConfigurationE2ETests.swift
@@ -1,0 +1,66 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Datadog
+
+class TracingConfigurationE2ETests: E2ETests {
+    override func setUp() {
+        skipSDKInitialization = true // we will initialize it in each test
+        super.setUp()
+    }
+
+    /// - api-surface: Datadog.Configuration.Builder.enableTracing(_ enabled: Bool) -> Builder
+    ///
+    /// - data monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_config_feature_enabled_data
+    /// $monitor_name = "[RUM] [iOS] Nightly - trace_config_feature_enabled: number of hits is below expected value"
+    /// $monitor_query = "sum(last_1d):avg:trace.trace_config_feature_enabled_observed_span.hits{service:com.datadog.ios.nightly,env:instrumentation}.as_count() < 1"
+    /// $monitor_threshold = 1
+    /// ```
+    func test_trace_config_feature_enabled() {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(
+                trackingConsent: .granted,
+                configuration: Datadog.Configuration.builderUsingE2EConfig()
+                    .enableLogging(true)
+                    .enableTracing(true)
+                    .enableRUM(true)
+                    .build()
+            )
+        }
+
+        let span = Global.sharedTracer.startRootSpan(operationName: "trace_config_feature_enabled_observed_span")
+        span.finish()
+    }
+
+    /// - api-surface: Datadog.Configuration.Builder.enableTracing(_ enabled: Bool) -> Builder
+    ///
+    /// - data monitor:
+    /// ```apm
+    /// $feature = trace
+    /// $monitor_id = trace_config_feature_disabled_data
+    /// $monitor_name = "[RUM] [iOS] Nightly - trace_config_feature_disabled: number of hits is below expected value"
+    /// $monitor_query = "sum(last_1d):avg:trace.trace_config_feature_disabled_observed_span.hits{service:com.datadog.ios.nightly,env:instrumentation}.as_count() > 0"
+    /// $monitor_threshold = 0
+    /// ```
+    func test_trace_config_feature_disabled() {
+        measure(resourceName: DD.PerfSpanName.sdkInitialize) {
+            initializeSDK(
+                trackingConsent: .granted,
+                configuration: Datadog.Configuration.builderUsingE2EConfig()
+                    .enableLogging(true)
+                    .enableTracing(true)
+                    .enableRUM(true)
+                    .build()
+            )
+        }
+
+        let span = Global.sharedTracer.startRootSpan(operationName: "test_trace_config_feature_disabled_observed_span")
+        span.finish()
+    }
+}

--- a/tools/nightly-e2e-tests/monitors-gen/templates/monitor-logs.tf.src
+++ b/tools/nightly-e2e-tests/monitors-gen/templates/monitor-logs.tf.src
@@ -1,7 +1,7 @@
 resource "datadog_monitor" ${{monitor_id}} {
   name               = ${{monitor_name}}
   type               = "log alert"
-  tags               = ["service:com.datadog.ios.nightly", "env:instrumentation", "team:rumm", "source:ios", "feature:logs", "monitor:behavior"]
+  tags               = ["service:com.datadog.ios.nightly", "env:instrumentation", "team:rumm", "source:ios", "feature:${{feature:-logs}}", "monitor:behavior"]
   message            = <<EOT
 @maciek.grzybowski@datadoghq.com
 @mert.buran@datadoghq.com

--- a/tools/nightly-e2e-tests/src/lint.py
+++ b/tools/nightly-e2e-tests/src/lint.py
@@ -21,7 +21,7 @@ def lint_test_methods(test_methods: [TestMethod]):
                         __monitor_id_has_method_name_prefix(
                             monitor=monitor, tested_method_name=tested_method_name
                         )
-                        __method_name_occurs_in_monitor_name_and_query(
+                        __method_name_occurs_in_monitor_name(
                             monitor=monitor, tested_method_name=tested_method_name
                         )
             elif not __is_excluded_from_lint(method=test_method):
@@ -48,9 +48,9 @@ def __monitor_id_has_method_name_prefix(monitor: MonitorConfiguration, tested_me
                 Linter.shared.emit_error(f'$monitor_id must start with method name ({tested_method_name})')
 
 
-def __method_name_occurs_in_monitor_name_and_query(monitor: MonitorConfiguration, tested_method_name: str):
+def __method_name_occurs_in_monitor_name(monitor: MonitorConfiguration, tested_method_name: str):
     """
-    The test method name must occur in $monitor_name and $monitor_query.
+    The test method name must occur in $monitor_name.
     """
     regex = re.compile(rf"^.*(\W+){tested_method_name}(\W+).*$")
 
@@ -58,10 +58,6 @@ def __method_name_occurs_in_monitor_name_and_query(monitor: MonitorConfiguration
         if not re.match(regex, monitor_name_variable.value):
             with linter_context(code_reference=monitor_name_variable.code_reference):
                 Linter.shared.emit_warning(f'$monitor_name must include method name ({tested_method_name})')
-    if monitor_query_variable := __find_monitor_variable(monitor=monitor, variable_name='$monitor_query'):
-        if not re.match(regex, monitor_query_variable.value):
-            with linter_context(code_reference=monitor_query_variable.code_reference):
-                Linter.shared.emit_warning(f'$monitor_query must include method name ({tested_method_name})')
 
 
 def lint_monitors(monitors: [MonitorConfiguration]):

--- a/tools/nightly-e2e-tests/src/lint.py
+++ b/tools/nightly-e2e-tests/src/lint.py
@@ -68,6 +68,7 @@ def lint_monitors(monitors: [MonitorConfiguration]):
     __have_unique_variable_values(monitors=monitors, variable_name='$monitor_id')
     __have_unique_variable_values(monitors=monitors, variable_name='$monitor_name')
     __have_unique_variable_values(monitors=monitors, variable_name='$monitor_query')
+    __feature_variable_has_allowed_value(monitors=monitors)
 
 
 def __have_unique_variable_values(monitors: [MonitorConfiguration], variable_name: str):
@@ -90,7 +91,19 @@ def __have_unique_variable_values(monitors: [MonitorConfiguration], variable_nam
                     Linter.shared.emit_error(f'{variable_name} must be unique - {occurrence.value} is already used.')
 
 
-def __find_monitor_variable(monitor: MonitorConfiguration, variable_name: str):
+def __feature_variable_has_allowed_value(monitors: [MonitorConfiguration]):
+    """
+    Checks if `$feature` variable is one of allowed values. Skips if this variable is not defined.
+    """
+    allowed_values = ['core', 'logs', 'trace', 'rum', 'crash']
+    for monitor in monitors:
+        if variable := __find_monitor_variable(monitor=monitor, variable_name='$feature'):
+            if variable.value not in allowed_values:
+                with linter_context(code_reference=variable.code_reference):
+                    Linter.shared.emit_error(f'$feature must be one of: {allowed_values}')
+
+
+def __find_monitor_variable(monitor: MonitorConfiguration, variable_name: str) -> MonitorVariable:
     return next((v for v in monitor.variables if v.name == variable_name), None)
 
 


### PR DESCRIPTION
### What and why?

📦 This PR adds E2E tests and their monitor definitions for Tracing product.

### How?

Added tests with their monitors (`terraform plan` works fine). I haven't yet updated monitors in Mobile Integration org - that needs to be done after merge otherwise they will have no data.

I also added two changes to E2E tests linter:
* it now checks if `$feature` variable is one of allowed values (`core`, `logs`, `trace`, `rum`, `crash`),
* it no longer checks if `$monitor_query` contains the test method name (the way we set up some monitors was not compatible with this rule).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
