### PR TITLE
RUMM-1803 Consider UIApplication init as warm start measurement

### DIFF
--- a/Sources/_Datadog_Private/ObjcAppLaunchHandler.m
+++ b/Sources/_Datadog_Private/ObjcAppLaunchHandler.m
@@ -6,21 +6,28 @@
 
 #import "ObjcAppLaunchHandler.h"
 #import <sys/sysctl.h>
+#import <objc/runtime.h>
 #import <UIKit/UIKit.h>
 #import <pthread.h>
 
 // `AppLaunchHandler` aims to track some times as part of the sequence described in Apple's "About the App Launch Sequence"
 // https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence
 
+#define IS_ACTIVE_PREWARM [NSProcessInfo.processInfo.environment[@"ActivePrewarm"] isEqual:@"1"]
+
 // A Read-Write lock to allow concurrent reads of TimeToApplicationDidBecomeActive, unless the initial (and only) write is locking it.
 static pthread_rwlock_t rwLock;
 // The framework load time  in seconds relative to the absolute reference date of Jan 1 2001 00:00:00 GMT.
 static NSTimeInterval FrameworkLoadTime = 0.0;
-// The time interval between the application starts and it's responsive and accepts touch events.
-static NSTimeInterval TimeToApplicationDidBecomeActive = 0.0;
+// The time when UIApplicationMain instantiante UIApplication.
+static NSTimeInterval UIApplicationInstantiateSingletonTime = 0.0;
+// The time when receiving UIApplicationDidBecomeActiveNotification.
+static NSTimeInterval UIApplicationDidBecomeActiveNotificationTime = 0.0;
+// The cold start threshold in seconds. Launch Time greater than this threshold should be considered as
+// pre-warmed.
+static NSTimeInterval ColdStartThreshold = 20;
 
-NS_INLINE NSTimeInterval QueryProcessStartTimeWithFallback(NSTimeInterval fallbackTime) {
-    NSTimeInterval processStartTime;
+NS_INLINE NSTimeInterval ProcessStartTime() {
     // Query the current process' start time:
     // https://www.freebsd.org/cgi/man.cgi?sysctl(3)
     // https://github.com/darwin-on-arm/xnu/blob/707bfdc4e9a46e3612e53994fffc64542d3f7e72/bsd/sys/sysctl.h#L681
@@ -34,20 +41,14 @@ NS_INLINE NSTimeInterval QueryProcessStartTimeWithFallback(NSTimeInterval fallba
     if (res == 0) {
         // The process' start time is provided relative to 1 Jan 1970
         struct timeval startTime = kip.kp_proc.p_starttime;
-        processStartTime = startTime.tv_sec + startTime.tv_usec / USEC_PER_SEC;
+        NSTimeInterval processStartTime = startTime.tv_sec + startTime.tv_usec / USEC_PER_SEC;
         // Convert to time since 1 Jan 2001 to align with CFAbsoluteTimeGetCurrent()
         processStartTime -= kCFAbsoluteTimeIntervalSince1970;
-    } else {
-        // Fallback to less accurate delta with DD's framework load time
-        processStartTime = fallbackTime;
+        return processStartTime;
     }
-    return processStartTime;
-}
 
-NS_INLINE NSTimeInterval ComputeProcessTimeFromStart() {
-    NSTimeInterval now = CFAbsoluteTimeGetCurrent();
-    NSTimeInterval processStartTime = QueryProcessStartTimeWithFallback(FrameworkLoadTime);
-    return now - processStartTime;
+    // Fallback to less accurate delta with DD's framework load time
+    return FrameworkLoadTime;
 }
 
 @interface AppLaunchHandler : NSObject
@@ -56,32 +57,60 @@ NS_INLINE NSTimeInterval ComputeProcessTimeFromStart() {
 @implementation AppLaunchHandler
 
 + (void)load {
+    pthread_rwlock_init(&rwLock, NULL);
+
     // This is called at the `_Datadog_Private` load time, keep the work minimal
     FrameworkLoadTime = CFAbsoluteTimeGetCurrent();
 
     NSNotificationCenter * __weak center = NSNotificationCenter.defaultCenter;
-    id __block token = [center
-                        addObserverForName:UIApplicationDidBecomeActiveNotification
-                        object:nil
-                        queue:NSOperationQueue.mainQueue
-                        usingBlock:^(NSNotification *_){
-
-        pthread_rwlock_init(&rwLock, NULL);
+    id __weak __block token = [center addObserverForName:UIApplicationDidBecomeActiveNotification
+                                                  object:nil
+                                                   queue:NSOperationQueue.mainQueue
+                                              usingBlock:^(NSNotification *_){
         pthread_rwlock_wrlock(&rwLock);
-        TimeToApplicationDidBecomeActive = ComputeProcessTimeFromStart();
+        UIApplicationDidBecomeActiveNotificationTime = CFAbsoluteTimeGetCurrent();
         pthread_rwlock_unlock(&rwLock);
-
         [center removeObserver:token];
-        token = nil;
     }];
+}
+
+@end
+
+@implementation UIApplication (Tracking)
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        method_exchangeImplementations(
+            class_getInstanceMethod(self, @selector(init)),
+            class_getInstanceMethod(self, @selector(dd_init))
+        );
+    });
+}
+
+- (instancetype)dd_init {
+    pthread_rwlock_wrlock(&rwLock);
+    UIApplicationInstantiateSingletonTime = CFAbsoluteTimeGetCurrent();
+    pthread_rwlock_unlock(&rwLock);
+    // Invoke original init
+    return [self dd_init];
 }
 
 @end
 
 CFTimeInterval __dd_private_AppLaunchTime() {
     pthread_rwlock_rdlock(&rwLock);
-    CFTimeInterval time = TimeToApplicationDidBecomeActive;
-    if (time == 0) time = ComputeProcessTimeFromStart();
+
+    CFTimeInterval time = UIApplicationDidBecomeActiveNotificationTime;
+    if (!time) {
+        time = CFAbsoluteTimeGetCurrent();
+    }
+
+    NSTimeInterval launchTime = time - ProcessStartTime();
+    if (IS_ACTIVE_PREWARM || launchTime > ColdStartThreshold) {
+        launchTime = time - UIApplicationInstantiateSingletonTime;
+    }
+
     pthread_rwlock_unlock(&rwLock);
-    return time;
+    return launchTime;
 }


### PR DESCRIPTION
🚧  do not merge

### What and why?

Starting in iOS 15, the [pre-warm optimisation](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence) can start the application process hours before an actual launch. This new feature results in very long launch time measurement as we consider Application Launch Time as the interval between Process Start Time and `UIApplicationDidBecomeActiveNotification`.

Prewarming executes an app’s launch sequence up until, but not including, when `main()` calls `UIApplicationMain(_:_:_:_:)`. We need to define a new application starting point in time. In this proposal we measure the warm start time as when the `UIApplication` is initialised.

### How?

To measure the point time when the `UIApplication` is initialised by `UIApplicationMain`, this proposal implement swizzling on `UIApplication.init` to record the time it get invoked.

To differentiate between a cold and a warm start we can either use a time interval threshold, or use this - not documented - yet to be validated - process variable:
```objective-c
#define IS_ACTIVE_PREWARM [NSProcessInfo.processInfo.environment[@"ActivePrewarm"] isEqual:@"1"]
```
This variable is currently being evaluated in dogfooding.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
