### PR TITLE
RUMM-1911 Prepare WebView tracking for dogfooding

### DIFF
--- a/Datadog/Example/Debugging/DebugWebviewViewController.swift
+++ b/Datadog/Example/Debugging/DebugWebviewViewController.swift
@@ -85,7 +85,7 @@ class WebviewViewController: UIViewController {
         super.viewDidLoad()
 
         let controller = WKUserContentController()
-        controller.addDatadogMessageHandler(allowedWebViewHosts: [request.url!.host!])
+        controller.trackDatadogEvents(in: [request.url!.host!])
         let config = WKWebViewConfiguration()
         config.userContentController = controller
 

--- a/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
+++ b/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
@@ -28,7 +28,7 @@ class ShopistWebviewViewController: UIViewController {
         super.viewDidLoad()
 
         let controller = WKUserContentController()
-        controller.addDatadogMessageHandler(allowedWebViewHosts: ["shopist.io"])
+        controller.trackDatadogEvents(in: ["shopist.io"])
         let config = WKWebViewConfiguration()
         config.userContentController = controller
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ export DD_SDK_TESTING_XCCONFIG_CI
 define DD_SDK_BASE_XCCONFIG
 // Active compilation conditions - only enabled on local machine:\n
 // - DD_SDK_ENABLE_INTERNAL_MONITORING - enables Internal Monitoring APIs\n
+// - DD_SDK_ENABLE_EXPERIMENTAL_APIS - enables APIs which are not available in released version of the SDK\n
 // - DD_SDK_COMPILED_FOR_TESTING - conditions the SDK code compiled for testing\n
-SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) DD_SDK_ENABLE_INTERNAL_MONITORING DD_SDK_COMPILED_FOR_TESTING\n
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) DD_SDK_ENABLE_INTERNAL_MONITORING DD_SDK_ENABLE_EXPERIMENTAL_APIS DD_SDK_COMPILED_FOR_TESTING\n
 \n
 // To build only active architecture for all configurations. This gives us ~10% build time gain\n
 // in targets which do not use 'Debug' configuration.\n

--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -8,13 +8,18 @@
 import Foundation
 import WebKit
 
-// TODO: RUMM-1794 rename the methods
 public extension WKUserContentController {
-    func addDatadogMessageHandler(allowedWebViewHosts: Set<String>) {
-        __addDatadogMessageHandler(allowedWebViewHosts: allowedWebViewHosts, hostsSanitizer: HostsSanitizer())
+    /// Enables SDK to correlate Datadog RUM events and Logs from the WebView with native RUM session.
+    ///
+    /// If the content loaded in WebView uses Datadog Browser SDK (`v4.2.0+`) and matches specified `hosts`, web events will be correlated
+    /// with the RUM session from native SDK.
+    ///
+    /// - Parameter hosts: a list of hosts instrumented with Browser SDK to capture Datadog events from
+    func trackDatadogEvents(in hosts: Set<String>) {
+        addDatadogMessageHandler(allowedWebViewHosts: hosts, hostsSanitizer: HostsSanitizer())
     }
 
-    internal func __addDatadogMessageHandler(allowedWebViewHosts: Set<String>, hostsSanitizer: HostsSanitizing) {
+    internal func addDatadogMessageHandler(allowedWebViewHosts: Set<String>, hostsSanitizer: HostsSanitizing) {
         let bridgeName = DatadogMessageHandler.name
 
         let globalRUMMonitor = Global.rum as? RUMMonitor

--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -4,6 +4,7 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
+#if DD_SDK_ENABLE_EXPERIMENTAL_APIS
 import Foundation
 import WebKit
 
@@ -109,3 +110,4 @@ internal class DatadogMessageHandler: NSObject, WKScriptMessageHandler {
         }
     }
 }
+#endif

--- a/Tests/DatadogIntegrationTests/Scenarios/WebView/WebViewScenarioTest.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/WebView/WebViewScenarioTest.swift
@@ -58,14 +58,14 @@ class WebViewScenarioTest: IntegrationTests, RUMCommonAsserts {
             XCTAssertEqual(browserViewEvent.application.id, expectedBrowserRUMApplicationID, "Webview events should use iOS SDK application ID")
             XCTAssertEqual(browserViewEvent.session.id, expectedBrowserSessionID, "Webview events should use iOS SDK session ID")
             XCTAssertEqual(browserViewEvent.service, expectedBrowserServiceName, "Webview events should use Browser SDK `service`")
-            XCTAssertNotEqual(browserViewEvent.source, .ios, "Webview events should use Browser SDK `source`")
+            XCTAssertEqual(browserViewEvent.source, .browser, "Webview events should use Browser SDK `source`")
         }
         XCTAssertGreaterThan(browserView.resourceEvents.count, 0, "It should track some Webview resources")
         browserView.resourceEvents.forEach { browserResourceEvent in
             XCTAssertEqual(browserResourceEvent.application.id, expectedBrowserRUMApplicationID, "Webview events should use iOS SDK application ID")
             XCTAssertEqual(browserResourceEvent.session.id, expectedBrowserSessionID, "Webview events should use iOS SDK session ID")
             XCTAssertEqual(browserResourceEvent.service, expectedBrowserServiceName, "Webview events should use Browser SDK `service`")
-            XCTAssertNotEqual(browserResourceEvent.source, .ios, "Webview events should use Browser SDK `source`")
+            XCTAssertEqual(browserResourceEvent.source, .browser, "Webview events should use Browser SDK `source`")
         }
 
         // Get `LogMatchers`

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -50,7 +50,7 @@ class WKUserContentController_DatadogTests: XCTestCase {
 
         let initialUserScriptCount = controller.userScripts.count
 
-        controller.__addDatadogMessageHandler(allowedWebViewHosts: ["datadoghq.com"], hostsSanitizer: mockSanitizer)
+        controller.addDatadogMessageHandler(allowedWebViewHosts: ["datadoghq.com"], hostsSanitizer: mockSanitizer)
 
         XCTAssertEqual(controller.userScripts.count, initialUserScriptCount + 1)
         XCTAssertEqual(controller.messageHandlers.map({ $0.name }), ["DatadogEventBridge"])
@@ -68,7 +68,7 @@ class WKUserContentController_DatadogTests: XCTestCase {
         userLogger = .mockWith(logOutput: output)
 
         let controller = DDUserContentController()
-        controller.__addDatadogMessageHandler(allowedWebViewHosts: ["datadoghq.com"], hostsSanitizer: MockHostsSanitizer())
+        controller.addDatadogMessageHandler(allowedWebViewHosts: ["datadoghq.com"], hostsSanitizer: MockHostsSanitizer())
 
         let messageHandler = try XCTUnwrap(controller.messageHandlers.first?.handler) as? DatadogMessageHandler
         // non-string body is passed
@@ -111,7 +111,7 @@ class WKUserContentController_DatadogTests: XCTestCase {
         }
 
         let controller = DDUserContentController()
-        controller.__addDatadogMessageHandler(
+        controller.addDatadogMessageHandler(
             allowedWebViewHosts: ["datadoghq.com"],
             hostsSanitizer: MockHostsSanitizer()
         )

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WebRUMEventConsumerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WebRUMEventConsumerTests.swift
@@ -7,7 +7,6 @@
 import XCTest
 @testable import Datadog
 
-// TODO: RUMM-1786 test mutations (session_id, application_id, date)
 class WebRUMEventConsumerTests: XCTestCase {
     let mockWriter = FileWriterMock()
     let mockDateCorrector = DateCorrectorMock()


### PR DESCRIPTION
### What and why?

📦 This PR adds last changes to `hybrid-application` branch to prepare it for dogfooding.

### How?

* Adjusted public API naming, added docs string comments;
* Resolved obsolete `TODOs`;

Additionally, it hides the entry code to WebView tracking behind `DD_SDK_ENABLE_EXPERIMENTAL_APIS` compiler flag. We used this feature flag successfully to disable Crash Reporting in #487. This will let us safely merge `hybrid-application` to `master` and further to `dogfooding`. This flag is defined in [`dogfooding/Package.swift`](https://github.com/DataDog/dd-sdk-ios/blob/ab6796174f8b9a80ea205b335430d1afe911fef5/Package.swift#L54) so the feature will be visible in dogfood projects.

⚠️ This will require adding `DD_SDK_ENABLE_EXPERIMENTAL_APIS` to `Base.local.xcconfig` for local development. This is automated as part of `make dependencies` for CI.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
