### PR TITLE
RUMM-1765 Collect RUM events during application launch - part 1

### DIFF
--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -675,7 +675,7 @@ extension Datadog {
                 return self
             }
 
-            /// Enables or disables automatic tracking of background events (events hapenning when no UIViewController is active).
+            /// Enables or disables automatic tracking of background events (events hapenning when no `UIViewController` is active).
             ///
             /// When enabled, the SDK will track RUM Events into an automatically created Background RUM View (named `Background`)
             ///

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -36,11 +36,6 @@ internal struct RUMStartViewCommand: RUMCommand {
     /// The path of this View, rendered in RUM Explorer as `VIEW URL`.
     let path: String
 
-    /// Used to indicate if this command starts the very first View in the app.
-    /// * default `false` means _it's not yet known_,
-    /// * it can be set to `true` by the `RUMApplicationScope` which tracks this state.
-    var isInitialView = false
-
     init(
         time: Date,
         identity: RUMViewIdentifiable,

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -12,10 +12,11 @@ internal protocol RUMCommand {
     var time: Date { set get }
     /// Attributes associated with the command.
     var attributes: [AttributeKey: AttributeValue] { set get }
-
     /// Whether or not receiving this command should start the "Background" view if no view is active
     /// and ``Datadog.Configuration.Builder.trackBackgroundEvents(_:)`` is enabled.
     var canStartBackgroundView: Bool { get }
+    /// Whether or not receiving this command should start the "ApplicationLaunch" view if no view was yet started in current app process.
+    var canStartApplicationLaunchView: Bool { get }
 }
 
 // MARK: - RUM View related commands
@@ -24,6 +25,7 @@ internal struct RUMStartViewCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, it should start its own view, not the "Background"
+    let canStartApplicationLaunchView = false // no, it should start its own view, not the "ApplicationLaunch"
 
     /// The value holding stable identity of the RUM View.
     let identity: RUMViewIdentifiable
@@ -58,6 +60,7 @@ internal struct RUMStopViewCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view
+    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view
 
     /// The value holding stable identity of the RUM View.
     let identity: RUMViewIdentifiable
@@ -67,6 +70,7 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track errors in "Background" view
+    let canStartApplicationLaunchView = true // yes, we want to track errors in "ApplicationLaunch" view
 
     /// The error message.
     let message: String
@@ -124,6 +128,7 @@ internal struct RUMAddViewTimingCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, it doesn't make sense to start "Background" view on receiving custom timing, as it will be `0ns` timing
+    let canStartApplicationLaunchView = false // no, it doesn't make sense to start "ApplicationLaunch" view on receiving custom timing, as it will be `0ns` timing
 
     /// The name of the timing. It will be used as a JSON key, whereas the value will be the timing duration,
     /// measured since the start of the View.
@@ -149,6 +154,7 @@ internal struct RUMStartResourceCommand: RUMResourceCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track resources in "Background" view
+    let canStartApplicationLaunchView = true // yes, we want to track resources in "ApplicationLaunch" view
 
     /// Resource url
     let url: String
@@ -167,6 +173,7 @@ internal struct RUMAddResourceMetricsCommand: RUMResourceCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
+    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
 
     /// Resource metrics.
     let metrics: ResourceMetrics
@@ -177,6 +184,7 @@ internal struct RUMStopResourceCommand: RUMResourceCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
+    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
 
     /// A type of the Resource
     let kind: RUMResourceType
@@ -191,6 +199,7 @@ internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
+    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
 
     /// The error message.
     let errorMessage: String
@@ -263,6 +272,7 @@ internal struct RUMStartUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
+    let canStartApplicationLaunchView = true // yes, we want to track actions in "ApplicationLaunch" view (e.g. it makes sense for custom actions)
 
     let actionType: RUMUserActionType
     let name: String
@@ -273,6 +283,7 @@ internal struct RUMStopUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartUserActionCommand`)
+    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartUserActionCommand`)
 
     let actionType: RUMUserActionType
     let name: String?
@@ -283,6 +294,7 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
+    let canStartApplicationLaunchView = true // yes, we want to track actions in "ApplicationLaunch" view (e.g. it makes sense for custom actions)
 
     let actionType: RUMUserActionType
     let name: String
@@ -294,6 +306,7 @@ internal struct RUMAddLongTaskCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving long tasks in "Background" view
+    let canStartApplicationLaunchView = true // yes, we want to track long tasks in "ApplicationLaunch" view (e.g. any hitches before presenting first UI)
 
     let duration: TimeInterval
 }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -12,6 +12,10 @@ internal protocol RUMCommand {
     var time: Date { set get }
     /// Attributes associated with the command.
     var attributes: [AttributeKey: AttributeValue] { set get }
+
+    /// Whether or not receiving this command should start the "Background" view if no view is active
+    /// and ``Datadog.Configuration.Builder.trackBackgroundEvents(_:)`` is enabled.
+    var canStartBackgroundView: Bool { get }
 }
 
 // MARK: - RUM View related commands
@@ -19,6 +23,7 @@ internal protocol RUMCommand {
 internal struct RUMStartViewCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false // no, it should start its own view, not the "Background"
 
     /// The value holding stable identity of the RUM View.
     let identity: RUMViewIdentifiable
@@ -52,6 +57,7 @@ internal struct RUMStartViewCommand: RUMCommand {
 internal struct RUMStopViewCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false // no, we don't expect receiving it without an active view
 
     /// The value holding stable identity of the RUM View.
     let identity: RUMViewIdentifiable
@@ -60,6 +66,7 @@ internal struct RUMStopViewCommand: RUMCommand {
 internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = true // yes, we want to track errors in "Background" view
 
     /// The error message.
     let message: String
@@ -116,6 +123,7 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
 internal struct RUMAddViewTimingCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false // no, it doesn't make sense to start "Background" view on receiving custom timing, as it will be `0ns` timing
 
     /// The name of the timing. It will be used as a JSON key, whereas the value will be the timing duration,
     /// measured since the start of the View.
@@ -140,6 +148,7 @@ internal struct RUMStartResourceCommand: RUMResourceCommand {
     let resourceKey: String
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = true // yes, we want to track resources in "Background" view
 
     /// Resource url
     let url: String
@@ -157,6 +166,7 @@ internal struct RUMAddResourceMetricsCommand: RUMResourceCommand {
     let resourceKey: String
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
 
     /// Resource metrics.
     let metrics: ResourceMetrics
@@ -166,6 +176,7 @@ internal struct RUMStopResourceCommand: RUMResourceCommand {
     let resourceKey: String
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
 
     /// A type of the Resource
     let kind: RUMResourceType
@@ -179,6 +190,7 @@ internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
     let resourceKey: String
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
 
     /// The error message.
     let errorMessage: String
@@ -250,6 +262,7 @@ internal protocol RUMUserActionCommand: RUMCommand {
 internal struct RUMStartUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
 
     let actionType: RUMUserActionType
     let name: String
@@ -259,6 +272,7 @@ internal struct RUMStartUserActionCommand: RUMUserActionCommand {
 internal struct RUMStopUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartUserActionCommand`)
 
     let actionType: RUMUserActionType
     let name: String?
@@ -268,6 +282,7 @@ internal struct RUMStopUserActionCommand: RUMUserActionCommand {
 internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
 
     let actionType: RUMUserActionType
     let name: String
@@ -278,6 +293,7 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
 internal struct RUMAddLongTaskCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = false // no, we don't expect receiving long tasks in "Background" view
 
     let duration: TimeInterval
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -101,6 +101,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         startInitialViewCommand.isInitialView = true
 
         let initialSession = RUMSessionScope(
+            isInitialSession: true,
             parent: self,
             dependencies: dependencies,
             samplingRate: samplingRate,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -36,6 +36,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     let sessionUUID: RUMUUID
     /// Tells if events from this Session should be sampled-out (not send).
     let shouldBeSampledOut: Bool
+    /// If this is the very first session created in the current app process (`false` for session created upon expiration of a previous one).
+    let isInitialSession: Bool
     /// RUM Session sampling rate.
     private let samplingRate: Float
     /// The start time of this Session.
@@ -44,6 +46,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     private var lastInteractionTime: Date
 
     init(
+        isInitialSession: Bool,
         parent: RUMContextProvider,
         dependencies: RUMScopeDependencies,
         samplingRate: Float,
@@ -55,6 +58,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         self.samplingRate = samplingRate
         self.shouldBeSampledOut = RUMSessionScope.randomizeSampling(using: samplingRate)
         self.sessionUUID = shouldBeSampledOut ? .nullUUID : dependencies.rumUUIDGenerator.generateUnique()
+        self.isInitialSession = isInitialSession
         self.sessionStartTime = startTime
         self.lastInteractionTime = startTime
         self.backgroundEventTrackingEnabled = backgroundEventTrackingEnabled
@@ -66,6 +70,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         startTime: Date
     ) {
         self.init(
+            isInitialSession: false,
             parent: expiredSession.parent,
             dependencies: expiredSession.dependencies,
             samplingRate: expiredSession.samplingRate,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -94,6 +94,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 return nil // if the underlying identifiable (`UIVIewController`) no longer exists, skip transferring its scope
             }
             return RUMViewScope(
+                isInitialView: false,
                 parent: self,
                 dependencies: dependencies,
                 identity: expiredViewIdentifiable,
@@ -159,8 +160,10 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     // MARK: - RUMCommands Processing
 
     private func startView(on command: RUMStartViewCommand) {
+        let isStartingInitialView = isInitialSession && !hasTrackedAnyView
         viewScopes.append(
             RUMViewScope(
+                isInitialView: isStartingInitialView,
                 parent: self,
                 dependencies: dependencies,
                 identity: command.identity,
@@ -176,6 +179,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     private func startApplicationLaunchView(on command: RUMCommand) {
         viewScopes.append(
             RUMViewScope(
+                isInitialView: true,
                 parent: self,
                 dependencies: dependencies,
                 identity: Constants.applicationLaunchViewURL,
@@ -189,8 +193,10 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     }
 
     private func startBackgroundView(on command: RUMCommand) {
+        let isStartingInitialView = isInitialSession && !hasTrackedAnyView
         viewScopes.append(
             RUMViewScope(
+                isInitialView: isStartingInitialView,
                 parent: self,
                 dependencies: dependencies,
                 identity: Constants.backgroundViewURL,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -8,9 +8,6 @@ import Foundation
 
 internal class RUMViewScope: RUMScope, RUMContextProvider {
     struct Constants {
-        static let backgroundViewURL = "com/datadog/background/view"
-        static let backgroundViewName = "Background"
-
         static let frozenFrameThresholdInNs = (0.07).toInt64Nanoseconds // 70ms
         static let slowRenderingThresholdFPS = 55.0
     }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -201,6 +201,12 @@ extension RUMActionEvent: RandomMockable {
     }
 }
 
+extension RUMErrorEvent.Error.SourceType: RandomMockable {
+    static func mockRandom() -> RUMErrorEvent.Error.SourceType {
+        return [.android, .browser, .ios, .reactNative].randomElement()!
+    }
+}
+
 extension RUMErrorEvent: RandomMockable {
     static func mockRandom() -> RUMErrorEvent {
         return RUMErrorEvent(
@@ -229,7 +235,7 @@ extension RUMErrorEvent: RandomMockable {
                     url: .mockRandom()
                 ),
                 source: [.source, .network, .custom].randomElement()!,
-                sourceType: [.android, .browser, .ios, .reactNative].randomElement()!,
+                sourceType: .mockRandom(),
                 stack: .mockRandom(),
                 type: .mockRandom()
             ),

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -159,8 +159,37 @@ struct RUMCommandMock: RUMCommand {
     var canStartApplicationLaunchView = false
 }
 
-extension RUMStartViewCommand {
+/// Creates random `RUMCommand` from available ones.
+func mockRandomRUMCommand(where predicate: (RUMCommand) -> Bool = { _ in true }) -> RUMCommand {
+    let allCommands: [RUMCommand] = [
+        RUMStartViewCommand.mockRandom(),
+        RUMStopViewCommand.mockRandom(),
+        RUMAddCurrentViewErrorCommand.mockRandom(),
+        RUMAddViewTimingCommand.mockRandom(),
+        RUMStartResourceCommand.mockRandom(),
+        RUMAddResourceMetricsCommand.mockRandom(),
+        RUMStopResourceCommand.mockRandom(),
+        RUMStopResourceWithErrorCommand.mockRandom(),
+        RUMStartUserActionCommand.mockRandom(),
+        RUMStopUserActionCommand.mockRandom(),
+        RUMAddUserActionCommand.mockRandom(),
+        RUMAddLongTaskCommand.mockRandom(),
+    ]
+    return allCommands.filter(predicate).randomElement()!
+}
+
+extension RUMStartViewCommand: AnyMockable, RandomMockable {
     static func mockAny() -> RUMStartViewCommand { mockWith() }
+
+    static func mockRandom() -> RUMStartViewCommand {
+        return .mockWith(
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            identity: String.mockRandom(),
+            name: .mockRandom(),
+            path: .mockRandom()
+        )
+    }
 
     static func mockWith(
         time: Date = Date(),
@@ -179,8 +208,16 @@ extension RUMStartViewCommand {
     }
 }
 
-extension RUMStopViewCommand {
+extension RUMStopViewCommand: AnyMockable, RandomMockable {
     static func mockAny() -> RUMStopViewCommand { mockWith() }
+
+    static func mockRandom() -> RUMStopViewCommand {
+        return .mockWith(
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            identity: String.mockRandom()
+        )
+    }
 
     static func mockWith(
         time: Date = Date(),
@@ -193,7 +230,29 @@ extension RUMStopViewCommand {
     }
 }
 
-extension RUMAddCurrentViewErrorCommand {
+extension RUMAddCurrentViewErrorCommand: AnyMockable, RandomMockable {
+    static func mockAny() -> RUMAddCurrentViewErrorCommand { .mockWithErrorObject() }
+
+    static func mockRandom() -> RUMAddCurrentViewErrorCommand {
+        if Bool.random() {
+            return .mockWithErrorObject(
+                time: .mockRandomInThePast(),
+                error: ErrorMock(.mockRandom()),
+                source: .mockRandom(),
+                attributes: mockRandomAttributes()
+            )
+        } else {
+            return .mockWithErrorMessage(
+                time: .mockRandomInThePast(),
+                message: .mockRandom(),
+                type: .mockRandom(),
+                source: .mockRandom(),
+                stack: .mockRandom(),
+                attributes: mockRandomAttributes()
+            )
+        }
+    }
+
     static func mockWithErrorObject(
         time: Date = Date(),
         error: Error = ErrorMock(),
@@ -219,7 +278,17 @@ extension RUMAddCurrentViewErrorCommand {
     }
 }
 
-extension RUMAddViewTimingCommand {
+extension RUMAddViewTimingCommand: AnyMockable, RandomMockable {
+    static func mockAny() -> RUMAddViewTimingCommand { .mockWith() }
+
+    static func mockRandom() -> RUMAddViewTimingCommand {
+        return .mockWith(
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            timingName: .mockRandom()
+        )
+    }
+
     static func mockWith(
         time: Date = Date(),
         attributes: [AttributeKey: AttributeValue] = [:],
@@ -231,8 +300,21 @@ extension RUMAddViewTimingCommand {
     }
 }
 
-extension RUMStartResourceCommand {
+extension RUMStartResourceCommand: AnyMockable, RandomMockable {
     static func mockAny() -> RUMStartResourceCommand { mockWith() }
+
+    static func mockRandom() -> RUMStartResourceCommand {
+        return .mockWith(
+            resourceKey: .mockRandom(),
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            url: .mockRandom(),
+            httpMethod: .mockRandom(),
+            kind: .mockAny(),
+            isFirstPartyRequest: .mockRandom(),
+            spanContext: .init(traceID: .mockRandom(), spanID: .mockRandom())
+        )
+    }
 
     static func mockWith(
         resourceKey: String = .mockAny(),
@@ -257,8 +339,46 @@ extension RUMStartResourceCommand {
     }
 }
 
-extension RUMStopResourceCommand {
+extension RUMAddResourceMetricsCommand: AnyMockable, RandomMockable {
+    static func mockAny() -> RUMAddResourceMetricsCommand { mockWith() }
+
+    static func mockRandom() -> RUMAddResourceMetricsCommand {
+        return mockWith(
+            resourceKey: .mockRandom(),
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            metrics: .mockAny()
+        )
+    }
+
+    static func mockWith(
+        resourceKey: String = .mockAny(),
+        time: Date = .mockAny(),
+        attributes: [AttributeKey: AttributeValue] = [:],
+        metrics: ResourceMetrics = .mockAny()
+    ) -> RUMAddResourceMetricsCommand {
+        return RUMAddResourceMetricsCommand(
+            resourceKey: resourceKey,
+            time: time,
+            attributes: attributes,
+            metrics: metrics
+        )
+    }
+}
+
+extension RUMStopResourceCommand: AnyMockable, RandomMockable {
     static func mockAny() -> RUMStopResourceCommand { mockWith() }
+
+    static func mockRandom() -> RUMStopResourceCommand {
+        return mockWith(
+            resourceKey: .mockRandom(),
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            kind: [.native, .image, .font, .other].randomElement()!,
+            httpStatusCode: .mockRandom(),
+            size: .mockRandom()
+        )
+    }
 
     static func mockWith(
         resourceKey: String = .mockAny(),
@@ -274,7 +394,32 @@ extension RUMStopResourceCommand {
     }
 }
 
-extension RUMStopResourceWithErrorCommand {
+extension RUMStopResourceWithErrorCommand: AnyMockable, RandomMockable {
+    static func mockAny() -> RUMStopResourceWithErrorCommand { mockWithErrorMessage() }
+
+    static func mockRandom() -> RUMStopResourceWithErrorCommand {
+        if Bool.random() {
+            return mockWithErrorObject(
+                resourceKey: .mockRandom(),
+                time: .mockRandomInThePast(),
+                error: ErrorMock(.mockRandom()),
+                source: .mockRandom(),
+                httpStatusCode: .mockRandom(),
+                attributes: mockRandomAttributes()
+            )
+        } else {
+            return mockWithErrorMessage(
+                resourceKey: .mockRandom(),
+                time: .mockRandomInThePast(),
+                message: .mockRandom(),
+                type: .mockRandom(),
+                source: .mockRandom(),
+                httpStatusCode: .mockRandom(),
+                attributes: mockRandomAttributes()
+            )
+        }
+    }
+
     static func mockWithErrorObject(
         resourceKey: String = .mockAny(),
         time: Date = Date(),
@@ -303,8 +448,17 @@ extension RUMStopResourceWithErrorCommand {
     }
 }
 
-extension RUMStartUserActionCommand {
+extension RUMStartUserActionCommand: AnyMockable, RandomMockable {
     static func mockAny() -> RUMStartUserActionCommand { mockWith() }
+
+    static func mockRandom() -> RUMStartUserActionCommand {
+        return mockWith(
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            actionType: [.swipe, .scroll, .custom].randomElement()!,
+            name: .mockRandom()
+        )
+    }
 
     static func mockWith(
         time: Date = Date(),
@@ -318,8 +472,17 @@ extension RUMStartUserActionCommand {
     }
 }
 
-extension RUMStopUserActionCommand {
+extension RUMStopUserActionCommand: AnyMockable, RandomMockable {
     static func mockAny() -> RUMStopUserActionCommand { mockWith() }
+
+    static func mockRandom() -> RUMStopUserActionCommand {
+        return mockWith(
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            actionType: [.swipe, .scroll, .custom].randomElement()!,
+            name: .mockRandom()
+        )
+    }
 
     static func mockWith(
         time: Date = Date(),
@@ -333,8 +496,17 @@ extension RUMStopUserActionCommand {
     }
 }
 
-extension RUMAddUserActionCommand {
+extension RUMAddUserActionCommand: AnyMockable, RandomMockable {
     static func mockAny() -> RUMAddUserActionCommand { mockWith() }
+
+    static func mockRandom() -> RUMAddUserActionCommand {
+        return mockWith(
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            actionType: [.tap, .custom].randomElement()!,
+            name: .mockRandom()
+        )
+    }
 
     static func mockWith(
         time: Date = Date(),
@@ -345,6 +517,38 @@ extension RUMAddUserActionCommand {
         return RUMAddUserActionCommand(
             time: time, attributes: attributes, actionType: actionType, name: name
         )
+    }
+}
+
+extension RUMAddLongTaskCommand: AnyMockable, RandomMockable {
+    static func mockAny() -> RUMAddLongTaskCommand { mockWith() }
+
+    static func mockRandom() -> RUMAddLongTaskCommand {
+        return mockWith(
+            time: .mockRandomInThePast(),
+            attributes: mockRandomAttributes(),
+            duration: .mockRandom(min: 0.01, max: 1)
+        )
+    }
+
+    static func mockWith(
+        time: Date = .mockAny(),
+        attributes: [AttributeKey: AttributeValue] = [:],
+        duration: TimeInterval = 0.01
+    ) -> RUMAddLongTaskCommand {
+        return RUMAddLongTaskCommand(
+            time: time,
+            attributes: attributes,
+            duration: duration
+        )
+    }
+}
+
+// MARK: - RUMCommand Property Mocks
+
+extension RUMInternalErrorSource: RandomMockable {
+    static func mockRandom() -> RUMInternalErrorSource {
+        return [.custom, .source, .network, .webview, .logger, .console].randomElement()!
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -155,6 +155,7 @@ extension RUMEventsMapper {
 struct RUMCommandMock: RUMCommand {
     var time = Date()
     var attributes: [AttributeKey: AttributeValue] = [:]
+    var canStartBackgroundView = false
 }
 
 extension RUMStartViewCommand {

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -474,13 +474,15 @@ extension RUMSessionScope {
     }
 
     static func mockWith(
-        parent: RUMApplicationScope = .mockAny(),
+        isInitialSession: Bool = .mockAny(),
+        parent: RUMContextProvider = RUMContextProviderMock(),
         dependencies: RUMScopeDependencies = .mockAny(),
         samplingRate: Float = 100,
         startTime: Date = .mockAny(),
         backgroundEventTrackingEnabled: Bool = .mockAny()
     ) -> RUMSessionScope {
         return RUMSessionScope(
+            isInitialSession: isInitialSession,
             parent: parent,
             dependencies: dependencies,
             samplingRate: samplingRate,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -167,18 +167,15 @@ extension RUMStartViewCommand {
         attributes: [AttributeKey: AttributeValue] = [:],
         identity: RUMViewIdentifiable = mockView,
         name: String = .mockAny(),
-        path: String? = nil,
-        isInitialView: Bool = false
+        path: String? = nil
     ) -> RUMStartViewCommand {
-        var command = RUMStartViewCommand(
+        return RUMStartViewCommand(
             time: time,
             identity: identity,
             name: name,
             path: path,
             attributes: attributes
         )
-        command.isInitialView = isInitialView
-        return command
     }
 }
 
@@ -535,6 +532,7 @@ extension RUMViewScope {
     }
 
     static func mockWith(
+        isInitialView: Bool = false,
         parent: RUMContextProvider = RUMContextProviderMock(),
         dependencies: RUMScopeDependencies = .mockAny(),
         identity: RUMViewIdentifiable = mockView,
@@ -545,6 +543,7 @@ extension RUMViewScope {
         startTime: Date = .mockAny()
     ) -> RUMViewScope {
         return RUMViewScope(
+            isInitialView: isInitialView,
             parent: parent,
             dependencies: dependencies,
             identity: identity,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -156,6 +156,7 @@ struct RUMCommandMock: RUMCommand {
     var time = Date()
     var attributes: [AttributeKey: AttributeValue] = [:]
     var canStartBackgroundView = false
+    var canStartApplicationLaunchView = false
 }
 
 extension RUMStartViewCommand {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -95,15 +95,6 @@ class RUMApplicationScopeTests: XCTestCase {
         XCTAssertFalse(nextSession.isInitialSession, "Any next session in the application must be marked as 'not initial'")
     }
 
-    func testUntilSessionIsStarted_itIgnoresOtherCommands() {
-        let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: .mockAny(), samplingRate: 100, backgroundEventTrackingEnabled: .mockAny())
-
-        XCTAssertTrue(scope.process(command: RUMStopViewCommand.mockAny()))
-        XCTAssertTrue(scope.process(command: RUMAddUserActionCommand.mockAny()))
-        XCTAssertTrue(scope.process(command: RUMStopResourceCommand.mockAny()))
-        XCTAssertNil(scope.sessionScope)
-    }
-
     // MARK: - RUM Session Sampling
 
     func testWhenSamplingRateIs100_allEventsAreSent() {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -23,7 +23,7 @@ class RUMApplicationScopeTests: XCTestCase {
         XCTAssertNil(scope.context.activeUserActionID)
     }
 
-    func testWhenFirstViewIsStarted_itStartsNewSession() throws {
+    func testWhenFirstEventIsReceived_itStartsNewSession() throws {
         let expectation = self.expectation(description: "onSessionStart is called")
         let onSessionStart: RUMSessionListener = { sessionId, isDiscarded in
             XCTAssertTrue(sessionId.matches(regex: .uuidRegex))
@@ -41,7 +41,7 @@ class RUMApplicationScopeTests: XCTestCase {
         )
 
         XCTAssertNil(scope.sessionScope)
-        XCTAssertTrue(scope.process(command: RUMStartViewCommand.mockAny()))
+        XCTAssertTrue(scope.process(command: mockRandomRUMCommand()))
         waitForExpectations(timeout: 0.5)
 
         let sessionScope = try XCTUnwrap(scope.sessionScope)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -12,7 +12,7 @@ class RUMSessionScopeTests: XCTestCase {
 
     func testDefaultContext() {
         let parent: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
-        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: .mockAny(), backgroundEventTrackingEnabled: .mockAny())
+        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 100)
 
         XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
         XCTAssertNotEqual(scope.context.sessionID, .nullUUID)
@@ -23,7 +23,7 @@ class RUMSessionScopeTests: XCTestCase {
 
     func testContextWhenSessionIsSampled() {
         let parent: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
-        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 0, startTime: .mockAny(), backgroundEventTrackingEnabled: .mockAny())
+        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 0)
 
         XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
         XCTAssertEqual(scope.context.sessionID, .nullUUID)
@@ -35,7 +35,7 @@ class RUMSessionScopeTests: XCTestCase {
     func testWhenSessionExceedsMaxDuration_itGetsClosed() {
         var currentTime = Date()
         let parent = RUMContextProviderMock()
-        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 50, startTime: currentTime, backgroundEventTrackingEnabled: .mockAny())
+        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 50, startTime: currentTime)
 
         XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)))
 
@@ -48,7 +48,7 @@ class RUMSessionScopeTests: XCTestCase {
     func testWhenSessionIsInactiveForCertainDuration_itGetsClosed() {
         var currentTime = Date()
         let parent = RUMContextProviderMock()
-        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 50, startTime: currentTime, backgroundEventTrackingEnabled: .mockAny())
+        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 50, startTime: currentTime)
 
         XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)))
 
@@ -66,7 +66,7 @@ class RUMSessionScopeTests: XCTestCase {
     func testItManagesViewScopeLifecycle() {
         let parent = RUMContextProviderMock()
 
-        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date(), backgroundEventTrackingEnabled: .mockAny())
+        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 100, startTime: Date())
         XCTAssertEqual(scope.viewScopes.count, 0)
         _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
         XCTAssertEqual(scope.viewScopes.count, 1)
@@ -189,7 +189,7 @@ class RUMSessionScopeTests: XCTestCase {
     func testWhenSessionIsSampled_itDoesNotCreateViewScopes() {
         let parent = RUMContextProviderMock()
 
-        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 0, startTime: Date(), backgroundEventTrackingEnabled: .mockAny())
+        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 0, startTime: Date())
         XCTAssertEqual(scope.viewScopes.count, 0)
         XCTAssertTrue(
             scope.process(command: RUMStartViewCommand.mockWith(identity: mockView)),
@@ -204,7 +204,7 @@ class RUMSessionScopeTests: XCTestCase {
         // Given
         let parent = RUMContextProviderMock()
 
-        let scope = RUMSessionScope(parent: parent, dependencies: .mockAny(), samplingRate: 100, startTime: Date(), backgroundEventTrackingEnabled: .mockAny())
+        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 100, startTime: Date())
         XCTAssertEqual(scope.viewScopes.count, 0)
 
         let previousUserLogger = userLogger

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -17,6 +17,7 @@ class RUMViewScopeTests: XCTestCase {
         let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         let sessionScope: RUMSessionScope = .mockWith(parent: applicationScope)
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: sessionScope,
             dependencies: .mockAny(),
             identity: mockView,
@@ -39,6 +40,7 @@ class RUMViewScopeTests: XCTestCase {
         let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         let sessionScope: RUMSessionScope = .mockWith(parent: applicationScope)
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: sessionScope,
             dependencies: .mockAny(),
             identity: mockView,
@@ -59,9 +61,10 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(scope.context.activeUserActionID, try XCTUnwrap(scope.userActionScope?.actionUUID))
     }
 
-    func testWhenInitialViewIsStarted_itSendsApplicationStartAction() throws {
+    func testWhenInitialViewReceivesAnyCommand_itSendsApplicationStartAction() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
+            isInitialView: true,
             parent: parent,
             dependencies: .mockWith(
                 launchTimeProvider: LaunchTimeProviderMock(launchTime: 2), // 2 seconds
@@ -75,11 +78,7 @@ class RUMViewScopeTests: XCTestCase {
             startTime: currentTime
         )
 
-        XCTAssertTrue(
-            scope.process(
-                command: RUMStartViewCommand.mockWith(time: currentTime, attributes: ["foo": "bar"], identity: mockView, isInitialView: true)
-            )
-        )
+        _ = scope.process(command: RUMCommandMock(time: currentTime))
 
         let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMActionEvent>.self).first)
         XCTAssertEqual(event.model.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toInt64Milliseconds)
@@ -95,9 +94,10 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
-    func testWhenInitialViewIsStarted_itSendsViewUpdateEvent() throws {
+    func testWhenInitialViewReceivesAnyCommand_itSendsViewUpdateEvent() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
+            isInitialView: true,
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -108,11 +108,7 @@ class RUMViewScopeTests: XCTestCase {
             startTime: currentTime
         )
 
-        XCTAssertTrue(
-            scope.process(
-                command: RUMStartViewCommand.mockWith(time: currentTime, attributes: ["foo": "bar"], identity: mockView, isInitialView: true)
-            )
-        )
+        _ = scope.process(command: RUMCommandMock(time: currentTime))
 
         let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).first)
         XCTAssertEqual(event.model.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toInt64Milliseconds)
@@ -129,13 +125,14 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.view.error.count, 0)
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)
-        XCTAssertEqual(event.model.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(event.model.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
     func testWhenViewIsStarted_itSendsViewUpdateEvent() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let isInitialView: Bool = .mockRandom()
         let scope = RUMViewScope(
+            isInitialView: isInitialView,
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -163,7 +160,7 @@ class RUMViewScopeTests: XCTestCase {
         let viewIsActive = try XCTUnwrap(event.model.view.isActive)
         XCTAssertTrue(viewIsActive)
         XCTAssertEqual(event.model.view.timeSpent, 0)
-        XCTAssertEqual(event.model.view.action.count, 0)
+        XCTAssertEqual(event.model.view.action.count, isInitialView ? 1 : 0, "It must track application start action only if this is an initial view")
         XCTAssertEqual(event.model.view.error.count, 0)
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 1)
@@ -172,7 +169,9 @@ class RUMViewScopeTests: XCTestCase {
 
     func testWhenViewIsStopped_itSendsViewUpdateEvent_andEndsTheScope() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
+        let isInitialView: Bool = .mockRandom()
         let scope = RUMViewScope(
+            isInitialView: isInitialView,
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -213,7 +212,7 @@ class RUMViewScopeTests: XCTestCase {
         let viewIsActive = try XCTUnwrap(event.model.view.isActive)
         XCTAssertFalse(viewIsActive)
         XCTAssertEqual(event.model.view.timeSpent, TimeInterval(2).toInt64Nanoseconds)
-        XCTAssertEqual(event.model.view.action.count, 0)
+        XCTAssertEqual(event.model.view.action.count, isInitialView ? 1 : 0, "It must track application start action only if this is an initial view")
         XCTAssertEqual(event.model.view.error.count, 0)
         XCTAssertEqual(event.model.view.resource.count, 0)
         XCTAssertEqual(event.model.dd.documentVersion, 2)
@@ -225,6 +224,7 @@ class RUMViewScopeTests: XCTestCase {
         let view2 = createMockView(viewControllerClassName: "SecondViewController")
         var currentTime = Date()
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: view1,
@@ -260,6 +260,7 @@ class RUMViewScopeTests: XCTestCase {
     func testWhenTheViewIsStartedAnotherTime_itEndsTheScope() throws {
         var currentTime = Date()
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -295,6 +296,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenMultipleViewScopes_whenSendingViewEvent_eachScopeUsesUniqueViewID() throws {
         func createScope(uri: String, name: String) -> RUMViewScope {
             RUMViewScope(
+                isInitialView: false,
                 parent: parent,
                 dependencies: dependencies,
                 identity: mockView,
@@ -331,6 +333,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testItManagesResourceScopesLifecycle() throws {
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -380,6 +383,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testGivenViewWithPendingResources_whenItGetsStopped_itDoesNotFinishUntilResourcesComplete() throws {
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -426,6 +430,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testItManagesContinuousUserActionScopeLifecycle() throws {
         let scope = RUMViewScope(
+            isInitialView: false,
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -486,6 +491,7 @@ class RUMViewScopeTests: XCTestCase {
     func testItManagesDiscreteUserActionScopeLifecycle() throws {
         var currentTime = Date()
         let scope = RUMViewScope(
+            isInitialView: false,
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -547,6 +553,7 @@ class RUMViewScopeTests: XCTestCase {
     func testWhenViewErrorIsAdded_itSendsErrorEventAndViewUpdateEvent() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -559,7 +566,7 @@ class RUMViewScopeTests: XCTestCase {
 
         XCTAssertTrue(
             scope.process(
-                command: RUMStartViewCommand.mockWith(time: currentTime, attributes: ["foo": "bar"], identity: mockView, isInitialView: true)
+                command: RUMStartViewCommand.mockWith(time: currentTime, attributes: ["foo": "bar"], identity: mockView)
             )
         )
 
@@ -629,6 +636,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testWhenResourceIsFinishedWithError_itSendsViewUpdateEvent() throws {
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -641,7 +649,7 @@ class RUMViewScopeTests: XCTestCase {
 
         XCTAssertTrue(
             scope.process(
-                command: RUMStartViewCommand.mockWith(attributes: ["foo": "bar"], identity: mockView, isInitialView: true)
+                command: RUMStartViewCommand.mockWith(attributes: ["foo": "bar"], identity: mockView)
             )
         )
 
@@ -668,6 +676,7 @@ class RUMViewScopeTests: XCTestCase {
         let startViewDate: Date = .mockDecember15th2019At10AMUTC()
 
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -680,7 +689,7 @@ class RUMViewScopeTests: XCTestCase {
 
         XCTAssertTrue(
             scope.process(
-                command: RUMStartViewCommand.mockWith(time: startViewDate, attributes: ["foo": "bar"], identity: mockView, isInitialView: true)
+                command: RUMStartViewCommand.mockWith(time: startViewDate, attributes: ["foo": "bar"], identity: mockView)
             )
         )
 
@@ -718,6 +727,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenActiveView_whenCustomTimingIsRegistered_itSendsViewUpdateEvent() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -770,6 +780,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenInactiveView_whenCustomTimingIsRegistered_itDoesNotSendViewUpdateEvent() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -804,6 +815,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenActiveView_whenCustomTimingIsRegistered_itSanitizesCustomTiming() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
+            isInitialView: .mockRandom(),
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -866,6 +878,7 @@ class RUMViewScopeTests: XCTestCase {
 
         // Given
         let scope = RUMViewScope(
+            isInitialView: false,
             parent: parent,
             dependencies: dependencies.replacing(dateCorrector: dateCorrectorMock),
             identity: mockView,
@@ -955,6 +968,7 @@ class RUMViewScopeTests: XCTestCase {
         let dependencies: RUMScopeDependencies = .mockWith(eventBuilder: eventBuilder, eventOutput: output)
 
         let scope = RUMViewScope(
+            isInitialView: true,
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -965,7 +979,7 @@ class RUMViewScopeTests: XCTestCase {
             startTime: Date()
         )
         XCTAssertTrue(
-            scope.process(command: RUMStartViewCommand.mockWith(identity: mockView, isInitialView: true))
+            scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
         )
 
         XCTAssertTrue(
@@ -1024,7 +1038,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.model.dd.documentVersion, 3, "After starting the application, stopping the view, starting/stopping one resource out of 2, discarding a user action and an error, the View scope should have sent 3 View events.")
     }
 
-    func testGivenViewScopeWithDroppingEventsMapper_whenProcessingApplicationStartAction_thenNoEventIsSent() throws {
+    func testGivenViewScopeWithDroppingEventsMapper_whenProcessingApplicationStartAction_thenCountIsAdjusted() throws {
         let eventBuilder = RUMEventBuilder(
             eventsMapper: .mockWith(
                 actionEventMapper: { event in
@@ -1034,7 +1048,9 @@ class RUMViewScopeTests: XCTestCase {
         )
         let dependencies: RUMScopeDependencies = .mockWith(eventBuilder: eventBuilder, eventOutput: output)
 
+        // Given
         let scope = RUMViewScope(
+            isInitialView: true,
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -1044,10 +1060,15 @@ class RUMViewScopeTests: XCTestCase {
             customTimings: [:],
             startTime: Date()
         )
+
+        // When
         XCTAssertTrue(
-            scope.process(command: RUMStartViewCommand.mockWith(identity: mockView, isInitialView: true))
+            scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
         )
 
-        XCTAssertNil(try output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)
+        // Then
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)
+        XCTAssertEqual(event.model.view.action.count, 0, "All actions, including ApplicationStart action should be dropped")
+        XCTAssertEqual(event.model.dd.documentVersion, 1, "It should record only one view update")
     }
 }


### PR DESCRIPTION
### What and why?

📦 This is the first PR on _application launch events tracking_. It implements the base logic of starting "ApplicationLaunch" view if any RUM event is received before tracking the first view:

<img width="383" alt="Screenshot 2021-12-01 at 14 55 22" src="https://user-images.githubusercontent.com/2358722/144247072-3e16eb9d-c024-42a8-b270-4c145a58fcd1.png">

### How?

It was known that this feature will collide with existing [Background Events Tracking](https://github.com/DataDog/dd-sdk-ios/blob/b28016175691665c9c2e1d3d867e90d6f4437ab2/Sources/Datadog/DatadogConfiguration.swift#L678-L690) option, which creates "Background" view for capturing off-view events. Most of the effort in this PR is focused on decoupling both and implementing a clear separation of following cases:
* when event is received and existing session didn't yet track any view → start "ApplicationLaunch" view;
* when event is received and existing session has tracked some view → start "Background" view (if [BET](https://github.com/DataDog/dd-sdk-ios/blob/b28016175691665c9c2e1d3d867e90d6f4437ab2/Sources/Datadog/DatadogConfiguration.swift#L678-L690) is enabled);

This required introducing a notion of "initial RUM session" - the very first session in current app process. If session times out, next RUM session is not marked as "initial".

To make code more readable and the implementation more explicit, I added two values to the `RUMCommand` interface, so we can clearly know if a given event should result with a side effect in off-view tracking:
```swift
/// Whether or not receiving this command should start the "Background" view if no view is active
/// and ``Datadog.Configuration.Builder.trackBackgroundEvents(_:)`` is enabled.
var canStartBackgroundView: Bool { get }

/// Whether or not receiving this command should start the "ApplicationLaunch" view if no view was yet started in current app process.
var canStartApplicationLaunchView: Bool { get }
```

#### Next PRs

There are two key elements missing in this PR, which will be delivered in separate PRs:
* When the app is launched in background (e.g. due to location change), we should not create "ApplicationLaunch" view - instead, "Background" view should be created if user opted-in for [BET](https://github.com/DataDog/dd-sdk-ios/blob/b28016175691665c9c2e1d3d867e90d6f4437ab2/Sources/Datadog/DatadogConfiguration.swift#L678-L690).
* When the app crashes while there is no active RUM view, we need to handle this crash respectively from restarted session. We need to consider if it should be sent within "ApplicationLaunch" view, "Background" view or sampled.

More on these edge cases can be read in _"RFC - Collecting App Launch Crashes in Mobile SDKs"_.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
