### PR TITLE
RUMM-2025 Filter out unrecognized trailing stack frame in `error.stack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [FEATURE] Add tvOS Support. See [#793][]
 * [BUGFIX] Strip query parameters from span resource. See [#728][]
 * [BUGFIX] Stop reporting pre-warmed application launch time. See [#789][]
+* [IMPROVEMENT] Crash Reporting: Filter out unrecognized trailing `???` stack frame in `error.stack`. See [#794][]
 
 # 1.9.0 / 01-26-2022
 
@@ -328,6 +329,7 @@
 [#729]: https://github.com/DataDog/dd-sdk-ios/issues/729
 [#789]: https://github.com/DataDog/dd-sdk-ios/issues/789
 [#793]: https://github.com/DataDog/dd-sdk-ios/issues/793
+[#794]: https://github.com/DataDog/dd-sdk-ios/issues/794
 [@00FA9A]: https://github.com/00FA9A
 [@Britton-Earnin]: https://github.com/Britton-Earnin
 [@Hengyu]: https://github.com/Hengyu


### PR DESCRIPTION
### What and why?

📦 This PR aims at improving the symbolicated `error.stack` by removing trailing `???` frame (if present). 

Going from this:
<img width="1288" alt="Screenshot 2022-03-29 at 14 09 37" src="https://user-images.githubusercontent.com/2358722/160625883-7e8f5af6-b75f-4545-a06b-e0ebaf3e4385.png">

to this:
<img width="1283" alt="Screenshot 2022-03-29 at 14 35 32" src="https://user-images.githubusercontent.com/2358722/160625903-c7bd13ab-159a-434c-8f8c-0d81e23c73fd.png">

The root cause of `???` is lack of library base address resolved for the frame. This makes its symbolication impossible. This line describes the very entry point to the code execution (even before `main`), so nothing actionable. To keep the symbolicated stack clean and avoid false positive symbolication errors, we truncate it.

### How?

Only the last frame is dropped and only if it couldn't be symbolicated.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing change. 
