### PR TITLE
RUMM-1924 Fix bug with WebView logs not appearing in Logs Explorer

### DIFF
--- a/Datadog/Example/Debugging/DebugWebviewViewController.swift
+++ b/Datadog/Example/Debugging/DebugWebviewViewController.swift
@@ -85,7 +85,7 @@ class WebviewViewController: UIViewController {
         super.viewDidLoad()
 
         let controller = WKUserContentController()
-        controller.addDatadogMessageHandler(allowedWebViewHosts: ["datadoghq.dev"])
+        controller.addDatadogMessageHandler(allowedWebViewHosts: [request.url!.host!])
         let config = WKWebViewConfiguration()
         config.userContentController = controller
 

--- a/Sources/Datadog/FeaturesIntegration/WebView/WebLogEventConsumer.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WebLogEventConsumer.swift
@@ -60,10 +60,10 @@ internal class DefaultWebLogEventConsumer: WebLogEventConsumer {
             mutableEvent[Constants.ddTagsKey] = ddTags
         }
 
-        if let date = mutableEvent[Constants.dateKey] as? Int {
-            let serverTimeOffsetInNs = dateCorrector.currentCorrection.serverTimeOffset.toInt64Nanoseconds
-            let correctedDate = Int64(date) + serverTimeOffsetInNs
-            mutableEvent[Constants.dateKey] = correctedDate
+        if let timestampInMs = mutableEvent[Constants.dateKey] as? Int {
+            let serverTimeOffsetInMs = dateCorrector.currentCorrection.serverTimeOffset.toInt64Milliseconds
+            let correctedTimestamp = Int64(timestampInMs) + serverTimeOffsetInMs
+            mutableEvent[Constants.dateKey] = correctedTimestamp
         }
 
         if let context = rumContextProvider?.context {

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WebLogEventConsumerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WebLogEventConsumerTests.swift
@@ -14,7 +14,7 @@ class WebLogEventConsumerTests: XCTestCase {
     let mockContextProvider = RUMContextProviderMock(context: .mockWith(rumApplicationID: "123456"))
 
     func testWhenValidWebLogEventPassed_itDecoratesAndPassesToWriter() throws {
-        let mockSessionID = UUID(uuidString: "e9796469-c2a1-43d6-b0f6-65c47d33cf5f")!
+        let mockSessionID: UUID = .mockRandom()
         mockContextProvider.context.sessionID = RUMUUID(rawValue: mockSessionID)
         mockDateCorrector.correctionOffset = 123
         let applicationVersion = String.mockRandom()
@@ -37,7 +37,7 @@ class WebLogEventConsumerTests: XCTestCase {
             "view": ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"]
         ]
         let expectedWebLogEvent: JSON = [
-            "date": 1_635_932_927_012 + 123.toInt64Nanoseconds,
+            "date": 1_635_932_927_012 + 123.toInt64Milliseconds,
             "error": ["origin": "console"],
             "message": "console error: error",
             "application_id": "123456",
@@ -58,7 +58,7 @@ class WebLogEventConsumerTests: XCTestCase {
     }
 
     func testWhenValidWebInternalLogEventPassed_itDecoratesAndPassesToWriter() throws {
-        let mockSessionID = UUID(uuidString: "e9796469-c2a1-43d6-b0f6-65c47d33cf5f")!
+        let mockSessionID: UUID = .mockRandom()
         mockContextProvider.context.sessionID = RUMUUID(rawValue: mockSessionID)
         mockDateCorrector.correctionOffset = 123
         let applicationVersion = String.mockRandom()
@@ -81,7 +81,7 @@ class WebLogEventConsumerTests: XCTestCase {
             "view": ["referrer": "", "url": "https://datadoghq.dev/browser-sdk-test-playground"]
         ]
         let expectedWebLogEvent: JSON = [
-            "date": 1_635_932_927_012 + 123.toInt64Nanoseconds,
+            "date": 1_635_932_927_012 + 123.toInt64Milliseconds,
             "error": ["origin": "console"],
             "message": "console error: error",
             "application_id": "123456",


### PR DESCRIPTION
### What and why?

🐞 This PR fixes bug with WebView logs processing. Due to wrong date correction, WebView logs were rejected by BE.

### How?

Correction logic was using `ns`, instead of `ms`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
