### PR TITLE
RUMM-1765 Do not start "ApplicationLaunch" view when app launches in background - part 2

### DIFF
--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -29,6 +29,7 @@ internal struct FeaturesCommonDependencies {
     let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
     let carrierInfoProvider: CarrierInfoProviderType
     let launchTimeProvider: LaunchTimeProviderType
+    let appStateListener: AppStateListening
 }
 
 internal struct FeatureStorage {

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -23,6 +23,8 @@ internal struct FeaturesCommonDependencies {
     let performance: PerformancePreset
     let httpClient: HTTPClient
     let mobileDevice: MobileDevice
+    /// Time of SDK initialization, measured in device date.
+    let sdkInitDate: Date
     let dateProvider: DateProvider
     let dateCorrector: DateCorrectorType
     let userInfoProvider: UserInfoProvider

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -212,6 +212,7 @@ public class Datadog {
             performance: configuration.common.performance,
             httpClient: HTTPClient(proxyConfiguration: configuration.common.proxyConfiguration),
             mobileDevice: MobileDevice(),
+            sdkInitDate: dateProvider.currentDate(),
             dateProvider: dateProvider,
             dateCorrector: dateCorrector,
             userInfoProvider: userInfoProvider,

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -217,7 +217,8 @@ public class Datadog {
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider,
-            launchTimeProvider: launchTimeProvider
+            launchTimeProvider: launchTimeProvider,
+            appStateListener: AppStateListener(dateProvider: dateProvider)
         )
 
         if let internalMonitoringConfiguration = configuration.internalMonitoring {
@@ -273,8 +274,7 @@ public class Datadog {
         if let urlSessionAutoInstrumentationConfiguration = configuration.urlSessionAutoInstrumentation {
             urlSessionAutoInstrumentation = URLSessionAutoInstrumentation(
                 configuration: urlSessionAutoInstrumentationConfiguration,
-                dateProvider: dateProvider,
-                appStateListener: AppStateListener(dateProvider: dateProvider)
+                commonDependencies: commonDependencies
             )
         }
 

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -30,6 +30,7 @@ internal final class RUMFeature {
 
     // MARK: - Dependencies
 
+    let sdkInitDate: Date
     let dateProvider: DateProvider
     let dateCorrector: DateCorrectorType
     let appStateListener: AppStateListening
@@ -168,6 +169,7 @@ internal final class RUMFeature {
         self.configuration = configuration
 
         // Bundle dependencies
+        self.sdkInitDate = commonDependencies.sdkInitDate
         self.dateProvider = commonDependencies.dateProvider
         self.dateCorrector = commonDependencies.dateCorrector
         self.appStateListener = commonDependencies.appStateListener

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -32,6 +32,7 @@ internal final class RUMFeature {
 
     let dateProvider: DateProvider
     let dateCorrector: DateCorrectorType
+    let appStateListener: AppStateListening
     let userInfoProvider: UserInfoProvider
     let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
     let carrierInfoProvider: CarrierInfoProviderType
@@ -169,6 +170,7 @@ internal final class RUMFeature {
         // Bundle dependencies
         self.dateProvider = commonDependencies.dateProvider
         self.dateCorrector = commonDependencies.dateCorrector
+        self.appStateListener = commonDependencies.appStateListener
         self.userInfoProvider = commonDependencies.userInfoProvider
         self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
         self.carrierInfoProvider = commonDependencies.carrierInfoProvider

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -37,6 +37,9 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     /// RUM Sessions sampling rate.
     internal let samplingRate: Float
 
+    /// Time of SDK initialization, measured in device date.
+    internal let sdkInitDate: Date
+
     /// Automatically detect background events
     internal let backgroundEventTrackingEnabled: Bool
 
@@ -48,10 +51,12 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         rumApplicationID: String,
         dependencies: RUMScopeDependencies,
         samplingRate: Float,
+        sdkInitDate: Date,
         backgroundEventTrackingEnabled: Bool
     ) {
         self.dependencies = dependencies
         self.samplingRate = samplingRate
+        self.sdkInitDate = sdkInitDate
         self.backgroundEventTrackingEnabled = backgroundEventTrackingEnabled
         self.context = RUMContext(
             rumApplicationID: rumApplicationID,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -10,6 +10,7 @@ internal typealias RUMSessionListener = (String, Bool) -> Void
 
 /// Injection container for common dependencies used by all `RUMScopes`.
 internal struct RUMScopeDependencies {
+    let appStateListener: AppStateListening
     let userInfoProvider: RUMUserInfoProvider
     let launchTimeProvider: LaunchTimeProviderType
     let connectivityInfoProvider: RUMConnectivityInfoProvider

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -37,8 +37,8 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     /// RUM Sessions sampling rate.
     internal let samplingRate: Float
 
-    /// Time of SDK initialization, measured in device date.
-    internal let sdkInitDate: Date
+    /// The start time of the application, measured in device date. It equals the time of SDK init.
+    private let applicationStartTime: Date
 
     /// Automatically detect background events
     internal let backgroundEventTrackingEnabled: Bool
@@ -51,12 +51,12 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         rumApplicationID: String,
         dependencies: RUMScopeDependencies,
         samplingRate: Float,
-        sdkInitDate: Date,
+        applicationStartTime: Date,
         backgroundEventTrackingEnabled: Bool
     ) {
         self.dependencies = dependencies
         self.samplingRate = samplingRate
-        self.sdkInitDate = sdkInitDate
+        self.applicationStartTime = applicationStartTime
         self.backgroundEventTrackingEnabled = backgroundEventTrackingEnabled
         self.context = RUMContext(
             rumApplicationID: rumApplicationID,
@@ -76,7 +76,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
     func process(command: RUMCommand) -> Bool {
         if sessionScope == nil {
-            startInitialSession(on: command)
+            startInitialSession()
         }
 
         if let currentSession = sessionScope {
@@ -99,13 +99,13 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         _ = refreshedSession.process(command: command)
     }
 
-    private func startInitialSession(on command: RUMCommand) {
+    private func startInitialSession() {
         let initialSession = RUMSessionScope(
             isInitialSession: true,
             parent: self,
             dependencies: dependencies,
             samplingRate: samplingRate,
-            startTime: command.time,
+            startTime: applicationStartTime,
             backgroundEventTrackingEnabled: backgroundEventTrackingEnabled
         )
         sessionScope = initialSession

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -49,7 +49,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
     let isInitialSession: Bool
     /// RUM Session sampling rate.
     private let samplingRate: Float
-    /// The start time of this Session.
+    /// The start time of this Session, measured in device date. In initial session this is the time of SDK init.
     private let sessionStartTime: Date
     /// Time of the last RUM interaction noticed by this Session.
     private var lastInteractionTime: Date
@@ -191,7 +191,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
                 name: Constants.applicationLaunchViewName,
                 attributes: command.attributes,
                 customTimings: [:],
-                startTime: command.time
+                startTime: sessionStartTime
             )
         )
     }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -129,9 +129,14 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         // Consider starting an active view, "ApplicationLaunch" view or "Background" view
         if let startViewCommand = command as? RUMStartViewCommand {
             startView(on: startViewCommand)
-        } else if isInitialSession && !hasTrackedAnyView && command.canStartApplicationLaunchView {
-            startApplicationLaunchView(on: command)
-        } else if backgroundEventTrackingEnabled && !hasActiveView && command.canStartBackgroundView {
+        } else if isInitialSession && !hasTrackedAnyView { // if initial session with no views history
+            let appInForeground = dependencies.appStateListener.history.currentState.isActive
+            if appInForeground && command.canStartApplicationLaunchView { // when app is in foreground, start "ApplicationLaunch" view
+                startApplicationLaunchView(on: command)
+            } else if backgroundEventTrackingEnabled && command.canStartBackgroundView { // when app is in background and BET is enabled, start "Background" view
+                startBackgroundView(on: command)
+            }
+        } else if backgroundEventTrackingEnabled && !hasActiveView && command.canStartBackgroundView { // if existing session with views history and BET is enabled
             startBackgroundView(on: command)
         }
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -171,9 +171,14 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             }
         case let command as RUMAddUserActionCommand where isActiveView:
             if userActionScope == nil {
-                addDiscreteUserAction(on: command)
+                if command.actionType == .custom {
+                    // send it instantly without waiting for child events (e.g. resource associated to this action)
+                    sendDiscreteCustomUserAction(on: command)
+                } else {
+                    addDiscreteUserAction(on: command)
+                }
             } else if command.actionType == .custom {
-                // still let it go, just instantly without any dependencies
+                // still let it go, just instantly without waiting for child events (e.g. resource associated to this action)
                 sendDiscreteCustomUserAction(on: command)
             } else {
                 reportActionDropped(type: command.actionType, name: command.name)

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -199,6 +199,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     onSessionStart: rumFeature.onSessionStart
                 ),
                 samplingRate: rumFeature.configuration.sessionSamplingRate,
+                sdkInitDate: rumFeature.sdkInitDate,
                 backgroundEventTrackingEnabled: rumFeature.configuration.backgroundEventTrackingEnabled
             ),
             dateProvider: rumFeature.dateProvider

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -199,7 +199,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     onSessionStart: rumFeature.onSessionStart
                 ),
                 samplingRate: rumFeature.configuration.sessionSamplingRate,
-                sdkInitDate: rumFeature.sdkInitDate,
+                applicationStartTime: rumFeature.sdkInitDate,
                 backgroundEventTrackingEnabled: rumFeature.configuration.backgroundEventTrackingEnabled
             ),
             dateProvider: rumFeature.dateProvider

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -178,6 +178,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
             applicationScope: RUMApplicationScope(
                 rumApplicationID: rumFeature.configuration.applicationID,
                 dependencies: RUMScopeDependencies(
+                    appStateListener: rumFeature.appStateListener,
                     userInfoProvider: RUMUserInfoProvider(userInfoProvider: rumFeature.userInfoProvider),
                     launchTimeProvider: rumFeature.launchTimeProvider,
                     connectivityInfoProvider: RUMConnectivityInfoProvider(

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
@@ -15,16 +15,15 @@ internal final class URLSessionAutoInstrumentation: RUMCommandPublisher {
 
     convenience init?(
         configuration: FeaturesConfiguration.URLSessionAutoInstrumentation,
-        dateProvider: DateProvider,
-        appStateListener: AppStateListening
+        commonDependencies: FeaturesCommonDependencies
     ) {
         do {
             self.init(
                 swizzler: try URLSessionSwizzler(),
                 interceptor: URLSessionInterceptor(
                     configuration: configuration,
-                    dateProvider: dateProvider,
-                    appStateListener: appStateListener
+                    dateProvider: commonDependencies.dateProvider,
+                    appStateListener: commonDependencies.appStateListener
                 )
             )
         } catch {

--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -28,7 +28,8 @@ extension FeaturesCommonDependencies {
             userInfoProvider: UserInfoProvider(),
             networkConnectionInfoProvider: NetworkConnectionInfoProvider(),
             carrierInfoProvider: CarrierInfoProvider(),
-            launchTimeProvider: LaunchTimeProvider()
+            launchTimeProvider: LaunchTimeProvider(),
+            appStateListener: AppStateListener(dateProvider: SystemDateProvider())
         )
     }
 }

--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -23,6 +23,7 @@ extension FeaturesCommonDependencies {
             performance: .benchmarksPreset,
             httpClient: HTTPClient(),
             mobileDevice: MobileDevice(),
+            sdkInitDate: Date(),
             dateProvider: SystemDateProvider(),
             dateCorrector: DateCorrectorMock(),
             userInfoProvider: UserInfoProvider(),

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -454,6 +454,7 @@ extension FeaturesCommonDependencies {
                 return BatteryStatus(state: .full, level: 1, isLowPowerModeEnabled: false)
             }
         ),
+        sdkInitDate: Date = Date(),
         dateProvider: DateProvider = SystemDateProvider(),
         dateCorrector: DateCorrectorType = DateCorrectorMock(),
         userInfoProvider: UserInfoProvider = .mockAny(),
@@ -497,6 +498,7 @@ extension FeaturesCommonDependencies {
             performance: performance,
             httpClient: httpClient,
             mobileDevice: mobileDevice,
+            sdkInitDate: sdkInitDate,
             dateProvider: dateProvider,
             dateCorrector: dateCorrector,
             userInfoProvider: userInfoProvider,
@@ -513,6 +515,7 @@ extension FeaturesCommonDependencies {
         performance: PerformancePreset? = nil,
         httpClient: HTTPClient? = nil,
         mobileDevice: MobileDevice? = nil,
+        sdkInitDate: Date? = nil,
         dateProvider: DateProvider? = nil,
         dateCorrector: DateCorrectorType? = nil,
         userInfoProvider: UserInfoProvider? = nil,
@@ -526,6 +529,7 @@ extension FeaturesCommonDependencies {
             performance: performance ?? self.performance,
             httpClient: httpClient ?? self.httpClient,
             mobileDevice: mobileDevice ?? self.mobileDevice,
+            sdkInitDate: sdkInitDate ?? self.sdkInitDate,
             dateProvider: dateProvider ?? self.dateProvider,
             dateCorrector: dateCorrector ?? self.dateCorrector,
             userInfoProvider: userInfoProvider ?? self.userInfoProvider,

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -468,7 +468,8 @@ extension FeaturesCommonDependencies {
             )
         ),
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny(),
-        launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock()
+        launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock(),
+        appStateListener: AppStateListening = AppStateListenerMock.mockAny()
     ) -> FeaturesCommonDependencies {
         let httpClient: HTTPClient
 
@@ -501,7 +502,8 @@ extension FeaturesCommonDependencies {
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider,
-            launchTimeProvider: launchTimeProvider
+            launchTimeProvider: launchTimeProvider,
+            appStateListener: appStateListener
         )
     }
 
@@ -516,7 +518,8 @@ extension FeaturesCommonDependencies {
         userInfoProvider: UserInfoProvider? = nil,
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType? = nil,
         carrierInfoProvider: CarrierInfoProviderType? = nil,
-        launchTimeProvider: LaunchTimeProviderType? = nil
+        launchTimeProvider: LaunchTimeProviderType? = nil,
+        appStateListener: AppStateListening? = nil
     ) -> FeaturesCommonDependencies {
         return FeaturesCommonDependencies(
             consentProvider: consentProvider ?? self.consentProvider,
@@ -528,7 +531,8 @@ extension FeaturesCommonDependencies {
             userInfoProvider: userInfoProvider ?? self.userInfoProvider,
             networkConnectionInfoProvider: networkConnectionInfoProvider ?? self.networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider ?? self.carrierInfoProvider,
-            launchTimeProvider: launchTimeProvider ?? self.launchTimeProvider
+            launchTimeProvider: launchTimeProvider ?? self.launchTimeProvider,
+            appStateListener: appStateListener ?? self.appStateListener
         )
     }
 }
@@ -653,6 +657,23 @@ class DateCorrectorMock: DateCorrectorType {
 
 struct LaunchTimeProviderMock: LaunchTimeProviderType {
     var launchTime: TimeInterval = 0
+}
+
+class AppStateListenerMock: AppStateListening, AnyMockable {
+    let history: AppStateHistory
+
+    required init(history: AppStateHistory) {
+        self.history = history
+    }
+
+    static func mockAny() -> Self {
+        return .init(
+            history: .init(
+                initialState: .init(isActive: true, date: .mockDecember15th2019At10AMUTC()),
+                recentDate: .mockDecember15th2019At10AMUTC()
+            )
+        )
+    }
 }
 
 extension UserInfo: AnyMockable, RandomMockable {
@@ -988,12 +1009,6 @@ class CarrierInfoProviderMock: CarrierInfoProviderType {
         carrierInfo: CarrierInfo = .mockAny()
     ) -> CarrierInfoProviderMock {
         return CarrierInfoProviderMock(carrierInfo: carrierInfo)
-    }
-}
-
-extension AppStateListener {
-    static func mockAny() -> AppStateListener {
-        return AppStateListener(dateProvider: SystemDateProvider())
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -662,13 +662,15 @@ extension RUMApplicationScope {
     static func mockWith(
         rumApplicationID: String = .mockAny(),
         dependencies: RUMScopeDependencies = .mockAny(),
-        samplingRate: Float = 100,
+        samplingRate: Float = .mockAny(),
+        sdkInitDate: Date = .mockAny(),
         backgroundEventTrackingEnabled: Bool = .mockAny()
     ) -> RUMApplicationScope {
         return RUMApplicationScope(
             rumApplicationID: rumApplicationID,
             dependencies: dependencies,
             samplingRate: samplingRate,
+            sdkInitDate: sdkInitDate,
             backgroundEventTrackingEnabled: backgroundEventTrackingEnabled
         )
     }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -178,6 +178,15 @@ func mockRandomRUMCommand(where predicate: (RUMCommand) -> Bool = { _ in true })
     return allCommands.filter(predicate).randomElement()!
 }
 
+extension RUMCommand {
+    func replacing(time: Date? = nil, attributes: [AttributeKey: AttributeValue]? = nil) -> RUMCommand {
+        var command = self
+        command.time = time ?? command.time
+        command.attributes = attributes ?? command.attributes
+        return command
+    }
+}
+
 extension RUMStartViewCommand: AnyMockable, RandomMockable {
     static func mockAny() -> RUMStartViewCommand { mockWith() }
 
@@ -663,14 +672,14 @@ extension RUMApplicationScope {
         rumApplicationID: String = .mockAny(),
         dependencies: RUMScopeDependencies = .mockAny(),
         samplingRate: Float = .mockAny(),
-        sdkInitDate: Date = .mockAny(),
+        applicationStartTime: Date = .mockAny(),
         backgroundEventTrackingEnabled: Bool = .mockAny()
     ) -> RUMApplicationScope {
         return RUMApplicationScope(
             rumApplicationID: rumApplicationID,
             dependencies: dependencies,
             samplingRate: samplingRate,
-            sdkInitDate: sdkInitDate,
+            applicationStartTime: applicationStartTime,
             backgroundEventTrackingEnabled: backgroundEventTrackingEnabled
         )
     }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -596,6 +596,7 @@ extension RUMScopeDependencies {
     }
 
     static func mockWith(
+        appStateListener: AppStateListening = AppStateListenerMock.mockAny(),
         userInfoProvider: RUMUserInfoProvider = RUMUserInfoProvider(userInfoProvider: .mockAny()),
         launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock(),
         connectivityInfoProvider: RUMConnectivityInfoProvider = RUMConnectivityInfoProvider(
@@ -609,6 +610,7 @@ extension RUMScopeDependencies {
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListerner()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
+            appStateListener: appStateListener,
             userInfoProvider: userInfoProvider,
             launchTimeProvider: launchTimeProvider,
             connectivityInfoProvider: connectivityInfoProvider,
@@ -625,6 +627,7 @@ extension RUMScopeDependencies {
 
     /// Creates new instance of `RUMScopeDependencies` by replacing individual dependencies.
     func replacing(
+        appStateListener: AppStateListening? = nil,
         userInfoProvider: RUMUserInfoProvider? = nil,
         launchTimeProvider: LaunchTimeProviderType? = nil,
         connectivityInfoProvider: RUMConnectivityInfoProvider? = nil,
@@ -635,6 +638,7 @@ extension RUMScopeDependencies {
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListerner()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
+            appStateListener: appStateListener ?? self.appStateListener,
             userInfoProvider: userInfoProvider ?? self.userInfoProvider,
             launchTimeProvider: launchTimeProvider ?? self.launchTimeProvider,
             connectivityInfoProvider: connectivityInfoProvider ?? self.connectivityInfoProvider,

--- a/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
@@ -13,12 +13,7 @@ class RUMDebuggingTests: XCTestCase {
         let expectation = self.expectation(description: "Render RUMDebugging")
 
         // when
-        let applicationScope = RUMApplicationScope(
-            rumApplicationID: "abc-123",
-            dependencies: .mockAny(),
-            samplingRate: 100,
-            backgroundEventTrackingEnabled: .mockAny()
-        )
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockView, name: "FirstView")
         )
@@ -45,12 +40,7 @@ class RUMDebuggingTests: XCTestCase {
         let expectation = self.expectation(description: "Render RUMDebugging")
 
         // when
-        let applicationScope = RUMApplicationScope(
-            rumApplicationID: "abc-123",
-            dependencies: .mockAny(),
-            samplingRate: 100,
-            backgroundEventTrackingEnabled: .mockAny()
-        )
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockView, name: "FirstView")
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
@@ -13,7 +13,7 @@ class RUMCurrentContextTests: XCTestCase {
     private let queue = DispatchQueue(label: "\(#file)")
 
     func testContextAfterInitializingTheApplication() {
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: .mockAny(), backgroundEventTrackingEnabled: .mockAny())
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         XCTAssertEqual(
@@ -30,7 +30,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextAfterStartingView() throws {
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100, backgroundEventTrackingEnabled: .mockAny())
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
@@ -49,7 +49,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextWhilePendingUserAction() throws {
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100, backgroundEventTrackingEnabled: .mockAny())
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
@@ -69,7 +69,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextChangeWhenNavigatingBetweenViews() throws {
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100, backgroundEventTrackingEnabled: .mockAny())
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         let firstView = createMockViewInWindow()
@@ -97,7 +97,7 @@ class RUMCurrentContextTests: XCTestCase {
 
     func testContextChangeWhenSessionIsRenewed() throws {
         var currentTime = Date()
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 100, backgroundEventTrackingEnabled: .mockAny())
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         let view = createMockViewInWindow()
@@ -140,7 +140,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextWhenSessionIsSampled() throws {
-        let applicationScope = RUMApplicationScope(rumApplicationID: "rum-123", dependencies: .mockAny(), samplingRate: 0, backgroundEventTrackingEnabled: .mockAny())
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 0)
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: mockView))

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -13,6 +13,7 @@ class RUMApplicationScopeTests: XCTestCase {
             rumApplicationID: "abc-123",
             dependencies: .mockAny(),
             samplingRate: .mockAny(),
+            sdkInitDate: .mockAny(),
             backgroundEventTrackingEnabled: .mockAny()
         )
 
@@ -33,10 +34,9 @@ class RUMApplicationScopeTests: XCTestCase {
 
         let scope = RUMApplicationScope(
             rumApplicationID: .mockAny(),
-            dependencies: .mockWith(
-                onSessionStart: onSessionStart
-            ),
+            dependencies: .mockWith(onSessionStart: onSessionStart),
             samplingRate: 0,
+            sdkInitDate: .mockAny(),
             backgroundEventTrackingEnabled: .mockRandom()
         )
 
@@ -62,10 +62,9 @@ class RUMApplicationScopeTests: XCTestCase {
         // Given
         let scope = RUMApplicationScope(
             rumApplicationID: .mockAny(),
-            dependencies: .mockWith(
-                onSessionStart: onSessionStart
-            ),
+            dependencies: .mockWith(onSessionStart: onSessionStart),
             samplingRate: 100,
+            sdkInitDate: .mockAny(),
             backgroundEventTrackingEnabled: .mockAny()
         )
 
@@ -101,7 +100,13 @@ class RUMApplicationScopeTests: XCTestCase {
         let output = RUMEventOutputMock()
         let dependencies: RUMScopeDependencies = .mockWith(eventOutput: output)
 
-        let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: dependencies, samplingRate: 100, backgroundEventTrackingEnabled: .mockAny())
+        let scope = RUMApplicationScope(
+            rumApplicationID: .mockAny(),
+            dependencies: dependencies,
+            samplingRate: 100,
+            sdkInitDate: .mockAny(),
+            backgroundEventTrackingEnabled: .mockAny()
+        )
 
         _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
         _ = scope.process(command: RUMStopViewCommand.mockWith(identity: mockView))
@@ -113,7 +118,13 @@ class RUMApplicationScopeTests: XCTestCase {
         let output = RUMEventOutputMock()
         let dependencies: RUMScopeDependencies = .mockWith(eventOutput: output)
 
-        let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: dependencies, samplingRate: 0, backgroundEventTrackingEnabled: .mockAny())
+        let scope = RUMApplicationScope(
+            rumApplicationID: .mockAny(),
+            dependencies: dependencies,
+            samplingRate: 0,
+            sdkInitDate: .mockAny(),
+            backgroundEventTrackingEnabled: .mockAny()
+        )
 
         _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
         _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
@@ -125,7 +136,13 @@ class RUMApplicationScopeTests: XCTestCase {
         let output = RUMEventOutputMock()
         let dependencies: RUMScopeDependencies = .mockWith(eventOutput: output)
 
-        let scope = RUMApplicationScope(rumApplicationID: .mockAny(), dependencies: dependencies, samplingRate: 50, backgroundEventTrackingEnabled: .mockAny())
+        let scope = RUMApplicationScope(
+            rumApplicationID: .mockAny(),
+            dependencies: dependencies,
+            samplingRate: 50,
+            sdkInitDate: .mockAny(),
+            backgroundEventTrackingEnabled: .mockAny()
+        )
 
         var currentTime = Date()
         let simulatedSessionsCount = 200

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -241,6 +241,11 @@ class RUMSessionScopeTests: XCTestCase {
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: true, // initial session
             parent: parent,
+            dependencies: .mockWith(
+                appStateListener: AppStateListenerMock(
+                    history: .init(initialState: .init(isActive: true, date: currentTime), recentDate: currentTime) // app in foreground
+                )
+            ),
             samplingRate: 100,
             startTime: currentTime,
             backgroundEventTrackingEnabled: true // BET enabled
@@ -264,6 +269,11 @@ class RUMSessionScopeTests: XCTestCase {
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: true, // initial session
             parent: parent,
+            dependencies: .mockWith(
+                appStateListener: AppStateListenerMock(
+                    history: .init(initialState: .init(isActive: false, date: currentTime), recentDate: currentTime) // app in background
+                )
+            ),
             samplingRate: 100,
             startTime: currentTime,
             backgroundEventTrackingEnabled: true // BET enabled
@@ -287,6 +297,11 @@ class RUMSessionScopeTests: XCTestCase {
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: true, // initial session
             parent: parent,
+            dependencies: .mockWith(
+                appStateListener: AppStateListenerMock(
+                    history: .init(initialState: .init(isActive: false, date: currentTime), recentDate: currentTime) // app in background
+                )
+            ),
             samplingRate: 100,
             startTime: currentTime,
             backgroundEventTrackingEnabled: false // BET disabled

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -170,41 +170,43 @@ class RUMSessionScopeTests: XCTestCase {
 
     func testGivenInitialSessionWithNoViewTrackedBefore_whenCommandCanStartApplicationLaunchView_itCreatesAppLaunchScope() {
         // Given
-        let currentTime = Date()
+        let sessionStartTime = Date()
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: true,
             parent: parent,
             samplingRate: 100,
-            startTime: currentTime,
+            startTime: sessionStartTime,
             backgroundEventTrackingEnabled: .mockRandom() // no matter of BET state
         )
         XCTAssertTrue(scope.viewScopes.isEmpty)
 
         // When
-        let command = RUMCommandMock(time: currentTime, canStartBackgroundView: false, canStartApplicationLaunchView: true)
+        let commandTime = sessionStartTime.addingTimeInterval(1)
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: false, canStartApplicationLaunchView: true)
         XCTAssertTrue(scope.process(command: command))
 
         // Then
         XCTAssertEqual(scope.viewScopes.count, 1, "It should start application launch view scope")
-        XCTAssertEqual(scope.viewScopes[0].viewStartTime, currentTime)
+        XCTAssertEqual(scope.viewScopes[0].viewStartTime, sessionStartTime, "Application launch view should start at session start time")
         XCTAssertEqual(scope.viewScopes[0].viewName, RUMSessionScope.Constants.applicationLaunchViewName)
         XCTAssertEqual(scope.viewScopes[0].viewPath, RUMSessionScope.Constants.applicationLaunchViewURL)
     }
 
     func testGivenNotInitialSessionWithNoViewTrackedBefore_whenCommandCanStartApplicationLaunchView_itDoesNotCreateAppLaunchScope() {
         // Given
-        let currentTime = Date()
+        let sessionStartTime = Date()
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: false,
             parent: parent,
             samplingRate: 100,
-            startTime: currentTime,
+            startTime: sessionStartTime,
             backgroundEventTrackingEnabled: .mockRandom() // no matter of BET state
         )
         XCTAssertTrue(scope.viewScopes.isEmpty)
 
         // When
-        let command = RUMCommandMock(time: currentTime, canStartBackgroundView: false, canStartApplicationLaunchView: true)
+        let commandTime = sessionStartTime.addingTimeInterval(1)
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: false, canStartApplicationLaunchView: true)
         XCTAssertTrue(scope.process(command: command))
 
         // Then
@@ -213,20 +215,22 @@ class RUMSessionScopeTests: XCTestCase {
 
     func testGivenAnySessionWithSomeViewsTrackedBefore_whenCommandCanStartApplicationLaunchView_itDoesNotCreateAppLaunchScope() {
         // Given
-        let currentTime = Date()
+        let sessionStartTime = Date()
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: .mockRandom(), // any session, no matter if initial or not
             parent: parent,
             samplingRate: 100,
-            startTime: currentTime,
+            startTime: sessionStartTime,
             backgroundEventTrackingEnabled: .mockRandom() // no matter of BET state
         )
-        _ = scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: "view"))
-        _ = scope.process(command: RUMStopViewCommand.mockWith(time: currentTime.addingTimeInterval(1), identity: "view"))
+
+        let commandsTime = sessionStartTime.addingTimeInterval(1)
+        _ = scope.process(command: RUMStartViewCommand.mockWith(time: commandsTime, identity: "view"))
+        _ = scope.process(command: RUMStopViewCommand.mockWith(time: commandsTime.addingTimeInterval(1), identity: "view"))
         XCTAssertTrue(scope.viewScopes.isEmpty)
 
         // When
-        let command = RUMCommandMock(time: currentTime.addingTimeInterval(2), canStartBackgroundView: false, canStartApplicationLaunchView: true)
+        let command = RUMCommandMock(time: commandsTime.addingTimeInterval(2), canStartBackgroundView: false, canStartApplicationLaunchView: true)
         XCTAssertTrue(scope.process(command: command))
 
         // Then
@@ -237,79 +241,82 @@ class RUMSessionScopeTests: XCTestCase {
 
     func testGivenAppInForegroundAndBETEnabledAndInitialSession_whenCommandCanStartBothApplicationLaunchAndBackgroundViews_itCreatesAppLaunchScope() {
         // Given
-        let currentTime = Date()
+        let sessionStartTime = Date()
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: true, // initial session
             parent: parent,
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock(
-                    history: .init(initialState: .init(isActive: true, date: currentTime), recentDate: currentTime) // app in foreground
+                    history: .init(initialState: .init(isActive: true, date: sessionStartTime), recentDate: sessionStartTime) // app in foreground
                 )
             ),
             samplingRate: 100,
-            startTime: currentTime,
+            startTime: sessionStartTime,
             backgroundEventTrackingEnabled: true // BET enabled
         )
         XCTAssertTrue(scope.viewScopes.isEmpty, "No views tracked before")
 
         // When
-        let command = RUMCommandMock(time: currentTime, canStartBackgroundView: true, canStartApplicationLaunchView: true)
+        let commandTime = sessionStartTime.addingTimeInterval(1)
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: true, canStartApplicationLaunchView: true)
         XCTAssertTrue(scope.process(command: command))
 
         // Then
         XCTAssertEqual(scope.viewScopes.count, 1, "It should start application launch view scope")
-        XCTAssertEqual(scope.viewScopes[0].viewStartTime, currentTime)
+        XCTAssertEqual(scope.viewScopes[0].viewStartTime, sessionStartTime, "Application launch view should start at session start time")
         XCTAssertEqual(scope.viewScopes[0].viewName, RUMSessionScope.Constants.applicationLaunchViewName)
         XCTAssertEqual(scope.viewScopes[0].viewPath, RUMSessionScope.Constants.applicationLaunchViewURL)
     }
 
     func testGivenAppInBackgroundAndBETEnabledAndInitialSession_whenCommandCanStartBothApplicationLaunchAndBackgroundViews_itCreatesBackgroundScope() {
         // Given
-        let currentTime = Date()
+        let sessionStartTime = Date()
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: true, // initial session
             parent: parent,
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock(
-                    history: .init(initialState: .init(isActive: false, date: currentTime), recentDate: currentTime) // app in background
+                    history: .init(initialState: .init(isActive: false, date: sessionStartTime), recentDate: sessionStartTime) // app in background
                 )
             ),
             samplingRate: 100,
-            startTime: currentTime,
+            startTime: sessionStartTime,
             backgroundEventTrackingEnabled: true // BET enabled
         )
         XCTAssertTrue(scope.viewScopes.isEmpty, "No views tracked before")
 
         // When
-        let command = RUMCommandMock(time: currentTime, canStartBackgroundView: true, canStartApplicationLaunchView: true)
+        let commandTime = sessionStartTime.addingTimeInterval(1)
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: true, canStartApplicationLaunchView: true)
         XCTAssertTrue(scope.process(command: command))
 
         // Then
         XCTAssertEqual(scope.viewScopes.count, 1, "It should start background view scope")
-        XCTAssertEqual(scope.viewScopes[0].viewStartTime, currentTime)
+        XCTAssertEqual(scope.viewScopes[0].viewStartTime, commandTime, "Background view should be started at command time")
         XCTAssertEqual(scope.viewScopes[0].viewName, RUMSessionScope.Constants.backgroundViewName)
         XCTAssertEqual(scope.viewScopes[0].viewPath, RUMSessionScope.Constants.backgroundViewURL)
     }
 
     func testGivenAppInBackgroundAndBETDisabledAndInitialSession_whenCommandCanStartBothApplicationLaunchAndBackgroundViews_itDoesNotCreateAnyScope() {
         // Given
-        let currentTime = Date()
+        let sessionStartTime = Date()
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: true, // initial session
             parent: parent,
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock(
-                    history: .init(initialState: .init(isActive: false, date: currentTime), recentDate: currentTime) // app in background
+                    history: .init(initialState: .init(isActive: false, date: sessionStartTime), recentDate: sessionStartTime) // app in background
                 )
             ),
             samplingRate: 100,
-            startTime: currentTime,
+            startTime: sessionStartTime,
             backgroundEventTrackingEnabled: false // BET disabled
         )
         XCTAssertTrue(scope.viewScopes.isEmpty, "No views tracked before")
 
         // When
-        let command = RUMCommandMock(time: currentTime, canStartBackgroundView: true, canStartApplicationLaunchView: true)
+        let commandTime = sessionStartTime.addingTimeInterval(1)
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: true, canStartApplicationLaunchView: true)
         XCTAssertTrue(scope.process(command: command))
 
         // Then

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -7,17 +7,17 @@
 import XCTest
 @testable import Datadog
 
-private class MockAppStateListener: AppStateListening {
-    let history = AppStateHistory(
-        initialState: .init(isActive: true, date: .mockDecember15th2019At10AMUTC()),
-        finalDate: .mockDecember15th2019At10AMUTC() + 10
-    )
-}
-
 class URLSessionTracingHandlerTests: XCTestCase {
     private let spanOutput = SpanOutputMock()
     private let logOutput = LogOutputMock()
-    private let handler = URLSessionTracingHandler(appStateListener: MockAppStateListener())
+    private let handler = URLSessionTracingHandler(
+        appStateListener: AppStateListenerMock(
+            history: .init(
+                initialState: .init(isActive: true, date: .mockDecember15th2019At10AMUTC()),
+                recentDate: .mockDecember15th2019At10AMUTC() + 10
+            )
+        )
+    )
 
     override func setUp() {
         Global.sharedTracer = Tracer.mockWith(

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/AppStateListenerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/AppStateListenerTests.swift
@@ -13,7 +13,7 @@ class AppStateHistoryTests: XCTestCase {
         let history = AppStateHistory(
             initialState: .init(isActive: true, date: startDate),
             changes: [],
-            finalDate: startDate + 1.0
+            recentDate: startDate + 1.0
         )
 
         XCTAssertEqual(history.foregroundDuration, 1.0)
@@ -29,7 +29,7 @@ class AppStateHistoryTests: XCTestCase {
                 .init(isActive: false, date: startDate + 3.0),
                 .init(isActive: true, date: startDate + 4.0)
             ],
-            finalDate: startDate + 5.0
+            recentDate: startDate + 5.0
         )
 
         XCTAssertEqual(history.foregroundDuration, 3.0)
@@ -43,7 +43,7 @@ class AppStateHistoryTests: XCTestCase {
                 .init(isActive: false, date: startDate + 1.0),
                 .init(isActive: false, date: startDate + 3.0)
             ],
-            finalDate: startDate + 5.0
+            recentDate: startDate + 5.0
         )
 
         XCTAssertEqual(history.foregroundDuration, 1.0)
@@ -54,7 +54,7 @@ class AppStateHistoryTests: XCTestCase {
         let history = AppStateHistory(
             initialState: .init(isActive: true, date: startDate),
             changes: [],
-            finalDate: startDate + 5.0
+            recentDate: startDate + 5.0
         )
         let extrapolatedHistory = history.take(
             between: (startDate - 5.0)...(startDate + 15.0)
@@ -63,7 +63,7 @@ class AppStateHistoryTests: XCTestCase {
         let expectedHistory = AppStateHistory(
             initialState: .init(isActive: true, date: startDate - 5.0),
             changes: [],
-            finalDate: startDate + 15.0
+            recentDate: startDate + 15.0
         )
         XCTAssertEqual(extrapolatedHistory, expectedHistory)
     }
@@ -73,7 +73,7 @@ class AppStateHistoryTests: XCTestCase {
         let history = AppStateHistory(
             initialState: .init(isActive: true, date: startDate),
             changes: [],
-            finalDate: startDate + 20.0
+            recentDate: startDate + 20.0
         )
         let limitedHistory = history.take(
             between: (startDate + 5.0)...(startDate + 10.0)
@@ -82,7 +82,7 @@ class AppStateHistoryTests: XCTestCase {
         let expectedHistory = AppStateHistory(
             initialState: .init(isActive: true, date: startDate + 5.0),
             changes: [],
-            finalDate: startDate + 10.0
+            recentDate: startDate + 10.0
         )
         XCTAssertEqual(limitedHistory, expectedHistory)
     }
@@ -108,7 +108,7 @@ class AppStateHistoryTests: XCTestCase {
         let history = AppStateHistory(
             initialState: .init(isActive: true, date: startDate),
             changes: allChanges,
-            finalDate: startDate + 4_000
+            recentDate: startDate + 4_000
         )
 
         let limitedHistory = history.take(
@@ -118,7 +118,7 @@ class AppStateHistoryTests: XCTestCase {
         let expectedHistory = AppStateHistory(
             initialState: .init(isActive: true, date: startDate + 1_250),
             changes: [.init(isActive: false, date: startDate + 1_500)],
-            finalDate: startDate + 1_750
+            recentDate: startDate + 1_750
         )
         XCTAssertEqual(limitedHistory, expectedHistory)
     }
@@ -143,7 +143,7 @@ class AppStateListenerTests: XCTestCase {
                 .init(isActive: false, date: startDate + 1.0),
                 .init(isActive: true, date: startDate + 2.0)
             ],
-            finalDate: startDate + 3.0
+            recentDate: startDate + 3.0
         )
         XCTAssertEqual(listener.history, expected)
     }
@@ -163,7 +163,7 @@ class AppStateListenerTests: XCTestCase {
                 .init(isActive: true, date: startDate + 1.0),
                 .init(isActive: false, date: startDate + 2.0)
             ],
-            finalDate: startDate + 3.0
+            recentDate: startDate + 3.0
         )
         XCTAssertEqual(listener.history, expected)
     }
@@ -177,7 +177,7 @@ class AppStateListenerTests: XCTestCase {
         let history1 = listener.history
         let history2 = listener.history
 
-        XCTAssertEqual(history2.finalState.date.timeIntervalSince(history1.finalState.date), 1.0)
+        XCTAssertEqual(history2.currentState.date.timeIntervalSince(history1.currentState.date), 1.0)
     }
 
     func testWhenAppStateListenerIsCalledFromDifferentThreads_thenItWorks() {

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptorTests.swift
@@ -26,7 +26,7 @@ class URLSessionInterceptorTests: XCTestCase {
         let instrumentRUM = false
 
         // When
-        let appStateListener = AppStateListener.mockAny()
+        let appStateListener = AppStateListenerMock.mockAny()
         let interceptor = URLSessionInterceptor(
             configuration: .mockWith(instrumentTracing: instrumentTracing, instrumentRUM: instrumentRUM),
             dateProvider: SystemDateProvider(),
@@ -55,7 +55,7 @@ class URLSessionInterceptorTests: XCTestCase {
         let interceptor = URLSessionInterceptor(
             configuration: .mockWith(instrumentTracing: instrumentTracing, instrumentRUM: instrumentRUM),
             dateProvider: SystemDateProvider(),
-            appStateListener: AppStateListener.mockAny()
+            appStateListener: AppStateListenerMock.mockAny()
         )
 
         // Then
@@ -79,7 +79,7 @@ class URLSessionInterceptorTests: XCTestCase {
         let interceptor = URLSessionInterceptor(
             configuration: .mockWith(instrumentTracing: instrumentTracing, instrumentRUM: instrumentRUM),
             dateProvider: SystemDateProvider(),
-            appStateListener: AppStateListener.mockAny()
+            appStateListener: AppStateListenerMock.mockAny()
         )
 
         // Then

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
@@ -24,11 +24,9 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
         // When
         URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
             configuration: .mockAny(),
-            dateProvider: SystemDateProvider(),
-            appStateListener: AppStateListener.mockAny()
+            commonDependencies: .mockAny()
         )
         defer {
-            URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
             URLSessionAutoInstrumentation.instance?.deinitialize()
         }
 
@@ -43,11 +41,9 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
 
         URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
             configuration: .mockAny(),
-            dateProvider: SystemDateProvider(),
-            appStateListener: AppStateListener.mockAny()
+            commonDependencies: .mockAny()
         )
         defer {
-            URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
             URLSessionAutoInstrumentation.instance?.deinitialize()
         }
 


### PR DESCRIPTION
### What and why?

📦 This PR limits _application launch events tracking_ feature to only consider events received while app is in foreground. It adds necessary implementation to not start "ApplicationLaunch" view if app is not in `active` state.

When app launches in background, its events can still be tracked if [Background Events Tracking](https://github.com/DataDog/dd-sdk-ios/blob/b28016175691665c9c2e1d3d867e90d6f4437ab2/Sources/Datadog/DatadogConfiguration.swift#L678-L690) feature is enabled. This makes a clear separation of "ApplicationLaunch" and "Background" activities.

### How?

Determining app state is done using existing `AppStateListener` - it is now injected to RUM feature as well. It is used to check the app state and consider starting either:
* "ApplicationLaunch" view - if app receives off-view events in `active` state;
* "Background" view - if app receives off-view events in not `active` state and [BET](https://github.com/DataDog/dd-sdk-ios/blob/b28016175691665c9c2e1d3d867e90d6f4437ab2/Sources/Datadog/DatadogConfiguration.swift#L678-L690) is enabled.

Below, list of cases covered with new and existing (#677) tests.

---

#### ✅ (1) Receive off-view events when app launches in foreground and BET is enabled.

The "ApplicationLaunch" view spans from SDK init to starting another view.

<img width="618" alt="SC1" src="https://user-images.githubusercontent.com/2358722/145833872-3f7085b4-9b2c-42c5-81f0-1d2d176ae7c0.png">

#### ✅ (2) Receive off-view events when app launches in background and BET is enabled.

There is no "ApplicationLaunch" view. Instead, "Background" view is created and it starts at the time of first event.

<img width="856" alt="SC2" src="https://user-images.githubusercontent.com/2358722/145834321-904e7587-6fac-4fc0-b1f4-e365091905de.png">

#### ✅ (3) Receive events in background when BET is enabled.

No change - receiving off-view event after app goes to background starts the "Background" view at the time of the event.

<img width="848" alt="SC3" src="https://user-images.githubusercontent.com/2358722/145834919-cc4e9bd0-74e5-4af2-a12a-3e5d3597b940.png">

#### ✅ (4) Receive off-view events when app launches in foreground and BET is disabled.

Same as scenario 1, the "ApplicationLaunch" view tracks off-view event and the view starts on SDK init.

<img width="620" alt="SC4" src="https://user-images.githubusercontent.com/2358722/145839380-b2e1f04f-3ea1-48fd-82ba-dec0ea609d3a.png">

#### ✅ (5) Receive events in background when BET is disabled.

Nothing is tracked in this case. If BET is disabled, we do not create any view for tracking off-view background events.

#### ✅ (6) Receive events in background when BET is disabled.

Only foreground events are tracked in user-defined view. "Background" view is not started as BET is disabled.

<img width="561" alt="SC6" src="https://user-images.githubusercontent.com/2358722/145839754-26a21462-a13d-4e76-8cdf-0257a7e6c538.png">

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
