### PR TITLE
RUMM-1926 Do not print warning when receiving 'keep alive' command in WebView tracking

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -146,14 +146,16 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             case .handleInBackgroundView where command.canStartBackgroundView:
                 startBackgroundView(on: command)
             default:
-                // As no view scope will handle this command, warn the user on dropping it
-                userLogger.warn(
-                    """
-                    \(String(describing: command)) was detected, but no view is active. To track views automatically, try calling the
-                    DatadogConfiguration.Builder.trackUIKitRUMViews() method. You can also track views manually using
-                    the RumMonitor.startView() and RumMonitor.stopView() methods.
-                    """
-                )
+                if !(command is RUMKeepSessionAliveCommand) { // it is expected to receive 'keep alive' while no active view (when tracking WebView events)
+                    // As no view scope will handle this command, warn the user on dropping it.
+                    userLogger.warn(
+                        """
+                        \(String(describing: command)) was detected, but no view is active. To track views automatically, try calling the
+                        DatadogConfiguration.Builder.trackUIKitRUMViews() method. You can also track views manually using
+                        the RumMonitor.startView() and RumMonitor.stopView() methods.
+                        """
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
### What and why?

📦 This PR fixes an issue in reporting user warnings to debugger console. If SDK receives particular RUM commands while no RUM view is active, [it print a warning](https://github.com/DataDog/dd-sdk-ios/blob/744191cb1f52a7db952f1011652fa63de93daa82/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift#L150-L156) to user console, saying that event will be lost.

With the addition of `RUMKeepSessionAliveCommand`, this gives false-positives if tracking WebView events while no view is active in native code. In result, it spams the user console on each event received from Browser SDK:
```
[DATADOG SDK] 🐶 → 17:29:41.186 [WARN] RUMKeepSessionAliveCommand(canStartBackgroundView: false, canStartApplicationLaunchView: false, time: 2022-01-18 16:29:41 +0000, attributes: [:]) was detected, but no view is active. To track views automatically, try calling the
DatadogConfiguration.Builder.trackUIKitRUMViews() method. You can also track views manually using
the RumMonitor.startView() and RumMonitor.stopView() methods.
[DATADOG SDK] 🐶 → 17:29:41.187 [WARN] RUMKeepSessionAliveCommand(canStartBackgroundView: false, canStartApplicationLaunchView: false, time: 2022-01-18 16:29:41 +0000, attributes: [:]) was detected, but no view is active. To track views automatically, try calling the
DatadogConfiguration.Builder.trackUIKitRUMViews() method. You can also track views manually using
the RumMonitor.startView() and RumMonitor.stopView() methods.
[DATADOG SDK] 🐶 → 17:29:42.744 [WARN] RUMKeepSessionAliveCommand(canStartBackgroundView: false, canStartApplicationLaunchView: false, time: 2022-01-18 16:29:42 +0000, attributes: [:]) was detected, but no view is active. To track views automatically, try calling the
DatadogConfiguration.Builder.trackUIKitRUMViews() method. You can also track views manually using
the RumMonitor.startView() and RumMonitor.stopView() methods.
```

### How?

Added basic condition to skip warning on `RUMKeepSessionAliveCommand`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
