### PR TITLE
RUMM-1780 Prevent FileManager from throwing

### DIFF
--- a/Sources/Datadog/Core/Persistence/Files/Directory.swift
+++ b/Sources/Datadog/Core/Persistence/Files/Directory.swift
@@ -59,7 +59,9 @@ internal struct Directory {
         try retry(times: 3, delay: 0.001) {
             _ = try FileManager.default.replaceItemAt(url, withItemAt: temporaryDirectory.url)
         }
-        try? FileManager.default.removeItem(at: temporaryDirectory.url)
+        if FileManager.default.fileExists(atPath: temporaryDirectory.url.path) {
+            try FileManager.default.removeItem(at: temporaryDirectory.url)
+        }
     }
 
     /// Moves all files from this directory to `destinationDirectory`.


### PR DESCRIPTION
Closes https://github.com/DataDog/dd-sdk-ios/issues/653

### What and why?

`try? FileManager.default.removeItem(at: tempDirectory.url)` is called as an extra safety measure.
It throws most of the time, for example at the app launch it typically throws 3 times: once per feature.
When `Swift Error Breakpoint` is enabled, that causes debugger to halt multiple times.

### How?

`try? FileManager.default.removeItem(at: tempDirectory.url)` should only be called if `FileManager.default.replaceItemAt(url, withItemAt: tempDirectory.url)` fails.
Now this method call is wrapped with a `do-catch` and `removeItem` is called only if an error is caught.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
