### PR TITLE
RUMM-1758 Fix Example app compilation in Xcode 12

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -3570,7 +3570,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = Datadog;
 				TargetAttributes = {
 					61133B81242393DE00786299 = {

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2EInstrumentationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2EInstrumentationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2ETests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2ETests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
@@ -44,23 +44,23 @@ private class DebugRUMSessionViewModel: ObservableObject {
             return
         }
 
-        let viewKey = viewKey
+        let key = viewKey
         sessionItems.append(
             SessionItem(
-                label: viewKey,
+                label: key,
                 type: .view,
                 isPending: true,
                 stopAction: { [weak self] in
-                    self?.modifySessionItem(type: .view, label: viewKey) { mutableSessionItem in
+                    self?.modifySessionItem(type: .view, label: key) { mutableSessionItem in
                         mutableSessionItem.isPending = false
                         mutableSessionItem.stopAction = nil
-                        Global.rum.stopView(key: viewKey)
+                        Global.rum.stopView(key: key)
                     }
                 }
             )
         )
 
-        Global.rum.startView(key: viewKey)
+        Global.rum.startView(key: key)
         self.viewKey = ""
     }
 
@@ -95,23 +95,23 @@ private class DebugRUMSessionViewModel: ObservableObject {
             return
         }
 
-        let resourceKey = self.resourceKey
+        let key = self.resourceKey
         sessionItems.append(
             SessionItem(
-                label: resourceKey,
+                label: key,
                 type: .resource,
                 isPending: true,
                 stopAction: { [weak self] in
-                    self?.modifySessionItem(type: .resource, label: resourceKey) { mutableSessionItem in
+                    self?.modifySessionItem(type: .resource, label: key) { mutableSessionItem in
                         mutableSessionItem.isPending = false
                         mutableSessionItem.stopAction = nil
-                        Global.rum.stopResourceLoading(resourceKey: resourceKey, statusCode: nil, kind: .other)
+                        Global.rum.stopResourceLoading(resourceKey: key, statusCode: nil, kind: .other)
                     }
                 }
             )
         )
 
-        Global.rum.startResourceLoading(resourceKey: resourceKey, url: mockURL())
+        Global.rum.startResourceLoading(resourceKey: key, url: mockURL())
         self.resourceKey = ""
     }
 
@@ -171,7 +171,7 @@ internal struct DebugRUMSessionView: View {
                     .listRowInsets(EdgeInsets())
                     .padding(4)
             }
-            .listStyle(.plain)
+            .listStyle(PlainListStyle())
         }
         .buttonStyle(DatadogButtonStyle())
         .padding()


### PR DESCRIPTION
### What and why?

🐞⚙️ This PR fixes `Example` compilation problem in Xcode 12 (used in nightly tests). 

The issue was introduced in `SwiftUI` code added in #669, where we use a construct not available for Xcode 12.

### How?

Just replacing:
```diff
- .listStyle(.plain)
+ .listStyle(PlainListStyle())
```
and not shadowing class fields with local variables:
```diff
- let viewKey = viewKey
+ let key = viewKey
```

I also migrated our xcworkspace by dismissing recommended changes for Xcode 13.1 (none of them was applicable in our setup).

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
