### PR TITLE
RUMM-1805 Set `PLCrashReporter` custom path

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "lyft/Kronos" ~> 4.2
-github "microsoft/plcrashreporter" ~> 1.10.0
+github "microsoft/plcrashreporter" ~> 1.10.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "lyft/Kronos" "4.2.1"
-github "microsoft/plcrashreporter" "1.10.0"
+github "microsoft/plcrashreporter" "1.10.1"

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -515,6 +515,7 @@
 		B3FC3C3C2653A97700DEED9E /* VitalInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FC3C3B2653A97700DEED9E /* VitalInfoTests.swift */; };
 		D2135330270CA722000315AD /* DataCompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213532F270CA722000315AD /* DataCompressionTests.swift */; };
 		D22C1F5C271484B400922024 /* LogEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C1F5B271484B400922024 /* LogEventMapper.swift */; };
+		D243BBC0276C9D640019C857 /* PLCrashReporterIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D243BBBF276C9D640019C857 /* PLCrashReporterIntegrationTests.swift */; };
 		D244B3A3271EDACD003E1B29 /* SwiftUIExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D244B3A2271EDACD003E1B29 /* SwiftUIExtensionsTests.swift */; };
 		D24985A22728048B00B4F72D /* SwiftUIViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24985A12728048B00B4F72D /* SwiftUIViewHandler.swift */; };
 		D24985A327280FD100B4F72D /* SwiftUIViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D249859F2728042200B4F72D /* SwiftUIViewModifier.swift */; };
@@ -1182,6 +1183,7 @@
 		B3FC3C3B2653A97700DEED9E /* VitalInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalInfoTests.swift; sourceTree = "<group>"; };
 		D213532F270CA722000315AD /* DataCompressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompressionTests.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
+		D243BBBF276C9D640019C857 /* PLCrashReporterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLCrashReporterIntegrationTests.swift; sourceTree = "<group>"; };
 		D244B3A2271EDACD003E1B29 /* SwiftUIExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExtensionsTests.swift; sourceTree = "<group>"; };
 		D249859F2728042200B4F72D /* SwiftUIViewModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIViewModifier.swift; sourceTree = "<group>"; };
 		D24985A12728048B00B4F72D /* SwiftUIViewHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIViewHandler.swift; sourceTree = "<group>"; };
@@ -3169,6 +3171,7 @@
 		61FCBFE525DBBE7D00CCF864 /* PLCrashReporterIntegration */ = {
 			isa = PBXGroup;
 			children = (
+				D243BBBF276C9D640019C857 /* PLCrashReporterIntegrationTests.swift */,
 				615CC4122695957C0005F08C /* CrashReportTests.swift */,
 				61FDBA14269722B4001D9D43 /* CrashReportMinifierTests.swift */,
 				61E95D872695C00200EA3115 /* DDCrashReportExporterTests.swift */,
@@ -4481,6 +4484,7 @@
 				61FDBA1726974CA9001D9D43 /* DDCrashReportBuilderTests.swift in Sources */,
 				612556BC26933228002BCE74 /* FoundationMocks.swift in Sources */,
 				615CC4102694A64D0005F08C /* SwiftExtensionTests.swift in Sources */,
+				D243BBC0276C9D640019C857 /* PLCrashReporterIntegrationTests.swift in Sources */,
 				61FDBA15269722B4001D9D43 /* CrashReportMinifierTests.swift in Sources */,
 				61E95D882695C00200EA3115 /* DDCrashReportExporterTests.swift in Sources */,
 				612556BD2693348F002BCE74 /* EquatableInTests.swift in Sources */,

--- a/Datadog/Example/Utils/PersistenceHelper.swift
+++ b/Datadog/Example/Utils/PersistenceHelper.swift
@@ -12,7 +12,7 @@ internal struct PersistenceHelpers {
         do {
             try FileManager.default
                 .getCacheSubdirectories()
-                .filter { isFeatureDirectory($0) || isCrashReporterDirectory($0) }
+                .filter { isFeatureDirectory($0) }
                 .forEach { FileManager.default.delete($0) }
         } catch {
             print("🔥 Failed to delete SDK data directory: \(error)")

--- a/DatadogSDKCrashReporting.podspec.src
+++ b/DatadogSDKCrashReporting.podspec.src
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
   s.dependency 'DatadogSDK', '__DATADOG_VERSION__'
-  s.dependency 'PLCrashReporter', '~> 1.10.0'
+  s.dependency 'PLCrashReporter', '~> 1.10.1'
 end

--- a/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
+++ b/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
@@ -360,7 +360,7 @@ class DDCrashReportExporterTests: XCTestCase {
     // MARK: - Comparing with PLCR text format
 
     func testExportedStacksHaveTheSameFormatAndValuesAsIfTheyWereExportedFromPLCR() throws {
-        let crashReporter = PLCrashReporter(configuration: .ddConfiguration())!
+        let crashReporter = try PLCrashReporter(configuration: .ddConfiguration())!
 
         // Given
         let plCrashReport = try PLCrashReport(
@@ -393,7 +393,7 @@ class DDCrashReportExporterTests: XCTestCase {
     }
 
     func testExportedBinaryImagesHaveTheSameValuesAsIfTheyWereExportedFromPLCR() throws {
-        let crashReporter = PLCrashReporter(configuration: .ddConfiguration())!
+        let crashReporter = try PLCrashReporter(configuration: .ddConfiguration())!
 
         // Given
         let plCrashReport = try PLCrashReport(

--- a/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/PLCrashReporterIntegrationTests.swift
+++ b/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/PLCrashReporterIntegrationTests.swift
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogCrashReporting
+import CrashReporter
+
+class PLCrashReporterIntegrationTests: XCTestCase {
+    func testGivenPLCrashReporter_whenInitializingWithDDConfig_itSetsCustomPath() throws {
+        // Given
+        let configuration = try PLCrashReporterConfig.ddConfiguration()
+
+        // When
+        let reporter = PLCrashReporter(configuration: configuration)
+
+        // Then
+        let reporterPath = reporter?.crashReportPath()
+        let expected = "/Library/Caches/com.datadoghq.crash-reporting/v1/"
+        XCTAssertTrue(reporterPath?.contains(expected) ?? false)
+    }
+}


### PR DESCRIPTION
### What and why?

Configure `PLCrashReporter` with a custom storage location to `/Library/Caches/com.datadoghq.crash-reporting/v1`.

By setting a custom path, we allow other instances of `PLCrashReporter` to work alongside the SDK without altering the reports.

### How?

Sets the `basePath` property of the [PLCrashReporterConfig](https://github.com/microsoft/plcrashreporter/blob/master/Source/PLCrashReporterConfig.h#L185).

The `PLCrashReporter` version has been incremented to `1.10.1` to use the `[PLCrashReporter crashReportPath]` in tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [X] Make sure each commit and the PR mention the Issue number or JIRA reference
