### PR TITLE
🚩RUM-1755 Add config overrides for debug launch arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ instrumented-tests/LICENSE
 venv
 *.pyc
 __pycache__
+*.swp

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -50,6 +50,16 @@
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "DD_DEBUG"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "DD_DEBUG_RUM"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "DD_TEST_SCENARIO_CLASS_NAME"

--- a/Sources/Datadog/Core/System/MobileDevice.swift
+++ b/Sources/Datadog/Core/System/MobileDevice.swift
@@ -79,50 +79,29 @@ internal class MobileDevice {
         )
     }
 
-    // MARK: - Singleton
-    private static var _instance: MobileDevice?
-
-    /// Returns current mobile device  if `UIDevice` is available on this platform.
-    /// On other platforms returns `nil`.
-    static var current: MobileDevice {
-        get {
-            if let instance = _instance {
-                return instance
-            }
-
-            #if !targetEnvironment(simulator)
-            // Real device
-            _instance = MobileDevice(
-                uiDevice: UIDevice.current,
-                processInfo: ProcessInfo.processInfo,
-                notificationCenter: .default
-            )
-            #else
-            // iOS Simulator - battery monitoring doesn't work on Simulator, so return "always OK" value
-            _instance = MobileDevice(
-                model: UIDevice.current.model,
-                osName: UIDevice.current.systemName,
-                osVersion: UIDevice.current.systemVersion,
-                processInfo: ProcessInfo.processInfo,
-                enableBatteryStatusMonitoring: {},
-                resetBatteryStatusMonitoring: {},
-                currentBatteryStatus: { BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false) }
-            )
-            #endif
-
-            // swiftlint:disable:next force_unwrapping
-            return _instance!
-        }
-        set(newInstance) {
-            _instance = newInstance
-        }
+    convenience init() {
+        #if !targetEnvironment(simulator)
+        // Real device
+        self.init(
+            uiDevice: UIDevice.current,
+            processInfo: ProcessInfo.processInfo,
+            notificationCenter: .default
+        )
+        #else
+        // iOS Simulator - battery monitoring doesn't work on Simulator, so return "always OK" value
+        self.init(
+            model: UIDevice.current.model,
+            osName: UIDevice.current.systemName,
+            osVersion: UIDevice.current.systemVersion,
+            processInfo: ProcessInfo.processInfo,
+            enableBatteryStatusMonitoring: {},
+            resetBatteryStatusMonitoring: {},
+            currentBatteryStatus: { BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false) }
+        )
+        #endif
     }
 
-    #if DD_SDK_COMPILED_FOR_TESTING
-    static func clearForTesting() {
-        _instance = nil
-    }
-    #endif
+    static var current = MobileDevice()
 
     private static func toBatteryState(_ uiDeviceBatteryState: UIDevice.BatteryState) -> BatteryStatus.State {
         switch uiDeviceBatteryState {

--- a/Sources/Datadog/Core/System/MobileDevice.swift
+++ b/Sources/Datadog/Core/System/MobileDevice.swift
@@ -13,7 +13,6 @@ internal class MobileDevice {
     let model: String
     let osName: String
     let osVersion: String
-    let processInfo: ProcessInfo
 
     // MARK: - Battery status monitoring
 
@@ -41,7 +40,6 @@ internal class MobileDevice {
         model: String,
         osName: String,
         osVersion: String,
-        processInfo: ProcessInfo,
         enableBatteryStatusMonitoring: @escaping () -> Void,
         resetBatteryStatusMonitoring: @escaping () -> Void,
         currentBatteryStatus: @escaping () -> BatteryStatus
@@ -49,7 +47,6 @@ internal class MobileDevice {
         self.model = model
         self.osName = osName
         self.osVersion = osVersion
-        self.processInfo = processInfo
         self.enableBatteryStatusMonitoring = enableBatteryStatusMonitoring
         self.resetBatteryStatusMonitoring = resetBatteryStatusMonitoring
         self.currentBatteryStatus = currentBatteryStatus
@@ -66,7 +63,6 @@ internal class MobileDevice {
             model: uiDevice.model,
             osName: uiDevice.systemName,
             osVersion: uiDevice.systemVersion,
-            processInfo: processInfo,
             enableBatteryStatusMonitoring: { uiDevice.isBatteryMonitoringEnabled = true },
             resetBatteryStatusMonitoring: { uiDevice.isBatteryMonitoringEnabled = wasBatteryMonitoringEnabled },
             currentBatteryStatus: {
@@ -93,15 +89,12 @@ internal class MobileDevice {
             model: UIDevice.current.model,
             osName: UIDevice.current.systemName,
             osVersion: UIDevice.current.systemVersion,
-            processInfo: ProcessInfo.processInfo,
             enableBatteryStatusMonitoring: {},
             resetBatteryStatusMonitoring: {},
             currentBatteryStatus: { BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false) }
         )
         #endif
     }
-
-    static var current = MobileDevice()
 
     private static func toBatteryState(_ uiDeviceBatteryState: UIDevice.BatteryState) -> BatteryStatus.State {
         switch uiDeviceBatteryState {

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -345,6 +345,11 @@ extension Datadog {
                 )
             }
 
+            /// Used internally to rebuild a configuration based on launch arguments
+            internal init(configuration: Configuration) {
+                self.configuration = configuration
+            }
+
             /// Sets the Datadog server endpoint where data is sent.
             ///
             /// If set, it will override values set by any of these deprecated APIs:

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -345,11 +345,6 @@ extension Datadog {
                 )
             }
 
-            /// Used internally to rebuild a configuration based on launch arguments
-            internal init(configuration: Configuration) {
-                self.configuration = configuration
-            }
-
             /// Sets the Datadog server endpoint where data is sent.
             ///
             /// If set, it will override values set by any of these deprecated APIs:

--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -22,7 +22,7 @@ extension FeaturesCommonDependencies {
             consentProvider: ConsentProvider(initialConsent: .granted),
             performance: .benchmarksPreset,
             httpClient: HTTPClient(),
-            mobileDevice: .current,
+            mobileDevice: MobileDevice(),
             dateProvider: SystemDateProvider(),
             dateCorrector: DateCorrectorMock(),
             userInfoProvider: UserInfoProvider(),

--- a/Tests/DatadogTests/Datadog/Core/System/MobileDeviceTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/System/MobileDeviceTests.swift
@@ -11,10 +11,6 @@ import UIKit
 class MobileDeviceTests: XCTestCase {
     private let notificationCenter = NotificationCenter()
 
-    func testWhenRunningOnMobile_itReturnsDevice() {
-        XCTAssertNotNil(MobileDevice.current)
-    }
-
     func testWhenRunningOnMobile_itUsesUIDeviceInfo() {
         let uiDevice = UIDeviceMock(
             model: "model mock",

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -25,6 +25,8 @@ class DatadogTests: XCTestCase {
     }
 
     override func tearDown() {
+        MobileDevice.current = .init()
+
         consolePrint = { print($0) }
         printFunction = nil
         XCTAssertFalse(Datadog.isInitialized)
@@ -338,7 +340,6 @@ class DatadogTests: XCTestCase {
         MobileDevice.current = MobileDevice.mockWith(
             processInfo: mockProcessInfo
         )
-        defer { MobileDevice.current = .init() }
 
         let configuration = rumBuilder
             .set(uploadFrequency: .rare)
@@ -375,7 +376,6 @@ class DatadogTests: XCTestCase {
         MobileDevice.current = MobileDevice.mockWith(
             processInfo: mockProcessInfo
         )
-        defer { MobileDevice.current = .init() }
 
         let configuration = rumBuilder
             .build()

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -18,6 +18,8 @@ class DatadogTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        MobileDevice.clearForTesting()
+
         XCTAssertFalse(Datadog.isInitialized)
         printFunction = PrintFunctionMock()
         consolePrint = printFunction.print
@@ -327,6 +329,67 @@ class DatadogTests: XCTestCase {
                 "When client token for internal monitoring is NOT set, the Internal Monitoring feature should be disabled"
             )
         }
+    }
+
+    func testSupplyingDebugLaunchArgument_itOverridesUserSettings() {
+        let mockProcessInfo = ProcessInfoMock(
+            arguments: [Datadog.LaunchArguments.Debug]
+        )
+
+        MobileDevice.current = MobileDevice.mockWith(
+            processInfo: mockProcessInfo
+        )
+
+        let configuration = rumBuilder
+            .set(uploadFrequency: .rare)
+            .set(rumSessionsSamplingRate: 20.0)
+            .set(batchSize: .medium)
+            .build()
+
+        Datadog.initialize(
+            appContext: .mockAny(),
+            trackingConsent: .pending,
+            configuration: configuration
+        )
+
+        let expectedPerformancePreset = PerformancePreset(
+            batchSize: .small,
+            uploadFrequency: .frequent,
+            bundleType: .iOSApp
+        )
+        XCTAssertEqual(RUMFeature.instance?.configuration.sessionSamplingRate, 100)
+        XCTAssertEqual(TracingFeature.instance?.configuration.common.performance, expectedPerformancePreset)
+        XCTAssertEqual(LoggingFeature.instance?.configuration.common.performance, expectedPerformancePreset)
+        XCTAssertEqual(Datadog.verbosityLevel, .debug)
+
+        // Clear default verbosity after this test
+        Datadog.verbosityLevel = nil
+        Datadog.flushAndDeinitialize()
+    }
+
+    func testSupplyingRumDebugLaunchArgument_itSetsRumDebug() {
+        let mockProcessInfo = ProcessInfoMock(
+            arguments: [Datadog.LaunchArguments.DebugRUM]
+        )
+
+        MobileDevice.current = MobileDevice.mockWith(
+            processInfo: mockProcessInfo
+        )
+
+        let configuration = rumBuilder
+            .build()
+
+        Datadog.initialize(
+            appContext: .mockAny(),
+            trackingConsent: .pending,
+            configuration: configuration
+        )
+
+        XCTAssertTrue(Datadog.debugRUM)
+
+        // Clear debug after test
+        Datadog.debugRUM = false
+        Datadog.flushAndDeinitialize()
     }
 
     // MARK: - Public APIs

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -18,7 +18,6 @@ class DatadogTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        MobileDevice.clearForTesting()
 
         XCTAssertFalse(Datadog.isInitialized)
         printFunction = PrintFunctionMock()
@@ -339,6 +338,7 @@ class DatadogTests: XCTestCase {
         MobileDevice.current = MobileDevice.mockWith(
             processInfo: mockProcessInfo
         )
+        defer { MobileDevice.current = .init() }
 
         let configuration = rumBuilder
             .set(uploadFrequency: .rare)
@@ -375,6 +375,7 @@ class DatadogTests: XCTestCase {
         MobileDevice.current = MobileDevice.mockWith(
             processInfo: mockProcessInfo
         )
+        defer { MobileDevice.current = .init() }
 
         let configuration = rumBuilder
             .build()

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -25,8 +25,6 @@ class DatadogTests: XCTestCase {
     }
 
     override func tearDown() {
-        MobileDevice.current = .init()
-
         consolePrint = { print($0) }
         printFunction = nil
         XCTAssertFalse(Datadog.isInitialized)
@@ -337,10 +335,6 @@ class DatadogTests: XCTestCase {
             arguments: [Datadog.LaunchArguments.Debug]
         )
 
-        MobileDevice.current = MobileDevice.mockWith(
-            processInfo: mockProcessInfo
-        )
-
         let configuration = rumBuilder
             .set(uploadFrequency: .rare)
             .set(rumSessionsSamplingRate: 20.0)
@@ -348,7 +342,9 @@ class DatadogTests: XCTestCase {
             .build()
 
         Datadog.initialize(
-            appContext: .mockAny(),
+            appContext: .mockWith(
+                processInfo: mockProcessInfo
+            ),
             trackingConsent: .pending,
             configuration: configuration
         )
@@ -373,15 +369,13 @@ class DatadogTests: XCTestCase {
             arguments: [Datadog.LaunchArguments.DebugRUM]
         )
 
-        MobileDevice.current = MobileDevice.mockWith(
-            processInfo: mockProcessInfo
-        )
-
         let configuration = rumBuilder
             .build()
 
         Datadog.initialize(
-            appContext: .mockAny(),
+            appContext: .mockWith(
+                processInfo: mockProcessInfo
+            ),
             trackingConsent: .pending,
             configuration: configuration
         )

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -328,13 +328,15 @@ extension AppContext {
         bundleType: BundleType = .iOSApp,
         bundleIdentifier: String? = .mockAny(),
         bundleVersion: String? = .mockAny(),
-        bundleName: String? = .mockAny()
+        bundleName: String? = .mockAny(),
+        processInfo: ProcessInfo = ProcessInfoMock()
     ) -> AppContext {
         return AppContext(
             bundleType: bundleType,
             bundleIdentifier: bundleIdentifier,
             bundleVersion: bundleVersion,
-            bundleName: bundleName
+            bundleName: bundleName,
+            processInfo: processInfo
         )
     }
 }
@@ -786,7 +788,6 @@ extension MobileDevice {
         model: String = .mockAny(),
         osName: String = .mockAny(),
         osVersion: String = .mockAny(),
-        processInfo: ProcessInfo = ProcessInfoMock(),
         enableBatteryStatusMonitoring: @escaping () -> Void = {},
         resetBatteryStatusMonitoring: @escaping () -> Void = {},
         currentBatteryStatus: @escaping () -> BatteryStatus = { .mockAny() }
@@ -795,7 +796,6 @@ extension MobileDevice {
             model: model,
             osName: osName,
             osVersion: osVersion,
-            processInfo: processInfo,
             enableBatteryStatusMonitoring: enableBatteryStatusMonitoring,
             resetBatteryStatusMonitoring: resetBatteryStatusMonitoring,
             currentBatteryStatus: currentBatteryStatus

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -786,6 +786,7 @@ extension MobileDevice {
         model: String = .mockAny(),
         osName: String = .mockAny(),
         osVersion: String = .mockAny(),
+        processInfo: ProcessInfo = ProcessInfoMock(),
         enableBatteryStatusMonitoring: @escaping () -> Void = {},
         resetBatteryStatusMonitoring: @escaping () -> Void = {},
         currentBatteryStatus: @escaping () -> BatteryStatus = { .mockAny() }
@@ -794,6 +795,7 @@ extension MobileDevice {
             model: model,
             osName: osName,
             osVersion: osVersion,
+            processInfo: processInfo,
             enableBatteryStatusMonitoring: enableBatteryStatusMonitoring,
             resetBatteryStatusMonitoring: resetBatteryStatusMonitoring,
             currentBatteryStatus: currentBatteryStatus

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -408,12 +408,16 @@ extension URLRequest: AnyMockable {
 
 class ProcessInfoMock: ProcessInfo {
     private var _isLowPowerModeEnabled: Bool
+    private var _arguments: [String]
 
-    init(isLowPowerModeEnabled: Bool = .mockAny()) {
+    init(isLowPowerModeEnabled: Bool = .mockAny(), arguments: [String] = []) {
         _isLowPowerModeEnabled = isLowPowerModeEnabled
+        _arguments = arguments
     }
 
     override var isLowPowerModeEnabled: Bool { _isLowPowerModeEnabled }
+
+    override var arguments: [String] { _arguments }
 }
 
 // MARK: - URLSession


### PR DESCRIPTION
Adds two launch arguments:
DD_DEBUG sets sampling to 100%, verbosity to debug, and upload frequency to frequent
DD_DEBUG_RUM enables Datadog.debugRUM

All of these settings are changed during initialization to override whatever configuration the user set

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
