### PR TITLE
RUMM-1765 Handle App Launch crashes - part 4

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		613BE04A25640FF80015216C /* BenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613BE04925640FF80015216C /* BenchmarkTests.swift */; };
 		613BE06225642F790015216C /* RUMStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613BE06125642F790015216C /* RUMStorageBenchmarkTests.swift */; };
 		613BE073256431960015216C /* FoundationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C202423990D00786299 /* FoundationMocks.swift */; };
+		613C6B902768FDDE00870CBF /* Sampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613C6B8F2768FDDE00870CBF /* Sampler.swift */; };
+		613C6B922768FF3100870CBF /* SamplerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613C6B912768FF3100870CBF /* SamplerTests.swift */; };
 		613E79282577B0EE00DFCC17 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E79272577B0EE00DFCC17 /* Writer.swift */; };
 		613E792F2577B0F900DFCC17 /* Reader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E792E2577B0F900DFCC17 /* Reader.swift */; };
 		613E793B2577B6EE00DFCC17 /* DataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613E793A2577B6EE00DFCC17 /* DataReader.swift */; };
@@ -822,6 +824,8 @@
 		613BE0422563FB9E0015216C /* RUMBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMBenchmarkTests.swift; sourceTree = "<group>"; };
 		613BE04925640FF80015216C /* BenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchmarkTests.swift; sourceTree = "<group>"; };
 		613BE06125642F790015216C /* RUMStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMStorageBenchmarkTests.swift; sourceTree = "<group>"; };
+		613C6B8F2768FDDE00870CBF /* Sampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sampler.swift; sourceTree = "<group>"; };
+		613C6B912768FF3100870CBF /* SamplerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplerTests.swift; sourceTree = "<group>"; };
 		613E79272577B0EE00DFCC17 /* Writer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
 		613E792E2577B0F900DFCC17 /* Reader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reader.swift; sourceTree = "<group>"; };
 		613E793A2577B6EE00DFCC17 /* DataReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataReader.swift; sourceTree = "<group>"; };
@@ -1474,6 +1478,7 @@
 				61363D9C24D999F70084CD6F /* DDError.swift */,
 				6139CD702589FAFD007E8BB7 /* Retrying.swift */,
 				611529A425E3DD51004F740E /* ValuePublisher.swift */,
+				613C6B8F2768FDDE00870CBF /* Sampler.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2562,6 +2567,7 @@
 				618C365E248E85B400520CDE /* DateFormattingTests.swift */,
 				9E58E8E224615EDA008E5063 /* JSONEncoderTests.swift */,
 				61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */,
+				613C6B912768FF3100870CBF /* SamplerTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4108,6 +4114,7 @@
 				614E9EB3244719FA007EE3E1 /* BundleType.swift in Sources */,
 				61F3CDA72512144600C816E5 /* UIKitRUMViewsPredicate.swift in Sources */,
 				61133BCE2423979B00786299 /* BatteryStatusProvider.swift in Sources */,
+				613C6B902768FDDE00870CBF /* Sampler.swift in Sources */,
 				9E9973F1268DF69500D8059B /* VitalInfoSampler.swift in Sources */,
 				9EA3CA6926775A3500B16871 /* VitalRefreshRateReader.swift in Sources */,
 				E13A880C257922EC004FB174 /* EnvironmentSpanIntegration.swift in Sources */,
@@ -4154,6 +4161,7 @@
 				618C365F248E85B400520CDE /* DateFormattingTests.swift in Sources */,
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
 				61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */,
+				613C6B922768FF3100870CBF /* SamplerTests.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
 				D2135330270CA722000315AD /* DataCompressionTests.swift in Sources */,
 				61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */,

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -48,7 +48,8 @@ internal struct FeaturesConfiguration {
         let uploadURL: URL
         let clientToken: String
         let applicationID: String
-        let sessionSamplingRate: Float
+        let sessionSampler: Sampler
+        let uuidGenerator: RUMUUIDGenerator
         let viewEventMapper: RUMViewEventMapper?
         let resourceEventMapper: RUMResourceEventMapper?
         let actionEventMapper: RUMActionEventMapper?
@@ -205,7 +206,8 @@ extension FeaturesConfiguration {
                     uploadURL: try ifValid(endpointURLString: rumEndpoint.url),
                     clientToken: try ifValid(clientToken: configuration.clientToken),
                     applicationID: rumApplicationID,
-                    sessionSamplingRate: debugOverride ? 100.0 : configuration.rumSessionsSamplingRate,
+                    sessionSampler: Sampler(samplingRate: debugOverride ? 100.0 : configuration.rumSessionsSamplingRate),
+                    uuidGenerator: DefaultRUMUUIDGenerator(),
                     viewEventMapper: configuration.rumViewEventMapper,
                     resourceEventMapper: configuration.rumResourceEventMapper,
                     actionEventMapper: configuration.rumActionEventMapper,

--- a/Sources/Datadog/Core/Utils/Sampler.swift
+++ b/Sources/Datadog/Core/Utils/Sampler.swift
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Sampler, deciding if events should be sent do Datadog or dropped.
+internal struct Sampler {
+    /// Value between `0.0` and `100.0`, where `0.0` means NO event will be sent and `100.0` means ALL events will be sent.
+    let samplingRate: Float
+
+    init(samplingRate: Float) {
+        self.samplingRate = max(0, min(100, samplingRate))
+    }
+
+    /// Based on the sampling rate, it returns random value deciding if an event should be "sampled" or not.
+    /// - Returns: `true` if event should be sent to Datadog and `false` if it should be dropped.
+    func sample() -> Bool {
+        return Float.random(in: 0.0..<100.0) < samplingRate
+    }
+}

--- a/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
@@ -33,7 +33,7 @@ internal struct RUMWithCrashContextIntegration {
         self.rumSessionStateProvider = rumSessionStateProvider
     }
 
-    func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>) {
+    func update(lastRUMViewEvent: RUMEvent<RUMViewEvent>?) {
         rumViewEventProvider?.publishAsync(lastRUMViewEvent)
     }
 

--- a/Sources/Datadog/RUM/RUMEvent/RUMConnectivityInfoProvider.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMConnectivityInfoProvider.swift
@@ -14,21 +14,29 @@ internal struct RUMConnectivityInfoProvider {
     let carrierInfoProvider: CarrierInfoProviderType
 
     var current: RUMConnectivity? {
-        guard let networkInfo = networkConnectionInfoProvider.current else {
+        return RUMConnectivity(
+            networkInfo: networkConnectionInfoProvider.current,
+            carrierInfo: carrierInfoProvider.current
+        )
+    }
+}
+
+extension RUMConnectivity {
+    init?(networkInfo: NetworkConnectionInfo?, carrierInfo: CarrierInfo?) {
+        guard let networkInfo = networkInfo else {
             return nil
         }
-        let carrierInfo = carrierInfoProvider.current
 
-        return RUMConnectivity(
-            cellular: carrierInfo.flatMap { connectivityCellularInfo(for: $0) },
-            interfaces: connectivityInterfaces(for: networkInfo),
-            status: connectivityStatus(for: networkInfo)
+        self.init(
+            cellular: carrierInfo.flatMap { RUMConnectivity.connectivityCellularInfo(for: $0) },
+            interfaces: RUMConnectivity.connectivityInterfaces(for: networkInfo),
+            status: RUMConnectivity.connectivityStatus(for: networkInfo)
         )
     }
 
     // MARK: - Private
 
-    private func connectivityStatus(for networkInfo: NetworkConnectionInfo) -> RUMConnectivity.Status {
+    private static func connectivityStatus(for networkInfo: NetworkConnectionInfo) -> RUMConnectivity.Status {
         switch networkInfo.reachability {
         case .yes:   return .connected
         case .maybe: return .maybe
@@ -36,7 +44,7 @@ internal struct RUMConnectivityInfoProvider {
         }
     }
 
-    private func connectivityInterfaces(for networkInfo: NetworkConnectionInfo) -> [RUMConnectivity.Interfaces] {
+    private static func connectivityInterfaces(for networkInfo: NetworkConnectionInfo) -> [RUMConnectivity.Interfaces] {
         guard let availableInterfaces = networkInfo.availableInterfaces, !availableInterfaces.isEmpty else {
             return [.none]
         }
@@ -51,7 +59,7 @@ internal struct RUMConnectivityInfoProvider {
         }
     }
 
-    private func connectivityCellularInfo(for carrierInfo: CarrierInfo) -> RUMConnectivity.Cellular {
+    private static func connectivityCellularInfo(for carrierInfo: CarrierInfo) -> RUMConnectivity.Cellular {
         return RUMConnectivity.Cellular(
             carrierName: carrierInfo.carrierName,
             technology: carrierInfo.radioAccessTechnology.rawValue

--- a/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMUserInfoProvider.swift
@@ -12,18 +12,24 @@ internal struct RUMUserInfoProvider {
     let userInfoProvider: UserInfoProvider
 
     var current: RUMUser? {
-        let user = userInfoProvider.value
+        let userInfo = userInfoProvider.value
 
         // Returns nil if UserInfo has no data
-        if user.id == nil, user.name == nil, user.email == nil, user.extraInfo.isEmpty {
+        if userInfo.id == nil, userInfo.name == nil, userInfo.email == nil, userInfo.extraInfo.isEmpty {
             return nil
         }
 
-        return RUMUser(
-            email: user.email,
-            id: user.id,
-            name: user.name,
-            usrInfo: user.extraInfo
+        return RUMUser(userInfo: userInfo)
+    }
+}
+
+extension RUMUser {
+    init(userInfo: UserInfo) {
+        self.init(
+            email: userInfo.email,
+            id: userInfo.id,
+            name: userInfo.name,
+            usrInfo: userInfo.extraInfo
         )
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -37,8 +37,8 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     /// Might be re-created later according to session duration constraints.
     private(set) var sessionScope: RUMSessionScope?
 
-    /// RUM Sessions sampling rate.
-    internal let samplingRate: Float
+    /// RUM Sessions sampler.
+    internal let sampler: Sampler
 
     /// The start time of the application, measured in device date. It equals the time of SDK init.
     private let applicationStartTime: Date
@@ -53,12 +53,12 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     init(
         rumApplicationID: String,
         dependencies: RUMScopeDependencies,
-        samplingRate: Float,
+        sampler: Sampler,
         applicationStartTime: Date,
         backgroundEventTrackingEnabled: Bool
     ) {
         self.dependencies = dependencies
-        self.samplingRate = samplingRate
+        self.sampler = sampler
         self.applicationStartTime = applicationStartTime
         self.backgroundEventTrackingEnabled = backgroundEventTrackingEnabled
         self.context = RUMContext(
@@ -107,7 +107,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             isInitialSession: true,
             parent: self,
             dependencies: dependencies,
-            samplingRate: samplingRate,
+            sampler: sampler,
             startTime: applicationStartTime,
             backgroundEventTrackingEnabled: backgroundEventTrackingEnabled
         )
@@ -117,6 +117,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
     private func sessionScopeDidUpdate(_ sessionScope: RUMSessionScope) {
         let sessionID = sessionScope.sessionUUID.rawValue.uuidString
-        dependencies.onSessionStart?(sessionID, sessionScope.shouldBeSampledOut)
+        let isDiscarded = !sessionScope.isSampled
+        dependencies.onSessionStart?(sessionID, isDiscarded)
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -42,12 +42,12 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
 
     /// This Session UUID. Equals `.nullUUID` if the Session is sampled.
     let sessionUUID: RUMUUID
-    /// Tells if events from this Session should be sampled-out (not send).
-    let shouldBeSampledOut: Bool
+    /// If events from this session should be sampled (send to Datadog).
+    let isSampled: Bool
     /// If this is the very first session created in the current app process (`false` for session created upon expiration of a previous one).
     let isInitialSession: Bool
-    /// RUM Session sampling rate.
-    private let samplingRate: Float
+    /// RUM Session sampler.
+    private let sampler: Sampler
     /// The start time of this Session, measured in device date. In initial session this is the time of SDK init.
     private let sessionStartTime: Date
     /// Time of the last RUM interaction noticed by this Session.
@@ -57,15 +57,15 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         isInitialSession: Bool,
         parent: RUMContextProvider,
         dependencies: RUMScopeDependencies,
-        samplingRate: Float,
+        sampler: Sampler,
         startTime: Date,
         backgroundEventTrackingEnabled: Bool
     ) {
         self.parent = parent
         self.dependencies = dependencies
-        self.samplingRate = samplingRate
-        self.shouldBeSampledOut = RUMSessionScope.randomizeSampling(using: samplingRate)
-        self.sessionUUID = shouldBeSampledOut ? .nullUUID : dependencies.rumUUIDGenerator.generateUnique()
+        self.sampler = sampler
+        self.isSampled = sampler.sample()
+        self.sessionUUID = isSampled ? dependencies.rumUUIDGenerator.generateUnique() : .nullUUID
         self.isInitialSession = isInitialSession
         self.sessionStartTime = startTime
         self.lastInteractionTime = startTime
@@ -85,7 +85,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             isInitialSession: false,
             parent: expiredSession.parent,
             dependencies: expiredSession.dependencies,
-            samplingRate: expiredSession.samplingRate,
+            sampler: expiredSession.sampler,
             startTime: startTime,
             backgroundEventTrackingEnabled: expiredSession.backgroundEventTrackingEnabled
         )
@@ -125,8 +125,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         }
         lastInteractionTime = command.time
 
-        if shouldBeSampledOut {
-            return true
+        if !isSampled {
+            return true // discard all events in this session
         }
 
         if let startViewCommand = command as? RUMStartViewCommand {
@@ -230,10 +230,5 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         let expired = sessionDuration >= Constants.sessionMaxDuration
 
         return timedOut || expired
-    }
-
-    private static func randomizeSampling(using samplingRate: Float) -> Bool {
-        let sendSessionEvents = Float.random(in: 0.0..<100.0) < samplingRate
-        return !sendSessionEvents
     }
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -162,6 +162,14 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             viewScopes = manage(childScopes: viewScopes, byPropagatingCommand: command)
         }
 
+        if !hasActiveView {
+            // If there is no active view, update `CrashContext` accordingly, so eventual crash
+            // won't be associated to an inactive view and instead we will consider starting background view to track it.
+            // It means that with Background Events Tracking disabled, eventual off-view crashes will be dropped
+            // similar to how we drop other events.
+            dependencies.crashContextIntegration?.update(lastRUMViewEvent: nil)
+        }
+
         return true
     }
 

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -191,7 +191,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     eventOutput: RUMEventFileOutput(
                         fileWriter: rumFeature.storage.writer
                     ),
-                    rumUUIDGenerator: DefaultRUMUUIDGenerator(),
+                    rumUUIDGenerator: rumFeature.configuration.uuidGenerator,
                     dateCorrector: rumFeature.dateCorrector,
                     crashContextIntegration: RUMWithCrashContextIntegration(),
                     vitalCPUReader: rumFeature.vitalCPUReader,
@@ -199,7 +199,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     vitalRefreshRateReader: rumFeature.vitalRefreshRateReader,
                     onSessionStart: rumFeature.onSessionStart
                 ),
-                samplingRate: rumFeature.configuration.sessionSamplingRate,
+                sampler: rumFeature.configuration.sessionSampler,
                 applicationStartTime: rumFeature.sdkInitDate,
                 backgroundEventTrackingEnabled: rumFeature.configuration.backgroundEventTrackingEnabled
             ),

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -395,7 +395,7 @@ class FeaturesConfigurationTests: XCTestCase {
             appContext: .mockAny()
         )
         XCTAssertEqual(custom.rum?.applicationID, "rum-app-id")
-        XCTAssertEqual(custom.rum?.sessionSamplingRate, 45.2)
+        XCTAssertEqual(custom.rum?.sessionSampler.samplingRate, 45.2)
     }
 
     func testRUMAutoInstrumentationConfiguration() throws {

--- a/Tests/DatadogTests/Datadog/Core/Utils/SamplerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Utils/SamplerTests.swift
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+ class SamplerTests: XCTestCase {
+     private let measurements = 0..<500
+
+     func testWhenSamplingRateIs0_itAlwaysReturnsNotSampled() {
+         // Given
+         let sampler = Sampler(samplingRate: 0)
+
+         // When
+         var notSampledCount = 0
+         measurements.forEach { _ in
+             notSampledCount += sampler.sample() ? 0 : 1
+         }
+
+         // Then
+         XCTAssertEqual(notSampledCount, measurements.count)
+     }
+
+     func testWhenSamplingRateIs100_itAlwaysReturnsIsSampled() {
+         // Given
+         let sampler = Sampler(samplingRate: 100)
+
+         // When
+         var isSampledCount = 0
+         measurements.forEach { _ in
+             isSampledCount += sampler.sample() ? 1 : 0
+         }
+
+         // Then
+         XCTAssertEqual(isSampledCount, measurements.count)
+     }
+
+     func testWhenSamplingRateIsLow_itReturnsNotSampledMoreOften() {
+         // Given
+         let sampler = Sampler(samplingRate: .random(in: (0..<30)))
+
+         // When
+         var isSampledCount = 0
+         var notSampledCount = 0
+         measurements.forEach { _ in
+             let value = sampler.sample()
+             isSampledCount += value ? 1 : 0
+             notSampledCount += value ? 0 : 1
+         }
+
+         // Then
+         XCTAssertGreaterThan(notSampledCount, isSampledCount)
+     }
+
+     func testWhenSamplingRateIsHigh_itReturnsNotSampledMoreOften() {
+         // Given
+         let sampler = Sampler(samplingRate: .random(in: (70..<100)))
+
+         // When
+         var isSampledCount = 0
+         var notSampledCount = 0
+         measurements.forEach { _ in
+             let value = sampler.sample()
+             isSampledCount += value ? 1 : 0
+             notSampledCount += value ? 0 : 1
+         }
+
+         // Then
+         XCTAssertGreaterThan(isSampledCount, notSampledCount)
+     }
+
+     func testWhenInitializing_itSanitizesSamplingRateToAllowedRange() {
+         measurements.forEach { _ in
+             // Given
+             let randomRate: Float = .random(in: -100..<200)
+
+             // When
+             let sampler = Sampler(samplingRate: randomRate)
+
+             // Then
+             XCTAssertGreaterThanOrEqual(sampler.samplingRate, 0)
+             XCTAssertLessThanOrEqual(sampler.samplingRate, 100)
+         }
+     }
+ }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -354,7 +354,7 @@ class DatadogTests: XCTestCase {
             uploadFrequency: .frequent,
             bundleType: .iOSApp
         )
-        XCTAssertEqual(RUMFeature.instance?.configuration.sessionSamplingRate, 100)
+        XCTAssertEqual(RUMFeature.instance?.configuration.sessionSampler.samplingRate, 100)
         XCTAssertEqual(TracingFeature.instance?.configuration.common.performance, expectedPerformancePreset)
         XCTAssertEqual(LoggingFeature.instance?.configuration.common.performance, expectedPerformancePreset)
         XCTAssertEqual(Datadog.verbosityLevel, .debug)

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -12,18 +12,18 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
     // MARK: - Testing Conditional Uploads
 
-    func testGivenCrashDuringRUMSessionCollectedLessThan4HoursAgo_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
+    func testGivenCrashDuringRUMSessionWithActiveViewCollectedLessThan4HoursAgo_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
         let secondsIn4Hours: TimeInterval = 4 * 60 * 60
 
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()
         let crashDate: Date = currentDate.secondsAgo(.random(in: 0..<secondsIn4Hours))
-        let someRUMView: RUMEvent<RUMViewEvent> = .mockRandom()
+        let activeRUMView: RUMEvent<RUMViewEvent> = .mockRandom()
 
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: someRUMView // means there was a RUM session and it was sampled
+            lastRUMViewEvent: activeRUMView // means there was a RUM session and it was sampled
         )
 
         let integration = CrashReportingWithRUMIntegration(
@@ -45,18 +45,18 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).count, 1)
     }
 
-    func testGivenCrashDuringRUMSessionCollectedMoreThan4HoursAgo_whenSending_itSendsOnlyRUMError() throws {
+    func testGivenCrashDuringRUMSessionWithActiveViewCollectedMoreThan4HoursAgo_whenSending_itSendsOnlyRUMError() throws {
         let secondsIn4Hours: TimeInterval = 4 * 60 * 60
 
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()
         let crashDate: Date = currentDate.secondsAgo(.random(in: secondsIn4Hours..<TimeInterval.greatestFiniteMagnitude))
-        let someRUMView: RUMEvent<RUMViewEvent> = .mockRandom()
+        let activeRUMView: RUMEvent<RUMViewEvent> = .mockRandom()
 
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: someRUMView // means there was a RUM session and it was sampled
+            lastRUMViewEvent: activeRUMView // means there was a RUM session and it was sampled
         )
 
         let integration = CrashReportingWithRUMIntegration(
@@ -77,7 +77,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).count, 1)
     }
 
-    func testGivenCrashBeforeRUMSession_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
+    func testGivenCrashDuringBackgroundRUMSessionWithNoActiveView_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()
         let crashDate: Date = currentDate.secondsAgo(.random(in: 10..<1_000))
@@ -85,8 +85,40 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: nil, // means there was no RUM session
-            lastRUMSessionState: nil, // means there was no RUM session
+            lastRUMViewEvent: nil, // means there was no active view in this RUM session
+            lastRUMSessionState: .mockRandom(), // means there was RUM session (sampled)
+            lastIsAppInForeground: false // app in background
+        )
+
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: 0),
+            rumConfiguration: .mockWith(
+                sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
+                backgroundEventTrackingEnabled: true // BET enabled
+            )
+        )
+
+        // When
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 2, "It must send both RUM error and RUM view")
+        XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).count, 1)
+        XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).count, 1)
+    }
+
+    func testGivenCrashDuringApplicationLaunch_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: 10..<1_000))
+
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: nil, // means there was no active view
+            lastRUMSessionState: Bool.random() ? nil : .mockWith(isInitialSession: true, hasTrackedAnyView: false), // there was no RUM session OR it was just started w/o yet tracking first view
             lastIsAppInForeground: .mockRandom() // no matter if crashed in foreground or in background
         )
 
@@ -134,7 +166,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(rumEventOutput.recordedEvents.count, 0, "Crash must not be send as it doesn't have `.granted` consent")
     }
 
-    func testGivenCrashBeforeRUMSessionAndNoSampling_whenSending_itIsDropped() throws {
+    func testGivenCrashDuringAppLaunchAndNoSampling_whenSending_itIsDropped() throws {
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()
         let crashDate: Date = currentDate.secondsAgo(.random(in: 10..<1_000))
@@ -164,17 +196,81 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(rumEventOutput.recordedEvents.count, 0, "Crash must not be send as it is rejected by sampler")
     }
 
-    // MARK: - Testing Uploaded Data - Crashes During RUM Session
-
-    func testGivenCrashDuringRUMSession_whenSendingRUMViewEvent_itIsLinkedToPreviousRUMSessionAndIncludesErrorInformation() throws {
-        let lastRUMViewEvent: RUMViewEvent = .mockRandom()
-
+    func testGivenCrashDuringAppLaunchInBackgroundAndBETDisabled_whenSending_itIsDropped() throws {
         // Given
         let crashDate: Date = .mockDecember15th2019At10AMUTC()
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: RUMEvent(model: lastRUMViewEvent) // means there was a RUM session and it was sampled
+            lastRUMViewEvent: nil, // means there was no RUM session (it crashed during app launch)
+            lastRUMSessionState: nil, // means there was no RUM session (it crashed during app launch)
+            lastIsAppInForeground: false // app was in background
+        )
+
+        let dateCorrectionOffset: TimeInterval = .mockRandom()
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: crashDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
+            rumConfiguration: .mockWith(
+                sessionSampler: .mockKeepAll(),
+                backgroundEventTrackingEnabled: false // BET disabled
+            )
+        )
+
+        // When
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0, "Crash must not be send as it happened in background and BET is disabled")
+    }
+
+    func testGivenCrashDuringSampledRUMSession_whenSending_itIsDropped() throws {
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: 10..<1_000))
+
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: nil, // means there was no active view
+            lastRUMSessionState: .mockWith(
+                sessionUUID: .nullUUID, // there was RUM session but it was not sampled
+                isInitialSession: .mockRandom(),
+                hasTrackedAnyView: false // as it was not sampled, it couldn't track any view
+            ),
+            lastIsAppInForeground: .mockRandom() // no matter if crashed in foreground or in background
+        )
+
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: 0),
+            rumConfiguration: .mockWith(
+                sessionSampler: .mockRandom(), // no matter current session sampling
+                backgroundEventTrackingEnabled: .mockRandom()
+            )
+        )
+
+        // When
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0, "Crash must not be send as it the session was rejected by sampler")
+    }
+
+    // MARK: - Testing Uploaded Data - Crashes During RUM Session With Active View
+
+    func testGivenCrashDuringRUMSessionWithActiveView_whenSendingRUMViewEvent_itIsLinkedToPreviousRUMSessionAndIncludesErrorInformation() throws {
+        let lastRUMViewEvent: RUMViewEvent = .mockRandom()
+
+        // Given
+        let crashDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let activeRUMView = RUMEvent(model: lastRUMViewEvent) // means there was a RUM session and it was sampled
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: activeRUMView
         )
 
         // When
@@ -219,13 +315,13 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(sendRUMViewEvent.view.action.count, lastRUMViewEvent.view.action.count)
         XCTAssertEqual(
             sendRUMViewEvent.date,
-            crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds,
-            "The `RUMViewEvent` sent must include crash date corrected by current correction offset."
+            crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds - 1,
+            "The `RUMViewEvent` sent must include crash date corrected by current correction offset and shifted back by 1ms."
         )
         XCTAssertEqual(sendRUMViewEvent.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
-    func testGivenCrashDuringRUMSession_whenSendingRUMErrorEvent_itIsLinkedToPreviousRUMSessionAndIncludesCrashInformation() throws {
+    func testGivenCrashDuringRUMSessionWithActiveView_whenSendingRUMErrorEvent_itIsLinkedToPreviousRUMSessionAndIncludesCrashInformation() throws {
         let lastRUMViewEvent: RUMViewEvent = .mockRandom()
 
         // Given
@@ -259,16 +355,21 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
                 exceptionCodes: "EXCEPTION_CODES"
             )
         )
+        let activeRUMView = RUMEvent(model: lastRUMViewEvent) // means there was a RUM session and it was sampled
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: RUMEvent(model: lastRUMViewEvent) // means there was a RUM session and it was sampled
+            lastRUMViewEvent: activeRUMView
         )
 
         // When
-        let dateCorrectionOffset: TimeInterval = .mockRandom()
+        let dateCorrectionOffset: TimeInterval = .mockRandom(min: 1, max: 5)
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: crashDate),
+            dateProvider: RelativeDateProvider(
+                using: crashDate.addingTimeInterval(
+                    .mockRandom(min: 10, max: 2 * CrashReportingWithRUMIntegration.Constants.viewEventAvailabilityThreshold) // simulate restarting app from 10s to 8h later
+                )
+            ),
             dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
             rumConfiguration: .mockWith(
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
@@ -316,6 +417,136 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.binaryImages] as? [DDCrashReport.BinaryImage], crashReport.binaryImages)
         XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.meta] as? DDCrashReport.Meta, crashReport.meta)
         XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.wasTruncated] as? Bool, crashReport.wasTruncated)
+    }
+
+    // MARK: - Testing Uploaded Data - Crashes During RUM Session With No Active View
+
+    func testGivenCrashDuringRUMSessionWithNoActiveView_whenSendingRUMViewEvent_itIsLinkedToPreviousRUMSessionAndIncludesErrorInformation() throws {
+        let randomRUMAppID: String = .mockRandom(among: .alphanumerics)
+        let randomNetworkConnectionInfo: NetworkConnectionInfo = .mockRandom()
+        let randomCarrierInfo: CarrierInfo = .mockRandom()
+        let randomUserInfo: UserInfo = .mockRandom()
+        let randomCrashType: String = .mockRandom()
+
+        func test(
+            lastRUMSessionState: RUMSessionState,
+            launchInForeground: Bool,
+            backgroundEventsTrackingEnabled: Bool,
+            expectViewName expectedViewName: String,
+            expectViewURL expectedViewURL: String
+        ) throws {
+            let rumEventOutput = RUMEventOutputMock()
+
+            // Given
+            let crashDate: Date = .mockDecember15th2019At10AMUTC()
+            let crashReport: DDCrashReport = .mockWith(
+                date: crashDate,
+                type: randomCrashType
+            )
+            let crashContext: CrashContext = .mockWith(
+                lastTrackingConsent: .granted,
+                lastUserInfo: randomUserInfo,
+                lastRUMViewEvent: nil, // means there was no active RUM view
+                lastNetworkConnectionInfo: randomNetworkConnectionInfo,
+                lastCarrierInfo: randomCarrierInfo,
+                lastRUMSessionState: lastRUMSessionState, // means there was RUM session (sampled)
+                lastIsAppInForeground: launchInForeground
+            )
+
+            let dateCorrectionOffset: TimeInterval = .mockRandom()
+            let integration = CrashReportingWithRUMIntegration(
+                rumEventOutput: rumEventOutput,
+                dateProvider: RelativeDateProvider(using: crashDate),
+                dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
+                rumConfiguration: .mockWith(
+                    applicationID: randomRUMAppID,
+                    sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled),
+                    backgroundEventTrackingEnabled: backgroundEventsTrackingEnabled
+                )
+            )
+
+            // When
+            integration.send(crashReport: crashReport, with: crashContext)
+
+            // Then
+            let sentRUMView = try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self)[0].model
+            let sentRUMErrorEvent = try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self)[0]
+            let sentRUMError = sentRUMErrorEvent.model
+
+            // Assert RUM view properties
+            XCTAssertTrue(
+                sentRUMView.application.id == randomRUMAppID
+                && sentRUMView.session.id == RUMUUID(rawValue: lastRUMSessionState.sessionUUID).toRUMDataFormat
+                && sentRUMView.view.id.matches(regex: .uuidRegex),
+                "It must send `RUMViewEvent` linked to previous RUM Session"
+            )
+            XCTAssertEqual(
+                sentRUMView.connectivity,
+                RUMConnectivity(networkInfo: randomNetworkConnectionInfo, carrierInfo: randomCarrierInfo),
+                "It must contain connectity info from the moment of crash"
+            )
+            XCTAssertEqual(
+                sentRUMView.usr,
+                RUMUser(userInfo: randomUserInfo),
+                "It must contain user info from the moment of crash"
+            )
+            XCTAssertEqual(sentRUMView.view.crash?.count, 1, "The view must include 1 crash")
+            XCTAssertTrue(sentRUMView.view.isActive == false, "The view must be marked inactive")
+            XCTAssertEqual(sentRUMView.view.name, expectedViewName)
+            XCTAssertEqual(sentRUMView.view.url, expectedViewURL)
+            XCTAssertEqual(sentRUMView.view.error.count, 0)
+            XCTAssertEqual(sentRUMView.view.resource.count, 0)
+            XCTAssertEqual(sentRUMView.view.action.count, 0)
+            XCTAssertEqual(
+                sentRUMView.date,
+                crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds - 1,
+                "The view must include crash date corrected by current correction offset and shifted back by 1ms."
+            )
+            XCTAssertEqual(sentRUMView.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
+
+            // Assert RUM error properties
+            XCTAssertEqual(sentRUMError.application.id, sentRUMView.application.id, "It must be linked to the same application as RUM view")
+            XCTAssertEqual(sentRUMError.session.id, sentRUMView.session.id, "It must be linked to the same session as RUM view")
+            XCTAssertEqual(sentRUMError.view.id, sentRUMView.view.id, "It must be linked to the RUM view")
+            XCTAssertEqual(
+                sentRUMError.connectivity,
+                RUMConnectivity(networkInfo: randomNetworkConnectionInfo, carrierInfo: randomCarrierInfo),
+                "It must contain connectity info from the moment of crash"
+            )
+            XCTAssertEqual(
+                sentRUMError.usr,
+                RUMUser(userInfo: randomUserInfo),
+                "It must contain user info from the moment of crash"
+            )
+            XCTAssertTrue(sentRUMError.error.isCrash == true, "RUM error must be marked as crash.")
+            XCTAssertEqual(
+                sentRUMError.date,
+                crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds,
+                "RUM error must include crash date corrected by current correction offset."
+            )
+            XCTAssertEqual(sentRUMError.error.type, randomCrashType)
+            XCTAssertEqual(sentRUMError.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
+            XCTAssertNotNil(sentRUMErrorEvent.errorAttributes?[DDError.threads], "It must contain crash details")
+            XCTAssertNotNil(sentRUMErrorEvent.errorAttributes?[DDError.binaryImages], "It must contain crash details")
+            XCTAssertNotNil(sentRUMErrorEvent.errorAttributes?[DDError.meta], "It must contain crash details")
+            XCTAssertNotNil(sentRUMErrorEvent.errorAttributes?[DDError.wasTruncated], "It must contain crash details")
+        }
+
+        try test(
+            lastRUMSessionState: .mockWith(isInitialSession: true, hasTrackedAnyView: false), // when initial session with no views history
+            launchInForeground: true, // launch in foreground
+            backgroundEventsTrackingEnabled: .mockRandom(), // no matter BET
+            expectViewName: RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName,
+            expectViewURL: RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL
+        )
+
+        try test(
+            lastRUMSessionState: .mockRandom(), // any sampled session
+            launchInForeground: false, // launch in background
+            backgroundEventsTrackingEnabled: true, // BET enabled
+            expectViewName: RUMOffViewEventsHandlingRule.Constants.backgroundViewName,
+            expectViewURL: RUMOffViewEventsHandlingRule.Constants.backgroundViewURL
+        )
     }
 
     // MARK: - Testing Uploaded Data - Crashes During App Launch
@@ -397,8 +628,8 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
             XCTAssertEqual(sentRUMView.view.action.count, 0)
             XCTAssertEqual(
                 sentRUMView.date,
-                crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds,
-                "The vie must include crash date corrected by current correction offset."
+                crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds - 1,
+                "The view must include crash date corrected by current correction offset and shifted back by 1ms."
             )
             XCTAssertEqual(sentRUMView.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
 
@@ -443,34 +674,5 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
             expectViewName: RUMOffViewEventsHandlingRule.Constants.backgroundViewName,
             expectViewURL: RUMOffViewEventsHandlingRule.Constants.backgroundViewURL
         )
-    }
-
-    func testGivenCrashDuringAppLaunchInBackgroundAndBETDisabled_whenSending_itIsDropped() throws {
-        // Given
-        let crashDate: Date = .mockDecember15th2019At10AMUTC()
-        let crashReport: DDCrashReport = .mockWith(date: crashDate)
-        let crashContext: CrashContext = .mockWith(
-            lastTrackingConsent: .granted,
-            lastRUMViewEvent: nil, // means there was no RUM session (it crashed during app launch)
-            lastRUMSessionState: nil, // means there was no RUM session (it crashed during app launch)
-            lastIsAppInForeground: false // app was in background
-        )
-
-        let dateCorrectionOffset: TimeInterval = .mockRandom()
-        let integration = CrashReportingWithRUMIntegration(
-            rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: crashDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
-            rumConfiguration: .mockWith(
-                sessionSampler: .mockKeepAll(),
-                backgroundEventTrackingEnabled: false // BET disabled
-            )
-        )
-
-        // When
-        integration.send(crashReport: crashReport, with: crashContext)
-
-        // Then
-        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0, "Crash must not be send as it happened in background and BET is disabled")
     }
 }

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -12,102 +12,161 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
     // MARK: - Testing Conditional Uploads
 
-    func testWhenSendingCrashReportCollectedLessThan4HoursAgo_itSendsBothRUMErrorAndRUMViewEvent() throws {
+    func testGivenCrashDuringRUMSessionCollectedLessThan4HoursAgo_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
         let secondsIn4Hours: TimeInterval = 4 * 60 * 60
 
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()
         let crashDate: Date = currentDate.secondsAgo(.random(in: 0..<secondsIn4Hours))
+        let someRUMView: RUMEvent<RUMViewEvent> = .mockRandom()
 
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: .mockRandom()
+            lastRUMViewEvent: someRUMView // means there was a RUM session and it was sampled
         )
 
-        // When
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
             dateProvider: RelativeDateProvider(using: currentDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: 0)
+            dateCorrector: DateCorrectorMock(correctionOffset: 0),
+            rumConfiguration: .mockWith(
+                sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
+                backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            )
         )
+
+        // When
         integration.send(crashReport: crashReport, with: crashContext)
 
         // Then
-        XCTAssertEqual(rumEventOutput.recordedEvents.count, 2)
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 2, "It must send both RUM error and RUM view")
         XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).count, 1)
         XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).count, 1)
     }
 
-    func testWhenSendingCrashReportCollectedMoreThan4HoursAgo_itSendsOnlyRUMError() throws {
+    func testGivenCrashDuringRUMSessionCollectedMoreThan4HoursAgo_whenSending_itSendsOnlyRUMError() throws {
         let secondsIn4Hours: TimeInterval = 4 * 60 * 60
 
         // Given
         let currentDate: Date = .mockDecember15th2019At10AMUTC()
         let crashDate: Date = currentDate.secondsAgo(.random(in: secondsIn4Hours..<TimeInterval.greatestFiniteMagnitude))
+        let someRUMView: RUMEvent<RUMViewEvent> = .mockRandom()
 
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: .mockRandom()
+            lastRUMViewEvent: someRUMView // means there was a RUM session and it was sampled
         )
 
-        // When
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
             dateProvider: RelativeDateProvider(using: currentDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: 0)
+            dateCorrector: DateCorrectorMock(correctionOffset: 0),
+            rumConfiguration: .mockWith(
+                sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
+                backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            )
         )
+
+        // When
         integration.send(crashReport: crashReport, with: crashContext)
 
         // Then
-        XCTAssertEqual(rumEventOutput.recordedEvents.count, 1)
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 1, "It must send only RUM error")
         XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).count, 1)
     }
 
-    func testWhenCrashReportHasUnauthorizedTrackingConsent_itIsNotSent() throws {
+    func testGivenCrashBeforeRUMSession_whenSending_itSendsBothRUMErrorAndRUMViewEvent() throws {
+        // Given
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: 10..<1_000))
+
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: nil, // means there was no RUM session
+            lastRUMSessionState: nil, // means there was no RUM session
+            lastIsAppInForeground: .mockRandom() // no matter if crashed in foreground or in background
+        )
+
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: 0),
+            rumConfiguration: .mockWith(
+                sessionSampler: .mockKeepAll(),
+                backgroundEventTrackingEnabled: true
+            )
+        )
+
+        // When
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 2, "It must send both RUM error and RUM view")
+        XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self).count, 1)
+        XCTAssertEqual(try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).count, 1)
+    }
+
+    func testGivenAnyCrashWithUnauthorizedTrackingConsent_whenSending_itIsDropped() throws {
         // Given
         let crashReport: DDCrashReport = .mockWith(date: .mockDecember15th2019At10AMUTC())
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: [.pending, .notGranted].randomElement()!,
-            lastRUMViewEvent: .mockRandom()
+            lastRUMViewEvent: Bool.random() ? .mockRandom() : nil // no matter if in RUM session or not
         )
 
-        // When
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
             dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
-            dateCorrector: DateCorrectorMock()
+            dateCorrector: DateCorrectorMock(),
+            rumConfiguration: .mockWith(
+                sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling
+                backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            )
         )
+
+        // When
         integration.send(crashReport: crashReport, with: crashContext)
 
         // Then
-        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0)
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0, "Crash must not be send as it doesn't have `.granted` consent")
     }
 
-    func testWhenCrashReportHasNoAssociatedLastRUMViewEvent_itIsNotSent() throws {
+    func testGivenCrashBeforeRUMSessionAndNoSampling_whenSending_itIsDropped() throws {
         // Given
-        let crashReport: DDCrashReport = .mockWith(date: .mockDecember15th2019At10AMUTC())
+        let currentDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashDate: Date = currentDate.secondsAgo(.random(in: 10..<1_000))
+
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: nil
+            lastRUMViewEvent: nil, // means there was no RUM session
+            lastRUMSessionState: nil, // means there was no RUM session
+            lastIsAppInForeground: .mockRandom() // no matter if crashed in foreground or in background
+        )
+
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: currentDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: 0),
+            rumConfiguration: .mockWith(
+                sessionSampler: .mockRejectAll(), // no sampling (no session should be sent)
+                backgroundEventTrackingEnabled: true
+            )
         )
 
         // When
-        let integration = CrashReportingWithRUMIntegration(
-            rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
-            dateCorrector: DateCorrectorMock()
-        )
         integration.send(crashReport: crashReport, with: crashContext)
 
         // Then
-        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0)
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0, "Crash must not be send as it is rejected by sampler")
     }
 
-    // MARK: - Testing Uploaded Data
+    // MARK: - Testing Uploaded Data - Crashes During RUM Session
 
-    func testWhenSendingRUMViewEvent_itIncludesErrorInformation() throws {
+    func testGivenCrashDuringRUMSession_whenSendingRUMViewEvent_itIsLinkedToPreviousRUMSessionAndIncludesErrorInformation() throws {
         let lastRUMViewEvent: RUMViewEvent = .mockRandom()
 
         // Given
@@ -115,7 +174,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let crashReport: DDCrashReport = .mockWith(date: crashDate)
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: RUMEvent(model: lastRUMViewEvent)
+            lastRUMViewEvent: RUMEvent(model: lastRUMViewEvent) // means there was a RUM session and it was sampled
         )
 
         // When
@@ -123,7 +182,11 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
             dateProvider: RelativeDateProvider(using: crashDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset)
+            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
+            rumConfiguration: .mockWith(
+                sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
+                backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            )
         )
         integration.send(crashReport: crashReport, with: crashContext)
 
@@ -162,7 +225,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(sendRUMViewEvent.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
     }
 
-    func testWhenSendingRUMErrorEvent_itIncludesCrashInformation() throws {
+    func testGivenCrashDuringRUMSession_whenSendingRUMErrorEvent_itIsLinkedToPreviousRUMSessionAndIncludesCrashInformation() throws {
         let lastRUMViewEvent: RUMViewEvent = .mockRandom()
 
         // Given
@@ -198,7 +261,7 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         )
         let crashContext: CrashContext = .mockWith(
             lastTrackingConsent: .granted,
-            lastRUMViewEvent: RUMEvent(model: lastRUMViewEvent)
+            lastRUMViewEvent: RUMEvent(model: lastRUMViewEvent) // means there was a RUM session and it was sampled
         )
 
         // When
@@ -206,7 +269,11 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
             dateProvider: RelativeDateProvider(using: crashDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset)
+            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
+            rumConfiguration: .mockWith(
+                sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
+                backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            )
         )
         integration.send(crashReport: crashReport, with: crashContext)
 
@@ -249,5 +316,161 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.binaryImages] as? [DDCrashReport.BinaryImage], crashReport.binaryImages)
         XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.meta] as? DDCrashReport.Meta, crashReport.meta)
         XCTAssertEqual(sendRUMEvent.errorAttributes?[DDError.wasTruncated] as? Bool, crashReport.wasTruncated)
+    }
+
+    // MARK: - Testing Uploaded Data - Crashes During App Launch
+
+    func testGivenCrashDuringAppLaunch_whenSending_itIsSendAsRUMErrorInNewRUMSession() throws {
+        let randomRUMAppID: String = .mockRandom(among: .alphanumerics)
+        let randomNetworkConnectionInfo: NetworkConnectionInfo = .mockRandom()
+        let randomCarrierInfo: CarrierInfo = .mockRandom()
+        let randomUserInfo: UserInfo = .mockRandom()
+        let randomCrashType: String = .mockRandom()
+
+        func test(
+            launchInForeground: Bool,
+            backgroundEventsTrackingEnabled: Bool,
+            expectViewName expectedViewName: String,
+            expectViewURL expectedViewURL: String
+        ) throws {
+            let rumEventOutput = RUMEventOutputMock()
+
+            // Given
+            let crashDate: Date = .mockDecember15th2019At10AMUTC()
+            let crashReport: DDCrashReport = .mockWith(
+                date: crashDate,
+                type: randomCrashType
+            )
+            let crashContext: CrashContext = .mockWith(
+                lastTrackingConsent: .granted,
+                lastUserInfo: randomUserInfo,
+                lastRUMViewEvent: nil, // means there was no RUM session (it crashed during app launch)
+                lastNetworkConnectionInfo: randomNetworkConnectionInfo,
+                lastCarrierInfo: randomCarrierInfo,
+                lastRUMSessionState: nil, // means there was no RUM session (it crashed during app launch)
+                lastIsAppInForeground: launchInForeground
+            )
+
+            let dateCorrectionOffset: TimeInterval = .mockRandom()
+            let integration = CrashReportingWithRUMIntegration(
+                rumEventOutput: rumEventOutput,
+                dateProvider: RelativeDateProvider(using: crashDate),
+                dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
+                rumConfiguration: .mockWith(
+                    applicationID: randomRUMAppID,
+                    sessionSampler: .mockKeepAll(),
+                    backgroundEventTrackingEnabled: backgroundEventsTrackingEnabled
+                )
+            )
+
+            // When
+            integration.send(crashReport: crashReport, with: crashContext)
+
+            // Then
+            let sentRUMView = try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self)[0].model
+            let sentRUMErrorEvent = try rumEventOutput.recordedEvents(ofType: RUMEvent<RUMErrorEvent>.self)[0]
+            let sentRUMError = sentRUMErrorEvent.model
+
+            // Assert RUM view properties
+            XCTAssertTrue(
+                sentRUMView.application.id == randomRUMAppID
+                && sentRUMView.session.id.matches(regex: .uuidRegex)
+                && sentRUMView.view.id.matches(regex: .uuidRegex),
+                "It must send `RUMViewEvent` linked to new RUM Session"
+            )
+            XCTAssertEqual(
+                sentRUMView.connectivity,
+                RUMConnectivity(networkInfo: randomNetworkConnectionInfo, carrierInfo: randomCarrierInfo),
+                "It must contain connectity info from the moment of crash"
+            )
+            XCTAssertEqual(
+                sentRUMView.usr,
+                RUMUser(userInfo: randomUserInfo),
+                "It must contain user info from the moment of crash"
+            )
+            XCTAssertEqual(sentRUMView.view.crash?.count, 1, "The view must include 1 crash")
+            XCTAssertTrue(sentRUMView.view.isActive == false, "The view must be marked inactive")
+            XCTAssertEqual(sentRUMView.view.name, expectedViewName)
+            XCTAssertEqual(sentRUMView.view.url, expectedViewURL)
+            XCTAssertEqual(sentRUMView.view.error.count, 0)
+            XCTAssertEqual(sentRUMView.view.resource.count, 0)
+            XCTAssertEqual(sentRUMView.view.action.count, 0)
+            XCTAssertEqual(
+                sentRUMView.date,
+                crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds,
+                "The vie must include crash date corrected by current correction offset."
+            )
+            XCTAssertEqual(sentRUMView.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
+
+            // Assert RUM error properties
+            XCTAssertEqual(sentRUMError.application.id, sentRUMView.application.id, "It must be linked to the same application as RUM view")
+            XCTAssertEqual(sentRUMError.session.id, sentRUMView.session.id, "It must be linked to the same session as RUM view")
+            XCTAssertEqual(sentRUMError.view.id, sentRUMView.view.id, "It must be linked to the RUM view")
+            XCTAssertEqual(
+                sentRUMError.connectivity,
+                RUMConnectivity(networkInfo: randomNetworkConnectionInfo, carrierInfo: randomCarrierInfo),
+                "It must contain connectity info from the moment of crash"
+            )
+            XCTAssertEqual(
+                sentRUMError.usr,
+                RUMUser(userInfo: randomUserInfo),
+                "It must contain user info from the moment of crash"
+            )
+            XCTAssertTrue(sentRUMError.error.isCrash == true, "RUM error must be marked as crash.")
+            XCTAssertEqual(
+                sentRUMError.date,
+                crashDate.addingTimeInterval(dateCorrectionOffset).timeIntervalSince1970.toInt64Milliseconds,
+                "RUM error must include crash date corrected by current correction offset."
+            )
+            XCTAssertEqual(sentRUMError.error.type, randomCrashType)
+            XCTAssertEqual(sentRUMError.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
+            XCTAssertNotNil(sentRUMErrorEvent.errorAttributes?[DDError.threads], "It must contain crash details")
+            XCTAssertNotNil(sentRUMErrorEvent.errorAttributes?[DDError.binaryImages], "It must contain crash details")
+            XCTAssertNotNil(sentRUMErrorEvent.errorAttributes?[DDError.meta], "It must contain crash details")
+            XCTAssertNotNil(sentRUMErrorEvent.errorAttributes?[DDError.wasTruncated], "It must contain crash details")
+        }
+
+        try test(
+            launchInForeground: true, // launch in foreground
+            backgroundEventsTrackingEnabled: .mockRandom(), // no matter BET
+            expectViewName: RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName,
+            expectViewURL: RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL
+        )
+
+        try test(
+            launchInForeground: false, // launch in background
+            backgroundEventsTrackingEnabled: true, // BET enabled
+            expectViewName: RUMOffViewEventsHandlingRule.Constants.backgroundViewName,
+            expectViewURL: RUMOffViewEventsHandlingRule.Constants.backgroundViewURL
+        )
+    }
+
+    func testGivenCrashDuringAppLaunchInBackgroundAndBETDisabled_whenSending_itIsDropped() throws {
+        // Given
+        let crashDate: Date = .mockDecember15th2019At10AMUTC()
+        let crashReport: DDCrashReport = .mockWith(date: crashDate)
+        let crashContext: CrashContext = .mockWith(
+            lastTrackingConsent: .granted,
+            lastRUMViewEvent: nil, // means there was no RUM session (it crashed during app launch)
+            lastRUMSessionState: nil, // means there was no RUM session (it crashed during app launch)
+            lastIsAppInForeground: false // app was in background
+        )
+
+        let dateCorrectionOffset: TimeInterval = .mockRandom()
+        let integration = CrashReportingWithRUMIntegration(
+            rumEventOutput: rumEventOutput,
+            dateProvider: RelativeDateProvider(using: crashDate),
+            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
+            rumConfiguration: .mockWith(
+                sessionSampler: .mockKeepAll(),
+                backgroundEventTrackingEnabled: false // BET disabled
+            )
+        )
+
+        // When
+        integration.send(crashReport: crashReport, with: crashContext)
+
+        // Then
+        XCTAssertEqual(rumEventOutput.recordedEvents.count, 0, "Crash must not be send as it happened in background and BET is disabled")
     }
 }

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -33,12 +33,12 @@ class RUMIntegrationsTests: XCTestCase {
         XCTAssertValidRumUUID(attributes["user_action.id"] as? String)
     }
 
-    func testGivenRUMMonitorRegistered_whenSessionIsSampled_itProvidesEmptyRUMContextAttributes() throws {
+    func testGivenRUMMonitorRegistered_whenSessionIsRejectedBySampler_itProvidesEmptyRUMContextAttributes() throws {
         RUMFeature.instance = RUMFeature(
             eventsMapper: .mockNoOp(),
             storage: .mockNoOp(),
             upload: .mockNoOp(),
-            configuration: .mockWith(sessionSamplingRate: 0.0),
+            configuration: .mockWith(sessionSampler: .mockRejectAll()),
             commonDependencies: .mockAny(),
             vitalCPUReader: SamplingBasedVitalReaderMock(),
             vitalMemoryReader: SamplingBasedVitalReaderMock(),

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -10,15 +10,19 @@ import XCTest
 class RUMWithCrashContextIntegrationTests: XCTestCase {
     func testWhenCrashReportingIsEnabled_itUpdatesCrashContextWithLastRUMView() throws {
         // When
-        CrashReportingFeature.instance = .mockNoOp()
+        let crashReporting: CrashReportingFeature = .mockNoOp()
+        CrashReportingFeature.instance = crashReporting
         defer { CrashReportingFeature.instance?.deinitialize() }
 
-        // Then
         let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration())
+
+        // Then
         let randomRUMViewEvent: RUMEvent<RUMViewEvent> = .mockRandom()
         rumWithCrashContextIntegration.update(lastRUMViewEvent: randomRUMViewEvent)
+        XCTAssertEqual(crashReporting.rumViewEventProvider.currentValue, randomRUMViewEvent)
 
-        XCTAssertEqual(CrashReportingFeature.instance?.rumViewEventProvider.currentValue, randomRUMViewEvent)
+        rumWithCrashContextIntegration.update(lastRUMViewEvent: nil)
+        XCTAssertNil(crashReporting.rumViewEventProvider.currentValue)
     }
 
     func testWhenCrashReportingIsEnabled_itUpdatesCrashContextWithRUMSessionState() throws {

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -93,6 +93,24 @@ extension Datadog.Configuration {
     }
 }
 
+extension Sampler: AnyMockable, RandomMockable {
+    static func mockAny() -> Sampler {
+        return .init(samplingRate: 50)
+    }
+
+    static func mockRandom() -> Sampler {
+        return .init(samplingRate: .random(in: (0.0...100.0)))
+    }
+
+    static func mockKeepAll() -> Sampler {
+        return .init(samplingRate: 100)
+    }
+
+    static func mockRejectAll() -> Sampler {
+        return .init(samplingRate: 0)
+    }
+}
+
 typealias BatchSize = Datadog.Configuration.BatchSize
 
 extension BatchSize: CaseIterable {
@@ -237,7 +255,8 @@ extension FeaturesConfiguration.RUM {
         uploadURL: URL = .mockAny(),
         clientToken: String = .mockAny(),
         applicationID: String = .mockAny(),
-        sessionSamplingRate: Float = 100.0,
+        sessionSampler: Sampler = Sampler(samplingRate: 100),
+        uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
         viewEventMapper: RUMViewEventMapper? = nil,
         resourceEventMapper: RUMResourceEventMapper? = nil,
         actionEventMapper: RUMActionEventMapper? = nil,
@@ -252,7 +271,8 @@ extension FeaturesConfiguration.RUM {
             uploadURL: uploadURL,
             clientToken: clientToken,
             applicationID: applicationID,
-            sessionSamplingRate: sessionSamplingRate,
+            sessionSampler: sessionSampler,
+            uuidGenerator: uuidGenerator,
             viewEventMapper: viewEventMapper,
             resourceEventMapper: resourceEventMapper,
             actionEventMapper: actionEventMapper,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -595,11 +595,19 @@ extension RUMContext {
 
 extension RUMSessionState: AnyMockable, RandomMockable {
     static func mockAny() -> RUMSessionState {
-        return .init(sessionUUID: .mockAny(), isInitialSession: .mockAny(), hasTrackedAnyView: .mockAny())
+        return mockWith()
     }
 
     static func mockRandom() -> RUMSessionState {
         return .init(sessionUUID: .mockRandom(), isInitialSession: .mockRandom(), hasTrackedAnyView: .mockRandom())
+    }
+
+    static func mockWith(
+        sessionUUID: UUID = .mockAny(),
+        isInitialSession: Bool = .mockAny(),
+        hasTrackedAnyView: Bool = .mockAny()
+    ) -> RUMSessionState {
+        return RUMSessionState(sessionUUID: sessionUUID, isInitialSession: isInitialSession, hasTrackedAnyView: hasTrackedAnyView)
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -685,14 +685,14 @@ extension RUMApplicationScope {
     static func mockWith(
         rumApplicationID: String = .mockAny(),
         dependencies: RUMScopeDependencies = .mockAny(),
-        samplingRate: Float = .mockAny(),
+        sampler: Sampler = .mockKeepAll(),
         applicationStartTime: Date = .mockAny(),
         backgroundEventTrackingEnabled: Bool = .mockAny()
     ) -> RUMApplicationScope {
         return RUMApplicationScope(
             rumApplicationID: rumApplicationID,
             dependencies: dependencies,
-            samplingRate: samplingRate,
+            sampler: sampler,
             applicationStartTime: applicationStartTime,
             backgroundEventTrackingEnabled: backgroundEventTrackingEnabled
         )
@@ -708,7 +708,7 @@ extension RUMSessionScope {
         isInitialSession: Bool = .mockAny(),
         parent: RUMContextProvider = RUMContextProviderMock(),
         dependencies: RUMScopeDependencies = .mockAny(),
-        samplingRate: Float = 100,
+        sampler: Sampler = .mockKeepAll(),
         startTime: Date = .mockAny(),
         backgroundEventTrackingEnabled: Bool = .mockAny()
     ) -> RUMSessionScope {
@@ -716,7 +716,7 @@ extension RUMSessionScope {
             isInitialSession: isInitialSession,
             parent: parent,
             dependencies: dependencies,
-            samplingRate: samplingRate,
+            sampler: sampler,
             startTime: startTime,
             backgroundEventTrackingEnabled: backgroundEventTrackingEnabled
         )

--- a/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
@@ -13,7 +13,7 @@ class RUMDebuggingTests: XCTestCase {
         let expectation = self.expectation(description: "Render RUMDebugging")
 
         // when
-        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockView, name: "FirstView")
         )
@@ -40,7 +40,7 @@ class RUMDebuggingTests: XCTestCase {
         let expectation = self.expectation(description: "Render RUMDebugging")
 
         // when
-        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         _ = applicationScope.process(
             command: RUMStartViewCommand.mockWith(identity: mockView, name: "FirstView")
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMContext/RUMCurrentContextTests.swift
@@ -30,7 +30,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextAfterStartingView() throws {
-        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
@@ -49,7 +49,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextWhilePendingUserAction() throws {
-        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
@@ -69,7 +69,7 @@ class RUMCurrentContextTests: XCTestCase {
     }
 
     func testContextChangeWhenNavigatingBetweenViews() throws {
-        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         let firstView = createMockViewInWindow()
@@ -97,7 +97,7 @@ class RUMCurrentContextTests: XCTestCase {
 
     func testContextChangeWhenSessionIsRenewed() throws {
         var currentTime = Date()
-        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 100)
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         let view = createMockViewInWindow()
@@ -139,8 +139,8 @@ class RUMCurrentContextTests: XCTestCase {
         )
     }
 
-    func testContextWhenSessionIsSampled() throws {
-        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", samplingRate: 0)
+    func testContextWhenSessionIsRejectedBySampler() throws {
+        let applicationScope: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123", sampler: .mockRejectAll())
         let provider = RUMCurrentContext(applicationScope: applicationScope, queue: queue)
 
         _ = applicationScope.process(command: RUMStartViewCommand.mockWith(identity: mockView))

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -12,7 +12,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(
             rumApplicationID: "abc-123",
             dependencies: .mockAny(),
-            samplingRate: .mockAny(),
+            sampler: .mockAny(),
             applicationStartTime: .mockAny(),
             backgroundEventTrackingEnabled: .mockAny()
         )
@@ -37,7 +37,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(
             rumApplicationID: .mockAny(),
             dependencies: .mockWith(onSessionStart: onSessionStart),
-            samplingRate: 0,
+            sampler: .mockRejectAll(),
             applicationStartTime: currentTime,
             backgroundEventTrackingEnabled: .mockRandom()
         )
@@ -69,7 +69,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(
             rumApplicationID: .mockAny(),
             dependencies: .mockWith(onSessionStart: onSessionStart),
-            samplingRate: 100,
+            sampler: .mockKeepAll(),
             applicationStartTime: currentTime,
             backgroundEventTrackingEnabled: .mockAny()
         )
@@ -108,7 +108,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(
             rumApplicationID: .mockAny(),
             dependencies: dependencies,
-            samplingRate: 100,
+            sampler: Sampler(samplingRate: 100),
             applicationStartTime: currentTime,
             backgroundEventTrackingEnabled: .mockAny()
         )
@@ -127,7 +127,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(
             rumApplicationID: .mockAny(),
             dependencies: dependencies,
-            samplingRate: 0,
+            sampler: Sampler(samplingRate: 0),
             applicationStartTime: currentTime,
             backgroundEventTrackingEnabled: .mockAny()
         )
@@ -146,7 +146,7 @@ class RUMApplicationScopeTests: XCTestCase {
         let scope = RUMApplicationScope(
             rumApplicationID: .mockAny(),
             dependencies: dependencies,
-            samplingRate: 50,
+            sampler: Sampler(samplingRate: 50),
             applicationStartTime: currentTime,
             backgroundEventTrackingEnabled: .mockAny()
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -11,7 +11,7 @@ class RUMSessionScopeTests: XCTestCase {
     private let parent: RUMApplicationScope = .mockWith(rumApplicationID: "rum-123")
 
     func testDefaultContext() {
-        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 100)
+        let scope: RUMSessionScope = .mockWith(parent: parent)
 
         XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
         XCTAssertNotEqual(scope.context.sessionID, .nullUUID)
@@ -20,8 +20,8 @@ class RUMSessionScopeTests: XCTestCase {
         XCTAssertNil(scope.context.activeUserActionID)
     }
 
-    func testContextWhenSessionIsSampled() {
-        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 0)
+    func testContextWhenSessionIsRejectedBySampler() {
+        let scope: RUMSessionScope = .mockWith(parent: parent, sampler: .mockRejectAll())
 
         XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
         XCTAssertEqual(scope.context.sessionID, .nullUUID)
@@ -32,7 +32,7 @@ class RUMSessionScopeTests: XCTestCase {
 
     func testWhenSessionExceedsMaxDuration_itGetsClosed() {
         var currentTime = Date()
-        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 50, startTime: currentTime)
+        let scope: RUMSessionScope = .mockWith(parent: parent, sampler: .mockRandom(), startTime: currentTime)
 
         XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)))
 
@@ -44,7 +44,7 @@ class RUMSessionScopeTests: XCTestCase {
 
     func testWhenSessionIsInactiveForCertainDuration_itGetsClosed() {
         var currentTime = Date()
-        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 50, startTime: currentTime)
+        let scope: RUMSessionScope = .mockWith(parent: parent, sampler: .mockRandom(), startTime: currentTime)
 
         XCTAssertTrue(scope.process(command: RUMCommandMock(time: currentTime)))
 
@@ -60,7 +60,7 @@ class RUMSessionScopeTests: XCTestCase {
     }
 
     func testItManagesViewScopeLifecycle() {
-        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 100, startTime: Date())
+        let scope: RUMSessionScope = .mockWith(parent: parent, startTime: Date())
         XCTAssertEqual(scope.viewScopes.count, 0)
         _ = scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
         XCTAssertEqual(scope.viewScopes.count, 1)
@@ -84,7 +84,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockAppInBackground(since: sessionStartTime) // app in background
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: true // BET enabled
         )
@@ -111,7 +110,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockAppInBackground(since: sessionStartTime) // app in background
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: true // BET enabled
         )
@@ -145,7 +143,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockAppInBackground(since: sessionStartTime) // app in background
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: true // BET enabled
         )
@@ -169,7 +166,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockRandom(since: sessionStartTime) // no matter of app state (if foreground or background)
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: false // BET disabled
         )
@@ -195,7 +191,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockAppInForeground(since: sessionStartTime) // app in foreground
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: .mockRandom() // no matter of BET state
         )
@@ -222,7 +217,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockAppInForeground(since: sessionStartTime) // app in foreground
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: .mockRandom() // no matter of BET state
         )
@@ -246,7 +240,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockRandom(since: sessionStartTime) // no matter of app state (if foreground or background)
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: .mockRandom() // no matter of BET state
         )
@@ -276,7 +269,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockAppInForeground(since: sessionStartTime) // app in foreground
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: true // BET enabled
         )
@@ -303,7 +295,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockAppInBackground(since: sessionStartTime) // app in background
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: true // BET enabled
         )
@@ -330,7 +321,6 @@ class RUMSessionScopeTests: XCTestCase {
             dependencies: .mockWith(
                 appStateListener: AppStateListenerMock.mockAppInBackground(since: sessionStartTime) // app in background
             ),
-            samplingRate: 100,
             startTime: sessionStartTime,
             backgroundEventTrackingEnabled: false // BET disabled
         )
@@ -347,12 +337,17 @@ class RUMSessionScopeTests: XCTestCase {
 
     // MARK: - Sampling
 
-    func testWhenSessionIsRejected_itDoesNotCreateViewScopes() {
-        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 0, startTime: Date())
+    func testWhenSessionIsRejectedBySampler_itDoesNotCreateViewScopes() {
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            sampler: .mockRejectAll(),
+            startTime: Date()
+        )
+
         XCTAssertEqual(scope.viewScopes.count, 0)
         XCTAssertTrue(
             scope.process(command: RUMStartViewCommand.mockWith(identity: mockView)),
-            "Sampled session should be kept until it expires or reaches the timeout."
+            "Rejected session should be kept until it expires or reaches the timeout."
         )
         XCTAssertEqual(scope.viewScopes.count, 0)
     }
@@ -373,7 +368,7 @@ class RUMSessionScopeTests: XCTestCase {
                     rumSessionStateProvider: rumSessionStateProvider
                 )
             ),
-            samplingRate: 50
+            sampler: .mockRandom() // no matter if sampled or not
         )
 
         // Then
@@ -401,7 +396,6 @@ class RUMSessionScopeTests: XCTestCase {
                     rumSessionStateProvider: rumSessionStateProvider
                 )
             ),
-            samplingRate: 100,
             startTime: sessionStartTime
         )
 
@@ -423,7 +417,7 @@ class RUMSessionScopeTests: XCTestCase {
 
     func testWhenNoActiveViewScopes_itLogsWarning() {
         // Given
-        let scope: RUMSessionScope = .mockWith(parent: parent, samplingRate: 100, startTime: Date())
+        let scope: RUMSessionScope = .mockWith(parent: parent, startTime: Date())
         XCTAssertEqual(scope.viewScopes.count, 0)
 
         let previousUserLogger = userLogger

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -24,7 +24,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
                     environment: "tests"
                 ),
                 applicationID: "rum-123",
-                sessionSamplingRate: 42.5
+                sessionSampler: Sampler(samplingRate: 42.5)
             ),
             dependencies: .mockWith(
                 networkConnectionInfoProvider: networkConnectionInfoProvider,
@@ -41,7 +41,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
         XCTAssertTrue(scopeDependencies.userInfoProvider.userInfoProvider === feature.userInfoProvider)
         XCTAssertTrue(scopeDependencies.connectivityInfoProvider.networkConnectionInfoProvider as AnyObject === feature.networkConnectionInfoProvider as AnyObject)
         XCTAssertTrue(scopeDependencies.connectivityInfoProvider.carrierInfoProvider as AnyObject === feature.carrierInfoProvider as AnyObject)
-        XCTAssertEqual(monitor.applicationScope.samplingRate, 42.5)
+        XCTAssertEqual(monitor.applicationScope.sampler.samplingRate, 42.5)
         XCTAssertEqual(monitor.applicationScope.context.rumApplicationID, "rum-123")
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -802,7 +802,7 @@ class RUMMonitorTests: XCTestCase {
         RUMFeature.instance = .mockWith(
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
-                sessionSamplingRate: keepAllSessions ? 100 : 0,
+                sessionSampler: keepAllSessions ? .mockKeepAll() : .mockRejectAll(),
                 onSessionStart: onSessionStart
             )
         )

--- a/Tests/DatadogTests/Helpers/EquatableInTests.swift
+++ b/Tests/DatadogTests/Helpers/EquatableInTests.swift
@@ -38,7 +38,6 @@ private func equalsAny(lhs: Any, rhs: Any) -> Bool {
 
     switch (lhsMirror.displayStyle, rhsMirror.displayStyle) {
     case (.dictionary?, .dictionary?): // two dictionaries
-        print("Two dictionaries: \(lhs) vs \(rhs)")
         let lhsDictionary = lhs as! [String: Any]
         let rhsDictionary = rhs as! [String: Any]
 

--- a/Tests/DatadogTests/Helpers/SwiftExtensions.swift
+++ b/Tests/DatadogTests/Helpers/SwiftExtensions.swift
@@ -47,7 +47,7 @@ extension String {
         return Bool.random() ? self.lowercased() : self.uppercased()
     }
 
-    static let uuidRegex = "^[0-9A-F]{8}(-[0-9A-F]{4}){3}-[0-9A-F]{12}$"
+    static let uuidRegex = "^[0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12}$"
 
     func matches(regex: String) -> Bool {
         range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil


### PR DESCRIPTION
### What and why?

📦 This PR adds the actual handling of _application launch crashes_. When app crashes **before** starting the RUM session, the crash is uploaded in a new, artificial session indicated either by "ApplicationLaunch" or "Background" view, depending on the app state during crash.

### How?

The `RUMOffViewEventsHandlingRule` introduced in #690 is now reused in `CrashReportingWithRUMIntegration` to decided on how to send the crash. The overall logic of processing crashes in RUM looks this:

![application-launch-events](https://user-images.githubusercontent.com/2358722/146964575-d2afe8e8-ead6-4f22-8332-78132337695d.png)

To make it work as described in the original RFC, I had to inject sampling logic into `CrashReportingWithRUMIntegration`. To reuse existing code, I isolated it into single `Sampler` component (defined in "core").

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
