### PR TITLE
RUMM-1779 Keep view active until all resources are consumed

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -345,8 +345,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         version += 1
         attributes.merge(rumCommandAttributes: command.attributes)
 
-        let timeSpent = command.time.timeIntervalSince(viewStartTime)
+        // RUMM-1779 Keep view active as long as we have ongoing resources
+        let isActive = isActiveView || !resourceScopes.isEmpty
 
+        let timeSpent = command.time.timeIntervalSince(viewStartTime)
         let cpuInfo = vitalInfoSampler.cpu
         let memoryInfo = vitalInfoSampler.memory
         let refreshRateInfo = vitalInfoSampler.refreshRate
@@ -384,7 +386,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 frozenFrame: .init(count: frozenFramesCount),
                 id: viewUUID.toRUMDataFormat,
                 inForegroundPeriods: nil,
-                isActive: isActiveView,
+                isActive: isActive,
                 isSlowRendered: isSlowRendered,
                 largestContentfulPaint: nil,
                 loadEvent: nil,

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -416,14 +416,19 @@ class RUMViewScopeTests: XCTestCase {
             scope.process(command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1")),
             "The View should be kept alive as all its Resources haven't yet finished loading"
         )
+
+        var event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)
+        XCTAssertTrue(event.model.view.isActive ?? false, "View should stay active")
+
         XCTAssertFalse(
             scope.process(command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/2")),
             "The View should stop as all its Resources finished loading"
         )
 
-        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)
+        event = try XCTUnwrap(output.recordedEvents(ofType: RUMEvent<RUMViewEvent>.self).last)
         XCTAssertEqual(event.model.view.resource.count, 1, "View should record 1 successful Resource")
         XCTAssertEqual(event.model.view.error.count, 1, "View should record 1 error due to second Resource failure")
+        XCTAssertFalse(event.model.view.isActive ?? true, "View should be inactive")
     }
 
     // MARK: - User Action Tracking

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -213,23 +213,26 @@ internal class RUMSessionMatcher {
 
         // Validate ViewVisit's view.isActive for each events
         try visits.forEach { visit in
-            var viewWasPreviouslyActive = false
+            var viewIsInactive = false
             try visit.viewEvents.enumerated().forEach { index, viewEvent in
-                let viewIsActive = viewEvent.view.isActive!
-                if index == 0 {
-                    if !viewIsActive {
-                        throw RUMSessionConsistencyException(
-                            description: "A `RUMSessionMatcher.ViewVisit` can't have a first event with an inactive `View`."
-                        )
-                    }
-                } else {
-                    if !viewWasPreviouslyActive && viewIsActive {
-                        throw RUMSessionConsistencyException(
-                            description: "A `RUMSessionMatcher.ViewVisit` can't have an event where a `View` is active after the `View` was marked as inactive."
-                        )
-                    }
+                guard let viewIsActive = viewEvent.view.isActive else {
+                    throw RUMSessionConsistencyException(
+                        description: "A `RUMSessionMatcher.ViewVisit` can't have an event without the `isActive` parameter set."
+                    )
                 }
-                viewWasPreviouslyActive = viewIsActive
+
+                if index == 0 && !viewIsActive {
+                    throw RUMSessionConsistencyException(
+                        description: "A `RUMSessionMatcher.ViewVisit` can't have a first event with an inactive `View`."
+                    )
+                }
+
+                if viewIsInactive {
+                    throw RUMSessionConsistencyException(
+                        description: "A `RUMSessionMatcher.ViewVisit` can't have an event after the `View` was marked as inactive."
+                    )
+                }
+                viewIsInactive = !viewIsActive
             }
         }
 


### PR DESCRIPTION
### What and why?

Backend stop processing view updates when one view reports `is_active: false`. 

### How?

Only send the attribute `is_active: false` after ongoing resources are consumed.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
