### PR TITLE
RUMM-1649 WebViewTracking integration test added

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -518,6 +518,10 @@
 		9EA3CA6926775A3500B16871 /* VitalRefreshRateReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA3CA6826775A3500B16871 /* VitalRefreshRateReader.swift */; };
 		9EA8A7F1275E1518007D6FDB /* HostsSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA8A7F0275E1518007D6FDB /* HostsSanitizerTests.swift */; };
 		9EA8A7F82768A72B007D6FDB /* WebLogEventConsumerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA8A7F72768A72B007D6FDB /* WebLogEventConsumerTests.swift */; };
+		9EA95C1C2791C9BE00F6C1F3 /* WebViewTrackingFixtureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA95C192791C9BE00F6C1F3 /* WebViewTrackingFixtureViewController.swift */; };
+		9EA95C1D2791C9BE00F6C1F3 /* WebViewTrackingScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9EA95C1A2791C9BE00F6C1F3 /* WebViewTrackingScenario.storyboard */; };
+		9EA95C1E2791C9BE00F6C1F3 /* WebViewScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA95C1B2791C9BE00F6C1F3 /* WebViewScenarios.swift */; };
+		9EA95C212791C9E200F6C1F3 /* WebViewScenarioTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA95C202791C9E200F6C1F3 /* WebViewScenarioTest.swift */; };
 		9EAF0CF6275A21100044E8CA /* WKUserContentController+DatadogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAF0CF5275A21100044E8CA /* WKUserContentController+DatadogTests.swift */; };
 		9EAF0CF8275A2FDC0044E8CA /* HostsSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAF0CF7275A2FDC0044E8CA /* HostsSanitizer.swift */; };
 		9EB4B862274E79D50041CD03 /* WKUserContentController+Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EB4B861274E79D50041CD03 /* WKUserContentController+Datadog.swift */; };
@@ -1213,6 +1217,10 @@
 		9EA3CA6826775A3500B16871 /* VitalRefreshRateReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalRefreshRateReader.swift; sourceTree = "<group>"; };
 		9EA8A7F0275E1518007D6FDB /* HostsSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostsSanitizerTests.swift; sourceTree = "<group>"; };
 		9EA8A7F72768A72B007D6FDB /* WebLogEventConsumerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebLogEventConsumerTests.swift; sourceTree = "<group>"; };
+		9EA95C192791C9BE00F6C1F3 /* WebViewTrackingFixtureViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewTrackingFixtureViewController.swift; sourceTree = "<group>"; };
+		9EA95C1A2791C9BE00F6C1F3 /* WebViewTrackingScenario.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = WebViewTrackingScenario.storyboard; sourceTree = "<group>"; };
+		9EA95C1B2791C9BE00F6C1F3 /* WebViewScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewScenarios.swift; sourceTree = "<group>"; };
+		9EA95C202791C9E200F6C1F3 /* WebViewScenarioTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewScenarioTest.swift; sourceTree = "<group>"; };
 		9EAF0CF5275A21100044E8CA /* WKUserContentController+DatadogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKUserContentController+DatadogTests.swift"; sourceTree = "<group>"; };
 		9EAF0CF7275A2FDC0044E8CA /* HostsSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostsSanitizer.swift; sourceTree = "<group>"; };
 		9EB4B861274E79D50041CD03 /* WKUserContentController+Datadog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKUserContentController+Datadog.swift"; sourceTree = "<group>"; };
@@ -2055,6 +2063,7 @@
 				6111542325C992D9007C84C9 /* CrashReporting */,
 				611EA12B2580F40E00BC0E56 /* TrackingConsent */,
 				6164AE7D252B4CE2000D78C4 /* URLSession */,
+				9EA95C182791C9BE00F6C1F3 /* WebView */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -3197,6 +3206,7 @@
 				61F3CD9F2511070300C816E5 /* RUM */,
 				61B6811D25F0E8480015B4AF /* CrashReporting */,
 				611EA15325815EDC00BC0E56 /* TrackingConsent */,
+				9EA95C1F2791C9E200F6C1F3 /* WebView */,
 			);
 			path = Scenarios;
 			sourceTree = "<group>";
@@ -3387,6 +3397,24 @@
 			);
 			name = _Datadog_Private;
 			path = ../Sources/_Datadog_Private;
+			sourceTree = "<group>";
+		};
+		9EA95C182791C9BE00F6C1F3 /* WebView */ = {
+			isa = PBXGroup;
+			children = (
+				9EA95C192791C9BE00F6C1F3 /* WebViewTrackingFixtureViewController.swift */,
+				9EA95C1A2791C9BE00F6C1F3 /* WebViewTrackingScenario.storyboard */,
+				9EA95C1B2791C9BE00F6C1F3 /* WebViewScenarios.swift */,
+			);
+			path = WebView;
+			sourceTree = "<group>";
+		};
+		9EA95C1F2791C9E200F6C1F3 /* WebView */ = {
+			isa = PBXGroup;
+			children = (
+				9EA95C202791C9E200F6C1F3 /* WebViewScenarioTest.swift */,
+			);
+			path = WebView;
 			sourceTree = "<group>";
 		};
 		9EB4B860274E79620041CD03 /* WebView */ = {
@@ -3899,6 +3927,7 @@
 				D2F5BB36271831C200BDE2A4 /* RUMSwiftUIInstrumentationScenario.storyboard in Resources */,
 				611EA13C2580F77400BC0E56 /* TrackingConsentScenario.storyboard in Resources */,
 				61441C1124616DEC003D8BB8 /* LaunchScreen.storyboard in Resources */,
+				9EA95C1D2791C9BE00F6C1F3 /* WebViewTrackingScenario.storyboard in Resources */,
 				61337039250F852E00236D58 /* RUMManualInstrumentationScenario.storyboard in Resources */,
 				6193DCA4251B5691009B8011 /* RUMTapActionScenario.storyboard in Resources */,
 				6167ACC7251A0BCE0012B4D0 /* NSURLSessionScenario.storyboard in Resources */,
@@ -4492,6 +4521,7 @@
 				D2F5BB382718331800BDE2A4 /* SwiftUIRootViewController.swift in Sources */,
 				618DCFE124C766F500589570 /* SendRUMFixture2ViewController.swift in Sources */,
 				61441C982461A649003D8BB8 /* DebugTracingViewController.swift in Sources */,
+				9EA95C1E2791C9BE00F6C1F3 /* WebViewScenarios.swift in Sources */,
 				61F9CA8025125C01000A5E61 /* RUMNCSScreen3ViewController.swift in Sources */,
 				6164AE89252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift in Sources */,
 				611EA14225810E1900BC0E56 /* TSHomeViewController.swift in Sources */,
@@ -4528,6 +4558,7 @@
 				617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */,
 				6193DCE1251B692C009B8011 /* RUMTASTableViewController.swift in Sources */,
 				6111544825C9A88B007C84C9 /* PersistenceHelper.swift in Sources */,
+				9EA95C1C2791C9BE00F6C1F3 /* WebViewTrackingFixtureViewController.swift in Sources */,
 				61D50C462580EF19006038A3 /* TracingScenarios.swift in Sources */,
 				61776CED273BEA5500F93802 /* DebugRUMSessionViewController.swift in Sources */,
 				618DCFE324C766FB00589570 /* SendRUMFixture3ViewController.swift in Sources */,
@@ -4557,6 +4588,7 @@
 				61441C4124617013003D8BB8 /* LoggingScenarioTests.swift in Sources */,
 				612D8F8125AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift in Sources */,
 				613B77382521E80800155458 /* RUMTabBarControllerScenarioTests.swift in Sources */,
+				9EA95C212791C9E200F6C1F3 /* WebViewScenarioTest.swift in Sources */,
 				61441C4B24618052003D8BB8 /* SpanMatcher.swift in Sources */,
 				6167ACFD251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift in Sources */,
 				611EA16625825FB300BC0E56 /* TrackingConsentScenarioTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -151,6 +151,11 @@
             value = "CrashReportingCollectOrSendWithLoggingScenario"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_TEST_SCENARIO_CLASS_NAME"
+            value = "WebViewTrackingScenario"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/Datadog/Example/Debugging/DebugWebviewViewController.swift
+++ b/Datadog/Example/Debugging/DebugWebviewViewController.swift
@@ -85,7 +85,6 @@ class WebviewViewController: UIViewController {
         super.viewDidLoad()
 
         let controller = WKUserContentController()
-        // TODO: RUMM-1794 remove internal method call and use public API
         controller.addDatadogMessageHandler(allowedWebViewHosts: ["datadoghq.dev"])
         let config = WKWebViewConfiguration()
         config.userContentController = controller

--- a/Datadog/Example/Scenarios/WebView/WebViewScenarios.swift
+++ b/Datadog/Example/Scenarios/WebView/WebViewScenarios.swift
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import Datadog
+
+/// Scenario which uses RUM only. Blocks the main thread and expects to have non-zero MobileVitals values
+final class WebViewTrackingScenario: TestScenario {
+    static var storyboardName: String = "WebViewTrackingScenario"
+
+    func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder
+            .trackUIKitRUMViews()
+            .enableLogging(true)
+            .enableRUM(true)
+    }
+}

--- a/Datadog/Example/Scenarios/WebView/WebViewScenarios.swift
+++ b/Datadog/Example/Scenarios/WebView/WebViewScenarios.swift
@@ -4,16 +4,27 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-import Foundation
+import UIKit
 import Datadog
 
-/// Scenario which uses RUM only. Blocks the main thread and expects to have non-zero MobileVitals values
+private struct WebViewTrackingScenarioPredicate: UIKitRUMViewsPredicate {
+    private let defaultPredicate = DefaultUIKitRUMViewsPredicate()
+
+    func rumView(for viewController: UIViewController) -> RUMView? {
+        if viewController is ShopistWebviewViewController {
+            return nil // do not consider the webview itself as RUM view
+        } else {
+            return defaultPredicate.rumView(for: viewController)
+        }
+    }
+}
+
 final class WebViewTrackingScenario: TestScenario {
     static var storyboardName: String = "WebViewTrackingScenario"
 
     func configureSDK(builder: Datadog.Configuration.Builder) {
         _ = builder
-            .trackUIKitRUMViews()
+            .trackUIKitRUMViews(using: WebViewTrackingScenarioPredicate())
             .enableLogging(true)
             .enableRUM(true)
     }

--- a/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
+++ b/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
@@ -1,0 +1,138 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+import WebKit
+import Datadog
+
+class WebViewTrackingFixtureViewController: UIViewController, WKNavigationDelegate {
+    let html = """
+         <head>
+         <meta charset="utf-8">
+         <title>Mobile SDK Detection test page</title>
+         <link rel="icon" type="image/x-icon" href="./favicon.ico">
+         <script type="text/javascript">
+               function show(message) {
+                 const p = document.createElement("p");
+                 p.innerHTML = message;
+                 if (document.body) {
+                   document.body.appendChild(p);
+                 } else {
+                   window.addEventListener("DOMContentLoaded", () =>
+                     document.body.appendChild(p)
+                   );
+                 }
+               }
+               function isEventBridgePresent() {
+                 const isPresent = window.DatadogEventBridge;
+                 if (!isPresent) {
+                   show(`window.DatadogEventBridge absent!`);
+                   return false;
+                 }
+                 if (!isViewHostAllowed()) {
+                   show(
+                     `This page does not respect window.DatadogEventBridge.getAllowedWebViewHosts: <br>${window.DatadogEventBridge.getAllowedWebViewHosts()}`
+                   );
+                   return false;
+                 }
+                 return true;
+               }
+               function getEventBridge() {
+                 const datadogEventBridge = window.DatadogEventBridge;
+                 return {
+                   getAllowedWebViewHosts() {
+                     try {
+                       return JSON.parse(
+                         window.DatadogEventBridge.getAllowedWebViewHosts()
+                       );
+                     } catch (e) {
+                       show(
+                         `allowWebViewHosts is not a valid json ${window.DatadogEventBridge.getAllowedWebViewHosts()}`
+                       );
+                     }
+                     return [];
+                   },
+                   send(eventType, event) {
+                     const eventStr = JSON.stringify({
+                       eventType,
+                       event,
+                       tags: ["browser_sdk_version:3.6.13"],
+                     });
+                     datadogEventBridge.send(eventStr);
+                     show(
+                       `window.DatadogEventBridge: ${eventType} sent! <br><br>${eventStr}`
+                     );
+                   },
+                 };
+               }
+               function sendLog() {
+                 if (!isEventBridgePresent()) {
+                   return;
+                 }
+                 try {
+                   const log = {
+                     date: 1635932927012,
+                     error: { origin: "console" },
+                     message: "console error: error",
+                     session_id: "0110cab4-7471-480e-aa4e-7ce039ced355",
+                     status: "error",
+                     view: {
+                       referrer: "",
+                       url: "https://datadoghq.dev/browser-sdk-test-playground",
+                     },
+                   };
+                   getEventBridge().send("log", log);
+                 } catch (err) {
+                   show(`window.DatadogEventBridge: Could not send ${err}`);
+                 }
+               }
+               function isViewHostAllowed() {
+                 return getEventBridge()
+                   .getAllowedWebViewHosts()
+                   .some((o) => o.includes(window.location.hostname));
+               }
+
+               show(
+                 `window.DatadogEventBridge: <br>${JSON.stringify(
+                   window.DatadogEventBridge
+                 )}`
+               );
+             </script>
+         </head>
+         <body>
+         <button onclick="sendLog()">Send dummy log</button>
+         <p>window.DatadogEventBridge: <br>undefined</p></body>
+         """
+
+    private var webView: WKWebView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let controller = WKUserContentController()
+        controller.addDatadogMessageHandler(allowedWebViewHosts: ["datadoghq.dev"])
+        let config = WKWebViewConfiguration()
+        config.userContentController = controller
+
+        webView = WKWebView(frame: view.bounds, configuration: config)
+        webView.navigationDelegate = self
+        view.addSubview(webView)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        let js = """
+            window.sendLog()
+        """
+        webView.evaluateJavaScript(js) { res, err in
+            assert(err == nil, "JS execution shouldn't return an error")
+        }
+    }
+}

--- a/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
+++ b/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
@@ -9,111 +9,13 @@ import WebKit
 import Datadog
 
 class WebViewTrackingFixtureViewController: UIViewController, WKNavigationDelegate {
-    let html = """
-         <head>
-         <meta charset="utf-8">
-         <title>Mobile SDK Detection test page</title>
-         <link rel="icon" type="image/x-icon" href="./favicon.ico">
-         <script type="text/javascript">
-               function show(message) {
-                 const p = document.createElement("p");
-                 p.innerHTML = message;
-                 if (document.body) {
-                   document.body.appendChild(p);
-                 } else {
-                   window.addEventListener("DOMContentLoaded", () =>
-                     document.body.appendChild(p)
-                   );
-                 }
-               }
-               function isEventBridgePresent() {
-                 const isPresent = window.DatadogEventBridge;
-                 if (!isPresent) {
-                   show(`window.DatadogEventBridge absent!`);
-                   return false;
-                 }
-                 if (!isViewHostAllowed()) {
-                   show(
-                     `This page does not respect window.DatadogEventBridge.getAllowedWebViewHosts: <br>${window.DatadogEventBridge.getAllowedWebViewHosts()}`
-                   );
-                   return false;
-                 }
-                 return true;
-               }
-               function getEventBridge() {
-                 const datadogEventBridge = window.DatadogEventBridge;
-                 return {
-                   getAllowedWebViewHosts() {
-                     try {
-                       return JSON.parse(
-                         window.DatadogEventBridge.getAllowedWebViewHosts()
-                       );
-                     } catch (e) {
-                       show(
-                         `allowWebViewHosts is not a valid json ${window.DatadogEventBridge.getAllowedWebViewHosts()}`
-                       );
-                     }
-                     return [];
-                   },
-                   send(eventType, event) {
-                     const eventStr = JSON.stringify({
-                       eventType,
-                       event,
-                       tags: ["browser_sdk_version:3.6.13"],
-                     });
-                     datadogEventBridge.send(eventStr);
-                     show(
-                       `window.DatadogEventBridge: ${eventType} sent! <br><br>${eventStr}`
-                     );
-                   },
-                 };
-               }
-               function sendLog() {
-                 if (!isEventBridgePresent()) {
-                   return;
-                 }
-                 try {
-                   const log = {
-                     date: 1635932927012,
-                     error: { origin: "console" },
-                     message: "console error: error",
-                     session_id: "0110cab4-7471-480e-aa4e-7ce039ced355",
-                     status: "error",
-                     view: {
-                       referrer: "",
-                       url: "https://datadoghq.dev/browser-sdk-test-playground",
-                     },
-                   };
-                   getEventBridge().send("log", log);
-                 } catch (err) {
-                   show(`window.DatadogEventBridge: Could not send ${err}`);
-                 }
-               }
-               function isViewHostAllowed() {
-                 return getEventBridge()
-                   .getAllowedWebViewHosts()
-                   .some((o) => o.includes(window.location.hostname));
-               }
-
-               show(
-                 `window.DatadogEventBridge: <br>${JSON.stringify(
-                   window.DatadogEventBridge
-                 )}`
-               );
-             </script>
-         </head>
-         <body>
-         <button onclick="sendLog()">Send dummy log</button>
-         <p>window.DatadogEventBridge: <br>undefined</p></body>
-         """
-
     private var webView: WKWebView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         let controller = WKUserContentController()
-        controller.addDatadogMessageHandler(allowedWebViewHosts: ["datadoghq.dev"])
+        controller.addDatadogMessageHandler(allowedWebViewHosts: ["shopist.io"])
         let config = WKWebViewConfiguration()
         config.userContentController = controller
 
@@ -124,15 +26,9 @@ class WebViewTrackingFixtureViewController: UIViewController, WKNavigationDelega
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        webView.loadHTMLString(html, baseURL: nil)
-    }
 
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        let js = """
-            window.sendLog()
-        """
-        webView.evaluateJavaScript(js) { res, err in
-            assert(err == nil, "JS execution shouldn't return an error")
-        }
+        // swiftlint:disable:next force_unwrapping
+        let request = URLRequest(url: URL(string: "https://shopist.io")!)
+        webView.load(request)
     }
 }

--- a/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
+++ b/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
@@ -9,6 +9,19 @@ import WebKit
 import Datadog
 
 class WebViewTrackingFixtureViewController: UIViewController, WKNavigationDelegate {
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // An action sent from native iOS SDK.
+        Global.rum.addUserAction(type: .custom, name: "Native action")
+
+        // Opens a webview configured to pass all its Browser SDK events to native iOS SDK.
+        show(ShopistWebviewViewController(), sender: nil)
+    }
+}
+
+class ShopistWebviewViewController: UIViewController {
+    private let request = URLRequest(url: URL(string: "https://shopist.io")!)
     private var webView: WKWebView!
 
     override func viewDidLoad() {
@@ -19,16 +32,12 @@ class WebViewTrackingFixtureViewController: UIViewController, WKNavigationDelega
         let config = WKWebViewConfiguration()
         config.userContentController = controller
 
-        webView = WKWebView(frame: view.bounds, configuration: config)
-        webView.navigationDelegate = self
+        webView = WKWebView(frame: UIScreen.main.bounds, configuration: config)
         view.addSubview(webView)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        // swiftlint:disable:next force_unwrapping
-        let request = URLRequest(url: URL(string: "https://shopist.io")!)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         webView.load(request)
     }
 }

--- a/Datadog/Example/Scenarios/WebView/WebViewTrackingScenario.storyboard
+++ b/Datadog/Example/Scenarios/WebView/WebViewTrackingScenario.storyboard
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Web View Tracking Fixture View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" customClass="WebViewTrackingFixtureViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="114" y="80"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Datadog/TargetSupport/DatadogIntegrationTests/DatadogCrashReportingIntegrationTests.xctestplan
+++ b/Datadog/TargetSupport/DatadogIntegrationTests/DatadogCrashReportingIntegrationTests.xctestplan
@@ -33,21 +33,9 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "IntegrationTests",
-        "LoggingScenarioTests",
-        "RUMManualInstrumentationScenarioTests",
-        "RUMMobileVitalsScenarioTests",
-        "RUMModalViewsScenarioTests",
-        "RUMNavigationControllerScenarioTests",
-        "RUMResourcesScenarioTests",
-        "RUMScrubbingScenarioTests",
-        "RUMSwiftUIScenarioTests",
-        "RUMTabBarControllerScenarioTests",
-        "RUMTapActionScenarioTests",
-        "TracingManualInstrumentationScenarioTests",
-        "TracingURLSessionScenarioTests",
-        "TrackingConsentScenarioTests"
+      "selectedTests" : [
+        "CrashReportingWithLoggingScenarioTests\/testCrashReportingCollectOrSendWithLoggingScenario()",
+        "CrashReportingWithRUMScenarioTests\/testCrashReportingCollectOrSendWithRUMScenario()"
       ],
       "target" : {
         "containerPath" : "container:Datadog.xcodeproj",

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
@@ -60,14 +60,16 @@ extension RUMCommonAsserts {
 
 extension RUMSessionMatcher {
     /// Retrieves single RUM Session from given `requests`.
-    class func singleSession(from requests: [HTTPServerMock.Request]) throws -> RUMSessionMatcher? {
-        return try sessions(maxCount: 1, from: requests).first
+    /// - Parameter eventsPatch: optional transformation to apply on each event within the payload before instantiating matcher (default: `nil`)
+    class func singleSession(from requests: [HTTPServerMock.Request], eventsPatch: ((Data) throws -> Data)? = nil) throws -> RUMSessionMatcher? {
+        return try sessions(maxCount: 1, from: requests, eventsPatch: eventsPatch).first
     }
 
     /// Retrieves `maxCount` RUM Sessions from given `requests`.
-    class func sessions(maxCount: Int, from requests: [HTTPServerMock.Request]) throws -> [RUMSessionMatcher] {
+    /// - Parameter eventsPatch: optional transformation to apply on each event within the payload before instantiating matcher (default: `nil`)
+    class func sessions(maxCount: Int, from requests: [HTTPServerMock.Request], eventsPatch: ((Data) throws -> Data)? = nil) throws -> [RUMSessionMatcher] {
         let eventMatchers = try requests
-            .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody) }
+            .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody, eventsPatch: eventsPatch) }
         let sessionMatchers = try RUMSessionMatcher.groupMatchersBySessions(eventMatchers)
 
         if sessionMatchers.count > maxCount {

--- a/Tests/DatadogIntegrationTests/Scenarios/WebView/WebViewScenarioTest.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/WebView/WebViewScenarioTest.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import HTTPServerMock
+import XCTest
+
+class WebViewScenarioTest: IntegrationTests, LoggingCommonAsserts {
+    func testWebViewLoggingScenario() throws {
+        let loggingServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenarioClassName: "WebViewTrackingScenario",
+            serverConfiguration: HTTPServerMockConfiguration(
+                logsEndpoint: loggingServerSession.recordingURL
+            )
+        )
+
+        // Get expected number of `LogMatchers`
+        let recordedRequests = try loggingServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            try LogMatcher.from(requests: requests).count >= 1
+        }
+        let logMatchers = try LogMatcher.from(requests: recordedRequests)
+
+        // Assert common things
+        assertLogging(requests: recordedRequests)
+
+        logMatchers[0].assertStatus(equals: "error")
+        logMatchers[0].assertMessage(equals: "console error: error")
+    }
+}

--- a/Tests/DatadogIntegrationTests/Scenarios/WebView/WebViewScenarioTest.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/WebView/WebViewScenarioTest.swift
@@ -9,35 +9,76 @@ import HTTPServerMock
 import XCTest
 
 class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
-    func testWebViewRUMEventsScenario() throws {
+    /// In this test, the app opens a WebView which loads Browser SDK instrumented content.
+    /// The iOS SDK should capture all RUM events and Logs produced by Browser SDK.
+    func testWebViewEventsScenario() throws {
         // Server session recording RUM events send to `HTTPServerMock`.
         let rumServerSession = server.obtainUniqueRecordingSession()
+        // Server session recording Logs send to `HTTPServerMock`.
+        let loggingServerSession = server.obtainUniqueRecordingSession()
 
         let app = ExampleApplication()
         app.launchWith(
             testScenarioClassName: "WebViewTrackingScenario",
             serverConfiguration: HTTPServerMockConfiguration(
+                logsEndpoint: loggingServerSession.recordingURL,
                 rumEndpoint: rumServerSession.recordingURL
             )
         )
 
-        // Get RUM Sessions with expected number of View visits
+        // Get single RUM Session with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
             try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 2
         }
-
         assertRUM(requests: recordedRUMRequests)
 
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
+        XCTAssertEqual(session.viewVisits.count, 2, "There should be 2 RUM views - one native and one received from Browser SDK")
 
-        XCTAssertEqual(session.viewVisits.count, 2)
-        session.viewVisits[0].viewEvents.forEach { nativeView in
-            XCTAssertEqual(nativeView.source, .ios)
+        // Check iOS SDK events:
+        let nativeView = session.viewVisits[0]
+        XCTAssertEqual(nativeView.name, "Example.WebViewTrackingFixtureViewController")
+        XCTAssertEqual(nativeView.path, "Example.WebViewTrackingFixtureViewController")
+
+        nativeView.viewEvents.forEach { nativeViewEvent in
+            XCTAssertEqual(nativeViewEvent.source, .ios)
         }
-        session.viewVisits[1].viewEvents.forEach { browserView in
-            // ideally `source` should be `.browser`
-            // but it's not implemented in `browser-sdk` yet
-            XCTAssertNotEqual(browserView.source, .ios)
+        XCTAssertEqual(nativeView.actionEvents.count, 2, "It should track 2 native actions")
+
+        // Check Browser SDK events:
+        let expectedBrowserServiceName = "shopist-web-ui"
+        let expectedBrowserRUMApplicationID = nativeView.viewEvents[0].application.id
+        let expectedBrowserSessionID = nativeView.viewEvents[0].session.id
+
+        let browserView = session.viewVisits[1]
+        XCTAssertNil(browserView.name, "Browser views should have no `name`")
+        XCTAssertEqual(browserView.path, "https://shopist.io/")
+
+        browserView.viewEvents.forEach { browserViewEvent in
+            XCTAssertEqual(browserViewEvent.application.id, expectedBrowserRUMApplicationID, "Webview events should use iOS SDK application ID")
+            XCTAssertEqual(browserViewEvent.session.id, expectedBrowserSessionID, "Webview events should use iOS SDK session ID")
+            XCTAssertEqual(browserViewEvent.service, expectedBrowserServiceName, "Webview events should use Browser SDK `service`")
+            XCTAssertNotEqual(browserViewEvent.source, .ios, "Webview events should use Browser SDK `source`")
         }
+        XCTAssertGreaterThan(browserView.resourceEvents.count, 0, "It should track some Webview resources")
+        browserView.resourceEvents.forEach { browserResourceEvent in
+            XCTAssertEqual(browserResourceEvent.application.id, expectedBrowserRUMApplicationID, "Webview events should use iOS SDK application ID")
+            XCTAssertEqual(browserResourceEvent.session.id, expectedBrowserSessionID, "Webview events should use iOS SDK session ID")
+            XCTAssertEqual(browserResourceEvent.service, expectedBrowserServiceName, "Webview events should use Browser SDK `service`")
+            XCTAssertNotEqual(browserResourceEvent.source, .ios, "Webview events should use Browser SDK `source`")
+        }
+
+        // Get `LogMatchers`
+        let recordedRequests = try loggingServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            try LogMatcher.from(requests: requests).count >= 1 // get at least one log
+        }
+        let logMatchers = try LogMatcher.from(requests: recordedRequests)
+
+        let browserLog = logMatchers[0]
+        browserLog.assertServiceName(equals: expectedBrowserServiceName)
+        browserLog.assertAttributes(equal: [
+            "application_id": expectedBrowserRUMApplicationID,
+            "session_id": expectedBrowserSessionID,
+        ])
     }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/WebView/WebViewScenarioTest.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/WebView/WebViewScenarioTest.swift
@@ -28,11 +28,11 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
 
         // Get single RUM Session with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 2
+            try RUMSessionMatcher.singleSession(from: requests, eventsPatch: patchBrowserResourceEvents)?.viewVisits.count == 2
         }
         assertRUM(requests: recordedRUMRequests)
 
-        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
+        let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests, eventsPatch: patchBrowserResourceEvents))
         XCTAssertEqual(session.viewVisits.count, 2, "There should be 2 RUM views - one native and one received from Browser SDK")
 
         // Check iOS SDK events:
@@ -81,4 +81,25 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
             "session_id": expectedBrowserSessionID,
         ])
     }
+}
+
+/// Patch applied to RUM resource events received from Browser SDK.
+///
+/// Browser SDK v4.1.0 uses lowercase string values for `resource.method` field, whereas RUM format schema
+/// defines it as uppercase string (e.g. `"get"` instead of `"GET"`). Here we patch `resource.method` to be
+/// uppercased, so it can be read and validated in `RUMEventMatcher`.
+///
+/// This can be removed once `resource.method` is fixed in future Browser SDK version.
+private func patchBrowserResourceEvents(_ data: Data) throws -> Data {
+    var json = try data.toJSONObject()
+
+    if let eventType = json["type"] as? String,
+       eventType == "resource",
+       var resource = json["resource"] as? [String: Any],
+       let method = resource["method"] as? String {
+        resource["method"] = method.uppercased()
+        json["resource"] = resource
+    }
+
+    return try JSONSerialization.data(withJSONObject: json, options: [])
 }

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -48,7 +48,8 @@ internal class RUMSessionMatcher {
 
         /// The `name` of the visited RUM View.
         /// Corresponds to the "VIEW NAME" in RUM Explorer.
-        fileprivate(set) var name: String = ""
+        /// Might be `nil` for events received from Browser SDK.
+        fileprivate(set) var name: String?
 
         /// The `path` of the visited RUM View.
         /// Corresponds to the "VIEW URL" in RUM Explorer.
@@ -136,8 +137,8 @@ internal class RUMSessionMatcher {
             if let visit = visitsByViewID[rumEvent.view.id] {
                 visit.viewEvents.append(rumEvent)
                 visit.viewEventMatchers.append(matcher)
-                if visit.name.isEmpty {
-                    visit.name = rumEvent.view.name ?? ""
+                if visit.name == nil {
+                    visit.name = rumEvent.view.name
                 } else if visit.name != rumEvent.view.name {
                     throw RUMSessionConsistencyException(
                         description: "The RUM View name: \(rumEvent) is different than other RUM View names for the same `view.id`."
@@ -324,7 +325,7 @@ extension RUMSessionMatcher: CustomStringConvertible {
             return "    → [⛔️ Invalid View - it has no view events]"
         }
 
-        var description = "    → [📸 View (name: '\(viewVisit.name)', id: \(viewVisit.viewID), duration: \(seconds(from: lastViewEvent.view.timeSpent)) actions.count: \(lastViewEvent.view.action.count), resources.count: \(lastViewEvent.view.resource.count), errors.count: \(lastViewEvent.view.error.count), longTask.count: \(lastViewEvent.view.longTask?.count ?? 0), frozenFrames.count: \(lastViewEvent.view.frozenFrame?.count ?? 0)]"
+        var description = "    → [📸 View (name: '\(viewVisit.name ?? "nil")', id: \(viewVisit.viewID), duration: \(seconds(from: lastViewEvent.view.timeSpent)) actions.count: \(lastViewEvent.view.action.count), resources.count: \(lastViewEvent.view.resource.count), errors.count: \(lastViewEvent.view.error.count), longTask.count: \(lastViewEvent.view.longTask?.count ?? 0), frozenFrames.count: \(lastViewEvent.view.frozenFrame?.count ?? 0)]"
 
         if !viewVisit.actionEvents.isEmpty {
             description += "\n        → action events:"

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -137,7 +137,7 @@ internal class RUMSessionMatcher {
                 visit.viewEvents.append(rumEvent)
                 visit.viewEventMatchers.append(matcher)
                 if visit.name.isEmpty {
-                    visit.name = rumEvent.view.name!
+                    visit.name = rumEvent.view.name ?? ""
                 } else if visit.name != rumEvent.view.name {
                     throw RUMSessionConsistencyException(
                         description: "The RUM View name: \(rumEvent) is different than other RUM View names for the same `view.id`."


### PR DESCRIPTION
### What and why?

Adding integration test to WebView tracking feature.

### How?

In this new test, the app opens a WebView which loads Browser SDK instrumented content. The iOS SDK should transport all RUM events and Logs received from Browser SDK.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
