### PR TITLE
RUMM-1200 Remove Carthage workaround for missing `arm64` slice in PLCR's xcframework

### DIFF
--- a/Datadog/TargetSupport/DatadogCrashReporting/DatadogCrashReporting.xcconfig
+++ b/Datadog/TargetSupport/DatadogCrashReporting/DatadogCrashReporting.xcconfig
@@ -3,30 +3,3 @@
 
 // Include base config
 #include "../xcconfigs/Base.xcconfig"
-
-// This setting adjusts `DatadogCrashReporting.xcframework` simulator slices produced
-// by `carthage update --use-xcframeworks` when installing the SDK so it can link
-// its dependencies properly with `ld` (`CrashReporter.xcframework` and `Datadog.xcframework`).
-//
-// `CrashReporter.xcframework` built from sources produces `ios-i386_x86_64-simulator` slice.
-// As mentioned in its `1.8.0` release note, it does not contain the `arm64` architecture.
-//
-// To ensure that `carthage update --use-xcframeworks` links resultant xcframeworks with no error
-// for simulator builds, the resultant slice for `DatadogCrashReporting.xcframework` must be a subset of the
-// architectures defined for its dependencies:
-// - CrashReporter.xcframework - `ios_i386_x86_64-simulator`
-// - Datadog.xcframework - `ios-arm64_x86_64-simulator`
-// - Kronos.xcframework - `ios-arm64_i386_x86_64-simulator`
-// 
-// The only subset of dependant slices is `ios_x86_64-simulator` and this is what we're enforcing here.
-// 
-// Without this adjustment excluding `arm64-simulator` the `ld` will fail for `carthage update --use-xcframeworks` 
-// as it will not find the `arm64` architecture in `CrashReporter.xcframework` slice.
-//
-// Note: this is only problematic when `carthage update --use-xcframeworks` builds `CrashReporter.xcframework` from source
-// and should not be an issue once pre-build xcframeworks support is added to Carthage: https://github.com/Carthage/Carthage/pull/3123
-// However, carthage always falls back to build from source if it can't download pre-build binaries, so this adjustment
-// will be still required.
-//
-ARCHS[sdk=iphonesimulator*] = x86_64
-ARCHS[sdk=iphoneos*] = $(ARCHS_STANDARD)

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,8 @@ define DD_SDK_BASE_XCCONFIG
 // - DD_SDK_COMPILED_FOR_TESTING - conditions the SDK code compiled for testing\n
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) DD_SDK_ENABLE_INTERNAL_MONITORING DD_SDK_COMPILED_FOR_TESTING\n
 \n
-// To build only active architecture for all configurations.\n
-// TODO: RUMM-1200 We can perhaps remove this fix when carthage supports pre-build xcframeworks.\n
-//		 The only "problematic" dependency is `CrashReporter.xcframework` which doesn't produce\n
-//		 the `arm64-simulator` architecture when compiled from source. Its pre-build `CrashReporter.xcframework`\n
-//		 available since `1.8.0` contains the `ios-arm64_i386_x86_64-simulator` slice and should link fine in all configurations.\n
+// To build only active architecture for all configurations. This gives us ~10% build time gain\n
+// in targets which do not use 'Debug' configuration.\n
 ONLY_ACTIVE_ARCH = YES\n
 endef
 export DD_SDK_BASE_XCCONFIG


### PR DESCRIPTION
### What and why?

📦 This PR removes workaround added in early development of `DatadogCrashReporting` when `PLCR's` xcframework (`1.8.0`) was missing the `arm64-simulator` slice.

The recent version of `PLCR's` xcframework (`1.10.0`) includes the missing slice, so this workaround is not needed anymore. It also means that now all targets in `Datadog.xcworkspace` can be compiled on Apple Silicon.

### How?

Made necessary updates in `xcconfigs`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
