### PR TITLE
RUMM-1821 Fix flakiness in `RUMResourcesScenarioTests`

### DIFF
--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -51,6 +51,7 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
+        sendCIAppLog(session)
 
         let view1 = session.viewVisits[0]
         XCTAssertEqual(view1.name, "SendRUMFixture1View")

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMMobileVitalsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMMobileVitalsScenarioTests.swift
@@ -47,6 +47,7 @@ class RUMMobileVitalsScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
+        sendCIAppLog(session)
 
         XCTAssertEqual(session.viewVisits[0].viewEvents.count, 5)
 

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
@@ -59,6 +59,8 @@ class RUMModalViewsScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
+        sendCIAppLog(session)
+
         let visits = session.viewVisits
         XCTAssertEqual(visits[0].name, "Screen")
         XCTAssertEqual(visits[0].path, "Example.RUMMVSViewController")

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -56,8 +56,9 @@ class RUMNavigationControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
-        let visits = session.viewVisits
+        sendCIAppLog(session)
 
+        let visits = session.viewVisits
         XCTAssertEqual(visits[0].name, "Screen1")
         XCTAssertEqual(visits[0].path, "UIViewController")
         XCTAssertEqual(visits[0].actionEvents[0].action.type, .applicationStart)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -61,9 +61,9 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
         let firstPartyBadResourceURL = URL(string: "https://foo.bar")!
 
         // Requesting this third party by the app should create the RUM Resource.
-        let thirdPartyGETResourceURL = URL(string: "https://bitrise.io")!
+        let thirdPartyGETResourceURL = URL(string: "https://httpbin.org/get")!
         // Requesting this third party by the app should create the RUM Resource.
-        let thirdPartyPOSTResourceURL = URL(string: "https://bitrise.io/about")!
+        let thirdPartyPOSTResourceURL = URL(string: "https://httpbin.org/post")!
 
         let app = ExampleApplication()
         app.launchWith(
@@ -113,7 +113,11 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         // Get RUM Sessions with expected number of View visits and Resources
         let rumRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 2
+            let session = try RUMSessionMatcher.singleSession(from: requests)
+            let hasAllViews = session?.viewVisits.count == 2
+            let hasAllResources = session?.resourceEventMatchers.count == 4
+            let hasAllErrors = session?.errorEventMatchers.count == 1
+            return hasAllViews && hasAllResources && hasAllErrors
         }
 
         assertRUM(requests: rumRequests)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -123,7 +123,7 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: rumRequests)
 
         let session = try XCTUnwrap(try RUMSessionMatcher.singleSession(from: rumRequests))
-        XCTAssertEqual(session.viewVisits.count, 2)
+        sendCIAppLog(session)
 
         // Asserts in `SendFirstPartyRequestsVC` RUM View
         XCTAssertEqual(session.viewVisits[0].name, expectations.expectedFirstPartyRequestsViewControllerName)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
@@ -27,6 +27,7 @@ class RUMScrubbingScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
+        sendCIAppLog(session)
 
         XCTAssertEqual(session.viewVisits.count, 1)
         let viewVisit = session.viewVisits[0]

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMSwiftUIScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMSwiftUIScenarioTests.swift
@@ -71,8 +71,9 @@ class RUMSwiftUIScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: requests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: requests))
-        let visits = session.viewVisits
+        sendCIAppLog(session)
 
+        let visits = session.viewVisits
         XCTAssertEqual(visits[0].name, "SwiftUI View 1")
         XCTAssertTrue(visits[0].path.matches(regex: "SwiftUI View 1\\/[0-9]*"))
         XCTAssertEqual(visits[0].actionEvents[0].action.type, .applicationStart)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
@@ -51,8 +51,9 @@ class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
-        let visits = session.viewVisits
+        sendCIAppLog(session)
 
+        let visits = session.viewVisits
         XCTAssertEqual(session.viewVisits[0].name, "Screen A")
         XCTAssertEqual(session.viewVisits[0].path, "UIViewController")
         XCTAssertEqual(session.viewVisits[0].actionEvents[0].action.type, .applicationStart)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -114,6 +114,7 @@ class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
+        sendCIAppLog(session)
 
         XCTAssertEqual(session.viewVisits[0].name, "MenuView")
         XCTAssertEqual(session.viewVisits[0].path, "Example.RUMTASScreen1ViewController")

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -86,3 +86,9 @@ extension XCUIElement {
         }
     }
 }
+
+/// Prints given value to `STDOUT`, which is captured by CI App instrumentation.
+/// This is an oportunity to associate additional logs to UI test execution.
+func sendCIAppLog(_ value: CustomStringConvertible) {
+    print(value.description)
+}

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -90,5 +90,5 @@ extension XCUIElement {
 /// Prints given value to `STDOUT`, which is captured by CI App instrumentation.
 /// This is an oportunity to associate additional logs to UI test execution.
 func sendCIAppLog(_ value: CustomStringConvertible) {
-    print(value.description)
+    print(value)
 }


### PR DESCRIPTION
### What and why?

⚙️🐞 This PR fixes two issues in `RUMResourcesScenarioTests` which causes recent flakiness.

Frequent problem (> 10 CI failures in last `15d`):
<img width="1050" alt="Screenshot 2021-12-09 at 14 00 00" src="https://user-images.githubusercontent.com/2358722/145401298-03a047de-3a26-417b-9c1e-8c60d52cdc0e.png">


Rare problem (2 CI failures in last `15d`):
<img width="1124" alt="Screenshot 2021-12-09 at 14 00 47" src="https://user-images.githubusercontent.com/2358722/145401308-e89361ea-74a4-4b8f-aeda-1b97f9faa6e4.png">

### How?

The **frequent problem** was caused by sending requests to these 3rd party URLs:
```diff
-let thirdPartyGETResourceURL = URL(string: "https://bitrise.io")!
-let thirdPartyPOSTResourceURL = URL(string: "https://bitrise.io/about")!
```
For some reason, when running this in Bitrise container the SSL and DNS phases were sometimes skipped. I don't know the exact reason (it might be related to Bitrise infra), but changing these to proper `GET` and `POST` endpoints (external) seems to improve situation. I ran these tests successfully 20 times in a CI loop.
```diff
+let thirdPartyGETResourceURL = URL(string: "https://httpbin.org/get")!
+let thirdPartyPOSTResourceURL = URL(string: "https://httpbin.org/post")!
```

The **rare problem** was caused by using too weak condition for pulling requests from Python server:
```diff
// Get RUM Sessions with expected number of View visits and Resources
let rumRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-    try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 2
}
```
Depending on SDK batching, 2 views could be sent within one batch, whereas their resources and errors would be transported in a separate one. Pulling condition was fulfilled too early leading to incomplete `RUMSessionMatcher` being used in further assertions.

I changed pulling condition to be more strict:
```diff
// Get RUM Sessions with expected number of View visits and Resources
let rumRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+    let session = try RUMSessionMatcher.singleSession(from: requests)
+    let hasAllViews = session?.viewVisits.count == 2
+    let hasAllResources = session?.resourceEventMatchers.count == 4
+    let hasAllErrors = session?.errorEventMatchers.count == 1
+    return hasAllViews && hasAllResources && hasAllErrors
}
```

To avoid this sort of problems, I also updated debug description for `RUMSessionMatcher` and now we log it for each CI run. In result, we have a nice description of RUM session attached to each test execution in CI app, which will help debugging similar issues next time.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
