### PR TITLE
RUMM-1763 Read `_dd.error.is_crash` crossplatform attribute

### DIFF
--- a/Sources/Datadog/Core/Attributes/Attributes.swift
+++ b/Sources/Datadog/Core/Attributes/Attributes.swift
@@ -87,6 +87,11 @@ internal struct CrossPlatformAttributes {
     /// Expects `String` value.
     static let errorSourceType = "_dd.error.source_type"
 
+    /// Custom attribute of the error passed from bridge SDK. Used in RUM errors reported by cross platform SDK.
+    /// It flags the error has being fatal for the host application.
+    /// Expects `Bool` value.
+    static let errorIsCrash = "_dd.error.is_crash"
+
     /// Trace ID passed from bridge SDK. Used in RUM resources created by cross platform SDK.
     /// When cross-platform SDK injects tracing headers to intercepted resource, we pass tracing information through this attribute
     /// and send it within the RUM resource, so the RUM backend can issue corresponding APM span on behalf of the mobile app.

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -67,6 +67,8 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
     let type: String?
     /// Error stacktrace.
     let stack: String?
+    /// Whether this error crashed the host application
+    let isCrash: Bool?
     /// The origin of this error.
     let source: RUMInternalErrorSource
     /// The platform type of the error (iOS, React Native, ...)
@@ -88,6 +90,7 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
         self.stack = stack
 
         self.errorSourceType = RUMErrorSourceType.extract(from: &self.attributes)
+        self.isCrash = self.attributes.removeValue(forKey: CrossPlatformAttributes.errorIsCrash) as? Bool
     }
 
     init(
@@ -106,6 +109,7 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
         self.stack = dderror.stack
 
         self.errorSourceType = RUMErrorSourceType.extract(from: &self.attributes)
+        self.isCrash = self.attributes.removeValue(forKey: CrossPlatformAttributes.errorIsCrash) as? Bool
     }
 }
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -429,7 +429,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 handling: nil,
                 handlingStack: nil,
                 id: nil,
-                isCrash: nil,
+                isCrash: command.isCrash,
                 message: command.message,
                 resource: nil,
                 source: command.source.toRUMDataFormat,

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMCommandTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/RUMCommandTests.swift
@@ -65,6 +65,24 @@ class RUMCommandTests: XCTestCase {
         XCTAssertEqual(defaultCommand2.errorSourceType, .ios)
     }
 
+    func testWhenRUMAddCurrentViewErrorCommand_isPassedErrorIsCrashAttribute() {
+        let command1: RUMAddCurrentViewErrorCommand = .mockWithErrorObject(attributes: [CrossPlatformAttributes.errorIsCrash: true])
+
+        XCTAssertTrue(command1.isCrash ?? false)
+        XCTAssertTrue(command1.attributes.isEmpty)
+
+        let command2: RUMAddCurrentViewErrorCommand = .mockWithErrorMessage(attributes: [CrossPlatformAttributes.errorIsCrash: false])
+
+        XCTAssertFalse(command2.isCrash ?? true)
+        XCTAssertTrue(command2.attributes.isEmpty)
+
+        let defaultCommand1: RUMAddCurrentViewErrorCommand = .mockWithErrorObject(attributes: [:])
+        let defaultCommand2: RUMAddCurrentViewErrorCommand = .mockWithErrorMessage(attributes: [:])
+
+        XCTAssertNil(defaultCommand1.isCrash)
+        XCTAssertNil(defaultCommand2.isCrash)
+    }
+
     func testWhenRUMStopResourceWithErrorCommand_isPassedErrorSourceTypeAttribute() {
         let command1: RUMStopResourceWithErrorCommand = .mockWithErrorObject(attributes: [CrossPlatformAttributes.errorSourceType: "react-native"])
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -521,9 +521,10 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.model.error.sourceType, .ios)
     }
 
-    func testGivenStartedResource_whenResourceLoadingEndsWithErrorWithCustomSourceType_itSendsErrorEventWithCustomSourceType() throws {
+    func testGivenStartedResource_whenResourceLoadingEndsWithCrossPlatformError_itSendsCorrectErrorEvent() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let resourceKey = "/resource/1"
+        let isCrash: Bool = .random()
         // Given
         let scope = RUMResourceScope.mockWith(
             context: context,
@@ -545,7 +546,10 @@ class RUMResourceScopeTests: XCTestCase {
                 command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(
                     resourceKey: resourceKey,
                     time: currentTime,
-                    attributes: [CrossPlatformAttributes.errorSourceType: "react-native"]
+                    attributes: [
+                        CrossPlatformAttributes.errorSourceType: "react-native",
+                        CrossPlatformAttributes.errorIsCrash: isCrash
+                    ]
                 )
             )
         )
@@ -553,6 +557,7 @@ class RUMResourceScopeTests: XCTestCase {
         // Then
         let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).first)
         XCTAssertEqual(event.model.error.sourceType, .reactNative)
+        XCTAssertEqual(event.model.error.isCrash, isCrash)
     }
 
     // MARK: - Events sending callbacks


### PR DESCRIPTION
### What and why?

Fatal errors from RN (and future cross plateform sdks)  are reported with a custom attribute `_dd.error.is_crash`. 

### How?

The value of `_dd.error.is_crash` will map to RUM Error’s `error.is_crash`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
