### PR TITLE
RUMM-1939 Document data storage regarding encryption

### DIFF
--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -214,9 +214,9 @@ The SDK changes its behavior according to the new value. For example, if the cur
 - if changed to `.granted`, the SDK will send all current and future data to Datadog;
 - if changed to `.notGranted`, the SDK will wipe all current data and will not collect any future data.
 
-Before uploading to Datadog, data is stored in cleartext in the cache directory (`Library/Caches`) of your application sandbox.
+Before data is uploaded to Datadog, it is stored in cleartext in the cache directory (`Library/Caches`) of your application sandbox.
 
-When writing your application, you can enable development logs. All internal messages in the SDK with a priority equal to or higher than the provided level are then logged to console logs.
+When writing your application, enable development logs to log to console all internal messages in the SDK with a priority equal to or higher than the provided level.
 
     {{< tabs >}}
     {{% tab "Swift" %}}

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -214,7 +214,9 @@ The SDK changes its behavior according to the new value. For example, if the cur
 - if changed to `.granted`, the SDK will send all current and future data to Datadog;
 - if changed to `.notGranted`, the SDK will wipe all current data and will not collect any future data.
 
-    When writing your application, you can enable development logs. All internal messages in the SDK with a priority equal to or higher than the provided level are then logged to console logs.
+Before uploading to Datadog, data is stored in cleartext in the cache directory (`Library/Caches`) of your application sandbox.
+
+When writing your application, you can enable development logs. All internal messages in the SDK with a priority equal to or higher than the provided level are then logged to console logs.
 
     {{< tabs >}}
     {{% tab "Swift" %}}

--- a/docs/rum_collection/data_collected.md
+++ b/docs/rum_collection/data_collected.md
@@ -218,7 +218,9 @@ Network errors include information about failing HTTP requests. The following fa
 | `action.name`        | string | Name of the user action.                                                        |
 | `action.target.name` | string | Element that the user interacted with. Only for automatically collected actions |
 
+## Data Storage
 
+Before uploading to Datadog, data is stored in cleartext in the cache directory (`Library/Caches`) of your application sandbox.
 
 ## Further Reading
 

--- a/docs/rum_collection/data_collected.md
+++ b/docs/rum_collection/data_collected.md
@@ -220,7 +220,7 @@ Network errors include information about failing HTTP requests. The following fa
 
 ## Data Storage
 
-Before uploading to Datadog, data is stored in cleartext in the cache directory (`Library/Caches`) of your application sandbox.
+Before data is uploaded to Datadog, it is stored in cleartext in the cache directory (`Library/Caches`) of your application sandbox.
 
 ## Further Reading
 

--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -212,6 +212,8 @@ For example, if the current tracking consent is `.pending`:
 - If changed to `.granted`, the SDK sends all current and future data to Datadog.
 - If changed to `.notGranted`, the SDK wipes all current data and does not collect future data.
 
+Before uploading to Datadog, data is stored in cleartext in the cache directory (`Library/Caches`) of your application sandbox.
+
 When writing your application, you can enable development logs. All internal messages in the SDK with a priority equal to or higher than the provided level are then logged to console logs.
 
     {{< tabs >}}

--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -212,9 +212,9 @@ For example, if the current tracking consent is `.pending`:
 - If changed to `.granted`, the SDK sends all current and future data to Datadog.
 - If changed to `.notGranted`, the SDK wipes all current data and does not collect future data.
 
-Before uploading to Datadog, data is stored in cleartext in the cache directory (`Library/Caches`) of your application sandbox.
+Before data is uploaded to Datadog, it is stored in cleartext in the cache directory (`Library/Caches`) of your application sandbox.
 
-When writing your application, you can enable development logs. All internal messages in the SDK with a priority equal to or higher than the provided level are then logged to console logs.
+When writing your application, enable development logs to log to console all internal messages in the SDK with a priority equal to or higher than the provided level.
 
     {{< tabs >}}
     {{% tab "Swift" %}}


### PR DESCRIPTION
### What and why?

Document cleartext data storage in cache directory.

### Review checklist

- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
