### PR TITLE
RUMM-1955 Multiple calls to trackDatadogEvents handled

### DIFF
--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -67,7 +67,7 @@ class WKUserContentController_DatadogTests: XCTestCase {
         XCTAssertEqual(sanitization.warningMessage, "The allowed WebView host configured for Datadog SDK is not valid")
     }
 
-    func testItAddsUserScriptAndMessageHandlerMultipleTimes() throws {
+    func testWhenAddingMessageHandlerMultipleTimes_itIgnoresExtraOnesAndPrintsWarning() throws {
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }
 


### PR DESCRIPTION
### What and why?

If `trackDatadogEvents` method is called multiple times, it crashes the app.
The reason is that calling `WKUserContentController.add(messageHandler:, name:)` multiple times with the same `name` crashes the app.

### How?

`trackDatadogEvents` method removes already-added components before adding them.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
