### PR TITLE
RUMS-481 Add tests and docs for advanced use of `DDURLSessionDelegate`

### DIFF
--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -56,7 +56,7 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
         interceptor?.taskCompleted(task: task, error: error)
     }
 
-    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
 
         interceptor?.taskReceivedData(task: dataTask, data: data)


### PR DESCRIPTION
### What and why?

📦📖 This PR improves existing **integration test** and enhances **documentation** with advanced techniques of using `DDURLSessionDelegate` in apps that implement their own session delegate.

This is to answer frequently asked question and help solution engineers in their job.

### How?

If the app defines its own session delegate, it can still use `DDURLSessionDelegate` through inheritance or composition. This PR adds both methods as variant of running our instrumentation tests and updates troubleshooting guide with description of both techniques.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
