### PR TITLE
RUMM-1931 stopTrackingDatadogEvents added to avoid memory leaks

### DIFF
--- a/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
+++ b/Datadog/Example/Scenarios/WebView/WebViewTrackingFixtureViewController.swift
@@ -27,13 +27,18 @@ class ShopistWebviewViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let controller = WKUserContentController()
-        controller.trackDatadogEvents(in: ["shopist.io"])
-        let config = WKWebViewConfiguration()
-        config.userContentController = controller
-
-        webView = WKWebView(frame: UIScreen.main.bounds, configuration: config)
+        webView = WKWebView(frame: UIScreen.main.bounds, configuration: WKWebViewConfiguration())
         view.addSubview(webView)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        webView.configuration.userContentController.trackDatadogEvents(in: ["shopist.io"])
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        webView.configuration.userContentController.stopTrackingDatadogEvents()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -30,7 +30,7 @@ public extension WKUserContentController {
     /// Disables Datadog iOS SDK and Datadog Browser SDK integration.
     ///
     /// Removes Datadog's ScriptMessageHandler and UserScript from the caller.
-    /// _NOTE:_ This method **must** be called when the webview can be deinitialized.
+    /// - Note: This method **must** be called when the webview can be deinitialized.
     func stopTrackingDatadogEvents() {
         removeScriptMessageHandler(forName: DatadogMessageHandler.name)
 

--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -27,6 +27,22 @@ public extension WKUserContentController {
         addDatadogMessageHandler(allowedWebViewHosts: hosts, hostsSanitizer: HostsSanitizer())
     }
 
+    /// Disables Datadog iOS SDK and Datadog Browser SDK integration.
+    ///
+    /// Removes Datadog's ScriptMessageHandler and UserScript from the caller.
+    /// _NOTE:_ This method **must** be called when the webview can be deinitialized.
+    func stopTrackingDatadogEvents() {
+        removeScriptMessageHandler(forName: DatadogMessageHandler.name)
+
+        let nonDatadogUserScripts = userScripts.filter {
+            return !$0.source.starts(with: Self.jsCodePrefix)
+        }
+        removeAllUserScripts()
+        nonDatadogUserScripts.forEach {
+            addUserScript($0)
+        }
+    }
+
     internal func addDatadogMessageHandler(allowedWebViewHosts: Set<String>, hostsSanitizer: HostsSanitizing) {
         guard !isTracking else {
               userLogger.warn("`trackDatadogEvents(in:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.")

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -24,9 +24,7 @@ final class DDUserContentController: WKUserContentController {
 }
 
 final class MockMessageHandler: NSObject, WKScriptMessageHandler {
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        return
-    }
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) { }
 }
 
 final class MockScriptMessage: WKScriptMessage {

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -23,6 +23,12 @@ final class DDUserContentController: WKUserContentController {
     }
 }
 
+final class MockMessageHandler: NSObject, WKScriptMessageHandler {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        return
+    }
+}
+
 final class MockScriptMessage: WKScriptMessage {
     let mockBody: Any
 
@@ -94,6 +100,31 @@ class WKUserContentController_DatadogTests: XCTestCase {
 
         let recordedLogMessages = output.allRecordedLogs.map { return $0.message }
         XCTAssertEqual(recordedLogMessages, Array(repeating: "`trackDatadogEvents(in:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.", count: multipleTimes - 1))
+    }
+
+    func testWhenStoppingTracking_itKeepsNonDatadogComponents() throws {
+        let controller = DDUserContentController()
+
+        controller.trackDatadogEvents(in: [])
+
+        let componentCount = 10
+        for i in 0..<componentCount {
+            let userScript = WKUserScript(
+                source: String.mockRandom(),
+                injectionTime: (i % 2 == 0 ? .atDocumentStart : .atDocumentEnd),
+                forMainFrameOnly: i % 2 == 0
+            )
+            controller.addUserScript(userScript)
+            controller.add(MockMessageHandler(), name: String.mockRandom())
+        }
+
+        XCTAssertEqual(controller.userScripts.count, componentCount + 1)
+        XCTAssertEqual(controller.messageHandlers.count, componentCount + 1)
+
+        controller.stopTrackingDatadogEvents()
+
+        XCTAssertEqual(controller.userScripts.count, componentCount)
+        XCTAssertEqual(controller.messageHandlers.count, componentCount)
     }
 
     func testItLogsInvalidWebMessages() throws {


### PR DESCRIPTION
### What and why?

Without removing `WKScriptMessageHandlers` explicitly, they stay alive in memory even after deallocation of the webview

### How?

By calling `stopTrackingDatadogEvents`, our users can remove Datadog components from their `WKWebViewConfiguration` instances so that `DatadogMessageHandler` can be deallocated.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
