### PR TITLE
RUMM-1786 Mutable RUMDataModels

### DIFF
--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -96,10 +96,12 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
 
         let rumError = RUMErrorEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
             action: nil,
             application: .init(id: lastRUMView.application.id),
+            ciTest: nil,
             connectivity: lastRUMView.connectivity,
             context: nil,
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds,
@@ -142,10 +144,12 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         let original = rumViewEvent.model
         let rumView = RUMViewEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 documentVersion: original.dd.documentVersion + 1,
                 session: .init(plan: .plan1)
             ),
             application: original.application,
+            ciTest: nil,
             connectivity: original.connectivity,
             context: original.context,
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds,

--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -11,10 +11,13 @@ internal protocol RUMDataModel: Codable {}
 /// Schema of all properties of a View event
 public struct RUMViewEvent: RUMDataModel {
     /// Internal properties
-    public let dd: DD
+    public internal(set) var dd: DD
 
     /// Application properties
-    public let application: Application
+    public internal(set) var application: Application
+
+    /// CI Visibility properties
+    public let ciTest: CiTest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -23,13 +26,13 @@ public struct RUMViewEvent: RUMDataModel {
     public internal(set) var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
-    public let date: Int64
+    public internal(set) var date: Int64
 
     /// The service name for this application
-    public let service: String?
+    public internal(set) var service: String?
 
     /// Session properties
-    public let session: Session
+    public internal(set) var session: Session
 
     /// Synthetics properties
     public let synthetics: Synthetics?
@@ -46,6 +49,7 @@ public struct RUMViewEvent: RUMDataModel {
     enum CodingKeys: String, CodingKey {
         case dd = "_dd"
         case application = "application"
+        case ciTest = "ci_test"
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
@@ -59,6 +63,9 @@ public struct RUMViewEvent: RUMDataModel {
 
     /// Internal properties
     public struct DD: Codable {
+        /// Browser SDK version
+        public let browserSdkVersion: String?
+
         /// Version of the update of the view event
         public let documentVersion: Int64
 
@@ -66,9 +73,10 @@ public struct RUMViewEvent: RUMDataModel {
         public let formatVersion: Int64 = 2
 
         /// Session-related internal properties
-        public let session: Session?
+        public internal(set) var session: Session?
 
         enum CodingKeys: String, CodingKey {
+            case browserSdkVersion = "browser_sdk_version"
             case documentVersion = "document_version"
             case formatVersion = "format_version"
             case session = "session"
@@ -77,7 +85,7 @@ public struct RUMViewEvent: RUMDataModel {
         /// Session-related internal properties
         public struct Session: Codable {
             /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
-            public let plan: Plan
+            public internal(set) var plan: Plan
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -94,10 +102,20 @@ public struct RUMViewEvent: RUMDataModel {
     /// Application properties
     public struct Application: Codable {
         /// UUID of the application
-        public let id: String
+        public internal(set) var id: String
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
+        }
+    }
+
+    /// CI Visibility properties
+    public struct CiTest: Codable {
+        /// The identifier of the current CI Visibility test execution
+        public let testExecutionId: String
+
+        enum CodingKeys: String, CodingKey {
+            case testExecutionId = "test_execution_id"
         }
     }
 
@@ -107,7 +125,7 @@ public struct RUMViewEvent: RUMDataModel {
         public let hasReplay: Bool?
 
         /// UUID of the session
-        public let id: String
+        public internal(set) var id: String
 
         /// Type of the session
         public let type: SessionType
@@ -122,11 +140,15 @@ public struct RUMViewEvent: RUMDataModel {
         public enum SessionType: String, Codable {
             case user = "user"
             case synthetics = "synthetics"
+            case ciTest = "ci_test"
         }
     }
 
     /// Synthetics properties
     public struct Synthetics: Codable {
+        /// Whether the event comes from a SDK instance injected by Synthetics
+        public let injected: Bool?
+
         /// The identifier of the current Synthetics test results
         public let resultId: String
 
@@ -134,6 +156,7 @@ public struct RUMViewEvent: RUMDataModel {
         public let testId: String
 
         enum CodingKeys: String, CodingKey {
+            case injected = "injected"
             case resultId = "result_id"
             case testId = "test_id"
         }
@@ -363,13 +386,16 @@ public struct RUMViewEvent: RUMDataModel {
 /// Schema of all properties of a Resource event
 public struct RUMResourceEvent: RUMDataModel {
     /// Internal properties
-    public let dd: DD
+    public internal(set) var dd: DD
 
     /// Action properties
     public let action: Action?
 
     /// Application properties
-    public let application: Application
+    public internal(set) var application: Application
+
+    /// CI Visibility properties
+    public let ciTest: CiTest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -378,16 +404,16 @@ public struct RUMResourceEvent: RUMDataModel {
     public internal(set) var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
-    public let date: Int64
+    public internal(set) var date: Int64
 
     /// Resource properties
     public var resource: Resource
 
     /// The service name for this application
-    public let service: String?
+    public internal(set) var service: String?
 
     /// Session properties
-    public let session: Session
+    public internal(set) var session: Session
 
     /// Synthetics properties
     public let synthetics: Synthetics?
@@ -405,6 +431,7 @@ public struct RUMResourceEvent: RUMDataModel {
         case dd = "_dd"
         case action = "action"
         case application = "application"
+        case ciTest = "ci_test"
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
@@ -419,11 +446,14 @@ public struct RUMResourceEvent: RUMDataModel {
 
     /// Internal properties
     public struct DD: Codable {
+        /// Browser SDK version
+        public let browserSdkVersion: String?
+
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
         /// Session-related internal properties
-        public let session: Session?
+        public internal(set) var session: Session?
 
         /// span identifier in decimal format
         public let spanId: String?
@@ -432,6 +462,7 @@ public struct RUMResourceEvent: RUMDataModel {
         public let traceId: String?
 
         enum CodingKeys: String, CodingKey {
+            case browserSdkVersion = "browser_sdk_version"
             case formatVersion = "format_version"
             case session = "session"
             case spanId = "span_id"
@@ -441,7 +472,7 @@ public struct RUMResourceEvent: RUMDataModel {
         /// Session-related internal properties
         public struct Session: Codable {
             /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
-            public let plan: Plan
+            public internal(set) var plan: Plan
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -468,10 +499,20 @@ public struct RUMResourceEvent: RUMDataModel {
     /// Application properties
     public struct Application: Codable {
         /// UUID of the application
-        public let id: String
+        public internal(set) var id: String
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
+        }
+    }
+
+    /// CI Visibility properties
+    public struct CiTest: Codable {
+        /// The identifier of the current CI Visibility test execution
+        public let testExecutionId: String
+
+        enum CodingKeys: String, CodingKey {
+            case testExecutionId = "test_execution_id"
         }
     }
 
@@ -678,7 +719,7 @@ public struct RUMResourceEvent: RUMDataModel {
         public let hasReplay: Bool?
 
         /// UUID of the session
-        public let id: String
+        public internal(set) var id: String
 
         /// Type of the session
         public let type: SessionType
@@ -693,11 +734,15 @@ public struct RUMResourceEvent: RUMDataModel {
         public enum SessionType: String, Codable {
             case user = "user"
             case synthetics = "synthetics"
+            case ciTest = "ci_test"
         }
     }
 
     /// Synthetics properties
     public struct Synthetics: Codable {
+        /// Whether the event comes from a SDK instance injected by Synthetics
+        public let injected: Bool?
+
         /// The identifier of the current Synthetics test results
         public let resultId: String
 
@@ -705,6 +750,7 @@ public struct RUMResourceEvent: RUMDataModel {
         public let testId: String
 
         enum CodingKeys: String, CodingKey {
+            case injected = "injected"
             case resultId = "result_id"
             case testId = "test_id"
         }
@@ -736,13 +782,16 @@ public struct RUMResourceEvent: RUMDataModel {
 /// Schema of all properties of an Action event
 public struct RUMActionEvent: RUMDataModel {
     /// Internal properties
-    public let dd: DD
+    public internal(set) var dd: DD
 
     /// Action properties
     public var action: Action
 
     /// Application properties
-    public let application: Application
+    public internal(set) var application: Application
+
+    /// CI Visibility properties
+    public let ciTest: CiTest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -751,13 +800,13 @@ public struct RUMActionEvent: RUMDataModel {
     public internal(set) var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
-    public let date: Int64
+    public internal(set) var date: Int64
 
     /// The service name for this application
-    public let service: String?
+    public internal(set) var service: String?
 
     /// Session properties
-    public let session: Session
+    public internal(set) var session: Session
 
     /// Synthetics properties
     public let synthetics: Synthetics?
@@ -775,6 +824,7 @@ public struct RUMActionEvent: RUMDataModel {
         case dd = "_dd"
         case action = "action"
         case application = "application"
+        case ciTest = "ci_test"
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
@@ -788,13 +838,17 @@ public struct RUMActionEvent: RUMDataModel {
 
     /// Internal properties
     public struct DD: Codable {
+        /// Browser SDK version
+        public let browserSdkVersion: String?
+
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
         /// Session-related internal properties
-        public let session: Session?
+        public internal(set) var session: Session?
 
         enum CodingKeys: String, CodingKey {
+            case browserSdkVersion = "browser_sdk_version"
             case formatVersion = "format_version"
             case session = "session"
         }
@@ -802,7 +856,7 @@ public struct RUMActionEvent: RUMDataModel {
         /// Session-related internal properties
         public struct Session: Codable {
             /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
-            public let plan: Plan
+            public internal(set) var plan: Plan
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -918,10 +972,20 @@ public struct RUMActionEvent: RUMDataModel {
     /// Application properties
     public struct Application: Codable {
         /// UUID of the application
-        public let id: String
+        public internal(set) var id: String
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
+        }
+    }
+
+    /// CI Visibility properties
+    public struct CiTest: Codable {
+        /// The identifier of the current CI Visibility test execution
+        public let testExecutionId: String
+
+        enum CodingKeys: String, CodingKey {
+            case testExecutionId = "test_execution_id"
         }
     }
 
@@ -931,7 +995,7 @@ public struct RUMActionEvent: RUMDataModel {
         public let hasReplay: Bool?
 
         /// UUID of the session
-        public let id: String
+        public internal(set) var id: String
 
         /// Type of the session
         public let type: SessionType
@@ -946,11 +1010,15 @@ public struct RUMActionEvent: RUMDataModel {
         public enum SessionType: String, Codable {
             case user = "user"
             case synthetics = "synthetics"
+            case ciTest = "ci_test"
         }
     }
 
     /// Synthetics properties
     public struct Synthetics: Codable {
+        /// Whether the event comes from a SDK instance injected by Synthetics
+        public let injected: Bool?
+
         /// The identifier of the current Synthetics test results
         public let resultId: String
 
@@ -958,6 +1026,7 @@ public struct RUMActionEvent: RUMDataModel {
         public let testId: String
 
         enum CodingKeys: String, CodingKey {
+            case injected = "injected"
             case resultId = "result_id"
             case testId = "test_id"
         }
@@ -993,13 +1062,16 @@ public struct RUMActionEvent: RUMDataModel {
 /// Schema of all properties of an Error event
 public struct RUMErrorEvent: RUMDataModel {
     /// Internal properties
-    public let dd: DD
+    public internal(set) var dd: DD
 
     /// Action properties
     public let action: Action?
 
     /// Application properties
-    public let application: Application
+    public internal(set) var application: Application
+
+    /// CI Visibility properties
+    public let ciTest: CiTest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -1008,16 +1080,16 @@ public struct RUMErrorEvent: RUMDataModel {
     public internal(set) var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
-    public let date: Int64
+    public internal(set) var date: Int64
 
     /// Error properties
     public var error: Error
 
     /// The service name for this application
-    public let service: String?
+    public internal(set) var service: String?
 
     /// Session properties
-    public let session: Session
+    public internal(set) var session: Session
 
     /// Synthetics properties
     public let synthetics: Synthetics?
@@ -1035,6 +1107,7 @@ public struct RUMErrorEvent: RUMDataModel {
         case dd = "_dd"
         case action = "action"
         case application = "application"
+        case ciTest = "ci_test"
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
@@ -1049,13 +1122,17 @@ public struct RUMErrorEvent: RUMDataModel {
 
     /// Internal properties
     public struct DD: Codable {
+        /// Browser SDK version
+        public let browserSdkVersion: String?
+
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
         /// Session-related internal properties
-        public let session: Session?
+        public internal(set) var session: Session?
 
         enum CodingKeys: String, CodingKey {
+            case browserSdkVersion = "browser_sdk_version"
             case formatVersion = "format_version"
             case session = "session"
         }
@@ -1063,7 +1140,7 @@ public struct RUMErrorEvent: RUMDataModel {
         /// Session-related internal properties
         public struct Session: Codable {
             /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
-            public let plan: Plan
+            public internal(set) var plan: Plan
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -1090,10 +1167,20 @@ public struct RUMErrorEvent: RUMDataModel {
     /// Application properties
     public struct Application: Codable {
         /// UUID of the application
-        public let id: String
+        public internal(set) var id: String
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
+        }
+    }
+
+    /// CI Visibility properties
+    public struct CiTest: Codable {
+        /// The identifier of the current CI Visibility test execution
+        public let testExecutionId: String
+
+        enum CodingKeys: String, CodingKey {
+            case testExecutionId = "test_execution_id"
         }
     }
 
@@ -1232,7 +1319,7 @@ public struct RUMErrorEvent: RUMDataModel {
         public let hasReplay: Bool?
 
         /// UUID of the session
-        public let id: String
+        public internal(set) var id: String
 
         /// Type of the session
         public let type: SessionType
@@ -1247,11 +1334,15 @@ public struct RUMErrorEvent: RUMDataModel {
         public enum SessionType: String, Codable {
             case user = "user"
             case synthetics = "synthetics"
+            case ciTest = "ci_test"
         }
     }
 
     /// Synthetics properties
     public struct Synthetics: Codable {
+        /// Whether the event comes from a SDK instance injected by Synthetics
+        public let injected: Bool?
+
         /// The identifier of the current Synthetics test results
         public let resultId: String
 
@@ -1259,6 +1350,7 @@ public struct RUMErrorEvent: RUMDataModel {
         public let testId: String
 
         enum CodingKeys: String, CodingKey {
+            case injected = "injected"
             case resultId = "result_id"
             case testId = "test_id"
         }
@@ -1294,13 +1386,16 @@ public struct RUMErrorEvent: RUMDataModel {
 /// Schema of all properties of a Long Task event
 public struct RUMLongTaskEvent: RUMDataModel {
     /// Internal properties
-    public let dd: DD
+    public internal(set) var dd: DD
 
     /// Action properties
     public let action: Action?
 
     /// Application properties
-    public let application: Application
+    public internal(set) var application: Application
+
+    /// CI Visibility properties
+    public let ciTest: CiTest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -1309,16 +1404,16 @@ public struct RUMLongTaskEvent: RUMDataModel {
     public internal(set) var context: RUMEventAttributes?
 
     /// Start of the event in ms from epoch
-    public let date: Int64
+    public internal(set) var date: Int64
 
     /// Long Task properties
     public let longTask: LongTask
 
     /// The service name for this application
-    public let service: String?
+    public internal(set) var service: String?
 
     /// Session properties
-    public let session: Session
+    public internal(set) var session: Session
 
     /// Synthetics properties
     public let synthetics: Synthetics?
@@ -1336,6 +1431,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         case dd = "_dd"
         case action = "action"
         case application = "application"
+        case ciTest = "ci_test"
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
@@ -1350,13 +1446,17 @@ public struct RUMLongTaskEvent: RUMDataModel {
 
     /// Internal properties
     public struct DD: Codable {
+        /// Browser SDK version
+        public let browserSdkVersion: String?
+
         /// Version of the RUM event format
         public let formatVersion: Int64 = 2
 
         /// Session-related internal properties
-        public let session: Session?
+        public internal(set) var session: Session?
 
         enum CodingKeys: String, CodingKey {
+            case browserSdkVersion = "browser_sdk_version"
             case formatVersion = "format_version"
             case session = "session"
         }
@@ -1364,7 +1464,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         /// Session-related internal properties
         public struct Session: Codable {
             /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
-            public let plan: Plan
+            public internal(set) var plan: Plan
 
             enum CodingKeys: String, CodingKey {
                 case plan = "plan"
@@ -1391,10 +1491,20 @@ public struct RUMLongTaskEvent: RUMDataModel {
     /// Application properties
     public struct Application: Codable {
         /// UUID of the application
-        public let id: String
+        public internal(set) var id: String
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
+        }
+    }
+
+    /// CI Visibility properties
+    public struct CiTest: Codable {
+        /// The identifier of the current CI Visibility test execution
+        public let testExecutionId: String
+
+        enum CodingKeys: String, CodingKey {
+            case testExecutionId = "test_execution_id"
         }
     }
 
@@ -1422,7 +1532,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         public let hasReplay: Bool?
 
         /// UUID of the session
-        public let id: String
+        public internal(set) var id: String
 
         /// Type of the session
         public let type: SessionType
@@ -1437,11 +1547,15 @@ public struct RUMLongTaskEvent: RUMDataModel {
         public enum SessionType: String, Codable {
             case user = "user"
             case synthetics = "synthetics"
+            case ciTest = "ci_test"
         }
     }
 
     /// Synthetics properties
     public struct Synthetics: Codable {
+        /// Whether the event comes from a SDK instance injected by Synthetics
+        public let injected: Bool?
+
         /// The identifier of the current Synthetics test results
         public let resultId: String
 
@@ -1449,6 +1563,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         public let testId: String
 
         enum CodingKeys: String, CodingKey {
+            case injected = "injected"
             case resultId = "result_id"
             case testId = "test_id"
         }
@@ -1640,4 +1755,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/9c135e77bb1da61ebbb6b2fb3b39e156d5120a8e
+// Generated from https://github.com/DataDog/rum-events-format/tree/23a95f774864d3beb15ad39204d58a559d41cff4

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -130,6 +130,7 @@ internal class RUMResourceScope: RUMScope {
 
         let eventData = RUMResourceEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 session: .init(plan: .plan1),
                 spanId: spanId,
                 traceId: traceId
@@ -138,6 +139,7 @@ internal class RUMResourceScope: RUMScope {
                 .init(id: rumUUID.toRUMDataFormat)
             },
             application: .init(id: context.rumApplicationID),
+            ciTest: nil,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: resourceStartTime).timeIntervalSince1970.toInt64Milliseconds,
@@ -211,12 +213,14 @@ internal class RUMResourceScope: RUMScope {
 
         let eventData = RUMErrorEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
             action: context.activeUserActionID.flatMap { rumUUID in
                 .init(id: rumUUID.toRUMDataFormat)
             },
             application: .init(id: context.rumApplicationID),
+            ciTest: nil,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -134,6 +134,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
 
         let eventData = RUMActionEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
             action: .init(
@@ -147,6 +148,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 type: actionType.toRUMDataFormat
             ),
             application: .init(id: context.rumApplicationID),
+            ciTest: nil,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: actionStartTime).timeIntervalSince1970.toInt64Milliseconds,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -305,6 +305,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     private func sendApplicationStartAction(on command: RUMCommand) -> Bool {
         let eventData = RUMActionEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
             action: .init(
@@ -318,6 +319,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 type: .applicationStart
             ),
             application: .init(id: context.rumApplicationID),
+            ciTest: nil,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
@@ -354,10 +356,12 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         let eventData = RUMViewEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 documentVersion: version.toInt64,
                 session: .init(plan: .plan1)
             ),
             application: .init(id: context.rumApplicationID),
+            ciTest: nil,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
@@ -416,12 +420,14 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         let eventData = RUMErrorEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
             action: context.activeUserActionID.flatMap { rumUUID in
                 .init(id: rumUUID.toRUMDataFormat)
             },
             application: .init(id: context.rumApplicationID),
+            ciTest: nil,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
@@ -464,9 +470,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let isFrozenFrame = taskDurationInNs > Constants.frozenFrameThresholdInNs
 
         let eventData = RUMLongTaskEvent(
-            dd: .init(session: .init(plan: .plan1)),
+            dd: .init(browserSdkVersion: nil, session: .init(plan: .plan1)),
             action: context.activeUserActionID.flatMap { RUMLongTaskEvent.Action(id: $0.toRUMDataFormat) },
             application: .init(id: context.rumApplicationID),
+            ciTest: nil,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time - command.duration).timeIntervalSince1970.toInt64Milliseconds,

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -28,6 +28,10 @@ public class DDRUMViewEvent: NSObject {
         DDRUMViewEventApplication(root: root)
     }
 
+    @objc public var ciTest: DDRUMViewEventCiTest? {
+        root.swiftModel.ciTest != nil ? DDRUMViewEventCiTest(root: root) : nil
+    }
+
     @objc public var connectivity: DDRUMViewEventRUMConnectivity? {
         root.swiftModel.connectivity != nil ? DDRUMViewEventRUMConnectivity(root: root) : nil
     }
@@ -71,6 +75,10 @@ public class DDRUMViewEventDD: NSObject {
 
     internal init(root: DDRUMViewEvent) {
         self.root = root
+    }
+
+    @objc public var browserSdkVersion: String? {
+        root.swiftModel.dd.browserSdkVersion
     }
 
     @objc public var documentVersion: NSNumber {
@@ -129,6 +137,19 @@ public class DDRUMViewEventApplication: NSObject {
 
     @objc public var id: String {
         root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMViewEventCiTest: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var testExecutionId: String {
+        root.swiftModel.ciTest!.testExecutionId
     }
 }
 
@@ -274,6 +295,7 @@ public enum DDRUMViewEventSessionSessionType: Int {
         switch swift {
         case .user: self = .user
         case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
         }
     }
 
@@ -281,11 +303,13 @@ public enum DDRUMViewEventSessionSessionType: Int {
         switch self {
         case .user: return .user
         case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
         }
     }
 
     case user
     case synthetics
+    case ciTest
 }
 
 @objc
@@ -294,6 +318,10 @@ public class DDRUMViewEventSynthetics: NSObject {
 
     internal init(root: DDRUMViewEvent) {
         self.root = root
+    }
+
+    @objc public var injected: NSNumber? {
+        root.swiftModel.synthetics!.injected as NSNumber?
     }
 
     @objc public var resultId: String {
@@ -628,6 +656,10 @@ public class DDRUMResourceEvent: NSObject {
         DDRUMResourceEventApplication(root: root)
     }
 
+    @objc public var ciTest: DDRUMResourceEventCiTest? {
+        root.swiftModel.ciTest != nil ? DDRUMResourceEventCiTest(root: root) : nil
+    }
+
     @objc public var connectivity: DDRUMResourceEventRUMConnectivity? {
         root.swiftModel.connectivity != nil ? DDRUMResourceEventRUMConnectivity(root: root) : nil
     }
@@ -675,6 +707,10 @@ public class DDRUMResourceEventDD: NSObject {
 
     internal init(root: DDRUMResourceEvent) {
         self.root = root
+    }
+
+    @objc public var browserSdkVersion: String? {
+        root.swiftModel.dd.browserSdkVersion
     }
 
     @objc public var formatVersion: NSNumber {
@@ -750,6 +786,19 @@ public class DDRUMResourceEventApplication: NSObject {
 
     @objc public var id: String {
         root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMResourceEventCiTest: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var testExecutionId: String {
+        root.swiftModel.ciTest!.testExecutionId
     }
 }
 
@@ -1225,6 +1274,7 @@ public enum DDRUMResourceEventSessionSessionType: Int {
         switch swift {
         case .user: self = .user
         case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
         }
     }
 
@@ -1232,11 +1282,13 @@ public enum DDRUMResourceEventSessionSessionType: Int {
         switch self {
         case .user: return .user
         case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
         }
     }
 
     case user
     case synthetics
+    case ciTest
 }
 
 @objc
@@ -1245,6 +1297,10 @@ public class DDRUMResourceEventSynthetics: NSObject {
 
     internal init(root: DDRUMResourceEvent) {
         self.root = root
+    }
+
+    @objc public var injected: NSNumber? {
+        root.swiftModel.synthetics!.injected as NSNumber?
     }
 
     @objc public var resultId: String {
@@ -1330,6 +1386,10 @@ public class DDRUMActionEvent: NSObject {
         DDRUMActionEventApplication(root: root)
     }
 
+    @objc public var ciTest: DDRUMActionEventCiTest? {
+        root.swiftModel.ciTest != nil ? DDRUMActionEventCiTest(root: root) : nil
+    }
+
     @objc public var connectivity: DDRUMActionEventRUMConnectivity? {
         root.swiftModel.connectivity != nil ? DDRUMActionEventRUMConnectivity(root: root) : nil
     }
@@ -1373,6 +1433,10 @@ public class DDRUMActionEventDD: NSObject {
 
     internal init(root: DDRUMActionEvent) {
         self.root = root
+    }
+
+    @objc public var browserSdkVersion: String? {
+        root.swiftModel.dd.browserSdkVersion
     }
 
     @objc public var formatVersion: NSNumber {
@@ -1573,6 +1637,19 @@ public class DDRUMActionEventApplication: NSObject {
 }
 
 @objc
+public class DDRUMActionEventCiTest: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var testExecutionId: String {
+        root.swiftModel.ciTest!.testExecutionId
+    }
+}
+
+@objc
 public class DDRUMActionEventRUMConnectivity: NSObject {
     internal let root: DDRUMActionEvent
 
@@ -1714,6 +1791,7 @@ public enum DDRUMActionEventSessionSessionType: Int {
         switch swift {
         case .user: self = .user
         case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
         }
     }
 
@@ -1721,11 +1799,13 @@ public enum DDRUMActionEventSessionSessionType: Int {
         switch self {
         case .user: return .user
         case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
         }
     }
 
     case user
     case synthetics
+    case ciTest
 }
 
 @objc
@@ -1734,6 +1814,10 @@ public class DDRUMActionEventSynthetics: NSObject {
 
     internal init(root: DDRUMActionEvent) {
         self.root = root
+    }
+
+    @objc public var injected: NSNumber? {
+        root.swiftModel.synthetics!.injected as NSNumber?
     }
 
     @objc public var resultId: String {
@@ -1823,6 +1907,10 @@ public class DDRUMErrorEvent: NSObject {
         DDRUMErrorEventApplication(root: root)
     }
 
+    @objc public var ciTest: DDRUMErrorEventCiTest? {
+        root.swiftModel.ciTest != nil ? DDRUMErrorEventCiTest(root: root) : nil
+    }
+
     @objc public var connectivity: DDRUMErrorEventRUMConnectivity? {
         root.swiftModel.connectivity != nil ? DDRUMErrorEventRUMConnectivity(root: root) : nil
     }
@@ -1870,6 +1958,10 @@ public class DDRUMErrorEventDD: NSObject {
 
     internal init(root: DDRUMErrorEvent) {
         self.root = root
+    }
+
+    @objc public var browserSdkVersion: String? {
+        root.swiftModel.dd.browserSdkVersion
     }
 
     @objc public var formatVersion: NSNumber {
@@ -1937,6 +2029,19 @@ public class DDRUMErrorEventApplication: NSObject {
 
     @objc public var id: String {
         root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMErrorEventCiTest: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var testExecutionId: String {
+        root.swiftModel.ciTest!.testExecutionId
     }
 }
 
@@ -2358,6 +2463,7 @@ public enum DDRUMErrorEventSessionSessionType: Int {
         switch swift {
         case .user: self = .user
         case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
         }
     }
 
@@ -2365,11 +2471,13 @@ public enum DDRUMErrorEventSessionSessionType: Int {
         switch self {
         case .user: return .user
         case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
         }
     }
 
     case user
     case synthetics
+    case ciTest
 }
 
 @objc
@@ -2378,6 +2486,10 @@ public class DDRUMErrorEventSynthetics: NSObject {
 
     internal init(root: DDRUMErrorEvent) {
         self.root = root
+    }
+
+    @objc public var injected: NSNumber? {
+        root.swiftModel.synthetics!.injected as NSNumber?
     }
 
     @objc public var resultId: String {
@@ -2467,6 +2579,10 @@ public class DDRUMLongTaskEvent: NSObject {
         DDRUMLongTaskEventApplication(root: root)
     }
 
+    @objc public var ciTest: DDRUMLongTaskEventCiTest? {
+        root.swiftModel.ciTest != nil ? DDRUMLongTaskEventCiTest(root: root) : nil
+    }
+
     @objc public var connectivity: DDRUMLongTaskEventRUMConnectivity? {
         root.swiftModel.connectivity != nil ? DDRUMLongTaskEventRUMConnectivity(root: root) : nil
     }
@@ -2514,6 +2630,10 @@ public class DDRUMLongTaskEventDD: NSObject {
 
     internal init(root: DDRUMLongTaskEvent) {
         self.root = root
+    }
+
+    @objc public var browserSdkVersion: String? {
+        root.swiftModel.dd.browserSdkVersion
     }
 
     @objc public var formatVersion: NSNumber {
@@ -2581,6 +2701,19 @@ public class DDRUMLongTaskEventApplication: NSObject {
 
     @objc public var id: String {
         root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventCiTest: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var testExecutionId: String {
+        root.swiftModel.ciTest!.testExecutionId
     }
 }
 
@@ -2747,6 +2880,7 @@ public enum DDRUMLongTaskEventSessionSessionType: Int {
         switch swift {
         case .user: self = .user
         case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
         }
     }
 
@@ -2754,11 +2888,13 @@ public enum DDRUMLongTaskEventSessionSessionType: Int {
         switch self {
         case .user: return .user
         case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
         }
     }
 
     case user
     case synthetics
+    case ciTest
 }
 
 @objc
@@ -2767,6 +2903,10 @@ public class DDRUMLongTaskEventSynthetics: NSObject {
 
     internal init(root: DDRUMLongTaskEvent) {
         self.root = root
+    }
+
+    @objc public var injected: NSNumber? {
+        root.swiftModel.synthetics!.injected as NSNumber?
     }
 
     @objc public var resultId: String {
@@ -2833,4 +2973,4 @@ public class DDRUMLongTaskEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/9c135e77bb1da61ebbb6b2fb3b39e156d5120a8e
+// Generated from https://github.com/DataDog/rum-events-format/tree/23a95f774864d3beb15ad39204d58a559d41cff4

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -55,10 +55,12 @@ extension RUMViewEvent: RandomMockable {
     static func mockRandom() -> RUMViewEvent {
         return RUMViewEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 documentVersion: .mockRandom(),
                 session: .init(plan: .plan1)
             ),
             application: .init(id: .mockRandom()),
+            ciTest: nil,
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
@@ -117,12 +119,14 @@ extension RUMResourceEvent: RandomMockable {
     static func mockRandom() -> RUMResourceEvent {
         return RUMResourceEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 session: .init(plan: .plan1),
                 spanId: .mockRandom(),
                 traceId: .mockRandom()
             ),
             action: .init(id: .mockRandom()),
             application: .init(id: .mockRandom()),
+            ciTest: nil,
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
@@ -167,6 +171,7 @@ extension RUMActionEvent: RandomMockable {
     static func mockRandom() -> RUMActionEvent {
         return RUMActionEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
             action: .init(
@@ -180,6 +185,7 @@ extension RUMActionEvent: RandomMockable {
                 type: [.tap, .swipe, .scroll].randomElement()!
             ),
             application: .init(id: .mockRandom()),
+            ciTest: nil,
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
@@ -205,10 +211,12 @@ extension RUMErrorEvent: RandomMockable {
     static func mockRandom() -> RUMErrorEvent {
         return RUMErrorEvent(
             dd: .init(
+                browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
             action: .init(id: .mockRandom()),
             application: .init(id: .mockRandom()),
+            ciTest: nil,
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
@@ -254,9 +262,10 @@ extension RUMErrorEvent: RandomMockable {
 extension RUMLongTaskEvent: RandomMockable {
     static func mockRandom() -> RUMLongTaskEvent {
         return RUMLongTaskEvent(
-            dd: .init(session: .init(plan: .plan1)),
+            dd: .init(browserSdkVersion: nil, session: .init(plan: .plan1)),
             action: .init(id: .mockRandom()),
             application: .init(id: .mockRandom()),
+            ciTest: nil,
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),


### PR DESCRIPTION
### What and why?

Web events coming from `browser-sdk` need to be mutated and decorated with the contextual info of native RUM session (e.g: application ID, active session ID, etc.)

### How?

Such properties are made to be `internally mutable` so that we can mutate them within SDK while outside of the SDK they are immutable as they were.

### TODO

- [ ] https://github.com/DataDog/dd-sdk-ios/pull/683 needs to be merged first

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
