### PR TITLE
RUMM-1765 Add debug utility to test background events

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		61020C2A2757AD91005EEAEA /* BackgroundLocationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */; };
+		61020C2C2758E853005EEAEA /* DebugBackgroundEventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */; };
 		6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */; };
 		610DE00E26613E990042763D /* PersistenceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111544725C9A88B007C84C9 /* PersistenceHelper.swift */; };
 		6111542525C992F8007C84C9 /* CrashReportingScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111542425C992F8007C84C9 /* CrashReportingScenarios.swift */; };
@@ -670,6 +672,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundLocationMonitor.swift; sourceTree = "<group>"; };
+		61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBackgroundEventsViewController.swift; sourceTree = "<group>"; };
 		6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingWithActiveSpanIntegration.swift; sourceTree = "<group>"; };
 		6111542425C992F8007C84C9 /* CrashReportingScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingScenarios.swift; sourceTree = "<group>"; };
 		6111543525C993C2007C84C9 /* CrashReportingScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CrashReportingScenario.storyboard; sourceTree = "<group>"; };
@@ -1307,6 +1311,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		61020C272757AD63005EEAEA /* BackgroundEvents */ = {
+			isa = PBXGroup;
+			children = (
+				61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */,
+				61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */,
+			);
+			path = BackgroundEvents;
+			sourceTree = "<group>";
+		};
 		6111542325C992D9007C84C9 /* CrashReporting */ = {
 			isa = PBXGroup;
 			children = (
@@ -2260,6 +2273,7 @@
 				61F74AF326F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift */,
 				618236882710560900125326 /* DebugWebviewViewController.swift */,
 				61776CEC273BEA5500F93802 /* DebugRUMSessionViewController.swift */,
+				61020C272757AD63005EEAEA /* BackgroundEvents */,
 				61776D4C273E6D8100F93802 /* Helpers */,
 			);
 			path = Debugging;
@@ -4318,6 +4332,7 @@
 				6164AE89252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift in Sources */,
 				611EA14225810E1900BC0E56 /* TSHomeViewController.swift in Sources */,
 				612D8F6F25AEE6A7000E2E09 /* RUMScrubbingViewController.swift in Sources */,
+				61020C2A2757AD91005EEAEA /* BackgroundLocationMonitor.swift in Sources */,
 				61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */,
 				61441C952461A649003D8BB8 /* ConsoleOutputInterceptor.swift in Sources */,
 				61D50C5A2580EFF3006038A3 /* URLSessionScenarios.swift in Sources */,
@@ -4344,6 +4359,7 @@
 				61441C0524616DE9003D8BB8 /* ExampleAppDelegate.swift in Sources */,
 				6193DCCE251B6201009B8011 /* RUMTASScreen1ViewController.swift in Sources */,
 				61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */,
+				61020C2C2758E853005EEAEA /* DebugBackgroundEventsViewController.swift in Sources */,
 				61441C992461A649003D8BB8 /* DebugLoggingViewController.swift in Sources */,
 				617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */,
 				6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */,

--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -56,6 +56,7 @@ struct ExampleAppConfiguration: AppConfiguration {
                 .enableTracing(true)
                 .enableRUM(true)
                 .enableCrashReporting(using: DDCrashReportingPlugin())
+                .trackBackgroundEvents()
         }
 
         return configuration.build()

--- a/Datadog/Example/Base.lproj/Main.storyboard
+++ b/Datadog/Example/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gra-d4-cht">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="wle-IX-rUl">
-                            <rect key="frame" x="0.0" y="328" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="371.5" width="414" height="0.0"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         </view>
@@ -143,6 +143,26 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="RlD-sM-dFb" kind="show" id="QXc-jH-vs4"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="QlD-DZ-9oo" style="IBUITableViewCellStyleDefault" id="TPI-rh-103">
+                                        <rect key="frame" x="0.0" y="305.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TPI-rh-103" id="UxM-nw-ttW">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Background events" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QlD-DZ-9oo">
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="mzn-Uj-AaH" kind="show" id="WAp-KR-rgX"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -1613,6 +1633,34 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="84N-sO-Ve9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-2039" y="1175"/>
+        </scene>
+        <!--Debug Background Events View Controller-->
+        <scene sceneID="O0O-3T-Hyb">
+            <objects>
+                <viewController id="mzn-Uj-AaH" customClass="DebugBackgroundEventsViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="JlK-N8-DqF">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This screen requires iO13+" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pei-Ww-c4Z">
+                                <rect key="frame" x="105.5" y="437.5" width="203" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="hcp-O1-u1G"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="pei-Ww-c4Z" firstAttribute="centerY" secondItem="JlK-N8-DqF" secondAttribute="centerY" id="s4u-Ay-B5z"/>
+                            <constraint firstItem="pei-Ww-c4Z" firstAttribute="centerX" secondItem="JlK-N8-DqF" secondAttribute="centerX" id="zAY-DU-dDH"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="wz7-7i-0Fh"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="juJ-nb-ezT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1419" y="1175"/>
         </scene>
     </scenes>
     <resources>

--- a/Datadog/Example/Debugging/BackgroundEvents/BackgroundLocationMonitor.swift
+++ b/Datadog/Example/Debugging/BackgroundEvents/BackgroundLocationMonitor.swift
@@ -23,7 +23,7 @@ internal class BackgroundLocationMonitor: NSObject, CLLocationManagerDelegate {
     ///
     /// Note: `BackgroundLocationMonitor` can be started independently from receiving location monitoring authorization status.
     /// Even if this value is `true`, location updates might not be delivered due to restricted or denied status.
-    var isStarted: Bool {
+    private(set) var isStarted: Bool {
         get { UserDefaults.standard.bool(forKey: Constants.locationMonitoringUserDefaultsKey) }
         set { UserDefaults.standard.set(newValue, forKey: Constants.locationMonitoringUserDefaultsKey) }
     }

--- a/Datadog/Example/Debugging/BackgroundEvents/BackgroundLocationMonitor.swift
+++ b/Datadog/Example/Debugging/BackgroundEvents/BackgroundLocationMonitor.swift
@@ -1,0 +1,129 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import Datadog
+import CoreLocation
+
+internal var backgroundLocationMonitor: BackgroundLocationMonitor?
+
+/// Location monitor used in "Example" app for debugging and testing iOS SDK features in background.
+internal class BackgroundLocationMonitor: NSObject, CLLocationManagerDelegate {
+    private struct Constants {
+        static let locationMonitoringUserDefaultsKey = "is-location-monitoring-started"
+    }
+
+    private let locationManager = CLLocationManager()
+
+    /// Tells if location monitoring is started.
+    /// This setting is preserved between application launches. Defaults to `false`.
+    ///
+    /// Note: `BackgroundLocationMonitor` can be started independently from receiving location monitoring authorization status.
+    /// Even if this value is `true`, location updates might not be delivered due to restricted or denied status.
+    var isStarted: Bool {
+        get { UserDefaults.standard.bool(forKey: Constants.locationMonitoringUserDefaultsKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Constants.locationMonitoringUserDefaultsKey) }
+    }
+
+    /// Current authorization status for location monitoring.
+    var currentAuthorizationStatus: String { authorizationStatusDescription(for: locationManager) }
+
+    /// Notifies change of authorization status for location monitoring.
+    var onAuthorizationStatusChange: ((String) -> Void)? = nil
+
+    override init() {
+        super.init()
+        if isStarted {
+            // If location monitoring was enabled in previous app session, here we start it for current session.
+            // This will keep location tracking when the app is woken up in background due to significant location change.
+            startMonitoring()
+        }
+    }
+
+    func startMonitoring() {
+        logger.debug("Starting 'BackgroundLocationMonitor' with authorizationStatus: '\(authorizationStatusDescription(for: locationManager))'")
+
+        if CLLocationManager.significantLocationChangeMonitoringAvailable() {
+            locationManager.delegate = self
+            locationManager.allowsBackgroundLocationUpdates = true
+
+            locationManager.requestAlwaysAuthorization()
+            locationManager.startMonitoringSignificantLocationChanges()
+            isStarted = true
+        } else {
+            Global.rum.addError(message: "Significant location changes monitoring is not available")
+        }
+    }
+
+    func stopMonitoring() {
+        locationManager.stopMonitoringSignificantLocationChanges()
+        isStarted = false
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = authorizationStatusDescription(for: locationManager)
+        logger.debug("Changed 'BackgroundLocationMonitor' authorizationStatus: '\(status)'")
+        onAuthorizationStatusChange?(status)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let recentLocation = locations.last else {
+            Global.rum.addError(message: "Received update with no locations")
+            return
+        }
+
+        logger.debug(
+            "Location changed at \(recentLocation.timestamp)",
+            attributes: [
+                "latitude": recentLocation.coordinate.latitude,
+                "longitude": recentLocation.coordinate.longitude,
+                "speed": recentLocation.speed,
+            ]
+        )
+
+        Global.rum.addUserAction(
+            type: .custom,
+            name: "Location changed at \(recentLocation.timestamp)",
+            attributes: [
+                "latitude": recentLocation.coordinate.latitude,
+                "longitude": recentLocation.coordinate.longitude,
+                "speed": recentLocation.speed,
+            ]
+        )
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        if let error = error as? CLError {
+            if error.code == .denied {
+                manager.stopMonitoringSignificantLocationChanges()
+            }
+            logger.error("Location manager failed with CLError (error.code: \(error.code)", error: error)
+            Global.rum.addError(message: "Location manager failed with CLError (error.code: \(error.code)")
+        } else {
+            logger.error("Location manager failed", error: error)
+            Global.rum.addError(error: error)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func authorizationStatusDescription(for manager: CLLocationManager) -> String {
+        if #available(iOS 14.0, *) {
+            switch locationManager.authorizationStatus {
+            case .authorizedAlways: return "authorizedAlways"
+            case .notDetermined: return "notDetermined"
+            case .restricted: return "restricted"
+            case .denied: return "denied"
+            case .authorizedWhenInUse: return "authorizedWhenInUse"
+            @unknown default: return "unrecognized (sth new)"
+            }
+        } else {
+            return "unavailable prior to iOS 14.0"
+        }
+    }
+}

--- a/Datadog/Example/Debugging/BackgroundEvents/DebugBackgroundEventsViewController.swift
+++ b/Datadog/Example/Debugging/BackgroundEvents/DebugBackgroundEventsViewController.swift
@@ -1,0 +1,102 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import SwiftUI
+import Datadog
+
+@available(iOS 13, *)
+internal class DebugBackgroundEventsViewController: UIHostingController<DebugBackgroundEventsView> {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder, rootView: DebugBackgroundEventsView())
+    }
+}
+
+@available(iOS 13.0, *)
+private class DebugBackgroundEventsViewModel: ObservableObject {
+    private let locationMonitor: BackgroundLocationMonitor
+
+    @Published var isLocationMonitoringON = false
+    @Published var authorizationStatus = ""
+
+    init() {
+        locationMonitor = backgroundLocationMonitor!
+        isLocationMonitoringON = locationMonitor.isStarted
+        authorizationStatus = locationMonitor.currentAuthorizationStatus
+        locationMonitor.onAuthorizationStatusChange = { [weak self] newStatus in
+            self?.authorizationStatus = newStatus
+        }
+    }
+
+    func startLocationMonitoring() {
+        locationMonitor.startMonitoring()
+        isLocationMonitoringON = locationMonitor.isStarted
+    }
+
+    func stopLocationMonitoring() {
+        locationMonitor.stopMonitoring()
+        isLocationMonitoringON = locationMonitor.isStarted
+    }
+}
+
+@available(iOS 13.0, *)
+internal struct DebugBackgroundEventsView: View {
+    @ObservedObject private var viewModel = DebugBackgroundEventsViewModel()
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Text("CLLocationManager")
+                .font(.headline)
+                .padding()
+            Divider()
+            HStack {
+                Text("Authorization Status:")
+                    .font(.body).fontWeight(.light)
+                Spacer()
+                Text(viewModel.authorizationStatus)
+                    .font(.body)
+            }
+            HStack {
+                Text("Location Monitoring:")
+                    .font(.body).fontWeight(.light)
+                Spacer()
+                if #available(iOS 14.0, *) {
+                    if viewModel.isLocationMonitoringON {
+                        ProgressView().padding(.trailing, 8)
+                    }
+                }
+                Button(viewModel.isLocationMonitoringON ? "STOP" : "START") {
+                    if viewModel.isLocationMonitoringON {
+                        viewModel.stopLocationMonitoring()
+                    } else {
+                        viewModel.startLocationMonitoring()
+                    }
+                }
+            }
+            Divider()
+            Text("Above settings are preserved between application launches, so they are also effective when app is launched in the background due to **significant** location change.")
+                .font(.footnote)
+            Spacer()
+        }
+        .buttonStyle(DatadogButtonStyle())
+        .padding()
+    }
+}
+
+// MARK - Preview
+
+@available(iOS 13.0, *)
+internal struct DebugBackgroundEventsView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            DebugBackgroundEventsView()
+                .previewLayout(.fixed(width: 400, height: 500))
+                .preferredColorScheme(.light)
+            DebugBackgroundEventsView()
+                .previewLayout(.fixed(width: 400, height: 500))
+                .preferredColorScheme(.dark)
+        }
+    }
+}

--- a/Datadog/Example/Environment.swift
+++ b/Datadog/Example/Environment.swift
@@ -59,6 +59,11 @@ internal struct Environment {
         return ProcessInfo.processInfo.arguments.contains(Argument.isRunningUITests)
     }
 
+    /// If running `Example` in interactive, debug mode (launching it with 'Run' in Xcode or by tapping on the app icon).
+    static func isRunningInteractive() -> Bool {
+        return !isRunningUITests() && !isRunningUnitTests()
+    }
+
     static func shouldClearPersistentData() -> Bool {
         return !ProcessInfo.processInfo.arguments.contains(Argument.doNotClearPersistentData)
     }

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -72,6 +72,13 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
             launch(storyboard: storyboard)
         }
 
+        // Instantiate location monitor if the Example app is run in interactive mode. This will
+        // enable background location tracking if it was started in previous session.
+        let isRunningExampleApp = !Environment.isRunningUnitTests() && !Environment.isRunningUITests()
+        if isRunningExampleApp {
+            backgroundLocationMonitor = BackgroundLocationMonitor()
+        }
+
         return true
     }
 

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -74,8 +74,7 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
 
         // Instantiate location monitor if the Example app is run in interactive mode. This will
         // enable background location tracking if it was started in previous session.
-        let isRunningExampleApp = !Environment.isRunningUnitTests() && !Environment.isRunningUITests()
-        if isRunningExampleApp {
+        if Environment.isRunningInteractive() {
             backgroundLocationMonitor = BackgroundLocationMonitor()
         }
 

--- a/Datadog/TargetSupport/Example/Info.plist
+++ b/Datadog/TargetSupport/Example/Info.plist
@@ -22,8 +22,18 @@
 	<string>$(DATADOG_CLIENT_TOKEN)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Location updates are used to test SDK support for tracking events while the app is in background. (always and when in use)</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Location updates are used to test SDK support for tracking events while the app is in background. (always)</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Location updates are used to test SDK support for tracking events while the app is in background. (when in use)</string>
 	<key>RUMApplicationID</key>
 	<string>$(RUM_APPLICATION_ID)</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
### What and why?

🧰🐞 This PR adds debug utility to Example app for testing [Background Events Tracking](https://github.com/DataDog/dd-sdk-ios/blob/8e7c19e90ed3d53ec61e40ddb1b202a660303dc4/Sources/Datadog/DatadogConfiguration.swift#L678-L690) feature. This will also come extremely handy in my current work on collecting application launch events (`RUMM-1765`).

So far we didn't have an easy way of debugging scenario where the app is launched by the OS in background. Thanks to this utility I located a bug 🐞 in our BET implementation, where "Background" view was not created automatically if there was no RUM session (starting initial RUM session [required an explicit "start view" command](https://github.com/DataDog/dd-sdk-ios/blob/8e7c19e90ed3d53ec61e40ddb1b202a660303dc4/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift#L80-L81)). This problem was fixed in #677.

### How?

This utility leverages [iOS background location tracking](https://developer.apple.com/documentation/corelocation/getting_the_user_s_location/handling_location_events_in_the_background). Location tracking can be enabled and the app will keep sending RUM actions for each location change even if the app is sent to background or terminated.

**To use it:**

1. Open "Background events" debug screen.
2. Tap "START" - it will request location tracking.
3. Authorize it for "While Using App" - since now, the app will be tracking location changes in foreground.
4. Kill the app - it will request authorizing location tracking in background, answer "Change To Always Allow".

From now on, it will start tracking _significant location changes_ even if the app is not running. To stop tracking, open the app again and tap "STOP". To reset authorization status, uninstall the app from Simulator or device.

<img width="1197" alt="Screenshot 2021-12-06 at 16 58 01" src="https://user-images.githubusercontent.com/2358722/144878970-11e23c85-a2b1-41ea-bc67-40c6d328ed67.png">

It can be easily tested when simulating location changes, e.g. in "Freeway Drive" mode:

<img width="438" alt="Screenshot 2021-12-06 at 16 59 08" src="https://user-images.githubusercontent.com/2358722/144879377-6492d697-d696-4880-ade5-3807216d2ed0.png">

For each location update it sends both logs and RUM actions:

<img width="986" alt="Screenshot 2021-12-06 at 15 58 56" src="https://user-images.githubusercontent.com/2358722/144879053-cee9b1d8-e06b-42b4-9b12-4265f38eb969.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
