### PR TITLE
RUMM-1706: RUM Resource scope should provide optional value type to the size field of the Resource event

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -176,7 +176,7 @@ internal class RUMResourceScope: RUMScope {
                         start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
                     )
                 },
-                size: size ?? 0,
+                size: size,
                 ssl: resourceMetrics?.ssl.flatMap { metric in
                     .init(
                         duration: metric.duration.toInt64Nanoseconds,


### PR DESCRIPTION
### What and why?

According to the resource event schema https://github.com/DataDog/rum-events-format/blob/cdf9a70e6be9cfec5e9524c58abfe79a9fea1f64/schemas/resource-schema.json#L67 `size` field should allow taking optional values. This change removes fallback to `0` if there is no resource size provided.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
