### PR TITLE
RUMM-1758 Add RUM Session debug utility

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -260,6 +260,8 @@
 		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
 		617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */; };
 		617247B825DAB0E2007085B3 /* DDCrashReportBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617247B725DAB0E2007085B3 /* DDCrashReportBuilder.swift */; };
+		61776CED273BEA5500F93802 /* DebugRUMSessionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61776CEC273BEA5500F93802 /* DebugRUMSessionViewController.swift */; };
+		61776D4E273E6D9F00F93802 /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61776D4D273E6D9F00F93802 /* SwiftUI.swift */; };
 		61786F7724FCDE05009E6BAB /* RUMDebuggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */; };
 		6179FFD3254ADB1700556A0B /* ObjcAppLaunchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */; };
 		6179FFDE254ADBEF00556A0B /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -914,6 +916,8 @@
 		617247AD25DA9BEA007085B3 /* CrashReportingObjcHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrashReportingObjcHelpers.h; sourceTree = "<group>"; };
 		617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CrashReportingObjcHelpers.m; sourceTree = "<group>"; };
 		617247B725DAB0E2007085B3 /* DDCrashReportBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportBuilder.swift; sourceTree = "<group>"; };
+		61776CEC273BEA5500F93802 /* DebugRUMSessionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRUMSessionViewController.swift; sourceTree = "<group>"; };
+		61776D4D273E6D9F00F93802 /* SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI.swift; sourceTree = "<group>"; };
 		61786F7624FCDE04009E6BAB /* RUMDebuggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDebuggingTests.swift; sourceTree = "<group>"; };
 		6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjcAppLaunchHandler.h; sourceTree = "<group>"; };
 		6179FFD2254ADB1100556A0B /* ObjcAppLaunchHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcAppLaunchHandler.m; sourceTree = "<group>"; };
@@ -2235,6 +2239,8 @@
 				61E5333724B84EE2003D6C4E /* DebugRUMViewController.swift */,
 				61F74AF326F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift */,
 				618236882710560900125326 /* DebugWebviewViewController.swift */,
+				61776CEC273BEA5500F93802 /* DebugRUMSessionViewController.swift */,
+				61776D4C273E6D8100F93802 /* Helpers */,
 			);
 			path = Debugging;
 			sourceTree = "<group>";
@@ -2423,6 +2429,14 @@
 			);
 			name = DatadogCrashReportingTests;
 			path = ../Tests/DatadogCrashReportingTests;
+			sourceTree = "<group>";
+		};
+		61776D4C273E6D8100F93802 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				61776D4D273E6D9F00F93802 /* SwiftUI.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		61786F7524FCDDE2009E6BAB /* Debugging */ = {
@@ -4256,7 +4270,9 @@
 				6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */,
 				6111544825C9A88B007C84C9 /* PersistenceHelper.swift in Sources */,
 				61D50C462580EF19006038A3 /* TracingScenarios.swift in Sources */,
+				61776CED273BEA5500F93802 /* DebugRUMSessionViewController.swift in Sources */,
 				618DCFE324C766FB00589570 /* SendRUMFixture3ViewController.swift in Sources */,
+				61776D4E273E6D9F00F93802 /* SwiftUI.swift in Sources */,
 				61441C962461A649003D8BB8 /* UIButton+Disabling.swift in Sources */,
 				611EA12D2580F42600BC0E56 /* TrackingConsentScenarios.swift in Sources */,
 				614CADD72510BAC000B93D2D /* Environment.swift in Sources */,

--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="wle-IX-rUl">
-                            <rect key="frame" x="0.0" y="284.5" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="328" width="414" height="0.0"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         </view>
@@ -85,8 +85,28 @@
                                             <segue destination="CBf-fg-exz" kind="show" id="5Im-MK-mpd"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="rh1-Lx-HwO" style="IBUITableViewCellStyleDefault" id="cuG-eI-g1N">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="x5x-Et-kvY" style="IBUITableViewCellStyleDefault" id="FqS-dJ-mor">
                                         <rect key="frame" x="0.0" y="175" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="FqS-dJ-mor" id="GvD-oe-TaI">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="RUM Session" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="x5x-Et-kvY">
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="PmE-vw-JRi" kind="show" id="hDE-Gx-X61"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="rh1-Lx-HwO" style="IBUITableViewCellStyleDefault" id="cuG-eI-g1N">
+                                        <rect key="frame" x="0.0" y="218.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cuG-eI-g1N" id="GVN-Oe-gtW">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -106,7 +126,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="gdR-qL-Lyw" style="IBUITableViewCellStyleDefault" id="w16-YT-5Xj">
-                                        <rect key="frame" x="0.0" y="218.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="262" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="w16-YT-5Xj" id="NKU-A4-XkK">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1373,6 +1393,34 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="z20-g6-vwL" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-239" y="1175"/>
+        </scene>
+        <!--DebugRUM Session View Controller-->
+        <scene sceneID="Jsp-EZ-IMP">
+            <objects>
+                <viewController id="PmE-vw-JRi" customClass="DebugRUMSessionViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="e1b-CD-UPJ">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This screen requires iO13+" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="msA-Jf-jga">
+                                <rect key="frame" x="105.5" y="437.5" width="203" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="eD4-Fl-X14"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="msA-Jf-jga" firstAttribute="centerY" secondItem="e1b-CD-UPJ" secondAttribute="centerY" id="W1y-uX-xiR"/>
+                            <constraint firstItem="msA-Jf-jga" firstAttribute="centerX" secondItem="e1b-CD-UPJ" secondAttribute="centerX" id="vqm-ID-sMc"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="GRY-pt-311"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="56a-IG-m2B" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="678" y="1175"/>
         </scene>
         <!--Debug Webview View Controller-->
         <scene sceneID="na3-2j-vu9">

--- a/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
@@ -1,0 +1,275 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import SwiftUI
+import Datadog
+
+@available(iOS 13, *)
+internal class DebugRUMSessionViewController: UIHostingController<DebugRUMSessionView> {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder, rootView: DebugRUMSessionView())
+    }
+}
+
+private enum SessionItemType {
+    case view
+    case resource
+    case action
+    case error
+}
+
+@available(iOS 13.0, *)
+private class DebugRUMSessionViewModel: ObservableObject {
+    struct SessionItem: Identifiable {
+        let label: String
+        let type: SessionItemType
+        var isPending: Bool
+        var stopAction: (() -> Void)?
+
+        var id: UUID = UUID()
+    }
+
+    @Published var sessionItems: [SessionItem] = []
+
+    @Published var viewKey: String = ""
+    @Published var actionName: String = ""
+    @Published var errorMessage: String = ""
+    @Published var resourceKey: String = ""
+
+    func startView() {
+        guard !viewKey.isEmpty else {
+            return
+        }
+
+        let viewKey = viewKey
+        sessionItems.append(
+            SessionItem(
+                label: viewKey,
+                type: .view,
+                isPending: true,
+                stopAction: { [weak self] in
+                    self?.modifySessionItem(type: .view, label: viewKey) { mutableSessionItem in
+                        mutableSessionItem.isPending = false
+                        mutableSessionItem.stopAction = nil
+                        Global.rum.stopView(key: viewKey)
+                    }
+                }
+            )
+        )
+
+        Global.rum.startView(key: viewKey)
+        self.viewKey = ""
+    }
+
+    func addAction() {
+        guard !actionName.isEmpty else {
+            return
+        }
+
+        sessionItems.append(
+            SessionItem(label: actionName, type: .action, isPending: false, stopAction: nil)
+        )
+
+        Global.rum.addUserAction(type: .custom, name: actionName)
+        self.actionName = ""
+    }
+
+    func addError() {
+        guard !errorMessage.isEmpty else {
+            return
+        }
+
+        sessionItems.append(
+            SessionItem(label: errorMessage, type: .error, isPending: false, stopAction: nil)
+        )
+
+        Global.rum.addError(message: errorMessage)
+        self.errorMessage = ""
+    }
+
+    func startResource() {
+        guard !resourceKey.isEmpty else {
+            return
+        }
+
+        let resourceKey = self.resourceKey
+        sessionItems.append(
+            SessionItem(
+                label: resourceKey,
+                type: .resource,
+                isPending: true,
+                stopAction: { [weak self] in
+                    self?.modifySessionItem(type: .resource, label: resourceKey) { mutableSessionItem in
+                        mutableSessionItem.isPending = false
+                        mutableSessionItem.stopAction = nil
+                        Global.rum.stopResourceLoading(resourceKey: resourceKey, statusCode: nil, kind: .other)
+                    }
+                }
+            )
+        )
+
+        Global.rum.startResourceLoading(resourceKey: resourceKey, url: mockURL())
+        self.resourceKey = ""
+    }
+
+    // MARK: - Private
+
+    private func modifySessionItem(type: SessionItemType, label: String, change: (inout SessionItem) -> Void) {
+        sessionItems = sessionItems.map { item in
+            var item = item
+            if item.type == type, item.label == label {
+                change(&item)
+            }
+            return item
+        }
+    }
+
+    private func mockURL() -> URL {
+        return URL(string: "https://foo.com/\(UUID().uuidString)")!
+    }
+}
+
+@available(iOS 13.0, *)
+internal struct DebugRUMSessionView: View {
+    @ObservedObject private var viewModel = DebugRUMSessionViewModel()
+
+    var body: some View {
+        VStack() {
+            HStack {
+                FormItemView(
+                    title: "RUM View", placeholder: "view key", accent: .rumViewColor, value: $viewModel.viewKey
+                )
+                Button("START") { viewModel.startView() }
+            }
+            HStack {
+                FormItemView(
+                    title: "RUM Action", placeholder: "name", accent: .rumActionColor, value: $viewModel.actionName
+                )
+                Button("ADD") { viewModel.addAction() }
+            }
+            HStack {
+                FormItemView(
+                    title: "RUM Error", placeholder: "message", accent: .rumErrorColor, value: $viewModel.errorMessage
+                )
+                Button("ADD") { viewModel.addError() }
+            }
+            HStack {
+                FormItemView(
+                    title: "RUM Resource", placeholder: "key", accent: .rumResourceColor, value: $viewModel.resourceKey
+                )
+                Button("START") { viewModel.startResource() }
+            }
+            Divider()
+            Text("RUM Session:")
+                .bold()
+                .font(.footnote)
+            List(viewModel.sessionItems) { sessionItem in
+                SessionItemView(item: sessionItem)
+                    .listRowInsets(EdgeInsets())
+                    .padding(4)
+            }
+            .listStyle(.plain)
+        }
+        .buttonStyle(DatadogButtonStyle())
+        .padding()
+    }
+}
+
+@available(iOS 13.0, *)
+private struct FormItemView: View {
+    let title: String
+    let placeholder: String
+    let accent: Color
+
+    @Binding var value: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .bold()
+                .font(.system(size: 10))
+                .padding(8)
+                .background(accent)
+                .foregroundColor(Color.white)
+                .cornerRadius(8)
+            TextField(placeholder, text: $value)
+                .font(.system(size: 12))
+                .padding(8)
+                .background(Color(UIColor.secondarySystemFill))
+                .cornerRadius(8)
+        }
+        .padding(8)
+        .background(Color(UIColor.systemFill))
+        .foregroundColor(Color.secondary)
+        .cornerRadius(8)
+    }
+}
+
+@available(iOS 13.0, *)
+private struct SessionItemView: View {
+    let item: DebugRUMSessionViewModel.SessionItem
+
+    var body: some View {
+        HStack() {
+            HStack() {
+                Text(label(for: item.type))
+                    .bold()
+                    .font(.system(size: 10))
+                    .padding(8)
+                    .background(color(for: item.type))
+                    .foregroundColor(Color.white)
+                    .cornerRadius(8)
+                Text(item.label)
+                    .bold()
+                    .font(.system(size: 14))
+                Spacer()
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity)
+            .background(Color(UIColor.systemFill))
+            .foregroundColor(Color.secondary)
+            .cornerRadius(8)
+
+            if item.isPending {
+                Button("STOP") { item.stopAction?() }
+            }
+        }
+    }
+
+    private func color(for sessionItemType: SessionItemType) -> Color {
+        switch sessionItemType {
+        case .view:     return .rumViewColor
+        case .resource: return .rumResourceColor
+        case .action:   return .rumActionColor
+        case .error:    return .rumErrorColor
+        }
+    }
+
+    private func label(for sessionItemType: SessionItemType) -> String {
+        switch sessionItemType {
+        case .view:     return "RUM View"
+        case .resource: return "RUM Resource"
+        case .action:   return "RUM Action"
+        case .error:    return "RUM Error"
+        }
+    }
+}
+
+// MARK - Preview
+
+@available(iOS 13.0, *)
+struct DebugRUMSessionViewController_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            DebugRUMSessionView()
+                .previewLayout(.fixed(width: 400, height: 500))
+                .preferredColorScheme(.light)
+            DebugRUMSessionView()
+                .previewLayout(.fixed(width: 400, height: 500))
+                .preferredColorScheme(.dark)
+        }
+    }
+}

--- a/Datadog/Example/Debugging/Helpers/SwiftUI.swift
+++ b/Datadog/Example/Debugging/Helpers/SwiftUI.swift
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+extension Color {
+    /// Datadog purple.
+    static var datadogPurple: Color {
+        return Color(UIColor(red: 99/256, green: 44/256, blue: 166/256, alpha: 1))
+    }
+
+    static var rumViewColor: Color {
+        return Color(UIColor(red: 0/256, green: 107/256, blue: 194/256, alpha: 1))
+    }
+
+    static var rumResourceColor: Color {
+        return Color(UIColor(red: 113/256, green: 184/256, blue: 231/256, alpha: 1))
+    }
+
+    static var rumActionColor: Color {
+        return Color(UIColor(red: 150/256, green: 95/256, blue: 204/256, alpha: 1))
+    }
+
+    static var rumErrorColor: Color {
+        return Color(UIColor(red: 235/256, green: 54/256, blue: 7/256, alpha: 1))
+    }
+}
+
+@available(iOS 13.0, *)
+internal struct DatadogButtonStyle: ButtonStyle {
+    func makeBody(configuration: DatadogButtonStyle.Configuration) -> some View {
+        return configuration.label
+            .font(.system(size: 14, weight: .medium))
+            .padding(10)
+            .background(Color.datadogPurple)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+    }
+}


### PR DESCRIPTION
### What and why?

📦 As part of `RUMM-1758` work (proposing RFC to reduce number of view updates), I made a simple tool to debug RUM session. I think we can leverage it on a longer run, so I'm adding it to our existing debug toolset.

### How?

Unlike existing "Debug RUM" tool, this new "Debug RUM session" utility allows for sending RUM session composed from different events (actions, errors, resources). Additionally, resources can be controlled by their "start" and "stop", so it is possible to debug sequences like:
* start view A
* start resource R1
* start resource R2
* stop resource R1
* start view B
* stop resource R2

It's also all made in SwiftUI, so adding new features / utils could be easier.

<img width="533" alt="Screenshot 2021-11-19 at 14 29 24" src="https://user-images.githubusercontent.com/2358722/142630648-6ff42478-d6b4-4266-9839-8df914b7c2d2.png">

### Review checklist

~- [] Feature or bugfix MUST have appropriate tests (unit, integration)~
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
