### PR TITLE
RUMM-2010 Sanitize app name in User Agent

### DIFF
--- a/Sources/Datadog/Core/Upload/RequestBuilder.swift
+++ b/Sources/Datadog/Core/Upload/RequestBuilder.swift
@@ -57,9 +57,17 @@ internal struct RequestBuilder {
 
         /// Standard "User-Agent" header.
         static func userAgentHeader(appName: String, appVersion: String, device: MobileDevice) -> HTTPHeader {
+            let sanitizedAppName: String
+            do {
+                let regex = try NSRegularExpression(pattern: "[^a-zA-Z0-9 -]+")
+                sanitizedAppName = regex.stringByReplacingMatches(in: appName, options: [], range: NSRange((appName.startIndex..<appName.endIndex), in: appName), withTemplate: "").trimmingCharacters(in: .whitespacesAndNewlines)
+            } catch {
+                sanitizedAppName = appName
+            }
+
             return HTTPHeader(
                 field: userAgentHeaderField,
-                value: .constant("\(appName)/\(appVersion) CFNetwork (\(device.model); \(device.osName)/\(device.osVersion))")
+                value: .constant("\(sanitizedAppName)/\(appVersion) CFNetwork (\(device.model); \(device.osName)/\(device.osVersion))")
             )
         }
 

--- a/Tests/DatadogTests/Datadog/Core/Upload/RequestBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/RequestBuilderTests.swift
@@ -64,6 +64,26 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], "FoobarApp/1.2.3 CFNetwork (iPhone; iOS/13.3.1)")
     }
 
+    func testBuildingRequestWithComplexUserAgentHeader() {
+        let builder = RequestBuilder(
+            url: .mockRandom(),
+            queryItems: .mockRandom(),
+            headers: [
+                .userAgentHeader(
+                    appName: "Foobar 電話 𝛼β",
+                    appVersion: "1.2.3",
+                    device: .mockWith(
+                        model: "iPhone",
+                        osName: "iOS",
+                        osVersion: "13.3.1"
+                    )
+                )
+            ]
+        )
+        let request = builder.uploadRequest(with: .mockRandom())
+        XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], "Foobar/1.2.3 CFNetwork (iPhone; iOS/13.3.1)")
+    }
+
     func testBuildingRequestWithDDAPIKeyHeader() {
         let randomClientToken: String = .mockRandom()
         let builder = RequestBuilder(url: .mockRandom(), queryItems: .mockRandom(), headers: [.ddAPIKeyHeader(clientToken: randomClientToken)])


### PR DESCRIPTION
### What and why?

Prevent any non alpha numeric character from app name when building the user agent