### PR TITLE
RUMM-1806 Custom Logs/RUM endpoints are read from xcconfig

### DIFF
--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -41,6 +41,15 @@ struct ExampleAppConfiguration: AppConfiguration {
             .set(batchSize: .small)
             .set(uploadFrequency: .frequent)
 
+        if let customLogsURL = Environment.readCustomLogsURL(),
+            let constructedURL = URL(string: customLogsURL) {
+            _ = configuration.set(customLogsEndpoint: constructedURL)
+        }
+        if let customRUMURL = Environment.readCustomRUMURL(),
+           let constructedURL = URL(string: customRUMURL) {
+            _ = configuration.set(customRUMEndpoint: constructedURL)
+        }
+
 #if DD_SDK_ENABLE_INTERNAL_MONITORING
         _ = configuration
             .enableInternalMonitoring(clientToken: Environment.readClientToken())

--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -41,13 +41,14 @@ struct ExampleAppConfiguration: AppConfiguration {
             .set(batchSize: .small)
             .set(uploadFrequency: .frequent)
 
-        if let customLogsURL = Environment.readCustomLogsURL(),
-            let constructedURL = URL(string: customLogsURL) {
-            _ = configuration.set(customLogsEndpoint: constructedURL)
+        if let customLogsURL = Environment.readCustomLogsURL() {
+            _ = configuration.set(customLogsEndpoint: customLogsURL)
         }
-        if let customRUMURL = Environment.readCustomRUMURL(),
-           let constructedURL = URL(string: customRUMURL) {
-            _ = configuration.set(customRUMEndpoint: constructedURL)
+        if let customTraceURL = Environment.readCustomTraceURL() {
+            _ = configuration.set(customTracesEndpoint: customTraceURL)
+        }
+        if let customRUMURL = Environment.readCustomRUMURL() {
+            _ = configuration.set(customRUMEndpoint: customRUMURL)
         }
 
 #if DD_SDK_ENABLE_INTERNAL_MONITORING

--- a/Datadog/Example/Environment.swift
+++ b/Datadog/Example/Environment.swift
@@ -48,8 +48,9 @@ internal struct Environment {
         static let clientToken      = "DatadogClientToken"
         static let rumApplicationID = "RUMApplicationID"
 
-        static let customLogsURL = "CustomLogsURL"
-        static let customRUMURL = "CustomRUMURL"
+        static let customLogsURL    = "CustomLogsURL"
+        static let customTraceURL   = "CustomTraceURL"
+        static let customRUMURL     = "CustomRUMURL"
     }
 
     // MARK: - Launch Arguments
@@ -110,13 +111,27 @@ internal struct Environment {
         return rumApplicationID
     }
 
-    static func readCustomLogsURL() -> String? {
-        let customLogsURL = Bundle.main.infoDictionary![InfoPlistKey.customLogsURL] as? String
-        return customLogsURL?.isEmpty == true ? nil : customLogsURL
+    static func readCustomLogsURL() -> URL? {
+        if let customLogsURL = Bundle.main.infoDictionary![InfoPlistKey.customLogsURL] as? String,
+           !customLogsURL.isEmpty {
+            return URL(string: "https://\(customLogsURL)")
+        }
+        return nil
     }
 
-    static func readCustomRUMURL() -> String? {
-        let customRUMURL = Bundle.main.infoDictionary![InfoPlistKey.customRUMURL] as? String
-        return customRUMURL?.isEmpty == true ? nil : customRUMURL
+    static func readCustomTraceURL() -> URL? {
+        if let customTraceURL = Bundle.main.infoDictionary![InfoPlistKey.customTraceURL] as? String,
+           !customTraceURL.isEmpty {
+            return URL(string: "https://\(customTraceURL)")
+        }
+        return nil
+    }
+
+    static func readCustomRUMURL() -> URL? {
+        if let customRUMURL = Bundle.main.infoDictionary![InfoPlistKey.customRUMURL] as? String,
+           !customRUMURL.isEmpty {
+            return URL(string: "https://\(customRUMURL)")
+        }
+        return nil
     }
 }

--- a/Datadog/Example/Environment.swift
+++ b/Datadog/Example/Environment.swift
@@ -47,6 +47,9 @@ internal struct Environment {
     struct InfoPlistKey {
         static let clientToken      = "DatadogClientToken"
         static let rumApplicationID = "RUMApplicationID"
+
+        static let customLogsURL = "CustomLogsURL"
+        static let customRUMURL = "CustomRUMURL"
     }
 
     // MARK: - Launch Arguments
@@ -105,5 +108,15 @@ internal struct Environment {
             """)
         }
         return rumApplicationID
+    }
+
+    static func readCustomLogsURL() -> String? {
+        let customLogsURL = Bundle.main.infoDictionary![InfoPlistKey.customLogsURL] as? String
+        return customLogsURL?.isEmpty == true ? nil : customLogsURL
+    }
+
+    static func readCustomRUMURL() -> String? {
+        let customRUMURL = Bundle.main.infoDictionary![InfoPlistKey.customRUMURL] as? String
+        return customRUMURL?.isEmpty == true ? nil : customRUMURL
     }
 }

--- a/Datadog/TargetSupport/Example/Info.plist
+++ b/Datadog/TargetSupport/Example/Info.plist
@@ -3,9 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CustomLogsURL</key>
-	<string>https://$(CUSTOM_LOGS_URL)</string>
+	<string>$(CUSTOM_LOGS_URL)</string>
+	<key>CustomTraceURL</key>
+	<string>$(CUSTOM_TRACE_URL)</string>
 	<key>CustomRUMURL</key>
-	<string>https://$(CUSTOM_RUM_URL)</string>
+	<string>$(CUSTOM_RUM_URL)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/Datadog/TargetSupport/Example/Info.plist
+++ b/Datadog/TargetSupport/Example/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CustomLogsURL</key>
+	<string>https://$(CUSTOM_LOGS_URL)</string>
+	<key>CustomRUMURL</key>
+	<string>https://$(CUSTOM_RUM_URL)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/xcconfigs/Datadog.xcconfig
+++ b/xcconfigs/Datadog.xcconfig
@@ -11,5 +11,9 @@ DATADOG_CLIENT_TOKEN=// use your own Client Token, generated for RUM_APPLICATION
 E2E_RUM_APPLICATION_ID=// use your own RUM Application ID obtained on datadoghq.com
 E2E_DATADOG_CLIENT_TOKEN=// use your own Client Token, generated for E2E_RUM_APPLICATION_ID
 
+CUSTOM_LOGS_URL=// Do NOT add https! example: foo.com/api/v2/logs
+CUSTOM_TRACE_URL=// Do NOT add https! example: foo.com/api/v2/spans
+CUSTOM_RUM_URL=// Do NOT add https! example: foo.com/api/v2/rum
+
 // Overwrite with secrets
 #include? "Datadog.local.xcconfig"


### PR DESCRIPTION
### What and why?

This PR is only for making it easier to switch between production and staging environments during development.

### How?

`Custom Logs/RUM URL`s are read from local `xcconfig` files, which are gitignored.

```
/// Datadog.local.xcconfig

// prod
CUSTOM_LOGS_URL=my.production.url
...
// staging
CUSTOM_LOGS_URL=my.staging.url
...
```
Now you can comment out the section you'd like and switch your development environment.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
