### PR TITLE
RUMM-1765 Fix foreground app state reporting in `AppStateListener` - part 5 🏁

### DIFF
--- a/Datadog/Example/Debugging/BackgroundEvents/DebugBackgroundEventsViewController.swift
+++ b/Datadog/Example/Debugging/BackgroundEvents/DebugBackgroundEventsViewController.swift
@@ -19,6 +19,8 @@ private class DebugBackgroundEventsViewModel: ObservableObject {
     private let locationMonitor: BackgroundLocationMonitor
 
     @Published var isLocationMonitoringON = false
+    @Published var willCrashDuringNextBackgroundLaunch = false
+    @Published var willCrashOnNextBackgroundEvent = false
     @Published var authorizationStatus = ""
 
     init() {
@@ -28,6 +30,8 @@ private class DebugBackgroundEventsViewModel: ObservableObject {
         locationMonitor.onAuthorizationStatusChange = { [weak self] newStatus in
             self?.authorizationStatus = newStatus
         }
+        willCrashDuringNextBackgroundLaunch = locationMonitor.shouldCrashDuringNextBackgroundLaunch
+        willCrashOnNextBackgroundEvent = locationMonitor.shouldCrashOnNextBackgroundEvent
     }
 
     func startLocationMonitoring() {
@@ -38,6 +42,16 @@ private class DebugBackgroundEventsViewModel: ObservableObject {
     func stopLocationMonitoring() {
         locationMonitor.stopMonitoring()
         isLocationMonitoringON = locationMonitor.isStarted
+    }
+
+    func toggleCrashDuringNextBackgroundLaunch() {
+        locationMonitor.setCrashDuringNextBackgroundLaunch(!locationMonitor.shouldCrashDuringNextBackgroundLaunch)
+        willCrashDuringNextBackgroundLaunch = locationMonitor.shouldCrashDuringNextBackgroundLaunch
+    }
+
+    func toggleCrashOnNextBackgroundEvent() {
+        locationMonitor.setCrashOnNextBackgroundEvent(!locationMonitor.shouldCrashOnNextBackgroundEvent)
+        willCrashOnNextBackgroundEvent = locationMonitor.shouldCrashOnNextBackgroundEvent
     }
 }
 
@@ -73,6 +87,21 @@ internal struct DebugBackgroundEventsView: View {
                     } else {
                         viewModel.startLocationMonitoring()
                     }
+                }
+            }
+            Divider()
+            HStack {
+                Text("Crash during next background launch:").font(.footnote).fontWeight(.light)
+                Spacer()
+                Button(viewModel.willCrashDuringNextBackgroundLaunch ? "🔥 ENABLED" : "DISABLED") {
+                    viewModel.toggleCrashDuringNextBackgroundLaunch()
+                }
+            }
+            HStack {
+                Text("Crash on next background event:").font(.footnote).fontWeight(.light)
+                Spacer()
+                Button(viewModel.willCrashOnNextBackgroundEvent ? "🔥 ENABLED" : "DISABLED") {
+                    viewModel.toggleCrashOnNextBackgroundEvent()
                 }
             }
             Divider()

--- a/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
+++ b/Sources/Datadog/CrashReporting/CrashContext/CrashContextProvider.swift
@@ -70,7 +70,7 @@ internal class CrashContextProvider: CrashContextProviderType {
 
     /// Updates `CrashContext` with last app foreground / background state information.
     private lazy var isAppInForegroundUpdater = ContextValueUpdater<AppStateHistory>(queue: queue) { newValue in
-        self.unsafeCrashContext.lastIsAppInForeground = newValue.currentState.isActive
+        self.unsafeCrashContext.lastIsAppInForeground = newValue.currentSnapshot.state.isRunningInForeground
     }
 
     // MARK: - Initializer
@@ -96,7 +96,7 @@ internal class CrashContextProvider: CrashContextProviderType {
             lastNetworkConnectionInfo: networkConnectionInfoProvider.current,
             lastCarrierInfo: carrierInfoProvider.current,
             lastRUMSessionState: rumSessionStateProvider.currentValue,
-            lastIsAppInForeground: appStateListener.history.currentState.isActive
+            lastIsAppInForeground: appStateListener.history.currentSnapshot.state.isRunningInForeground
         )
 
         // Subscribe for context updates

--- a/Sources/Datadog/RUM/Instrumentation/Views/RUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/Instrumentation/Views/RUMViewsHandler.swift
@@ -30,9 +30,9 @@ internal final class RUMViewsHandler {
     /// disabled.
     private let predicate: UIKitRUMViewsPredicate?
 
-    /// The notification center where this handler observe the following notifications:
-    /// - `UIApplicationDidEnterBackgroundNotification`
-    /// - `UIApplicationWillEnterForegroundNotification`
+    /// The notification center where this handler observes following `UIApplication` notifications:
+    /// - `.didEnterBackgroundNotification`
+    /// - `.willEnterForegroundNotification`
     private weak var notificationCenter: NotificationCenter?
 
     /// The RUM Command subscriber responsible for processing

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -136,7 +136,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             // Otherwise, if there is no active view scope, consider starting artificial scope for handling this command
             let handlingRule = RUMOffViewEventsHandlingRule(
                 sessionState: state,
-                isAppInForeground: dependencies.appStateListener.history.currentState.isActive,
+                isAppInForeground: dependencies.appStateListener.history.currentSnapshot.state.isRunningInForeground,
                 isBETEnabled: backgroundEventTrackingEnabled
             )
 

--- a/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
+++ b/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
@@ -79,7 +79,10 @@ internal class URLSessionTracingHandler: URLSessionInterceptionHandler {
             between: resourceMetrics.fetch.start...resourceMetrics.fetch.end
         )
         span.setTag(key: DDTags.foregroundDuration, value: appStateHistory.foregroundDuration.toNanoseconds)
-        span.setTag(key: DDTags.isBackground, value: appStateHistory.didRunInBackground)
+
+        let didStartInBackground = appStateHistory.initialSnapshot.state == .background
+        let doesEndInBackground = appStateHistory.currentSnapshot.state == .background
+        span.setTag(key: DDTags.isBackground, value: didStartInBackground || doesEndInBackground)
 
         span.finish(at: resourceMetrics.fetch.end)
     }

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashContext/CrashContextProviderTests.swift
@@ -286,6 +286,7 @@ class CrashContextProviderTests: XCTestCase {
         let notificationCenter = NotificationCenter()
         let appStateListener = AppStateListener(
             dateProvider: SystemDateProvider(),
+            initialAppState: .active,
             notificationCenter: notificationCenter
         )
 
@@ -307,7 +308,7 @@ class CrashContextProviderTests: XCTestCase {
             updatedContext = newContext
             expectation.fulfill()
         }
-        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil) // app goes to background
+        notificationCenter.post(name: UIApplication.didEnterBackgroundNotification, object: nil) // app goes to background
 
         // Then
         waitForExpectations(timeout: 1, handler: nil)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -683,6 +683,20 @@ struct LaunchTimeProviderMock: LaunchTimeProviderType {
     var launchTime: TimeInterval = 0
 }
 
+extension AppState: AnyMockable, RandomMockable {
+    static func mockAny() -> AppState {
+        return .active
+    }
+
+    static func mockRandom() -> AppState {
+        return [.active, .inactive, .background].randomElement()!
+    }
+
+    static func mockRandom(runningInForeground: Bool) -> AppState {
+        return runningInForeground ? [.active, .inactive].randomElement()! : .background
+    }
+}
+
 class AppStateListenerMock: AppStateListening, AnyMockable {
     let history: AppStateHistory
 
@@ -696,13 +710,13 @@ class AppStateListenerMock: AppStateListening, AnyMockable {
 
     static func mockAppInForeground(since date: Date = Date()) -> Self {
         return .init(
-            history: .init(initialState: .init(isActive: true, date: date), recentDate: date)
+            history: .init(initialSnapshot: .init(state: .active, date: date), recentDate: date)
         )
     }
 
     static func mockAppInBackground(since date: Date = Date()) -> Self {
         return .init(
-            history: .init(initialState: .init(isActive: false, date: date), recentDate: date)
+            history: .init(initialSnapshot: .init(state: .background, date: date), recentDate: date)
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/UIKitMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/UIKitMocks.swift
@@ -94,3 +94,13 @@ private class UITouchMock: UITouch {
     override var phase: UITouch.Phase { _phase }
     override var view: UIView? { _view }
 }
+
+extension UIApplication.State: AnyMockable, RandomMockable {
+    static func mockAny() -> UIApplication.State {
+        return .active
+    }
+
+    static func mockRandom() -> UIApplication.State {
+        return [.active, .inactive, .background].randomElement()!
+    }
+}

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -13,7 +13,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
     private let handler = URLSessionTracingHandler(
         appStateListener: AppStateListenerMock(
             history: .init(
-                initialState: .init(isActive: true, date: .mockDecember15th2019At10AMUTC()),
+                initialSnapshot: .init(state: .active, date: .mockDecember15th2019At10AMUTC()),
                 recentDate: .mockDecember15th2019At10AMUTC() + 10
             )
         )

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/AppStateListenerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/AppStateListenerTests.swift
@@ -181,7 +181,7 @@ class AppStateListenerTests: XCTestCase {
         )
 
         // When
-        (0..<1).forEach { _ in
+        (0..<10).forEach { _ in
             let randomNotification = supportedNotifications.randomElement()!
             notificationCenter.post(name: randomNotification.name, object: nil)
             expectedHistoryStates.append(randomNotification.expectedState)

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/AppStateListenerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/Interception/AppStateListenerTests.swift
@@ -8,52 +8,48 @@ import XCTest
 @testable import Datadog
 
 class AppStateHistoryTests: XCTestCase {
-    func testForegroundDurationWithoutChanges() {
-        let startDate = Date.mockDecember15th2019At10AMUTC()
-        let history = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate),
-            changes: [],
-            recentDate: startDate + 1.0
-        )
-
-        XCTAssertEqual(history.foregroundDuration, 1.0)
+    func testItBuildsAppStateFromUIApplicationState() {
+        XCTAssertEqual(AppState(uiApplicationState: .active), .active)
+        XCTAssertEqual(AppState(uiApplicationState: .inactive), .inactive)
+        XCTAssertEqual(AppState(uiApplicationState: .background), .background)
     }
 
-    func testForegroundDuration() {
-        let startDate = Date.mockDecember15th2019At10AMUTC()
+    func testWhenAppTransitionsBetweenForegroundAndBackground_itComputesTotalForegroundDuration() {
+        let numberOfForegroundSnapshots: Int = .mockRandom(min: 0, max: 20)
+        let numberOfBackgroundSnapshots: Int = .mockRandom(min: numberOfForegroundSnapshots == 0 ? 1 : 0, max: 20) // must include at least one snapshot
+        let numberOfSnapshots = numberOfForegroundSnapshots + numberOfBackgroundSnapshots
+        let snapshotDuration: TimeInterval = .mockRandom(min: 0.1, max: 5)
+
+        // Given
+        let date: Date = .mockRandomInThePast()
+        let snapshotDates: [Date] = (0..<numberOfSnapshots).shuffled()
+            .map { idx in date.addingTimeInterval(TimeInterval(idx) * snapshotDuration) }
+        let foregroundSnapshots = snapshotDates.dropLast(numberOfBackgroundSnapshots)
+            .map { AppStateHistory.Snapshot(state: .mockRandom(runningInForeground: true), date: $0) }
+        let backgroundSnapshots = snapshotDates.dropFirst(numberOfForegroundSnapshots)
+            .map { AppStateHistory.Snapshot(state: .mockRandom(runningInForeground: false), date: $0) }
+
+        // When
+        let allSnapshots = (foregroundSnapshots + backgroundSnapshots).sorted { $0.date < $1.date }
+        let totalDuration = TimeInterval(numberOfSnapshots) * snapshotDuration
+
         let history = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate),
-            changes: [
-                .init(isActive: false, date: startDate + 1.0),
-                .init(isActive: true, date: startDate + 2.0),
-                .init(isActive: false, date: startDate + 3.0),
-                .init(isActive: true, date: startDate + 4.0)
-            ],
-            recentDate: startDate + 5.0
+            initialSnapshot: allSnapshots[0],
+            snapshots: Array(allSnapshots.dropFirst()),
+            recentDate: date.addingTimeInterval(totalDuration)
         )
 
-        XCTAssertEqual(history.foregroundDuration, 3.0)
-    }
-
-    func testForegroundDurationWithMissingChange() {
-        let startDate = Date.mockDecember15th2019At10AMUTC()
-        let history = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate),
-            changes: [
-                .init(isActive: false, date: startDate + 1.0),
-                .init(isActive: false, date: startDate + 3.0)
-            ],
-            recentDate: startDate + 5.0
-        )
-
-        XCTAssertEqual(history.foregroundDuration, 1.0)
+        // Then
+        let expectedForegroundDuration = TimeInterval(numberOfForegroundSnapshots) * snapshotDuration
+        XCTAssertEqual(history.foregroundDuration, expectedForegroundDuration, accuracy: 0.01)
     }
 
     func testExtrapolation() {
+        let randomAppState: AppState = .mockRandom()
         let startDate = Date.mockDecember15th2019At10AMUTC()
         let history = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate),
-            changes: [],
+            initialSnapshot: .init(state: randomAppState, date: startDate),
+            snapshots: [],
             recentDate: startDate + 5.0
         )
         let extrapolatedHistory = history.take(
@@ -61,18 +57,19 @@ class AppStateHistoryTests: XCTestCase {
         )
 
         let expectedHistory = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate - 5.0),
-            changes: [],
+            initialSnapshot: .init(state: randomAppState, date: startDate - 5.0),
+            snapshots: [],
             recentDate: startDate + 15.0
         )
         XCTAssertEqual(extrapolatedHistory, expectedHistory)
     }
 
     func testLimiting() {
+        let randomAppState: AppState = .mockRandom()
         let startDate = Date.mockDecember15th2019At10AMUTC()
         let history = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate),
-            changes: [],
+            initialSnapshot: .init(state: randomAppState, date: startDate),
+            snapshots: [],
             recentDate: startDate + 20.0
         )
         let limitedHistory = history.take(
@@ -80,34 +77,37 @@ class AppStateHistoryTests: XCTestCase {
         )
 
         let expectedHistory = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate + 5.0),
-            changes: [],
+            initialSnapshot: .init(state: randomAppState, date: startDate + 5.0),
+            snapshots: [],
             recentDate: startDate + 10.0
         )
         XCTAssertEqual(limitedHistory, expectedHistory)
     }
 
     func testLimitingWithChanges() {
+        let randomFirstAppState: AppState = .mockRandom()
+        let randomLastAppState: AppState = .mockRandom()
+
         let startDate = Date(timeIntervalSinceReferenceDate: 0.0)
         let firstChanges = (0...100).map { _ in
             AppStateHistory.Snapshot(
-                isActive: false,
+                state: randomFirstAppState,
                 date: startDate + TimeInterval.random(in: 1...1_000)
             )
         }
         let lastChanges = (0...100).map { _ in
             AppStateHistory.Snapshot(
-                isActive: true,
+                state: randomLastAppState,
                 date: startDate + TimeInterval.random(in: 2_000...3_000)
             )
         }
         var allChanges = (firstChanges + lastChanges)
-        allChanges.append(.init(isActive: true, date: startDate + 1_200))
-        allChanges.append(.init(isActive: false, date: startDate + 1_500))
+        allChanges.append(.init(state: randomFirstAppState, date: startDate + 1_200))
+        allChanges.append(.init(state: randomLastAppState, date: startDate + 1_500))
         allChanges.sort { $0.date < $1.date }
         let history = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate),
-            changes: allChanges,
+            initialSnapshot: .init(state: randomFirstAppState, date: startDate),
+            snapshots: allChanges,
             recentDate: startDate + 4_000
         )
 
@@ -116,8 +116,8 @@ class AppStateHistoryTests: XCTestCase {
         )
 
         let expectedHistory = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate + 1_250),
-            changes: [.init(isActive: false, date: startDate + 1_500)],
+            initialSnapshot: .init(state: randomFirstAppState, date: startDate + 1_250),
+            snapshots: [.init(state: randomLastAppState, date: startDate + 1_500)],
             recentDate: startDate + 1_750
         )
         XCTAssertEqual(limitedHistory, expectedHistory)
@@ -125,78 +125,89 @@ class AppStateHistoryTests: XCTestCase {
 }
 
 class AppStateListenerTests: XCTestCase {
+    private let dateProvider = SystemDateProvider()
     private let notificationCenter = NotificationCenter()
+    private let supportedNotifications = [
+        (name: UIApplication.didBecomeActiveNotification, expectedState: AppState.active),
+        (name: UIApplication.willResignActiveNotification, expectedState: AppState.inactive),
+        (name: UIApplication.didEnterBackgroundNotification, expectedState: AppState.background),
+        (name: UIApplication.willEnterForegroundNotification, expectedState: AppState.inactive),
+    ]
 
-    func testWhenAppResignActiveAndBecomeActive_thenAppStateHistoryIsRecorded() {
-        let startDate = Date.mockDecember15th2019At10AMUTC()
+    // MARK: - Handling UIApplication Notifications
+
+    func testWhenReceivingAppLifecycleNotification_itRecordsItsState() {
+        // Given
         let listener = AppStateListener(
-            dateProvider: RelativeDateProvider(startingFrom: startDate, advancingBySeconds: 1.0),
+            dateProvider: dateProvider,
+            initialAppState: .mockRandom(),
             notificationCenter: notificationCenter
         )
 
-        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
-        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        // When
+        let randomNotification = supportedNotifications.randomElement()!
+        notificationCenter.post(name: randomNotification.name, object: nil)
 
-        let expected = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate),
-            changes: [
-                .init(isActive: false, date: startDate + 1.0),
-                .init(isActive: true, date: startDate + 2.0)
-            ],
-            recentDate: startDate + 3.0
+        // Then
+        XCTAssertEqual(
+            listener.history.currentSnapshot.state,
+            randomNotification.expectedState,
+            "It must record \(randomNotification.expectedState) after receiving '\(randomNotification.name)'"
         )
-        XCTAssertEqual(listener.history, expected)
     }
 
-    func testWhenAppBecomeActiveAndResignActive_thenAppStateHistoryIsRecorded() {
-        let startDate = Date.mockDecember15th2019At10AMUTC()
-        let listener = AppStateListener(
-            dateProvider: RelativeDateProvider(startingFrom: startDate, advancingBySeconds: 1.0),
-            notificationCenter: notificationCenter
-        )
-        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
+    // MARK: - Recording History
 
-        let expected = AppStateHistory(
-            initialState: .init(isActive: true, date: startDate),
-            changes: [
-                .init(isActive: true, date: startDate + 1.0),
-                .init(isActive: false, date: startDate + 2.0)
-            ],
-            recentDate: startDate + 3.0
-        )
-        XCTAssertEqual(listener.history, expected)
-    }
-
-    func testWhenAppStateHistoryIsRetrieved_thenFinalDateOfHistoryChanges() {
-        let startDate = Date.mockDecember15th2019At10AMUTC()
+    func testWhenAppStatesHistoryIsRetrieved_thenCurrentSnapshotIsSignedWithRecentDate() {
         let listener = AppStateListener(
-            dateProvider: RelativeDateProvider(startingFrom: startDate, advancingBySeconds: 1.0),
+            dateProvider: RelativeDateProvider(startingFrom: .mockRandomInThePast(), advancingBySeconds: 1.0),
+            initialAppState: .mockRandom(),
             notificationCenter: notificationCenter
         )
         let history1 = listener.history
         let history2 = listener.history
 
-        XCTAssertEqual(history2.currentState.date.timeIntervalSince(history1.currentState.date), 1.0)
+        XCTAssertEqual(history2.currentSnapshot.date.timeIntervalSince(history1.currentSnapshot.date), 1.0)
     }
+
+    func testWhenReceivingStateChangeNotifications_itRecordsHistoryOfAppStates() {
+        var expectedHistoryStates: [AppState] = []
+
+        // Given
+        let listener = AppStateListener(
+            dateProvider: RelativeDateProvider(startingFrom: .mockRandomInThePast(), advancingBySeconds: 1.0),
+            initialAppState: .mockRandom(),
+            notificationCenter: notificationCenter
+        )
+
+        // When
+        (0..<1).forEach { _ in
+            let randomNotification = supportedNotifications.randomElement()!
+            notificationCenter.post(name: randomNotification.name, object: nil)
+            expectedHistoryStates.append(randomNotification.expectedState)
+        }
+
+        // Then
+        XCTAssertEqual(listener.history.snapshots.map({ $0.state }), expectedHistoryStates, "It must record all app state changes")
+    }
+
+    // MARK: - Thread Safety
 
     func testWhenAppStateListenerIsCalledFromDifferentThreads_thenItWorks() {
         let listener = AppStateListener(
             dateProvider: SystemDateProvider(),
+            initialAppState: .mockAny(),
             notificationCenter: notificationCenter
         )
+        let notificationNames = supportedNotifications.map { $0.name }
+
         DispatchQueue.concurrentPerform(iterations: 10_000) { iteration in
             // write
             if iteration < 1_000 {
-                notificationCenter.post(
-                    name: (Bool.random() ?
-                            UIApplication.willResignActiveNotification :
-                            UIApplication.didBecomeActiveNotification),
-                    object: nil
-                )
+                notificationCenter.post(name: notificationNames.randomElement()!, object: nil)
             }
             // read
-            XCTAssertFalse(listener.history.changes.isEmpty)
+            XCTAssertFalse(listener.history.snapshots.isEmpty)
         }
     }
 }


### PR DESCRIPTION
### What and why?

📦 This is the final PR closing topic of _tracking app launch events (and crashes)_. While testing it (with new options added to debug UI 👇), I found a bug 🐞 in `AppStateListener`, which I'm solving in this PR.

<img width="265" alt="Screenshot 2021-12-20 at 16 41 10" src="https://user-images.githubusercontent.com/2358722/146793754-605def26-a946-4b4c-8cc3-a869b6854bc9.png">


### How?

Problem was that [`AppStateListener` was only considering `UIApplication.State.active` as "foreground" application state](https://github.com/DataDog/dd-sdk-ios/blob/ad16182bba3f757406834044bf0d9d1fdcdd3dea/Sources/Datadog/Core/System/AppStateListener.swift#L103), whereas app lifecycle is more complex than that and it can be also in "foreground" while in `.inactive` state:

> [**`applicationState`**](https://developer.apple.com/documentation/uikit/uiapplication/1623003-applicationstate)
> The app is **inactive at launch**, and then is generally in either an active or background state. The app **may become inactive for a short period** — for example, when transitioning between active and background states, when the system presents an alert in front of it, or when the system displays the application switcher.

Because `.inactive` was not considered "foreground", any event tracked during application launch (e.g. from `application(_:didFinishLaunching:)`) was starting "Background" instead of "ApplicationLaunch" view. I fixed this issue by exposing `AppState` directly from `AppStateListener` and letting other components decide by their own on handling particular states.

#### 🏁 Final Testing

With all logic in place, I made last tests, ensuring everything works as expected. Here are some explored scenarios:
* Tracking app launch event in foreground:
<img width="1284" alt="foreground-launch-event" src="https://user-images.githubusercontent.com/2358722/146794336-2582957c-c42f-4434-8dc0-587629e75580.png">

* Tracking app launch crash in foreground:
<img width="1284" alt="foreground-launch-crash" src="https://user-images.githubusercontent.com/2358722/146794348-2ce93b37-ff51-40ad-aef9-022f9b4b2740.png">

* Tracking app launch event in background:
<img width="1284" alt="background-launch-event" src="https://user-images.githubusercontent.com/2358722/146794407-1399759b-4b7b-4b6c-958f-1ea29e045a00.png">

* Tracking app launch crash in background:
<img width="1282" alt="background-launch-crash" src="https://user-images.githubusercontent.com/2358722/146794438-789cfb30-1365-47e5-890b-765a0127a4c9.png">

* Tracking background event:
<img width="1280" alt="background-event" src="https://user-images.githubusercontent.com/2358722/146794463-9e4c52d2-8e7b-4e2e-9459-2935198b74e5.png">

* Tracking background crash:
<img width="1281" alt="background-crash" src="https://user-images.githubusercontent.com/2358722/146794478-5b499366-a1a8-4a30-8080-6242147064e9.png">

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
