### PR TITLE
RUMM-1386 Fix `BinaryImage.imageName` resolution on iOS Simulator with Xcode 13.1

### DIFF
--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReport.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReport.swift
@@ -93,7 +93,7 @@ internal struct BinaryImageInfo {
     /// The UUID of this image.
     var uuid: String
     /// The name of this image (referenced by "library name" in the stack frame).
-    var imageName: String?
+    var imageName: String
     /// If its a system library image.
     var isSystemImage: Bool
     /// Image code type (code architecture information).
@@ -240,7 +240,7 @@ extension BinaryImageInfo {
         }
 
         self.uuid = imageUUID
-        self.imageName = URL(string: imagePath)?.lastPathComponent
+        self.imageName = URL(fileURLWithPath: imagePath).lastPathComponent
 
         #if targetEnvironment(simulator)
         self.isSystemImage = Self.isPathSystemImageInSimulator(imagePath)
@@ -309,7 +309,7 @@ extension StackFrame {
             self.libraryBaseAddress = imageInfo.imageBaseAddress
         } else {
             // Without "library name" and its "base address" symbolication will not be possible,
-            // but the presence of this frame int the stack will be still relevant.
+            // but the presence of this frame in the stack will be still relevant.
             self.libraryName = nil
             self.libraryBaseAddress = nil
         }

--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReportMinifier.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/CrashReportMinifier.swift
@@ -88,11 +88,7 @@ internal struct CrashReportMinifier {
         }
 
         return binaryImages.filter { image in
-            if let imageName = image.imageName {
-                return imageNamesFromStackFrames.contains(imageName) // it is referenced, keep the image
-            } else {
-                return false // image has no name, we can drop it
-            }
+            return imageNamesFromStackFrames.contains(image.imageName) // if it's referenced in the stack trace
         }
     }
 }

--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/DDCrashReportExporter.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/DDCrashReportExporter.swift
@@ -149,7 +149,7 @@ internal struct DDCrashReportExporter {
             let maxAddressHex = "0x\(maxAddress.toHex)"
 
             return DDCrashReport.BinaryImage(
-                libraryName: image.imageName ?? unavailable,
+                libraryName: image.imageName,
                 uuid: image.uuid,
                 architecture: image.codeType?.architectureName ?? unavailable,
                 isSystemLibrary: image.isSystemImage,

--- a/Tests/DatadogCrashReportingTests/Mocks.swift
+++ b/Tests/DatadogCrashReportingTests/Mocks.swift
@@ -253,7 +253,7 @@ extension ThreadInfo {
 extension BinaryImageInfo {
     static func mockWith(
         uuid: String = .mockAny(),
-        imageName: String? = .mockAny(),
+        imageName: String = .mockAny(),
         isSystemImage: Bool = .random(),
         architectureName: String? = .mockAny(),
         imageBaseAddress: UInt64 = .mockAny(),

--- a/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/CrashReportMinifierTests.swift
+++ b/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/CrashReportMinifierTests.swift
@@ -186,7 +186,7 @@ class CrashReportMinifierTests: XCTestCase {
         imageNamesFromStackFrames.formUnion(crashReport.threads.flatMap { $0.stackFrames.map { $0.libraryName! } })
 
         var imageNamesFromBinaryImages: Set<String> = []
-        imageNamesFromBinaryImages.formUnion(crashReport.binaryImages.map { $0.imageName! })
+        imageNamesFromBinaryImages.formUnion(crashReport.binaryImages.map { $0.imageName })
 
         XCTAssertEqual(
             imageNamesFromStackFrames,


### PR DESCRIPTION
### What and why?

⚙️🐞 This PR fixes bug discovered by recent upgrade to Xcode 13.1 on CI.

### How?

With Xcode 13.1 and iOS Simulator some paths to binary images may include illegal characters (e.g. spaces) which return `nil` for `URL(string:)`:

```swift
let path = "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 13.4.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
//                                                                ^ 🤨
print(URL(string: path)) // nil
```

We shouldn't use `URL(string:)` for path processing, so I'm replacing it with `URL(fileURLWithPath:)` to fix the issue. The improvement is that now it returns `URL`, not `URL?` so I also managed to simplify the code a little bit.

🛡 Tested on real device as well.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
