### PR TITLE
RUMS-481 Fix nightly tests compilation issue in Xcode 12.x

### DIFF
--- a/Datadog/Example/Scenarios/URLSession/URLSessionScenarios.swift
+++ b/Datadog/Example/Scenarios/URLSession/URLSessionScenarios.swift
@@ -89,7 +89,7 @@ class URLSessionBaseScenario: NSObject {
     private var ddURLSessionDelegate: DDURLSessionDelegate?
 
     override init() {
-        instrumentationMethod = .allCases.randomElement()!
+        instrumentationMethod = InstrumentationMethod.allCases.randomElement()!
         lazyInitURLSession = .random()
 
         if ProcessInfo.processInfo.arguments.contains("IS_RUNNING_UI_TESTS") {


### PR DESCRIPTION
### What and why?

⚙️ In #750 we added syntax to `Example` target which is not compatible with Xcode 12.x compiler:
```
❌  /Users/vagrant/git/Datadog/Example/Scenarios/URLSession/URLSessionScenarios.swift:92:34: cannot infer contextual base in reference to member 'allCases'
        instrumentationMethod = .allCases.randomElement()!
                                ~^~~~~~~~
```
It makes our nightly tests for iOS 11.x-13.x fail to compile, as these require Xcode 12.x.

### How?

```diff
-        instrumentationMethod = .allCases.randomElement()!
+        instrumentationMethod = InstrumentationMethod.allCases.randomElement()!
```

I made sure everything else compiles in Xcode 12.x.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
