### PR TITLE
clarifying a sentence in crash reporting doc

### DIFF
--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -45,7 +45,7 @@ end
 {{% tab "Swift Package Manager" %}}
 Add the package at `https://github.com/DataDog/dd-sdk-ios` and link `DatadogCrashReporting` to your application target.
 
-**Note:** If you link to `Datadog` or the `DatadogStatic` library, replace it with `DatadogCrashReporting`.
+**Note:** If you link to `Datadog` or the `DatadogStatic` library, link instead to `DatadogCrashReporting`.
 
 {{% /tab %}}
 {{% tab "Carthage" %}}


### PR DESCRIPTION
this is a really small nitpicky PR. the pronoun `it` in the previous version had an unclear antecedent, which was flagged by transifex. i've rewritten this sentence for better syntactical clarity.