### PR TITLE
RUMM-2033 Rename iOS targets

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -3591,9 +3591,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		61133B81242393DE00786299 /* Datadog */ = {
+		61133B81242393DE00786299 /* Datadog iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 61133B96242393DE00786299 /* Build configuration list for PBXNativeTarget "Datadog" */;
+			buildConfigurationList = 61133B96242393DE00786299 /* Build configuration list for PBXNativeTarget "Datadog iOS" */;
 			buildPhases = (
 				61133B7D242393DE00786299 /* Headers */,
 				61133B7E242393DE00786299 /* Sources */,
@@ -3605,14 +3605,14 @@
 			);
 			dependencies = (
 			);
-			name = Datadog;
+			name = "Datadog iOS";
 			productName = Datadog;
 			productReference = 61133B82242393DE00786299 /* Datadog.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		61133B8A242393DE00786299 /* DatadogTests */ = {
+		61133B8A242393DE00786299 /* DatadogTests iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 61133B99242393DE00786299 /* Build configuration list for PBXNativeTarget "DatadogTests" */;
+			buildConfigurationList = 61133B99242393DE00786299 /* Build configuration list for PBXNativeTarget "DatadogTests iOS" */;
 			buildPhases = (
 				61133B87242393DE00786299 /* Sources */,
 				61133B88242393DE00786299 /* Frameworks */,
@@ -3624,14 +3624,14 @@
 			dependencies = (
 				61441C5A24619A08003D8BB8 /* PBXTargetDependency */,
 			);
-			name = DatadogTests;
+			name = "DatadogTests iOS";
 			productName = DatadogTests;
 			productReference = 61133B8B242393DE00786299 /* DatadogTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		61133BEF242397DA00786299 /* DatadogObjc */ = {
+		61133BEF242397DA00786299 /* DatadogObjc iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 61133C01242397DA00786299 /* Build configuration list for PBXNativeTarget "DatadogObjc" */;
+			buildConfigurationList = 61133C01242397DA00786299 /* Build configuration list for PBXNativeTarget "DatadogObjc iOS" */;
 			buildPhases = (
 				61133BEB242397DA00786299 /* Headers */,
 				61133BEC242397DA00786299 /* Sources */,
@@ -3643,7 +3643,7 @@
 			dependencies = (
 				61133C732423993200786299 /* PBXTargetDependency */,
 			);
-			name = DatadogObjc;
+			name = "DatadogObjc iOS";
 			productName = DatadogObjc;
 			productReference = 61133BF0242397DA00786299 /* DatadogObjc.framework */;
 			productType = "com.apple.product-type.framework";
@@ -3771,9 +3771,9 @@
 			productReference = 61993665265BBEDC009D7EA8 /* E2ETests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		61B7885325C180CB002675B5 /* DatadogCrashReporting */ = {
+		61B7885325C180CB002675B5 /* DatadogCrashReporting iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 61B7886B25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReporting" */;
+			buildConfigurationList = 61B7886B25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReporting iOS" */;
 			buildPhases = (
 				61B7884F25C180CB002675B5 /* Headers */,
 				61B7885025C180CB002675B5 /* Sources */,
@@ -3786,14 +3786,14 @@
 			dependencies = (
 				61DE335825C82941008E3EC2 /* PBXTargetDependency */,
 			);
-			name = DatadogCrashReporting;
+			name = "DatadogCrashReporting iOS";
 			productName = DatadogCrashReporting;
 			productReference = 61B7885425C180CB002675B5 /* DatadogCrashReporting.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		61B7885B25C180CB002675B5 /* DatadogCrashReportingTests */ = {
+		61B7885B25C180CB002675B5 /* DatadogCrashReportingTests iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 61B7886C25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReportingTests" */;
+			buildConfigurationList = 61B7886C25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReportingTests iOS" */;
 			buildPhases = (
 				61B7885825C180CB002675B5 /* Sources */,
 				61B7885925C180CB002675B5 /* Frameworks */,
@@ -3806,7 +3806,7 @@
 				61B7885F25C180CB002675B5 /* PBXTargetDependency */,
 				61B7888025C18147002675B5 /* PBXTargetDependency */,
 			);
-			name = DatadogCrashReportingTests;
+			name = "DatadogCrashReportingTests iOS";
 			productName = DatadogCrashReportingTests;
 			productReference = 61B7885C25C180CB002675B5 /* DatadogCrashReportingTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -3878,11 +3878,11 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				61133B81242393DE00786299 /* Datadog */,
-				61133BEF242397DA00786299 /* DatadogObjc */,
-				61B7885325C180CB002675B5 /* DatadogCrashReporting */,
-				61133B8A242393DE00786299 /* DatadogTests */,
-				61B7885B25C180CB002675B5 /* DatadogCrashReportingTests */,
+				61133B81242393DE00786299 /* Datadog iOS */,
+				61133BEF242397DA00786299 /* DatadogObjc iOS */,
+				61B7885325C180CB002675B5 /* DatadogCrashReporting iOS */,
+				61133B8A242393DE00786299 /* DatadogTests iOS */,
+				61B7885B25C180CB002675B5 /* DatadogCrashReportingTests iOS */,
 				61441C6724619FE4003D8BB8 /* DatadogBenchmarkTests */,
 				61441C2924616F1D003D8BB8 /* DatadogIntegrationTests */,
 				61441C0124616DE9003D8BB8 /* Example */,
@@ -4705,7 +4705,7 @@
 /* Begin PBXTargetDependency section */
 		61133C732423993200786299 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 61133B81242393DE00786299 /* Datadog */;
+			target = 61133B81242393DE00786299 /* Datadog iOS */;
 			targetProxy = 61133C722423993200786299 /* PBXContainerItemProxy */;
 		};
 		61441C3024616F1D003D8BB8 /* PBXTargetDependency */ = {
@@ -4715,7 +4715,7 @@
 		};
 		61441C5024619499003D8BB8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 61133B81242393DE00786299 /* Datadog */;
+			target = 61133B81242393DE00786299 /* Datadog iOS */;
 			targetProxy = 61441C4F24619499003D8BB8 /* PBXContainerItemProxy */;
 		};
 		61441C5A24619A08003D8BB8 /* PBXTargetDependency */ = {
@@ -4730,12 +4730,12 @@
 		};
 		614ED39D260357FA00C8C519 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
+			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting iOS */;
 			targetProxy = 614ED39C260357FA00C8C519 /* PBXContainerItemProxy */;
 		};
 		6170DC5325C18E57003AED5C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
+			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting iOS */;
 			targetProxy = 6170DC5225C18E57003AED5C /* PBXContainerItemProxy */;
 		};
 		618F9846265BC486009959F8 /* PBXTargetDependency */ = {
@@ -4745,12 +4745,12 @@
 		};
 		61993659265BB6A6009D7EA8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 61133B81242393DE00786299 /* Datadog */;
+			target = 61133B81242393DE00786299 /* Datadog iOS */;
 			targetProxy = 61993658265BB6A6009D7EA8 /* PBXContainerItemProxy */;
 		};
 		6199365D265BB6A6009D7EA8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
+			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting iOS */;
 			targetProxy = 6199365C265BB6A6009D7EA8 /* PBXContainerItemProxy */;
 		};
 		6199366B265BBEDC009D7EA8 /* PBXTargetDependency */ = {
@@ -4760,7 +4760,7 @@
 		};
 		61B7885F25C180CB002675B5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting */;
+			target = 61B7885325C180CB002675B5 /* DatadogCrashReporting iOS */;
 			targetProxy = 61B7885E25C180CB002675B5 /* PBXContainerItemProxy */;
 		};
 		61B7888025C18147002675B5 /* PBXTargetDependency */ = {
@@ -4770,7 +4770,7 @@
 		};
 		61DE335825C82941008E3EC2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 61133B81242393DE00786299 /* Datadog */;
+			target = 61133B81242393DE00786299 /* Datadog iOS */;
 			targetProxy = 61DE335725C82941008E3EC2 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -4944,7 +4944,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.Datadog;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
@@ -4973,7 +4973,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.Datadog;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
@@ -4995,7 +4995,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)Tests";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -5018,7 +5018,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)Tests";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -5047,7 +5047,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogObjc;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(DD_OBJC_SDK_PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
@@ -5076,7 +5076,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogObjc;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(DD_OBJC_SDK_PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
@@ -5461,7 +5461,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReporting;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -5492,7 +5492,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReporting;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
@@ -5522,7 +5522,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReporting;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
@@ -5543,7 +5543,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)Tests";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
@@ -5562,7 +5562,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)Tests";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
@@ -5581,7 +5581,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogCrashReportingTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(DD_CR_SDK_PRODUCT_NAME)Tests";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
@@ -5666,7 +5666,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.Datadog;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
@@ -5695,7 +5695,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogObjc;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(DD_OBJC_SDK_PRODUCT_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
@@ -5717,7 +5717,7 @@
 					"@loader_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.DatadogTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(DD_SWIFT_SDK_PRODUCT_NAME)Tests";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "TargetSupport/DatadogTests/DatadogTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -5738,7 +5738,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		61133B96242393DE00786299 /* Build configuration list for PBXNativeTarget "Datadog" */ = {
+		61133B96242393DE00786299 /* Build configuration list for PBXNativeTarget "Datadog iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				61133B97242393DE00786299 /* Debug */,
@@ -5748,7 +5748,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		61133B99242393DE00786299 /* Build configuration list for PBXNativeTarget "DatadogTests" */ = {
+		61133B99242393DE00786299 /* Build configuration list for PBXNativeTarget "DatadogTests iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				61133B9A242393DE00786299 /* Debug */,
@@ -5758,7 +5758,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		61133C01242397DA00786299 /* Build configuration list for PBXNativeTarget "DatadogObjc" */ = {
+		61133C01242397DA00786299 /* Build configuration list for PBXNativeTarget "DatadogObjc iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				61133C02242397DA00786299 /* Debug */,
@@ -5828,7 +5828,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		61B7886B25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReporting" */ = {
+		61B7886B25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReporting iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				61B7886525C180CB002675B5 /* Debug */,
@@ -5838,7 +5838,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		61B7886C25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReportingTests" */ = {
+		61B7886C25C180CB002675B5 /* Build configuration list for PBXNativeTarget "DatadogCrashReportingTests iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				61B7886825C180CB002675B5 /* Debug */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog iOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61133B81242393DE00786299"
                BuildableName = "Datadog.framework"
-               BlueprintName = "Datadog"
+               BlueprintName = "Datadog iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -35,7 +35,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133B8A242393DE00786299"
             BuildableName = "DatadogTests.xctest"
-            BlueprintName = "DatadogTests"
+            BlueprintName = "DatadogTests iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -127,14 +127,14 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133B81242393DE00786299"
             BuildableName = "Datadog.framework"
-            BlueprintName = "Datadog"
+            BlueprintName = "Datadog iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133BEF242397DA00786299"
             BuildableName = "DatadogObjc.framework"
-            BlueprintName = "DatadogObjc"
+            BlueprintName = "DatadogObjc iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
@@ -146,7 +146,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61133B8A242393DE00786299"
                BuildableName = "DatadogTests.xctest"
-               BlueprintName = "DatadogTests"
+               BlueprintName = "DatadogTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -174,7 +174,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133B81242393DE00786299"
             BuildableName = "Datadog.framework"
-            BlueprintName = "Datadog"
+            BlueprintName = "Datadog iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61B7885325C180CB002675B5"
                BuildableName = "DatadogCrashReporting.framework"
-               BlueprintName = "DatadogCrashReporting"
+               BlueprintName = "DatadogCrashReporting iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -35,7 +35,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61B7885B25C180CB002675B5"
             BuildableName = "DatadogCrashReportingTests.xctest"
-            BlueprintName = "DatadogCrashReportingTests"
+            BlueprintName = "DatadogCrashReportingTests iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -182,7 +182,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61B7885325C180CB002675B5"
             BuildableName = "DatadogCrashReporting.framework"
-            BlueprintName = "DatadogCrashReporting"
+            BlueprintName = "DatadogCrashReporting iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
@@ -193,7 +193,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61B7885B25C180CB002675B5"
                BuildableName = "DatadogCrashReportingTests.xctest"
-               BlueprintName = "DatadogCrashReportingTests"
+               BlueprintName = "DatadogCrashReportingTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -221,7 +221,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61B7885325C180CB002675B5"
             BuildableName = "DatadogCrashReporting.framework"
-            BlueprintName = "DatadogCrashReporting"
+            BlueprintName = "DatadogCrashReporting iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
@@ -143,14 +143,14 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133B81242393DE00786299"
             BuildableName = "Datadog.framework"
-            BlueprintName = "Datadog"
+            BlueprintName = "Datadog iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133BEF242397DA00786299"
             BuildableName = "DatadogObjc.framework"
-            BlueprintName = "DatadogObjc"
+            BlueprintName = "DatadogObjc iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc iOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61133BEF242397DA00786299"
                BuildableName = "DatadogObjc.framework"
-               BlueprintName = "DatadogObjc"
+               BlueprintName = "DatadogObjc iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -34,7 +34,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133B8A242393DE00786299"
             BuildableName = "DatadogTests.xctest"
-            BlueprintName = "DatadogTests"
+            BlueprintName = "DatadogTests iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -121,14 +121,14 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133B81242393DE00786299"
             BuildableName = "Datadog.framework"
-            BlueprintName = "Datadog"
+            BlueprintName = "Datadog iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133BEF242397DA00786299"
             BuildableName = "DatadogObjc.framework"
-            BlueprintName = "DatadogObjc"
+            BlueprintName = "DatadogObjc iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </CodeCoverageTargets>
@@ -139,7 +139,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "61133B8A242393DE00786299"
                BuildableName = "DatadogTests.xctest"
-               BlueprintName = "DatadogTests"
+               BlueprintName = "DatadogTests iOS"
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -167,7 +167,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "61133BEF242397DA00786299"
             BuildableName = "DatadogObjc.framework"
-            BlueprintName = "DatadogObjc"
+            BlueprintName = "DatadogObjc iOS"
             ReferencedContainer = "container:Datadog.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,9 @@ rum-models-verify:
 api-surface:
 		@cd tools/api-surface/ && swift build --configuration release
 		@echo "Generating api-surface-swift"
-		./tools/api-surface/.build/x86_64-apple-macosx/release/api-surface workspace --workspace-name Datadog.xcworkspace --scheme Datadog --path . > api-surface-swift
+		./tools/api-surface/.build/x86_64-apple-macosx/release/api-surface workspace --workspace-name Datadog.xcworkspace --scheme "Datadog iOS" --path . > api-surface-swift
 		@echo "Generating api-surface-objc"
-		./tools/api-surface/.build/x86_64-apple-macosx/release/api-surface workspace --workspace-name Datadog.xcworkspace --scheme DatadogObjc --path . > api-surface-objc
+		./tools/api-surface/.build/x86_64-apple-macosx/release/api-surface workspace --workspace-name Datadog.xcworkspace --scheme "DatadogObjc iOS" --path . > api-surface-objc
 
 # Generate Datadog monitors terraform definition for E2E tests:
 e2e-monitors-generate:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -129,22 +129,22 @@ workflows:
     - xcode-test:
         title: Run unit tests for Datadog - iOS Simulator
         inputs:
-        - scheme: Datadog
-        - simulator_device: iPhone 11
+        - scheme: Datadog iOS
+        - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
         - is_clean_build: 'yes'
         - test_repetition_mode: 'retry_on_failure'
         - maximum_test_repetitions: 2
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
-        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Datadog-unit-tests.html"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Datadog-ios-unit-tests.html"
     - xcode-test:
         title: Run unit tests for DatadogCrashReporting - iOS Simulator
         inputs:
-        - scheme: DatadogCrashReporting
-        - simulator_device: iPhone 11
+        - scheme: DatadogCrashReporting iOS
+        - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
-        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogCrashReporting-unit-tests.html"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogCrashReporting-ios-unit-tests.html"
     - xcode-test:
         title: Run benchmarks - DatadogBenchmarkTests on iOS Simulator
         inputs:

--- a/tools/nightly-unit-tests/bitrise.yml.src
+++ b/tools/nightly-unit-tests/bitrise.yml.src
@@ -6,7 +6,7 @@ project_type: other
 app:
   envs:
   - PROJECT_PATH: Datadog.xcworkspace
-  - PROJECT_SCHEME: Datadog
+  - PROJECT_SCHEME: Datadog iOS
 
 workflows:
   run_all:

--- a/xcconfigs/Base.xcconfig
+++ b/xcconfigs/Base.xcconfig
@@ -1,5 +1,9 @@
 // Base configuration file for all targets.
 // Note: all configuration here will be applied to `Datadog*.framework` produced by Carthage.
 
+DD_SWIFT_SDK_PRODUCT_NAME=Datadog
+DD_OBJC_SDK_PRODUCT_NAME=DatadogObjc
+DD_CR_SDK_PRODUCT_NAME=DatadogCrashReporting
+
 // Include internal base config (git-ignored, so excluded from Carthage build)
 #include? "Base.local.xcconfig"


### PR DESCRIPTION
### What and why?

Add `iOS` suffix to iOS targets to prepare addition of `tvOS` targets.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing change. 
