### PR TITLE
Fix integration test flakiness

### DIFF
--- a/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/CrashReporting/CrashReportingWithLoggingScenarioTests.swift
@@ -9,7 +9,7 @@ import XCTest
 private extension ExampleApplication {
     /// Tapping this button will crash the app.
     func tapCallFatalError() {
-        buttons["Call fatalError()"].tap()
+        buttons["Call fatalError()"].safeTap()
     }
 }
 


### PR DESCRIPTION
### What and why?

Fix `CrashReportingWithLoggingScenarioTests.testCrashReportingCollectOrSendWithLoggingScenario` flakiness.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
