### PR TITLE
RUMM-1709 Allow to specify custom SDK version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ e2e-monitors-generate:
 
 bump:
 		@read -p "Enter version number: " version;  \
-		echo "// GENERATED FILE: Do not edit directly\n\ninternal let sdkVersion = \"$$version\"" > Sources/Datadog/Versioning.swift; \
+		echo "// GENERATED FILE: Do not edit directly\n\ninternal let __sdkVersion = \"$$version\"" > Sources/Datadog/Versioning.swift; \
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDK.podspec.src > DatadogSDK.podspec; \
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKObjc.podspec.src > DatadogSDKObjc.podspec; \
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKAlamofireExtension.podspec.src > DatadogSDKAlamofireExtension.podspec; \

--- a/Sources/Datadog/Core/Attributes/Attributes.swift
+++ b/Sources/Datadog/Core/Attributes/Attributes.swift
@@ -26,7 +26,7 @@ import Foundation
 ///
 public typealias AttributeKey = String
 
-/// Any `Ecodable` value of the attribute (`String`, `Int`, `Bool`, `Date` etc.).
+/// Any `Encodable` value of the attribute (`String`, `Int`, `Bool`, `Date` etc.).
 ///
 /// Custom `Encodable` types are supported as well with nested encoding containers:
 ///
@@ -61,3 +61,36 @@ public typealias AttributeKey = String
 /// defined as sum of key levels and value levels exceeds 10, the data may not be delivered.
 ///
 public typealias AttributeValue = Encodable
+
+// MARK: - Internal attributes
+
+/// Internal attributes, passed from cross-platform bridge.
+/// Used to configure or override SDK internal features and attributes for the need of cross-platform SDKs (e.g. React Native SDK).
+internal struct CrossPlatformAttributes {
+    /// Custom SDK `source` passed from bridge SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
+    /// It should replace the default native `ddsource` value (`"ios"`).
+    /// Expects `String` value.
+    static let ddsource: String = "_dd.source"
+
+    /// Event timestamp passed from bridge SDK. Used for all RUM events issued by cross platform SDK.
+    /// It should replace event time obtained from `DateProvider` to ensure that events are not skewed due to time difference in native and cross-platform SDKs.
+    /// Expects `Int64` value (milliseconds).
+    static let timestampInMilliseconds = "_dd.timestamp"
+
+    /// Custom "source type" of the error passed from bridge SDK. Used in RUM errors reported by cross platform SDK.
+    /// It names the language or platform of the RUM error stack trace, so the SCI backend knows how to symbolicate it.
+    /// Expects `String` value.
+    static let errorSourceType = "_dd.error.source_type"
+
+    /// Trace ID passed from bridge SDK. Used in RUM resources created by cross platform SDK.
+    /// When cross-platform SDK injects tracing headers to intercepted resource, we pass tracing information through this attribute
+    /// and send it within the RUM resource, so the RUM backend can issue corresponding APM span on behalf of the mobile app.
+    /// Expects `String` value.
+    static let traceID = "_dd.trace_id"
+
+    /// Span ID passed from bridge SDK. Used in RUM resources created by cross platform SDK.
+    /// When cross-platform SDK injects tracing headers to intercepted resource, we pass tracing information through this attribute
+    /// and send it within the RUM resource, so the RUM backend can issue corresponding APM span on behalf of the mobile app.
+    /// Expects `String` value.
+    static let spanID = "_dd.span_id"
+}

--- a/Sources/Datadog/Core/Attributes/Attributes.swift
+++ b/Sources/Datadog/Core/Attributes/Attributes.swift
@@ -67,6 +67,11 @@ public typealias AttributeValue = Encodable
 /// Internal attributes, passed from cross-platform bridge.
 /// Used to configure or override SDK internal features and attributes for the need of cross-platform SDKs (e.g. React Native SDK).
 internal struct CrossPlatformAttributes {
+    /// Custom SDK version passed from bridge SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
+    /// It should replace the default native `sdkVersion`.
+    /// Expects `String` value (semantic version).
+    static let sdkVersion: String = "_dd.sdk_version"
+
     /// Custom SDK `source` passed from bridge SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
     /// It should replace the default native `ddsource` value (`"ios"`).
     /// Expects `String` value.

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -125,7 +125,7 @@ extension FeaturesConfiguration {
         var tracesEndpoint = configuration.tracesEndpoint
         var rumEndpoint = configuration.rumEndpoint
 
-        let source = (configuration.additionalConfiguration["_dd.source"] as? String) ?? Datadog.Constants.ddsource
+        let source = (configuration.additionalConfiguration[CrossPlatformAttributes.ddsource] as? String) ?? Datadog.Constants.ddsource
 
         if let datadogEndpoint = configuration.datadogEndpoint {
             // If `.set(endpoint:)` API was used, it should override the values

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -19,6 +19,7 @@ internal struct FeaturesConfiguration {
         let environment: String
         let performance: PerformancePreset
         let source: String
+        let sdkVersion: String
         let proxyConfiguration: [AnyHashable: Any]?
     }
 
@@ -125,8 +126,6 @@ extension FeaturesConfiguration {
         var tracesEndpoint = configuration.tracesEndpoint
         var rumEndpoint = configuration.rumEndpoint
 
-        let source = (configuration.additionalConfiguration[CrossPlatformAttributes.ddsource] as? String) ?? Datadog.Constants.ddsource
-
         if let datadogEndpoint = configuration.datadogEndpoint {
             // If `.set(endpoint:)` API was used, it should override the values
             // set by deprecated `.set(<feature>Endpoint:)` APIs.
@@ -150,6 +149,9 @@ extension FeaturesConfiguration {
             rumEndpoint = .custom(url: customRUMEndpoint.absoluteString)
         }
 
+        let source = (configuration.additionalConfiguration[CrossPlatformAttributes.ddsource] as? String) ?? Datadog.Constants.ddsource
+        let sdkVersion = (configuration.additionalConfiguration[CrossPlatformAttributes.sdkVersion] as? String) ?? __sdkVersion
+
         let common = Common(
             applicationName: appContext.bundleName ?? appContext.bundleType.rawValue,
             applicationVersion: appContext.bundleVersion ?? "0.0.0",
@@ -162,6 +164,7 @@ extension FeaturesConfiguration {
                 bundleType: appContext.bundleType
             ),
             source: source,
+            sdkVersion: sdkVersion,
             proxyConfiguration: configuration.proxyConfiguration
         )
 

--- a/Sources/Datadog/Core/Upload/RequestBuilder.swift
+++ b/Sources/Datadog/Core/Upload/RequestBuilder.swift
@@ -76,7 +76,7 @@ internal struct RequestBuilder {
         }
 
         /// An observability and troubleshooting Datadog header for tracking the origin which is sending the request.
-        static func ddEVPOriginVersionHeader() -> HTTPHeader {
+        static func ddEVPOriginVersionHeader(sdkVersion: String) -> HTTPHeader {
             return HTTPHeader(field: ddEVPOriginVersionHeaderField, value: .constant(sdkVersion))
         }
 

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -169,6 +169,7 @@ public class Datadog {
         // First, initialize internal loggers:
 
         let internalLoggerConfiguration = InternalLoggerConfiguration(
+            sdkVersion: configuration.common.sdkVersion,
             applicationVersion: configuration.common.applicationVersion,
             environment: configuration.common.environment,
             userInfoProvider: userInfoProvider,

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
@@ -88,7 +88,7 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
             serviceName: configuration.serviceName,
             environment: configuration.environment,
             loggerName: Constants.loggerName,
-            loggerVersion: sdkVersion,
+            loggerVersion: configuration.sdkVersion,
             threadName: nil,
             applicationVersion: configuration.applicationVersion,
             userInfo: .init(

--- a/Sources/Datadog/FeaturesIntegration/LoggingForTracingAdapter.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingForTracingAdapter.swift
@@ -19,6 +19,7 @@ internal struct LoggingForTracingAdapter {
     func resolveLogOutput(usingTracingFeature tracingFeature: TracingFeature, tracerConfiguration: Tracer.Configuration) -> AdaptedLogOutput {
         return AdaptedLogOutput(
             logBuilder: LogEventBuilder(
+                sdkVersion: tracingFeature.configuration.common.sdkVersion,
                 applicationVersion: tracingFeature.configuration.common.applicationVersion,
                 environment: tracingFeature.configuration.common.environment,
                 serviceName: tracerConfiguration.serviceName ?? tracingFeature.configuration.common.serviceName,

--- a/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
+++ b/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
@@ -80,7 +80,7 @@ internal final class InternalMonitoringFeature {
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
                     .ddEVPOriginHeader(source: configuration.common.source),
-                    .ddEVPOriginVersionHeader(),
+                    .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],
                 // (!) Do not inject monitoring bundle, otherwise the feature will be monitoring itself
@@ -122,6 +122,7 @@ internal final class InternalMonitoringFeature {
         // Initialize internal monitor
         let internalLogger = Logger(
             logBuilder: LogEventBuilder(
+                sdkVersion: configuration.common.sdkVersion,
                 applicationVersion: configuration.common.applicationVersion,
                 environment: configuration.sdkEnvironment,
                 serviceName: configuration.sdkServiceName,

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -425,6 +425,7 @@ public class Logger {
 
         private func resolveLogBuilderAndOutput(for loggingFeature: LoggingFeature) -> (LogEventBuilder, LogOutput)? {
             let logBuilder = LogEventBuilder(
+                sdkVersion: loggingFeature.configuration.common.sdkVersion,
                 applicationVersion: loggingFeature.configuration.common.applicationVersion,
                 environment: loggingFeature.configuration.common.environment,
                 serviceName: serviceName ?? loggingFeature.configuration.common.serviceName,

--- a/Sources/Datadog/Logging/Log/LogEventBuilder.swift
+++ b/Sources/Datadog/Logging/Log/LogEventBuilder.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Builds `Log` representation (for later serialization) from data received from user.
 internal struct LogEventBuilder {
+    /// SDK version to encode in the log.
+    let sdkVersion: String
     /// Application version to write in log.
     let applicationVersion: String
     /// Environment to write in log.

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -86,7 +86,7 @@ internal final class LoggingFeature {
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
                     .ddEVPOriginHeader(source: configuration.common.source),
-                    .ddEVPOriginVersionHeader(),
+                    .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],
                 internalMonitor: internalMonitor

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -90,7 +90,7 @@ internal final class RUMFeature {
                         tags: [
                             "service:\(configuration.common.serviceName)",
                             "version:\(configuration.common.applicationVersion)",
-                            "sdk_version:\(sdkVersion)",
+                            "sdk_version:\(configuration.common.sdkVersion)",
                             "env:\(configuration.common.environment)"
                         ]
                     )
@@ -104,7 +104,7 @@ internal final class RUMFeature {
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
                     .ddEVPOriginHeader(source: configuration.common.source),
-                    .ddEVPOriginVersionHeader(),
+                    .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],
                 internalMonitor: internalMonitor

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -113,8 +113,8 @@ internal class RUMResourceScope: RUMScope {
         let size: Int64?
 
         // Check trace attributes
-        let traceId = (attributes.removeValue(forKey: "_dd.trace_id") as? String) ?? spanContext?.traceID
-        let spanId = (attributes.removeValue(forKey: "_dd.span_id") as? String) ?? spanContext?.spanID
+        let traceId = (attributes.removeValue(forKey: CrossPlatformAttributes.traceID) as? String) ?? spanContext?.traceID
+        let spanId = (attributes.removeValue(forKey: CrossPlatformAttributes.spanID) as? String) ?? spanContext?.spanID
 
         /// Metrics values take precedence over other values.
         if let metrics = resourceMetrics {

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -66,7 +66,7 @@ internal typealias RUMErrorSourceType = RUMErrorEvent.Error.SourceType
 
 internal extension RUMErrorSourceType {
     static func extract(from attributes: inout [AttributeKey: AttributeValue]) -> Self {
-        return (attributes.removeValue(forKey: RUMAttribute.internalErrorSourceType) as? String)
+        return (attributes.removeValue(forKey: CrossPlatformAttributes.errorSourceType) as? String)
             .flatMap {
                 return RUMErrorEvent.Error.SourceType(rawValue: $0)
             } ?? .ios
@@ -112,13 +112,6 @@ internal enum RUMInternalErrorSource {
         case .console: self = .console
         }
     }
-}
-
-// MARK: - Special attributes
-
-internal enum RUMAttribute {
-    static let internalTimestamp = "_dd.timestamp"
-    static let internalErrorSourceType = "_dd.error.source_type"
 }
 
 /// A class enabling Datadog RUM features.
@@ -637,7 +630,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         var combinedUserAttributes = self.rumAttributes
         combinedUserAttributes.merge(rumCommandAttributes: command.attributes)
 
-        if let customTimestampInMiliseconds = combinedUserAttributes.removeValue(forKey: RUMAttribute.internalTimestamp) as? Int64 {
+        if let customTimestampInMiliseconds = combinedUserAttributes.removeValue(forKey: CrossPlatformAttributes.timestampInMilliseconds) as? Int64 {
             let customTimeInterval = TimeInterval(fromMilliseconds: customTimestampInMiliseconds)
             mutableCommand.time = Date(timeIntervalSince1970: customTimeInterval)
         }

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -100,6 +100,7 @@ public class Tracer: OTTracer {
     internal convenience init(tracingFeature: TracingFeature, tracerConfiguration: Configuration) {
         self.init(
             spanBuilder: SpanEventBuilder(
+                sdkVersion: tracingFeature.configuration.common.sdkVersion,
                 applicationVersion: tracingFeature.configuration.common.applicationVersion,
                 serviceName: tracerConfiguration.serviceName ?? tracingFeature.configuration.common.serviceName,
                 userInfoProvider: tracingFeature.userInfoProvider,

--- a/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Builds `SpanEvent` representation (for later serialization) from span information recorded in `DDSpan` and values received from global configuration.
 internal struct SpanEventBuilder {
+    /// SDK version to encode in the span.
+    let sdkVersion: String
     /// Application version to encode in span.
     let applicationVersion: String
     /// Service name to encode in span.

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -91,7 +91,7 @@ internal final class TracingFeature {
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
                     .ddEVPOriginHeader(source: configuration.common.source),
-                    .ddEVPOriginVersionHeader(),
+                    .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],
                 internalMonitor: internalMonitor

--- a/Sources/Datadog/Utils/InternalLoggers.swift
+++ b/Sources/Datadog/Utils/InternalLoggers.swift
@@ -8,6 +8,7 @@ import Foundation
 
 /// Necessary configuration to instantiate `developerLogger` and `userLogger`.
 internal struct InternalLoggerConfiguration {
+    let sdkVersion: String
     let applicationVersion: String
     let environment: String
     let userInfoProvider: UserInfoProvider
@@ -42,6 +43,7 @@ internal func createSDKUserLogger(
     timeZone: TimeZone = .current
 ) -> Logger {
     let logBuilder = LogEventBuilder(
+        sdkVersion: configuration.sdkVersion,
         applicationVersion: configuration.applicationVersion,
         environment: configuration.environment,
         serviceName: "sdk-user",

--- a/Sources/Datadog/Versioning.swift
+++ b/Sources/Datadog/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let sdkVersion = "1.8.0-beta1"
+internal let __sdkVersion = "1.8.0-beta1"

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -121,6 +121,36 @@ class FeaturesConfigurationTests: XCTestCase {
             }
     }
 
+    func testSource() throws {
+        var configuration = try FeaturesConfiguration(
+            configuration: .mockWith(additionalConfiguration: [:]),
+            appContext: .mockAny()
+        )
+        XCTAssertEqual(configuration.common.source, "ios", "Default `source` must be `ios`")
+
+        let randomSource: String = .mockRandom()
+        configuration = try FeaturesConfiguration(
+            configuration: .mockWith(additionalConfiguration: [CrossPlatformAttributes.ddsource: randomSource]),
+            appContext: .mockAny()
+        )
+        XCTAssertEqual(configuration.common.source, randomSource, "Source can be customized through additional configuration")
+    }
+
+    func testSDKVersion() throws {
+        var configuration = try FeaturesConfiguration(
+            configuration: .mockWith(additionalConfiguration: [:]),
+            appContext: .mockAny()
+        )
+        XCTAssertEqual(configuration.common.sdkVersion, __sdkVersion, "Default `sdkVersion` must be equal to `__sdkVersion`")
+
+        let randomSDKVersion: String = .mockRandom()
+        configuration = try FeaturesConfiguration(
+            configuration: .mockWith(additionalConfiguration: [CrossPlatformAttributes.sdkVersion: randomSDKVersion]),
+            appContext: .mockAny()
+        )
+        XCTAssertEqual(configuration.common.sdkVersion, randomSDKVersion, "SDK version can be customized through additional configuration")
+    }
+
     func testClientToken() throws {
         let clientToken: String = .mockRandom(among: "abcdefgh")
         let configuration = try createConfiguration(clientToken: clientToken)

--- a/Tests/DatadogTests/Datadog/Core/Upload/RequestBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/RequestBuilderTests.swift
@@ -79,9 +79,10 @@ class RequestBuilderTests: XCTestCase {
     }
 
     func testBuildingRequestWithDDEVPOriginVersionHeader() {
-        let builder = RequestBuilder(url: .mockRandom(), queryItems: .mockRandom(), headers: [.ddEVPOriginVersionHeader()])
+        let randomSDKVersion: String = .mockRandom()
+        let builder = RequestBuilder(url: .mockRandom(), queryItems: .mockRandom(), headers: [.ddEVPOriginVersionHeader(sdkVersion: randomSDKVersion)])
         let request = builder.uploadRequest(with: .mockRandom())
-        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], sdkVersion)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
     }
 
     func testBuildingRequestWithDDRequestIDHeader() throws {
@@ -111,7 +112,7 @@ class RequestBuilderTests: XCTestCase {
                 .userAgentHeader(appName: .mockAny(), appVersion: .mockAny(), device: .mockAny()),
                 .ddAPIKeyHeader(clientToken: .mockAny()),
                 .ddEVPOriginHeader(source: .mockAny()),
-                .ddEVPOriginVersionHeader(),
+                .ddEVPOriginVersionHeader(sdkVersion: .mockAny()),
                 .ddRequestIDHeader(),
             ]
         )

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
@@ -38,7 +38,8 @@ class CrashReportingWithLoggingIntegrationTests: XCTestCase {
         let configuration: FeaturesConfiguration.Common = .mockWith(
             applicationVersion: .mockRandom(),
             serviceName: .mockRandom(),
-            environment: .mockRandom()
+            environment: .mockRandom(),
+            sdkVersion: .mockRandom()
         )
         let dateCorrectionOffset: TimeInterval = .mockRandom()
 
@@ -101,7 +102,7 @@ class CrashReportingWithLoggingIntegrationTests: XCTestCase {
             serviceName: configuration.serviceName,
             environment: configuration.environment,
             loggerName: CrashReportingWithLoggingIntegration.Constants.loggerName,
-            loggerVersion: sdkVersion,
+            loggerVersion: configuration.sdkVersion,
             threadName: nil,
             applicationVersion: configuration.applicationVersion,
             userInfo: .init(

--- a/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
@@ -28,6 +28,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
         let randomApplicationName: String = .mockRandom()
         let randomApplicationVersion: String = .mockRandom()
         let randomSource: String = .mockRandom(among: .alphanumerics)
+        let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
         let randomUploadURL: URL = .mockRandom()
         let randomClientToken: String = .mockRandom()
         let randomDeviceModel: String = .mockRandom()
@@ -43,7 +44,8 @@ class InternalMonitoringFeatureTests: XCTestCase {
                 common: .mockWith(
                     applicationName: randomApplicationName,
                     applicationVersion: randomApplicationVersion,
-                    source: randomSource
+                    source: randomSource,
+                    sdkVersion: randomSDKVersion
                 ),
                 logsUploadURL: randomUploadURL,
                 clientToken: randomClientToken
@@ -74,7 +76,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Encoding"], "deflate")
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomSource)
-        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], sdkVersion)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
     }
 
@@ -89,7 +91,8 @@ class InternalMonitoringFeatureTests: XCTestCase {
                     applicationVersion: "2.0.0",
                     applicationBundleIdentifier: "com.application.bundle.id",
                     serviceName: .mockRandom(),
-                    environment: .mockRandom()
+                    environment: .mockRandom(),
+                    sdkVersion: "1.2.3"
                 ),
                 sdkServiceName: "sdk-service-name",
                 sdkEnvironment: "sdk-environment"
@@ -110,7 +113,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
         logMatcher.assertValue(forKeyPath: Attribute.message, equals: "internal error message")
         logMatcher.assertValue(forKeyPath: Attribute.serviceName, equals: "sdk-service-name")
         logMatcher.assertValue(forKeyPath: Attribute.loggerName, equals: "im-logger")
-        logMatcher.assertValue(forKeyPath: Attribute.loggerVersion, equals: sdkVersion)
+        logMatcher.assertValue(forKeyPath: Attribute.loggerVersion, equals: "1.2.3")
         logMatcher.assertTags(equal: ["env:sdk-environment"])
         logMatcher.assertValue(forKeyPath: Attribute.applicationVersion, equals: "2.0.0")
         logMatcher.assertValue(forKeyPath: "application.name", equals: "ApplicationName")

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -33,7 +33,8 @@ class LoggerTests: XCTestCase {
                     applicationVersion: "1.0.0",
                     applicationBundleIdentifier: "com.datadoghq.ios-sdk",
                     serviceName: "default-service-name",
-                    environment: "tests"
+                    environment: "tests",
+                    sdkVersion: "1.2.3"
                 )
             ),
             dependencies: .mockWith(
@@ -52,7 +53,7 @@ class LoggerTests: XCTestCase {
           "message" : "message",
           "service" : "default-service-name",
           "logger.name" : "com.datadoghq.ios-sdk",
-          "logger.version": "\(sdkVersion)",
+          "logger.version": "1.2.3",
           "logger.thread_name" : "main",
           "date" : "2019-12-15T10:00:00.000Z",
           "version": "1.0.0",

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -28,6 +28,7 @@ class LoggingFeatureTests: XCTestCase {
         let randomApplicationName: String = .mockRandom()
         let randomApplicationVersion: String = .mockRandom()
         let randomSource: String = .mockRandom(among: .alphanumerics)
+        let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
         let randomUploadURL: URL = .mockRandom()
         let randomClientToken: String = .mockRandom()
         let randomDeviceModel: String = .mockRandom()
@@ -43,7 +44,8 @@ class LoggingFeatureTests: XCTestCase {
                 common: .mockWith(
                     applicationName: randomApplicationName,
                     applicationVersion: randomApplicationVersion,
-                    source: randomSource
+                    source: randomSource,
+                    sdkVersion: randomSDKVersion
                 ),
                 uploadURL: randomUploadURL,
                 clientToken: randomClientToken
@@ -74,7 +76,7 @@ class LoggingFeatureTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Encoding"], "deflate")
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomSource)
-        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], sdkVersion)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -174,6 +174,7 @@ extension FeaturesConfiguration.Common {
         environment: String = .mockAny(),
         performance: PerformancePreset = .init(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
         source: String = .mockAny(),
+        sdkVersion: String = .mockAny(),
         proxyConfiguration: [AnyHashable: Any]? = nil
     ) -> Self {
         return .init(
@@ -184,6 +185,7 @@ extension FeaturesConfiguration.Common {
             environment: environment,
             performance: performance,
             source: source,
+            sdkVersion: sdkVersion,
             proxyConfiguration: proxyConfiguration
         )
     }
@@ -703,14 +705,14 @@ extension RequestBuilder.HTTPHeader: RandomMockable, AnyMockable {
             .userAgentHeader(appName: .mockRandom(among: .alphanumerics), appVersion: .alphanumerics, device: .mockAny()),
             .ddAPIKeyHeader(clientToken: .mockRandom(among: .alphanumerics)),
             .ddEVPOriginHeader(source: .mockRandom(among: .alphanumerics)),
-            .ddEVPOriginVersionHeader(),
+            .ddEVPOriginVersionHeader(sdkVersion: .mockRandom(among: .alphanumerics)),
             .ddRequestIDHeader()
         ]
         return all.randomElement()!
     }
 
     static func mockAny() -> RequestBuilder.HTTPHeader {
-        return .ddEVPOriginVersionHeader()
+        return .ddEVPOriginVersionHeader(sdkVersion: "1.2.3")
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -205,6 +205,7 @@ extension LogEventBuilder {
     }
 
     static func mockWith(
+        sdkVersion: String = .mockAny(),
         applicationVersion: String = .mockAny(),
         environment: String = .mockAny(),
         serviceName: String = .mockAny(),
@@ -216,6 +217,7 @@ extension LogEventBuilder {
         logEventMapper: LogEventMapper? = nil
     ) -> LogEventBuilder {
         return LogEventBuilder(
+            sdkVersion: sdkVersion,
             applicationVersion: applicationVersion,
             environment: environment,
             serviceName: serviceName,

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -300,9 +300,11 @@ extension SpanEventBuilder {
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny(),
         dateCorrector: DateCorrectorType = DateCorrectorMock(),
         source: String = .mockAny(),
+        sdkVersion: String = .mockAny(),
         eventsMapper: SpanEventMapper? = nil
     ) -> SpanEventBuilder {
         return SpanEventBuilder(
+            sdkVersion: sdkVersion,
             applicationVersion: applicationVersion,
             serviceName: serviceName,
             userInfoProvider: userInfoProvider,

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -30,6 +30,7 @@ class RUMFeatureTests: XCTestCase {
         let randomServiceName: String = .mockRandom(among: .alphanumerics)
         let randomEnvironmentName: String = .mockRandom(among: .alphanumerics)
         let randomSource: String = .mockRandom(among: .alphanumerics)
+        let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
         let randomUploadURL: URL = .mockRandom()
         let randomClientToken: String = .mockRandom()
         let randomDeviceModel: String = .mockRandom()
@@ -47,7 +48,8 @@ class RUMFeatureTests: XCTestCase {
                     applicationVersion: randomApplicationVersion,
                     serviceName: randomServiceName,
                     environment: randomEnvironmentName,
-                    source: randomSource
+                    source: randomSource,
+                    sdkVersion: randomSDKVersion
                 ),
                 uploadURL: randomUploadURL,
                 clientToken: randomClientToken
@@ -70,7 +72,7 @@ class RUMFeatureTests: XCTestCase {
         XCTAssertEqual(
             requestURL.query,
             """
-            ddsource=\(randomSource)&ddtags=service:\(randomServiceName),version:\(randomApplicationVersion),sdk_version:\(sdkVersion),env:\(randomEnvironmentName)
+            ddsource=\(randomSource)&ddtags=service:\(randomServiceName),version:\(randomApplicationVersion),sdk_version:\(randomSDKVersion),env:\(randomEnvironmentName)
             """
         )
         XCTAssertEqual(
@@ -83,7 +85,7 @@ class RUMFeatureTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Encoding"], "deflate")
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomSource)
-        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], sdkVersion)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMCommandTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMCommandTests.swift
@@ -48,34 +48,38 @@ class RUMCommandTests: XCTestCase {
     }
 
     func testWhenRUMAddCurrentViewErrorCommand_isPassedErrorSourceTypeAttribute() {
-        let command1 = RUMAddCurrentViewErrorCommand(time: .mockAny(), error: SwiftError(), source: .source, attributes: [RUMAttribute.internalErrorSourceType: "react-native"])
+        let command1: RUMAddCurrentViewErrorCommand = .mockWithErrorObject(attributes: [CrossPlatformAttributes.errorSourceType: "react-native"])
 
         XCTAssertEqual(command1.errorSourceType, .reactNative)
         XCTAssertTrue(command1.attributes.isEmpty)
 
-        let command2 = RUMAddCurrentViewErrorCommand(time: .mockAny(), message: .mockAny(), type: .mockAny(), stack: .mockAny(), source: .source, attributes: [RUMAttribute.internalErrorSourceType: "react-native"])
+        let command2: RUMAddCurrentViewErrorCommand = .mockWithErrorMessage(attributes: [CrossPlatformAttributes.errorSourceType: "react-native"])
 
         XCTAssertEqual(command2.errorSourceType, .reactNative)
         XCTAssertTrue(command2.attributes.isEmpty)
 
-        let defaultCommand = RUMAddCurrentViewErrorCommand(time: .mockAny(), message: .mockAny(), type: .mockAny(), stack: .mockAny(), source: .source, attributes: [:])
+        let defaultCommand1: RUMAddCurrentViewErrorCommand = .mockWithErrorObject(attributes: [:])
+        let defaultCommand2: RUMAddCurrentViewErrorCommand = .mockWithErrorMessage(attributes: [:])
 
-        XCTAssertEqual(defaultCommand.errorSourceType, .ios)
+        XCTAssertEqual(defaultCommand1.errorSourceType, .ios)
+        XCTAssertEqual(defaultCommand2.errorSourceType, .ios)
     }
 
     func testWhenRUMStopResourceWithErrorCommand_isPassedErrorSourceTypeAttribute() {
-        let command1 = RUMStopResourceWithErrorCommand(resourceKey: .mockAny(), time: .mockAny(), error: SwiftError(), source: .source, httpStatusCode: .mockAny(), attributes: [RUMAttribute.internalErrorSourceType: "react-native"])
+        let command1: RUMStopResourceWithErrorCommand = .mockWithErrorObject(attributes: [CrossPlatformAttributes.errorSourceType: "react-native"])
 
         XCTAssertEqual(command1.errorSourceType, .reactNative)
         XCTAssertTrue(command1.attributes.isEmpty)
 
-        let command2 = RUMStopResourceWithErrorCommand(resourceKey: .mockAny(), time: .mockAny(), message: .mockAny(), type: .mockAny(), source: .source, httpStatusCode: .mockAny(), attributes: [RUMAttribute.internalErrorSourceType: "react-native"])
+        let command2: RUMStopResourceWithErrorCommand = .mockWithErrorMessage(attributes: [CrossPlatformAttributes.errorSourceType: "react-native"])
 
         XCTAssertEqual(command2.errorSourceType, .reactNative)
         XCTAssertTrue(command2.attributes.isEmpty)
 
-        let defaultCommand = RUMStopResourceWithErrorCommand(resourceKey: .mockAny(), time: .mockAny(), message: .mockAny(), type: .mockAny(), source: .source, httpStatusCode: .mockAny(), attributes: [:])
+        let defaultCommand1: RUMStopResourceWithErrorCommand = .mockWithErrorObject(attributes: [:])
+        let defaultCommand2: RUMStopResourceWithErrorCommand = .mockWithErrorMessage(attributes: [:])
 
-        XCTAssertEqual(defaultCommand.errorSourceType, .ios)
+        XCTAssertEqual(defaultCommand1.errorSourceType, .ios)
+        XCTAssertEqual(defaultCommand2.errorSourceType, .ios)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -108,7 +108,7 @@ class RUMResourceScopeTests: XCTestCase {
             context: context,
             dependencies: dependencies,
             resourceKey: "/resource/1",
-            attributes: ["_dd.trace_id": "100", "_dd.span_id": "200"],
+            attributes: [CrossPlatformAttributes.traceID: "100", CrossPlatformAttributes.spanID: "200"],
             startTime: currentTime,
             dateCorrection: .zero,
             url: "https://foo.com/resource/1",
@@ -542,7 +542,11 @@ class RUMResourceScopeTests: XCTestCase {
         // When
         XCTAssertFalse(
             scope.process(
-                command: RUMStopResourceWithErrorCommand(resourceKey: resourceKey, time: currentTime, message: .mockAny(), type: .mockAny(), source: .source, httpStatusCode: .mockAny(), attributes: [RUMAttribute.internalErrorSourceType: "react-native"])
+                command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(
+                    resourceKey: resourceKey,
+                    time: currentTime,
+                    attributes: [CrossPlatformAttributes.errorSourceType: "react-native"]
+                )
             )
         )
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1293,7 +1293,7 @@ class RUMMonitorTests: XCTestCase {
 
         var mockCommand = RUMCommandMock()
         mockCommand.attributes = [
-            RUMAttribute.internalTimestamp: Int64(1_000) // 1000 in milliseconds
+            CrossPlatformAttributes.timestampInMilliseconds: Int64(1_000)
         ]
 
         let monitor = try XCTUnwrap(RUMMonitor.initialize() as? RUMMonitor)

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -34,7 +34,8 @@ class TracerTests: XCTestCase {
                     applicationBundleIdentifier: "com.datadoghq.ios-sdk",
                     serviceName: "default-service-name",
                     environment: "custom",
-                    source: "abc"
+                    source: "abc",
+                    sdkVersion: "1.2.3"
                 )
             ),
             dependencies: .mockWith(
@@ -64,7 +65,7 @@ class TracerTests: XCTestCase {
               "duration": 500000000,
               "error": 0,
               "type": "custom",
-              "meta.tracer.version": "\(sdkVersion)",
+              "meta.tracer.version": "1.2.3",
               "meta.version": "1.0.0",
               "meta._dd.source": "abc",
               "metrics._top_level": 1,

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanEventBuilderTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 class SpanEventBuilderTests: XCTestCase {
     func testBuildingBasicSpan() {
-        let builder: SpanEventBuilder = .mockWith(serviceName: "test-service-name")
+        let builder: SpanEventBuilder = .mockWith(serviceName: "test-service-name", sdkVersion: "1.2.3")
 
         let span = builder.createSpanEvent(
             traceID: 1,
@@ -35,7 +35,7 @@ class SpanEventBuilderTests: XCTestCase {
         XCTAssertEqual(span.startTime, .mockDecember15th2019At10AMUTC())
         XCTAssertEqual(span.duration, 0.50, accuracy: 0.01)
         XCTAssertFalse(span.isError)
-        XCTAssertEqual(span.tracerVersion, sdkVersion)
+        XCTAssertEqual(span.tracerVersion, "1.2.3")
         XCTAssertEqual(span.tags, ["foo": "bar", "bizz": "123"])
     }
 

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -28,6 +28,7 @@ class TracingFeatureTests: XCTestCase {
         let randomApplicationName: String = .mockRandom()
         let randomApplicationVersion: String = .mockRandom()
         let randomSource: String = .mockRandom()
+        let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
         let randomUploadURL: URL = .mockRandom()
         let randomClientToken: String = .mockRandom()
         let randomDeviceModel: String = .mockRandom()
@@ -43,7 +44,8 @@ class TracingFeatureTests: XCTestCase {
                 common: .mockWith(
                     applicationName: randomApplicationName,
                     applicationVersion: randomApplicationVersion,
-                    source: randomSource
+                    source: randomSource,
+                    sdkVersion: randomSDKVersion
                 ),
                 uploadURL: randomUploadURL,
                 clientToken: randomClientToken
@@ -75,7 +77,7 @@ class TracingFeatureTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Encoding"], "deflate")
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomSource)
-        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], sdkVersion)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
     }
 

--- a/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/InternalLoggersTests.swift
@@ -9,6 +9,7 @@ import XCTest
 
 class InternalLoggersTests: XCTestCase {
     private let internalLoggerConfigurationMock = InternalLoggerConfiguration(
+        sdkVersion: .mockAny(),
         applicationVersion: .mockAny(),
         environment: .mockAny(),
         userInfoProvider: UserInfoProvider.mockAny(),

--- a/tools/distribution/src/utils.py
+++ b/tools/distribution/src/utils.py
@@ -44,7 +44,7 @@ def read_sdk_version() -> str:
     Reads SDK version from 'Sources/Datadog/Versioning.swift'.
     """
     file = 'Sources/Datadog/Versioning.swift'
-    version_regex = r'^.+\"([0-9]+\.[0-9]+\.[0-9]+[\-a-z0-9]*)\"'  # e.g. 'internal let sdkVersion = "1.8.0-beta1"'
+    version_regex = r'^.+\"([0-9]+\.[0-9]+\.[0-9]+[\-a-z0-9]*)\"'  # e.g. 'internal let __sdkVersion = "1.8.0-beta1"'
 
     versions: [str] = []
     with open(file) as version_file:


### PR DESCRIPTION
### What and why?

📦 This PR adds an option to set custom `sdkVersion` with existing `set(additionalConfiguration:)` used by `bridge-ios`. The goal is to enable React Native and other cross-platform SDKs to send data using their own SDK version.

Counterpart of https://github.com/DataDog/dd-sdk-android/pull/747

### How?

Custom version can be passed through `_dd.sdk_version` attribute. When specified, it is resolved against the default `sdkVersion` from `Versioning.swift`. Version resolution happens on SDK startup and resolved value is consistently passed to downstream components leveraging existing dependency injection of `FeaturesConfiguration`.

**Alternatively**, we could naively override the `sdkVersion` (in `Versioning.swift`) when starting the SDK, but that would come with the classic price of introducing side effects (potential inconsistencies; state alternation in unit testing; refactoring need once we switch to supporting multiple instances of the SDK in one process). I rejected this approach.

I also did refactoring of all cross-platform attributes in the first commit (https://github.com/DataDog/dd-sdk-ios/commit/56af3d7e7da60890551b20fc187c4daa891bbbe8), by gathering all of them in a single place with describing their context and giving documentation comments.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
