### PR TITLE
RUMM-1583 Fix attributes reading in Objective-C

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 		61C5A8A024509C1100DA608C /* Casting+Tracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A89C24509C1100DA608C /* Casting+Tracing.swift */; };
 		61C5A8A624509FAA00DA608C /* SpanEventEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A424509FAA00DA608C /* SpanEventEncoder.swift */; };
 		61C5A8A724509FAA00DA608C /* SpanEventBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C5A8A524509FAA00DA608C /* SpanEventBuilder.swift */; };
+		61D03BE0273404E700367DE0 /* RUMDataModels+objcTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D03BDF273404E700367DE0 /* RUMDataModels+objcTests.swift */; };
 		61D447E224917F8F00649287 /* DateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D447E124917F8F00649287 /* DateFormatting.swift */; };
 		61D50C3C2580EEF8006038A3 /* LoggingScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D50C3B2580EEF8006038A3 /* LoggingScenarios.swift */; };
 		61D50C462580EF19006038A3 /* TracingScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D50C452580EF19006038A3 /* TracingScenarios.swift */; };
@@ -513,8 +514,8 @@
 		B3FC3C0926526F0000DEED9E /* VitalInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FC3C0626526EFF00DEED9E /* VitalInfo.swift */; };
 		B3FC3C3C2653A97700DEED9E /* VitalInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FC3C3B2653A97700DEED9E /* VitalInfoTests.swift */; };
 		D2135330270CA722000315AD /* DataCompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213532F270CA722000315AD /* DataCompressionTests.swift */; };
-		D24C27EA270C8BEE005DE596 /* DataCompression.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24C27E9270C8BEE005DE596 /* DataCompression.swift */; };
 		D22C1F5C271484B400922024 /* LogEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C1F5B271484B400922024 /* LogEventMapper.swift */; };
+		D24C27EA270C8BEE005DE596 /* DataCompression.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24C27E9270C8BEE005DE596 /* DataCompression.swift */; };
 		D2F1B81126D795F3009F3293 /* DDNoopRUMMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1B81026D795F3009F3293 /* DDNoopRUMMonitor.swift */; };
 		D2F1B81326D8DA68009F3293 /* DDNoopRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1B81226D8DA68009F3293 /* DDNoopRUMMonitorTests.swift */; };
 		D2F1B81526D8E5FF009F3293 /* DDNoopTracerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1B81426D8E5FF009F3293 /* DDNoopTracerTests.swift */; };
@@ -1043,6 +1044,7 @@
 		61C5A89C24509C1100DA608C /* Casting+Tracing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Casting+Tracing.swift"; sourceTree = "<group>"; };
 		61C5A8A424509FAA00DA608C /* SpanEventEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanEventEncoder.swift; sourceTree = "<group>"; };
 		61C5A8A524509FAA00DA608C /* SpanEventBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpanEventBuilder.swift; sourceTree = "<group>"; };
+		61D03BDF273404E700367DE0 /* RUMDataModels+objcTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMDataModels+objcTests.swift"; sourceTree = "<group>"; };
 		61D447E124917F8F00649287 /* DateFormatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateFormatting.swift; sourceTree = "<group>"; };
 		61D50C3B2580EEF8006038A3 /* LoggingScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingScenarios.swift; sourceTree = "<group>"; };
 		61D50C452580EF19006038A3 /* TracingScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingScenarios.swift; sourceTree = "<group>"; };
@@ -1169,8 +1171,8 @@
 		B3FC3C0626526EFF00DEED9E /* VitalInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VitalInfo.swift; sourceTree = "<group>"; };
 		B3FC3C3B2653A97700DEED9E /* VitalInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalInfoTests.swift; sourceTree = "<group>"; };
 		D213532F270CA722000315AD /* DataCompressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompressionTests.swift; sourceTree = "<group>"; };
-		D24C27E9270C8BEE005DE596 /* DataCompression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompression.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
+		D24C27E9270C8BEE005DE596 /* DataCompression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompression.swift; sourceTree = "<group>"; };
 		D2F1B81026D795F3009F3293 /* DDNoopRUMMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopRUMMonitor.swift; sourceTree = "<group>"; };
 		D2F1B81226D8DA68009F3293 /* DDNoopRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopRUMMonitorTests.swift; sourceTree = "<group>"; };
 		D2F1B81426D8E5FF009F3293 /* DDNoopTracerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopTracerTests.swift; sourceTree = "<group>"; };
@@ -1627,6 +1629,7 @@
 				615A4A8624A3452800233986 /* DDTracerConfigurationTests.swift */,
 				616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */,
 				9EE5AD8126205B82001E699E /* DDNSURLSessionDelegateTests.swift */,
+				61D03BDE273404BB00367DE0 /* RUM */,
 			);
 			path = DatadogObjc;
 			sourceTree = "<group>";
@@ -2858,6 +2861,14 @@
 			path = Span;
 			sourceTree = "<group>";
 		};
+		61D03BDE273404BB00367DE0 /* RUM */ = {
+			isa = PBXGroup;
+			children = (
+				61D03BDF273404E700367DE0 /* RUMDataModels+objcTests.swift */,
+			);
+			path = RUM;
+			sourceTree = "<group>";
+		};
 		61D50C3A2580EED5006038A3 /* ManualInstrumentation */ = {
 			isa = PBXGroup;
 			children = (
@@ -4058,6 +4069,7 @@
 				613E81F725A743600084B751 /* RUMEventsMapperTests.swift in Sources */,
 				61EF78B7257E37D500EDCCB3 /* MoveDataMigratorTests.swift in Sources */,
 				61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */,
+				61D03BE0273404E700367DE0 /* RUMDataModels+objcTests.swift in Sources */,
 				615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */,
 				61E917CF2464270500E6C631 /* CodableValueTests.swift in Sources */,
 				61133C542423990D00786299 /* NetworkConnectionInfoProviderTests.swift in Sources */,

--- a/Sources/DatadogObjc/ObjcIntercompatibility/AnyEncodable.swift
+++ b/Sources/DatadogObjc/ObjcIntercompatibility/AnyEncodable.swift
@@ -17,6 +17,14 @@ internal func castAttributesToObjectiveC(_ attributes: [String: Encodable]) -> [
         .compactMapValues { value in (value as? AnyEncodable)?.value }
 }
 
+/// Helper extension to use `castAttributesToObjectiveC(_:)` in auto generated ObjC interop `RUMDataModels`.
+/// Unlike the function it wraps, it has postfix notation which makes it easier to use in generated code.
+internal extension Dictionary where Key == String, Value == Encodable {
+    func castToObjectiveC() -> [String: Any] {
+        return castAttributesToObjectiveC(self)
+    }
+}
+
 /// Type erasing `Encodable` wrapper to bridge Objective-C's `Any` to Swift `Encodable`.
 ///
 /// Inspired by `AnyCodable` by Flight-School (MIT):

--- a/Sources/DatadogObjc/ObjcIntercompatibility/AnyEncodable.swift
+++ b/Sources/DatadogObjc/ObjcIntercompatibility/AnyEncodable.swift
@@ -6,8 +6,15 @@
 
 import Foundation
 
+/// Casts `[String: Any]` attributes to their `Encodable` representation by wrapping each `Any` into `AnyEncodable`.
 internal func castAttributesToSwift(_ attributes: [String: Any]) -> [String: Encodable] {
     return attributes.mapValues { AnyEncodable($0) }
+}
+
+/// Casts `[String: Encodable]` attributes to their `Any` representation by unwrapping each `AnyEncodable` into `Any`.
+internal func castAttributesToObjectiveC(_ attributes: [String: Encodable]) -> [String: Any] {
+    return attributes
+        .compactMapValues { value in (value as? AnyEncodable)?.value }
 }
 
 /// Type erasing `Encodable` wrapper to bridge Objective-C's `Any` to Swift `Encodable`.

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -243,7 +243,7 @@ public class DDRUMViewEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo
+        root.swiftModel.context!.contextInfo.castToObjectiveC()
     }
 }
 
@@ -326,7 +326,7 @@ public class DDRUMViewEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo
+        root.swiftModel.usr!.usrInfo.castToObjectiveC()
     }
 }
 
@@ -864,7 +864,7 @@ public class DDRUMResourceEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo
+        root.swiftModel.context!.contextInfo.castToObjectiveC()
     }
 }
 
@@ -1277,7 +1277,7 @@ public class DDRUMResourceEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo
+        root.swiftModel.usr!.usrInfo.castToObjectiveC()
     }
 }
 
@@ -1683,7 +1683,7 @@ public class DDRUMActionEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo
+        root.swiftModel.context!.contextInfo.castToObjectiveC()
     }
 }
 
@@ -1766,7 +1766,7 @@ public class DDRUMActionEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo
+        root.swiftModel.usr!.usrInfo.castToObjectiveC()
     }
 }
 
@@ -2051,7 +2051,7 @@ public class DDRUMErrorEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo
+        root.swiftModel.context!.contextInfo.castToObjectiveC()
     }
 }
 
@@ -2377,7 +2377,7 @@ public class DDRUMErrorEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo
+        root.swiftModel.usr!.usrInfo.castToObjectiveC()
     }
 }
 
@@ -2662,7 +2662,7 @@ public class DDRUMLongTaskEventRUMEventAttributes: NSObject {
     }
 
     @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo
+        root.swiftModel.context!.contextInfo.castToObjectiveC()
     }
 }
 
@@ -2766,7 +2766,7 @@ public class DDRUMLongTaskEventRUMUser: NSObject {
     }
 
     @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo
+        root.swiftModel.usr!.usrInfo.castToObjectiveC()
     }
 }
 

--- a/Sources/DatadogObjc/RUMMonitor+objc.swift
+++ b/Sources/DatadogObjc/RUMMonitor+objc.swift
@@ -30,7 +30,7 @@ public class DDRUMView: NSObject {
     let swiftView: RUMView
 
     @objc public var name: String { swiftView.name }
-    @objc public var attributes: [String: Any] { swiftView.attributes }
+    @objc public var attributes: [String: Any] { castAttributesToObjectiveC(swiftView.attributes) }
 
     /// Initializes the RUM View description.
     /// - Parameters:
@@ -66,7 +66,7 @@ public class DDRUMAction: NSObject {
     let swiftAction: RUMAction
 
     @objc public var name: String { swiftAction.name }
-    @objc public var attributes: [String: Any] { swiftAction.attributes }
+    @objc public var attributes: [String: Any] { castAttributesToObjectiveC(swiftAction.attributes) }
 
     /// Initializes the RUM Action description.
     /// - Parameters:

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -33,7 +33,7 @@ class DDRUMViewTests: XCTestCase {
         XCTAssertEqual(objcRUMView.swiftView.name, "name")
         XCTAssertEqual((objcRUMView.swiftView.attributes["foo"] as? AnyEncodable)?.value as? String, "bar")
         XCTAssertEqual(objcRUMView.name, "name")
-        XCTAssertEqual((objcRUMView.attributes["foo"] as? AnyEncodable)?.value as? String, "bar")
+        XCTAssertEqual(objcRUMView.attributes["foo"] as? String, "bar")
     }
 }
 
@@ -62,7 +62,7 @@ class DDRUMActionTests: XCTestCase {
         XCTAssertEqual(objcRUMAction.swiftAction.name, "name")
         XCTAssertEqual((objcRUMAction.swiftAction.attributes["foo"] as? AnyEncodable)?.value as? String, "bar")
         XCTAssertEqual(objcRUMAction.name, "name")
-        XCTAssertEqual((objcRUMAction.attributes["foo"] as? AnyEncodable)?.value as? String, "bar")
+        XCTAssertEqual(objcRUMAction.attributes["foo"] as? String, "bar")
     }
 }
 

--- a/Tests/DatadogTests/DatadogObjc/RUM/RUMDataModels+objcTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/RUM/RUMDataModels+objcTests.swift
@@ -1,0 +1,111 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+@testable import DatadogObjc
+
+class RUMDataModels_objcTests: XCTestCase {
+    func testGivenObjectiveCViewEventWithAnyAttributes_whenReadingAttributes_theirTypeIsNotAltered() throws {
+        let expectedContextAttributes: [String: Any] = mockRandomAttributes()
+        let expectedUserInfoAttributes: [String: Any] = mockRandomAttributes()
+
+        // Given
+        var swiftView: RUMViewEvent = .mockRandom()
+        swiftView.context?.contextInfo = castAttributesToSwift(expectedContextAttributes)
+        swiftView.usr?.usrInfo = castAttributesToSwift(expectedUserInfoAttributes)
+
+        let objcView = DDRUMViewEvent(swiftModel: swiftView)
+
+        // When
+        let receivedContextAttributes = try XCTUnwrap(objcView.context?.contextInfo)
+        let receivedUserInfoAttributes = try XCTUnwrap(objcView.usr?.usrInfo)
+
+        // Then
+        AssertDictionariesEqual(receivedContextAttributes, expectedContextAttributes)
+        AssertDictionariesEqual(receivedUserInfoAttributes, expectedUserInfoAttributes)
+    }
+
+    func testGivenObjectiveCResourceEventWithAnyAttributes_whenReadingAttributes_theirTypeIsNotAltered() throws {
+        let expectedContextAttributes: [String: Any] = mockRandomAttributes()
+        let expectedUserInfoAttributes: [String: Any] = mockRandomAttributes()
+
+        // Given
+        var swiftResource: RUMResourceEvent = .mockRandom()
+        swiftResource.context?.contextInfo = castAttributesToSwift(expectedContextAttributes)
+        swiftResource.usr?.usrInfo = castAttributesToSwift(expectedUserInfoAttributes)
+
+        let objcResource = DDRUMResourceEvent(swiftModel: swiftResource)
+
+        // When
+        let receivedContextAttributes = try XCTUnwrap(objcResource.context?.contextInfo)
+        let receivedUserInfoAttributes = try XCTUnwrap(objcResource.usr?.usrInfo)
+
+        // Then
+        AssertDictionariesEqual(receivedContextAttributes, expectedContextAttributes)
+        AssertDictionariesEqual(receivedUserInfoAttributes, expectedUserInfoAttributes)
+    }
+
+    func testGivenObjectiveCActionEventWithAnyAttributes_whenReadingAttributes_theirTypeIsNotAltered() throws {
+        let expectedContextAttributes: [String: Any] = mockRandomAttributes()
+        let expectedUserInfoAttributes: [String: Any] = mockRandomAttributes()
+
+        // Given
+        var swiftAction: RUMActionEvent = .mockRandom()
+        swiftAction.context?.contextInfo = castAttributesToSwift(expectedContextAttributes)
+        swiftAction.usr?.usrInfo = castAttributesToSwift(expectedUserInfoAttributes)
+
+        let objcAction = DDRUMActionEvent(swiftModel: swiftAction)
+
+        // When
+        let receivedContextAttributes = try XCTUnwrap(objcAction.context?.contextInfo)
+        let receivedUserInfoAttributes = try XCTUnwrap(objcAction.usr?.usrInfo)
+
+        // Then
+        AssertDictionariesEqual(receivedContextAttributes, expectedContextAttributes)
+        AssertDictionariesEqual(receivedUserInfoAttributes, expectedUserInfoAttributes)
+    }
+
+    func testGivenObjectiveCErrorEventWithAnyAttributes_whenReadingAttributes_theirTypeIsNotAltered() throws {
+        let expectedContextAttributes: [String: Any] = mockRandomAttributes()
+        let expectedUserInfoAttributes: [String: Any] = mockRandomAttributes()
+
+        // Given
+        var swiftError: RUMErrorEvent = .mockRandom()
+        swiftError.context?.contextInfo = castAttributesToSwift(expectedContextAttributes)
+        swiftError.usr?.usrInfo = castAttributesToSwift(expectedUserInfoAttributes)
+
+        let objcError = DDRUMErrorEvent(swiftModel: swiftError)
+
+        // When
+        let receivedContextAttributes = try XCTUnwrap(objcError.context?.contextInfo)
+        let receivedUserInfoAttributes = try XCTUnwrap(objcError.usr?.usrInfo)
+
+        // Then
+        AssertDictionariesEqual(receivedContextAttributes, expectedContextAttributes)
+        AssertDictionariesEqual(receivedUserInfoAttributes, expectedUserInfoAttributes)
+    }
+
+    func testGivenObjectiveCLongTaskEventWithAnyAttributes_whenReadingAttributes_theirTypeIsNotAltered() throws {
+        let expectedContextAttributes: [String: Any] = mockRandomAttributes()
+        let expectedUserInfoAttributes: [String: Any] = mockRandomAttributes()
+
+        // Given
+        var swiftLongTask: RUMLongTaskEvent = .mockRandom()
+        swiftLongTask.context?.contextInfo = castAttributesToSwift(expectedContextAttributes)
+        swiftLongTask.usr?.usrInfo = castAttributesToSwift(expectedUserInfoAttributes)
+
+        let objcLongTask = DDRUMLongTaskEvent(swiftModel: swiftLongTask)
+
+        // When
+        let receivedContextAttributes = try XCTUnwrap(objcLongTask.context?.contextInfo)
+        let receivedUserInfoAttributes = try XCTUnwrap(objcLongTask.usr?.usrInfo)
+
+        // Then
+        AssertDictionariesEqual(receivedContextAttributes, expectedContextAttributes)
+        AssertDictionariesEqual(receivedUserInfoAttributes, expectedUserInfoAttributes)
+    }
+}

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Output/ObjcInteropPrinterTests.swift
@@ -1280,11 +1280,11 @@ final class ObjcInteropPrinterTests: XCTestCase {
             }
 
             @objc public var immutableCodables: [String: Any] {
-                root.swiftModel.immutableCodables
+                root.swiftModel.immutableCodables.castToObjectiveC()
             }
 
             @objc public var optionalImmutableCodables: [String: Any]? {
-                root.swiftModel.optionalImmutableCodables
+                root.swiftModel.optionalImmutableCodables?.castToObjectiveC()
             }
         }
 


### PR DESCRIPTION
### What and why?

📦 This PR fixes `DatadogObjc` issue with retrieving back attribute values in public APIs.

It was not possible to obtain the value of `Any` attribute, i.e. this would fail:
```swift
let view = DDRUMView(name: "name", attributes: ["foo": "bar"])
XCTAssertEqual(view.attributes["foo"] as? String, "bar") // 🐞 fail
```
It would fail because `"bar"` is wrapped into `AnyEncodable(value: "bar")` type erasure as part of our Objective-C <> Swift interoperability (Swift SDK represents attributes as `Encodable`). `AnyEncodable` is `internal` type to `DatadogObjc` so it was not even possible to read the attribute value back in any other way.

### How?

I introduced `func castAttributesToObjectiveC(_ attributes: [String: Encodable]) -> [String: Any]` function to unpack `AnyEncodable` values before they are passed to the user.

This had to be used in `DDRUMView`, `DDRUMAction` and all generated `RUMDataModels` for Objective-C.

Now, users will get exactly what they set through our Objective-C API.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
