### PR TITLE
RUMM-1803 Monitor MetricKit through internal monitoring

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -511,13 +511,15 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     }
 }
 
+///
+/// THE FOLLOWING IMPLEMENTATION SHALL BE REMOVED ONCE
+/// METRICKIT HAS BEEN EVALUATED.
+///
 #if DD_SDK_ENABLE_INTERNAL_MONITORING
 import MetricKit
 
 /// The MetricMonitor only exists for internal testing, it will log the MetricKit payloads at reception to
 /// Internal Monitoring Feature.
-///
-/// TODO: This monitor shall be removed once MetricKit has been evaluated.
 private class MetricMonitor: NSObject, MXMetricManagerSubscriber {
     static var shared = MetricMonitor()
 
@@ -535,34 +537,179 @@ private class MetricMonitor: NSObject, MXMetricManagerSubscriber {
 
     @available(iOS 13.0, *)
     func didReceive(_ payloads: [MXMetricPayload]) {
-        let decoder = JSONDecoder()
-
-        let attributes = payloads
-            .map { $0.jsonRepresentation() }
-            .compactMap { try? decoder.decode(CodableValue.self, from: $0) }
+        let metrics = payloads
+            .map { $0.dictionaryRepresentation() }
+            .map(MetricEncodable.init)
 
         InternalMonitoringFeature.instance?.monitor.sdkLogger.info(
             "Did receive MetricKit metrics",
             attributes: [
                 "application_launch_time": launchTime,
-                "payloads": attributes
+                "payloads": MetricEncodable(metrics)
             ]
         )
     }
 
     @available(iOS 14.0, *)
     func didReceive(_ payloads: [MXDiagnosticPayload]) {
-        let decoder = JSONDecoder()
-
-        let attributes = payloads
-            .map { $0.jsonRepresentation() }
-            .compactMap { try? decoder.decode(CodableValue.self, from: $0) }
+        let diagnostics = payloads
+            .map { $0.dictionaryRepresentation() }
+            .map(MetricEncodable.init)
 
         InternalMonitoringFeature.instance?.monitor.sdkLogger.info(
             "Did receive MetricKit diagnostics",
-            attributes: ["payloads": attributes]
+            attributes: ["payloads": MetricEncodable(diagnostics)]
         )
     }
+}
+
+/**
+ https://github.com/Flight-School/AnyCodable
+
+ Copyright 2018 Read Evaluate Press, LLC
+
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ DEALINGS IN THE SOFTWARE
+ */
+
+/**
+ A type-erased `Encodable` value.
+ The `AnyEncodable` type forwards encoding responsibilities
+ to an underlying value, hiding its specific underlying type.
+ You can encode mixed-type values in dictionaries
+ and other collections that require `Encodable` conformance
+ by declaring their contained type to be `AnyEncodable`:
+     let dictionary: [String: AnyEncodable] = [
+         "boolean": true,
+         "integer": 42,
+         "double": 3.141592653589793,
+         "string": "string",
+         "array": [1, 2, 3],
+         "nested": [
+             "a": "alpha",
+             "b": "bravo",
+             "c": "charlie"
+         ],
+         "null": nil
+     ]
+     let encoder = JSONEncoder()
+     let json = try! encoder.encode(dictionary)
+ */
+private struct MetricEncodable: Encodable {
+    let value: Any
+
+    init<T>(_ value: T?) {
+        self.value = value ?? ()
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch value {
+        #if canImport(Foundation)
+        case let number as NSNumber:
+            try encode(nsnumber: number, into: &container)
+        case is NSNull:
+            try container.encodeNil()
+        #endif
+        case is Void:
+            try container.encodeNil()
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let int8 as Int8:
+            try container.encode(int8)
+        case let int16 as Int16:
+            try container.encode(int16)
+        case let int32 as Int32:
+            try container.encode(int32)
+        case let int64 as Int64:
+            try container.encode(int64)
+        case let uint as UInt:
+            try container.encode(uint)
+        case let uint8 as UInt8:
+            try container.encode(uint8)
+        case let uint16 as UInt16:
+            try container.encode(uint16)
+        case let uint32 as UInt32:
+            try container.encode(uint32)
+        case let uint64 as UInt64:
+            try container.encode(uint64)
+        case let float as Float:
+            try container.encode(float)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        #if canImport(Foundation)
+        case let date as Date:
+            try container.encode(date)
+        case let url as URL:
+            try container.encode(url)
+        #endif
+        case let array as [Any?]:
+            // DD Logs app fails to render arrays of JSON.
+            // Here we map the array to a dictionary with indexes as keys.
+            var dictionary: [String: MetricEncodable] = [:]
+            array.enumerated().forEach { dictionary["\($0.offset)"] = MetricEncodable($0.element) }
+            try container.encode(dictionary)
+        case let dictionary as [String: Any?]:
+            try container.encode(dictionary.mapValues { MetricEncodable($0) })
+        case let encodable as Encodable:
+            try encodable.encode(to: encoder)
+        default:
+            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "AnyEncodable value cannot be encoded")
+            throw EncodingError.invalidValue(value, context)
+        }
+    }
+
+    #if canImport(Foundation)
+    private func encode(nsnumber: NSNumber, into container: inout SingleValueEncodingContainer) throws {
+        switch Character(Unicode.Scalar(UInt8(nsnumber.objCType.pointee))) {
+        case "c", "C":
+            try container.encode(nsnumber.boolValue)
+        case "s":
+            try container.encode(nsnumber.int8Value)
+        case "i":
+            try container.encode(nsnumber.int16Value)
+        case "l":
+            try container.encode(nsnumber.int32Value)
+        case "q":
+            try container.encode(nsnumber.int64Value)
+        case "S":
+            try container.encode(nsnumber.uint8Value)
+        case "I":
+            try container.encode(nsnumber.uint16Value)
+        case "L":
+            try container.encode(nsnumber.uint32Value)
+        case "Q":
+            try container.encode(nsnumber.uint64Value)
+        case "f":
+            try container.encode(nsnumber.floatValue)
+        case "d":
+            try container.encode(nsnumber.doubleValue)
+        default:
+            let context = EncodingError.Context(codingPath: container.codingPath, debugDescription: "NSNumber cannot be encoded because its type is not handled")
+            throw EncodingError.invalidValue(nsnumber, context)
+        }
+    }
+    #endif
 }
 
 #endif

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -336,6 +336,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
 #if DD_SDK_ENABLE_INTERNAL_MONITORING
         if #available(iOS 15, *) {
+            // Starting MetricKit monitor from here, to ensure that our launch time was already reported
+            // in `.applicationStart` action and we could compare both measurements.
             MetricMonitor.shared.monitorMetricKit(launchTime: dependencies.launchTimeProvider.launchTime)
         }
 #endif

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -526,12 +526,16 @@ private class MetricMonitor: NSObject, MXMetricManagerSubscriber {
     /// The launch time reported by the sdk.
     private var launchTime: TimeInterval = 0
 
+    /// The time when this monitor starts.
+    private var timestamp: Date = .distantPast
+
     /// Request MetricKit payload by subscribing to MXMetricManager.
     ///
     /// - Parameter launchTime: The launch time reported by the sdk.
     @available(iOS 13.0, *)
     func monitorMetricKit(launchTime: TimeInterval) {
         self.launchTime = launchTime
+        self.timestamp = Date()
         MXMetricManager.shared.add(self)
     }
 
@@ -545,6 +549,7 @@ private class MetricMonitor: NSObject, MXMetricManagerSubscriber {
             "Did receive MetricKit metrics",
             attributes: [
                 "application_launch_time": launchTime,
+                "delay": Date().timeIntervalSince(timestamp),
                 "payloads": MetricEncodable(metrics)
             ]
         )
@@ -558,7 +563,10 @@ private class MetricMonitor: NSObject, MXMetricManagerSubscriber {
 
         InternalMonitoringFeature.instance?.monitor.sdkLogger.info(
             "Did receive MetricKit diagnostics",
-            attributes: ["payloads": MetricEncodable(diagnostics)]
+            attributes: [
+                "delay": Date().timeIntervalSince(timestamp),
+                "payloads": MetricEncodable(diagnostics)
+            ]
         )
     }
 }


### PR DESCRIPTION
### What and why?

Targeting 🐶 Dogfooding.

Log MetricKit payloads through internal monitoring.

### How?

Subscribe to `MXMetricManager` when sending `ApplicationStart` event to internal logs.
The logs will include the Application Launch Time measured by the SDK to later compare with values reported by `MetricKit`.

MetricKit payloads are transformed into logs attributes with the help of a modified version of [AnyEncodable](https://github.com/DataDog/dd-sdk-ios/pull/688/commits/dfd0d30abb3ccdefec92c04c598f3b2158b92bf3#diff-7e73bbe23d9ad1b6da3e7d82fdb3d85f13b0d077b56366fa5affcf76942a2a8eR566-R613).

[Here a sample of a log](https://app.datadoghq.com/logs?query=service%3Add-sdk-ios%20env%3Aprod&cols=host%2Cservice&event=AQAAAX291bHEpvAnaQAAAABBWDI5MWRzUkFBQ2poaDZJQlotc213QUE&index=&messageDisplay=inline&stream_sort=desc&from_ts=1639554622391&to_ts=1639569022391&live=true)

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
