### PR TITLE
RUMM-1649 Fix: WebRUMEvent date offset in Ms

### DIFF
--- a/Sources/Datadog/FeaturesIntegration/WebView/WebRUMEventConsumer.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WebRUMEventConsumer.swift
@@ -55,8 +55,8 @@ internal class DefaultWebRUMEventConsumer: WebRUMEventConsumer {
 
         if let date = mutableEvent["date"] as? Int {
             let viewID = (mutableEvent["view"] as? JSON)?["id"] as? String
-            let serverTimeOffsetInNs = getOffset(viewID: viewID)
-            let correctedDate = Int64(date) + serverTimeOffsetInNs
+            let serverTimeOffsetInMs = getOffsetInMs(viewID: viewID)
+            let correctedDate = Int64(date) + serverTimeOffsetInMs
             mutableEvent["date"] = correctedDate
         }
 
@@ -87,7 +87,7 @@ internal class DefaultWebRUMEventConsumer: WebRUMEventConsumer {
     private typealias ViewIDOffsetPair = (viewID: String, offset: Offset)
     private var viewIDOffsetPairs = [ViewIDOffsetPair]()
 
-    private func getOffset(viewID: String?) -> Offset {
+    private func getOffsetInMs(viewID: String?) -> Offset {
         guard let viewID = viewID else {
             return 0
         }
@@ -97,7 +97,7 @@ internal class DefaultWebRUMEventConsumer: WebRUMEventConsumer {
         if let found = found {
             return found.offset
         }
-        let offset = dateCorrector.currentCorrection.serverTimeOffset.toInt64Nanoseconds
+        let offset = dateCorrector.currentCorrection.serverTimeOffset.toInt64Milliseconds
         viewIDOffsetPairs.insert((viewID: viewID, offset: offset), at: 0)
         return offset
     }

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WebRUMEventConsumerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WebRUMEventConsumerTests.swift
@@ -45,7 +45,7 @@ class WebRUMEventConsumerTests: XCTestCase {
                 "session": ["plan": 1]
             ],
             "application": ["id": mockContextProvider.context.rumApplicationID],
-            "date": 1_640_252_823_292 + 123.toInt64Nanoseconds,
+            "date": 1_640_252_823_292 + 123.toInt64Milliseconds,
             "service": "shopist-web-ui",
             "session": ["id": mockContextProvider.context.sessionID.toRUMDataFormat],
             "view": [


### PR DESCRIPTION
### What and why?

`WebRUMEvent` dates were being corrected with time offsets in nanoseconds.
That resulted in dropped events as the date format is in milliseconds.

### How?

Time offsets format is changed to milliseconds, now the events are visible in Datadog UI.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
