### PR TITLE
RUMM-1394 Add more verbosity to flaky test errors

### DIFF
--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
@@ -94,9 +94,11 @@ class DDURLSessionDelegateTests: XCTestCase {
 
         // When
         let taskWithURL = session.dataTask(with: URL.mockAny())
+        taskWithURL.taskDescription = "taskWithURL"
         taskWithURL.resume()
 
         let taskWithURLRequest = session.dataTask(with: URLRequest(url: .mockAny()))
+        taskWithURLRequest.taskDescription = "taskWithURLRequest"
         taskWithURLRequest.resume()
 
         // Then
@@ -104,16 +106,16 @@ class DDURLSessionDelegateTests: XCTestCase {
         _ = server.waitAndReturnRequests(count: 1)
 
         let dateAfterAllRequests = Date()
-        XCTAssertTrue(interceptor.taskMetrics[0].task === taskWithURL)
+        AssertURLSessionTasksIdentical(interceptor.taskMetrics[0].task, taskWithURL)
         XCTAssertGreaterThan(interceptor.taskMetrics[0].metrics.taskInterval.start, dateBeforeAnyRequests)
         XCTAssertLessThan(interceptor.taskMetrics[0].metrics.taskInterval.end, dateAfterAllRequests)
-        XCTAssertTrue(interceptor.tasksCompleted[0].task === taskWithURL)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[0].task, taskWithURL)
         XCTAssertEqual((interceptor.tasksCompleted[0].error! as NSError).localizedDescription, "some error")
 
-        XCTAssertTrue(interceptor.taskMetrics[1].task === taskWithURLRequest)
+        AssertURLSessionTasksIdentical(interceptor.taskMetrics[1].task, taskWithURLRequest)
         XCTAssertGreaterThan(interceptor.taskMetrics[1].metrics.taskInterval.start, dateBeforeAnyRequests)
         XCTAssertLessThan(interceptor.taskMetrics[1].metrics.taskInterval.end, dateAfterAllRequests)
-        XCTAssertTrue(interceptor.tasksCompleted[1].task === taskWithURLRequest)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[1].task, taskWithURLRequest)
         XCTAssertEqual((interceptor.tasksCompleted[1].error! as NSError).localizedDescription, "some error")
 
         XCTAssertEqual(interceptor.tasksReceivedData.count, 0, "When tasks complete with failure, they should not receive data")
@@ -141,9 +143,11 @@ class DDURLSessionDelegateTests: XCTestCase {
 
         // When
         let taskWithURL = session.dataTask(with: URL.mockAny())
+        taskWithURL.taskDescription = "taskWithURL"
         taskWithURL.resume()
 
         let taskWithURLRequest = session.dataTask(with: URLRequest(url: .mockAny()))
+        taskWithURLRequest.taskDescription = "taskWithURLRequest"
         taskWithURLRequest.resume()
 
         // Then
@@ -151,20 +155,20 @@ class DDURLSessionDelegateTests: XCTestCase {
         _ = server.waitAndReturnRequests(count: 1)
 
         let dateAfterAllRequests = Date()
-        XCTAssertTrue(interceptor.taskMetrics[0].task === taskWithURL)
+        AssertURLSessionTasksIdentical(interceptor.taskMetrics[0].task, taskWithURL)
         XCTAssertGreaterThan(interceptor.taskMetrics[0].metrics.taskInterval.start, dateBeforeAnyRequests)
         XCTAssertLessThan(interceptor.taskMetrics[0].metrics.taskInterval.end, dateAfterAllRequests)
-        XCTAssertTrue(interceptor.tasksCompleted[0].task === taskWithURL)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[0].task, taskWithURL)
         XCTAssertNil(interceptor.tasksCompleted[0].error)
-        XCTAssertTrue(interceptor.tasksReceivedData[0].task === taskWithURL)
+        AssertURLSessionTasksIdentical(interceptor.tasksReceivedData[0].task, taskWithURL)
         XCTAssertEqual(interceptor.tasksReceivedData[0].data, randomData)
 
-        XCTAssertTrue(interceptor.taskMetrics[1].task === taskWithURLRequest)
+        AssertURLSessionTasksIdentical(interceptor.taskMetrics[1].task, taskWithURLRequest)
         XCTAssertGreaterThan(interceptor.taskMetrics[1].metrics.taskInterval.start, dateBeforeAnyRequests)
         XCTAssertLessThan(interceptor.taskMetrics[1].metrics.taskInterval.end, dateAfterAllRequests)
-        XCTAssertTrue(interceptor.tasksCompleted[1].task === taskWithURLRequest)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[1].task, taskWithURLRequest)
         XCTAssertNil(interceptor.tasksCompleted[1].error)
-        XCTAssertTrue(interceptor.tasksReceivedData[1].task === taskWithURLRequest)
+        AssertURLSessionTasksIdentical(interceptor.tasksReceivedData[1].task, taskWithURLRequest)
         XCTAssertEqual(interceptor.tasksReceivedData[1].data, randomData)
     }
 }

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -262,6 +262,7 @@ class URLSessionSwizzlerTests: XCTestCase {
             XCTAssertNil(error)
             completionHandlersCalled.fulfill()
         }
+        taskWithURLRequestAndCompletion.taskDescription = "taskWithURLRequestAndCompletion"
         taskWithURLRequestAndCompletion.resume()
 
         let taskWithURLAndCompletion = session.dataTask(with: URL.mockAny()) { data, response, error in
@@ -270,12 +271,15 @@ class URLSessionSwizzlerTests: XCTestCase {
             XCTAssertNil(error)
             completionHandlersCalled.fulfill()
         }
+        taskWithURLAndCompletion.taskDescription = "taskWithURLAndCompletion"
         taskWithURLAndCompletion.resume()
 
         let taskWithURLRequest = session.dataTask(with: URLRequest(url: .mockAny()))
+        taskWithURLRequest.taskDescription = "taskWithURLRequest"
         taskWithURLRequest.resume()
 
         let taskWithURL = session.dataTask(with: URL.mockAny())
+        taskWithURL.taskDescription = "taskWithURL"
         taskWithURL.resume()
 
         // Then
@@ -285,23 +289,23 @@ class URLSessionSwizzlerTests: XCTestCase {
         XCTAssertEqual(interceptor.tasksCreated.count, 4, "Interceptor should record all 4 tasks created.")
         XCTAssertEqual(interceptor.tasksCompleted.count, 4, "Interceptor should record all 4 tasks completed.")
 
-        XCTAssertTrue(interceptor.tasksCreated[0] === taskWithURLRequestAndCompletion)
-        XCTAssertTrue(interceptor.tasksCompleted[0].task === taskWithURLRequestAndCompletion)
+        AssertURLSessionTasksIdentical(interceptor.tasksCreated[0], taskWithURLRequestAndCompletion)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[0].task, taskWithURLRequestAndCompletion)
         XCTAssertNil(interceptor.tasksCompleted[0].error)
         XCTAssertEqual(interceptor.tasksReceivedData[0].data, expectedData)
 
-        XCTAssertTrue(interceptor.tasksCreated[1] === taskWithURLAndCompletion)
-        XCTAssertTrue(interceptor.tasksCompleted[1].task === taskWithURLAndCompletion)
+        AssertURLSessionTasksIdentical(interceptor.tasksCreated[1], taskWithURLAndCompletion)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[1].task, taskWithURLAndCompletion)
         XCTAssertNil(interceptor.tasksCompleted[1].error)
         XCTAssertEqual(interceptor.tasksReceivedData[1].data, expectedData)
 
-        XCTAssertTrue(interceptor.tasksCreated[2] === taskWithURLRequest)
-        XCTAssertTrue(interceptor.tasksCompleted[2].task === taskWithURLRequest)
+        AssertURLSessionTasksIdentical(interceptor.tasksCreated[2], taskWithURLRequest)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[2].task, taskWithURLRequest)
         XCTAssertNil(interceptor.tasksCompleted[2].error)
         XCTAssertEqual(interceptor.tasksReceivedData[2].data, expectedData)
 
-        XCTAssertTrue(interceptor.tasksCreated[3] === taskWithURL)
-        XCTAssertTrue(interceptor.tasksCompleted[3].task === taskWithURL)
+        AssertURLSessionTasksIdentical(interceptor.tasksCreated[3], taskWithURL)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[3].task, taskWithURL)
         XCTAssertNil(interceptor.tasksCompleted[3].error)
         XCTAssertEqual(interceptor.tasksReceivedData[3].data, expectedData)
     }
@@ -329,6 +333,7 @@ class URLSessionSwizzlerTests: XCTestCase {
             XCTAssertEqual((error! as NSError).localizedDescription, "some error")
             completionHandlersCalled.fulfill()
         }
+        taskWithURLRequestAndCompletion.taskDescription = "taskWithURLRequestAndCompletion"
         taskWithURLRequestAndCompletion.resume()
 
         let taskWithURLAndCompletion = session.dataTask(with: URL.mockAny()) { data, response, error in
@@ -337,12 +342,15 @@ class URLSessionSwizzlerTests: XCTestCase {
             XCTAssertEqual((error! as NSError).localizedDescription, "some error")
             completionHandlersCalled.fulfill()
         }
+        taskWithURLAndCompletion.taskDescription = "taskWithURLAndCompletion"
         taskWithURLAndCompletion.resume()
 
         let taskWithURLRequest = session.dataTask(with: URLRequest(url: .mockAny()))
+        taskWithURLRequest.taskDescription = "taskWithURLRequest"
         taskWithURLRequest.resume()
 
         let taskWithURL = session.dataTask(with: URL.mockAny())
+        taskWithURL.taskDescription = "taskWithURL"
         taskWithURL.resume()
 
         // Then
@@ -352,20 +360,20 @@ class URLSessionSwizzlerTests: XCTestCase {
         XCTAssertEqual(interceptor.tasksCreated.count, 4, "Interceptor should record all 4 tasks created.")
         XCTAssertEqual(interceptor.tasksCompleted.count, 4, "Interceptor should record all 4 tasks completed.")
 
-        XCTAssertTrue(interceptor.tasksCreated[0] === taskWithURLRequestAndCompletion)
-        XCTAssertTrue(interceptor.tasksCompleted[0].task === taskWithURLRequestAndCompletion)
+        AssertURLSessionTasksIdentical(interceptor.tasksCreated[0], taskWithURLRequestAndCompletion)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[0].task, taskWithURLRequestAndCompletion)
         XCTAssertEqual((interceptor.tasksCompleted[0].error! as NSError).localizedDescription, "some error")
 
-        XCTAssertTrue(interceptor.tasksCreated[1] === taskWithURLAndCompletion)
-        XCTAssertTrue(interceptor.tasksCompleted[1].task === taskWithURLAndCompletion)
+        AssertURLSessionTasksIdentical(interceptor.tasksCreated[1], taskWithURLAndCompletion)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[1].task, taskWithURLAndCompletion)
         XCTAssertEqual((interceptor.tasksCompleted[1].error! as NSError).localizedDescription, "some error")
 
-        XCTAssertTrue(interceptor.tasksCreated[2] === taskWithURLRequest)
-        XCTAssertTrue(interceptor.tasksCompleted[2].task === taskWithURLRequest)
+        AssertURLSessionTasksIdentical(interceptor.tasksCreated[2], taskWithURLRequest)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[2].task, taskWithURLRequest)
         XCTAssertEqual((interceptor.tasksCompleted[2].error! as NSError).localizedDescription, "some error")
 
-        XCTAssertTrue(interceptor.tasksCreated[3] === taskWithURL)
-        XCTAssertTrue(interceptor.tasksCompleted[3].task === taskWithURL)
+        AssertURLSessionTasksIdentical(interceptor.tasksCreated[3], taskWithURL)
+        AssertURLSessionTasksIdentical(interceptor.tasksCompleted[3].task, taskWithURL)
         XCTAssertEqual((interceptor.tasksCompleted[3].error! as NSError).localizedDescription, "some error")
 
         XCTAssertEqual(interceptor.tasksReceivedData.count, 0, "When tasks complete with failure, they should not receive data")

--- a/Tests/DatadogTests/Helpers/SwiftExtensions.swift
+++ b/Tests/DatadogTests/Helpers/SwiftExtensions.swift
@@ -92,6 +92,76 @@ extension URLRequest {
         request.setValue(nil, forHTTPHeaderField: httpHeaderField)
         return request
     }
+
+    func dump() -> String {
+        var headersDump: String = ""
+        var bodyDump: String = ""
+
+        if let allHTTPHeaderFields = self.allHTTPHeaderFields {
+            if allHTTPHeaderFields.isEmpty {
+                headersDump = "[]"
+            } else {
+                headersDump = "\n"
+                allHTTPHeaderFields.forEach { field, value in
+                    headersDump += "'\(field): \(value)'\n"
+                }
+            }
+        } else {
+            headersDump = "<nil>"
+        }
+
+        if let httpBody = self.httpBody {
+            bodyDump = "'''"
+            bodyDump += String(data: httpBody, encoding: .utf8) ?? "<invalid>"
+            bodyDump += "\n'''"
+        } else {
+            bodyDump = "<nil>"
+        }
+
+        return """
+        URLRequest:
+        - url: '\(self.url?.absoluteString ?? "<nil>")'
+        - headers:
+        \(headersDump)
+        - body:
+        \(bodyDump)
+        """
+    }
+}
+
+extension URLSessionTask.State {
+    func dump() -> String {
+        switch self {
+        case .running: return "running"
+        case .suspended: return "suspended"
+        case .canceling: return "canceling"
+        case .completed: return "completed"
+        @unknown default: return "unknown"
+        }
+    }
+}
+
+extension URLSessionTask {
+    func dump() -> String {
+        func indent(string: String, by prefix: String) -> String {
+            return string
+                .split(separator: "\n")
+                .map { prefix + $0 }
+                .joined(separator: "\n")
+        }
+
+        return """
+        URLSessionTask:
+        - taskIdentifier: '\(self.taskIdentifier)'
+        - taskDescription: '\(self.taskDescription ?? "<nil>")'
+        - debugDescription: '\(self.debugDescription)'
+        - state: '\(self.state.dump())'
+        - originalRequest:
+        \(indent(string: self.originalRequest?.dump() ?? "<nil>", by: "   "))
+        - currentRequest:
+        \(indent(string: self.currentRequest?.dump() ?? "<nil>", by: "   "))
+        """
+    }
 }
 
 /// Combines two arrays together, e.g. `["a", "b"].combined(with: [1, 2, 3])` gives

--- a/Tests/DatadogTests/Helpers/XCTestCase.swift
+++ b/Tests/DatadogTests/Helpers/XCTestCase.swift
@@ -148,9 +148,8 @@ extension XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        XCTAssertIdentical(
-            actualTask,
-            expectedTask,
+        XCTAssertTrue(
+            actualTask === expectedTask,
             """
             Both tasks must be identical ('===').
 

--- a/Tests/DatadogTests/Helpers/XCTestCase.swift
+++ b/Tests/DatadogTests/Helpers/XCTestCase.swift
@@ -141,4 +141,27 @@ extension XCTestCase {
         let value2JSONString = encodedValue2.utf8String
         XCTAssertEqual(value1JSONString, value2JSONString, file: file, line: line)
     }
+
+    func AssertURLSessionTasksIdentical(
+        _ actualTask: URLSessionTask,
+        _ expectedTask: URLSessionTask,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertIdentical(
+            actualTask,
+            expectedTask,
+            """
+            Both tasks must be identical ('===').
+
+            Actual task:
+            \(actualTask.dump())
+
+            Expected task:
+            \(expectedTask.dump())
+            """,
+            file: file,
+            line: line
+        )
+    }
 }


### PR DESCRIPTION
### What and why?

📦 This PR adds a bit more verbosity to errors which we capture in flaky tests. 

Looking at last `7d`, we got 11 failures in nightly tests:
<img width="1141" alt="Screenshot 2021-10-01 at 17 42 37" src="https://user-images.githubusercontent.com/2358722/135649221-fdf8dbab-a8c2-44e9-842a-9aa19d8cf73d.png">

Unfortunately, the error messages are not handy in troubleshooting:

<img width="829" alt="Screenshot 2021-10-01 at 17 44 45" src="https://user-images.githubusercontent.com/2358722/135649324-8e84db2b-5e34-4c32-b11c-937e43af1b87.png">

As I couldn't reproduce these failures locally (in exactly the same OS + simulator setup and with `dd-swift-testing` instrumentation enabled), I propose to first add more verbosity in this PR, and collect more data in CI App.

### How?

I improved the way we compare two task instances. Instead of:
```swift
XCTAssertTrue(actualTask === expectedTask)
```
now it uses a helper method:
```swift
AssertURLSessionTasksIdentical(actualTask, expectedTask)
```
which dumps additional information about the `lhs` and `rhs` tasks if they are not identical, e.g:

<img width="1135" alt="Screenshot 2021-10-01 at 17 48 41" src="https://user-images.githubusercontent.com/2358722/135649905-6ea9f33a-8e65-4778-9335-327170c9ba99.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
