### PR TITLE
Release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 1.9.0 / 01-26-2022
+
+### Changes
+
+* [BUGFIX] Strip query parameters from span resource. See [#728][]
+* [BUGFIX] Report binary image with no UUID. See [#724][]
+* [FEATURE] Add Application Launch events tracking. See [#699][]
+* [FEATURE] Set `PLCrashReporter` custom path. See [#692][]
+* [FEATURE] `SwiftUI` Instrumentation. See [#676][]
+* [IMPROVEMENT] Embed Kronos. See [#708][]
+* [IMPROVEMENT] Add `@service` attribute to all RUM events. See [#725][]
+* [IMPROVEMENT] Adds support for flutter error source. See [#715][]
+* [IMPROVEMENT] Add crash reporting console logs. See [#712][]
+* [IMPROVEMENT] Keep view active until all resources are consumed. See [#702][]
+* [IMPROVEMENT] Allow passing in a type for errors sent with a message. See [#680][] (Thanks [@AvdLee][])
+* [IMPROVEMENT] Add config overrides for debug launch arguments. See [#679][]
+
 # 1.8.0 / 11-23-2021
 
 ### Changes
@@ -290,6 +307,18 @@
 [#644]: https://github.com/DataDog/dd-sdk-ios/issues/644
 [#654]: https://github.com/DataDog/dd-sdk-ios/issues/654
 [#655]: https://github.com/DataDog/dd-sdk-ios/issues/655
+[#676]: https://github.com/DataDog/dd-sdk-ios/issues/676
+[#679]: https://github.com/DataDog/dd-sdk-ios/issues/679
+[#680]: https://github.com/DataDog/dd-sdk-ios/issues/680
+[#692]: https://github.com/DataDog/dd-sdk-ios/issues/692
+[#699]: https://github.com/DataDog/dd-sdk-ios/issues/699
+[#702]: https://github.com/DataDog/dd-sdk-ios/issues/702
+[#708]: https://github.com/DataDog/dd-sdk-ios/issues/708
+[#712]: https://github.com/DataDog/dd-sdk-ios/issues/712
+[#715]: https://github.com/DataDog/dd-sdk-ios/issues/715
+[#724]: https://github.com/DataDog/dd-sdk-ios/issues/724
+[#725]: https://github.com/DataDog/dd-sdk-ios/issues/725
+[#728]: https://github.com/DataDog/dd-sdk-ios/issues/728
 [@00FA9A]: https://github.com/00FA9A
 [@Britton-Earnin]: https://github.com/Britton-Earnin
 [@Hengyu]: https://github.com/Hengyu
@@ -314,3 +343,4 @@
 [@provTheodoreNewell]: https://github.com/provTheodoreNewell
 [@safa-ads]: https://github.com/safa-ads
 [@sdejesusF]: https://github.com/sdejesusF
+[@AvdLee]: https://github.com/AvdLee

--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
   s.module_name  = "Datadog"
-  s.version      = "1.8.0"
+  s.version      = "1.9.0"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKAlamofireExtension.podspec
+++ b/DatadogSDKAlamofireExtension.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKAlamofireExtension"
   s.module_name  = "DatadogAlamofireExtension"
-  s.version      = "1.8.0"
+  s.version      = "1.9.0"
   s.summary      = "An Official Extensions of Datadog Swift SDK for Alamofire."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKCrashReporting"
   s.module_name  = "DatadogCrashReporting"
-  s.version      = "1.8.0"
+  s.version      = "1.9.0"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
-  s.dependency 'DatadogSDK', '1.8.0'
-  s.dependency 'PLCrashReporter', '~> 1.10.0'
+  s.dependency 'DatadogSDK', '1.9.0'
+  s.dependency 'PLCrashReporter', '~> 1.10.1'
 end

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKObjc"
   s.module_name  = "DatadogObjc"
-  s.version      = "1.8.0"
+  s.version      = "1.9.0"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
 
   s.source_files = "Sources/DatadogObjc/**/*.swift"
-  s.dependency 'DatadogSDK', '1.8.0'
+  s.dependency 'DatadogSDK', '1.9.0'
 end

--- a/Sources/Datadog/Versioning.swift
+++ b/Sources/Datadog/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let __sdkVersion = "1.8.0"
+internal let __sdkVersion = "1.9.0"


### PR DESCRIPTION
### What and why?

This prepares `1.9.0` release 🚀 

### How?

`release/1.9.0` is pulled from last dogfooded commit on `master`.

> Webview tracking feature that is behind a feature flag is omitted in the changelog.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
