### PR TITLE
DOCS-2567 iOS Crash Reporting and Error Tracking Edits

### DIFF
--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -84,18 +84,18 @@ Crash reports are collected in a raw format and mostly contain memory addresses.
 
 ### Find your dYSM file
 
-Every iOS application produces dYSM files for each application module. Each application version contains a set of dYSM files.
+Every iOS application produces dYSM files for each application module. These files minimize an application's binary size and enable faster download speed. Each application version contains a set of dYSM files. 
 
 Depending on your setup, you may need to download dSYM files from App Store Connect or find them on your local machine. 
 
 | Bitcode Enabled | Description                                                                                                                                                                                                                                                                                       |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Yes             | dSYM files are available once [App Store Connect][6] completes processing your application's build.                                                                                                                                                                                                    |
-| No              | Xcode exports dSYM files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with dYSM File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** in release. |
+| No              | Xcode exports dSYM files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with dYSM File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** for the Release project configuration. |
 
 ### Upload your dYSM file
 
-dYSM files minimize an application's binary size and enable faster download speed. By uploading your dYSM file to Datadog, you gain access to the file path, line number, and code snippet of each frame in an error's related stack trace.
+By uploading your dYSM file to Datadog, you gain access to the file path, line number, and code snippet of each frame in an error's related stack trace.
 
 Once your application crashes and you restart the application, the iOS SDK uploads a crash report to Datadog. 
 

--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -176,7 +176,7 @@ To verify your iOS Crash Reporting and Error Tracking configuration, issue a cra
 1. Run your application on an iOS simulator or a real device. Ensure that the debugger is not attached. Otherwise, Xcode captures the crash before the iOS SDK does.
 2. Execute the code containing the crash:
 
-   ```
+   ```swift
    func didTapButton() {
    fatalError(“Crash the app”)
    }

--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -15,19 +15,24 @@ further_reading:
 <div class="alert alert-info"><p>iOS Crash Reporting and Error Tracking is in beta. Upgrade to <a href="https://github.com/DataDog/dd-sdk-ios/releases">dd-sdk-ios v1.7.0+</a> to get access.</p>
 </div>
 
-Enable iOS Crash Reporting and Error Tracking to get comprehensive crash reports and error trends with Real User Monitoring. With this feature, you get access to:
+Enable iOS Crash Reporting and Error Tracking to get comprehensive crash reports and error trends with Real User Monitoring. With this feature, you can access:
 
  - Aggregated iOS crash dashboards and attributes
  - Symbolicated iOS crash reports
  - Trend analysis with iOS error tracking
 
+In order to symbolicate your stack traces, find and upload your dYSM files to Datadog. Then, verify your configuration by running a test crash and restarting your application. 
+
+Your crash reports appear in [**Error Tracking**][8].
+
 ## Setup
 
-### Add crash reporting 
+If you have not set up the iOS SDK yet, follow the [in-app setup instructions][1] or see the [iOS RUM setup documentation][2].
 
-If you have not set up the SDK yet, follow the [in-app setup instructions][1] or see the [iOS RUM setup documentation][2].
+### Add Crash Reporting 
 
-#### Dependency Manager
+Add the package according to your dependency manager and update your initialize snippet.  
+
 {{< tabs >}}
 {{% tab "CocoaPods" %}}
 Add `DatadogSDKCrashReporting` to your `Podfile`:
@@ -51,7 +56,7 @@ Add `github "DataDog/dd-sdk-ios"` to your `Cartfile` and link `DatadogCrashRepor
 {{% /tab %}}
 {{< /tabs >}}
 
-Update your initialization snippet to include crash reporting:
+Update your initialization snippet to include Crash Reporting:
 
 ```
 import DatadogCrashReporting
@@ -73,32 +78,70 @@ Datadog.initialize(
 Global.rum = RUMMonitor.initialize()
 ```
 
-### Symbolicate reports
+## Symbolicate crash reports
 
-If your iOS error is unsymbolicated, upload your dSYM file using one of the following tools to symbolicate your different stack traces. For any given error, you have access to the file path, the line number, and a code snippet for each frame of the related stack trace.
+Crash reports are collected in a raw format and mostly contain memory addresses. To map these addresses into legible symbol information, Datadog requires dYSM files, which are generated in your application's build or distribution process.
+
+### Find your dYSM file
+
+Every iOS application produces dYSM files for each application module. Each application version contains a set of dYSM files.
+
+Depending on your setup, you may need to download dSYM files from App Store Connect or find them on your local machine. 
+
+| Bitcode Enabled | Description                                                                                                                                                                                                                                                                                       |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Yes             | dSYM files are available once [App Store Connect][6] completes processing your application's build.                                                                                                                                                                                                    |
+| No              | Xcode exports dSYM files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with dYSM File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** in release. |
+
+### Upload your dYSM file
+
+dYSM files minimize an application's binary size and enable faster download speed. By uploading your dYSM file to Datadog, you gain access to the file path, line number, and code snippet of each frame in an error's related stack trace.
+
+Once your application crashes and you restart the application, the iOS SDK uploads a crash report to Datadog. 
+
+#### Datadog CI
+
+You can use the command line tool [@datadog/datadog-ci][5] to upload your dSYM file:
+
+```sh
+export DATADOG_API_KEY="<API KEY>"
+
+// if you have a zip file containing dSYM files
+npx @datadog/datadog-ci dsyms upload appDsyms.zip
+
+// if you have a folder containing dSYM files
+npx @datadog/datadog-ci dsyms upload /path/to/appDsyms/
+```
+
+**Note**: To configure the tool using the EU endpoint, set the `DATADOG_SITE` environment variable to `datadoghq.eu`. To override the full URL for the intake endpoint, define the `DATADOG_DSYM_INTAKE_URL` environment variable. 
+
+Alternatively, if you use Fastlane or GitHub Actions in your workflows, you can leverage these integrations instead of `datadog-ci`:
 
 #### Fastlane Plugin
 
-The Datadog plugin helps you upload dSYM files to Datadog from your fastlane configuration.
+The Datadog plugin helps you upload dSYM files to Datadog from your Fastlane configuration.
 
-1. Add [`fastlane-plugin-datadog`][3] to your project
-```sh
-fastlane add_plugin datadog
-```
+1. Add [`fastlane-plugin-datadog`][3] to your project.
 
-2. Then configure fastlane to upload your symbols, e.g.:
-```ruby
-# download_dsyms action feeds dsym_paths automatically
-lane :upload_dsym_with_download_dsyms do
-  download_dsyms
-  upload_symbols_to_datadog(api_key: "datadog-api-key")
-end
-```
-> See [`fastlane-plugin-datadog`][3] for more instructions.
+   ```sh
+   fastlane add_plugin datadog
+   ```
 
-#### Github Action
+2. Configure Fastlane to upload your symbols.
 
-The [Datadog Upload dSYMs GitHub Action][4] let you upload your symbols during your GitHub Action jobs:
+   ```ruby
+   # download_dsyms action feeds dsym_paths automatically
+   lane :upload_dsym_with_download_dsyms do
+     download_dsyms
+     upload_symbols_to_datadog(api_key: "datadog-api-key")
+   end
+   ```
+
+For more information, see [`fastlane-plugin-datadog`][3].
+
+#### GitHub Action
+
+The [Datadog Upload dSYMs GitHub Action][4] allows you to upload your symbols in your GitHub Action jobs:
 
 ```yml
 name: Upload dSYM Files
@@ -124,24 +167,22 @@ jobs:
             path/to/zip/dsyms.zip
 ```
 
-#### Datadog CI
+For more information, see [dSYMs commands][7].
 
-You can also use the command line tool [@datadog/datadog-ci][5] to upload your dSYM file:
+## Verify crash reports
 
-```sh
-export DATADOG_API_KEY="<API KEY>"
+To verify your iOS Crash Reporting and Error Tracking configuration, issue a crash in your RUM application and confirm that the error appears in Datadog. 
 
-// if you have a zip file containing dSYMs
-npx @datadog/datadog-ci dsyms upload appDsyms.zip
+1. Run your application on an iOS simulator or a real device. Ensure that the debugger is not attached. Otherwise, Xcode captures the crash before the iOS SDK does.
+2. Execute the code containing the crash:
 
-// if you have a folder containing dSYMs
-npx @datadog/datadog-ci dsyms upload /path/to/appDsyms/
-```
+   ```
+   func didTapButton() {
+   fatalError(“Crash the app”)
+   }
+   ```
 
-**Note**: To configure the tool to use the EU endpoint, set the `DATADOG_SITE` environment variable to `datadoghq.eu`. To override the full URL for the intake endpoint, define the `DATADOG_DSYM_INTAKE_URL` environment variable. 
-
-If your application has Bitcode enabled, download your app's dSYM files on [App Store Connect][6]. For more information, see [dSYMs commands][7].
-
+3. After the crash happens, restart your application and wait for the iOS SDK to upload the crash report in [**Error Tracking**][8].
 
 ## Further Reading
 
@@ -154,3 +195,4 @@ If your application has Bitcode enabled, download your app's dSYM files on [App 
 [5]: https://www.npmjs.com/package/@datadog/datadog-ci
 [6]: https://appstoreconnect.apple.com/
 [7]: https://github.com/DataDog/datadog-ci/blob/master/src/commands/dsyms/README.md
+[8]: https://app.datadoghq.com/rum/error-tracking


### PR DESCRIPTION
### What and why?

Updates iOS Crash Reporting and Error Tracking page with improved information architecture and copy.

Thanks @ncreated for the insights and suggestions!

### How?

DOCS-2567

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing change. 
