### PR TITLE
RUMM-1911 Fix compilation issue in nightly tests (macOS Catalina)

### DIFF
--- a/Sources/Datadog/FeaturesIntegration/WebView/WebEventBridge.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WebEventBridge.swift
@@ -39,9 +39,9 @@ internal class WebEventBridge {
         self.rumEventConsumer = rumEventConsumer
     }
 
-    func consume(_ message: Any) throws {
-        guard let message = message as? String else {
-            throw WebEventError.invalidMessage(description: String(describing: message))
+    func consume(_ anyMessage: Any) throws {
+        guard let message = anyMessage as? String else {
+            throw WebEventError.invalidMessage(description: String(describing: anyMessage))
         }
         let eventJSON = try parse(message)
         guard let eventType = eventJSON[Constants.eventTypeKey] as? String else {


### PR DESCRIPTION
### What and why?

📦 This PR fixes compiler issue in nightly tests (Xcode 12.4 x macOS Catalina):
```
▸ Compiling WebEventBridge.swift
❌  /Users/vagrant/git/Sources/Datadog/FeaturesIntegration/WebView/WebEventBridge.swift:44:80: variable declared in 'guard' condition is not usable in its body
            throw WebEventError.invalidMessage(description: String(describing: message))
                                                                               ^
```

### How?

I just renamed this parameter to make it distinct in guard's scope.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
