### PR TITLE
RUMM-1934 Add option for including Xcode version in produced GH asset

### DIFF
--- a/tools/distribution/release.py
+++ b/tools/distribution/release.py
@@ -44,6 +44,12 @@ if __name__ == "__main__":
         default=os.environ.get('DD_RELEASE_OVERWRITE_GITHUB') == '1'
     )
     parser.add_argument(
+        "--add-xcode-version-to-github-asset",
+        action='store_true',
+        help="Add Xcode version to the GH Release asset.",
+        default=os.environ.get('DD_ADD_XCODE_VERSION_TO_GITHUB_ASSET') == '1'
+    )
+    parser.add_argument(
         "--dry-run",
         action='store_true',
         help="Run validation but skip publishing.",
@@ -56,6 +62,7 @@ if __name__ == "__main__":
         only_github = True if args.only_github else False
         only_cocoapods = True if args.only_cocoapods else False
         overwrite_github = True if args.overwrite_github else False
+        add_xcode_version_to_github_asset = True if args.add_xcode_version_to_github_asset else False
         dry_run = True if args.dry_run else False
 
         # Validate arguments:
@@ -65,24 +72,29 @@ if __name__ == "__main__":
         if only_cocoapods and overwrite_github:
             raise Exception('`--overwrite-github` and `--only-cocoapods` cannot be used together.')
 
+        if only_cocoapods and add_xcode_version_to_github_asset:
+            raise Exception('--add-xcode-version-to-github-asset` and `--only-cocoapods` cannot be used together.')
+
         tag_regex = r'^[0-9]+\.[0-9]+\.[0-9]+(\-(alpha|beta|rc)[0-9]+)?$'
         if not re.match(tag_regex, git_tag):
             raise Exception(f'Given git tag ("{git_tag}") seems invalid (it must match "{tag_regex}")')
 
         print(f'🛠️️ ENV:\n'
-              f'- BITRISE_GIT_TAG                = {os.environ.get("BITRISE_GIT_TAG")}\n'
-              f'- DD_RELEASE_GIT_TAG             = {os.environ.get("DD_RELEASE_GIT_TAG")}\n'
-              f'- DD_RELEASE_ONLY_GITHUB         = {os.environ.get("DD_RELEASE_ONLY_GITHUB")}\n'
-              f'- DD_RELEASE_ONLY_COCOAPODS      = {os.environ.get("DD_RELEASE_ONLY_COCOAPODS")}\n'
-              f'- DD_RELEASE_OVERWRITE_GITHUB    = {os.environ.get("DD_RELEASE_OVERWRITE_GITHUB")}\n'
-              f'- DD_RELEASE_DRY_RUN             = {os.environ.get("DD_RELEASE_DRY_RUN")}')
+              f'- BITRISE_GIT_TAG                       = {os.environ.get("BITRISE_GIT_TAG")}\n'
+              f'- DD_RELEASE_GIT_TAG                    = {os.environ.get("DD_RELEASE_GIT_TAG")}\n'
+              f'- DD_RELEASE_ONLY_GITHUB                = {os.environ.get("DD_RELEASE_ONLY_GITHUB")}\n'
+              f'- DD_RELEASE_ONLY_COCOAPODS             = {os.environ.get("DD_RELEASE_ONLY_COCOAPODS")}\n'
+              f'- DD_RELEASE_OVERWRITE_GITHUB           = {os.environ.get("DD_RELEASE_OVERWRITE_GITHUB")}\n'
+              f'- DD_ADD_XCODE_VERSION_TO_GITHUB_ASSET  = {os.environ.get("DD_ADD_XCODE_VERSION_TO_GITHUB_ASSET")}\n'
+              f'- DD_RELEASE_DRY_RUN                    = {os.environ.get("DD_RELEASE_DRY_RUN")}')
 
         print(f'🛠️️ ENV and CLI arguments resolved to:\n'
-              f'- git_tag           = {git_tag}\n'
-              f'- only_github       = {only_github}\n'
-              f'- only_cocoapods    = {only_cocoapods}\n'
-              f'- overwrite_github  = {overwrite_github}\n'
-              f'- dry_run           = {dry_run}.')
+              f'- git_tag                            = {git_tag}\n'
+              f'- only_github                        = {only_github}\n'
+              f'- only_cocoapods                     = {only_cocoapods}\n'
+              f'- overwrite_github                   = {overwrite_github}\n'
+              f'- add_xcode_version_to_github_asset  = {add_xcode_version_to_github_asset}\n'
+              f'- dry_run                            = {dry_run}.')
 
         print(f'🛠️ Git tag read to version: {Version.parse(git_tag)}')
 
@@ -101,7 +113,7 @@ if __name__ == "__main__":
 
             # Publish GH Release asset:
             if publish_to_gh:
-                gh_asset = GHAsset()
+                gh_asset = GHAsset(add_xcode_version=add_xcode_version_to_github_asset)
                 gh_asset.validate(git_tag=git_tag)
                 gh_asset.publish(git_tag=git_tag, overwrite_existing=overwrite_github, dry_run=dry_run)
 

--- a/tools/distribution/src/assets/gh_asset.py
+++ b/tools/distribution/src/assets/gh_asset.py
@@ -10,7 +10,7 @@
 import os
 import glob
 from tempfile import TemporaryDirectory, NamedTemporaryFile
-from src.utils import remember_cwd, shell, read_sdk_version
+from src.utils import remember_cwd, shell, read_sdk_version, read_xcode_version
 from src.directory_matcher import DirectoryMatcher
 from src.semver import Version
 
@@ -150,7 +150,7 @@ class GHAsset:
 
     __path: str  # The path to the asset `.zip` archive
 
-    def __init__(self):
+    def __init__(self, add_xcode_version: bool):
         print(f'⌛️️️ Creating the GH release asset from {os.getcwd()}')
 
         with NamedTemporaryFile(mode='w+', prefix='dd-gh-distro-', suffix='.xcconfig') as xcconfig:
@@ -166,7 +166,13 @@ class GHAsset:
 
         # Create `.zip` archive:
         zip_archive_name = f'Datadog-{read_sdk_version()}.zip'
+
+        if add_xcode_version:
+            xc_version = read_xcode_version().replace(' ', '-')
+            zip_archive_name = f'Datadog-{read_sdk_version()}-Xcode-{xc_version}.zip'
+
         with remember_cwd():
+            print(f'   → Creating GH asset: {zip_archive_name}')
             os.chdir('Carthage/Build')
             shell(f'zip -q --symlinks -r {zip_archive_name} *.xcframework')
 


### PR DESCRIPTION
### What and why?

📦 This PR adds an option to our distribution tool for including the Xcode version in produced GH assets. This is required as due to a 🐞 bug in Swift compiler (https://bugs.swift.org/browse/SR-14195) we can't produce truly portable XCFrameworks - the `.swiftinterface` emitted for [Module Stability](https://www.swift.org/blog/abi-stability-and-more/) of `Datadog.xcframework` is ambiguous (more on this in `RUMM-1934` JIRA).

The idea is to use this flag and produce multiple GH Assets for each release:
* `Datadog-x.y.z.zip` - built with recent version of Xcode;
* `Datadog-x.y.z-Xcode-a.b.c.zip` - built with previous version of Xcode;
* `...` - same for reasonable number of previous Xcode versions.

The existing `--overwrite-github` option in `release.py` will allow us to overwrite existing assets.

### How?

Added `--add-xcode-version-to-github-asset` option to `release.py`:
* it defaults to `False` and produces `Datadog-x.y.z.zip` asset;
* if set to `True` it will produce `Datadog-x.y.z-Xcode-a.b.c.zip` asset.

A counterpart `DD_ADD_XCODE_VERSION_TO_GITHUB_ASSET` ENV variable will allow us running the tool remotely on CI. Using different Bitrise stacks will let us produce XCFrameworks with different Xcode versions.

Tested with `--dry-run`:
```
$ release.py 1.8.0 --dry-run --only-github --add-xcode-version-to-github-asset
...
📦️️ Publishing [GHAsset: path = /private/var/folders/4p/_mspg7ld7298z4qkrf_66my40000gn/T/tmpxv5167h0/dd-sdk-ios/Carthage/Build/Datadog-1.8.0-Xcode-13.2.1.zip] to GH Release tag 1.8.0
   → running `gh release upload 1.8.0 /private/var/folders/4p/_mspg7ld7298z4qkrf_66my40000gn/T/tmpxv5167h0/dd-sdk-ios/Carthage/Build/Datadog-1.8.0-Xcode-13.2.1.zip --repo DataDog/dd-sdk-ios` - ⚡️ skipped (dry_run)
   → succeeded
✅️️ All good.


$ release.py 1.8.0 --dry-run --only-github
...
📦️️ Publishing [GHAsset: path = /private/var/folders/4p/_mspg7ld7298z4qkrf_66my40000gn/T/tmpgtrma3ra/dd-sdk-ios/Carthage/Build/Datadog-1.8.0.zip] to GH Release tag 1.8.0
   → running `gh release upload 1.8.0 /private/var/folders/4p/_mspg7ld7298z4qkrf_66my40000gn/T/tmpgtrma3ra/dd-sdk-ios/Carthage/Build/Datadog-1.8.0.zip --repo DataDog/dd-sdk-ios` - ⚡️ skipped (dry_run)
   → succeeded
✅️️ All good.
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
