### PR TITLE
RUMM-1839 Fix Application Launch Handler Memory Leak

### DIFF
--- a/Sources/_Datadog_Private/ObjcAppLaunchHandler.m
+++ b/Sources/_Datadog_Private/ObjcAppLaunchHandler.m
@@ -72,6 +72,7 @@ NS_INLINE NSTimeInterval ComputeProcessTimeFromStart() {
         pthread_rwlock_unlock(&rwLock);
 
         [center removeObserver:token];
+        token = nil;
     }];
 }
 


### PR DESCRIPTION
### What and why?

Fixes a memory leak in `AppLaunchHandler`.

### How?

The token generated by `NSNotificationCenter` was not released.

### Review checklist

- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
