### PR TITLE
RUMM-1770 test_repetition_mode is added for Xcode 13 stack

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -132,7 +132,8 @@ workflows:
         - scheme: Datadog
         - simulator_device: iPhone 11
         - is_clean_build: 'yes'
-        - should_retry_test_on_fail: 'yes' # temporarily mutes flakiness until we collect more info (in RUMM-839) then fix it
+        - test_repetition_mode: 'retry_on_failure'
+        - maximum_test_repetitions: 2
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Datadog-unit-tests.html"

--- a/tools/nightly-unit-tests/bitrise.yml.src
+++ b/tools/nightly-unit-tests/bitrise.yml.src
@@ -56,7 +56,7 @@ workflows:
         - simulator_device: $SIMULATOR_DEVICE
         - simulator_os_version: $SIMULATOR_OS_VERSION
         - is_clean_build: 'no'
-        - should_retry_test_on_fail: 'yes' # retry once to mitigate flakiness
+        - ## <RETRY_ON_FAIL> ##
         - generate_code_coverage_files: 'yes'
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests-${PROJECT_SCHEME}-${SIMULATOR_DEVICE} (${SIMULATOR_OS_VERSION}).html"
     - deploy-to-bitrise-io: {}

--- a/tools/nightly-unit-tests/src/bitrise_yml_writter.py
+++ b/tools/nightly-unit-tests/src/bitrise_yml_writter.py
@@ -91,6 +91,11 @@ class BitriseYML:
 
         template = template.replace('## <MACOS VERSION> ##', self.host_os_version)
 
+        if self.host_os_version.startswith('11'): # macOS 11.X Big Sur
+            template = template.replace('## <RETRY_ON_FAIL> ##', "test_repetition_mode: 'retry_on_failure'")
+        else:
+            template = template.replace('## <RETRY_ON_FAIL> ##', "should_retry_test_on_fail: 'yes'")
+
         return template
 
     @staticmethod


### PR DESCRIPTION
### What and why?

Bitrise's `xcode-test` step deprecates `should_retry_test_on_fail` input in favor of `test_repetition_mode: 'retry_on_failure`

### How?

Our main `bitrise.yml` uses the new input parameter.
`nightly-unit-tests` tool sets the input parameter accordingly.

### TODO

- [x] Once the PR is approved, I will update our stack in Bitrise and re-run CI

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
