### PR TITLE
Update DateFormatting

### DIFF
--- a/Sources/Datadog/Core/Utils/DateFormatting.swift
+++ b/Sources/Datadog/Core/Utils/DateFormatting.swift
@@ -8,6 +8,7 @@ import Foundation
 
 internal protocol DateFormatterType {
     func string(from date: Date) -> String
+    func date(from string: String) -> Date?
 }
 
 extension ISO8601DateFormatter: DateFormatterType {}


### PR DESCRIPTION
### What and why?

Both the `ISO8601Formatter` and the `DateFormatter` type also has the ability to get a date from the string. There's no reason not to include this as well to the protocol

### How?

Adds the method signature for the conforming protocol

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
