### PR TITLE
RUMM-1691 Reduce utilization of `CTTelephonyNetworkInfo` to mitigate `CarrierInfoProvider` crash

### DIFF
--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="wle-IX-rUl">
-                            <rect key="frame" x="0.0" y="223.00000034679067" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="241" width="414" height="0.0"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         </view>
@@ -26,7 +26,7 @@
                             <tableViewSection headerTitle="Debug features:" id="tgY-ka-MYv">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="xoO-Hn-N29" style="IBUITableViewCellStyleDefault" id="2Id-yJ-iEw">
-                                        <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2Id-yJ-iEw" id="wdg-my-MT5">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -46,7 +46,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="NMa-2j-8ux" style="IBUITableViewCellStyleDefault" id="xsC-bs-aKd">
-                                        <rect key="frame" x="0.0" y="68" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="88" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xsC-bs-aKd" id="M0h-rT-0mQ">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -66,7 +66,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="yCu-pq-IYL" style="IBUITableViewCellStyleDefault" id="3G8-Wa-fSQ">
-                                        <rect key="frame" x="0.0" y="111.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="131.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3G8-Wa-fSQ" id="7IJ-XI-RAR">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -86,7 +86,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="rh1-Lx-HwO" style="IBUITableViewCellStyleDefault" id="cuG-eI-g1N">
-                                        <rect key="frame" x="0.0" y="155" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="175" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cuG-eI-g1N" id="GVN-Oe-gtW">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -300,28 +300,74 @@
                                             <constraint firstAttribute="height" constant="44" id="qZn-EW-PqZ"/>
                                         </constraints>
                                     </stackView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rlt-GG-uem" userLabel="Vertical gap 10">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ghm-SJ-eBQ" userLabel="Vertical gap 10">
                                         <rect key="frame" x="0.0" y="251" width="384" height="10"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="10" id="d0W-7M-BGO"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="STRESS TESTING:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hVf-hM-tBK">
+                                        <rect key="frame" x="0.0" y="261" width="384" height="13.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                        <color key="textColor" systemColor="systemGrayColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VDB-9q-Bc1" userLabel="Vertical gap 5">
+                                        <rect key="frame" x="0.0" y="274.5" width="384" height="5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="5" id="ObB-P8-mKh"/>
+                                        </constraints>
+                                    </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="l6y-hy-nRu">
+                                        <rect key="frame" x="0.0" y="279.5" width="384" height="44"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="n8y-PP-kzI">
+                                                <rect key="frame" x="0.0" y="0.0" width="384" height="44"/>
+                                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <state key="normal" title="Keep sending ~500 logs/s for 10s">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="7"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="didTapStressTest:" destination="BYZ-38-t0r" eventType="touchUpInside" id="SzO-9c-7v5"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="VgF-xP-icc"/>
+                                        </constraints>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rlt-GG-uem" userLabel="Vertical gap 10">
+                                        <rect key="frame" x="0.0" y="323.5" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="oUy-Tr-5NI"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONSOLE OUTPUT:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x1i-in-lYX">
-                                        <rect key="frame" x="0.0" y="261" width="384" height="13.5"/>
+                                        <rect key="frame" x="0.0" y="333.5" width="384" height="13.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                         <color key="textColor" systemColor="systemGrayColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MU9-DG-sTJ" userLabel="Vertical gap 10">
-                                        <rect key="frame" x="0.0" y="274.5" width="384" height="10"/>
+                                        <rect key="frame" x="0.0" y="347" width="384" height="10"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="P0L-Pu-XZ9"/>
                                         </constraints>
                                     </view>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2G0-OF-tGX">
-                                        <rect key="frame" x="0.0" y="284.5" width="384" height="459.5"/>
+                                        <rect key="frame" x="0.0" y="357" width="384" height="387"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <color key="textColor" systemColor="systemGrayColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
@@ -347,6 +393,7 @@
                         <outlet property="logServiceNameTextField" destination="fGc-5E-uEZ" id="15I-2q-gUt"/>
                         <outlet property="send10xButton" destination="u78-T2-8Dx" id="EK9-y6-WQK"/>
                         <outlet property="sendOnceButton" destination="gtC-h0-4xC" id="9Cc-de-Und"/>
+                        <outlet property="stressTestButton" destination="n8y-PP-kzI" id="tKj-cc-sV9"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -66,87 +66,144 @@ extension CarrierInfo.RadioAccessTechnology {
     }
 }
 
-/// An interface for the target-specific carrier info provider.
-internal protocol WrappedCarrierInfoProvider {
-    var current: CarrierInfo? { get }
-}
-
+/// Platform-agnostic carrier info provider. It wraps the platform-specific provider inside.
 internal class CarrierInfoProvider: CarrierInfoProviderType {
     /// The `CarrierInfo` provider for the current platform.
-    private let wrappedProvider: WrappedCarrierInfoProvider
-    /// Publisher for notifying observers on `CarrierInfo` change.
-    private let publisher: ValuePublisher<CarrierInfo?>
+    private let wrappedProvider: CarrierInfoProviderType
 
     convenience init() {
         #if targetEnvironment(macCatalyst)
-            self.init(
-                wrappedProvider: MacCatalystCarrierInfoProvider()
-            )
+        self.init(
+            wrappedProvider: MacCatalystCarrierInfoProvider()
+        )
         #else
-            self.init(
-                wrappedProvider: iOSCarrierInfoProvider(
-                    networkInfo: CTTelephonyNetworkInfo()
-                )
-            )
+        if #available(iOS 12.0, *) {
+            self.init(wrappedProvider: iOS12CarrierInfoProvider(networkInfo: CTTelephonyNetworkInfo()))
+        } else {
+            self.init(wrappedProvider: iOS11CarrierInfoProvider(networkInfo: CTTelephonyNetworkInfo()))
+        }
         #endif
     }
 
-    init(wrappedProvider: WrappedCarrierInfoProvider) {
+    init(wrappedProvider: CarrierInfoProviderType) {
         self.wrappedProvider = wrappedProvider
-        self.publisher = ValuePublisher(initialValue: nil)
     }
 
     var current: CarrierInfo? {
-        let nextValue = wrappedProvider.current
-        // `CarrierInfo` subscribers are notified as a side-effect of retrieving the
-        // current `CarrierInfo` value.
-        publisher.publishAsync(nextValue)
-        return nextValue
+        wrappedProvider.current
     }
 
     func subscribe<Observer: CarrierInfoObserver>(_ subscriber: Observer) where Observer.ObservedValue == CarrierInfo? {
-        publisher.subscribe(subscriber)
+        wrappedProvider.subscribe(subscriber)
     }
 }
 
 #if targetEnvironment(macCatalyst)
 
-internal struct MacCatalystCarrierInfoProvider: WrappedCarrierInfoProvider {
-    /// Carrier info is not supported on macCatalyst
+/// Dummy provider for Mac Catalyst which doesn't support carrier info.
+internal struct MacCatalystCarrierInfoProvider: CarrierInfoProviderType {
     var current: CarrierInfo? { return nil }
+    func subscribe<Observer>(_ subscriber: Observer) where Observer: ValueObserver, Observer.ObservedValue == CarrierInfo? {}
 }
 
 #else
 
-internal struct iOSCarrierInfoProvider: WrappedCarrierInfoProvider {
-    let networkInfo: CTTelephonyNetworkInfo
+/// Carrier info provider for iOS 12 and above.
+/// It reads `CarrierInfo?` from `CTTelephonyNetworkInfo` only when `CTCarrier` has changed (e.g. when the SIM card was swapped).
+@available(iOS 12, *)
+internal class iOS12CarrierInfoProvider: CarrierInfoProviderType {
+    private let networkInfo: CTTelephonyNetworkInfo
+    /// Publisher for notifying observers on `CarrierInfo` change.
+    private let publisher: ValuePublisher<CarrierInfo?>
+
+    init(networkInfo: CTTelephonyNetworkInfo) {
+        self.networkInfo = networkInfo
+        self.publisher = ValuePublisher(
+            initialValue: iOS12CarrierInfoProvider.readCarrierInfo(
+                from: networkInfo,
+                cellularProviderKey: networkInfo.serviceCurrentRadioAccessTechnology?.keys.first
+            )
+        )
+
+        // The `serviceSubscriberCellularProvidersDidUpdateNotifier` block object executes on the default priority
+        // global dispatch queue when the user’s cellular provider information changes.
+        // This occurs, for example, if a user swaps the device’s SIM card with one from another provider, while the app is running.
+        // ref.: https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/3024512-servicesubscribercellularprovide
+        networkInfo.serviceSubscriberCellularProvidersDidUpdateNotifier = { [weak self] cellularProviderKey in
+            let carrierInfo = iOS12CarrierInfoProvider.readCarrierInfo(
+                from: networkInfo,
+                cellularProviderKey: networkInfo.serviceCurrentRadioAccessTechnology?.keys.first
+            )
+
+            // On iOS12+ `CarrierInfo` subscribers are notified on actual change to cellular provider.
+            self?.publisher.publishAsync(carrierInfo)
+        }
+    }
+
+    private static func readCarrierInfo(from networkInfo: CTTelephonyNetworkInfo, cellularProviderKey: String?) -> CarrierInfo? {
+        if let cellularProviderKey = cellularProviderKey,
+           let radioTechnology = networkInfo.serviceCurrentRadioAccessTechnology?[cellularProviderKey],
+           let carrier = networkInfo.serviceSubscriberCellularProviders?[cellularProviderKey] {
+            return CarrierInfo(
+                carrierName: carrier.carrierName,
+                carrierISOCountryCode: carrier.isoCountryCode,
+                carrierAllowsVOIP: carrier.allowsVOIP,
+                radioAccessTechnology: .init(ctRadioAccessTechnologyConstant: radioTechnology)
+            )
+        } else {
+            return nil // the service is not registered on any network
+        }
+    }
 
     var current: CarrierInfo? {
-        let carrier: CTCarrier?
-        let radioTechnology: String?
+        publisher.currentValue
+    }
 
-        if #available(iOS 12, *) {
-            guard let cellularProviderKey = networkInfo.serviceCurrentRadioAccessTechnology?.keys.first else {
-                return nil
-            }
-            radioTechnology = networkInfo.serviceCurrentRadioAccessTechnology?[cellularProviderKey]
-            carrier = networkInfo.serviceSubscriberCellularProviders?[cellularProviderKey]
-        } else {
-            radioTechnology = networkInfo.currentRadioAccessTechnology
-            carrier = networkInfo.subscriberCellularProvider
-        }
+    func subscribe<Observer>(_ subscriber: Observer) where Observer: ValueObserver, Observer.ObservedValue == CarrierInfo? {
+        publisher.subscribe(subscriber)
+    }
+}
 
-        guard let radioAccessTechnology = radioTechnology,
-            let currentCTCarrier = carrier else {
-                return nil
-        }
+/// Carrier info provider for iOS 11.
+/// It reads `CarrierInfo?` from `CTTelephonyNetworkInfo` each time.
+internal class iOS11CarrierInfoProvider: CarrierInfoProviderType {
+    private let networkInfo: CTTelephonyNetworkInfo
+    /// Publisher for notifying observers on `CarrierInfo` change.
+    private let publisher: ValuePublisher<CarrierInfo?>
 
-        return CarrierInfo(
-            carrierName: currentCTCarrier.carrierName,
-            carrierISOCountryCode: currentCTCarrier.isoCountryCode,
-            carrierAllowsVOIP: currentCTCarrier.allowsVOIP,
-            radioAccessTechnology: .init(ctRadioAccessTechnologyConstant: radioAccessTechnology)
+    init(networkInfo: CTTelephonyNetworkInfo) {
+        self.networkInfo = networkInfo
+        self.publisher = ValuePublisher(
+            initialValue: iOS11CarrierInfoProvider.readCarrierInfo(from: networkInfo)
         )
+    }
+
+    private static func readCarrierInfo(from networkInfo: CTTelephonyNetworkInfo) -> CarrierInfo? {
+        if let radioTechnology = networkInfo.currentRadioAccessTechnology,
+           let carrier = networkInfo.subscriberCellularProvider {
+            return CarrierInfo(
+                carrierName: carrier.carrierName,
+                carrierISOCountryCode: carrier.isoCountryCode,
+                carrierAllowsVOIP: carrier.allowsVOIP,
+                radioAccessTechnology: .init(ctRadioAccessTechnologyConstant: radioTechnology)
+            )
+        } else {
+            return nil
+        }
+    }
+
+    var current: CarrierInfo? {
+        let carrierInfo = iOS11CarrierInfoProvider.readCarrierInfo(from: networkInfo)
+
+        // On iOS11 `CarrierInfo` subscribers are notified as a side-effect of pulling the
+        // current `CarrierInfo` value.
+        publisher.publishAsync(carrierInfo)
+
+        return carrierInfo
+    }
+
+    func subscribe<Observer>(_ subscriber: Observer) where Observer: ValueObserver, Observer.ObservedValue == CarrierInfo? {
+        publisher.subscribe(subscriber)
     }
 }
 

--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -130,13 +130,17 @@ internal class iOS12CarrierInfoProvider: CarrierInfoProviderType {
         // This occurs, for example, if a user swaps the device’s SIM card with one from another provider, while the app is running.
         // ref.: https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/3024512-servicesubscribercellularprovide
         networkInfo.serviceSubscriberCellularProvidersDidUpdateNotifier = { [weak self] cellularProviderKey in
+            guard let strongSelf = self else {
+                return
+            }
+
             let carrierInfo = iOS12CarrierInfoProvider.readCarrierInfo(
-                from: networkInfo,
-                cellularProviderKey: networkInfo.serviceCurrentRadioAccessTechnology?.keys.first
+                from: strongSelf.networkInfo,
+                cellularProviderKey: cellularProviderKey
             )
 
             // On iOS12+ `CarrierInfo` subscribers are notified on actual change to cellular provider.
-            self?.publisher.publishAsync(carrierInfo)
+            strongSelf.publisher.publishAsync(carrierInfo)
         }
     }
 

--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -145,18 +145,17 @@ internal class iOS12CarrierInfoProvider: CarrierInfoProviderType {
     }
 
     private static func readCarrierInfo(from networkInfo: CTTelephonyNetworkInfo, cellularProviderKey: String?) -> CarrierInfo? {
-        if let cellularProviderKey = cellularProviderKey,
+        guard let cellularProviderKey = cellularProviderKey,
            let radioTechnology = networkInfo.serviceCurrentRadioAccessTechnology?[cellularProviderKey],
-           let carrier = networkInfo.serviceSubscriberCellularProviders?[cellularProviderKey] {
-            return CarrierInfo(
-                carrierName: carrier.carrierName,
-                carrierISOCountryCode: carrier.isoCountryCode,
-                carrierAllowsVOIP: carrier.allowsVOIP,
-                radioAccessTechnology: .init(ctRadioAccessTechnologyConstant: radioTechnology)
-            )
-        } else {
+           let carrier = networkInfo.serviceSubscriberCellularProviders?[cellularProviderKey] else {
             return nil // the service is not registered on any network
         }
+        return CarrierInfo(
+            carrierName: carrier.carrierName,
+            carrierISOCountryCode: carrier.isoCountryCode,
+            carrierAllowsVOIP: carrier.allowsVOIP,
+            radioAccessTechnology: .init(ctRadioAccessTechnologyConstant: radioTechnology)
+        )
     }
 
     var current: CarrierInfo? {
@@ -183,17 +182,16 @@ internal class iOS11CarrierInfoProvider: CarrierInfoProviderType {
     }
 
     private static func readCarrierInfo(from networkInfo: CTTelephonyNetworkInfo) -> CarrierInfo? {
-        if let radioTechnology = networkInfo.currentRadioAccessTechnology,
-           let carrier = networkInfo.subscriberCellularProvider {
-            return CarrierInfo(
-                carrierName: carrier.carrierName,
-                carrierISOCountryCode: carrier.isoCountryCode,
-                carrierAllowsVOIP: carrier.allowsVOIP,
-                radioAccessTechnology: .init(ctRadioAccessTechnologyConstant: radioTechnology)
-            )
-        } else {
-            return nil
+        guard let radioTechnology = networkInfo.currentRadioAccessTechnology,
+              let carrier = networkInfo.subscriberCellularProvider else {
+            return nil // the service is not registered on any network
         }
+        return CarrierInfo(
+            carrierName: carrier.carrierName,
+            carrierISOCountryCode: carrier.isoCountryCode,
+            carrierAllowsVOIP: carrier.allowsVOIP,
+            radioAccessTechnology: .init(ctRadioAccessTechnologyConstant: radioTechnology)
+        )
     }
 
     var current: CarrierInfo? {

--- a/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
+++ b/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
@@ -172,7 +172,7 @@ internal class iOS11NetworkConnectionInfoProvider: WrappedNetworkConnectionInfoP
     }
 }
 
-// MARK: Conversion helpers
+// MARK: - Conversion helpers
 
 extension NetworkConnectionInfo.Reachability {
     @available(iOS 12, *)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -924,7 +924,7 @@ extension CarrierInfo: RandomMockable {
     }
 }
 
-class CarrierInfoProviderMock: CarrierInfoProviderType, WrappedCarrierInfoProvider {
+class CarrierInfoProviderMock: CarrierInfoProviderType {
     private let queue = DispatchQueue(label: "com.datadoghq.CarrierInfoProviderMock")
     private var _current: CarrierInfo?
 

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/CoreTelephonyMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/CoreTelephonyMocks.swift
@@ -28,8 +28,8 @@ class CTCarrierMock: CTCarrier {
 }
 
 class CTTelephonyNetworkInfoMock: CTTelephonyNetworkInfo {
-    private let _serviceCurrentRadioAccessTechnology: [String: String]?
-    private let _serviceSubscriberCellularProviders: [String: CTCarrier]?
+    private var _serviceCurrentRadioAccessTechnology: [String: String]?
+    private var _serviceSubscriberCellularProviders: [String: CTCarrier]?
 
     init(
         serviceCurrentRadioAccessTechnology: [String: String],
@@ -37,6 +37,24 @@ class CTTelephonyNetworkInfoMock: CTTelephonyNetworkInfo {
     ) {
         _serviceCurrentRadioAccessTechnology = serviceCurrentRadioAccessTechnology
         _serviceSubscriberCellularProviders = serviceSubscriberCellularProviders
+    }
+
+    func changeCarrier(
+        newCarrierName: String,
+        newISOCountryCode: String,
+        newAllowsVOIP: Bool,
+        newRadioAccessTechnology: String
+    ) {
+        _serviceCurrentRadioAccessTechnology = [
+            "000001": newRadioAccessTechnology
+        ]
+        _serviceSubscriberCellularProviders = [
+            "000001": CTCarrierMock(carrierName: newCarrierName, isoCountryCode: newISOCountryCode, allowsVOIP: newAllowsVOIP)
+        ]
+
+        if #available(iOS 12.0, *) {
+            serviceSubscriberCellularProvidersDidUpdateNotifier?("000001")
+        }
     }
 
     // MARK: - iOS 12+


### PR DESCRIPTION
### What and why?

📦 This PR updates the way we retrieve `CarrierInfo` information on iOS 12+. It's an educated guess to mitigate infrequent (2 impacted users) crashes reported in #623 and #619. Instead of pulling `CTTelephonyNetworkInfo` for each collected event to create `CarrierInfo`, now we only listen to `CTTelephonyNetworkInfo` changes to update `CarrierInfo` when necessary.

We use `CTTelephonyNetworkInfo` (from `CoreTelephony` framework) to read carrier information:

<img width="180" alt="Screenshot 2021-10-07 at 12 46 30" src="https://user-images.githubusercontent.com/2358722/136369920-82f3bd4e-688d-4ced-a0a1-ef32eb30e271.png">

A loop of investigation, research and debugging, lead me to following conclusions:
* C1. Reported crashes are very infrequent (one report on iOS 14.8 and one on iOS 14.6),
* C2. I observed is that `CTTelephonyNetworkInfo` only changes when swapping SIM card to another one (it does not change when removing SIM card - the last known info is still available). This is the only example listed in [Apple doc](https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo).
* C3. We already had similar issues with utilization of Apple networking frameworks:
   * [recent crash on polling `ProcessInfo.isLowPowerModeEnabled`](https://github.com/DataDog/dd-sdk-ios/pull/613),
   * [old issue with pulling `NWPath.currentPath `](https://github.com/DataDog/dd-sdk-ios/pull/109).

Both issues in C3 were fixed by changing from pulling model, to subscription model (it was also a [recommendation I received](https://developer.apple.com/forums/thread/133112) for `NWPath` issue from Apple's engineer). Given that `CTTelephonyNetworkInfo` changes are very infrequent (C2) it makes no sense to pull this value and compute `Datadog.CarrierInfo` for each event we collect. Instead, we can listen to `CTTelephonyNetworkInfo` changes and update `Datadog.CarrierInfo` only when necessary.

I can't confirm if this fixes the crash, because I didn't manage to reproduce it even when stress testing our SDK with `~500logs/s` sent from iPhone X and swapping between different SIM cards during the test.

<img width="636" alt="Screenshot 2021-10-06 at 18 27 04" src="https://user-images.githubusercontent.com/2358722/136373020-1c7f12c5-a6dd-4b8c-b6f5-6c07158ae0fb.png">

### How?

Now, we use [`serviceSubscriberCellularProvidersDidUpdateNotifier`](https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/3024512-servicesubscribercellularprovide) available on iOS 12+ to update `CarrierInfo`. Initial value is read when SDK starts.

The logic for iOS 11 remains the same with the difference that now we also read initial value for `CarrierInfo` when starting the SDK. Although there is an API for listening to `CTTelephonyNetworkInfo` updates on iOS 11, it is deprecated (ref.: [`CTRadioAccessTechnologyDidChange `](https://developer.apple.com/documentation/foundation/nsnotification/name/1616908-ctradioaccesstechnologydidchange)) and because we have no reports for iOS 11, I decided to not change existing logic.

Last, I added simple utility to stress test Logging feature in Example app:

<img width="342" alt="Screenshot 2021-10-07 at 12 42 58" src="https://user-images.githubusercontent.com/2358722/136373647-6c1ac6d8-a446-476b-926d-92b9f741c4fe.png">

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
