### PR TITLE
Update to version 1.1.0 of testing framework

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog.xcscheme
@@ -111,6 +111,16 @@
             value = "$(BITRISE_BUILD_URL)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDOUT_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDERR_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <CodeCoverageTargets>
          <BuildableReference

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
@@ -146,6 +146,16 @@
             value = "$(BITRISE_BUILD_URL)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDOUT_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDERR_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <Testables>
          <TestableReference

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting.xcscheme
@@ -166,6 +166,16 @@
             value = "$(GIT_CLONE_COMMIT_COMMITER_EMAIL)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDOUT_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDERR_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <CodeCoverageTargets>
          <BuildableReference

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc.xcscheme
@@ -105,6 +105,16 @@
             value = "$(BITRISE_BUILD_URL)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDOUT_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "DD_ENABLE_STDERR_INSTRUMENTATION"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <CodeCoverageTargets>
          <BuildableReference

--- a/Datadog/TargetSupport/DatadogIntegrationTests/DatadogIntegrationTests.xctestplan
+++ b/Datadog/TargetSupport/DatadogIntegrationTests/DatadogIntegrationTests.xctestplan
@@ -4,6 +4,68 @@
       "id" : "D87CA41D-8EBB-4809-AC70-E3B8317FAAC7",
       "name" : "TSAN",
       "options" : {
+        "environmentVariableEntries" : [
+          {
+            "key" : "DD_TEST_RUNNER",
+            "value" : "$(DD_TEST_RUNNER)"
+          },
+          {
+            "key" : "DATADOG_CLIENT_TOKEN",
+            "value" : "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+          },
+          {
+            "key" : "DD_ENV",
+            "value" : "$(DD_SDK_SWIFT_TESTING_ENV)"
+          },
+          {
+            "key" : "DD_SERVICE",
+            "value" : "$(DD_SDK_SWIFT_TESTING_SERVICE)"
+          },
+          {
+            "key" : "DD_DISABLE_SDKIOS_INTEGRATION",
+            "value" : "1"
+          },
+          {
+            "key" : "DD_DISABLE_HEADERS_INJECTION",
+            "value" : "1"
+          },
+          {
+            "key" : "DD_ENABLE_RECORD_PAYLOAD",
+            "value" : "1"
+          },
+          {
+            "key" : "SRCROOT",
+            "value" : "$(SRCROOT)"
+          },
+          {
+            "key" : "BITRISE_SOURCE_DIR",
+            "value" : "$(BITRISE_SOURCE_DIR)"
+          },
+          {
+            "key" : "BITRISE_TRIGGERED_WORKFLOW_ID",
+            "value" : "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
+          },
+          {
+            "key" : "BITRISE_BUILD_SLUG",
+            "value" : "$(BITRISE_BUILD_SLUG)"
+          },
+          {
+            "key" : "BITRISE_BUILD_NUMBER",
+            "value" : "$(BITRISE_BUILD_NUMBER)"
+          },
+          {
+            "key" : "BITRISE_BUILD_URL",
+            "value" : "$(BITRISE_BUILD_URL)"
+          },
+          {
+            "key" : "DD_ENABLE_STDOUT_INSTRUMENTATION",
+            "value" : "1"
+          },
+          {
+            "key" : "DD_ENABLE_STDERR_INSTRUMENTATION",
+            "value" : "1"
+          }
+        ],
         "threadSanitizerEnabled" : true
       }
     }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: dependencies xcodeproj-httpservermock templates
 
 # The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
-DD_SDK_SWIFT_TESTING_VERSION = 1.0.3-beta.1
+DD_SDK_SWIFT_TESTING_VERSION = 1.1.0
 
 define DD_SDK_TESTING_XCCONFIG_CI
 FRAMEWORK_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n


### PR DESCRIPTION
### What and why?

Update to version 1.1.0 of testing framework 

### How?

Update the version in Makefile
Update test targets so they keep the previous behaviour (Stdout and Stderr capturing must be explicitly activated now)

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
