### PR TITLE
RUMM-1803 Add internal monitoring to 'ActivePrewarm' process variable

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -543,6 +543,15 @@ private class MetricMonitor: NSObject, MXMetricManagerSubscriber {
         self.launchTime = launchTime
         self.timestamp = Date()
         MXMetricManager.shared.add(self)
+
+        InternalMonitoringFeature.instance?.monitor.sdkLogger.info(
+            "Did request MetricKit metrics and diagnostics",
+            attributes: [
+                "application_launch_time": launchTime,
+                "active_pre_warm": ProcessInfo.processInfo.environment["ActivePrewarm"] ?? "(null)",
+                "os_version": ProcessInfo.processInfo.operatingSystemVersionString
+            ]
+        )
     }
 
     @available(iOS 13.0, *)
@@ -555,6 +564,8 @@ private class MetricMonitor: NSObject, MXMetricManagerSubscriber {
             "Did receive MetricKit metrics",
             attributes: [
                 "application_launch_time": launchTime,
+                "active_pre_warm": ProcessInfo.processInfo.environment["ActivePrewarm"] ?? "(null)",
+                "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
                 "delay": Date().timeIntervalSince(timestamp),
                 "payloads": MetricEncodable(metrics)
             ]
@@ -570,6 +581,7 @@ private class MetricMonitor: NSObject, MXMetricManagerSubscriber {
         InternalMonitoringFeature.instance?.monitor.sdkLogger.info(
             "Did receive MetricKit diagnostics",
             attributes: [
+                "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
                 "delay": Date().timeIntervalSince(timestamp),
                 "payloads": MetricEncodable(diagnostics)
             ]


### PR DESCRIPTION
### What and why?

Targeting 🐶 Dogfooding.

Log `ActivePrewarm` process variable while monitoring `MetricKit` with internal monitoring. This attribute will help us in deciding how we can leverage this value when reporting Application Launch Time.

### Review checklist

- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
