### PR TITLE
RUMM-1910 Strip query parameters from span resource

### DIFF
--- a/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
+++ b/Sources/Datadog/Tracing/AutoInstrumentation/URLSessionTracingHandler.swift
@@ -56,8 +56,14 @@ internal class URLSessionTracingHandler: URLSessionInterceptionHandler {
         }
 
         let url = interception.request.url?.absoluteString ?? "unknown_url"
+
+        if let requestUrl = interception.request.url {
+            var urlComponent = URLComponents(url: requestUrl, resolvingAgainstBaseURL: true)
+            urlComponent?.query = nil
+            let resourceUrl = urlComponent?.url?.absoluteString ?? "unknown_url"
+            span.setTag(key: DDTags.resource, value: resourceUrl)
+        }
         let method = interception.request.httpMethod ?? "unknown_method"
-        span.setTag(key: DDTags.resource, value: url)
         span.setTag(key: OTTags.httpUrl, value: url)
         span.setTag(key: OTTags.httpMethod, value: method)
 

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -175,6 +175,12 @@ extension URL: AnyMockable, RandomMockable {
         return URL(string: "https://www.foo.com/")!.appendingPathComponent(pathComponent)
     }
 
+    static func mockWith(url: String, queryParams: [URLQueryItem]) -> URL {
+        var urlComponents = URLComponents(string: url)
+        urlComponents!.queryItems = queryParams
+        return urlComponents!.url!
+    }
+
     static func mockRandom() -> URL {
         return URL(string: "https://www.foo.com/")!
             .appendingPathComponent(
@@ -409,6 +415,13 @@ extension URLRequest: AnyMockable {
 
     static func mockWith(httpMethod: String) -> URLRequest {
         var request = URLRequest(url: .mockAny())
+        request.httpMethod = httpMethod
+        return request
+    }
+
+    static func mockWith(url: String, queryParams: [URLQueryItem], httpMethod: String) -> URLRequest {
+        let url: URL = .mockWith(url: url, queryParams: queryParams)
+        var request = URLRequest(url: url)
         request.httpMethod = httpMethod
         return request
     }

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -113,7 +113,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
         spanOutput.onSpanRecorded = { _ in spanSentExpectation.fulfill() }
 
         // Given
-        let request: URLRequest = .mockWith(httpMethod: "GET")
+        let request: URLRequest = .mockWith(url: "https://www.example.com", queryParams: [URLQueryItem(name: "foo", value: "42"), URLQueryItem(name: "lang", value: "en")], httpMethod: "GET")
         let error = NSError(domain: "domain", code: 123, userInfo: [NSLocalizedDescriptionKey: "network error"])
         let interception = TaskInterception(request: request, isFirstParty: true)
         interception.register(completion: .mockWith(response: nil, error: error))
@@ -134,7 +134,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
 
         let span = try XCTUnwrap(spanOutput.lastRecordedSpan)
         XCTAssertEqual(span.operationName, "urlsession.request")
-        XCTAssertEqual(span.resource, request.url!.absoluteString)
+        XCTAssertEqual(span.resource, "https://www.example.com")
         XCTAssertEqual(span.duration, 30)
         XCTAssertTrue(span.isError)
         XCTAssertEqual(span.tags[OTTags.httpUrl], request.url!.absoluteString)


### PR DESCRIPTION
### What and why?

Spans have a limited number of unique resource values. Removing query parameters ensure we don't use too many unique slots, and aligns the iOS SDK with android and other APM implementations.