### PR TITLE
Fix `TrackingConsentScenarioTests` flakiness

### DIFF
--- a/Tests/DatadogIntegrationTests/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/TrackingConsent/TrackingConsentScenarioTests.swift
@@ -44,7 +44,7 @@ private class TSPictureScreen: XCUIApplication {
 
 private class TSConsentSettingsScreen: XCUIApplication {
     func selectConsent(value: String) {
-        buttons[value].tap()
+        buttons[value].safeTap()
     }
 
     func tapClose() -> TSHomeScreen {


### PR DESCRIPTION
### What and why?

`TrackingConsentScenarioTests.testStartWithPendingConsent_thenPlayScenario_thenChangeConsentToGranted()` happen to be flaky.

### How?

The segmented control tap gesture tend to fail during integration test. Using `safeTap` ensures control availability before interaction

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
