### PR TITLE
RUMM-1883 Report binary image with no UUID

### DIFF
--- a/Sources/DatadogCrashReporting/PLCrashReporterIntegration/DDCrashReportExporter.swift
+++ b/Sources/DatadogCrashReporting/PLCrashReporterIntegration/DDCrashReportExporter.swift
@@ -150,7 +150,7 @@ internal struct DDCrashReportExporter {
 
             return DDCrashReport.BinaryImage(
                 libraryName: image.imageName,
-                uuid: image.uuid,
+                uuid: image.uuid ?? unavailable,
                 architecture: image.codeType?.architectureName ?? unavailable,
                 isSystemLibrary: image.isSystemImage,
                 loadAddress: loadAddressHex,

--- a/Tests/DatadogCrashReportingTests/Mocks.swift
+++ b/Tests/DatadogCrashReportingTests/Mocks.swift
@@ -252,7 +252,7 @@ extension ThreadInfo {
 
 extension BinaryImageInfo {
     static func mockWith(
-        uuid: String = .mockAny(),
+        uuid: String? = .mockAny(),
         imageName: String = .mockAny(),
         isSystemImage: Bool = .random(),
         architectureName: String? = .mockAny(),

--- a/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
+++ b/Tests/DatadogCrashReportingTests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
@@ -275,6 +275,17 @@ class DDCrashReportExporterTests: XCTestCase {
         }
     }
 
+    func testExportingBinaryImageWhenUUIDIsUnavailable() {
+        // Given
+        crashReport.binaryImages = [.mockWith(uuid: nil)]
+
+        // When
+        let exportedImages = exporter.export(crashReport).binaryImages
+
+        // Then
+        XCTAssertEqual(exportedImages.first?.uuid, "???")
+    }
+
     func testExportingBinaryImageAddressRange() throws {
         let randomImageLoadAddress: UInt64 = .mockRandom()
         let randomImageSize: UInt64 = .mockRandom()


### PR DESCRIPTION
### What and why?

Stack frames in crash report could be reported as `???` if PLCR could not find the image or if the image's UUID is missing. To identify the root cause, we should keep reporting binary images without UUID.

### How?

- Set `StackFrame.libraryName` even for binary image with no UUID
- Allow optional `uuid` in `BinaryImageInfo`

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
