### PR TITLE
RUMM-1793 WebView events fire RUMWebViewCommand

### DIFF
--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -16,7 +16,7 @@ public extension WKUserContentController {
     internal func __addDatadogMessageHandler(allowedWebViewHosts: Set<String>, hostsSanitizer: HostsSanitizing) {
         let bridgeName = DatadogMessageHandler.name
 
-        let contextProvider = (Global.rum as? RUMMonitor)?.contextProvider
+        let globalRUMMonitor = Global.rum as? RUMMonitor
 
         var logEventConsumer: DefaultWebLogEventConsumer? = nil
         if let loggingFeature = LoggingFeature.instance {
@@ -24,7 +24,7 @@ public extension WKUserContentController {
                 userLogsWriter: loggingFeature.storage.writer,
                 internalLogsWriter: InternalMonitoringFeature.instance?.logsStorage.writer,
                 dateCorrector: loggingFeature.dateCorrector,
-                rumContextProvider: contextProvider,
+                rumContextProvider: globalRUMMonitor?.contextProvider,
                 applicationVersion: loggingFeature.configuration.common.applicationVersion,
                 environment: loggingFeature.configuration.common.environment
             )
@@ -35,7 +35,9 @@ public extension WKUserContentController {
             rumEventConsumer = DefaultWebRUMEventConsumer(
                 dataWriter: rumFeature.storage.writer,
                 dateCorrector: rumFeature.dateCorrector,
-                contextProvider: contextProvider
+                contextProvider: globalRUMMonitor?.contextProvider,
+                rumCommandSubscriber: globalRUMMonitor,
+                dateProvider: rumFeature.dateProvider
             )
         }
 

--- a/Sources/Datadog/FeaturesIntegration/WebView/WebRUMEventConsumer.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WebRUMEventConsumer.swift
@@ -10,20 +10,32 @@ internal class DefaultWebRUMEventConsumer: WebRUMEventConsumer {
     private let dataWriter: Writer
     private let dateCorrector: DateCorrectorType
     private let contextProvider: RUMContextProvider?
+    private let rumCommandSubscriber: RUMCommandSubscriber?
+    private let dateProvider: DateProvider
 
     private let jsonDecoder = JSONDecoder()
 
     init(
         dataWriter: Writer,
         dateCorrector: DateCorrectorType,
-        contextProvider: RUMContextProvider?
+        contextProvider: RUMContextProvider?,
+        rumCommandSubscriber: RUMCommandSubscriber?,
+        dateProvider: DateProvider
     ) {
         self.dataWriter = dataWriter
         self.dateCorrector = dateCorrector
         self.contextProvider = contextProvider
+        self.rumCommandSubscriber = rumCommandSubscriber
+        self.dateProvider = dateProvider
     }
 
     func consume(event: JSON) throws {
+        rumCommandSubscriber?.process(
+            command: RUMWebViewCommand(
+                time: dateProvider.currentDate(),
+                attributes: [:]
+            )
+        )
         let rumContext = contextProvider?.context
         let mappedEvent = map(event: event, with: rumContext)
 

--- a/Sources/Datadog/FeaturesIntegration/WebView/WebRUMEventConsumer.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WebRUMEventConsumer.swift
@@ -31,7 +31,7 @@ internal class DefaultWebRUMEventConsumer: WebRUMEventConsumer {
 
     func consume(event: JSON) throws {
         rumCommandSubscriber?.process(
-            command: RUMWebViewCommand(
+            command: RUMKeepSessionAliveCommand(
                 time: dateProvider.currentDate(),
                 attributes: [:]
             )

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -281,3 +281,10 @@ internal struct RUMAddLongTaskCommand: RUMCommand {
 
     let duration: TimeInterval
 }
+
+// MARK: - RUM Web Events related commands
+
+internal struct RUMWebViewCommand: RUMCommand {
+    var time: Date
+    var attributes: [AttributeKey: AttributeValue]
+}

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -284,7 +284,8 @@ internal struct RUMAddLongTaskCommand: RUMCommand {
 
 // MARK: - RUM Web Events related commands
 
-internal struct RUMWebViewCommand: RUMCommand {
+/// RUM Events received from WebView should keep the active session alive, therefore they fire this command to do so. (ref: RUMM-1793)
+internal struct RUMKeepSessionAliveCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
 }


### PR DESCRIPTION
### What and why?

With `browser-sdk` integration, iOS SDK can receive RUM events from the web views. Yet, these events don't pass through the same pipeline that regular RUM events pass. This may result in expired sessions while receiving events from the web views.

### How?

`RUMWebViewCommand` is an empty command that keeps the session alive and it is sent every time `WebRUMEventConsumer` receives an event.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
