### PR TITLE
RUMM-2010 Fix User-Agent tests flakiness

### DIFF
--- a/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
@@ -25,7 +25,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
     // MARK: - HTTP Message
 
     func testItUsesExpectedHTTPMessage() throws {
-        let randomApplicationName: String = .mockRandom()
+        let randomApplicationName: String = .mockRandom(among: .alphanumerics)
         let randomApplicationVersion: String = .mockRandom()
         let randomSource: String = .mockRandom(among: .alphanumerics)
         let randomSDKVersion: String = .mockRandom(among: .alphanumerics)

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -25,7 +25,7 @@ class LoggingFeatureTests: XCTestCase {
     // MARK: - HTTP Message
 
     func testItUsesExpectedHTTPMessage() throws {
-        let randomApplicationName: String = .mockRandom()
+        let randomApplicationName: String = .mockRandom(among: .alphanumerics)
         let randomApplicationVersion: String = .mockRandom()
         let randomSource: String = .mockRandom(among: .alphanumerics)
         let randomSDKVersion: String = .mockRandom(among: .alphanumerics)

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -25,7 +25,7 @@ class RUMFeatureTests: XCTestCase {
     // MARK: - HTTP Message
 
     func testItUsesExpectedHTTPMessage() throws {
-        let randomApplicationName: String = .mockRandom()
+        let randomApplicationName: String = .mockRandom(among: .alphanumerics)
         let randomApplicationVersion: String = .mockRandom(among: .decimalDigits)
         let randomServiceName: String = .mockRandom(among: .alphanumerics)
         let randomEnvironmentName: String = .mockRandom(among: .alphanumerics)

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -25,7 +25,7 @@ class TracingFeatureTests: XCTestCase {
     // MARK: - HTTP Message
 
     func testItUsesExpectedHTTPMessage() throws {
-        let randomApplicationName: String = .mockRandom()
+        let randomApplicationName: String = .mockRandom(among: .alphanumerics)
         let randomApplicationVersion: String = .mockRandom()
         let randomSource: String = .mockRandom()
         let randomSDKVersion: String = .mockRandom(among: .alphanumerics)


### PR DESCRIPTION
### What and why?

⚙️ This PR fixes user agent header tests flakiness.

### How?

In #769 we added sanitisation for the "app name" component in UA header. This change wasn't reflected in dependant HTTP message tests, which assert the value of UA header. The random input generated for these tests was allowing whitespaces, now sanitised in upstream logic.

Because we test random input sanitisation separately (in UA sanitisation tests), to fix the problem here, I only adjusted characters range for the input used in HTTP message tests.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing change. 
