### PR TITLE
RUMM-2020 Generate models from root schema file

### DIFF
--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -8,783 +8,6 @@
 
 internal protocol RUMDataModel: Codable {}
 
-/// Schema of all properties of a View event
-public struct RUMViewEvent: RUMDataModel {
-    /// Internal properties
-    public let dd: DD
-
-    /// Application properties
-    public let application: Application
-
-    /// CI Visibility properties
-    public let ciTest: RUMCITest?
-
-    /// Device connectivity properties
-    public let connectivity: RUMConnectivity?
-
-    /// User provided context
-    public internal(set) var context: RUMEventAttributes?
-
-    /// Start of the event in ms from epoch
-    public let date: Int64
-
-    /// The service name for this application
-    public let service: String?
-
-    /// Session properties
-    public let session: Session
-
-    /// The source of this event
-    public let source: Source?
-
-    /// Synthetics properties
-    public let synthetics: Synthetics?
-
-    /// RUM event type
-    public let type: String = "view"
-
-    /// User properties
-    public internal(set) var usr: RUMUser?
-
-    /// View properties
-    public var view: View
-
-    enum CodingKeys: String, CodingKey {
-        case dd = "_dd"
-        case application = "application"
-        case ciTest = "ci_test"
-        case connectivity = "connectivity"
-        case context = "context"
-        case date = "date"
-        case service = "service"
-        case session = "session"
-        case source = "source"
-        case synthetics = "synthetics"
-        case type = "type"
-        case usr = "usr"
-        case view = "view"
-    }
-
-    /// Internal properties
-    public struct DD: Codable {
-        /// Browser SDK version
-        public let browserSdkVersion: String?
-
-        /// Version of the update of the view event
-        public let documentVersion: Int64
-
-        /// Version of the RUM event format
-        public let formatVersion: Int64 = 2
-
-        /// Session-related internal properties
-        public let session: Session?
-
-        enum CodingKeys: String, CodingKey {
-            case browserSdkVersion = "browser_sdk_version"
-            case documentVersion = "document_version"
-            case formatVersion = "format_version"
-            case session = "session"
-        }
-
-        /// Session-related internal properties
-        public struct Session: Codable {
-            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
-            public let plan: Plan
-
-            enum CodingKeys: String, CodingKey {
-                case plan = "plan"
-            }
-
-            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
-            public enum Plan: Int, Codable {
-                case plan1 = 1
-                case plan2 = 2
-            }
-        }
-    }
-
-    /// Application properties
-    public struct Application: Codable {
-        /// UUID of the application
-        public let id: String
-
-        enum CodingKeys: String, CodingKey {
-            case id = "id"
-        }
-    }
-
-    /// Session properties
-    public struct Session: Codable {
-        /// Whether this session has a replay
-        public let hasReplay: Bool?
-
-        /// UUID of the session
-        public let id: String
-
-        /// Type of the session
-        public let type: SessionType
-
-        enum CodingKeys: String, CodingKey {
-            case hasReplay = "has_replay"
-            case id = "id"
-            case type = "type"
-        }
-
-        /// Type of the session
-        public enum SessionType: String, Codable {
-            case user = "user"
-            case synthetics = "synthetics"
-            case ciTest = "ci_test"
-        }
-    }
-
-    /// The source of this event
-    public enum Source: String, Codable {
-        case android = "android"
-        case ios = "ios"
-        case browser = "browser"
-        case flutter = "flutter"
-        case reactNative = "react-native"
-    }
-
-    /// Synthetics properties
-    public struct Synthetics: Codable {
-        /// Whether the event comes from a SDK instance injected by Synthetics
-        public let injected: Bool?
-
-        /// The identifier of the current Synthetics test results
-        public let resultId: String
-
-        /// The identifier of the current Synthetics test
-        public let testId: String
-
-        enum CodingKeys: String, CodingKey {
-            case injected = "injected"
-            case resultId = "result_id"
-            case testId = "test_id"
-        }
-    }
-
-    /// View properties
-    public struct View: Codable {
-        /// Properties of the actions of the view
-        public let action: Action
-
-        /// Total number of cpu ticks during the view’s lifetime
-        public let cpuTicksCount: Double?
-
-        /// Average number of cpu ticks per second during the view’s lifetime
-        public let cpuTicksPerSecond: Double?
-
-        /// Properties of the crashes of the view
-        public let crash: Crash?
-
-        /// Total layout shift score that occured on the view
-        public let cumulativeLayoutShift: Double?
-
-        /// User custom timings of the view. As timing name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
-        public let customTimings: [String: Int64]?
-
-        /// Duration in ns to the complete parsing and loading of the document and its sub resources
-        public let domComplete: Int64?
-
-        /// Duration in ns to the complete parsing and loading of the document without its sub resources
-        public let domContentLoaded: Int64?
-
-        /// Duration in ns to the end of the parsing of the document
-        public let domInteractive: Int64?
-
-        /// Properties of the errors of the view
-        public let error: Error
-
-        /// Duration in ns to the first rendering
-        public let firstContentfulPaint: Int64?
-
-        /// Duration in ns of the first input event delay
-        public let firstInputDelay: Int64?
-
-        /// Duration in ns to the first input
-        public let firstInputTime: Int64?
-
-        /// Properties of the frozen frames of the view
-        public let frozenFrame: FrozenFrame?
-
-        /// UUID of the view
-        public let id: String
-
-        /// List of the periods of time the user had the view in foreground (focused in the browser)
-        public let inForegroundPeriods: [InForegroundPeriods]?
-
-        /// Whether the View corresponding to this event is considered active
-        public let isActive: Bool?
-
-        /// Whether the View had a low average refresh rate
-        public let isSlowRendered: Bool?
-
-        /// Duration in ns to the largest contentful paint
-        public let largestContentfulPaint: Int64?
-
-        /// Duration in ns to the end of the load event handler execution
-        public let loadEvent: Int64?
-
-        /// Duration in ns to the view is considered loaded
-        public let loadingTime: Int64?
-
-        /// Type of the loading of the view
-        public let loadingType: LoadingType?
-
-        /// Properties of the long tasks of the view
-        public let longTask: LongTask?
-
-        /// Average memory used during the view lifetime (in bytes)
-        public let memoryAverage: Double?
-
-        /// Peak memory used during the view lifetime (in bytes)
-        public let memoryMax: Double?
-
-        /// User defined name of the view
-        public var name: String?
-
-        /// URL that linked to the initial view of the page
-        public var referrer: String?
-
-        /// Average refresh rate during the view’s lifetime (in frames per second)
-        public let refreshRateAverage: Double?
-
-        /// Minimum refresh rate during the view’s lifetime (in frames per second)
-        public let refreshRateMin: Double?
-
-        /// Properties of the resources of the view
-        public let resource: Resource
-
-        /// Time spent on the view in ns
-        public let timeSpent: Int64
-
-        /// URL of the view
-        public var url: String
-
-        enum CodingKeys: String, CodingKey {
-            case action = "action"
-            case cpuTicksCount = "cpu_ticks_count"
-            case cpuTicksPerSecond = "cpu_ticks_per_second"
-            case crash = "crash"
-            case cumulativeLayoutShift = "cumulative_layout_shift"
-            case customTimings = "custom_timings"
-            case domComplete = "dom_complete"
-            case domContentLoaded = "dom_content_loaded"
-            case domInteractive = "dom_interactive"
-            case error = "error"
-            case firstContentfulPaint = "first_contentful_paint"
-            case firstInputDelay = "first_input_delay"
-            case firstInputTime = "first_input_time"
-            case frozenFrame = "frozen_frame"
-            case id = "id"
-            case inForegroundPeriods = "in_foreground_periods"
-            case isActive = "is_active"
-            case isSlowRendered = "is_slow_rendered"
-            case largestContentfulPaint = "largest_contentful_paint"
-            case loadEvent = "load_event"
-            case loadingTime = "loading_time"
-            case loadingType = "loading_type"
-            case longTask = "long_task"
-            case memoryAverage = "memory_average"
-            case memoryMax = "memory_max"
-            case name = "name"
-            case referrer = "referrer"
-            case refreshRateAverage = "refresh_rate_average"
-            case refreshRateMin = "refresh_rate_min"
-            case resource = "resource"
-            case timeSpent = "time_spent"
-            case url = "url"
-        }
-
-        /// Properties of the actions of the view
-        public struct Action: Codable {
-            /// Number of actions that occurred on the view
-            public let count: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case count = "count"
-            }
-        }
-
-        /// Properties of the crashes of the view
-        public struct Crash: Codable {
-            /// Number of crashes that occurred on the view
-            public let count: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case count = "count"
-            }
-        }
-
-        /// Properties of the errors of the view
-        public struct Error: Codable {
-            /// Number of errors that occurred on the view
-            public let count: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case count = "count"
-            }
-        }
-
-        /// Properties of the frozen frames of the view
-        public struct FrozenFrame: Codable {
-            /// Number of frozen frames that occurred on the view
-            public let count: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case count = "count"
-            }
-        }
-
-        /// Properties of the foreground period of the view
-        public struct InForegroundPeriods: Codable {
-            /// Duration in ns of the view foreground period
-            public let duration: Int64
-
-            /// Duration in ns between start of the view and start of foreground period
-            public let start: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case duration = "duration"
-                case start = "start"
-            }
-        }
-
-        /// Type of the loading of the view
-        public enum LoadingType: String, Codable {
-            case initialLoad = "initial_load"
-            case routeChange = "route_change"
-            case activityDisplay = "activity_display"
-            case activityRedisplay = "activity_redisplay"
-            case fragmentDisplay = "fragment_display"
-            case fragmentRedisplay = "fragment_redisplay"
-            case viewControllerDisplay = "view_controller_display"
-            case viewControllerRedisplay = "view_controller_redisplay"
-        }
-
-        /// Properties of the long tasks of the view
-        public struct LongTask: Codable {
-            /// Number of long tasks that occurred on the view
-            public let count: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case count = "count"
-            }
-        }
-
-        /// Properties of the resources of the view
-        public struct Resource: Codable {
-            /// Number of resources that occurred on the view
-            public let count: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case count = "count"
-            }
-        }
-    }
-}
-
-/// Schema of all properties of a Resource event
-public struct RUMResourceEvent: RUMDataModel {
-    /// Internal properties
-    public let dd: DD
-
-    /// Action properties
-    public let action: Action?
-
-    /// Application properties
-    public let application: Application
-
-    /// CI Visibility properties
-    public let ciTest: RUMCITest?
-
-    /// Device connectivity properties
-    public let connectivity: RUMConnectivity?
-
-    /// User provided context
-    public internal(set) var context: RUMEventAttributes?
-
-    /// Start of the event in ms from epoch
-    public let date: Int64
-
-    /// Resource properties
-    public var resource: Resource
-
-    /// The service name for this application
-    public let service: String?
-
-    /// Session properties
-    public let session: Session
-
-    /// The source of this event
-    public let source: Source?
-
-    /// Synthetics properties
-    public let synthetics: Synthetics?
-
-    /// RUM event type
-    public let type: String = "resource"
-
-    /// User properties
-    public internal(set) var usr: RUMUser?
-
-    /// View properties
-    public var view: View
-
-    enum CodingKeys: String, CodingKey {
-        case dd = "_dd"
-        case action = "action"
-        case application = "application"
-        case ciTest = "ci_test"
-        case connectivity = "connectivity"
-        case context = "context"
-        case date = "date"
-        case resource = "resource"
-        case service = "service"
-        case session = "session"
-        case source = "source"
-        case synthetics = "synthetics"
-        case type = "type"
-        case usr = "usr"
-        case view = "view"
-    }
-
-    /// Internal properties
-    public struct DD: Codable {
-        /// Browser SDK version
-        public let browserSdkVersion: String?
-
-        /// Version of the RUM event format
-        public let formatVersion: Int64 = 2
-
-        /// Session-related internal properties
-        public let session: Session?
-
-        /// span identifier in decimal format
-        public let spanId: String?
-
-        /// trace identifier in decimal format
-        public let traceId: String?
-
-        enum CodingKeys: String, CodingKey {
-            case browserSdkVersion = "browser_sdk_version"
-            case formatVersion = "format_version"
-            case session = "session"
-            case spanId = "span_id"
-            case traceId = "trace_id"
-        }
-
-        /// Session-related internal properties
-        public struct Session: Codable {
-            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
-            public let plan: Plan
-
-            enum CodingKeys: String, CodingKey {
-                case plan = "plan"
-            }
-
-            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
-            public enum Plan: Int, Codable {
-                case plan1 = 1
-                case plan2 = 2
-            }
-        }
-    }
-
-    /// Action properties
-    public struct Action: Codable {
-        /// UUID of the action
-        public let id: String
-
-        enum CodingKeys: String, CodingKey {
-            case id = "id"
-        }
-    }
-
-    /// Application properties
-    public struct Application: Codable {
-        /// UUID of the application
-        public let id: String
-
-        enum CodingKeys: String, CodingKey {
-            case id = "id"
-        }
-    }
-
-    /// Resource properties
-    public struct Resource: Codable {
-        /// Connect phase properties
-        public let connect: Connect?
-
-        /// DNS phase properties
-        public let dns: DNS?
-
-        /// Download phase properties
-        public let download: Download?
-
-        /// Duration of the resource
-        public let duration: Int64
-
-        /// First Byte phase properties
-        public let firstByte: FirstByte?
-
-        /// UUID of the resource
-        public let id: String?
-
-        /// HTTP method of the resource
-        public let method: RUMMethod?
-
-        /// The provider for this resource
-        public let provider: Provider?
-
-        /// Redirect phase properties
-        public let redirect: Redirect?
-
-        /// Size in octet of the resource response body
-        public let size: Int64?
-
-        /// SSL phase properties
-        public let ssl: SSL?
-
-        /// HTTP status code of the resource
-        public let statusCode: Int64?
-
-        /// Resource type
-        public let type: ResourceType
-
-        /// URL of the resource
-        public var url: String
-
-        enum CodingKeys: String, CodingKey {
-            case connect = "connect"
-            case dns = "dns"
-            case download = "download"
-            case duration = "duration"
-            case firstByte = "first_byte"
-            case id = "id"
-            case method = "method"
-            case provider = "provider"
-            case redirect = "redirect"
-            case size = "size"
-            case ssl = "ssl"
-            case statusCode = "status_code"
-            case type = "type"
-            case url = "url"
-        }
-
-        /// Connect phase properties
-        public struct Connect: Codable {
-            /// Duration in ns of the resource connect phase
-            public let duration: Int64
-
-            /// Duration in ns between start of the request and start of the connect phase
-            public let start: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case duration = "duration"
-                case start = "start"
-            }
-        }
-
-        /// DNS phase properties
-        public struct DNS: Codable {
-            /// Duration in ns of the resource dns phase
-            public let duration: Int64
-
-            /// Duration in ns between start of the request and start of the dns phase
-            public let start: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case duration = "duration"
-                case start = "start"
-            }
-        }
-
-        /// Download phase properties
-        public struct Download: Codable {
-            /// Duration in ns of the resource download phase
-            public let duration: Int64
-
-            /// Duration in ns between start of the request and start of the download phase
-            public let start: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case duration = "duration"
-                case start = "start"
-            }
-        }
-
-        /// First Byte phase properties
-        public struct FirstByte: Codable {
-            /// Duration in ns of the resource first byte phase
-            public let duration: Int64
-
-            /// Duration in ns between start of the request and start of the first byte phase
-            public let start: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case duration = "duration"
-                case start = "start"
-            }
-        }
-
-        /// The provider for this resource
-        public struct Provider: Codable {
-            /// The domain name of the provider
-            public let domain: String?
-
-            /// The user friendly name of the provider
-            public let name: String?
-
-            /// The type of provider
-            public let type: ProviderType?
-
-            enum CodingKeys: String, CodingKey {
-                case domain = "domain"
-                case name = "name"
-                case type = "type"
-            }
-
-            /// The type of provider
-            public enum ProviderType: String, Codable {
-                case ad = "ad"
-                case advertising = "advertising"
-                case analytics = "analytics"
-                case cdn = "cdn"
-                case content = "content"
-                case customerSuccess = "customer-success"
-                case firstParty = "first party"
-                case hosting = "hosting"
-                case marketing = "marketing"
-                case other = "other"
-                case social = "social"
-                case tagManager = "tag-manager"
-                case utility = "utility"
-                case video = "video"
-            }
-        }
-
-        /// Redirect phase properties
-        public struct Redirect: Codable {
-            /// Duration in ns of the resource redirect phase
-            public let duration: Int64
-
-            /// Duration in ns between start of the request and start of the redirect phase
-            public let start: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case duration = "duration"
-                case start = "start"
-            }
-        }
-
-        /// SSL phase properties
-        public struct SSL: Codable {
-            /// Duration in ns of the resource ssl phase
-            public let duration: Int64
-
-            /// Duration in ns between start of the request and start of the ssl phase
-            public let start: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case duration = "duration"
-                case start = "start"
-            }
-        }
-
-        /// Resource type
-        public enum ResourceType: String, Codable {
-            case document = "document"
-            case xhr = "xhr"
-            case beacon = "beacon"
-            case fetch = "fetch"
-            case css = "css"
-            case js = "js"
-            case image = "image"
-            case font = "font"
-            case media = "media"
-            case other = "other"
-            case native = "native"
-        }
-    }
-
-    /// Session properties
-    public struct Session: Codable {
-        /// Whether this session has a replay
-        public let hasReplay: Bool?
-
-        /// UUID of the session
-        public let id: String
-
-        /// Type of the session
-        public let type: SessionType
-
-        enum CodingKeys: String, CodingKey {
-            case hasReplay = "has_replay"
-            case id = "id"
-            case type = "type"
-        }
-
-        /// Type of the session
-        public enum SessionType: String, Codable {
-            case user = "user"
-            case synthetics = "synthetics"
-            case ciTest = "ci_test"
-        }
-    }
-
-    /// The source of this event
-    public enum Source: String, Codable {
-        case android = "android"
-        case ios = "ios"
-        case browser = "browser"
-        case flutter = "flutter"
-        case reactNative = "react-native"
-    }
-
-    /// Synthetics properties
-    public struct Synthetics: Codable {
-        /// Whether the event comes from a SDK instance injected by Synthetics
-        public let injected: Bool?
-
-        /// The identifier of the current Synthetics test results
-        public let resultId: String
-
-        /// The identifier of the current Synthetics test
-        public let testId: String
-
-        enum CodingKeys: String, CodingKey {
-            case injected = "injected"
-            case resultId = "result_id"
-            case testId = "test_id"
-        }
-    }
-
-    /// View properties
-    public struct View: Codable {
-        /// UUID of the view
-        public let id: String
-
-        /// User defined name of the view
-        public var name: String?
-
-        /// URL that linked to the initial view of the page
-        public var referrer: String?
-
-        /// URL of the view
-        public var url: String
-
-        enum CodingKeys: String, CodingKey {
-            case id = "id"
-            case name = "name"
-            case referrer = "referrer"
-            case url = "url"
-        }
-    }
-}
-
 /// Schema of all properties of an Action event
 public struct RUMActionEvent: RUMDataModel {
     /// Internal properties
@@ -1305,6 +528,7 @@ public struct RUMErrorEvent: RUMDataModel {
             case agent = "agent"
             case webview = "webview"
             case custom = "custom"
+            case report = "report"
         }
 
         /// Source type of the error (the language or platform impacting the error stacktrace format)
@@ -1608,6 +832,993 @@ public struct RUMLongTaskEvent: RUMDataModel {
     }
 }
 
+/// Schema of all properties of a Resource event
+public struct RUMResourceEvent: RUMDataModel {
+    /// Internal properties
+    public let dd: DD
+
+    /// Action properties
+    public let action: Action?
+
+    /// Application properties
+    public let application: Application
+
+    /// CI Visibility properties
+    public let ciTest: RUMCITest?
+
+    /// Device connectivity properties
+    public let connectivity: RUMConnectivity?
+
+    /// User provided context
+    public internal(set) var context: RUMEventAttributes?
+
+    /// Start of the event in ms from epoch
+    public let date: Int64
+
+    /// Resource properties
+    public var resource: Resource
+
+    /// The service name for this application
+    public let service: String?
+
+    /// Session properties
+    public let session: Session
+
+    /// The source of this event
+    public let source: Source?
+
+    /// Synthetics properties
+    public let synthetics: Synthetics?
+
+    /// RUM event type
+    public let type: String = "resource"
+
+    /// User properties
+    public internal(set) var usr: RUMUser?
+
+    /// View properties
+    public var view: View
+
+    enum CodingKeys: String, CodingKey {
+        case dd = "_dd"
+        case action = "action"
+        case application = "application"
+        case ciTest = "ci_test"
+        case connectivity = "connectivity"
+        case context = "context"
+        case date = "date"
+        case resource = "resource"
+        case service = "service"
+        case session = "session"
+        case source = "source"
+        case synthetics = "synthetics"
+        case type = "type"
+        case usr = "usr"
+        case view = "view"
+    }
+
+    /// Internal properties
+    public struct DD: Codable {
+        /// Browser SDK version
+        public let browserSdkVersion: String?
+
+        /// Version of the RUM event format
+        public let formatVersion: Int64 = 2
+
+        /// Session-related internal properties
+        public let session: Session?
+
+        /// span identifier in decimal format
+        public let spanId: String?
+
+        /// trace identifier in decimal format
+        public let traceId: String?
+
+        enum CodingKeys: String, CodingKey {
+            case browserSdkVersion = "browser_sdk_version"
+            case formatVersion = "format_version"
+            case session = "session"
+            case spanId = "span_id"
+            case traceId = "trace_id"
+        }
+
+        /// Session-related internal properties
+        public struct Session: Codable {
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public let plan: Plan
+
+            enum CodingKeys: String, CodingKey {
+                case plan = "plan"
+            }
+
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public enum Plan: Int, Codable {
+                case plan1 = 1
+                case plan2 = 2
+            }
+        }
+    }
+
+    /// Action properties
+    public struct Action: Codable {
+        /// UUID of the action
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Application properties
+    public struct Application: Codable {
+        /// UUID of the application
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Resource properties
+    public struct Resource: Codable {
+        /// Connect phase properties
+        public let connect: Connect?
+
+        /// DNS phase properties
+        public let dns: DNS?
+
+        /// Download phase properties
+        public let download: Download?
+
+        /// Duration of the resource
+        public let duration: Int64
+
+        /// First Byte phase properties
+        public let firstByte: FirstByte?
+
+        /// UUID of the resource
+        public let id: String?
+
+        /// HTTP method of the resource
+        public let method: RUMMethod?
+
+        /// The provider for this resource
+        public let provider: Provider?
+
+        /// Redirect phase properties
+        public let redirect: Redirect?
+
+        /// Size in octet of the resource response body
+        public let size: Int64?
+
+        /// SSL phase properties
+        public let ssl: SSL?
+
+        /// HTTP status code of the resource
+        public let statusCode: Int64?
+
+        /// Resource type
+        public let type: ResourceType
+
+        /// URL of the resource
+        public var url: String
+
+        enum CodingKeys: String, CodingKey {
+            case connect = "connect"
+            case dns = "dns"
+            case download = "download"
+            case duration = "duration"
+            case firstByte = "first_byte"
+            case id = "id"
+            case method = "method"
+            case provider = "provider"
+            case redirect = "redirect"
+            case size = "size"
+            case ssl = "ssl"
+            case statusCode = "status_code"
+            case type = "type"
+            case url = "url"
+        }
+
+        /// Connect phase properties
+        public struct Connect: Codable {
+            /// Duration in ns of the resource connect phase
+            public let duration: Int64
+
+            /// Duration in ns between start of the request and start of the connect phase
+            public let start: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case duration = "duration"
+                case start = "start"
+            }
+        }
+
+        /// DNS phase properties
+        public struct DNS: Codable {
+            /// Duration in ns of the resource dns phase
+            public let duration: Int64
+
+            /// Duration in ns between start of the request and start of the dns phase
+            public let start: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case duration = "duration"
+                case start = "start"
+            }
+        }
+
+        /// Download phase properties
+        public struct Download: Codable {
+            /// Duration in ns of the resource download phase
+            public let duration: Int64
+
+            /// Duration in ns between start of the request and start of the download phase
+            public let start: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case duration = "duration"
+                case start = "start"
+            }
+        }
+
+        /// First Byte phase properties
+        public struct FirstByte: Codable {
+            /// Duration in ns of the resource first byte phase
+            public let duration: Int64
+
+            /// Duration in ns between start of the request and start of the first byte phase
+            public let start: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case duration = "duration"
+                case start = "start"
+            }
+        }
+
+        /// The provider for this resource
+        public struct Provider: Codable {
+            /// The domain name of the provider
+            public let domain: String?
+
+            /// The user friendly name of the provider
+            public let name: String?
+
+            /// The type of provider
+            public let type: ProviderType?
+
+            enum CodingKeys: String, CodingKey {
+                case domain = "domain"
+                case name = "name"
+                case type = "type"
+            }
+
+            /// The type of provider
+            public enum ProviderType: String, Codable {
+                case ad = "ad"
+                case advertising = "advertising"
+                case analytics = "analytics"
+                case cdn = "cdn"
+                case content = "content"
+                case customerSuccess = "customer-success"
+                case firstParty = "first party"
+                case hosting = "hosting"
+                case marketing = "marketing"
+                case other = "other"
+                case social = "social"
+                case tagManager = "tag-manager"
+                case utility = "utility"
+                case video = "video"
+            }
+        }
+
+        /// Redirect phase properties
+        public struct Redirect: Codable {
+            /// Duration in ns of the resource redirect phase
+            public let duration: Int64
+
+            /// Duration in ns between start of the request and start of the redirect phase
+            public let start: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case duration = "duration"
+                case start = "start"
+            }
+        }
+
+        /// SSL phase properties
+        public struct SSL: Codable {
+            /// Duration in ns of the resource ssl phase
+            public let duration: Int64
+
+            /// Duration in ns between start of the request and start of the ssl phase
+            public let start: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case duration = "duration"
+                case start = "start"
+            }
+        }
+
+        /// Resource type
+        public enum ResourceType: String, Codable {
+            case document = "document"
+            case xhr = "xhr"
+            case beacon = "beacon"
+            case fetch = "fetch"
+            case css = "css"
+            case js = "js"
+            case image = "image"
+            case font = "font"
+            case media = "media"
+            case other = "other"
+            case native = "native"
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// Whether this session has a replay
+        public let hasReplay: Bool?
+
+        /// UUID of the session
+        public let id: String
+
+        /// Type of the session
+        public let type: SessionType
+
+        enum CodingKeys: String, CodingKey {
+            case hasReplay = "has_replay"
+            case id = "id"
+            case type = "type"
+        }
+
+        /// Type of the session
+        public enum SessionType: String, Codable {
+            case user = "user"
+            case synthetics = "synthetics"
+            case ciTest = "ci_test"
+        }
+    }
+
+    /// The source of this event
+    public enum Source: String, Codable {
+        case android = "android"
+        case ios = "ios"
+        case browser = "browser"
+        case flutter = "flutter"
+        case reactNative = "react-native"
+    }
+
+    /// Synthetics properties
+    public struct Synthetics: Codable {
+        /// Whether the event comes from a SDK instance injected by Synthetics
+        public let injected: Bool?
+
+        /// The identifier of the current Synthetics test results
+        public let resultId: String
+
+        /// The identifier of the current Synthetics test
+        public let testId: String
+
+        enum CodingKeys: String, CodingKey {
+            case injected = "injected"
+            case resultId = "result_id"
+            case testId = "test_id"
+        }
+    }
+
+    /// View properties
+    public struct View: Codable {
+        /// UUID of the view
+        public let id: String
+
+        /// User defined name of the view
+        public var name: String?
+
+        /// URL that linked to the initial view of the page
+        public var referrer: String?
+
+        /// URL of the view
+        public var url: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+            case name = "name"
+            case referrer = "referrer"
+            case url = "url"
+        }
+    }
+}
+
+/// Schema of all properties of a View event
+public struct RUMViewEvent: RUMDataModel {
+    /// Internal properties
+    public let dd: DD
+
+    /// Application properties
+    public let application: Application
+
+    /// CI Visibility properties
+    public let ciTest: RUMCITest?
+
+    /// Device connectivity properties
+    public let connectivity: RUMConnectivity?
+
+    /// User provided context
+    public internal(set) var context: RUMEventAttributes?
+
+    /// Start of the event in ms from epoch
+    public let date: Int64
+
+    /// The service name for this application
+    public let service: String?
+
+    /// Session properties
+    public let session: Session
+
+    /// The source of this event
+    public let source: Source?
+
+    /// Synthetics properties
+    public let synthetics: Synthetics?
+
+    /// RUM event type
+    public let type: String = "view"
+
+    /// User properties
+    public internal(set) var usr: RUMUser?
+
+    /// View properties
+    public var view: View
+
+    enum CodingKeys: String, CodingKey {
+        case dd = "_dd"
+        case application = "application"
+        case ciTest = "ci_test"
+        case connectivity = "connectivity"
+        case context = "context"
+        case date = "date"
+        case service = "service"
+        case session = "session"
+        case source = "source"
+        case synthetics = "synthetics"
+        case type = "type"
+        case usr = "usr"
+        case view = "view"
+    }
+
+    /// Internal properties
+    public struct DD: Codable {
+        /// Browser SDK version
+        public let browserSdkVersion: String?
+
+        /// Version of the update of the view event
+        public let documentVersion: Int64
+
+        /// Version of the RUM event format
+        public let formatVersion: Int64 = 2
+
+        /// Session-related internal properties
+        public let session: Session?
+
+        enum CodingKeys: String, CodingKey {
+            case browserSdkVersion = "browser_sdk_version"
+            case documentVersion = "document_version"
+            case formatVersion = "format_version"
+            case session = "session"
+        }
+
+        /// Session-related internal properties
+        public struct Session: Codable {
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public let plan: Plan
+
+            enum CodingKeys: String, CodingKey {
+                case plan = "plan"
+            }
+
+            /// Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan
+            public enum Plan: Int, Codable {
+                case plan1 = 1
+                case plan2 = 2
+            }
+        }
+    }
+
+    /// Application properties
+    public struct Application: Codable {
+        /// UUID of the application
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// Whether this session has a replay
+        public let hasReplay: Bool?
+
+        /// UUID of the session
+        public let id: String
+
+        /// Type of the session
+        public let type: SessionType
+
+        enum CodingKeys: String, CodingKey {
+            case hasReplay = "has_replay"
+            case id = "id"
+            case type = "type"
+        }
+
+        /// Type of the session
+        public enum SessionType: String, Codable {
+            case user = "user"
+            case synthetics = "synthetics"
+            case ciTest = "ci_test"
+        }
+    }
+
+    /// The source of this event
+    public enum Source: String, Codable {
+        case android = "android"
+        case ios = "ios"
+        case browser = "browser"
+        case flutter = "flutter"
+        case reactNative = "react-native"
+    }
+
+    /// Synthetics properties
+    public struct Synthetics: Codable {
+        /// Whether the event comes from a SDK instance injected by Synthetics
+        public let injected: Bool?
+
+        /// The identifier of the current Synthetics test results
+        public let resultId: String
+
+        /// The identifier of the current Synthetics test
+        public let testId: String
+
+        enum CodingKeys: String, CodingKey {
+            case injected = "injected"
+            case resultId = "result_id"
+            case testId = "test_id"
+        }
+    }
+
+    /// View properties
+    public struct View: Codable {
+        /// Properties of the actions of the view
+        public let action: Action
+
+        /// Total number of cpu ticks during the view’s lifetime
+        public let cpuTicksCount: Double?
+
+        /// Average number of cpu ticks per second during the view’s lifetime
+        public let cpuTicksPerSecond: Double?
+
+        /// Properties of the crashes of the view
+        public let crash: Crash?
+
+        /// Total layout shift score that occured on the view
+        public let cumulativeLayoutShift: Double?
+
+        /// User custom timings of the view. As timing name is used as facet path, it must contain only letters, digits, or the characters - _ . @ $
+        public let customTimings: [String: Int64]?
+
+        /// Duration in ns to the complete parsing and loading of the document and its sub resources
+        public let domComplete: Int64?
+
+        /// Duration in ns to the complete parsing and loading of the document without its sub resources
+        public let domContentLoaded: Int64?
+
+        /// Duration in ns to the end of the parsing of the document
+        public let domInteractive: Int64?
+
+        /// Properties of the errors of the view
+        public let error: Error
+
+        /// Duration in ns to the first rendering
+        public let firstContentfulPaint: Int64?
+
+        /// Duration in ns of the first input event delay
+        public let firstInputDelay: Int64?
+
+        /// Duration in ns to the first input
+        public let firstInputTime: Int64?
+
+        /// Properties of the frozen frames of the view
+        public let frozenFrame: FrozenFrame?
+
+        /// UUID of the view
+        public let id: String
+
+        /// List of the periods of time the user had the view in foreground (focused in the browser)
+        public let inForegroundPeriods: [InForegroundPeriods]?
+
+        /// Whether the View corresponding to this event is considered active
+        public let isActive: Bool?
+
+        /// Whether the View had a low average refresh rate
+        public let isSlowRendered: Bool?
+
+        /// Duration in ns to the largest contentful paint
+        public let largestContentfulPaint: Int64?
+
+        /// Duration in ns to the end of the load event handler execution
+        public let loadEvent: Int64?
+
+        /// Duration in ns to the view is considered loaded
+        public let loadingTime: Int64?
+
+        /// Type of the loading of the view
+        public let loadingType: LoadingType?
+
+        /// Properties of the long tasks of the view
+        public let longTask: LongTask?
+
+        /// Average memory used during the view lifetime (in bytes)
+        public let memoryAverage: Double?
+
+        /// Peak memory used during the view lifetime (in bytes)
+        public let memoryMax: Double?
+
+        /// User defined name of the view
+        public var name: String?
+
+        /// URL that linked to the initial view of the page
+        public var referrer: String?
+
+        /// Average refresh rate during the view’s lifetime (in frames per second)
+        public let refreshRateAverage: Double?
+
+        /// Minimum refresh rate during the view’s lifetime (in frames per second)
+        public let refreshRateMin: Double?
+
+        /// Properties of the resources of the view
+        public let resource: Resource
+
+        /// Time spent on the view in ns
+        public let timeSpent: Int64
+
+        /// URL of the view
+        public var url: String
+
+        enum CodingKeys: String, CodingKey {
+            case action = "action"
+            case cpuTicksCount = "cpu_ticks_count"
+            case cpuTicksPerSecond = "cpu_ticks_per_second"
+            case crash = "crash"
+            case cumulativeLayoutShift = "cumulative_layout_shift"
+            case customTimings = "custom_timings"
+            case domComplete = "dom_complete"
+            case domContentLoaded = "dom_content_loaded"
+            case domInteractive = "dom_interactive"
+            case error = "error"
+            case firstContentfulPaint = "first_contentful_paint"
+            case firstInputDelay = "first_input_delay"
+            case firstInputTime = "first_input_time"
+            case frozenFrame = "frozen_frame"
+            case id = "id"
+            case inForegroundPeriods = "in_foreground_periods"
+            case isActive = "is_active"
+            case isSlowRendered = "is_slow_rendered"
+            case largestContentfulPaint = "largest_contentful_paint"
+            case loadEvent = "load_event"
+            case loadingTime = "loading_time"
+            case loadingType = "loading_type"
+            case longTask = "long_task"
+            case memoryAverage = "memory_average"
+            case memoryMax = "memory_max"
+            case name = "name"
+            case referrer = "referrer"
+            case refreshRateAverage = "refresh_rate_average"
+            case refreshRateMin = "refresh_rate_min"
+            case resource = "resource"
+            case timeSpent = "time_spent"
+            case url = "url"
+        }
+
+        /// Properties of the actions of the view
+        public struct Action: Codable {
+            /// Number of actions that occurred on the view
+            public let count: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case count = "count"
+            }
+        }
+
+        /// Properties of the crashes of the view
+        public struct Crash: Codable {
+            /// Number of crashes that occurred on the view
+            public let count: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case count = "count"
+            }
+        }
+
+        /// Properties of the errors of the view
+        public struct Error: Codable {
+            /// Number of errors that occurred on the view
+            public let count: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case count = "count"
+            }
+        }
+
+        /// Properties of the frozen frames of the view
+        public struct FrozenFrame: Codable {
+            /// Number of frozen frames that occurred on the view
+            public let count: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case count = "count"
+            }
+        }
+
+        /// Properties of the foreground period of the view
+        public struct InForegroundPeriods: Codable {
+            /// Duration in ns of the view foreground period
+            public let duration: Int64
+
+            /// Duration in ns between start of the view and start of foreground period
+            public let start: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case duration = "duration"
+                case start = "start"
+            }
+        }
+
+        /// Type of the loading of the view
+        public enum LoadingType: String, Codable {
+            case initialLoad = "initial_load"
+            case routeChange = "route_change"
+            case activityDisplay = "activity_display"
+            case activityRedisplay = "activity_redisplay"
+            case fragmentDisplay = "fragment_display"
+            case fragmentRedisplay = "fragment_redisplay"
+            case viewControllerDisplay = "view_controller_display"
+            case viewControllerRedisplay = "view_controller_redisplay"
+        }
+
+        /// Properties of the long tasks of the view
+        public struct LongTask: Codable {
+            /// Number of long tasks that occurred on the view
+            public let count: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case count = "count"
+            }
+        }
+
+        /// Properties of the resources of the view
+        public struct Resource: Codable {
+            /// Number of resources that occurred on the view
+            public let count: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case count = "count"
+            }
+        }
+    }
+}
+
+/// Schema of all properties of a telemetry error event
+public struct TelemetryErrorEvent: RUMDataModel {
+    /// Internal properties
+    public let dd: DD
+
+    /// Action properties
+    public let action: Action?
+
+    /// Application properties
+    public let application: Application?
+
+    /// Start of the event in ms from epoch
+    public let date: Int64
+
+    /// Error properties
+    public let error: Error?
+
+    /// Body of the log
+    public let message: String
+
+    /// The SDK generating the telemetry event
+    public let service: String
+
+    /// Session properties
+    public let session: Session?
+
+    /// Level/severity of the log
+    public let status: String = "error"
+
+    /// The version of the SDK generating the telemetry event
+    public let version: String
+
+    /// View properties
+    public let view: View?
+
+    enum CodingKeys: String, CodingKey {
+        case dd = "_dd"
+        case action = "action"
+        case application = "application"
+        case date = "date"
+        case error = "error"
+        case message = "message"
+        case service = "service"
+        case session = "session"
+        case status = "status"
+        case version = "version"
+        case view = "view"
+    }
+
+    /// Internal properties
+    public struct DD: Codable {
+        /// Event type
+        public let eventType: String = "internal_telemetry"
+
+        enum CodingKeys: String, CodingKey {
+            case eventType = "event_type"
+        }
+    }
+
+    /// Action properties
+    public struct Action: Codable {
+        /// UUID of the action
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Application properties
+    public struct Application: Codable {
+        /// UUID of the application
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Error properties
+    public struct Error: Codable {
+        /// The error type or kind (or code in some cases)
+        public let kind: String?
+
+        /// The stack trace or the complementary information about the error
+        public let stack: String?
+
+        enum CodingKeys: String, CodingKey {
+            case kind = "kind"
+            case stack = "stack"
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// UUID of the session
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// View properties
+    public struct View: Codable {
+        /// UUID of the view
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+}
+
+/// Schema of all properties of a telemetry debug event
+public struct TelemetryDebugEvent: RUMDataModel {
+    /// Internal properties
+    public let dd: DD
+
+    /// Action properties
+    public let action: Action?
+
+    /// Application properties
+    public let application: Application?
+
+    /// Start of the event in ms from epoch
+    public let date: Int64
+
+    /// Body of the log
+    public let message: String
+
+    /// The SDK generating the telemetry event
+    public let service: String
+
+    /// Session properties
+    public let session: Session?
+
+    /// Level/severity of the log
+    public let status: String = "debug"
+
+    /// The version of the SDK generating the telemetry event
+    public let version: String
+
+    /// View properties
+    public let view: View?
+
+    enum CodingKeys: String, CodingKey {
+        case dd = "_dd"
+        case action = "action"
+        case application = "application"
+        case date = "date"
+        case message = "message"
+        case service = "service"
+        case session = "session"
+        case status = "status"
+        case version = "version"
+        case view = "view"
+    }
+
+    /// Internal properties
+    public struct DD: Codable {
+        /// Event type
+        public let eventType: String = "internal_telemetry"
+
+        enum CodingKeys: String, CodingKey {
+            case eventType = "event_type"
+        }
+    }
+
+    /// Action properties
+    public struct Action: Codable {
+        /// UUID of the action
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Application properties
+    public struct Application: Codable {
+        /// UUID of the application
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// UUID of the session
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// View properties
+    public struct View: Codable {
+        /// UUID of the view
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+}
+
 /// CI Visibility properties
 public struct RUMCITest: Codable {
     /// The identifier of the current CI Visibility test execution
@@ -1781,4 +1992,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/114c173caac5ea15446a157b666acbab05431361
+// Generated from https://github.com/DataDog/rum-events-format/tree/c8a844abb59cb376be2fcdc9deda74dc328af660

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -12,1432 +12,6 @@ import Foundation
 // swiftlint:disable force_unwrapping
 
 @objc
-public class DDRUMViewEvent: NSObject {
-    internal var swiftModel: RUMViewEvent
-    internal var root: DDRUMViewEvent { self }
-
-    internal init(swiftModel: RUMViewEvent) {
-        self.swiftModel = swiftModel
-    }
-
-    @objc public var dd: DDRUMViewEventDD {
-        DDRUMViewEventDD(root: root)
-    }
-
-    @objc public var application: DDRUMViewEventApplication {
-        DDRUMViewEventApplication(root: root)
-    }
-
-    @objc public var ciTest: DDRUMViewEventRUMCITest? {
-        root.swiftModel.ciTest != nil ? DDRUMViewEventRUMCITest(root: root) : nil
-    }
-
-    @objc public var connectivity: DDRUMViewEventRUMConnectivity? {
-        root.swiftModel.connectivity != nil ? DDRUMViewEventRUMConnectivity(root: root) : nil
-    }
-
-    @objc public var context: DDRUMViewEventRUMEventAttributes? {
-        root.swiftModel.context != nil ? DDRUMViewEventRUMEventAttributes(root: root) : nil
-    }
-
-    @objc public var date: NSNumber {
-        root.swiftModel.date as NSNumber
-    }
-
-    @objc public var service: String? {
-        root.swiftModel.service
-    }
-
-    @objc public var session: DDRUMViewEventSession {
-        DDRUMViewEventSession(root: root)
-    }
-
-    @objc public var source: DDRUMViewEventSource {
-        .init(swift: root.swiftModel.source)
-    }
-
-    @objc public var synthetics: DDRUMViewEventSynthetics? {
-        root.swiftModel.synthetics != nil ? DDRUMViewEventSynthetics(root: root) : nil
-    }
-
-    @objc public var type: String {
-        root.swiftModel.type
-    }
-
-    @objc public var usr: DDRUMViewEventRUMUser? {
-        root.swiftModel.usr != nil ? DDRUMViewEventRUMUser(root: root) : nil
-    }
-
-    @objc public var view: DDRUMViewEventView {
-        DDRUMViewEventView(root: root)
-    }
-}
-
-@objc
-public class DDRUMViewEventDD: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var browserSdkVersion: String? {
-        root.swiftModel.dd.browserSdkVersion
-    }
-
-    @objc public var documentVersion: NSNumber {
-        root.swiftModel.dd.documentVersion as NSNumber
-    }
-
-    @objc public var formatVersion: NSNumber {
-        root.swiftModel.dd.formatVersion as NSNumber
-    }
-
-    @objc public var session: DDRUMViewEventDDSession? {
-        root.swiftModel.dd.session != nil ? DDRUMViewEventDDSession(root: root) : nil
-    }
-}
-
-@objc
-public class DDRUMViewEventDDSession: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var plan: DDRUMViewEventDDSessionPlan {
-        .init(swift: root.swiftModel.dd.session!.plan)
-    }
-}
-
-@objc
-public enum DDRUMViewEventDDSessionPlan: Int {
-    internal init(swift: RUMViewEvent.DD.Session.Plan) {
-        switch swift {
-        case .plan1: self = .plan1
-        case .plan2: self = .plan2
-        }
-    }
-
-    internal var toSwift: RUMViewEvent.DD.Session.Plan {
-        switch self {
-        case .plan1: return .plan1
-        case .plan2: return .plan2
-        }
-    }
-
-    case plan1
-    case plan2
-}
-
-@objc
-public class DDRUMViewEventApplication: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var id: String {
-        root.swiftModel.application.id
-    }
-}
-
-@objc
-public class DDRUMViewEventRUMCITest: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var testExecutionId: String {
-        root.swiftModel.ciTest!.testExecutionId
-    }
-}
-
-@objc
-public class DDRUMViewEventRUMConnectivity: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var cellular: DDRUMViewEventRUMConnectivityCellular? {
-        root.swiftModel.connectivity!.cellular != nil ? DDRUMViewEventRUMConnectivityCellular(root: root) : nil
-    }
-
-    @objc public var interfaces: [Int] {
-        root.swiftModel.connectivity!.interfaces.map { DDRUMViewEventRUMConnectivityInterfaces(swift: $0).rawValue }
-    }
-
-    @objc public var status: DDRUMViewEventRUMConnectivityStatus {
-        .init(swift: root.swiftModel.connectivity!.status)
-    }
-}
-
-@objc
-public class DDRUMViewEventRUMConnectivityCellular: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var carrierName: String? {
-        root.swiftModel.connectivity!.cellular!.carrierName
-    }
-
-    @objc public var technology: String? {
-        root.swiftModel.connectivity!.cellular!.technology
-    }
-}
-
-@objc
-public enum DDRUMViewEventRUMConnectivityInterfaces: Int {
-    internal init(swift: RUMConnectivity.Interfaces) {
-        switch swift {
-        case .bluetooth: self = .bluetooth
-        case .cellular: self = .cellular
-        case .ethernet: self = .ethernet
-        case .wifi: self = .wifi
-        case .wimax: self = .wimax
-        case .mixed: self = .mixed
-        case .other: self = .other
-        case .unknown: self = .unknown
-        case .none: self = .none
-        }
-    }
-
-    internal var toSwift: RUMConnectivity.Interfaces {
-        switch self {
-        case .bluetooth: return .bluetooth
-        case .cellular: return .cellular
-        case .ethernet: return .ethernet
-        case .wifi: return .wifi
-        case .wimax: return .wimax
-        case .mixed: return .mixed
-        case .other: return .other
-        case .unknown: return .unknown
-        case .none: return .none
-        }
-    }
-
-    case bluetooth
-    case cellular
-    case ethernet
-    case wifi
-    case wimax
-    case mixed
-    case other
-    case unknown
-    case none
-}
-
-@objc
-public enum DDRUMViewEventRUMConnectivityStatus: Int {
-    internal init(swift: RUMConnectivity.Status) {
-        switch swift {
-        case .connected: self = .connected
-        case .notConnected: self = .notConnected
-        case .maybe: self = .maybe
-        }
-    }
-
-    internal var toSwift: RUMConnectivity.Status {
-        switch self {
-        case .connected: return .connected
-        case .notConnected: return .notConnected
-        case .maybe: return .maybe
-        }
-    }
-
-    case connected
-    case notConnected
-    case maybe
-}
-
-@objc
-public class DDRUMViewEventRUMEventAttributes: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo.castToObjectiveC()
-    }
-}
-
-@objc
-public class DDRUMViewEventSession: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var hasReplay: NSNumber? {
-        root.swiftModel.session.hasReplay as NSNumber?
-    }
-
-    @objc public var id: String {
-        root.swiftModel.session.id
-    }
-
-    @objc public var type: DDRUMViewEventSessionSessionType {
-        .init(swift: root.swiftModel.session.type)
-    }
-}
-
-@objc
-public enum DDRUMViewEventSessionSessionType: Int {
-    internal init(swift: RUMViewEvent.Session.SessionType) {
-        switch swift {
-        case .user: self = .user
-        case .synthetics: self = .synthetics
-        case .ciTest: self = .ciTest
-        }
-    }
-
-    internal var toSwift: RUMViewEvent.Session.SessionType {
-        switch self {
-        case .user: return .user
-        case .synthetics: return .synthetics
-        case .ciTest: return .ciTest
-        }
-    }
-
-    case user
-    case synthetics
-    case ciTest
-}
-
-@objc
-public enum DDRUMViewEventSource: Int {
-    internal init(swift: RUMViewEvent.Source?) {
-        switch swift {
-        case nil: self = .none
-        case .android?: self = .android
-        case .ios?: self = .ios
-        case .browser?: self = .browser
-        case .flutter?: self = .flutter
-        case .reactNative?: self = .reactNative
-        }
-    }
-
-    internal var toSwift: RUMViewEvent.Source? {
-        switch self {
-        case .none: return nil
-        case .android: return .android
-        case .ios: return .ios
-        case .browser: return .browser
-        case .flutter: return .flutter
-        case .reactNative: return .reactNative
-        }
-    }
-
-    case none
-    case android
-    case ios
-    case browser
-    case flutter
-    case reactNative
-}
-
-@objc
-public class DDRUMViewEventSynthetics: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var injected: NSNumber? {
-        root.swiftModel.synthetics!.injected as NSNumber?
-    }
-
-    @objc public var resultId: String {
-        root.swiftModel.synthetics!.resultId
-    }
-
-    @objc public var testId: String {
-        root.swiftModel.synthetics!.testId
-    }
-}
-
-@objc
-public class DDRUMViewEventRUMUser: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var email: String? {
-        root.swiftModel.usr!.email
-    }
-
-    @objc public var id: String? {
-        root.swiftModel.usr!.id
-    }
-
-    @objc public var name: String? {
-        root.swiftModel.usr!.name
-    }
-
-    @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo.castToObjectiveC()
-    }
-}
-
-@objc
-public class DDRUMViewEventView: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var action: DDRUMViewEventViewAction {
-        DDRUMViewEventViewAction(root: root)
-    }
-
-    @objc public var cpuTicksCount: NSNumber? {
-        root.swiftModel.view.cpuTicksCount as NSNumber?
-    }
-
-    @objc public var cpuTicksPerSecond: NSNumber? {
-        root.swiftModel.view.cpuTicksPerSecond as NSNumber?
-    }
-
-    @objc public var crash: DDRUMViewEventViewCrash? {
-        root.swiftModel.view.crash != nil ? DDRUMViewEventViewCrash(root: root) : nil
-    }
-
-    @objc public var cumulativeLayoutShift: NSNumber? {
-        root.swiftModel.view.cumulativeLayoutShift as NSNumber?
-    }
-
-    @objc public var customTimings: [String: NSNumber]? {
-        root.swiftModel.view.customTimings as [String: NSNumber]?
-    }
-
-    @objc public var domComplete: NSNumber? {
-        root.swiftModel.view.domComplete as NSNumber?
-    }
-
-    @objc public var domContentLoaded: NSNumber? {
-        root.swiftModel.view.domContentLoaded as NSNumber?
-    }
-
-    @objc public var domInteractive: NSNumber? {
-        root.swiftModel.view.domInteractive as NSNumber?
-    }
-
-    @objc public var error: DDRUMViewEventViewError {
-        DDRUMViewEventViewError(root: root)
-    }
-
-    @objc public var firstContentfulPaint: NSNumber? {
-        root.swiftModel.view.firstContentfulPaint as NSNumber?
-    }
-
-    @objc public var firstInputDelay: NSNumber? {
-        root.swiftModel.view.firstInputDelay as NSNumber?
-    }
-
-    @objc public var firstInputTime: NSNumber? {
-        root.swiftModel.view.firstInputTime as NSNumber?
-    }
-
-    @objc public var frozenFrame: DDRUMViewEventViewFrozenFrame? {
-        root.swiftModel.view.frozenFrame != nil ? DDRUMViewEventViewFrozenFrame(root: root) : nil
-    }
-
-    @objc public var id: String {
-        root.swiftModel.view.id
-    }
-
-    @objc public var inForegroundPeriods: [DDRUMViewEventViewInForegroundPeriods]? {
-        root.swiftModel.view.inForegroundPeriods?.map { DDRUMViewEventViewInForegroundPeriods(swiftModel: $0) }
-    }
-
-    @objc public var isActive: NSNumber? {
-        root.swiftModel.view.isActive as NSNumber?
-    }
-
-    @objc public var isSlowRendered: NSNumber? {
-        root.swiftModel.view.isSlowRendered as NSNumber?
-    }
-
-    @objc public var largestContentfulPaint: NSNumber? {
-        root.swiftModel.view.largestContentfulPaint as NSNumber?
-    }
-
-    @objc public var loadEvent: NSNumber? {
-        root.swiftModel.view.loadEvent as NSNumber?
-    }
-
-    @objc public var loadingTime: NSNumber? {
-        root.swiftModel.view.loadingTime as NSNumber?
-    }
-
-    @objc public var loadingType: DDRUMViewEventViewLoadingType {
-        .init(swift: root.swiftModel.view.loadingType)
-    }
-
-    @objc public var longTask: DDRUMViewEventViewLongTask? {
-        root.swiftModel.view.longTask != nil ? DDRUMViewEventViewLongTask(root: root) : nil
-    }
-
-    @objc public var memoryAverage: NSNumber? {
-        root.swiftModel.view.memoryAverage as NSNumber?
-    }
-
-    @objc public var memoryMax: NSNumber? {
-        root.swiftModel.view.memoryMax as NSNumber?
-    }
-
-    @objc public var name: String? {
-        set { root.swiftModel.view.name = newValue }
-        get { root.swiftModel.view.name }
-    }
-
-    @objc public var referrer: String? {
-        set { root.swiftModel.view.referrer = newValue }
-        get { root.swiftModel.view.referrer }
-    }
-
-    @objc public var refreshRateAverage: NSNumber? {
-        root.swiftModel.view.refreshRateAverage as NSNumber?
-    }
-
-    @objc public var refreshRateMin: NSNumber? {
-        root.swiftModel.view.refreshRateMin as NSNumber?
-    }
-
-    @objc public var resource: DDRUMViewEventViewResource {
-        DDRUMViewEventViewResource(root: root)
-    }
-
-    @objc public var timeSpent: NSNumber {
-        root.swiftModel.view.timeSpent as NSNumber
-    }
-
-    @objc public var url: String {
-        set { root.swiftModel.view.url = newValue }
-        get { root.swiftModel.view.url }
-    }
-}
-
-@objc
-public class DDRUMViewEventViewAction: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var count: NSNumber {
-        root.swiftModel.view.action.count as NSNumber
-    }
-}
-
-@objc
-public class DDRUMViewEventViewCrash: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var count: NSNumber {
-        root.swiftModel.view.crash!.count as NSNumber
-    }
-}
-
-@objc
-public class DDRUMViewEventViewError: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var count: NSNumber {
-        root.swiftModel.view.error.count as NSNumber
-    }
-}
-
-@objc
-public class DDRUMViewEventViewFrozenFrame: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var count: NSNumber {
-        root.swiftModel.view.frozenFrame!.count as NSNumber
-    }
-}
-
-@objc
-public class DDRUMViewEventViewInForegroundPeriods: NSObject {
-    internal let swiftModel: RUMViewEvent.View.InForegroundPeriods
-    internal var root: DDRUMViewEventViewInForegroundPeriods { self }
-
-    internal init(swiftModel: RUMViewEvent.View.InForegroundPeriods) {
-        self.swiftModel = swiftModel
-    }
-
-    @objc public var duration: NSNumber {
-        root.swiftModel.duration as NSNumber
-    }
-
-    @objc public var start: NSNumber {
-        root.swiftModel.start as NSNumber
-    }
-}
-
-@objc
-public enum DDRUMViewEventViewLoadingType: Int {
-    internal init(swift: RUMViewEvent.View.LoadingType?) {
-        switch swift {
-        case nil: self = .none
-        case .initialLoad?: self = .initialLoad
-        case .routeChange?: self = .routeChange
-        case .activityDisplay?: self = .activityDisplay
-        case .activityRedisplay?: self = .activityRedisplay
-        case .fragmentDisplay?: self = .fragmentDisplay
-        case .fragmentRedisplay?: self = .fragmentRedisplay
-        case .viewControllerDisplay?: self = .viewControllerDisplay
-        case .viewControllerRedisplay?: self = .viewControllerRedisplay
-        }
-    }
-
-    internal var toSwift: RUMViewEvent.View.LoadingType? {
-        switch self {
-        case .none: return nil
-        case .initialLoad: return .initialLoad
-        case .routeChange: return .routeChange
-        case .activityDisplay: return .activityDisplay
-        case .activityRedisplay: return .activityRedisplay
-        case .fragmentDisplay: return .fragmentDisplay
-        case .fragmentRedisplay: return .fragmentRedisplay
-        case .viewControllerDisplay: return .viewControllerDisplay
-        case .viewControllerRedisplay: return .viewControllerRedisplay
-        }
-    }
-
-    case none
-    case initialLoad
-    case routeChange
-    case activityDisplay
-    case activityRedisplay
-    case fragmentDisplay
-    case fragmentRedisplay
-    case viewControllerDisplay
-    case viewControllerRedisplay
-}
-
-@objc
-public class DDRUMViewEventViewLongTask: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var count: NSNumber {
-        root.swiftModel.view.longTask!.count as NSNumber
-    }
-}
-
-@objc
-public class DDRUMViewEventViewResource: NSObject {
-    internal let root: DDRUMViewEvent
-
-    internal init(root: DDRUMViewEvent) {
-        self.root = root
-    }
-
-    @objc public var count: NSNumber {
-        root.swiftModel.view.resource.count as NSNumber
-    }
-}
-
-@objc
-public class DDRUMResourceEvent: NSObject {
-    internal var swiftModel: RUMResourceEvent
-    internal var root: DDRUMResourceEvent { self }
-
-    internal init(swiftModel: RUMResourceEvent) {
-        self.swiftModel = swiftModel
-    }
-
-    @objc public var dd: DDRUMResourceEventDD {
-        DDRUMResourceEventDD(root: root)
-    }
-
-    @objc public var action: DDRUMResourceEventAction? {
-        root.swiftModel.action != nil ? DDRUMResourceEventAction(root: root) : nil
-    }
-
-    @objc public var application: DDRUMResourceEventApplication {
-        DDRUMResourceEventApplication(root: root)
-    }
-
-    @objc public var ciTest: DDRUMResourceEventRUMCITest? {
-        root.swiftModel.ciTest != nil ? DDRUMResourceEventRUMCITest(root: root) : nil
-    }
-
-    @objc public var connectivity: DDRUMResourceEventRUMConnectivity? {
-        root.swiftModel.connectivity != nil ? DDRUMResourceEventRUMConnectivity(root: root) : nil
-    }
-
-    @objc public var context: DDRUMResourceEventRUMEventAttributes? {
-        root.swiftModel.context != nil ? DDRUMResourceEventRUMEventAttributes(root: root) : nil
-    }
-
-    @objc public var date: NSNumber {
-        root.swiftModel.date as NSNumber
-    }
-
-    @objc public var resource: DDRUMResourceEventResource {
-        DDRUMResourceEventResource(root: root)
-    }
-
-    @objc public var service: String? {
-        root.swiftModel.service
-    }
-
-    @objc public var session: DDRUMResourceEventSession {
-        DDRUMResourceEventSession(root: root)
-    }
-
-    @objc public var source: DDRUMResourceEventSource {
-        .init(swift: root.swiftModel.source)
-    }
-
-    @objc public var synthetics: DDRUMResourceEventSynthetics? {
-        root.swiftModel.synthetics != nil ? DDRUMResourceEventSynthetics(root: root) : nil
-    }
-
-    @objc public var type: String {
-        root.swiftModel.type
-    }
-
-    @objc public var usr: DDRUMResourceEventRUMUser? {
-        root.swiftModel.usr != nil ? DDRUMResourceEventRUMUser(root: root) : nil
-    }
-
-    @objc public var view: DDRUMResourceEventView {
-        DDRUMResourceEventView(root: root)
-    }
-}
-
-@objc
-public class DDRUMResourceEventDD: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var browserSdkVersion: String? {
-        root.swiftModel.dd.browserSdkVersion
-    }
-
-    @objc public var formatVersion: NSNumber {
-        root.swiftModel.dd.formatVersion as NSNumber
-    }
-
-    @objc public var session: DDRUMResourceEventDDSession? {
-        root.swiftModel.dd.session != nil ? DDRUMResourceEventDDSession(root: root) : nil
-    }
-
-    @objc public var spanId: String? {
-        root.swiftModel.dd.spanId
-    }
-
-    @objc public var traceId: String? {
-        root.swiftModel.dd.traceId
-    }
-}
-
-@objc
-public class DDRUMResourceEventDDSession: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var plan: DDRUMResourceEventDDSessionPlan {
-        .init(swift: root.swiftModel.dd.session!.plan)
-    }
-}
-
-@objc
-public enum DDRUMResourceEventDDSessionPlan: Int {
-    internal init(swift: RUMResourceEvent.DD.Session.Plan) {
-        switch swift {
-        case .plan1: self = .plan1
-        case .plan2: self = .plan2
-        }
-    }
-
-    internal var toSwift: RUMResourceEvent.DD.Session.Plan {
-        switch self {
-        case .plan1: return .plan1
-        case .plan2: return .plan2
-        }
-    }
-
-    case plan1
-    case plan2
-}
-
-@objc
-public class DDRUMResourceEventAction: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var id: String {
-        root.swiftModel.action!.id
-    }
-}
-
-@objc
-public class DDRUMResourceEventApplication: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var id: String {
-        root.swiftModel.application.id
-    }
-}
-
-@objc
-public class DDRUMResourceEventRUMCITest: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var testExecutionId: String {
-        root.swiftModel.ciTest!.testExecutionId
-    }
-}
-
-@objc
-public class DDRUMResourceEventRUMConnectivity: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var cellular: DDRUMResourceEventRUMConnectivityCellular? {
-        root.swiftModel.connectivity!.cellular != nil ? DDRUMResourceEventRUMConnectivityCellular(root: root) : nil
-    }
-
-    @objc public var interfaces: [Int] {
-        root.swiftModel.connectivity!.interfaces.map { DDRUMResourceEventRUMConnectivityInterfaces(swift: $0).rawValue }
-    }
-
-    @objc public var status: DDRUMResourceEventRUMConnectivityStatus {
-        .init(swift: root.swiftModel.connectivity!.status)
-    }
-}
-
-@objc
-public class DDRUMResourceEventRUMConnectivityCellular: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var carrierName: String? {
-        root.swiftModel.connectivity!.cellular!.carrierName
-    }
-
-    @objc public var technology: String? {
-        root.swiftModel.connectivity!.cellular!.technology
-    }
-}
-
-@objc
-public enum DDRUMResourceEventRUMConnectivityInterfaces: Int {
-    internal init(swift: RUMConnectivity.Interfaces) {
-        switch swift {
-        case .bluetooth: self = .bluetooth
-        case .cellular: self = .cellular
-        case .ethernet: self = .ethernet
-        case .wifi: self = .wifi
-        case .wimax: self = .wimax
-        case .mixed: self = .mixed
-        case .other: self = .other
-        case .unknown: self = .unknown
-        case .none: self = .none
-        }
-    }
-
-    internal var toSwift: RUMConnectivity.Interfaces {
-        switch self {
-        case .bluetooth: return .bluetooth
-        case .cellular: return .cellular
-        case .ethernet: return .ethernet
-        case .wifi: return .wifi
-        case .wimax: return .wimax
-        case .mixed: return .mixed
-        case .other: return .other
-        case .unknown: return .unknown
-        case .none: return .none
-        }
-    }
-
-    case bluetooth
-    case cellular
-    case ethernet
-    case wifi
-    case wimax
-    case mixed
-    case other
-    case unknown
-    case none
-}
-
-@objc
-public enum DDRUMResourceEventRUMConnectivityStatus: Int {
-    internal init(swift: RUMConnectivity.Status) {
-        switch swift {
-        case .connected: self = .connected
-        case .notConnected: self = .notConnected
-        case .maybe: self = .maybe
-        }
-    }
-
-    internal var toSwift: RUMConnectivity.Status {
-        switch self {
-        case .connected: return .connected
-        case .notConnected: return .notConnected
-        case .maybe: return .maybe
-        }
-    }
-
-    case connected
-    case notConnected
-    case maybe
-}
-
-@objc
-public class DDRUMResourceEventRUMEventAttributes: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var contextInfo: [String: Any] {
-        root.swiftModel.context!.contextInfo.castToObjectiveC()
-    }
-}
-
-@objc
-public class DDRUMResourceEventResource: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var connect: DDRUMResourceEventResourceConnect? {
-        root.swiftModel.resource.connect != nil ? DDRUMResourceEventResourceConnect(root: root) : nil
-    }
-
-    @objc public var dns: DDRUMResourceEventResourceDNS? {
-        root.swiftModel.resource.dns != nil ? DDRUMResourceEventResourceDNS(root: root) : nil
-    }
-
-    @objc public var download: DDRUMResourceEventResourceDownload? {
-        root.swiftModel.resource.download != nil ? DDRUMResourceEventResourceDownload(root: root) : nil
-    }
-
-    @objc public var duration: NSNumber {
-        root.swiftModel.resource.duration as NSNumber
-    }
-
-    @objc public var firstByte: DDRUMResourceEventResourceFirstByte? {
-        root.swiftModel.resource.firstByte != nil ? DDRUMResourceEventResourceFirstByte(root: root) : nil
-    }
-
-    @objc public var id: String? {
-        root.swiftModel.resource.id
-    }
-
-    @objc public var method: DDRUMResourceEventResourceRUMMethod {
-        .init(swift: root.swiftModel.resource.method)
-    }
-
-    @objc public var provider: DDRUMResourceEventResourceProvider? {
-        root.swiftModel.resource.provider != nil ? DDRUMResourceEventResourceProvider(root: root) : nil
-    }
-
-    @objc public var redirect: DDRUMResourceEventResourceRedirect? {
-        root.swiftModel.resource.redirect != nil ? DDRUMResourceEventResourceRedirect(root: root) : nil
-    }
-
-    @objc public var size: NSNumber? {
-        root.swiftModel.resource.size as NSNumber?
-    }
-
-    @objc public var ssl: DDRUMResourceEventResourceSSL? {
-        root.swiftModel.resource.ssl != nil ? DDRUMResourceEventResourceSSL(root: root) : nil
-    }
-
-    @objc public var statusCode: NSNumber? {
-        root.swiftModel.resource.statusCode as NSNumber?
-    }
-
-    @objc public var type: DDRUMResourceEventResourceResourceType {
-        .init(swift: root.swiftModel.resource.type)
-    }
-
-    @objc public var url: String {
-        set { root.swiftModel.resource.url = newValue }
-        get { root.swiftModel.resource.url }
-    }
-}
-
-@objc
-public class DDRUMResourceEventResourceConnect: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var duration: NSNumber {
-        root.swiftModel.resource.connect!.duration as NSNumber
-    }
-
-    @objc public var start: NSNumber {
-        root.swiftModel.resource.connect!.start as NSNumber
-    }
-}
-
-@objc
-public class DDRUMResourceEventResourceDNS: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var duration: NSNumber {
-        root.swiftModel.resource.dns!.duration as NSNumber
-    }
-
-    @objc public var start: NSNumber {
-        root.swiftModel.resource.dns!.start as NSNumber
-    }
-}
-
-@objc
-public class DDRUMResourceEventResourceDownload: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var duration: NSNumber {
-        root.swiftModel.resource.download!.duration as NSNumber
-    }
-
-    @objc public var start: NSNumber {
-        root.swiftModel.resource.download!.start as NSNumber
-    }
-}
-
-@objc
-public class DDRUMResourceEventResourceFirstByte: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var duration: NSNumber {
-        root.swiftModel.resource.firstByte!.duration as NSNumber
-    }
-
-    @objc public var start: NSNumber {
-        root.swiftModel.resource.firstByte!.start as NSNumber
-    }
-}
-
-@objc
-public enum DDRUMResourceEventResourceRUMMethod: Int {
-    internal init(swift: RUMMethod?) {
-        switch swift {
-        case nil: self = .none
-        case .post?: self = .post
-        case .get?: self = .get
-        case .head?: self = .head
-        case .put?: self = .put
-        case .delete?: self = .delete
-        case .patch?: self = .patch
-        }
-    }
-
-    internal var toSwift: RUMMethod? {
-        switch self {
-        case .none: return nil
-        case .post: return .post
-        case .get: return .get
-        case .head: return .head
-        case .put: return .put
-        case .delete: return .delete
-        case .patch: return .patch
-        }
-    }
-
-    case none
-    case post
-    case get
-    case head
-    case put
-    case delete
-    case patch
-}
-
-@objc
-public class DDRUMResourceEventResourceProvider: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var domain: String? {
-        root.swiftModel.resource.provider!.domain
-    }
-
-    @objc public var name: String? {
-        root.swiftModel.resource.provider!.name
-    }
-
-    @objc public var type: DDRUMResourceEventResourceProviderProviderType {
-        .init(swift: root.swiftModel.resource.provider!.type)
-    }
-}
-
-@objc
-public enum DDRUMResourceEventResourceProviderProviderType: Int {
-    internal init(swift: RUMResourceEvent.Resource.Provider.ProviderType?) {
-        switch swift {
-        case nil: self = .none
-        case .ad?: self = .ad
-        case .advertising?: self = .advertising
-        case .analytics?: self = .analytics
-        case .cdn?: self = .cdn
-        case .content?: self = .content
-        case .customerSuccess?: self = .customerSuccess
-        case .firstParty?: self = .firstParty
-        case .hosting?: self = .hosting
-        case .marketing?: self = .marketing
-        case .other?: self = .other
-        case .social?: self = .social
-        case .tagManager?: self = .tagManager
-        case .utility?: self = .utility
-        case .video?: self = .video
-        }
-    }
-
-    internal var toSwift: RUMResourceEvent.Resource.Provider.ProviderType? {
-        switch self {
-        case .none: return nil
-        case .ad: return .ad
-        case .advertising: return .advertising
-        case .analytics: return .analytics
-        case .cdn: return .cdn
-        case .content: return .content
-        case .customerSuccess: return .customerSuccess
-        case .firstParty: return .firstParty
-        case .hosting: return .hosting
-        case .marketing: return .marketing
-        case .other: return .other
-        case .social: return .social
-        case .tagManager: return .tagManager
-        case .utility: return .utility
-        case .video: return .video
-        }
-    }
-
-    case none
-    case ad
-    case advertising
-    case analytics
-    case cdn
-    case content
-    case customerSuccess
-    case firstParty
-    case hosting
-    case marketing
-    case other
-    case social
-    case tagManager
-    case utility
-    case video
-}
-
-@objc
-public class DDRUMResourceEventResourceRedirect: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var duration: NSNumber {
-        root.swiftModel.resource.redirect!.duration as NSNumber
-    }
-
-    @objc public var start: NSNumber {
-        root.swiftModel.resource.redirect!.start as NSNumber
-    }
-}
-
-@objc
-public class DDRUMResourceEventResourceSSL: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var duration: NSNumber {
-        root.swiftModel.resource.ssl!.duration as NSNumber
-    }
-
-    @objc public var start: NSNumber {
-        root.swiftModel.resource.ssl!.start as NSNumber
-    }
-}
-
-@objc
-public enum DDRUMResourceEventResourceResourceType: Int {
-    internal init(swift: RUMResourceEvent.Resource.ResourceType) {
-        switch swift {
-        case .document: self = .document
-        case .xhr: self = .xhr
-        case .beacon: self = .beacon
-        case .fetch: self = .fetch
-        case .css: self = .css
-        case .js: self = .js
-        case .image: self = .image
-        case .font: self = .font
-        case .media: self = .media
-        case .other: self = .other
-        case .native: self = .native
-        }
-    }
-
-    internal var toSwift: RUMResourceEvent.Resource.ResourceType {
-        switch self {
-        case .document: return .document
-        case .xhr: return .xhr
-        case .beacon: return .beacon
-        case .fetch: return .fetch
-        case .css: return .css
-        case .js: return .js
-        case .image: return .image
-        case .font: return .font
-        case .media: return .media
-        case .other: return .other
-        case .native: return .native
-        }
-    }
-
-    case document
-    case xhr
-    case beacon
-    case fetch
-    case css
-    case js
-    case image
-    case font
-    case media
-    case other
-    case native
-}
-
-@objc
-public class DDRUMResourceEventSession: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var hasReplay: NSNumber? {
-        root.swiftModel.session.hasReplay as NSNumber?
-    }
-
-    @objc public var id: String {
-        root.swiftModel.session.id
-    }
-
-    @objc public var type: DDRUMResourceEventSessionSessionType {
-        .init(swift: root.swiftModel.session.type)
-    }
-}
-
-@objc
-public enum DDRUMResourceEventSessionSessionType: Int {
-    internal init(swift: RUMResourceEvent.Session.SessionType) {
-        switch swift {
-        case .user: self = .user
-        case .synthetics: self = .synthetics
-        case .ciTest: self = .ciTest
-        }
-    }
-
-    internal var toSwift: RUMResourceEvent.Session.SessionType {
-        switch self {
-        case .user: return .user
-        case .synthetics: return .synthetics
-        case .ciTest: return .ciTest
-        }
-    }
-
-    case user
-    case synthetics
-    case ciTest
-}
-
-@objc
-public enum DDRUMResourceEventSource: Int {
-    internal init(swift: RUMResourceEvent.Source?) {
-        switch swift {
-        case nil: self = .none
-        case .android?: self = .android
-        case .ios?: self = .ios
-        case .browser?: self = .browser
-        case .flutter?: self = .flutter
-        case .reactNative?: self = .reactNative
-        }
-    }
-
-    internal var toSwift: RUMResourceEvent.Source? {
-        switch self {
-        case .none: return nil
-        case .android: return .android
-        case .ios: return .ios
-        case .browser: return .browser
-        case .flutter: return .flutter
-        case .reactNative: return .reactNative
-        }
-    }
-
-    case none
-    case android
-    case ios
-    case browser
-    case flutter
-    case reactNative
-}
-
-@objc
-public class DDRUMResourceEventSynthetics: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var injected: NSNumber? {
-        root.swiftModel.synthetics!.injected as NSNumber?
-    }
-
-    @objc public var resultId: String {
-        root.swiftModel.synthetics!.resultId
-    }
-
-    @objc public var testId: String {
-        root.swiftModel.synthetics!.testId
-    }
-}
-
-@objc
-public class DDRUMResourceEventRUMUser: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var email: String? {
-        root.swiftModel.usr!.email
-    }
-
-    @objc public var id: String? {
-        root.swiftModel.usr!.id
-    }
-
-    @objc public var name: String? {
-        root.swiftModel.usr!.name
-    }
-
-    @objc public var usrInfo: [String: Any] {
-        root.swiftModel.usr!.usrInfo.castToObjectiveC()
-    }
-}
-
-@objc
-public class DDRUMResourceEventView: NSObject {
-    internal let root: DDRUMResourceEvent
-
-    internal init(root: DDRUMResourceEvent) {
-        self.root = root
-    }
-
-    @objc public var id: String {
-        root.swiftModel.view.id
-    }
-
-    @objc public var name: String? {
-        set { root.swiftModel.view.name = newValue }
-        get { root.swiftModel.view.name }
-    }
-
-    @objc public var referrer: String? {
-        set { root.swiftModel.view.referrer = newValue }
-        get { root.swiftModel.view.referrer }
-    }
-
-    @objc public var url: String {
-        set { root.swiftModel.view.url = newValue }
-        get { root.swiftModel.view.url }
-    }
-}
-
-@objc
 public class DDRUMActionEvent: NSObject {
     internal var swiftModel: RUMActionEvent
     internal var root: DDRUMActionEvent { self }
@@ -2495,6 +1069,7 @@ public enum DDRUMErrorEventErrorSource: Int {
         case .agent: self = .agent
         case .webview: self = .webview
         case .custom: self = .custom
+        case .report: self = .report
         }
     }
 
@@ -2507,6 +1082,7 @@ public enum DDRUMErrorEventErrorSource: Int {
         case .agent: return .agent
         case .webview: return .webview
         case .custom: return .custom
+        case .report: return .report
         }
     }
 
@@ -2517,6 +1093,7 @@ public enum DDRUMErrorEventErrorSource: Int {
     case agent
     case webview
     case custom
+    case report
 }
 
 @objc
@@ -3154,6 +1731,1683 @@ public class DDRUMLongTaskEventView: NSObject {
     }
 }
 
+@objc
+public class DDRUMResourceEvent: NSObject {
+    internal var swiftModel: RUMResourceEvent
+    internal var root: DDRUMResourceEvent { self }
+
+    internal init(swiftModel: RUMResourceEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var dd: DDRUMResourceEventDD {
+        DDRUMResourceEventDD(root: root)
+    }
+
+    @objc public var action: DDRUMResourceEventAction? {
+        root.swiftModel.action != nil ? DDRUMResourceEventAction(root: root) : nil
+    }
+
+    @objc public var application: DDRUMResourceEventApplication {
+        DDRUMResourceEventApplication(root: root)
+    }
+
+    @objc public var ciTest: DDRUMResourceEventRUMCITest? {
+        root.swiftModel.ciTest != nil ? DDRUMResourceEventRUMCITest(root: root) : nil
+    }
+
+    @objc public var connectivity: DDRUMResourceEventRUMConnectivity? {
+        root.swiftModel.connectivity != nil ? DDRUMResourceEventRUMConnectivity(root: root) : nil
+    }
+
+    @objc public var context: DDRUMResourceEventRUMEventAttributes? {
+        root.swiftModel.context != nil ? DDRUMResourceEventRUMEventAttributes(root: root) : nil
+    }
+
+    @objc public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    @objc public var resource: DDRUMResourceEventResource {
+        DDRUMResourceEventResource(root: root)
+    }
+
+    @objc public var service: String? {
+        root.swiftModel.service
+    }
+
+    @objc public var session: DDRUMResourceEventSession {
+        DDRUMResourceEventSession(root: root)
+    }
+
+    @objc public var source: DDRUMResourceEventSource {
+        .init(swift: root.swiftModel.source)
+    }
+
+    @objc public var synthetics: DDRUMResourceEventSynthetics? {
+        root.swiftModel.synthetics != nil ? DDRUMResourceEventSynthetics(root: root) : nil
+    }
+
+    @objc public var type: String {
+        root.swiftModel.type
+    }
+
+    @objc public var usr: DDRUMResourceEventRUMUser? {
+        root.swiftModel.usr != nil ? DDRUMResourceEventRUMUser(root: root) : nil
+    }
+
+    @objc public var view: DDRUMResourceEventView {
+        DDRUMResourceEventView(root: root)
+    }
+}
+
+@objc
+public class DDRUMResourceEventDD: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var browserSdkVersion: String? {
+        root.swiftModel.dd.browserSdkVersion
+    }
+
+    @objc public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+
+    @objc public var session: DDRUMResourceEventDDSession? {
+        root.swiftModel.dd.session != nil ? DDRUMResourceEventDDSession(root: root) : nil
+    }
+
+    @objc public var spanId: String? {
+        root.swiftModel.dd.spanId
+    }
+
+    @objc public var traceId: String? {
+        root.swiftModel.dd.traceId
+    }
+}
+
+@objc
+public class DDRUMResourceEventDDSession: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var plan: DDRUMResourceEventDDSessionPlan {
+        .init(swift: root.swiftModel.dd.session!.plan)
+    }
+}
+
+@objc
+public enum DDRUMResourceEventDDSessionPlan: Int {
+    internal init(swift: RUMResourceEvent.DD.Session.Plan) {
+        switch swift {
+        case .plan1: self = .plan1
+        case .plan2: self = .plan2
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.DD.Session.Plan {
+        switch self {
+        case .plan1: return .plan1
+        case .plan2: return .plan2
+        }
+    }
+
+    case plan1
+    case plan2
+}
+
+@objc
+public class DDRUMResourceEventAction: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.action!.id
+    }
+}
+
+@objc
+public class DDRUMResourceEventApplication: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMResourceEventRUMCITest: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var testExecutionId: String {
+        root.swiftModel.ciTest!.testExecutionId
+    }
+}
+
+@objc
+public class DDRUMResourceEventRUMConnectivity: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var cellular: DDRUMResourceEventRUMConnectivityCellular? {
+        root.swiftModel.connectivity!.cellular != nil ? DDRUMResourceEventRUMConnectivityCellular(root: root) : nil
+    }
+
+    @objc public var interfaces: [Int] {
+        root.swiftModel.connectivity!.interfaces.map { DDRUMResourceEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    }
+
+    @objc public var status: DDRUMResourceEventRUMConnectivityStatus {
+        .init(swift: root.swiftModel.connectivity!.status)
+    }
+}
+
+@objc
+public class DDRUMResourceEventRUMConnectivityCellular: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var carrierName: String? {
+        root.swiftModel.connectivity!.cellular!.carrierName
+    }
+
+    @objc public var technology: String? {
+        root.swiftModel.connectivity!.cellular!.technology
+    }
+}
+
+@objc
+public enum DDRUMResourceEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces) {
+        switch swift {
+        case .bluetooth: self = .bluetooth
+        case .cellular: self = .cellular
+        case .ethernet: self = .ethernet
+        case .wifi: self = .wifi
+        case .wimax: self = .wimax
+        case .mixed: self = .mixed
+        case .other: self = .other
+        case .unknown: self = .unknown
+        case .none: self = .none
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces {
+        switch self {
+        case .bluetooth: return .bluetooth
+        case .cellular: return .cellular
+        case .ethernet: return .ethernet
+        case .wifi: return .wifi
+        case .wimax: return .wimax
+        case .mixed: return .mixed
+        case .other: return .other
+        case .unknown: return .unknown
+        case .none: return .none
+        }
+    }
+
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case none
+}
+
+@objc
+public enum DDRUMResourceEventRUMConnectivityStatus: Int {
+    internal init(swift: RUMConnectivity.Status) {
+        switch swift {
+        case .connected: self = .connected
+        case .notConnected: self = .notConnected
+        case .maybe: self = .maybe
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Status {
+        switch self {
+        case .connected: return .connected
+        case .notConnected: return .notConnected
+        case .maybe: return .maybe
+        }
+    }
+
+    case connected
+    case notConnected
+    case maybe
+}
+
+@objc
+public class DDRUMResourceEventRUMEventAttributes: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var contextInfo: [String: Any] {
+        root.swiftModel.context!.contextInfo.castToObjectiveC()
+    }
+}
+
+@objc
+public class DDRUMResourceEventResource: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var connect: DDRUMResourceEventResourceConnect? {
+        root.swiftModel.resource.connect != nil ? DDRUMResourceEventResourceConnect(root: root) : nil
+    }
+
+    @objc public var dns: DDRUMResourceEventResourceDNS? {
+        root.swiftModel.resource.dns != nil ? DDRUMResourceEventResourceDNS(root: root) : nil
+    }
+
+    @objc public var download: DDRUMResourceEventResourceDownload? {
+        root.swiftModel.resource.download != nil ? DDRUMResourceEventResourceDownload(root: root) : nil
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.duration as NSNumber
+    }
+
+    @objc public var firstByte: DDRUMResourceEventResourceFirstByte? {
+        root.swiftModel.resource.firstByte != nil ? DDRUMResourceEventResourceFirstByte(root: root) : nil
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.resource.id
+    }
+
+    @objc public var method: DDRUMResourceEventResourceRUMMethod {
+        .init(swift: root.swiftModel.resource.method)
+    }
+
+    @objc public var provider: DDRUMResourceEventResourceProvider? {
+        root.swiftModel.resource.provider != nil ? DDRUMResourceEventResourceProvider(root: root) : nil
+    }
+
+    @objc public var redirect: DDRUMResourceEventResourceRedirect? {
+        root.swiftModel.resource.redirect != nil ? DDRUMResourceEventResourceRedirect(root: root) : nil
+    }
+
+    @objc public var size: NSNumber? {
+        root.swiftModel.resource.size as NSNumber?
+    }
+
+    @objc public var ssl: DDRUMResourceEventResourceSSL? {
+        root.swiftModel.resource.ssl != nil ? DDRUMResourceEventResourceSSL(root: root) : nil
+    }
+
+    @objc public var statusCode: NSNumber? {
+        root.swiftModel.resource.statusCode as NSNumber?
+    }
+
+    @objc public var type: DDRUMResourceEventResourceResourceType {
+        .init(swift: root.swiftModel.resource.type)
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.resource.url = newValue }
+        get { root.swiftModel.resource.url }
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceConnect: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.connect!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.connect!.start as NSNumber
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceDNS: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.dns!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.dns!.start as NSNumber
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceDownload: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.download!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.download!.start as NSNumber
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceFirstByte: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.firstByte!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.firstByte!.start as NSNumber
+    }
+}
+
+@objc
+public enum DDRUMResourceEventResourceRUMMethod: Int {
+    internal init(swift: RUMMethod?) {
+        switch swift {
+        case nil: self = .none
+        case .post?: self = .post
+        case .get?: self = .get
+        case .head?: self = .head
+        case .put?: self = .put
+        case .delete?: self = .delete
+        case .patch?: self = .patch
+        }
+    }
+
+    internal var toSwift: RUMMethod? {
+        switch self {
+        case .none: return nil
+        case .post: return .post
+        case .get: return .get
+        case .head: return .head
+        case .put: return .put
+        case .delete: return .delete
+        case .patch: return .patch
+        }
+    }
+
+    case none
+    case post
+    case get
+    case head
+    case put
+    case delete
+    case patch
+}
+
+@objc
+public class DDRUMResourceEventResourceProvider: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var domain: String? {
+        root.swiftModel.resource.provider!.domain
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.resource.provider!.name
+    }
+
+    @objc public var type: DDRUMResourceEventResourceProviderProviderType {
+        .init(swift: root.swiftModel.resource.provider!.type)
+    }
+}
+
+@objc
+public enum DDRUMResourceEventResourceProviderProviderType: Int {
+    internal init(swift: RUMResourceEvent.Resource.Provider.ProviderType?) {
+        switch swift {
+        case nil: self = .none
+        case .ad?: self = .ad
+        case .advertising?: self = .advertising
+        case .analytics?: self = .analytics
+        case .cdn?: self = .cdn
+        case .content?: self = .content
+        case .customerSuccess?: self = .customerSuccess
+        case .firstParty?: self = .firstParty
+        case .hosting?: self = .hosting
+        case .marketing?: self = .marketing
+        case .other?: self = .other
+        case .social?: self = .social
+        case .tagManager?: self = .tagManager
+        case .utility?: self = .utility
+        case .video?: self = .video
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.Resource.Provider.ProviderType? {
+        switch self {
+        case .none: return nil
+        case .ad: return .ad
+        case .advertising: return .advertising
+        case .analytics: return .analytics
+        case .cdn: return .cdn
+        case .content: return .content
+        case .customerSuccess: return .customerSuccess
+        case .firstParty: return .firstParty
+        case .hosting: return .hosting
+        case .marketing: return .marketing
+        case .other: return .other
+        case .social: return .social
+        case .tagManager: return .tagManager
+        case .utility: return .utility
+        case .video: return .video
+        }
+    }
+
+    case none
+    case ad
+    case advertising
+    case analytics
+    case cdn
+    case content
+    case customerSuccess
+    case firstParty
+    case hosting
+    case marketing
+    case other
+    case social
+    case tagManager
+    case utility
+    case video
+}
+
+@objc
+public class DDRUMResourceEventResourceRedirect: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.redirect!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.redirect!.start as NSNumber
+    }
+}
+
+@objc
+public class DDRUMResourceEventResourceSSL: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.resource.ssl!.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.resource.ssl!.start as NSNumber
+    }
+}
+
+@objc
+public enum DDRUMResourceEventResourceResourceType: Int {
+    internal init(swift: RUMResourceEvent.Resource.ResourceType) {
+        switch swift {
+        case .document: self = .document
+        case .xhr: self = .xhr
+        case .beacon: self = .beacon
+        case .fetch: self = .fetch
+        case .css: self = .css
+        case .js: self = .js
+        case .image: self = .image
+        case .font: self = .font
+        case .media: self = .media
+        case .other: self = .other
+        case .native: self = .native
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.Resource.ResourceType {
+        switch self {
+        case .document: return .document
+        case .xhr: return .xhr
+        case .beacon: return .beacon
+        case .fetch: return .fetch
+        case .css: return .css
+        case .js: return .js
+        case .image: return .image
+        case .font: return .font
+        case .media: return .media
+        case .other: return .other
+        case .native: return .native
+        }
+    }
+
+    case document
+    case xhr
+    case beacon
+    case fetch
+    case css
+    case js
+    case image
+    case font
+    case media
+    case other
+    case native
+}
+
+@objc
+public class DDRUMResourceEventSession: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var hasReplay: NSNumber? {
+        root.swiftModel.session.hasReplay as NSNumber?
+    }
+
+    @objc public var id: String {
+        root.swiftModel.session.id
+    }
+
+    @objc public var type: DDRUMResourceEventSessionSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc
+public enum DDRUMResourceEventSessionSessionType: Int {
+    internal init(swift: RUMResourceEvent.Session.SessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.Session.SessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
+        }
+    }
+
+    case user
+    case synthetics
+    case ciTest
+}
+
+@objc
+public enum DDRUMResourceEventSource: Int {
+    internal init(swift: RUMResourceEvent.Source?) {
+        switch swift {
+        case nil: self = .none
+        case .android?: self = .android
+        case .ios?: self = .ios
+        case .browser?: self = .browser
+        case .flutter?: self = .flutter
+        case .reactNative?: self = .reactNative
+        }
+    }
+
+    internal var toSwift: RUMResourceEvent.Source? {
+        switch self {
+        case .none: return nil
+        case .android: return .android
+        case .ios: return .ios
+        case .browser: return .browser
+        case .flutter: return .flutter
+        case .reactNative: return .reactNative
+        }
+    }
+
+    case none
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+}
+
+@objc
+public class DDRUMResourceEventSynthetics: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var injected: NSNumber? {
+        root.swiftModel.synthetics!.injected as NSNumber?
+    }
+
+    @objc public var resultId: String {
+        root.swiftModel.synthetics!.resultId
+    }
+
+    @objc public var testId: String {
+        root.swiftModel.synthetics!.testId
+    }
+}
+
+@objc
+public class DDRUMResourceEventRUMUser: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var email: String? {
+        root.swiftModel.usr!.email
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.usr!.id
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.usr!.name
+    }
+
+    @objc public var usrInfo: [String: Any] {
+        root.swiftModel.usr!.usrInfo.castToObjectiveC()
+    }
+}
+
+@objc
+public class DDRUMResourceEventView: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.view.id
+    }
+
+    @objc public var name: String? {
+        set { root.swiftModel.view.name = newValue }
+        get { root.swiftModel.view.name }
+    }
+
+    @objc public var referrer: String? {
+        set { root.swiftModel.view.referrer = newValue }
+        get { root.swiftModel.view.referrer }
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.view.url = newValue }
+        get { root.swiftModel.view.url }
+    }
+}
+
+@objc
+public class DDRUMViewEvent: NSObject {
+    internal var swiftModel: RUMViewEvent
+    internal var root: DDRUMViewEvent { self }
+
+    internal init(swiftModel: RUMViewEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var dd: DDRUMViewEventDD {
+        DDRUMViewEventDD(root: root)
+    }
+
+    @objc public var application: DDRUMViewEventApplication {
+        DDRUMViewEventApplication(root: root)
+    }
+
+    @objc public var ciTest: DDRUMViewEventRUMCITest? {
+        root.swiftModel.ciTest != nil ? DDRUMViewEventRUMCITest(root: root) : nil
+    }
+
+    @objc public var connectivity: DDRUMViewEventRUMConnectivity? {
+        root.swiftModel.connectivity != nil ? DDRUMViewEventRUMConnectivity(root: root) : nil
+    }
+
+    @objc public var context: DDRUMViewEventRUMEventAttributes? {
+        root.swiftModel.context != nil ? DDRUMViewEventRUMEventAttributes(root: root) : nil
+    }
+
+    @objc public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    @objc public var service: String? {
+        root.swiftModel.service
+    }
+
+    @objc public var session: DDRUMViewEventSession {
+        DDRUMViewEventSession(root: root)
+    }
+
+    @objc public var source: DDRUMViewEventSource {
+        .init(swift: root.swiftModel.source)
+    }
+
+    @objc public var synthetics: DDRUMViewEventSynthetics? {
+        root.swiftModel.synthetics != nil ? DDRUMViewEventSynthetics(root: root) : nil
+    }
+
+    @objc public var type: String {
+        root.swiftModel.type
+    }
+
+    @objc public var usr: DDRUMViewEventRUMUser? {
+        root.swiftModel.usr != nil ? DDRUMViewEventRUMUser(root: root) : nil
+    }
+
+    @objc public var view: DDRUMViewEventView {
+        DDRUMViewEventView(root: root)
+    }
+}
+
+@objc
+public class DDRUMViewEventDD: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var browserSdkVersion: String? {
+        root.swiftModel.dd.browserSdkVersion
+    }
+
+    @objc public var documentVersion: NSNumber {
+        root.swiftModel.dd.documentVersion as NSNumber
+    }
+
+    @objc public var formatVersion: NSNumber {
+        root.swiftModel.dd.formatVersion as NSNumber
+    }
+
+    @objc public var session: DDRUMViewEventDDSession? {
+        root.swiftModel.dd.session != nil ? DDRUMViewEventDDSession(root: root) : nil
+    }
+}
+
+@objc
+public class DDRUMViewEventDDSession: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var plan: DDRUMViewEventDDSessionPlan {
+        .init(swift: root.swiftModel.dd.session!.plan)
+    }
+}
+
+@objc
+public enum DDRUMViewEventDDSessionPlan: Int {
+    internal init(swift: RUMViewEvent.DD.Session.Plan) {
+        switch swift {
+        case .plan1: self = .plan1
+        case .plan2: self = .plan2
+        }
+    }
+
+    internal var toSwift: RUMViewEvent.DD.Session.Plan {
+        switch self {
+        case .plan1: return .plan1
+        case .plan2: return .plan2
+        }
+    }
+
+    case plan1
+    case plan2
+}
+
+@objc
+public class DDRUMViewEventApplication: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.application.id
+    }
+}
+
+@objc
+public class DDRUMViewEventRUMCITest: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var testExecutionId: String {
+        root.swiftModel.ciTest!.testExecutionId
+    }
+}
+
+@objc
+public class DDRUMViewEventRUMConnectivity: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var cellular: DDRUMViewEventRUMConnectivityCellular? {
+        root.swiftModel.connectivity!.cellular != nil ? DDRUMViewEventRUMConnectivityCellular(root: root) : nil
+    }
+
+    @objc public var interfaces: [Int] {
+        root.swiftModel.connectivity!.interfaces.map { DDRUMViewEventRUMConnectivityInterfaces(swift: $0).rawValue }
+    }
+
+    @objc public var status: DDRUMViewEventRUMConnectivityStatus {
+        .init(swift: root.swiftModel.connectivity!.status)
+    }
+}
+
+@objc
+public class DDRUMViewEventRUMConnectivityCellular: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var carrierName: String? {
+        root.swiftModel.connectivity!.cellular!.carrierName
+    }
+
+    @objc public var technology: String? {
+        root.swiftModel.connectivity!.cellular!.technology
+    }
+}
+
+@objc
+public enum DDRUMViewEventRUMConnectivityInterfaces: Int {
+    internal init(swift: RUMConnectivity.Interfaces) {
+        switch swift {
+        case .bluetooth: self = .bluetooth
+        case .cellular: self = .cellular
+        case .ethernet: self = .ethernet
+        case .wifi: self = .wifi
+        case .wimax: self = .wimax
+        case .mixed: self = .mixed
+        case .other: self = .other
+        case .unknown: self = .unknown
+        case .none: self = .none
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Interfaces {
+        switch self {
+        case .bluetooth: return .bluetooth
+        case .cellular: return .cellular
+        case .ethernet: return .ethernet
+        case .wifi: return .wifi
+        case .wimax: return .wimax
+        case .mixed: return .mixed
+        case .other: return .other
+        case .unknown: return .unknown
+        case .none: return .none
+        }
+    }
+
+    case bluetooth
+    case cellular
+    case ethernet
+    case wifi
+    case wimax
+    case mixed
+    case other
+    case unknown
+    case none
+}
+
+@objc
+public enum DDRUMViewEventRUMConnectivityStatus: Int {
+    internal init(swift: RUMConnectivity.Status) {
+        switch swift {
+        case .connected: self = .connected
+        case .notConnected: self = .notConnected
+        case .maybe: self = .maybe
+        }
+    }
+
+    internal var toSwift: RUMConnectivity.Status {
+        switch self {
+        case .connected: return .connected
+        case .notConnected: return .notConnected
+        case .maybe: return .maybe
+        }
+    }
+
+    case connected
+    case notConnected
+    case maybe
+}
+
+@objc
+public class DDRUMViewEventRUMEventAttributes: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var contextInfo: [String: Any] {
+        root.swiftModel.context!.contextInfo.castToObjectiveC()
+    }
+}
+
+@objc
+public class DDRUMViewEventSession: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var hasReplay: NSNumber? {
+        root.swiftModel.session.hasReplay as NSNumber?
+    }
+
+    @objc public var id: String {
+        root.swiftModel.session.id
+    }
+
+    @objc public var type: DDRUMViewEventSessionSessionType {
+        .init(swift: root.swiftModel.session.type)
+    }
+}
+
+@objc
+public enum DDRUMViewEventSessionSessionType: Int {
+    internal init(swift: RUMViewEvent.Session.SessionType) {
+        switch swift {
+        case .user: self = .user
+        case .synthetics: self = .synthetics
+        case .ciTest: self = .ciTest
+        }
+    }
+
+    internal var toSwift: RUMViewEvent.Session.SessionType {
+        switch self {
+        case .user: return .user
+        case .synthetics: return .synthetics
+        case .ciTest: return .ciTest
+        }
+    }
+
+    case user
+    case synthetics
+    case ciTest
+}
+
+@objc
+public enum DDRUMViewEventSource: Int {
+    internal init(swift: RUMViewEvent.Source?) {
+        switch swift {
+        case nil: self = .none
+        case .android?: self = .android
+        case .ios?: self = .ios
+        case .browser?: self = .browser
+        case .flutter?: self = .flutter
+        case .reactNative?: self = .reactNative
+        }
+    }
+
+    internal var toSwift: RUMViewEvent.Source? {
+        switch self {
+        case .none: return nil
+        case .android: return .android
+        case .ios: return .ios
+        case .browser: return .browser
+        case .flutter: return .flutter
+        case .reactNative: return .reactNative
+        }
+    }
+
+    case none
+    case android
+    case ios
+    case browser
+    case flutter
+    case reactNative
+}
+
+@objc
+public class DDRUMViewEventSynthetics: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var injected: NSNumber? {
+        root.swiftModel.synthetics!.injected as NSNumber?
+    }
+
+    @objc public var resultId: String {
+        root.swiftModel.synthetics!.resultId
+    }
+
+    @objc public var testId: String {
+        root.swiftModel.synthetics!.testId
+    }
+}
+
+@objc
+public class DDRUMViewEventRUMUser: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var email: String? {
+        root.swiftModel.usr!.email
+    }
+
+    @objc public var id: String? {
+        root.swiftModel.usr!.id
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.usr!.name
+    }
+
+    @objc public var usrInfo: [String: Any] {
+        root.swiftModel.usr!.usrInfo.castToObjectiveC()
+    }
+}
+
+@objc
+public class DDRUMViewEventView: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var action: DDRUMViewEventViewAction {
+        DDRUMViewEventViewAction(root: root)
+    }
+
+    @objc public var cpuTicksCount: NSNumber? {
+        root.swiftModel.view.cpuTicksCount as NSNumber?
+    }
+
+    @objc public var cpuTicksPerSecond: NSNumber? {
+        root.swiftModel.view.cpuTicksPerSecond as NSNumber?
+    }
+
+    @objc public var crash: DDRUMViewEventViewCrash? {
+        root.swiftModel.view.crash != nil ? DDRUMViewEventViewCrash(root: root) : nil
+    }
+
+    @objc public var cumulativeLayoutShift: NSNumber? {
+        root.swiftModel.view.cumulativeLayoutShift as NSNumber?
+    }
+
+    @objc public var customTimings: [String: NSNumber]? {
+        root.swiftModel.view.customTimings as [String: NSNumber]?
+    }
+
+    @objc public var domComplete: NSNumber? {
+        root.swiftModel.view.domComplete as NSNumber?
+    }
+
+    @objc public var domContentLoaded: NSNumber? {
+        root.swiftModel.view.domContentLoaded as NSNumber?
+    }
+
+    @objc public var domInteractive: NSNumber? {
+        root.swiftModel.view.domInteractive as NSNumber?
+    }
+
+    @objc public var error: DDRUMViewEventViewError {
+        DDRUMViewEventViewError(root: root)
+    }
+
+    @objc public var firstContentfulPaint: NSNumber? {
+        root.swiftModel.view.firstContentfulPaint as NSNumber?
+    }
+
+    @objc public var firstInputDelay: NSNumber? {
+        root.swiftModel.view.firstInputDelay as NSNumber?
+    }
+
+    @objc public var firstInputTime: NSNumber? {
+        root.swiftModel.view.firstInputTime as NSNumber?
+    }
+
+    @objc public var frozenFrame: DDRUMViewEventViewFrozenFrame? {
+        root.swiftModel.view.frozenFrame != nil ? DDRUMViewEventViewFrozenFrame(root: root) : nil
+    }
+
+    @objc public var id: String {
+        root.swiftModel.view.id
+    }
+
+    @objc public var inForegroundPeriods: [DDRUMViewEventViewInForegroundPeriods]? {
+        root.swiftModel.view.inForegroundPeriods?.map { DDRUMViewEventViewInForegroundPeriods(swiftModel: $0) }
+    }
+
+    @objc public var isActive: NSNumber? {
+        root.swiftModel.view.isActive as NSNumber?
+    }
+
+    @objc public var isSlowRendered: NSNumber? {
+        root.swiftModel.view.isSlowRendered as NSNumber?
+    }
+
+    @objc public var largestContentfulPaint: NSNumber? {
+        root.swiftModel.view.largestContentfulPaint as NSNumber?
+    }
+
+    @objc public var loadEvent: NSNumber? {
+        root.swiftModel.view.loadEvent as NSNumber?
+    }
+
+    @objc public var loadingTime: NSNumber? {
+        root.swiftModel.view.loadingTime as NSNumber?
+    }
+
+    @objc public var loadingType: DDRUMViewEventViewLoadingType {
+        .init(swift: root.swiftModel.view.loadingType)
+    }
+
+    @objc public var longTask: DDRUMViewEventViewLongTask? {
+        root.swiftModel.view.longTask != nil ? DDRUMViewEventViewLongTask(root: root) : nil
+    }
+
+    @objc public var memoryAverage: NSNumber? {
+        root.swiftModel.view.memoryAverage as NSNumber?
+    }
+
+    @objc public var memoryMax: NSNumber? {
+        root.swiftModel.view.memoryMax as NSNumber?
+    }
+
+    @objc public var name: String? {
+        set { root.swiftModel.view.name = newValue }
+        get { root.swiftModel.view.name }
+    }
+
+    @objc public var referrer: String? {
+        set { root.swiftModel.view.referrer = newValue }
+        get { root.swiftModel.view.referrer }
+    }
+
+    @objc public var refreshRateAverage: NSNumber? {
+        root.swiftModel.view.refreshRateAverage as NSNumber?
+    }
+
+    @objc public var refreshRateMin: NSNumber? {
+        root.swiftModel.view.refreshRateMin as NSNumber?
+    }
+
+    @objc public var resource: DDRUMViewEventViewResource {
+        DDRUMViewEventViewResource(root: root)
+    }
+
+    @objc public var timeSpent: NSNumber {
+        root.swiftModel.view.timeSpent as NSNumber
+    }
+
+    @objc public var url: String {
+        set { root.swiftModel.view.url = newValue }
+        get { root.swiftModel.view.url }
+    }
+}
+
+@objc
+public class DDRUMViewEventViewAction: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.action.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewCrash: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.crash!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewError: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.error.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewFrozenFrame: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.frozenFrame!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewInForegroundPeriods: NSObject {
+    internal let swiftModel: RUMViewEvent.View.InForegroundPeriods
+    internal var root: DDRUMViewEventViewInForegroundPeriods { self }
+
+    internal init(swiftModel: RUMViewEvent.View.InForegroundPeriods) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var duration: NSNumber {
+        root.swiftModel.duration as NSNumber
+    }
+
+    @objc public var start: NSNumber {
+        root.swiftModel.start as NSNumber
+    }
+}
+
+@objc
+public enum DDRUMViewEventViewLoadingType: Int {
+    internal init(swift: RUMViewEvent.View.LoadingType?) {
+        switch swift {
+        case nil: self = .none
+        case .initialLoad?: self = .initialLoad
+        case .routeChange?: self = .routeChange
+        case .activityDisplay?: self = .activityDisplay
+        case .activityRedisplay?: self = .activityRedisplay
+        case .fragmentDisplay?: self = .fragmentDisplay
+        case .fragmentRedisplay?: self = .fragmentRedisplay
+        case .viewControllerDisplay?: self = .viewControllerDisplay
+        case .viewControllerRedisplay?: self = .viewControllerRedisplay
+        }
+    }
+
+    internal var toSwift: RUMViewEvent.View.LoadingType? {
+        switch self {
+        case .none: return nil
+        case .initialLoad: return .initialLoad
+        case .routeChange: return .routeChange
+        case .activityDisplay: return .activityDisplay
+        case .activityRedisplay: return .activityRedisplay
+        case .fragmentDisplay: return .fragmentDisplay
+        case .fragmentRedisplay: return .fragmentRedisplay
+        case .viewControllerDisplay: return .viewControllerDisplay
+        case .viewControllerRedisplay: return .viewControllerRedisplay
+        }
+    }
+
+    case none
+    case initialLoad
+    case routeChange
+    case activityDisplay
+    case activityRedisplay
+    case fragmentDisplay
+    case fragmentRedisplay
+    case viewControllerDisplay
+    case viewControllerRedisplay
+}
+
+@objc
+public class DDRUMViewEventViewLongTask: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.longTask!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewResource: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.resource.count as NSNumber
+    }
+}
+
+@objc
+public class DDTelemetryErrorEvent: NSObject {
+    internal var swiftModel: TelemetryErrorEvent
+    internal var root: DDTelemetryErrorEvent { self }
+
+    internal init(swiftModel: TelemetryErrorEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var dd: DDTelemetryErrorEventDD {
+        DDTelemetryErrorEventDD(root: root)
+    }
+
+    @objc public var action: DDTelemetryErrorEventAction? {
+        root.swiftModel.action != nil ? DDTelemetryErrorEventAction(root: root) : nil
+    }
+
+    @objc public var application: DDTelemetryErrorEventApplication? {
+        root.swiftModel.application != nil ? DDTelemetryErrorEventApplication(root: root) : nil
+    }
+
+    @objc public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    @objc public var error: DDTelemetryErrorEventError? {
+        root.swiftModel.error != nil ? DDTelemetryErrorEventError(root: root) : nil
+    }
+
+    @objc public var message: String {
+        root.swiftModel.message
+    }
+
+    @objc public var service: String {
+        root.swiftModel.service
+    }
+
+    @objc public var session: DDTelemetryErrorEventSession? {
+        root.swiftModel.session != nil ? DDTelemetryErrorEventSession(root: root) : nil
+    }
+
+    @objc public var status: String {
+        root.swiftModel.status
+    }
+
+    @objc public var version: String {
+        root.swiftModel.version
+    }
+
+    @objc public var view: DDTelemetryErrorEventView? {
+        root.swiftModel.view != nil ? DDTelemetryErrorEventView(root: root) : nil
+    }
+}
+
+@objc
+public class DDTelemetryErrorEventDD: NSObject {
+    internal let root: DDTelemetryErrorEvent
+
+    internal init(root: DDTelemetryErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var eventType: String {
+        root.swiftModel.dd.eventType
+    }
+}
+
+@objc
+public class DDTelemetryErrorEventAction: NSObject {
+    internal let root: DDTelemetryErrorEvent
+
+    internal init(root: DDTelemetryErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.action!.id
+    }
+}
+
+@objc
+public class DDTelemetryErrorEventApplication: NSObject {
+    internal let root: DDTelemetryErrorEvent
+
+    internal init(root: DDTelemetryErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.application!.id
+    }
+}
+
+@objc
+public class DDTelemetryErrorEventError: NSObject {
+    internal let root: DDTelemetryErrorEvent
+
+    internal init(root: DDTelemetryErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var kind: String? {
+        root.swiftModel.error!.kind
+    }
+
+    @objc public var stack: String? {
+        root.swiftModel.error!.stack
+    }
+}
+
+@objc
+public class DDTelemetryErrorEventSession: NSObject {
+    internal let root: DDTelemetryErrorEvent
+
+    internal init(root: DDTelemetryErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.session!.id
+    }
+}
+
+@objc
+public class DDTelemetryErrorEventView: NSObject {
+    internal let root: DDTelemetryErrorEvent
+
+    internal init(root: DDTelemetryErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.view!.id
+    }
+}
+
+@objc
+public class DDTelemetryDebugEvent: NSObject {
+    internal var swiftModel: TelemetryDebugEvent
+    internal var root: DDTelemetryDebugEvent { self }
+
+    internal init(swiftModel: TelemetryDebugEvent) {
+        self.swiftModel = swiftModel
+    }
+
+    @objc public var dd: DDTelemetryDebugEventDD {
+        DDTelemetryDebugEventDD(root: root)
+    }
+
+    @objc public var action: DDTelemetryDebugEventAction? {
+        root.swiftModel.action != nil ? DDTelemetryDebugEventAction(root: root) : nil
+    }
+
+    @objc public var application: DDTelemetryDebugEventApplication? {
+        root.swiftModel.application != nil ? DDTelemetryDebugEventApplication(root: root) : nil
+    }
+
+    @objc public var date: NSNumber {
+        root.swiftModel.date as NSNumber
+    }
+
+    @objc public var message: String {
+        root.swiftModel.message
+    }
+
+    @objc public var service: String {
+        root.swiftModel.service
+    }
+
+    @objc public var session: DDTelemetryDebugEventSession? {
+        root.swiftModel.session != nil ? DDTelemetryDebugEventSession(root: root) : nil
+    }
+
+    @objc public var status: String {
+        root.swiftModel.status
+    }
+
+    @objc public var version: String {
+        root.swiftModel.version
+    }
+
+    @objc public var view: DDTelemetryDebugEventView? {
+        root.swiftModel.view != nil ? DDTelemetryDebugEventView(root: root) : nil
+    }
+}
+
+@objc
+public class DDTelemetryDebugEventDD: NSObject {
+    internal let root: DDTelemetryDebugEvent
+
+    internal init(root: DDTelemetryDebugEvent) {
+        self.root = root
+    }
+
+    @objc public var eventType: String {
+        root.swiftModel.dd.eventType
+    }
+}
+
+@objc
+public class DDTelemetryDebugEventAction: NSObject {
+    internal let root: DDTelemetryDebugEvent
+
+    internal init(root: DDTelemetryDebugEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.action!.id
+    }
+}
+
+@objc
+public class DDTelemetryDebugEventApplication: NSObject {
+    internal let root: DDTelemetryDebugEvent
+
+    internal init(root: DDTelemetryDebugEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.application!.id
+    }
+}
+
+@objc
+public class DDTelemetryDebugEventSession: NSObject {
+    internal let root: DDTelemetryDebugEvent
+
+    internal init(root: DDTelemetryDebugEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.session!.id
+    }
+}
+
+@objc
+public class DDTelemetryDebugEventView: NSObject {
+    internal let root: DDTelemetryDebugEvent
+
+    internal init(root: DDTelemetryDebugEvent) {
+        self.root = root
+    }
+
+    @objc public var id: String {
+        root.swiftModel.view!.id
+    }
+}
+
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/114c173caac5ea15446a157b666acbab05431361
+// Generated from https://github.com/DataDog/rum-events-format/tree/c8a844abb59cb376be2fcdc9deda74dc328af660

--- a/tools/rum-models-generator/Package.swift
+++ b/tools/rum-models-generator/Package.swift
@@ -23,6 +23,8 @@ let package = Package(
         ),
         .testTarget(
             name: "rum-models-generator-coreTests",
-            dependencies: ["RUMModelsGeneratorCore", "Difference"]),
+            dependencies: ["RUMModelsGeneratorCore", "Difference"],
+            resources: [.copy("Fixtures")]
+        ),
     ]
 )

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUMModelsGenerator.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUMModelsGenerator.swift
@@ -6,40 +6,6 @@
 
 import Foundation
 
-public struct File {
-    internal let name: String
-    internal let content: Data
-}
-
-public extension File {
-    init(url: URL) throws {
-        self.name = url.lastPathComponent
-        self.content = try Data(contentsOf: url)
-    }
-}
-
-public struct RUMJSONSchemaFiles {
-    internal let commonSchema: File
-    internal let actionSchema: File
-    internal let errorSchema: File
-    internal let longTaskSchema: File
-    internal let resourceSchema: File
-    internal let viewSchema: File
-}
-
-public extension RUMJSONSchemaFiles {
-    init(folder url: URL) throws {
-        self.init(
-            commonSchema: try File(url: url.appendingPathComponent("_common-schema.json")),
-            actionSchema: try File(url: url.appendingPathComponent("action-schema.json")),
-            errorSchema: try File(url: url.appendingPathComponent("error-schema.json")),
-            longTaskSchema: try File(url: url.appendingPathComponent("long_task-schema.json")),
-            resourceSchema: try File(url: url.appendingPathComponent("resource-schema.json")),
-            viewSchema: try File(url: url.appendingPathComponent("view-schema.json"))
-        )
-    }
-}
-
 public class RUMModelsGenerator {
     public enum Printer {
         /// Swift code printer.
@@ -51,22 +17,10 @@ public class RUMModelsGenerator {
     public init() {}
 
     public func printRUMModels(
-        for schemaFiles: RUMJSONSchemaFiles,
+        path file: URL,
         using printer: Printer
     ) throws -> String {
-        let mainSchemaFiles = [
-            schemaFiles.viewSchema,
-            schemaFiles.resourceSchema,
-            schemaFiles.actionSchema,
-            schemaFiles.errorSchema,
-            schemaFiles.longTaskSchema,
-        ]
-
-        // Read ambiguous JSON schemas from `*.json` files
-        let jsonSchemas = try JSONSchemaReader().readJSONSchemas(
-            from: mainSchemaFiles,
-            resolvingAgainst: [schemaFiles.commonSchema]
-        )
+        let jsonSchemas = try JSONSchemaReader().readAll(from: file)
 
         // Transform into type-safe JSONObjects
         let jsonObjects = try JSONSchemaToJSONTypeTransformer().transform(jsonSchemas: jsonSchemas)

--- a/tools/rum-models-generator/Sources/rum-models-generator/main.swift
+++ b/tools/rum-models-generator/Sources/rum-models-generator/main.swift
@@ -28,10 +28,9 @@ private struct RootCommand: ParsableCommand {
 
         func run() {
             do {
-                let schemasFolderURL = URL(fileURLWithPath: path)
-                let schemas = try RUMJSONSchemaFiles(folder: schemasFolderURL)
+                let path = URL(fileURLWithPath: path)
                 let generator = RUMModelsGenerator()
-                print(try generator.printRUMModels(for: schemas, using: .swift))
+                print(try generator.printRUMModels(path: path, using: .swift))
             } catch {
                 print("Failed to generate Swift models: \(error)")
             }
@@ -49,10 +48,9 @@ private struct RootCommand: ParsableCommand {
 
         func run() {
             do {
-                let schemasFolderURL = URL(fileURLWithPath: path)
-                let schemas = try RUMJSONSchemaFiles(folder: schemasFolderURL)
+                let path = URL(fileURLWithPath: path)
                 let generator = RUMModelsGenerator()
-                print(try generator.printRUMModels(for: schemas, using: .objcInterop))
+                print(try generator.printRUMModels(path: path, using: .objcInterop))
             } catch {
                 print("Failed to generate Objc models: \(error)")
             }

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-json-schema-to-json-type-transformer.json
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-json-schema-to-json-type-transformer.json
@@ -1,0 +1,10 @@
+{
+    "$id": "fixture-json-schema-to-json-type-transformer.json",
+    "type": "object",
+    "description": "Fixture schema",
+    "oneOf": [
+      {
+        "$ref": "fixture-json-schema-to-json-type-transformer/main.json"
+      }
+    ]
+  }

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-json-schema-to-json-type-transformer/main.json
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-json-schema-to-json-type-transformer/main.json
@@ -1,0 +1,50 @@
+{
+    "type": "object",
+    "title": "Foo",
+    "description": "Description of Foo.",
+    "allOf": [
+        { "$ref": "schema-1.json" },
+        { "$ref": "schema-2.json" },
+        {
+            "properties": {
+                "stringEnumProperty": {
+                    "type": "string",
+                    "description": "Description of Foo's `stringEnumProperty`.",
+                    "enum": ["case1", "case2", "case3", "case4"],
+                    "const": "case2"
+                },
+                "integerEnumProperty": {
+                    "type": "number",
+                    "description": "Description of Foo's `integerEnumProperty`.",
+                    "enum": [1, 2, 3, 4],
+                    "const": 3
+                },
+                "arrayProperty": {
+                    "type": "array",
+                    "description": "Description of Foo's `arrayProperty`.",
+                    "items": {
+                        "type": "string",
+                        "enum": ["option1", "option2", "option3", "option4"]
+                    },
+                    "readOnly": false
+                },
+                "propertyWithAdditionalProperties": {
+                    "type": "object",
+                    "description": "Description of a property with nested additional properties.",
+                    "additionalProperties": {
+                         "type": "integer",
+                         "minimum": 0,
+                         "readOnly": true
+                    },
+                    "readOnly": true
+                }
+            },
+            "additionalProperties": {
+                "type": "string",
+                "description": "Additional properties of Foo.",
+                "readOnly": true
+            },
+            "required": ["stringEnumProperty"],
+        }
+    ]
+}

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-json-schema-to-json-type-transformer/schema-1.json
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-json-schema-to-json-type-transformer/schema-1.json
@@ -1,0 +1,17 @@
+{
+    "$id": "schema-1.json",
+    "type": "object",
+    "properties": {
+        "bar": {
+            "type": "object",
+            "description": "Description of Bar.",
+            "properties": {
+                "property1": {
+                    "type": "string",
+                    "description": "Description of Bar's `property1`.",
+                    "readOnly": true
+                }
+            }
+        }
+    }
+}

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-json-schema-to-json-type-transformer/schema-2.json
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-json-schema-to-json-type-transformer/schema-2.json
@@ -1,0 +1,18 @@
+{
+    "$id": "schema-2.json",
+    "type": "object",
+    "properties": {
+        "bar": {
+            "type": "object",
+            "description": "Description of Bar.",
+            "properties": {
+                "property2": {
+                    "type": "string",
+                    "description": "Description of Bar's `property2`.",
+                    "readOnly": false
+                }
+            },
+            "required": ["property2"]
+        }
+    }
+}

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-reading-schema-with-additional-properties-with-no-type.json
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-reading-schema-with-additional-properties-with-no-type.json
@@ -1,0 +1,13 @@
+{
+    "additionalProperties": true,
+    "properties": {
+        "foo": {
+            "type": "string",
+            "readOnly": true
+        },
+        "bar": {
+            "type": "object",
+            "additionalProperties": true
+        }
+    }
+}

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-reading-schema-with-typed-additional-properties.json
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Fixtures/fixture-reading-schema-with-typed-additional-properties.json
@@ -1,0 +1,44 @@
+{
+    "$id": "Schema ID",
+    "type": "object",
+    "title": "Schema title",
+    "description": "Schema description.",
+    "properties": {
+        "stringEnumProperty": {
+            "type": "string",
+            "description": "Description of `stringEnumProperty`.",
+            "enum": ["case1", "case2", "case3", "case4"],
+            "const": "case2"
+        },
+        "integerEnumProperty": {
+            "type": "number",
+            "description": "Description of `integerEnumProperty`.",
+            "enum": [1, 2, 3, 4],
+            "const": 3
+        },
+        "arrayProperty": {
+            "type": "array",
+            "description": "Description of `arrayProperty`.",
+            "items": {
+                "type": "string",
+                "enum": ["option1", "option2", "option3", "option4"]
+            },
+            "readOnly": false
+        },
+        "propertyWithAdditionalProperties": {
+            "type": "object",
+            "description": "Description of a property with nested additional properties.",
+            "additionalProperties": {
+                 "type": "integer",
+                 "readOnly": true
+            },
+            "readOnly": true
+        }
+    },
+    "additionalProperties": {
+        "type": "string",
+        "description": "Additional properties of main schema.",
+        "readOnly": true
+    },
+    "required": ["property1"]
+}

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaReaderTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaReaderTests.swift
@@ -9,58 +9,9 @@ import XCTest
 
 final class JSONSchemaReaderTests: XCTestCase {
     func testReadingSchemaWithTypedAdditionalProperties() throws {
-        let mainSchema = """
-        {
-            "$id": "Schema ID",
-            "type": "object",
-            "title": "Schema title",
-            "description": "Schema description.",
-            "properties": {
-                "stringEnumProperty": {
-                    "type": "string",
-                    "description": "Description of `stringEnumProperty`.",
-                    "enum": ["case1", "case2", "case3", "case4"],
-                    "const": "case2"
-                },
-                "integerEnumProperty": {
-                    "type": "number",
-                    "description": "Description of `integerEnumProperty`.",
-                    "enum": [1, 2, 3, 4],
-                    "const": 3
-                },
-                "arrayProperty": {
-                    "type": "array",
-                    "description": "Description of `arrayProperty`.",
-                    "items": {
-                        "type": "string",
-                        "enum": ["option1", "option2", "option3", "option4"]
-                    },
-                    "readOnly": false
-                },
-                "propertyWithAdditionalProperties": {
-                    "type": "object",
-                    "description": "Description of a property with nested additional properties.",
-                    "additionalProperties": {
-                         "type": "integer",
-                         "readOnly": true
-                    },
-                    "readOnly": true
-                }
-            },
-            "additionalProperties": {
-                "type": "string",
-                "description": "Additional properties of main schema.",
-                "readOnly": true
-            },
-            "required": ["property1"]
-        }
-        """
+        let file = Bundle.module.url(forResource: "Fixtures/fixture-reading-schema-with-typed-additional-properties", withExtension: "json")!
 
-        let schema = try JSONSchemaReader()
-            .readJSONSchema(
-                from: File(name: "main-schema", content: mainSchema.data(using: .utf8)!),
-                resolvingAgainst: []
-            )
+        let schema = try JSONSchemaReader().read(file)
 
         XCTAssertEqual(schema.id, "Schema ID")
         XCTAssertEqual(schema.title, "Schema title")
@@ -102,28 +53,9 @@ final class JSONSchemaReaderTests: XCTestCase {
     }
 
     func testReadingSchemaWithAdditionalPropertiesWithNoType() throws {
-        let mainSchema = """
-        {
-            "additionalProperties": true,
-            "properties": {
-                "foo": {
-                    "type": "string",
-                    "readOnly": true
-                },
-                "bar": {
-                    "type": "object",
-                    "additionalProperties": true
-                }
-            }
-        }
-        """
+        let file = Bundle.module.url(forResource: "Fixtures/fixture-reading-schema-with-additional-properties-with-no-type", withExtension: "json")!
 
-        let schema = try JSONSchemaReader()
-            .readJSONSchema(
-                from: File(name: "main-schema", content: mainSchema.data(using: .utf8)!),
-                resolvingAgainst: []
-            )
-
+        let schema = try JSONSchemaReader().read(file)
         XCTAssertEqual(schema.properties?.count, 2)
 
         XCTAssertNotNil(schema.properties?["foo"])

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONSchemaToJSONTypeTransformerTests.swift
@@ -9,100 +9,6 @@ import XCTest
 
 final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
     func testTransformingJSONSchemaIntoJSONObject() throws {
-        let referencedSchema1 = """
-        {
-            "$id": "referenced-schema1.json",
-            "type": "object",
-            "properties": {
-                "bar": {
-                    "type": "object",
-                    "description": "Description of Bar.",
-                    "properties": {
-                        "property1": {
-                            "type": "string",
-                            "description": "Description of Bar's `property1`.",
-                            "readOnly": true
-                        }
-                    }
-                }
-            }
-        }
-        """
-
-        let referencedSchema2 = """
-        {
-            "$id": "referenced-schema2.json",
-            "type": "object",
-            "properties": {
-                "bar": {
-                    "type": "object",
-                    "description": "Description of Bar.",
-                    "properties": {
-                        "property2": {
-                            "type": "string",
-                            "description": "Description of Bar's `property2`.",
-                            "readOnly": false
-                        }
-                    },
-                    "required": ["property2"]
-                }
-            }
-        }
-        """
-
-        let mainSchema = """
-        {
-            "type": "object",
-            "title": "Foo",
-            "description": "Description of Foo.",
-            "allOf": [
-                { "$ref": "referenced-schema1.json" },
-                { "$ref": "referenced-schema2.json" },
-                {
-                    "properties": {
-                        "stringEnumProperty": {
-                            "type": "string",
-                            "description": "Description of Foo's `stringEnumProperty`.",
-                            "enum": ["case1", "case2", "case3", "case4"],
-                            "const": "case2"
-                        },
-                        "integerEnumProperty": {
-                            "type": "number",
-                            "description": "Description of Foo's `integerEnumProperty`.",
-                            "enum": [1, 2, 3, 4],
-                            "const": 3
-                        },
-                        "arrayProperty": {
-                            "type": "array",
-                            "description": "Description of Foo's `arrayProperty`.",
-                            "items": {
-                                "type": "string",
-                                "enum": ["option1", "option2", "option3", "option4"]
-                            },
-                            "readOnly": false
-                        },
-                        "propertyWithAdditionalProperties": {
-                            "type": "object",
-                            "description": "Description of a property with nested additional properties.",
-                            "additionalProperties": {
-                                 "type": "integer",
-                                 "minimum": 0,
-                                 "readOnly": true
-                            },
-                            "readOnly": true
-                        }
-                    },
-                    "additionalProperties": {
-                        "type": "string",
-                        "description": "Additional properties of Foo.",
-                        "readOnly": true
-                    },
-                    "required": ["stringEnumProperty"],
-                }
-            ]
-        }
-        """
-
         let expected = JSONObject(
             name: "Foo",
             comment: "Description of Foo.",
@@ -200,16 +106,11 @@ final class JSONSchemaToJSONTypeTransformerTests: XCTestCase {
             )
         )
 
-        let jsonSchema = try JSONSchemaReader()
-            .readJSONSchema(
-                from: File(name: "main-schema", content: mainSchema.data(using: .utf8)!),
-                resolvingAgainst: [
-                    File(name: "referenced-schema-1", content: referencedSchema1.data(using: .utf8)!),
-                    File(name: "referenced-schema-2", content: referencedSchema2.data(using: .utf8)!),
-                ]
-            )
+        let file = Bundle.module.url(forResource: "Fixtures/fixture-json-schema-to-json-type-transformer", withExtension: "json")!
 
-        let actual = try JSONSchemaToJSONTypeTransformer().transform(jsonSchemas: [jsonSchema])
+        let jsonSchemas = try JSONSchemaReader().readAll(from: file)
+
+        let actual = try JSONSchemaToJSONTypeTransformer().transform(jsonSchemas: jsonSchemas)
 
         XCTAssertEqual(actual.count, 1)
         XCTAssertEqual(expected, actual[0])

--- a/tools/rum-models-generator/run.sh
+++ b/tools/rum-models-generator/run.sh
@@ -71,13 +71,13 @@ GENERATOR=".build/x86_64-apple-macosx/release/rum-models-generator"
 # Generate RUM models (Swift) file in temporary location
 mkdir -p ".temp"
 GENERATED_SWIFT_FILE=".temp/RUMDataModels.swift"
-$GENERATOR generate-swift --path "rum-events-format/schemas" > $GENERATED_SWIFT_FILE
+$GENERATOR generate-swift --path "rum-events-format/rum-events-format.json" > $GENERATED_SWIFT_FILE
 echo "// Generated from https://github.com/DataDog/rum-events-format/tree/$SHA" >> $GENERATED_SWIFT_FILE
 
 # Generate RUM models (Objc) file in temporary location
 mkdir -p ".temp"
 GENERATED_OBJC_FILE=".temp/RUMDataModels+objc.swift"
-$GENERATOR generate-objc --path "rum-events-format/schemas" > $GENERATED_OBJC_FILE
+$GENERATOR generate-objc --path "rum-events-format/rum-events-format.json" > $GENERATED_OBJC_FILE
 echo "// Generated from https://github.com/DataDog/rum-events-format/tree/$SHA" >> $GENERATED_OBJC_FILE
 
 if [[ $MODE == $MODE_VERIFY ]]; then


### PR DESCRIPTION
### What and why?

The `rum-models-generator` cli is too opinionated on the schema files tree, with recent changes in [rum-events-format](https://github.com/DataDog/rum-events-format) and the addition of telemetry events, the generator needs to be updated to digest the events formats from the root definition defined in [rum-events-format](https://github.com/DataDog/rum-events-format/blob/master/rum-events-format.json).

### How?

The `rum-models-generator` now takes the `rum-events-format.json` file path as an argument and is able to transverse schemas by navigating in the directories based on the `oneOf` references. This is possible because `$ref` value is always the relative path to the referred schema.

[`RUMDataModels.swift`](https://github.com/DataDog/dd-sdk-ios/compare/maxep/RUMM-2020/telemetry-schema?expand=1#diff-f36112341c95ac45cd547c02b7b296229ee812ad7d7b5eb90639b0823465bca0) and [`RUMDataModels+objc.swift`](https://github.com/DataDog/dd-sdk-ios/compare/maxep/RUMM-2020/telemetry-schema?expand=1#diff-32a755d205eba305d26630975910b99e01d740b29ebbd6dbc14c234c07b1fd6b) reflect changes in [rum-events-format](https://github.com/DataDog/rum-events-format) `master` branch, and the new generator implementation has an impact on the order of models definitions.

### Tests

Test fixtures are now defined in files and access as resources from the test bundle to allow testing against a real folder structure.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing change. 
