### PR TITLE
RUMM-1935 Make `consolePrint` public

### DIFF
--- a/Sources/Datadog/Utils/Globals.swift
+++ b/Sources/Datadog/Utils/Globals.swift
@@ -11,9 +11,7 @@ import _Datadog_Private
 #endif
 
 /// Function printing `String` content to console.
-internal var consolePrint: (String) -> Void = { content in
-    print(content)
-}
+public var consolePrint: (String) -> Void = { print($0) }
 
 /// Exception handler rethrowing `NSExceptions` to Swift `NSError`.
 internal var objcExceptionHandler = __dd_private_ObjcExceptionHandler()

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogConsoleOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogConsoleOutputTests.swift
@@ -11,6 +11,16 @@ import XCTest
 class LogConsoleOutputTests: XCTestCase {
     private let log: LogEvent = .mockWith(date: .mockDecember15th2019At10AMUTC(), status: .info, message: "Info message.")
 
+    func testItPrintsLogsUsingGlobalConsole() {
+        var messagePrinted: String = ""
+        consolePrint = { messagePrinted = $0 }
+        defer { consolePrint = { print($0) } }
+
+        let output1 = LogConsoleOutput(format: .short, timeZone: .UTC)
+        output1.write(log: log)
+        XCTAssertEqual(messagePrinted, "10:00:00.000 [INFO] Info message.")
+    }
+
     func testItPrintsLogsUsingShortFormat() {
         var messagePrinted: String = ""
 


### PR DESCRIPTION
### What and why?

Allow to mutate global console print. 

### How?

Make `var consolePrint` public.

Mutating this var is already covered in [tests](https://github.com/DataDog/dd-sdk-ios/blob/master/Tests/DatadogTests/Datadog/DatadogTests.swift#L19L32). Still, this PR adds a test case to `LogConsoleOutputTests` to test default `printingFunction`.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
