### PR TITLE
RUMM-1667: Fix distribution tool

### DIFF
--- a/tools/distribution/src/assets/gh_asset.py
+++ b/tools/distribution/src/assets/gh_asset.py
@@ -9,17 +9,17 @@
 
 import os
 import glob
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 from src.utils import remember_cwd, shell, read_sdk_version
 
-EXPECTED_ZIP_CONTENT = [
+SWIFT_CONTENT = [
     'Datadog.xcframework',
     'DatadogObjc.xcframework',
     'DatadogCrashReporting.xcframework',
     'Kronos.xcframework',
-    'CrashReporter.xcframework',
 ]
-
+OBJC_CONTENT = ['CrashReporter.xcframework']
+EXPECTED_ZIP_CONTENT = SWIFT_CONTENT + OBJC_CONTENT
 
 class GHAsset:
     """
@@ -32,11 +32,16 @@ class GHAsset:
     def __init__(self):
         print(f'⌛️️️ Creating the GH release asset from {os.getcwd()}')
 
-        # Produce XCFrameworks with carthage:
-        # - only checkout and `--no-build` as it will build in the next command:
-        shell('carthage bootstrap --platform iOS --no-build')
-        # - `--no-build` as it will build in the next command:
-        shell('carthage build --platform iOS --use-xcframeworks --no-use-binaries --no-skip-current')
+        with NamedTemporaryFile(mode='w+', prefix='dd-gh-distro-', suffix='.xcconfig') as xcconfig:
+            xcconfig.write('BUILD_LIBRARY_FOR_DISTRIBUTION = YES\n')
+            xcconfig.seek(0) # without this line, content isn't actually written
+            os.environ['XCODE_XCCONFIG_FILE'] = xcconfig.name
+
+            # Produce XCFrameworks with carthage:
+            # - only checkout and `--no-build` as it will build in the next command:
+            shell('carthage bootstrap --platform iOS --no-build')
+            # - `--no-build` as it will build in the next command:
+            shell('carthage build --platform iOS --use-xcframeworks --no-use-binaries --no-skip-current')
 
         # Create `.zip` archive:
         zip_archive_name = f'Datadog-{read_sdk_version()}.zip'
@@ -49,6 +54,15 @@ class GHAsset:
 
     def __repr__(self):
         return f'[GHAsset: path = {self.__path}]'
+
+    def __content_with_swiftinterface(self, dir: str) -> set:
+        # e.g: /TMP_DIR/X.xcframework/ios-arm64/X.framework/Modules/X.swiftmodule/arm64.swiftinterface
+        swiftinterfaces = glob.iglob(f'{dir}/*.xcframework/**/*.framework/Modules/*.swiftmodule/*.swiftinterface', recursive=True)
+        # e.g: X.xcframework/ios-arm64/X.framework/Modules/X.swiftmodule/arm64.swiftinterface
+        relative_paths = [abs_path.removeprefix(dir + '/') for abs_path in swiftinterfaces]
+        # e.g: X.xcframework
+        product_names = [rel_path[0:rel_path.find('/')] for rel_path in relative_paths]
+        return set(product_names)
 
     def validate(self, git_tag: str):
         """
@@ -73,6 +87,11 @@ class GHAsset:
                 raise Exception(f'The content of `.zip` archive is not correct: \n'
                                 f' - actual {actual_files}\n'
                                 f' - expected: {expected_files}')
+
+            missing_swiftinterface_content = set(SWIFT_CONTENT).difference(self.__content_with_swiftinterface(unzip_dir))
+            if missing_swiftinterface_content:
+                raise Exception(f'Frameworks missing .swiftinterface: \n {missing_swiftinterface_content} \n')
+        
             print(f'   → the content of `.zip` archive is correct: \n'
                   f'       - actual: {actual_files}\n'
                   f'       - expected: {expected_files}')


### PR DESCRIPTION
### What and why?

Pre-built binaries should be compatible with newer Xcode versions. 
Currently they are incompatible, this may lead to such errors:
```
Module compiled with Swift 5.3.2 cannot be imported by the Swift 5.5 compiler: /foo/bar/DerivedData/Build/Products/Debug-iphonesimulator/Datadog.framework/Modules/Datadog.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
```

### How?

`BUILD_LIBRARY_FOR_DISTRIBUTION = YES` is set while building

### TODO

- [x] Regenerate Github release assets once the PR is approved

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
