### PR TITLE
RUMM-1765 Update `CrashContext` with necessary info for handling App Launch crashes - part 3

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -312,6 +312,7 @@
 		619E16D82577C1CB00B2516B /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16D72577C1CB00B2516B /* DataProcessor.swift */; };
 		619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16E82578E73E00B2516B /* DataMigrator.swift */; };
 		619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */; };
+		61A614E8276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A614E7276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift */; };
 		61A763DC252DB2B3005A23F2 /* NSURLSessionBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */; };
 		61A9238E256FCAA2009B9667 /* DateCorrectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A9238D256FCAA2009B9667 /* DateCorrectionTests.swift */; };
 		61AADBDD263C7ECF008ABC6F /* EquatableInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AADBDC263C7ECF008ABC6F /* EquatableInTests.swift */; };
@@ -983,6 +984,7 @@
 		619E16D72577C1CB00B2516B /* DataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProcessor.swift; sourceTree = "<group>"; };
 		619E16E82578E73E00B2516B /* DataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrator.swift; sourceTree = "<group>"; };
 		619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllDataMigrator.swift; sourceTree = "<group>"; };
+		61A614E7276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOffViewEventsHandlingRule.swift; sourceTree = "<group>"; };
 		61A763D9252DB2B3005A23F2 /* DatadogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DatadogTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		61A763DA252DB2B3005A23F2 /* NSURLSessionBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionBridge.h; sourceTree = "<group>"; };
 		61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionBridge.m; sourceTree = "<group>"; };
@@ -2797,6 +2799,7 @@
 			isa = PBXGroup;
 			children = (
 				61FF9A4425AC5DEA001058CC /* RUMViewIdentity.swift */,
+				61A614E7276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift */,
 				61C3E63D24BF1B91008053F2 /* RUMApplicationScope.swift */,
 				61C2C20624C098FC00C0321C /* RUMSessionScope.swift */,
 				61C2C21124C5951400C0321C /* RUMViewScope.swift */,
@@ -4075,6 +4078,7 @@
 				61133BE72423979B00786299 /* LogUtilityOutputs.swift in Sources */,
 				61133BDA2423979B00786299 /* RequestBuilder.swift in Sources */,
 				61C3E63924BF19B4008053F2 /* RUMContext.swift in Sources */,
+				61A614E8276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift in Sources */,
 				61ED39D426C2A36B002C0F26 /* DataUploadStatus.swift in Sources */,
 				61133BE82423979B00786299 /* LogFileOutput.swift in Sources */,
 				61133BD72423979B00786299 /* DataUploadWorker.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 		619E16E92578E73E00B2516B /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16E82578E73E00B2516B /* DataMigrator.swift */; };
 		619E16F12578E89700B2516B /* DeleteAllDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */; };
 		61A614E8276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A614E7276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift */; };
+		61A614EA276B9D4C00A06CE7 /* RUMOffViewEventsHandlingRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A614E9276B9D4C00A06CE7 /* RUMOffViewEventsHandlingRuleTests.swift */; };
 		61A763DC252DB2B3005A23F2 /* NSURLSessionBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */; };
 		61A9238E256FCAA2009B9667 /* DateCorrectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A9238D256FCAA2009B9667 /* DateCorrectionTests.swift */; };
 		61AADBDD263C7ECF008ABC6F /* EquatableInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61AADBDC263C7ECF008ABC6F /* EquatableInTests.swift */; };
@@ -524,8 +525,8 @@
 		D24C27EA270C8BEE005DE596 /* DataCompression.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24C27E9270C8BEE005DE596 /* DataCompression.swift */; };
 		D2791EF927170A760046E07A /* RUMSwiftUIScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2791EF827170A760046E07A /* RUMSwiftUIScenarioTests.swift */; };
 		D29889C9273413ED00A4D1A9 /* RUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */; };
-		D2EFF3D32731822A00D09F33 /* RUMViewsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EFF3D22731822A00D09F33 /* RUMViewsHandler.swift */; };
 		D29D5A4D273BF8B400A687C1 /* SwiftUIActionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */; };
+		D2EFF3D32731822A00D09F33 /* RUMViewsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EFF3D22731822A00D09F33 /* RUMViewsHandler.swift */; };
 		D2F1B81126D795F3009F3293 /* DDNoopRUMMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1B81026D795F3009F3293 /* DDNoopRUMMonitor.swift */; };
 		D2F1B81326D8DA68009F3293 /* DDNoopRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1B81226D8DA68009F3293 /* DDNoopRUMMonitorTests.swift */; };
 		D2F1B81526D8E5FF009F3293 /* DDNoopTracerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1B81426D8E5FF009F3293 /* DDNoopTracerTests.swift */; };
@@ -985,6 +986,7 @@
 		619E16E82578E73E00B2516B /* DataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrator.swift; sourceTree = "<group>"; };
 		619E16F02578E89700B2516B /* DeleteAllDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAllDataMigrator.swift; sourceTree = "<group>"; };
 		61A614E7276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOffViewEventsHandlingRule.swift; sourceTree = "<group>"; };
+		61A614E9276B9D4C00A06CE7 /* RUMOffViewEventsHandlingRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMOffViewEventsHandlingRuleTests.swift; sourceTree = "<group>"; };
 		61A763D9252DB2B3005A23F2 /* DatadogTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DatadogTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		61A763DA252DB2B3005A23F2 /* NSURLSessionBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLSessionBridge.h; sourceTree = "<group>"; };
 		61A763DB252DB2B3005A23F2 /* NSURLSessionBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLSessionBridge.m; sourceTree = "<group>"; };
@@ -1194,8 +1196,8 @@
 		D24C27E9270C8BEE005DE596 /* DataCompression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompression.swift; sourceTree = "<group>"; };
 		D2791EF827170A760046E07A /* RUMSwiftUIScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSwiftUIScenarioTests.swift; sourceTree = "<group>"; };
 		D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandlerTests.swift; sourceTree = "<group>"; };
-		D2EFF3D22731822A00D09F33 /* RUMViewsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandler.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
+		D2EFF3D22731822A00D09F33 /* RUMViewsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandler.swift; sourceTree = "<group>"; };
 		D2F1B81026D795F3009F3293 /* DDNoopRUMMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopRUMMonitor.swift; sourceTree = "<group>"; };
 		D2F1B81226D8DA68009F3293 /* DDNoopRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopRUMMonitorTests.swift; sourceTree = "<group>"; };
 		D2F1B81426D8E5FF009F3293 /* DDNoopTracerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopTracerTests.swift; sourceTree = "<group>"; };
@@ -2490,6 +2492,7 @@
 			isa = PBXGroup;
 			children = (
 				61C1510C25AC8C1B00362D4B /* RUMViewIdentityTests.swift */,
+				61A614E9276B9D4C00A06CE7 /* RUMOffViewEventsHandlingRuleTests.swift */,
 				617B953F24BF4DB300E6F443 /* RUMApplicationScopeTests.swift */,
 				61C2C20824C0C75500C0321C /* RUMSessionScopeTests.swift */,
 				6198D27024C6E3B700493501 /* RUMViewScopeTests.swift */,
@@ -4196,6 +4199,7 @@
 				6184751526EFCF1300C7C9C5 /* DatadogTestsObserver.swift in Sources */,
 				61133C602423990D00786299 /* RequestBuilderTests.swift in Sources */,
 				61133C572423990D00786299 /* FileReaderTests.swift in Sources */,
+				61A614EA276B9D4C00A06CE7 /* RUMOffViewEventsHandlingRuleTests.swift in Sources */,
 				D2F1B81326D8DA68009F3293 /* DDNoopRUMMonitorTests.swift in Sources */,
 				61133C5F2423990D00786299 /* DataUploaderTests.swift in Sources */,
 				61D6FF7924E42A2900D0E375 /* DataUploadWorkerMock.swift in Sources */,

--- a/Sources/Datadog/Core/System/AppStateListener.swift
+++ b/Sources/Datadog/Core/System/AppStateListener.swift
@@ -89,9 +89,16 @@ internal struct AppStateHistory: Equatable {
     }
 }
 
+/// An observer of `AppStateHistory` value.
+internal typealias AppStateHistoryObserver = ValueObserver
+
 /// Provides history of app foreground / background states.
 internal protocol AppStateListening: AnyObject {
+    /// Last published `AppStateHistory`.
     var history: AppStateHistory { get }
+
+    /// Subscribers observer to be notified on `AppStateHistory` changes.
+    func subscribe<Observer: AppStateHistoryObserver>(_ subscriber: Observer) where Observer.ObservedValue == AppStateHistory
 }
 
 internal class AppStateListener: AppStateListening {
@@ -143,5 +150,11 @@ internal class AppStateListener: AppStateListening {
         var value = publisher.currentValue
         value.changes.append(Snapshot(isActive: true, date: now))
         publisher.publishAsync(value)
+    }
+
+    // MARK: - Managing Subscribers
+
+    func subscribe<Observer: AppStateHistoryObserver>(_ subscriber: Observer) where Observer.ObservedValue == AppStateHistory {
+        publisher.subscribe(subscriber)
     }
 }

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContext.swift
@@ -19,13 +19,17 @@ internal struct CrashContext: Codable {
         lastUserInfo: UserInfo,
         lastRUMViewEvent: RUMEvent<RUMViewEvent>?,
         lastNetworkConnectionInfo: NetworkConnectionInfo?,
-        lastCarrierInfo: CarrierInfo?
+        lastCarrierInfo: CarrierInfo?,
+        lastRUMSessionState: RUMSessionState?,
+        lastIsAppInForeground: Bool
     ) {
         self.codableTrackingConsent = .init(from: lastTrackingConsent)
         self.codableLastUserInfo = .init(from: lastUserInfo)
         self.codableLastRUMViewEvent = lastRUMViewEvent.flatMap { .init(from: $0) }
         self.codableLastNetworkConnectionInfo = lastNetworkConnectionInfo.flatMap { .init(from: $0) }
         self.codableLastCarrierInfo = lastCarrierInfo.flatMap { .init(from: $0) }
+        self.lastRUMSessionState = lastRUMSessionState
+        self.lastIsAppInForeground = lastIsAppInForeground
     }
 
     // MARK: - Codable values
@@ -42,6 +46,8 @@ internal struct CrashContext: Codable {
         case codableLastUserInfo = "lui"
         case codableLastNetworkConnectionInfo = "lni"
         case codableLastCarrierInfo = "lci"
+        case lastRUMSessionState = "rst"
+        case lastIsAppInForeground = "aif"
     }
 
     // MARK: - Setters & Getters using managed types
@@ -70,6 +76,14 @@ internal struct CrashContext: Codable {
         set { codableLastCarrierInfo = newValue.flatMap { CodableCarrierInfo(from: $0) } }
         get { codableLastCarrierInfo?.managedValue }
     }
+
+    // MARK: - Direct Codable values
+
+    /// State of the last RUM session in crashed app process.
+    var lastRUMSessionState: RUMSessionState?
+
+    /// The last _"Is app in foreground?"_ information from crashed app process.
+    var lastIsAppInForeground: Bool
 }
 
 // MARK: - Bridging managed types to Codable representation

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -50,7 +50,9 @@ internal class CrashReporter {
                 userInfoProvider: crashReportingFeature.userInfoProvider,
                 networkConnectionInfoProvider: crashReportingFeature.networkConnectionInfoProvider,
                 carrierInfoProvider: crashReportingFeature.carrierInfoProvider,
-                rumViewEventProvider: crashReportingFeature.rumViewEventProvider
+                rumViewEventProvider: crashReportingFeature.rumViewEventProvider,
+                rumSessionStateProvider: crashReportingFeature.rumSessionStateProvider,
+                appStateListener: crashReportingFeature.appStateListener
             ),
             loggingOrRUMIntegration: availableLoggingOrRUMIntegration
         )

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -29,7 +29,13 @@ internal final class CrashReportingFeature {
     /// Publishes recent `CarrierInfo` value so it can be persisted in `CrashContext`.
     let carrierInfoProvider: CarrierInfoProviderType
     /// Publishes recent `RUMEvent<RUMViewEvent>` value so it can be persisted in `CrashContext`.
+    /// It will provide `nil` until first view is tracked.
     let rumViewEventProvider: ValuePublisher<RUMEvent<RUMViewEvent>?>
+    /// Publishes recent RUM session state so it can be persisted in `CrashContext`.
+    /// It will be used to decide if and how to track crashes which happen while there was no active view.
+    let rumSessionStateProvider: ValuePublisher<RUMSessionState?>
+    /// Publishes changes to app "foreground" / "background" state.
+    let appStateListener: AppStateListening
 
     init(
         configuration: FeaturesConfiguration.CrashReporting,
@@ -40,7 +46,9 @@ internal final class CrashReportingFeature {
         self.userInfoProvider = commonDependencies.userInfoProvider
         self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
         self.carrierInfoProvider = commonDependencies.carrierInfoProvider
-        self.rumViewEventProvider = ValuePublisher(initialValue: nil)
+        self.rumViewEventProvider = ValuePublisher(initialValue: nil) // `nil` by default, because there cannot be any RUM view at this ponit
+        self.rumSessionStateProvider = ValuePublisher(initialValue: nil) // `nil` by default, because there cannot be any RUM session at this ponit
+        self.appStateListener = commonDependencies.appStateListener
     }
 
 #if DD_SDK_COMPILED_FOR_TESTING

--- a/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
@@ -6,26 +6,38 @@
 
 import Foundation
 
-/// Updates `CrashContext` passed to crash reporter with the last `RUMViewEvent`.
+/// Updates `CrashContext` passed to crash reporter with the last RUM view and RUM session state.
 /// When the app restarts after crash, this event is used to create and send `RUMErrorEvent` describing the crash.
 ///
 /// This integration isolates the direct link between RUM and Crash Reporting.
 internal struct RUMWithCrashContextIntegration {
     private weak var rumViewEventProvider: ValuePublisher<RUMEvent<RUMViewEvent>?>?
+    private weak var rumSessionStateProvider: ValuePublisher<RUMSessionState?>?
 
     init?() {
         if let crashReportingFeature = CrashReportingFeature.instance {
-            self.init(rumViewEventProvider: crashReportingFeature.rumViewEventProvider)
+            self.init(
+                rumViewEventProvider: crashReportingFeature.rumViewEventProvider,
+                rumSessionStateProvider: crashReportingFeature.rumSessionStateProvider
+            )
         } else {
             return nil
         }
     }
 
-    init(rumViewEventProvider: ValuePublisher<RUMEvent<RUMViewEvent>?>) {
+    init(
+        rumViewEventProvider: ValuePublisher<RUMEvent<RUMViewEvent>?>,
+        rumSessionStateProvider: ValuePublisher<RUMSessionState?>
+    ) {
         self.rumViewEventProvider = rumViewEventProvider
+        self.rumSessionStateProvider = rumSessionStateProvider
     }
 
     func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>) {
         rumViewEventProvider?.publishAsync(lastRUMViewEvent)
+    }
+
+    func update(lastRUMSessionState: RUMSessionState) {
+        rumSessionStateProvider?.publishAsync(lastRUMSessionState)
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -19,6 +19,9 @@ internal struct RUMScopeDependencies {
     let rumUUIDGenerator: RUMUUIDGenerator
     /// Adjusts RUM events time (device time) to server time.
     let dateCorrector: DateCorrectorType
+    /// Integration with Crash Reporting. It updates the crash context with RUM info.
+    /// `nil` if Crash Reporting feature is not enabled.
+    let crashContextIntegration: RUMWithCrashContextIntegration?
 
     let vitalCPUReader: SamplingBasedVitalReader
     let vitalMemoryReader: SamplingBasedVitalReader

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMOffViewEventsHandlingRule.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMOffViewEventsHandlingRule.swift
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Lightweight representation of current RUM session state, used to compute `RUMOffViewEventsHandlingRule`.
+/// It gets serialized into `CrashContext` for computing the rule upon app process restart after crash.
+internal struct RUMSessionState: Equatable, Codable {
+    /// The session ID. Can be `.nullUUID` if the session was rejected by sampler.
+    let sessionUUID: UUID
+    /// If this is the very first session in the app process (`true`) or was re-created upon timeout (`false`).
+    let isInitialSession: Bool
+    /// If this session has ever tracked any view (used to reason about "application launch" events).
+    let hasTrackedAnyView: Bool
+}
+
+/// The rule for handling RUM events which are tracked while there is no active view.
+///
+/// It isolates the logic behind starting artificial views like "ApplicationLaunch" or "Background". It is used by both RUM and Crash Reporting
+/// to decide on how to track off-view events and crashes.
+internal enum RUMOffViewEventsHandlingRule: Equatable {
+    struct Constants {
+        /// The name of the view created when receiving an event while there is no active view and Background Events Tracking is enabled.
+        static let backgroundViewName = "Background"
+        /// The url of the view created when receiving an event while there is no active view and Background Events Tracking is enabled.
+        static let backgroundViewURL = "com/datadog/background/view"
+        /// The name of the view created when receiving an event before any view was started in the initial session.
+        static let applicationLaunchViewName = "ApplicationLaunch"
+        /// The url of the view created when receiving an event before any view was started in the initial session.
+        static let applicationLaunchViewURL = "com/datadog/application-launch/view"
+    }
+
+    /// Start "ApplicationLaunch" view to track the event.
+    case handleInApplicationLaunchView
+    /// Start "Background" view to track the event.
+    case handleInBackgroundView
+    /// Do not start any view (drop the event).
+    case doNotHandle
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - sessionState: RUM session state or `nil` if no session is started
+    ///   - isAppInForeground: if the app is in foreground
+    ///   - isBETEnabled: if Background Events Tracking feature is enabled in SDK configuration
+    init(
+        sessionState: RUMSessionState?,
+        isAppInForeground: Bool,
+        isBETEnabled: Bool
+    ) {
+        if let session = sessionState {
+            guard session.sessionUUID != .nullUUID else {
+                self = .doNotHandle // when session is sampled, do not track off-view events at all
+                return
+            }
+
+            let thereWasNoViewInThisSession = !session.hasTrackedAnyView
+            let thereWasNoViewInThisAppProcess = session.isInitialSession && thereWasNoViewInThisSession
+
+            if thereWasNoViewInThisAppProcess {
+                if isAppInForeground {
+                    self = .handleInApplicationLaunchView
+                } else if isBETEnabled {
+                    self = .handleInBackgroundView
+                } else {
+                    self = .doNotHandle
+                }
+            } else {
+                if !isAppInForeground && isBETEnabled {
+                    self = .handleInBackgroundView
+                } else {
+                    self = .doNotHandle
+                }
+            }
+        } else {
+            if isAppInForeground {
+                self = .handleInApplicationLaunchView
+            } else if isBETEnabled {
+                self = .handleInBackgroundView
+            } else {
+                self = .doNotHandle
+            }
+        }
+    }
+}

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -69,10 +69,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     /// It can be toggled from inside `RUMResourceScope`/`RUMUserActionScope` callbacks, as they are called from processing `RUMCommand`s inside `process()`.
     private var needsViewUpdate = false
 
-    /// Integration with Crash Reporting. It updates the context of crash reporter with last `RUMViewEvent` information.
-    /// `nil` if Crash Reporting feature is not enabled.
-    private let crashContextIntegration: RUMWithCrashContextIntegration?
-
     private let vitalInfoSampler: VitalInfoSampler
 
     init(
@@ -97,7 +93,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         self.viewName = name
         self.viewStartTime = startTime
         self.dateCorrection = dependencies.dateCorrector.currentCorrection
-        self.crashContextIntegration = RUMWithCrashContextIntegration()
 
         self.vitalInfoSampler = VitalInfoSampler(
             cpuReader: dependencies.vitalCPUReader,
@@ -415,7 +410,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         if let event = dependencies.eventBuilder.createRUMEvent(with: eventData) {
             dependencies.eventOutput.write(rumEvent: event)
-            crashContextIntegration?.update(lastRUMViewEvent: event)
+
+            // Update `CrashContext` with recent RUM view:
+            dependencies.crashContextIntegration?.update(lastRUMViewEvent: event)
         } else {
             version -= 1
         }

--- a/Sources/Datadog/RUM/UUIDs/RUMUUID.swift
+++ b/Sources/Datadog/RUM/UUIDs/RUMUUID.swift
@@ -10,7 +10,7 @@ internal struct RUMUUID: Equatable {
     let rawValue: UUID
 
     /// UUID with all zeros, used to represent no-op values.
-    static let nullUUID = RUMUUID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000000") ?? UUID())
+    static let nullUUID = RUMUUID(rawValue: .nullUUID)
 }
 
 extension Optional where Wrapped == RUMUUID {

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -193,6 +193,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     ),
                     rumUUIDGenerator: DefaultRUMUUIDGenerator(),
                     dateCorrector: rumFeature.dateCorrector,
+                    crashContextIntegration: RUMWithCrashContextIntegration(),
                     vitalCPUReader: rumFeature.vitalCPUReader,
                     vitalMemoryReader: rumFeature.vitalMemoryReader,
                     vitalRefreshRateReader: rumFeature.vitalRefreshRateReader,

--- a/Sources/Datadog/Utils/SwiftExtensions.swift
+++ b/Sources/Datadog/Utils/SwiftExtensions.swift
@@ -25,6 +25,14 @@ extension Double {
     }
 }
 
+// MARK: - UUID
+
+extension UUID {
+    /// An UUID with all zeroes (`00000000-0000-0000-0000-000000000000`).
+    /// Used to represent "null" in types that cannot be given a proper UUID (e.g. rejected RUM session).
+    static let nullUUID = UUID(uuidString: "00000000-0000-0000-0000-000000000000") ?? UUID()
+}
+
 // MARK: - TimeInterval
 
 extension TimeInterval {

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -24,7 +24,9 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: .mockAny(),
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
             carrierInfoProvider: CarrierInfoProviderMock.mockAny(),
-            rumViewEventProvider: .mockRandom()
+            rumViewEventProvider: .mockRandom(),
+            rumSessionStateProvider: .mockAny(),
+            appStateListener: AppStateListenerMock.mockAny()
         )
 
         let initialContext = crashContextProvider.currentCrashContext
@@ -45,24 +47,30 @@ class CrashContextProviderTests: XCTestCase {
 
     // MARK: - `RUMViewEvent` Integration
 
-    func testWhenRUMWithCrashContextIntegrationIsUpdated_thenCrashContextProviderNotifiesNewContext() {
+    func testWhenRUMWithCrashContextIntegrationIsUpdatedWithRUMViewEvent_thenCrashContextProviderNotifiesNewContext() {
         let expectation = self.expectation(description: "Notify new crash context")
-        let randomRUMViewEvent: RUMEvent<RUMViewEvent> = RUMEvent(model: RUMViewEvent.mockRandom())
+        let initialRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandom()
+        let randomRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandom()
 
-        let rumViewEventProvider = ValuePublisher<RUMEvent<RUMViewEvent>?>(initialValue: randomRUMViewEvent)
+        let rumViewEventProvider = ValuePublisher<RUMEvent<RUMViewEvent>?>(initialValue: initialRUMViewEvent)
         let crashContextProvider = CrashContextProvider(
             consentProvider: .mockAny(),
             userInfoProvider: .mockAny(),
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
             carrierInfoProvider: CarrierInfoProviderMock.mockAny(),
-            rumViewEventProvider: rumViewEventProvider
+            rumViewEventProvider: rumViewEventProvider,
+            rumSessionStateProvider: .mockAny(),
+            appStateListener: AppStateListenerMock.mockAny()
         )
 
         let initialContext = crashContextProvider.currentCrashContext
         var updatedContext: CrashContext?
 
         // When
-        let rumWithCrashContextIntegration = RUMWithCrashContextIntegration(rumViewEventProvider: rumViewEventProvider)
+        let rumWithCrashContextIntegration = RUMWithCrashContextIntegration(
+            rumViewEventProvider: rumViewEventProvider,
+            rumSessionStateProvider: .mockAny()
+        )
         crashContextProvider.onCrashContextChange = { newContext in
             updatedContext = newContext
             expectation.fulfill()
@@ -71,8 +79,46 @@ class CrashContextProviderTests: XCTestCase {
 
         // Then
         waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertNil(initialContext.lastRUMViewEvent)
+        XCTAssertEqual(initialContext.lastRUMViewEvent, initialRUMViewEvent)
         XCTAssertEqual(updatedContext?.lastRUMViewEvent, randomRUMViewEvent)
+    }
+
+    // MARK: - RUM Session State Integration
+
+    func testWhenRUMWithCrashContextIntegrationIsUpdatedWithRUMSessionState_thenCrashContextProviderNotifiesNewContext() {
+        let expectation = self.expectation(description: "Notify new crash context")
+        let initialRUMSessionState: RUMSessionState = .mockRandom()
+        let randomRUMSessionState: RUMSessionState = .mockRandom()
+
+        let rumSessionStateProvider = ValuePublisher<RUMSessionState?>(initialValue: initialRUMSessionState)
+        let crashContextProvider = CrashContextProvider(
+            consentProvider: .mockAny(),
+            userInfoProvider: .mockAny(),
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
+            carrierInfoProvider: CarrierInfoProviderMock.mockAny(),
+            rumViewEventProvider: .mockRandom(),
+            rumSessionStateProvider: rumSessionStateProvider,
+            appStateListener: AppStateListenerMock.mockAny()
+        )
+
+        let initialContext = crashContextProvider.currentCrashContext
+        var updatedContext: CrashContext?
+
+        // When
+        let rumWithCrashContextIntegration = RUMWithCrashContextIntegration(
+            rumViewEventProvider: .mockRandom(),
+            rumSessionStateProvider: rumSessionStateProvider
+        )
+        crashContextProvider.onCrashContextChange = { newContext in
+            updatedContext = newContext
+            expectation.fulfill()
+        }
+        rumWithCrashContextIntegration.update(lastRUMSessionState: randomRUMSessionState)
+
+        // Then
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertEqual(initialContext.lastRUMSessionState, initialRUMSessionState)
+        XCTAssertEqual(updatedContext?.lastRUMSessionState, randomRUMSessionState)
     }
 
     // MARK: - `UserInfo` Integration
@@ -90,7 +136,9 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
             carrierInfoProvider: CarrierInfoProviderMock.mockAny(),
-            rumViewEventProvider: .mockRandom()
+            rumViewEventProvider: .mockRandom(),
+            rumSessionStateProvider: .mockAny(),
+            appStateListener: AppStateListenerMock.mockAny()
         )
 
         let initialContext = crashContextProvider.currentCrashContext
@@ -122,7 +170,9 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: .mockAny(),
             networkConnectionInfoProvider: mainProvider,
             carrierInfoProvider: CarrierInfoProviderMock.mockAny(),
-            rumViewEventProvider: .mockRandom()
+            rumViewEventProvider: .mockRandom(),
+            rumSessionStateProvider: .mockAny(),
+            appStateListener: AppStateListenerMock.mockAny()
         )
 
         let initialContext = crashContextProvider.currentCrashContext
@@ -160,7 +210,9 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: .mockAny(),
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
             carrierInfoProvider: carrierInfoProvider,
-            rumViewEventProvider: .mockRandom()
+            rumViewEventProvider: .mockRandom(),
+            rumSessionStateProvider: .mockAny(),
+            appStateListener: AppStateListenerMock.mockAny()
         )
 
         let initialContext = crashContextProvider.currentCrashContext
@@ -198,7 +250,9 @@ class CrashContextProviderTests: XCTestCase {
                 userInfoProvider: .mockAny(),
                 networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
                 carrierInfoProvider: carrierInfoProvider,
-                rumViewEventProvider: .mockRandom()
+                rumViewEventProvider: .mockRandom(),
+                rumSessionStateProvider: .mockAny(),
+                appStateListener: AppStateListenerMock.mockAny()
             )
 
             let initialContext = crashContextProvider.currentCrashContext
@@ -224,6 +278,43 @@ class CrashContextProviderTests: XCTestCase {
         }
     }
 
+    // MARK: - `AppStateListener` Integration
+
+    func testWhenAppStateChangeIsTrackedByAppStateListener_thenCrashContextProviderNotifiesNewContext() {
+        let expectation = self.expectation(description: "Notify new crash context")
+
+        let notificationCenter = NotificationCenter()
+        let appStateListener = AppStateListener(
+            dateProvider: SystemDateProvider(),
+            notificationCenter: notificationCenter
+        )
+
+        let crashContextProvider = CrashContextProvider(
+            consentProvider: .mockAny(),
+            userInfoProvider: .mockAny(),
+            networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockAny(),
+            carrierInfoProvider: CarrierInfoProviderMock.mockAny(),
+            rumViewEventProvider: .mockRandom(),
+            rumSessionStateProvider: .mockAny(),
+            appStateListener: appStateListener
+        )
+
+        let initialContext = crashContextProvider.currentCrashContext
+        var updatedContext: CrashContext?
+
+        // When
+        crashContextProvider.onCrashContextChange = { newContext in
+            updatedContext = newContext
+            expectation.fulfill()
+        }
+        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil) // app goes to background
+
+        // Then
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertTrue(initialContext.lastIsAppInForeground, "It must track initial app state ('foreground')")
+        XCTAssertEqual(updatedContext?.lastIsAppInForeground, false, "It must track app state update (to 'background')")
+    }
+
     // MARK: - Thread safety
 
     func testWhenContextIsWrittenAndReadFromDifferentThreads_itRunsAllOperationsSafely() {
@@ -240,7 +331,9 @@ class CrashContextProviderTests: XCTestCase {
             userInfoProvider: userInfoProvider,
             networkConnectionInfoProvider: networkInfoMainProvider,
             carrierInfoProvider: carrierInfoMainProvider,
-            rumViewEventProvider: .mockRandom()
+            rumViewEventProvider: .mockRandom(),
+            rumSessionStateProvider: .mockAny(),
+            appStateListener: AppStateListenerMock.mockAny()
         )
 
         withExtendedLifetime(provider) {

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextTests.swift
@@ -46,6 +46,24 @@ class CrashContextTests: XCTestCase {
         )
     }
 
+    func testGivenContextWithLastRUMSessionStateSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
+        let randomRUMSessionState: RUMSessionState? = Bool.random() ? .mockRandom() : nil
+
+        // Given
+        var context: CrashContext = .mockRandom()
+        context.lastRUMSessionState = randomRUMSessionState
+
+        // When
+        let serializedContext = try encoder.encode(context)
+
+        // Then
+        let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
+        try AssertEncodedRepresentationsEqual(
+            value1: deserializedContext.lastRUMSessionState,
+            value2: randomRUMSessionState
+        )
+    }
+
     func testGivenContextWithUserInfoSet_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
         let randomUserInfo: UserInfo = .mockRandom()
 
@@ -95,6 +113,21 @@ class CrashContextTests: XCTestCase {
         // Then
         let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
         XCTAssertEqual(deserializedContext.lastCarrierInfo, randomCarrierInfo)
+    }
+
+    func testGivenContextWithIsAppInForeground_whenItGetsEncoded_thenTheValueIsPreservedAfterDecoding() throws {
+        let randomIsAppInForeground: Bool = .mockRandom()
+
+        // Given
+        var context: CrashContext = .mockRandom()
+        context.lastIsAppInForeground = randomIsAppInForeground
+
+        // When
+        let serializedContext = try encoder.encode(context)
+
+        // Then
+        let deserializedContext = try decoder.decode(CrashContext.self, from: serializedContext)
+        XCTAssertEqual(deserializedContext.lastIsAppInForeground, randomIsAppInForeground)
     }
 
     // MARK: - Helpers

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -21,6 +21,19 @@ class RUMWithCrashContextIntegrationTests: XCTestCase {
         XCTAssertEqual(CrashReportingFeature.instance?.rumViewEventProvider.currentValue, randomRUMViewEvent)
     }
 
+    func testWhenCrashReportingIsEnabled_itUpdatesCrashContextWithRUMSessionState() throws {
+        // When
+        CrashReportingFeature.instance = .mockNoOp()
+        defer { CrashReportingFeature.instance?.deinitialize() }
+
+        // Then
+        let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration())
+        let randomRUMSessionState: RUMSessionState = .mockRandom()
+        rumWithCrashContextIntegration.update(lastRUMSessionState: randomRUMSessionState)
+
+        XCTAssertEqual(CrashReportingFeature.instance?.rumSessionStateProvider.currentValue, randomRUMSessionState)
+    }
+
     func testWhenCrashReportingIsNotEnabled_itCannotBeInitialized() {
         // When
         XCTAssertNil(CrashReportingFeature.instance)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -671,13 +671,26 @@ class AppStateListenerMock: AppStateListening, AnyMockable {
     }
 
     static func mockAny() -> Self {
+        return mockAppInForeground(since: .mockDecember15th2019At10AMUTC())
+    }
+
+    static func mockAppInForeground(since date: Date = Date()) -> Self {
         return .init(
-            history: .init(
-                initialState: .init(isActive: true, date: .mockDecember15th2019At10AMUTC()),
-                recentDate: .mockDecember15th2019At10AMUTC()
-            )
+            history: .init(initialState: .init(isActive: true, date: date), recentDate: date)
         )
     }
+
+    static func mockAppInBackground(since date: Date = Date()) -> Self {
+        return .init(
+            history: .init(initialState: .init(isActive: false, date: date), recentDate: date)
+        )
+    }
+
+    static func mockRandom(since date: Date = Date()) -> Self {
+        return Bool.random() ? mockAppInForeground(since: date) : mockAppInBackground(since: date)
+    }
+
+    func subscribe<Observer: AppStateHistoryObserver>(_ subscriber: Observer) where Observer.ObservedValue == AppStateHistory {}
 }
 
 extension UserInfo: AnyMockable, RandomMockable {

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -90,14 +90,18 @@ extension CrashContext {
         lastUserInfo: UserInfo = .mockAny(),
         lastRUMViewEvent: RUMEvent<RUMViewEvent>? = nil,
         lastNetworkConnectionInfo: NetworkConnectionInfo? = .mockAny(),
-        lastCarrierInfo: CarrierInfo? = .mockAny()
+        lastCarrierInfo: CarrierInfo? = .mockAny(),
+        lastRUMSessionState: RUMSessionState? = .mockAny(),
+        lastIsAppInForeground: Bool = .mockAny()
     ) -> CrashContext {
         return CrashContext(
             lastTrackingConsent: lastTrackingConsent,
             lastUserInfo: lastUserInfo,
             lastRUMViewEvent: lastRUMViewEvent,
             lastNetworkConnectionInfo: lastNetworkConnectionInfo,
-            lastCarrierInfo: lastCarrierInfo
+            lastCarrierInfo: lastCarrierInfo,
+            lastRUMSessionState: lastRUMSessionState,
+            lastIsAppInForeground: lastIsAppInForeground
         )
     }
 
@@ -107,7 +111,9 @@ extension CrashContext {
             lastUserInfo: .mockRandom(),
             lastRUMViewEvent: .mockRandom(),
             lastNetworkConnectionInfo: .mockRandom(),
-            lastCarrierInfo: .mockRandom()
+            lastCarrierInfo: .mockRandom(),
+            lastRUMSessionState: .mockRandom(),
+            lastIsAppInForeground: .mockRandom()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -593,6 +593,16 @@ extension RUMContext {
     }
 }
 
+extension RUMSessionState: AnyMockable, RandomMockable {
+    static func mockAny() -> RUMSessionState {
+        return .init(sessionUUID: .mockAny(), isInitialSession: .mockAny(), hasTrackedAnyView: .mockAny())
+    }
+
+    static func mockRandom() -> RUMSessionState {
+        return .init(sessionUUID: .mockRandom(), isInitialSession: .mockRandom(), hasTrackedAnyView: .mockRandom())
+    }
+}
+
 // MARK: - RUMScope Mocks
 
 func mockNoOpSessionListerner() -> RUMSessionListener {
@@ -616,6 +626,7 @@ extension RUMScopeDependencies {
         eventOutput: RUMEventOutput = RUMEventOutputMock(),
         rumUUIDGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
         dateCorrector: DateCorrectorType = DateCorrectorMock(),
+        crashContextIntegration: RUMWithCrashContextIntegration? = nil,
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListerner()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -627,6 +638,7 @@ extension RUMScopeDependencies {
             eventOutput: eventOutput,
             rumUUIDGenerator: rumUUIDGenerator,
             dateCorrector: dateCorrector,
+            crashContextIntegration: crashContextIntegration,
             vitalCPUReader: SamplingBasedVitalReaderMock(),
             vitalMemoryReader: SamplingBasedVitalReaderMock(),
             vitalRefreshRateReader: ContinuousVitalReaderMock(),
@@ -644,6 +656,7 @@ extension RUMScopeDependencies {
         eventOutput: RUMEventOutput? = nil,
         rumUUIDGenerator: RUMUUIDGenerator? = nil,
         dateCorrector: DateCorrectorType? = nil,
+        crashContextIntegration: RUMWithCrashContextIntegration? = nil,
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListerner()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -655,6 +668,7 @@ extension RUMScopeDependencies {
             eventOutput: eventOutput ?? self.eventOutput,
             rumUUIDGenerator: rumUUIDGenerator ?? self.rumUUIDGenerator,
             dateCorrector: dateCorrector ?? self.dateCorrector,
+            crashContextIntegration: crashContextIntegration ?? self.crashContextIntegration,
             vitalCPUReader: SamplingBasedVitalReaderMock(),
             vitalMemoryReader: SamplingBasedVitalReaderMock(),
             vitalRefreshRateReader: ContinuousVitalReaderMock(),

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -198,6 +198,16 @@ extension URL: AnyMockable, RandomMockable {
     }
 }
 
+extension UUID: AnyMockable, RandomMockable {
+    static func mockAny() -> UUID {
+        return UUID()
+    }
+
+    static func mockRandom() -> UUID {
+        return UUID()
+    }
+}
+
 extension String: AnyMockable, RandomMockable {
     static func mockAny() -> String {
         return "abc"

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMOffViewEventsHandlingRuleTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMOffViewEventsHandlingRuleTests.swift
@@ -1,0 +1,113 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMOffViewEventsHandlingRuleTests: XCTestCase {
+    // MARK: - When There Is No RUM Session
+
+    func testWhenThereIsNoRUMSessionAndAppIsInForeground_itShouldHandleEventsInApplicationLaunchView() {
+        let rule = RUMOffViewEventsHandlingRule(
+            sessionState: nil,
+            isAppInForeground: true,
+            isBETEnabled: .mockRandom()
+        )
+        XCTAssertEqual(rule, .handleInApplicationLaunchView, "It must start ApplicationLaunch view, because app is in foreground")
+    }
+
+    func testWhenThereIsNoRUMSessionAndAppIsInBackground_itShouldHandleEventsInBackgroundView_onlyWhenBETIsEnabled() {
+        let rule1 = RUMOffViewEventsHandlingRule(
+            sessionState: nil,
+            isAppInForeground: false,
+            isBETEnabled: true
+        )
+        XCTAssertEqual(rule1, .handleInBackgroundView, "It must start Background view")
+
+        let rule2 = RUMOffViewEventsHandlingRule(
+            sessionState: nil,
+            isAppInForeground: false,
+            isBETEnabled: false
+        )
+        XCTAssertEqual(rule2, .doNotHandle, "It must drop the event, because BET is disabled")
+    }
+
+    // MARK: - When There Is RUM Session
+
+    func testWhenThereIsRUMSessionAndAppIsInForeground_itShouldHandleEventsInApplicationLaunchView_onlyWhenInitialSessionWithNoViewsHistory() {
+        let rule1 = RUMOffViewEventsHandlingRule(
+            sessionState: .init(
+                sessionUUID: .mockRandom(),
+                isInitialSession: true,
+                hasTrackedAnyView: false
+            ),
+            isAppInForeground: true,
+            isBETEnabled: .mockRandom()
+        )
+        XCTAssertEqual(rule1, .handleInApplicationLaunchView, "It must start ApplicationLaunch view")
+
+        let rule2 = RUMOffViewEventsHandlingRule(
+            sessionState: .init(
+                sessionUUID: .mockRandom(),
+                isInitialSession: .mockRandom(),
+                hasTrackedAnyView: true
+            ),
+            isAppInForeground: true,
+            isBETEnabled: .mockRandom()
+        )
+        XCTAssertEqual(rule2, .doNotHandle, "It must drop the event, because this session already tracked some views")
+
+        let rule3 = RUMOffViewEventsHandlingRule(
+            sessionState: .init(
+                sessionUUID: .mockRandom(),
+                isInitialSession: false,
+                hasTrackedAnyView: .mockRandom()
+            ),
+            isAppInForeground: true,
+            isBETEnabled: .mockRandom()
+        )
+        XCTAssertEqual(rule3, .doNotHandle, "It must drop the event, because this is not initial session")
+    }
+
+    func testWhenThereIsRUMSessionAndAppIsInBackground_itShouldHandleEventsInBackgroundView_onlyWhenBETIsEnabled() {
+        let rule1 = RUMOffViewEventsHandlingRule(
+            sessionState: .init(
+                sessionUUID: .mockRandom(),
+                isInitialSession: .mockRandom(),
+                hasTrackedAnyView: .mockRandom()
+            ),
+            isAppInForeground: false,
+            isBETEnabled: true
+        )
+        XCTAssertEqual(rule1, .handleInBackgroundView, "It must start Background view")
+
+        let rule2 = RUMOffViewEventsHandlingRule(
+            sessionState: .init(
+                sessionUUID: .mockRandom(),
+                isInitialSession: .mockRandom(),
+                hasTrackedAnyView: .mockRandom()
+            ),
+            isAppInForeground: false,
+            isBETEnabled: false
+        )
+        XCTAssertEqual(rule2, .doNotHandle, "It must drop the event, because BET is disabled")
+    }
+
+    // MARK: - When There Is RUM Session But It Is Rejected By Sampler
+
+    func testWhenThereIsRUMSessionButItIsRejectedBySampler_itShouldDropAllEvents() {
+        let rule = RUMOffViewEventsHandlingRule(
+            sessionState: .init(
+                sessionUUID: .nullUUID, // session is not sampled
+                isInitialSession: .mockRandom(),
+                hasTrackedAnyView: .mockRandom()
+            ),
+            isAppInForeground: .mockRandom(),
+            isBETEnabled: .mockRandom()
+        )
+        XCTAssertEqual(rule, .doNotHandle, "It must drop the event, because session is not sampled")
+    }
+}

--- a/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
@@ -53,6 +53,13 @@ class TimeIntervalExtensionTests: XCTestCase {
     }
 }
 
+class UUIDExtensionTests: XCTestCase {
+    func testNullUUID() {
+        let uuid: UUID = .nullUUID
+        XCTAssertEqual(uuid.uuidString, "00000000-0000-0000-0000-000000000000", "It must be all zeroes")
+    }
+}
+
 class IntegerOverflowExtensionTests: XCTestCase {
     func testHappyPath() {
         let reasonableDouble = Double(1_000.123_456)


### PR DESCRIPTION
### What and why?

📦 This PR prepares `CrashContext` to handle crashes during application launch. This is necessary to decide:
* if the crash should be send in "ApplicationLaunch" view (when app crashed during foreground launch);
* if the crash should be send in "Background" view (when app crashed during background launch);
* if the crash should be dropped (e.g. when app crashed during background launch, but Background Events Tracking is disabled OR when crashed session was rejected by sampler).

### How?

First, I isolated the code deciding on "ApplicationLaunch" x "Background" x "no" view to `RUMOffViewEventsHandlingRule`. This logic is quite complex but very important (for customer billing 💸) so it's definitely worth having it separate as it will be used by both RUM and Crash Reporting to take similar decision on handling events or crashes while no active view:

![application-launch-events](https://user-images.githubusercontent.com/2358722/146406762-32db4490-2468-476c-b7c5-e6a68d836e85.png)

Second, I updated `CrashContext` with all values necessary for making the decision ☝️ in `RUMOffViewEventsHandlingRule`. This way, when the app restarts upon the crash, we will be able to run exactly the same logic and decide if the crash should be sent in "ApplicationLaunch" view, "Background" view or if it should be dropped (e.g. due to sampling).

Crash handling upon app restart will be delivered in separate, final PR to this topic.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
