### PR TITLE
RUMM-1803 Stop reporting pre-warmed application launch time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE] Web-view tracking. See [#729][]
 * [BUGFIX] Strip query parameters from span resource. See [#728][]
+* [BUGFIX] Stop reporting pre-warmed application launch time.
 
 # 1.9.0 / 01-26-2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [FEATURE] Web-view tracking. See [#729][]
 * [BUGFIX] Strip query parameters from span resource. See [#728][]
-* [BUGFIX] Stop reporting pre-warmed application launch time.
+* [BUGFIX] Stop reporting pre-warmed application launch time. See [#789][]
 
 # 1.9.0 / 01-26-2022
 
@@ -325,6 +325,7 @@
 [#725]: https://github.com/DataDog/dd-sdk-ios/issues/725
 [#728]: https://github.com/DataDog/dd-sdk-ios/issues/728
 [#729]: https://github.com/DataDog/dd-sdk-ios/issues/729
+[#789]: https://github.com/DataDog/dd-sdk-ios/issues/789
 [@00FA9A]: https://github.com/00FA9A
 [@Britton-Earnin]: https://github.com/Britton-Earnin
 [@Hengyu]: https://github.com/Hengyu

--- a/Sources/Datadog/Core/System/LaunchTimeProvider.swift
+++ b/Sources/Datadog/Core/System/LaunchTimeProvider.swift
@@ -19,14 +19,26 @@ internal protocol LaunchTimeProviderType {
     /// time this variable is requested, the value should represent the time interval between now and the
     /// process start time.
     var launchTime: TimeInterval { get }
+
+    /// Returns `true` if the application is pre-warmed.
+    var isActivePrewarm: Bool { get }
 }
 
 internal class LaunchTimeProvider: LaunchTimeProviderType {
     var launchTime: TimeInterval {
-        // Even if __dd_private_AppLaunchTime() is using a lock behind the scenes, TSAN will report a data race if there are no synchronizations at this level.
+        // Even if __dd_private_AppLaunchTime() is using a lock behind the
+        // scenes, TSAN will report a data race if there are no
+        // synchronizations at this level.
         objc_sync_enter(self)
         let time = __dd_private_AppLaunchTime()
         objc_sync_exit(self)
         return time
+    }
+
+    var isActivePrewarm: Bool {
+        objc_sync_enter(self)
+        let isActivePrewarm = __dd_private_isActivePrewarm()
+        objc_sync_exit(self)
+        return isActivePrewarm
     }
 }

--- a/Sources/_Datadog_Private/include/ObjcAppLaunchHandler.h
+++ b/Sources/_Datadog_Private/include/ObjcAppLaunchHandler.h
@@ -4,7 +4,7 @@
 * Copyright 2019-2020 Datadog, Inc.
 */
 
-#import <CoreFoundation/CFDate.h>
+#import <CoreFoundation/CoreFoundation.h>
 
 /// Returns the time interval between startup of the application process and the
 /// `UIApplicationDidBecomeActiveNotification`.
@@ -12,3 +12,8 @@
 /// If the `UIApplicationDidBecomeActiveNotification` has not been reached yet,
 /// it returns  time interval between startup of the application process and now.
 CFTimeInterval __dd_private_AppLaunchTime(void);
+
+/// Returns `true` when the application is pre-warmed.
+///
+/// System sets environment variable `ActivePrewarm` to 1 when app is pre-warmed.
+BOOL __dd_private_isActivePrewarm(void);

--- a/Tests/DatadogTests/Datadog/Core/System/LaunchTimeProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/System/LaunchTimeProviderTests.swift
@@ -8,6 +8,11 @@ import XCTest
 @testable import Datadog
 
 class LaunchTimeProviderTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+        setenv("ActivePrewarm", "", 1)
+    }
+
     func testGivenStartedApplication_whenRequestingLaunchTimeAtAnyTime_itReturnsTheSameValue() {
         // Given
         let provider = LaunchTimeProvider()
@@ -34,5 +39,28 @@ class LaunchTimeProviderTests: XCTestCase {
             iterations: 100
         )
         // swiftlint:enable opening_brace
+    }
+
+    func testIsActivePrewarm_returnsTrue() {
+        // Given
+        let provider = LaunchTimeProvider()
+
+        // When
+        setenv("ActivePrewarm", "1", 1)
+        NSClassFromString("AppLaunchHandler")?.load()
+
+        // Then
+        XCTAssertTrue(provider.isActivePrewarm)
+    }
+
+    func testIsActivePrewarm_returnsFalse() {
+        // Given
+        let provider = LaunchTimeProvider()
+
+        // When
+        NSClassFromString("AppLaunchHandler")?.load()
+
+        // Then
+        XCTAssertFalse(provider.isActivePrewarm)
     }
 }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -167,7 +167,7 @@ class LoggerTests: XCTestCase {
         Datadog.instance = Datadog(
             consentProvider: ConsentProvider(initialConsent: .granted),
             userInfoProvider: UserInfoProvider(),
-            launchTimeProvider: LaunchTimeProviderMock()
+            launchTimeProvider: LaunchTimeProviderMock.mockAny()
         )
         defer { Datadog.flushAndDeinitialize() }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -491,7 +491,7 @@ extension FeaturesCommonDependencies {
             )
         ),
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny(),
-        launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock(),
+        launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock.mockAny(),
         appStateListener: AppStateListening = AppStateListenerMock.mockAny()
     ) -> FeaturesCommonDependencies {
         let httpClient: HTTPClient
@@ -682,7 +682,22 @@ class DateCorrectorMock: DateCorrectorType {
 }
 
 struct LaunchTimeProviderMock: LaunchTimeProviderType {
-    var launchTime: TimeInterval = 0
+    let launchTime: TimeInterval
+    let isActivePrewarm: Bool
+}
+
+extension LaunchTimeProviderMock {
+    static func mockAny() -> LaunchTimeProviderMock {
+        return mockWith(launchTime: 0, isActivePrewarm: false)
+    }
+
+    static func mockWith(launchTime: TimeInterval, isActivePrewarm: Bool = false) -> LaunchTimeProviderMock {
+        return LaunchTimeProviderMock(launchTime: launchTime, isActivePrewarm: isActivePrewarm)
+    }
+
+    static func mockRandom(launchTime: TimeInterval = .mockRandom(), isActivePrewarm: Bool = .random()) -> LaunchTimeProviderMock {
+        return mockWith(launchTime: launchTime, isActivePrewarm: isActivePrewarm)
+    }
 }
 
 extension AppState: AnyMockable, RandomMockable {

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -613,7 +613,7 @@ extension RUMScopeDependencies {
     static func mockWith(
         appStateListener: AppStateListening = AppStateListenerMock.mockAny(),
         userInfoProvider: RUMUserInfoProvider = RUMUserInfoProvider(userInfoProvider: .mockAny()),
-        launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock(),
+        launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock.mockAny(),
         connectivityInfoProvider: RUMConnectivityInfoProvider = RUMConnectivityInfoProvider(
             networkConnectionInfoProvider: NetworkConnectionInfoProviderMock(networkConnectionInfo: nil),
             carrierInfoProvider: CarrierInfoProviderMock(carrierInfo: nil)

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -319,7 +319,7 @@ class TracerTests: XCTestCase {
         Datadog.instance = Datadog(
             consentProvider: ConsentProvider(initialConsent: .granted),
             userInfoProvider: UserInfoProvider(),
-            launchTimeProvider: LaunchTimeProviderMock()
+            launchTimeProvider: LaunchTimeProviderMock.mockAny()
         )
         defer { Datadog.flushAndDeinitialize() }
 


### PR DESCRIPTION
### What and why?

Don't report launch time for pre-warmed process.

[RFC 2353430547](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/2353430547)

### How?

```objective-c

// isActivePrewarm = [NSProcessInfo.processInfo.environment[@"ActivePrewarm"] isEqualToString:@"1"];

BOOL __dd_private_isActivePrewarm() {
    if (isActivePrewarm) return isActivePrewarm;
    CFTimeInterval time = __dd_private_AppLaunchTime();
    return time > ValidAppLaunchTimeThreshold;
}
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing change. 
