### PR TITLE
Integration with CI Visibility tests

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -563,6 +563,7 @@
 		E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */; };
 		E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */; };
 		E13A880C257922EC004FB174 /* EnvironmentSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13A880B257922EC004FB174 /* EnvironmentSpanIntegration.swift */; };
+		E143CCAF27D236F600F4018A /* CITestIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */; };
 		E1D202EA24C065CF00D1AF3A /* ActiveSpansPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D202E924C065CF00D1AF3A /* ActiveSpansPool.swift */; };
 		E1D203FD24C1885C00D1AF3A /* ActiveSpansPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D203FB24C1884500D1AF3A /* ActiveSpansPoolTests.swift */; };
 		E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D5AEA624B4D45A007F194B /* Versioning.swift */; };
@@ -1264,6 +1265,7 @@
 		E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingBenchmarkTests.swift; sourceTree = "<group>"; };
 		E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingStorageBenchmarkTests.swift; sourceTree = "<group>"; };
 		E13A880B257922EC004FB174 /* EnvironmentSpanIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentSpanIntegration.swift; sourceTree = "<group>"; };
+		E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CITestIntegrationTests.swift; sourceTree = "<group>"; };
 		E1B082CB25641DF9002DB9D2 /* Example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Example.xcconfig; sourceTree = "<group>"; };
 		E1D202E924C065CF00D1AF3A /* ActiveSpansPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpansPool.swift; sourceTree = "<group>"; };
 		E1D203FB24C1884500D1AF3A /* ActiveSpansPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpansPoolTests.swift; sourceTree = "<group>"; };
@@ -1991,6 +1993,7 @@
 			isa = PBXGroup;
 			children = (
 				61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */,
+				E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */,
 				61216279247D21FE00AC5D67 /* LoggingForTracingAdapterTests.swift */,
 				61FC5F4D25CC2920006BB4DE /* RUMWithCrashContextIntegrationTests.swift */,
 				6182374125D3DFB8006A375B /* CrashReporting */,
@@ -4363,6 +4366,7 @@
 				61EF78B7257E37D500EDCCB3 /* MoveDataMigratorTests.swift in Sources */,
 				61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */,
 				61D03BE0273404E700367DE0 /* RUMDataModels+objcTests.swift in Sources */,
+				E143CCAF27D236F600F4018A /* CITestIntegrationTests.swift in Sources */,
 				615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */,
 				61E917CF2464270500E6C631 /* CodableValueTests.swift in Sources */,
 				61D3E0E4277B3D92008BE766 /* KronosNTPPacketTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -559,6 +559,7 @@
 		D2F5BB36271831C200BDE2A4 /* RUMSwiftUIInstrumentationScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2F5BB35271831C200BDE2A4 /* RUMSwiftUIInstrumentationScenario.storyboard */; };
 		D2F5BB382718331800BDE2A4 /* SwiftUIRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F5BB372718331800BDE2A4 /* SwiftUIRootViewController.swift */; };
 		D2FCA239271D896E0020286F /* SwiftUIExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FCA238271D896E0020286F /* SwiftUIExtensions.swift */; };
+		E11625D827B681D200E428C6 /* CITestIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11625D727B681D200E428C6 /* CITestIntegration.swift */; };
 		E132727B24B333C700952F8B /* TracingBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */; };
 		E132727D24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */; };
 		E13A880C257922EC004FB174 /* EnvironmentSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13A880B257922EC004FB174 /* EnvironmentSpanIntegration.swift */; };
@@ -1259,6 +1260,7 @@
 		D2F5BB35271831C200BDE2A4 /* RUMSwiftUIInstrumentationScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMSwiftUIInstrumentationScenario.storyboard; sourceTree = "<group>"; };
 		D2F5BB372718331800BDE2A4 /* SwiftUIRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIRootViewController.swift; sourceTree = "<group>"; };
 		D2FCA238271D896E0020286F /* SwiftUIExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExtensions.swift; sourceTree = "<group>"; };
+		E11625D727B681D200E428C6 /* CITestIntegration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CITestIntegration.swift; sourceTree = "<group>"; };
 		E132727A24B333C700952F8B /* TracingBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingBenchmarkTests.swift; sourceTree = "<group>"; };
 		E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingStorageBenchmarkTests.swift; sourceTree = "<group>"; };
 		E13A880B257922EC004FB174 /* EnvironmentSpanIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentSpanIntegration.swift; sourceTree = "<group>"; };
@@ -1978,6 +1980,7 @@
 				6156CB9B24E18224008CB2B2 /* TracingWithRUMIntegration.swift */,
 				61FC5F4425CC23C9006BB4DE /* RUMWithCrashContextIntegration.swift */,
 				E13A880B257922EC004FB174 /* EnvironmentSpanIntegration.swift */,
+				E11625D727B681D200E428C6 /* CITestIntegration.swift */,
 				9EB4B860274E79620041CD03 /* WebView */,
 				6112B11C25C84E7F00B37771 /* CrashReporting */,
 			);
@@ -4131,6 +4134,7 @@
 				6116563B25D2A6C90070EC03 /* ArbitraryDataWriter.swift in Sources */,
 				61216276247D1CD700AC5D67 /* LoggingForTracingAdapter.swift in Sources */,
 				9EB4B866274FAB4C0041CD03 /* WebRUMEventConsumer.swift in Sources */,
+				E11625D827B681D200E428C6 /* CITestIntegration.swift in Sources */,
 				61E909EF24A24DD3005EA2DE /* Global.swift in Sources */,
 				D2EFF3D32731822A00D09F33 /* RUMViewsHandler.swift in Sources */,
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -144,19 +144,17 @@ internal struct FeatureStorage {
         dataOrchestrator.deleteAllData()
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     /// Flushes all async write operations and tears down the storage stack.
     /// - It completes all async writes by synchronously saving data to authorized files.
     /// - It cancels the storage by preventing all future write operations and marking all authorised files as "ready for upload".
     ///
     /// This method is executed synchronously. After return, the storage feature has no more
     /// pending asynchronous write operations so all its data is ready for upload.
-    func flushAndTearDown() {
+    internal func flushAndTearDown() {
         writer.flushAndCancelSynchronously()
         arbitraryAuthorizedWriter.flushAndCancelSynchronously()
         (dataOrchestrator as? DataOrchestrator)?.markAllFilesAsReadable()
     }
-#endif
 }
 
 internal struct FeatureUpload {
@@ -202,16 +200,14 @@ internal struct FeatureUpload {
         self.uploader = uploader
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     /// Flushes all authorised data and tears down the upload stack.
     /// - It completes all pending asynchronous work in upload worker and cancels its next schedules.
     /// - It flushes all data stored in authorized files by performing their arbitrary upload (without retrying).
     ///
     /// This method is executed synchronously. After return, the upload feature has no more
     /// pending asynchronous operations and all its authorized data should be considered uploaded.
-    func flushAndTearDown() {
+    internal func flushAndTearDown() {
         uploader.cancelSynchronously()
         uploader.flushSynchronously()
     }
-#endif
 }

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -152,7 +152,6 @@ extension FeaturesConfiguration {
         }
 
         let source = (configuration.additionalConfiguration[CrossPlatformAttributes.ddsource] as? String) ?? Datadog.Constants.ddsource
-        let origin = CITestIntegration.origin
         let sdkVersion = (configuration.additionalConfiguration[CrossPlatformAttributes.sdkVersion] as? String) ?? __sdkVersion
 
         let debugOverride = appContext.processInfo.arguments.contains(Datadog.LaunchArguments.Debug)
@@ -173,7 +172,7 @@ extension FeaturesConfiguration {
                 bundleType: appContext.bundleType
             ),
             source: source,
-            origin: origin,
+            origin: CITestIntegration.active?.origin,
             sdkVersion: sdkVersion,
             proxyConfiguration: configuration.proxyConfiguration
         )

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -19,7 +19,7 @@ internal struct FeaturesConfiguration {
         let environment: String
         let performance: PerformancePreset
         let source: String
-        let origin: String
+        let origin: String?
         let sdkVersion: String
         let proxyConfiguration: [AnyHashable: Any]?
     }
@@ -152,7 +152,7 @@ extension FeaturesConfiguration {
         }
 
         let source = (configuration.additionalConfiguration[CrossPlatformAttributes.ddsource] as? String) ?? Datadog.Constants.ddsource
-        let origin = CITestIntegration.origin ?? source
+        let origin = CITestIntegration.origin
         let sdkVersion = (configuration.additionalConfiguration[CrossPlatformAttributes.sdkVersion] as? String) ?? __sdkVersion
 
         let debugOverride = appContext.processInfo.arguments.contains(Datadog.LaunchArguments.Debug)

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -19,6 +19,7 @@ internal struct FeaturesConfiguration {
         let environment: String
         let performance: PerformancePreset
         let source: String
+        let origin: String
         let sdkVersion: String
         let proxyConfiguration: [AnyHashable: Any]?
     }
@@ -151,6 +152,7 @@ extension FeaturesConfiguration {
         }
 
         let source = (configuration.additionalConfiguration[CrossPlatformAttributes.ddsource] as? String) ?? Datadog.Constants.ddsource
+        let origin = CITestIntegration.origin ?? source
         let sdkVersion = (configuration.additionalConfiguration[CrossPlatformAttributes.sdkVersion] as? String) ?? __sdkVersion
 
         let debugOverride = appContext.processInfo.arguments.contains(Datadog.LaunchArguments.Debug)
@@ -171,6 +173,7 @@ extension FeaturesConfiguration {
                 bundleType: appContext.bundleType
             ),
             source: source,
+            origin: origin,
             sdkVersion: sdkVersion,
             proxyConfiguration: configuration.proxyConfiguration
         )

--- a/Sources/Datadog/Core/Persistence/DataOrchestrator.swift
+++ b/Sources/Datadog/Core/Persistence/DataOrchestrator.swift
@@ -26,12 +26,10 @@ internal struct DataOrchestrator: DataOrchestratorType {
         }
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func markAllFilesAsReadable() {
+    internal func markAllFilesAsReadable() {
         queue.sync {
             authorizedFilesOrchestrator.ignoreFilesAgeWhenReading = true
             unauthorizedFilesOrchestrator.ignoreFilesAgeWhenReading = true
         }
     }
-#endif
 }

--- a/Sources/Datadog/Core/Persistence/FilesOrchestrator.swift
+++ b/Sources/Datadog/Core/Persistence/FilesOrchestrator.swift
@@ -134,10 +134,8 @@ internal class FilesOrchestrator {
         }
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     /// If files age should be ignored for obtaining `ReadableFile`.
-    var ignoreFilesAgeWhenReading = false
-#endif
+    internal var ignoreFilesAgeWhenReading = false
 
     // MARK: - Directory size management
 

--- a/Sources/Datadog/Core/Persistence/Writing/ArbitraryDataWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writing/ArbitraryDataWriter.swift
@@ -33,11 +33,9 @@ internal class ArbitraryDataWriter: AsyncWriter {
         }
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     private var isCanceled = false
 
-    func flushAndCancelSynchronously() {
+    internal func flushAndCancelSynchronously() {
         queue.sync { self.isCanceled = true }
     }
-#endif
 }

--- a/Sources/Datadog/Core/Persistence/Writing/ConsentAwareDataWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writing/ConsentAwareDataWriter.swift
@@ -59,14 +59,12 @@ internal class ConsentAwareDataWriter: AsyncWriter, TrackingConsentObserver {
         }
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     private var isCanceled = false
 
-    func flushAndCancelSynchronously() {
+    internal func flushAndCancelSynchronously() {
         queue.sync {
             self.processor = nil
             self.isCanceled = true
         }
     }
-#endif
 }

--- a/Sources/Datadog/Core/Persistence/Writing/Writer.swift
+++ b/Sources/Datadog/Core/Persistence/Writing/Writer.swift
@@ -16,7 +16,5 @@ internal protocol AsyncWriter: Writer {
     /// Queue used for asynchronous writes.
     var queue: DispatchQueue { get }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     func flushAndCancelSynchronously()
-#endif
 }

--- a/Sources/Datadog/Core/Swizzling/MethodSwizzler.swift
+++ b/Sources/Datadog/Core/Swizzling/MethodSwizzler.swift
@@ -73,9 +73,8 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
         }
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     /// Removes swizzling and resets the method to its original implementation.
-    func unswizzle() {
+    internal func unswizzle() {
         for foundMethod in swizzledMethods {
             let originalTypedIMP = originalImplementation(of: foundMethod)
             let originalIMP: IMP = unsafeBitCast(originalTypedIMP, to: IMP.self)
@@ -84,7 +83,6 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
             activeSwizzlingNames.removeAll { $0 == foundMethod.swizzlingName }
         }
     }
-#endif
 
     // MARK: - Private methods
 
@@ -121,11 +119,9 @@ internal class MethodSwizzler<TypedIMP, TypedBlockIMP> {
     }
 }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-extension MethodSwizzler.FoundMethod {
+internal extension MethodSwizzler.FoundMethod {
     var swizzlingName: String { "\(klass).\(method_getName(method))" }
 }
 
 /// The list of active swizzlings to ensure integrity in unit tests.
 internal var activeSwizzlingNames: [String] = []
-#endif

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -8,10 +8,8 @@ import Foundation
 
 /// Abstracts the `DataUploadWorker`, so we can have no-op uploader in tests.
 internal protocol DataUploadWorkerType {
-#if DD_SDK_COMPILED_FOR_TESTING
     func flushSynchronously()
     func cancelSynchronously()
-#endif
 }
 
 internal class DataUploadWorker: DataUploadWorkerType {
@@ -109,10 +107,9 @@ internal class DataUploadWorker: DataUploadWorkerType {
         queue.asyncAfter(deadline: .now() + delay, execute: work)
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     /// Sends all unsent data synchronously.
     /// - It performs arbitrary upload (without checking upload condition and without re-transmitting failed uploads).
-    func flushSynchronously() {
+    internal func flushSynchronously() {
         queue.sync {
             while let nextBatch = self.fileReader.readNextBatch() {
                 _ = self.dataUploader.upload(data: nextBatch.data)
@@ -124,7 +121,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
     /// Cancels scheduled uploads and stops scheduling next ones.
     /// - It does not affect the upload that has already begun.
     /// - It blocks the caller thread if called in the middle of upload execution.
-    func cancelSynchronously() {
+    internal func cancelSynchronously() {
         queue.sync {
             // This cancellation must be performed on the `queue` to ensure that it is not called
             // in the middle of a `DispatchWorkItem` execution - otherwise, as the pending block would be
@@ -133,7 +130,6 @@ internal class DataUploadWorker: DataUploadWorkerType {
             self.uploadWork = nil
         }
     }
-#endif
 }
 
 extension DataUploadConditions.Blocker: CustomStringConvertible {

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -169,10 +169,8 @@ internal class CrashReporter {
         }
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func deinitialize() {
+    internal func deinitialize() {
         // Await asynchronous operations completion to safely sink all pending tasks.
         queue.sync {}
     }
-#endif
 }

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -51,9 +51,7 @@ internal final class CrashReportingFeature {
         self.appStateListener = commonDependencies.appStateListener
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func deinitialize() {
+    internal func deinitialize() {
         CrashReportingFeature.instance = nil
     }
-#endif
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -338,13 +338,18 @@ public class Datadog {
         InternalMonitoringFeature.instance?.logsStorage.clearAllData()
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     /// Flushes all authorised data for each feature, tears down and deinitializes the SDK.
     /// - It flushes all data authorised for each feature by performing its arbitrary upload (without retrying).
     /// - It completes all pending asynchronous work in each feature.
     ///
     /// This is highly experimental API and only supported in tests.
+#if DD_SDK_COMPILED_FOR_TESTING
     public static func flushAndDeinitialize() {
+        internalFlushAndDeinitialize()
+    }
+#endif
+
+    internal static func internalFlushAndDeinitialize() {
         assert(Datadog.instance != nil, "SDK must be first initialized.")
 
         // Tear down and deinitialize all features:
@@ -370,7 +375,6 @@ public class Datadog {
         // Reset internal loggers:
         userLogger = createNoOpSDKUserLogger()
     }
-#endif
 }
 
 /// Convenience typealias.

--- a/Sources/Datadog/FeaturesIntegration/CITestIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CITestIntegration.swift
@@ -7,39 +7,40 @@
 import Foundation
 
 private enum DDCFMessageID {
-    static let customTags: Int32 = 0x1111
+    static let setCustomTags: Int32 = 0x1111
     static let enableRUM: Int32 = 0x2222
     static let forceFlush: Int32 = 0x3333
 }
 
-internal enum CITestIntegration {
-    /// CI context to be attached to RUM events that identifies it was started by a CI test,
-    static var ciTestExecutionID: String? {
-        return ProcessInfo.processInfo.environment["CI_VISIBILITY_TEST_EXECUTION_ID"]
-    }
+internal class CITestIntegration {
+    /// Current and active integration with CIApp.
+    /// `nil` if the integration is not enabled.
+    static let active: CITestIntegration? = CITestIntegration()
 
-    /// Convinence function to check if RUM was started in a CIApp test
-    static func isEnabled() -> Bool {
-        return ciTestExecutionID != nil
-    }
+    /// CI context to be attached to RUM events that identifies that they were created in a CIApp test,
+    let ciTestExecutionID: String
+    /// RUMCITest model to be attached to events
+    let rumCITest: RUMCITest
+    /// Tag that must be added to spans and headers when running inside a CIApp test
+    let origin = "ciapp-test"
 
-    /// Origin value that must be set to Spans and headers to indicate that the trace was initiated by a CIApp test
-    static var origin: String? {
-        if isEnabled() {
-            return "ciapp-test"
+    private init?(processInfo: ProcessInfo = .processInfo) {
+        guard let testID = processInfo.environment["CI_VISIBILITY_TEST_EXECUTION_ID"] else {
+            return nil
         }
-        return nil
+        self.ciTestExecutionID = testID
+        self.rumCITest = RUMCITest(testExecutionId: ciTestExecutionID)
     }
 
     /// Entry point for running all the tasks needed for CIApp integration
-    static func startIntegration() {
+    func startIntegration() {
         startMessageListener()
         notifyRUMSession()
     }
 
     /// Notifies the CIApp framework that a RUM session is being started. It sends a message to a CFMessagePort that is
     /// created in the CIApp framework
-    private static func notifyRUMSession() {
+    private func notifyRUMSession() {
         let timeout: CFTimeInterval = 1.0
         guard let remotePort = CFMessagePortCreateRemote(nil, "DatadogTestingPort" as CFString) else {
             return
@@ -59,7 +60,7 @@ internal enum CITestIntegration {
 
     /// Creates a CFMessagePort that is used by the CIApp framework to notify that a test is going to finish, so all
     /// information must be flushed to the backend. It uses a non public API `internalFlushAndDeinitialize()`
-    private static func startMessageListener() {
+    private func startMessageListener() {
         func attributeCallback(port: CFMessagePort?, msgid: Int32, data: CFData?, info: UnsafeMutableRawPointer?) -> Unmanaged<CFData>? {
             switch msgid {
             case DDCFMessageID.forceFlush:

--- a/Sources/Datadog/FeaturesIntegration/CITestIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CITestIntegration.swift
@@ -1,0 +1,81 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+private enum DDCFMessageID {
+    static let customTags: Int32 = 0x1111
+    static let enableRUM: Int32 = 0x2222
+    static let forceFlush: Int32 = 0x3333
+}
+
+internal enum CITestIntegration {
+    /// CI context to be attached to RUM events that identifies it was started by a CI test,
+    static var ciTestExecutionID: String? {
+        return ProcessInfo.processInfo.environment["CI_VISIBILITY_TEST_EXECUTION_ID"]
+    }
+
+    /// Convinence function to check if RUM was started in a CIApp test
+    static func isEnabled() -> Bool {
+        return ciTestExecutionID != nil
+    }
+
+    /// Origin value that must be set to Spans and headers to indicate that the trace was initiated by a CIApp test
+    static var origin: String? {
+        if isEnabled() {
+            return "ciapp-test"
+        }
+        return nil
+    }
+
+    /// Entry point for running all the tasks needed for CIApp integration
+    static func startIntegration() {
+        startMessageListener()
+        notifyRUMSession()
+    }
+
+    /// Notifies the CIApp framework that a RUM session is being started. It sends a message to a CFMessagePort that is
+    /// created in the CIApp framework
+    private static func notifyRUMSession() {
+        let timeout: CFTimeInterval = 1.0
+        guard let remotePort = CFMessagePortCreateRemote(nil, "DatadogTestingPort" as CFString) else {
+            return
+        }
+        let status = CFMessagePortSendRequest(
+            remotePort,
+            DDCFMessageID.enableRUM, // Message ID for notifying the test that rum is enabled
+            nil,
+            timeout,
+            timeout,
+            nil,
+            nil
+        )
+        if status == kCFMessagePortSuccess {
+        } else {}
+    }
+
+    /// Creates a CFMessagePort that is used by the CIApp framework to notify that a test is going to finish, so all
+    /// information must be flushed to the backend. It uses a non public API `internalFlushAndDeinitialize()`
+    private static func startMessageListener() {
+        func attributeCallback(port: CFMessagePort?, msgid: Int32, data: CFData?, info: UnsafeMutableRawPointer?) -> Unmanaged<CFData>? {
+            switch msgid {
+            case DDCFMessageID.forceFlush:
+                    Datadog.internalFlushAndDeinitialize()
+            default:
+                break
+            }
+            return nil
+        }
+
+        let port = CFMessagePortCreateLocal(nil, "DatadogRUMTestingPort" as CFString, attributeCallback, nil, nil)
+        if port == nil {
+            print("DatadogTestingPort CFMessagePortCreateLocal failed")
+            return
+        }
+        let runLoopSource = CFMessagePortCreateRunLoopSource(nil, port, 0)
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
+    }
+}

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -224,13 +224,6 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         errorAttributes[DDError.meta] = crashReport.meta
         errorAttributes[DDError.wasTruncated] = crashReport.wasTruncated
 
-        let ciTest: RUMErrorEvent.CiTest? = {
-            if let testID = CITestIntegration.ciTestExecutionID {
-                return RUMErrorEvent.CiTest(testExecutionId: testID)
-            }
-            return nil
-        }()
-
         let event = RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -238,7 +231,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             ),
             action: nil,
             application: .init(id: lastRUMView.application.id),
-            ciTest: ciTest,
+            ciTest: lastRUMView.ciTest,
             connectivity: lastRUMView.connectivity,
             context: nil,
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds,
@@ -258,7 +251,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             session: .init(
                 hasReplay: lastRUMView.session.hasReplay,
                 id: lastRUMView.session.id,
-                type: ciTest != nil ? .ciTest : .user
+                type: lastRUMView.ciTest != nil ? .ciTest : .user
             ),
             source: .ios,
             synthetics: nil,
@@ -286,12 +279,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 session: .init(plan: .plan1)
             ),
             application: original.application,
-            ciTest: {
-                if let testID = CITestIntegration.ciTestExecutionID {
-                    return RUMViewEvent.CiTest(testExecutionId: testID)
-                }
-                return nil
-            }(),
+            ciTest: original.ciTest,
             connectivity: original.connectivity,
             context: original.context,
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds - 1, // -1ms to put the crash after view in RUM session
@@ -347,13 +335,6 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
     ) -> RUMViewEvent {
         let viewUUID = rumConfiguration.uuidGenerator.generateUnique()
 
-        let ciTest: RUMViewEvent.CiTest? = {
-            if let testID = CITestIntegration.ciTestExecutionID {
-                return RUMViewEvent.CiTest(testExecutionId: testID)
-            }
-            return nil
-        }()
-
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -363,7 +344,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             application: .init(
                 id: rumConfiguration.applicationID
             ),
-            ciTest: ciTest,
+            ciTest: CITestIntegration.active?.rumCITest,
             connectivity: RUMConnectivity(
                 networkInfo: crashContext.lastNetworkConnectionInfo,
                 carrierInfo: crashContext.lastCarrierInfo
@@ -374,7 +355,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             session: .init(
                 hasReplay: nil,
                 id: sessionUUID.toRUMDataFormat,
-                type: ciTest != nil ? .ciTest : .user
+                type: CITestIntegration.active != nil ? .ciTest : .user
             ),
             source: .ios,
             synthetics: nil,

--- a/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
+++ b/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
@@ -79,7 +79,7 @@ internal final class InternalMonitoringFeature {
                         device: commonDependencies.mobileDevice
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.source),
+                    .ddEVPOriginHeader(source: configuration.common.origin),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],
@@ -149,11 +149,9 @@ internal final class InternalMonitoringFeature {
         self.monitor = InternalMonitor(sdkLogger: internalLogger)
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func deinitialize() {
+    internal func deinitialize() {
         logsStorage.flushAndTearDown()
         logsUpload.flushAndTearDown()
         InternalMonitoringFeature.instance = nil
     }
-#endif
 }

--- a/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
+++ b/Sources/Datadog/InternalMonitoring/InternalMonitoringFeature.swift
@@ -79,7 +79,7 @@ internal final class InternalMonitoringFeature {
                         device: commonDependencies.mobileDevice
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.origin),
+                    .ddEVPOriginHeader(source: configuration.common.origin ?? configuration.common.source),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -85,7 +85,7 @@ internal final class LoggingFeature {
                         device: commonDependencies.mobileDevice
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.origin),
+                    .ddEVPOriginHeader(source: configuration.common.origin ?? configuration.common.source),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -85,7 +85,7 @@ internal final class LoggingFeature {
                         device: commonDependencies.mobileDevice
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.source),
+                    .ddEVPOriginHeader(source: configuration.common.origin),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],
@@ -142,11 +142,9 @@ internal final class LoggingFeature {
         self.upload = upload
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func deinitialize() {
+    internal func deinitialize() {
         storage.flushAndTearDown()
         upload.flushAndTearDown()
         LoggingFeature.instance = nil
     }
-#endif
 }

--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -17,7 +17,7 @@ public struct RUMViewEvent: RUMDataModel {
     public let application: Application
 
     /// CI Visibility properties
-    public let ciTest: CiTest?
+    public let ciTest: RUMCITest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -110,16 +110,6 @@ public struct RUMViewEvent: RUMDataModel {
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
-        }
-    }
-
-    /// CI Visibility properties
-    public struct CiTest: Codable {
-        /// The identifier of the current CI Visibility test execution
-        public let testExecutionId: String
-
-        enum CodingKeys: String, CodingKey {
-            case testExecutionId = "test_execution_id"
         }
     }
 
@@ -408,7 +398,7 @@ public struct RUMResourceEvent: RUMDataModel {
     public let application: Application
 
     /// CI Visibility properties
-    public let ciTest: CiTest?
+    public let ciTest: RUMCITest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -520,16 +510,6 @@ public struct RUMResourceEvent: RUMDataModel {
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
-        }
-    }
-
-    /// CI Visibility properties
-    public struct CiTest: Codable {
-        /// The identifier of the current CI Visibility test execution
-        public let testExecutionId: String
-
-        enum CodingKeys: String, CodingKey {
-            case testExecutionId = "test_execution_id"
         }
     }
 
@@ -817,7 +797,7 @@ public struct RUMActionEvent: RUMDataModel {
     public let application: Application
 
     /// CI Visibility properties
-    public let ciTest: CiTest?
+    public let ciTest: RUMCITest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -1009,16 +989,6 @@ public struct RUMActionEvent: RUMDataModel {
         }
     }
 
-    /// CI Visibility properties
-    public struct CiTest: Codable {
-        /// The identifier of the current CI Visibility test execution
-        public let testExecutionId: String
-
-        enum CodingKeys: String, CodingKey {
-            case testExecutionId = "test_execution_id"
-        }
-    }
-
     /// Session properties
     public struct Session: Codable {
         /// Whether this session has a replay
@@ -1110,7 +1080,7 @@ public struct RUMErrorEvent: RUMDataModel {
     public let application: Application
 
     /// CI Visibility properties
-    public let ciTest: CiTest?
+    public let ciTest: RUMCITest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -1214,16 +1184,6 @@ public struct RUMErrorEvent: RUMDataModel {
 
         enum CodingKeys: String, CodingKey {
             case id = "id"
-        }
-    }
-
-    /// CI Visibility properties
-    public struct CiTest: Codable {
-        /// The identifier of the current CI Visibility test execution
-        public let testExecutionId: String
-
-        enum CodingKeys: String, CodingKey {
-            case testExecutionId = "test_execution_id"
         }
     }
 
@@ -1448,7 +1408,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
     public let application: Application
 
     /// CI Visibility properties
-    public let ciTest: CiTest?
+    public let ciTest: RUMCITest?
 
     /// Device connectivity properties
     public let connectivity: RUMConnectivity?
@@ -1555,16 +1515,6 @@ public struct RUMLongTaskEvent: RUMDataModel {
         }
     }
 
-    /// CI Visibility properties
-    public struct CiTest: Codable {
-        /// The identifier of the current CI Visibility test execution
-        public let testExecutionId: String
-
-        enum CodingKeys: String, CodingKey {
-            case testExecutionId = "test_execution_id"
-        }
-    }
-
     /// Long Task properties
     public struct LongTask: Codable {
         /// Duration in ns of the long task
@@ -1655,6 +1605,16 @@ public struct RUMLongTaskEvent: RUMDataModel {
             case referrer = "referrer"
             case url = "url"
         }
+    }
+}
+
+/// CI Visibility properties
+public struct RUMCITest: Codable {
+    /// The identifier of the current CI Visibility test execution
+    public let testExecutionId: String
+
+    enum CodingKeys: String, CodingKey {
+        case testExecutionId = "test_execution_id"
     }
 }
 

--- a/Sources/Datadog/RUM/Instrumentation/Actions/UIKit/UIApplicationSwizzler.swift
+++ b/Sources/Datadog/RUM/Instrumentation/Actions/UIKit/UIApplicationSwizzler.swift
@@ -17,11 +17,9 @@ internal class UIApplicationSwizzler {
         sendEvent.swizzle()
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func unswizzle() {
+    internal func unswizzle() {
         sendEvent.unswizzle()
     }
-#endif
 
     // MARK: - Swizzlings
 

--- a/Sources/Datadog/RUM/Instrumentation/RUMInstrumentation.swift
+++ b/Sources/Datadog/RUM/Instrumentation/RUMInstrumentation.swift
@@ -84,12 +84,10 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
         longTasks?.publish(to: subscriber)
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     /// Removes RUM instrumentation swizzlings and deinitializes this component.
-    func deinitialize() {
+    internal func deinitialize() {
         viewControllerSwizzler?.unswizzle()
         userActionsAutoInstrumentation?.swizzler.unswizzle()
         RUMInstrumentation.instance = nil
     }
-#endif
 }

--- a/Sources/Datadog/RUM/Instrumentation/Views/UIKit/UIViewControllerSwizzler.swift
+++ b/Sources/Datadog/RUM/Instrumentation/Views/UIKit/UIViewControllerSwizzler.swift
@@ -20,12 +20,10 @@ internal class UIViewControllerSwizzler {
         viewDidDisappear.swizzle()
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func unswizzle() {
+    internal func unswizzle() {
         viewDidAppear.unswizzle()
         viewDidDisappear.unswizzle()
     }
-#endif
 
     // MARK: - Swizzlings
 

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -105,7 +105,7 @@ internal final class RUMFeature {
                         device: commonDependencies.mobileDevice
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.origin),
+                    .ddEVPOriginHeader(source: configuration.common.origin ?? configuration.common.source),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -105,7 +105,7 @@ internal final class RUMFeature {
                         device: commonDependencies.mobileDevice
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.source),
+                    .ddEVPOriginHeader(source: configuration.common.origin),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],
@@ -189,11 +189,9 @@ internal final class RUMFeature {
         self.onSessionStart = onSessionStart
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func deinitialize() {
+    internal func deinitialize() {
         storage.flushAndTearDown()
         upload.flushAndTearDown()
         RUMFeature.instance = nil
     }
-#endif
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -23,6 +23,8 @@ internal struct RUMScopeDependencies {
     /// Integration with Crash Reporting. It updates the crash context with RUM info.
     /// `nil` if Crash Reporting feature is not enabled.
     let crashContextIntegration: RUMWithCrashContextIntegration?
+    /// Integration with CIApp tests. It contains the CIApp test context when active.
+    let ciTest: RUMCITest?
 
     let vitalCPUReader: SamplingBasedVitalReader
     let vitalMemoryReader: SamplingBasedVitalReader

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -128,13 +128,6 @@ internal class RUMResourceScope: RUMScope {
         }
         let resourceType: RUMResourceType = resourceKindBasedOnRequest ?? command.kind
 
-        let ciTest: RUMResourceEvent.CiTest? = {
-            if let testID = CITestIntegration.ciTestExecutionID {
-                return RUMResourceEvent.CiTest(testExecutionId: testID)
-            }
-            return nil
-        }()
-
         let eventData = RUMResourceEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -146,7 +139,7 @@ internal class RUMResourceScope: RUMScope {
                 .init(id: rumUUID.toRUMDataFormat)
             },
             application: .init(id: context.rumApplicationID),
-            ciTest: ciTest,
+            ciTest:  dependencies.ciTest,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: resourceStartTime).timeIntervalSince1970.toInt64Milliseconds,
@@ -200,7 +193,7 @@ internal class RUMResourceScope: RUMScope {
             session: .init(
                 hasReplay: nil,
                 id: context.sessionID.toRUMDataFormat,
-                type: ciTest != nil ? .ciTest : .user
+                type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .ios,
             synthetics: nil,
@@ -222,12 +215,6 @@ internal class RUMResourceScope: RUMScope {
 
     private func sendErrorEvent(on command: RUMStopResourceWithErrorCommand) -> Bool {
         attributes.merge(rumCommandAttributes: command.attributes)
-        let ciTest: RUMErrorEvent.CiTest? = {
-            if let testID = CITestIntegration.ciTestExecutionID {
-                return RUMErrorEvent.CiTest(testExecutionId: testID)
-            }
-            return nil
-        }()
 
         let eventData = RUMErrorEvent(
             dd: .init(
@@ -238,7 +225,7 @@ internal class RUMResourceScope: RUMScope {
                 .init(id: rumUUID.toRUMDataFormat)
             },
             application: .init(id: context.rumApplicationID),
-            ciTest: ciTest,
+            ciTest: dependencies.ciTest,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
@@ -263,7 +250,7 @@ internal class RUMResourceScope: RUMScope {
             session: .init(
                 hasReplay: nil,
                 id: context.sessionID.toRUMDataFormat,
-                type: ciTest != nil ? .ciTest : .user
+                type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .ios,
             synthetics: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -139,7 +139,7 @@ internal class RUMResourceScope: RUMScope {
                 .init(id: rumUUID.toRUMDataFormat)
             },
             application: .init(id: context.rumApplicationID),
-            ciTest:  dependencies.ciTest,
+            ciTest: dependencies.ciTest,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: resourceStartTime).timeIntervalSince1970.toInt64Milliseconds,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -132,6 +132,13 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             attributes.merge(rumCommandAttributes: commandAttributes)
         }
 
+        let ciTest: RUMActionEvent.CiTest? = {
+            if let testID = CITestIntegration.ciTestExecutionID {
+                return RUMActionEvent.CiTest(testExecutionId: testID)
+            }
+            return nil
+        }()
+
         let eventData = RUMActionEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -148,12 +155,16 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 type: actionType.toRUMDataFormat
             ),
             application: .init(id: context.rumApplicationID),
-            ciTest: nil,
+            ciTest: ciTest,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: actionStartTime).timeIntervalSince1970.toInt64Milliseconds,
             service: dependencies.serviceName,
-            session: .init(hasReplay: nil, id: context.sessionID.toRUMDataFormat, type: .user),
+            session: .init(
+                hasReplay: nil,
+                id: context.sessionID.toRUMDataFormat,
+                type: ciTest != nil ? .ciTest : .user
+            ),
             source: .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -132,13 +132,6 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             attributes.merge(rumCommandAttributes: commandAttributes)
         }
 
-        let ciTest: RUMActionEvent.CiTest? = {
-            if let testID = CITestIntegration.ciTestExecutionID {
-                return RUMActionEvent.CiTest(testExecutionId: testID)
-            }
-            return nil
-        }()
-
         let eventData = RUMActionEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -155,7 +148,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 type: actionType.toRUMDataFormat
             ),
             application: .init(id: context.rumApplicationID),
-            ciTest: ciTest,
+            ciTest: dependencies.ciTest,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: actionStartTime).timeIntervalSince1970.toInt64Milliseconds,
@@ -163,7 +156,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: nil,
                 id: context.sessionID.toRUMDataFormat,
-                type: ciTest != nil ? .ciTest : .user
+                type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .ios,
             synthetics: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -303,7 +303,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     // MARK: - Sending RUM Events
 
     private func sendApplicationStartAction() -> Bool {
-
         let eventData = RUMActionEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -488,7 +487,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         let taskDurationInNs = command.duration.toInt64Nanoseconds
         let isFrozenFrame = taskDurationInNs > Constants.frozenFrameThresholdInNs
-        
         let eventData = RUMLongTaskEvent(
             dd: .init(
                 browserSdkVersion: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -303,12 +303,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     // MARK: - Sending RUM Events
 
     private func sendApplicationStartAction() -> Bool {
-        let ciTest: RUMActionEvent.CiTest? = {
-            if let testID = CITestIntegration.ciTestExecutionID {
-                return RUMActionEvent.CiTest(testExecutionId: testID)
-            }
-            return nil
-        }()
 
         let eventData = RUMActionEvent(
             dd: .init(
@@ -326,7 +320,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 type: .applicationStart
             ),
             application: .init(id: context.rumApplicationID),
-            ciTest: ciTest,
+            ciTest: dependencies.ciTest,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
@@ -334,7 +328,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: nil,
                 id: context.sessionID.toRUMDataFormat,
-                type: ciTest != nil ? .ciTest : .user
+                type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .ios,
             synthetics: nil,
@@ -368,13 +362,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let refreshRateInfo = vitalInfoSampler.refreshRate
         let isSlowRendered = refreshRateInfo.meanValue.flatMap { $0 < Constants.slowRenderingThresholdFPS }
 
-        let ciTest: RUMViewEvent.CiTest? = {
-            if let testID = CITestIntegration.ciTestExecutionID {
-                return RUMViewEvent.CiTest(testExecutionId: testID)
-            }
-            return nil
-        }()
-
         let eventData = RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -382,7 +369,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 session: .init(plan: .plan1)
             ),
             application: .init(id: context.rumApplicationID),
-            ciTest: ciTest,
+            ciTest: dependencies.ciTest,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
@@ -390,7 +377,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: nil,
                 id: context.sessionID.toRUMDataFormat,
-                type: ciTest != nil ? .ciTest : .user
+                type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .ios,
             synthetics: nil,
@@ -446,13 +433,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     private func sendErrorEvent(on command: RUMAddCurrentViewErrorCommand) -> Bool {
         attributes.merge(rumCommandAttributes: command.attributes)
 
-        let ciTest: RUMErrorEvent.CiTest? = {
-            if let testID = CITestIntegration.ciTestExecutionID {
-                return RUMErrorEvent.CiTest(testExecutionId: testID)
-            }
-            return nil
-        }()
-
         let eventData = RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -462,7 +442,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 .init(id: rumUUID.toRUMDataFormat)
             },
             application: .init(id: context.rumApplicationID),
-            ciTest: ciTest,
+            ciTest: dependencies.ciTest,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
@@ -482,7 +462,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: nil,
                 id: context.sessionID.toRUMDataFormat,
-                type: ciTest != nil ? .ciTest : .user
+                type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .ios,
             synthetics: nil,
@@ -508,14 +488,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         let taskDurationInNs = command.duration.toInt64Nanoseconds
         let isFrozenFrame = taskDurationInNs > Constants.frozenFrameThresholdInNs
-
-        let ciTest: RUMLongTaskEvent.CiTest? = {
-            if let testID = CITestIntegration.ciTestExecutionID {
-                return RUMLongTaskEvent.CiTest(testExecutionId: testID)
-            }
-            return nil
-        }()
-
+        
         let eventData = RUMLongTaskEvent(
             dd: .init(
                 browserSdkVersion: nil,
@@ -523,7 +496,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             ),
             action: context.activeUserActionID.flatMap { RUMLongTaskEvent.Action(id: $0.toRUMDataFormat) },
             application: .init(id: context.rumApplicationID),
-            ciTest: ciTest,
+            ciTest: dependencies.ciTest,
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time - command.duration).timeIntervalSince1970.toInt64Milliseconds,
@@ -532,7 +505,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: nil,
                 id: context.sessionID.toRUMDataFormat,
-                type: ciTest != nil ? .ciTest : .user
+                type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .ios,
             synthetics: nil,

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -195,6 +195,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     rumUUIDGenerator: rumFeature.configuration.uuidGenerator,
                     dateCorrector: rumFeature.dateCorrector,
                     crashContextIntegration: RUMWithCrashContextIntegration(),
+                    ciTest: CITestIntegration.active?.rumCITest,
                     vitalCPUReader: rumFeature.vitalCPUReader,
                     vitalMemoryReader: rumFeature.vitalMemoryReader,
                     vitalRefreshRateReader: rumFeature.vitalRefreshRateReader,
@@ -222,9 +223,8 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
             self.enableRUMDebugging(true)
         }
 
-        if CITestIntegration.isEnabled() {
-            CITestIntegration.startIntegration() }
-        }
+        CITestIntegration.active?.startIntegration()
+    }
 
     // MARK: - Public DDRUMMonitor conformance
 

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -221,7 +221,10 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         if Datadog.debugRUM {
             self.enableRUMDebugging(true)
         }
-    }
+
+        if CITestIntegration.isEnabled() {
+            CITestIntegration.startIntegration() }
+        }
 
     // MARK: - Public DDRUMMonitor conformance
 

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -108,6 +108,7 @@ public class Tracer: OTTracer {
                 carrierInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.carrierInfoProvider : nil,
                 dateCorrector: tracingFeature.dateCorrector,
                 source: tracingFeature.configuration.common.source,
+                origin: tracingFeature.configuration.common.origin ,
                 eventsMapper: tracingFeature.configuration.spanEventMapper
             ),
             spanOutput: SpanFileOutput(

--- a/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
@@ -24,6 +24,8 @@ internal struct SpanEventBuilder {
     let dateCorrector: DateCorrectorType
     /// Source tag to encode in span (e.g. `ios` for native iOS).
     let source: String
+    /// Optional Origin tag to encode in span (e.g. `ciapp-test`).
+    let origin: String?
     /// Span events mapper configured by the user, `nil` if not set.
     let eventsMapper: SpanEventMapper?
 
@@ -69,6 +71,7 @@ internal struct SpanEventBuilder {
             duration: finishTime.timeIntervalSince(startTime),
             isError: tagsReducer.extractedIsError ?? false,
             source: source,
+            origin: origin,
             tracerVersion: sdkVersion,
             applicationVersion: applicationVersion,
             networkConnectionInfo: networkConnectionInfoProvider?.current,

--- a/Sources/Datadog/Tracing/Span/SpanEventEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEventEncoder.swift
@@ -53,6 +53,8 @@ public struct SpanEvent: Encodable {
     public let isError: Bool
     /// Name of the component sourcing the span, for iOS SDK it is set to `ios`.
     internal let source: String
+    /// The origin for the Span, it is used to label the spans used created under testing
+    internal let origin: String?
 
     // MARK: - Meta
 
@@ -115,6 +117,8 @@ internal struct SpanEventEncoder {
         case source = "meta._dd.source"
         case applicationVersion = "meta.version"
         case tracerVersion = "meta.tracer.version"
+
+        case origin = "meta._dd.origin"
 
         case userId = "meta.usr.id"
         case userName = "meta.usr.name"
@@ -183,6 +187,8 @@ internal struct SpanEventEncoder {
         try container.encode(span.source, forKey: .source)
         try container.encode(span.tracerVersion, forKey: .tracerVersion)
         try container.encode(span.applicationVersion, forKey: .applicationVersion)
+
+        try span.origin.ifNotNil { try container.encode($0, forKey: .origin) }
 
         try span.userInfo.id.ifNotNil { try container.encode($0, forKey: .userId) }
         try span.userInfo.name.ifNotNil { try container.encode($0, forKey: .userName) }

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -90,7 +90,7 @@ internal final class TracingFeature {
                         device: commonDependencies.mobileDevice
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.source),
+                    .ddEVPOriginHeader(source: configuration.common.origin),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],
@@ -157,11 +157,9 @@ internal final class TracingFeature {
         self.upload = upload
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func deinitialize() {
+    internal func deinitialize() {
         storage.flushAndTearDown()
         upload.flushAndTearDown()
         TracingFeature.instance = nil
     }
-#endif
 }

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -90,7 +90,7 @@ internal final class TracingFeature {
                         device: commonDependencies.mobileDevice
                     ),
                     .ddAPIKeyHeader(clientToken: configuration.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.origin),
+                    .ddEVPOriginHeader(source: configuration.common.origin ?? configuration.common.source),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),
                 ],

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
@@ -48,11 +48,9 @@ internal final class URLSessionAutoInstrumentation: RUMCommandPublisher {
         rumResourceHandler?.publish(to: subscriber)
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     /// Removes `URLSession` swizzling and deinitializes this component.
-    func deinitialize() {
+    internal func deinitialize() {
         swizzler.unswizzle()
         URLSessionAutoInstrumentation.instance = nil
     }
-#endif
 }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
@@ -39,14 +39,12 @@ internal class URLSessionSwizzler {
         dataTaskWithURL?.swizzle()
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
-    func unswizzle() {
+    internal func unswizzle() {
         dataTaskWithURLRequestAndCompletion.unswizzle()
         dataTaskWithURLRequest.unswizzle()
         dataTaskWithURLAndCompletion?.unswizzle()
         dataTaskWithURL?.unswizzle()
     }
-#endif
 
     // MARK: - Swizzlings
 

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -28,8 +28,8 @@ public class DDRUMViewEvent: NSObject {
         DDRUMViewEventApplication(root: root)
     }
 
-    @objc public var ciTest: DDRUMViewEventCiTest? {
-        root.swiftModel.ciTest != nil ? DDRUMViewEventCiTest(root: root) : nil
+    @objc public var ciTest: DDRUMViewEventRUMCITest? {
+        root.swiftModel.ciTest != nil ? DDRUMViewEventRUMCITest(root: root) : nil
     }
 
     @objc public var connectivity: DDRUMViewEventRUMConnectivity? {
@@ -145,7 +145,7 @@ public class DDRUMViewEventApplication: NSObject {
 }
 
 @objc
-public class DDRUMViewEventCiTest: NSObject {
+public class DDRUMViewEventRUMCITest: NSObject {
     internal let root: DDRUMViewEvent
 
     internal init(root: DDRUMViewEvent) {
@@ -692,8 +692,8 @@ public class DDRUMResourceEvent: NSObject {
         DDRUMResourceEventApplication(root: root)
     }
 
-    @objc public var ciTest: DDRUMResourceEventCiTest? {
-        root.swiftModel.ciTest != nil ? DDRUMResourceEventCiTest(root: root) : nil
+    @objc public var ciTest: DDRUMResourceEventRUMCITest? {
+        root.swiftModel.ciTest != nil ? DDRUMResourceEventRUMCITest(root: root) : nil
     }
 
     @objc public var connectivity: DDRUMResourceEventRUMConnectivity? {
@@ -830,7 +830,7 @@ public class DDRUMResourceEventApplication: NSObject {
 }
 
 @objc
-public class DDRUMResourceEventCiTest: NSObject {
+public class DDRUMResourceEventRUMCITest: NSObject {
     internal let root: DDRUMResourceEvent
 
     internal init(root: DDRUMResourceEvent) {
@@ -1458,8 +1458,8 @@ public class DDRUMActionEvent: NSObject {
         DDRUMActionEventApplication(root: root)
     }
 
-    @objc public var ciTest: DDRUMActionEventCiTest? {
-        root.swiftModel.ciTest != nil ? DDRUMActionEventCiTest(root: root) : nil
+    @objc public var ciTest: DDRUMActionEventRUMCITest? {
+        root.swiftModel.ciTest != nil ? DDRUMActionEventRUMCITest(root: root) : nil
     }
 
     @objc public var connectivity: DDRUMActionEventRUMConnectivity? {
@@ -1713,7 +1713,7 @@ public class DDRUMActionEventApplication: NSObject {
 }
 
 @objc
-public class DDRUMActionEventCiTest: NSObject {
+public class DDRUMActionEventRUMCITest: NSObject {
     internal let root: DDRUMActionEvent
 
     internal init(root: DDRUMActionEvent) {
@@ -2015,8 +2015,8 @@ public class DDRUMErrorEvent: NSObject {
         DDRUMErrorEventApplication(root: root)
     }
 
-    @objc public var ciTest: DDRUMErrorEventCiTest? {
-        root.swiftModel.ciTest != nil ? DDRUMErrorEventCiTest(root: root) : nil
+    @objc public var ciTest: DDRUMErrorEventRUMCITest? {
+        root.swiftModel.ciTest != nil ? DDRUMErrorEventRUMCITest(root: root) : nil
     }
 
     @objc public var connectivity: DDRUMErrorEventRUMConnectivity? {
@@ -2145,7 +2145,7 @@ public class DDRUMErrorEventApplication: NSObject {
 }
 
 @objc
-public class DDRUMErrorEventCiTest: NSObject {
+public class DDRUMErrorEventRUMCITest: NSObject {
     internal let root: DDRUMErrorEvent
 
     internal init(root: DDRUMErrorEvent) {
@@ -2726,8 +2726,8 @@ public class DDRUMLongTaskEvent: NSObject {
         DDRUMLongTaskEventApplication(root: root)
     }
 
-    @objc public var ciTest: DDRUMLongTaskEventCiTest? {
-        root.swiftModel.ciTest != nil ? DDRUMLongTaskEventCiTest(root: root) : nil
+    @objc public var ciTest: DDRUMLongTaskEventRUMCITest? {
+        root.swiftModel.ciTest != nil ? DDRUMLongTaskEventRUMCITest(root: root) : nil
     }
 
     @objc public var connectivity: DDRUMLongTaskEventRUMConnectivity? {
@@ -2856,7 +2856,7 @@ public class DDRUMLongTaskEventApplication: NSObject {
 }
 
 @objc
-public class DDRUMLongTaskEventCiTest: NSObject {
+public class DDRUMLongTaskEventRUMCITest: NSObject {
     internal let root: DDRUMLongTaskEvent
 
     internal init(root: DDRUMLongTaskEvent) {

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -88,6 +88,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
             duration: Double.random(in: 0.0..<1.0),
             isError: false,
             source: "ios",
+            origin: nil,
             tracerVersion: "0.0.0",
             applicationVersion: "0.0.0",
             networkConnectionInfo: NetworkConnectionInfo(

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CITestIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CITestIntegrationTests.swift
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+@testable import Datadog
+import XCTest
+
+class CITestIntegrationTests: XCTestCase {
+    func testByDefaultCITestIntegrationIsNotConfigured() throws {
+        XCTAssertNil(CITestIntegration.active)
+    }
+}

--- a/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
@@ -28,6 +28,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
         let randomApplicationName: String = .mockRandom()
         let randomApplicationVersion: String = .mockRandom()
         let randomSource: String = .mockRandom(among: .alphanumerics)
+        let randomOrigin: String = .mockRandom(among: .alphanumerics)
         let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
         let randomUploadURL: URL = .mockRandom()
         let randomClientToken: String = .mockRandom()
@@ -45,6 +46,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
                     applicationName: randomApplicationName,
                     applicationVersion: randomApplicationVersion,
                     source: randomSource,
+                    origin: randomOrigin,
                     sdkVersion: randomSDKVersion
                 ),
                 logsUploadURL: randomUploadURL,
@@ -75,7 +77,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Encoding"], "deflate")
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
-        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomSource)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomOrigin)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
     }

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -28,6 +28,7 @@ class LoggingFeatureTests: XCTestCase {
         let randomApplicationName: String = .mockRandom()
         let randomApplicationVersion: String = .mockRandom()
         let randomSource: String = .mockRandom(among: .alphanumerics)
+        let randomOrigin: String = .mockRandom(among: .alphanumerics)
         let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
         let randomUploadURL: URL = .mockRandom()
         let randomClientToken: String = .mockRandom()
@@ -45,6 +46,7 @@ class LoggingFeatureTests: XCTestCase {
                     applicationName: randomApplicationName,
                     applicationVersion: randomApplicationVersion,
                     source: randomSource,
+                    origin: randomOrigin,
                     sdkVersion: randomSDKVersion
                 ),
                 uploadURL: randomUploadURL,
@@ -75,7 +77,7 @@ class LoggingFeatureTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "application/json")
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Encoding"], "deflate")
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
-        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomSource)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomOrigin)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
     }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -194,6 +194,7 @@ extension FeaturesConfiguration.Common {
         environment: String = .mockAny(),
         performance: PerformancePreset = .init(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
         source: String = .mockAny(),
+        origin: String? = nil,
         sdkVersion: String = .mockAny(),
         proxyConfiguration: [AnyHashable: Any]? = nil
     ) -> Self {
@@ -205,6 +206,7 @@ extension FeaturesConfiguration.Common {
             environment: environment,
             performance: performance,
             source: source,
+            origin: origin,
             sdkVersion: sdkVersion,
             proxyConfiguration: proxyConfiguration
         )

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -624,6 +624,7 @@ extension RUMScopeDependencies {
         rumUUIDGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
         dateCorrector: DateCorrectorType = DateCorrectorMock(),
         crashContextIntegration: RUMWithCrashContextIntegration? = nil,
+        ciTest: RUMCITest? = nil,
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListerner()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -637,6 +638,7 @@ extension RUMScopeDependencies {
             rumUUIDGenerator: rumUUIDGenerator,
             dateCorrector: dateCorrector,
             crashContextIntegration: crashContextIntegration,
+            ciTest: ciTest,
             vitalCPUReader: SamplingBasedVitalReaderMock(),
             vitalMemoryReader: SamplingBasedVitalReaderMock(),
             vitalRefreshRateReader: ContinuousVitalReaderMock(),
@@ -656,6 +658,7 @@ extension RUMScopeDependencies {
         rumUUIDGenerator: RUMUUIDGenerator? = nil,
         dateCorrector: DateCorrectorType? = nil,
         crashContextIntegration: RUMWithCrashContextIntegration? = nil,
+        ciTest: RUMCITest? = nil,
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListerner()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -669,6 +672,7 @@ extension RUMScopeDependencies {
             rumUUIDGenerator: rumUUIDGenerator ?? self.rumUUIDGenerator,
             dateCorrector: dateCorrector ?? self.dateCorrector,
             crashContextIntegration: crashContextIntegration ?? self.crashContextIntegration,
+            ciTest: ciTest,
             vitalCPUReader: SamplingBasedVitalReaderMock(),
             vitalMemoryReader: SamplingBasedVitalReaderMock(),
             vitalRefreshRateReader: ContinuousVitalReaderMock(),

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -178,6 +178,7 @@ extension SpanEvent: AnyMockable, RandomMockable {
         duration: TimeInterval = .mockAny(),
         isError: Bool = .mockAny(),
         source: String = .mockAny(),
+        origin: String? = nil,
         tracerVersion: String = .mockAny(),
         applicationVersion: String = .mockAny(),
         networkConnectionInfo: NetworkConnectionInfo? = .mockAny(),
@@ -196,6 +197,7 @@ extension SpanEvent: AnyMockable, RandomMockable {
             duration: duration,
             isError: isError,
             source: source,
+            origin: origin,
             tracerVersion: tracerVersion,
             applicationVersion: applicationVersion,
             networkConnectionInfo: networkConnectionInfo,
@@ -219,6 +221,7 @@ extension SpanEvent: AnyMockable, RandomMockable {
             duration: .mockRandom(),
             isError: .random(),
             source: .mockRandom(),
+            origin: .mockRandom(),
             tracerVersion: .mockRandom(),
             applicationVersion: .mockRandom(),
             networkConnectionInfo: .mockRandom(),
@@ -300,6 +303,7 @@ extension SpanEventBuilder {
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny(),
         dateCorrector: DateCorrectorType = DateCorrectorMock(),
         source: String = .mockAny(),
+        origin: String? = nil,
         sdkVersion: String = .mockAny(),
         eventsMapper: SpanEventMapper? = nil
     ) -> SpanEventBuilder {
@@ -312,6 +316,7 @@ extension SpanEventBuilder {
             carrierInfoProvider: carrierInfoProvider,
             dateCorrector: dateCorrector,
             source: source,
+            origin: origin,
             eventsMapper: eventsMapper
         )
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -30,6 +30,7 @@ class RUMFeatureTests: XCTestCase {
         let randomServiceName: String = .mockRandom(among: .alphanumerics)
         let randomEnvironmentName: String = .mockRandom(among: .alphanumerics)
         let randomSource: String = .mockRandom(among: .alphanumerics)
+        let randomOrigin: String = .mockRandom(among: .alphanumerics)
         let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
         let randomUploadURL: URL = .mockRandom()
         let randomClientToken: String = .mockRandom()
@@ -49,6 +50,7 @@ class RUMFeatureTests: XCTestCase {
                     serviceName: randomServiceName,
                     environment: randomEnvironmentName,
                     source: randomSource,
+                    origin: randomOrigin,
                     sdkVersion: randomSDKVersion
                 ),
                 uploadURL: randomUploadURL,
@@ -84,7 +86,7 @@ class RUMFeatureTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "text/plain;charset=UTF-8")
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Encoding"], "deflate")
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
-        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomSource)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomOrigin)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
     }

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -28,6 +28,7 @@ class TracingFeatureTests: XCTestCase {
         let randomApplicationName: String = .mockRandom()
         let randomApplicationVersion: String = .mockRandom()
         let randomSource: String = .mockRandom()
+        let randomOrigin: String = .mockRandom()
         let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
         let randomUploadURL: URL = .mockRandom()
         let randomClientToken: String = .mockRandom()
@@ -45,6 +46,7 @@ class TracingFeatureTests: XCTestCase {
                     applicationName: randomApplicationName,
                     applicationVersion: randomApplicationVersion,
                     source: randomSource,
+                    origin: randomOrigin,
                     sdkVersion: randomSDKVersion
                 ),
                 uploadURL: randomUploadURL,
@@ -76,7 +78,7 @@ class TracingFeatureTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Type"], "text/plain;charset=UTF-8")
         XCTAssertEqual(request.allHTTPHeaderFields?["Content-Encoding"], "deflate")
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
-        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomSource)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomOrigin)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
         XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
     }

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -10,7 +10,7 @@ import Foundation
 internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
     /// Types which will shared between all input `types`. Sharing means detaching those types from nested declaration
     /// and putting them at the root level of the resultant `types` array, so the type can be printed without being nested.
-    private let sharedTypeNames = ["RUMConnectivity", "RUMUser", "RUMMethod", "RUMEventAttributes"]
+    private let sharedTypeNames = ["RUMConnectivity", "RUMUser", "RUMMethod", "RUMEventAttributes", "RUMCITest"]
     /// `RUMDataModel` protocol, implemented by all RUM models.
     private let rumDataModelProtocol = SwiftProtocol(name: "RUMDataModel", conformance: [codableProtocol])
 
@@ -170,6 +170,10 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
 
         if fixedName == "Context" {
             fixedName = "RUMEventAttributes"
+        }
+
+        if fixedName == "CiTest" {
+            fixedName = "RUMCITest"
         }
 
         return fixedName


### PR DESCRIPTION
### What and why?

This PR enables a much deeper integration of RUM with CI Visibility product ([dd-sdk-swift-testing](https://github.com/DataDog/dd-sdk-swift-testing)). If a UI test instrumented with CI Visibility is run and a RUM sessions is configured, the session will be identified as a created by CI App and will be shown as part of the test.

There is a related [PR](https://github.com/DataDog/dd-sdk-swift-testing/pull/60) with the needed changes in the **dd-sdk-swift-testing** framework



### How?
RUM now detects on loading if is running under an instrumented test by checking if the environment variable `CI_VISIBILITY_TEST_EXECUTION_ID` is available, which contains the test identifier. If so it makes the following changes:
* Sets `session.type` to `ci-test`
* Injects `ci_visibility.test_execution_id` to every event
* Set `_dd.origin` to `ciapp-test` so that APM traces from RUM in CI Visibility mode can be distinguished.
* Send a message to a Mach Port initialized in the CI Visibility framework (TestMachPort) to notify RUM is enabled
* Creates a new Mach Port (RUMMachPort) that will receive a message when the test ends. RUM will flush the RUM events when the message is received.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing change. 
