### PR TITLE
Update to version 1.0.3-beta.1 of testing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: dependencies xcodeproj-httpservermock templates
 
 # The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
-DD_SDK_SWIFT_TESTING_VERSION = 1.0.2
+DD_SDK_SWIFT_TESTING_VERSION = 1.0.3-beta.1
 
 define DD_SDK_TESTING_XCCONFIG_CI
 FRAMEWORK_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n


### PR DESCRIPTION
### What and why?

Update to version 1.0.3-beta.1 of testing framework. It fixes test network instrumentation when running using `DD_DISABLE_SDKIOS_INTEGRATION` configuration

### How?

Updated version on Makefile

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
