### PR TITLE
RUMM-1870 Add data encryption interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [FEATURE] Web-view tracking. See [#729][]
 * [FEATURE] Integration with CI Visibility Tests. See[#761][]
 * [FEATURE] Add tvOS Support. See [#793][]
+* [FEATURE] Add data encryption interface on-disk data storage. See [#797][]
 * [BUGFIX] Strip query parameters from span resource. See [#728][]
 * [BUGFIX] Stop reporting pre-warmed application launch time. See [#789][]
 * [BUGFIX] Allow log event dropping. See [#795][]
@@ -334,6 +335,7 @@
 [#793]: https://github.com/DataDog/dd-sdk-ios/issues/793
 [#794]: https://github.com/DataDog/dd-sdk-ios/issues/794
 [#795]: https://github.com/DataDog/dd-sdk-ios/issues/795
+[#797]: https://github.com/DataDog/dd-sdk-ios/pull/797
 [@00FA9A]: https://github.com/00FA9A
 [@Britton-Earnin]: https://github.com/Britton-Earnin
 [@Hengyu]: https://github.com/Hengyu

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -981,6 +981,8 @@
 		D2CB6FF327C5369600A62B57 /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */; };
 		D2DC4BBC27F234D600E4FB96 /* CITestIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11625D727B681D200E428C6 /* CITestIntegration.swift */; };
 		D2DC4BBD27F234E000E4FB96 /* CITestIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */; };
+		D2DC4BF627F484AA00E4FB96 /* DataEncryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */; };
+		D2DC4BF727F484AA00E4FB96 /* DataEncryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */; };
 		D2EFF3D32731822A00D09F33 /* RUMViewsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EFF3D22731822A00D09F33 /* RUMViewsHandler.swift */; };
 		D2F1B81126D795F3009F3293 /* DDNoopRUMMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1B81026D795F3009F3293 /* DDNoopRUMMonitor.swift */; };
 		D2F1B81326D8DA68009F3293 /* DDNoopRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1B81226D8DA68009F3293 /* DDNoopRUMMonitorTests.swift */; };
@@ -1736,6 +1738,7 @@
 		D2CB6FB027C5217A00A62B57 /* DatadogObjc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogObjc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCrashReporting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogCrashReportingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataEncryption.swift; sourceTree = "<group>"; };
 		D2EFF3D22731822A00D09F33 /* RUMViewsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandler.swift; sourceTree = "<group>"; };
 		D2F1B81026D795F3009F3293 /* DDNoopRUMMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopRUMMonitor.swift; sourceTree = "<group>"; };
 		D2F1B81226D8DA68009F3293 /* DDNoopRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopRUMMonitorTests.swift; sourceTree = "<group>"; };
@@ -2098,6 +2101,7 @@
 			children = (
 				61AD4E3724531500006E34EA /* DataFormat.swift */,
 				6137C571271DAD4B00EFC4A1 /* DataOrchestrator.swift */,
+				D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */,
 				61133BA92423979B00786299 /* FilesOrchestrator.swift */,
 				613E79412577C08900DFCC17 /* Writing */,
 				613E79422577C09B00DFCC17 /* Reading */,
@@ -5020,6 +5024,7 @@
 				61133BDF2423979B00786299 /* SwiftExtensions.swift in Sources */,
 				61D3E0D3277B23F1008BE766 /* KronosDNSResolver.swift in Sources */,
 				6149FB3A2529D17F00EE387A /* InternalURLsFilter.swift in Sources */,
+				D2DC4BF627F484AA00E4FB96 /* DataEncryption.swift in Sources */,
 				611529A525E3DD51004F740E /* ValuePublisher.swift in Sources */,
 				61FFFB89278457D400401A28 /* KronosMonitor.swift in Sources */,
 				618DCFD724C7265300589570 /* RUMUUID.swift in Sources */,
@@ -5590,6 +5595,7 @@
 				D2CB6E4427C50EAE00A62B57 /* UIApplicationSwizzler.swift in Sources */,
 				D2CB6E4527C50EAE00A62B57 /* RUMResourceScope.swift in Sources */,
 				D2CB6E4627C50EAE00A62B57 /* RUMSessionScope.swift in Sources */,
+				D2DC4BF727F484AA00E4FB96 /* DataEncryption.swift in Sources */,
 				D2CB6E4727C50EAE00A62B57 /* TracingUUID.swift in Sources */,
 				D2CB6E4827C50EAE00A62B57 /* ServerDateProvider.swift in Sources */,
 				D2CB6E4927C50EAE00A62B57 /* AttributesSanitizer.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -32,6 +32,7 @@ internal struct FeaturesCommonDependencies {
     let carrierInfoProvider: CarrierInfoProviderType
     let launchTimeProvider: LaunchTimeProviderType
     let appStateListener: AppStateListening
+    let encryption: DataEncryption?
 }
 
 internal struct FeatureStorage {
@@ -82,12 +83,14 @@ internal struct FeatureStorage {
         let unauthorizedFileWriter = FileWriter(
             dataFormat: dataFormat,
             orchestrator: unauthorizedFilesOrchestrator,
+            encryption: commonDependencies.encryption,
             internalMonitor: internalMonitor
         )
 
         let authorizedFileWriter = FileWriter(
             dataFormat: dataFormat,
             orchestrator: authorizedFilesOrchestrator,
+            encryption: commonDependencies.encryption,
             internalMonitor: internalMonitor
         )
 
@@ -116,6 +119,7 @@ internal struct FeatureStorage {
             fileReader: FileReader(
                 dataFormat: dataFormat,
                 orchestrator: authorizedFilesOrchestrator,
+                encryption: commonDependencies.encryption,
                 internalMonitor: internalMonitor
             )
         )

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -22,6 +22,7 @@ internal struct FeaturesConfiguration {
         let origin: String?
         let sdkVersion: String
         let proxyConfiguration: [AnyHashable: Any]?
+        let encryption: DataEncryption?
     }
 
     struct Logging {
@@ -174,7 +175,8 @@ extension FeaturesConfiguration {
             source: source,
             origin: CITestIntegration.active?.origin,
             sdkVersion: sdkVersion,
-            proxyConfiguration: configuration.proxyConfiguration
+            proxyConfiguration: configuration.proxyConfiguration,
+            encryption: configuration.encryption
         )
 
         if configuration.loggingEnabled {

--- a/Sources/Datadog/Core/Persistence/DataEncryption.swift
+++ b/Sources/Datadog/Core/Persistence/DataEncryption.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2022 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Interface that allows storing data in encrypted format. Encryption/decryption round should
+/// return exactly the same data as it given for the encryption originally (even if decryption
+/// happens in another process/app launch).
+public protocol DataEncryption {
+    /// Encrypts given `Data` with user-chosen encryption.
+    ///
+    /// - Parameter data: Data to encrypt.
+    /// - Returns: The encrypted data.
+    func encrypt(data: Data) throws -> Data
+
+    /// Decrypts given `Data` with user-chosen encryption.
+    ///
+    /// Beware that data to decrypt could be encrypted in a previous
+    /// app launch, so implementation should be aware of the case when decryption could
+    /// fail (for example, key used for encryption is different from key used for decryption, if
+    /// they are unique for every app launch).
+    ///
+    /// - Parameter data: Data to decrypt.
+    /// - Returns: The decrypted data.
+    func decrypt(data: Data) throws -> Data
+}

--- a/Sources/Datadog/Core/Persistence/DataEncryption.swift
+++ b/Sources/Datadog/Core/Persistence/DataEncryption.swift
@@ -18,10 +18,10 @@ public protocol DataEncryption {
 
     /// Decrypts given `Data` with user-chosen encryption.
     ///
-    /// Beware that data to decrypt could be encrypted in a previous
-    /// app launch, so implementation should be aware of the case when decryption could
-    /// fail (for example, key used for encryption is different from key used for decryption, if
-    /// they are unique for every app launch).
+    /// Beware that data to decrypt could be encrypted in a previous app launch, so
+    /// implementation should be aware of the case when decryption could fail (for example,
+    /// key used for encryption is different from key used for decryption, if they are unique
+    /// for every app launch).
     ///
     /// - Parameter data: Data to decrypt.
     /// - Returns: The decrypted data.

--- a/Sources/Datadog/Core/Persistence/DataFormat.swift
+++ b/Sources/Datadog/Core/Persistence/DataFormat.swift
@@ -13,17 +13,17 @@ internal struct DataFormat {
     /// Suffixes the batch payload read from file.
     let suffixData: Data
     /// Separates entities written to file.
-    let separatorData: Data
+    let separatorByte: UInt8
 
     // MARK: - Initialization
 
     init(
         prefix: String,
         suffix: String,
-        separator: String
+        separator: Character
     ) {
         self.prefixData = prefix.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
         self.suffixData = suffix.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
-        self.separatorData = separator.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
+        self.separatorByte = separator.asciiValue!   // swiftlint:disable:this force_unwrapping
     }
 }

--- a/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
@@ -38,7 +38,7 @@ internal final class FileReader: Reader {
         }
 
         do {
-            let fileData = try decode(data: file.read())
+            let fileData = try decrypt(data: file.read())
             let batchData = dataFormat.prefixData + fileData + dataFormat.suffixData
             return Batch(data: batchData, file: file)
         } catch {
@@ -47,7 +47,16 @@ internal final class FileReader: Reader {
         }
     }
 
-    func decode(data: Data) -> Data {
+    /// Decrypts data if encryption is available.
+    ///
+    /// When encryption is provided, the data is splitted using data-format separator, each slices
+    /// is then decoded from base64 and decrypted. Data is finally re-joined with data-format separator.
+    ///
+    /// If no encryption, the data is returned.
+    ///
+    /// - Parameter data: The data to decrypt.
+    /// - Returns: Decrypted data.
+    private func decrypt(data: Data) -> Data {
         guard let encryption = encryption else {
             return data
         }

--- a/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
@@ -12,42 +12,63 @@ internal final class FileReader: Reader {
     private let dataFormat: DataFormat
     /// Orchestrator producing reference to readable file.
     private let orchestrator: FilesOrchestrator
+    private let encryption: DataEncryption?
     private let internalMonitor: InternalMonitor?
 
     /// Files marked as read.
-    private var filesRead: [ReadableFile] = []
+    private var filesRead: Set<String> = []
 
     init(
         dataFormat: DataFormat,
         orchestrator: FilesOrchestrator,
+        encryption: DataEncryption? = nil,
         internalMonitor: InternalMonitor? = nil
     ) {
         self.dataFormat = dataFormat
         self.orchestrator = orchestrator
+        self.encryption = encryption
         self.internalMonitor = internalMonitor
     }
 
     // MARK: - Reading batches
 
     func readNextBatch() -> Batch? {
-        if let file = orchestrator.getReadableFile(excludingFilesNamed: Set(filesRead.map { $0.name })) {
-            do {
-                let fileData = try file.read()
-                let batchData = dataFormat.prefixData + fileData + dataFormat.suffixData
-                return Batch(data: batchData, file: file)
-            } catch {
-                internalMonitor?.sdkLogger.error("Failed to read data from file", error: error)
-                return nil
-            }
+        guard let file = orchestrator.getReadableFile(excludingFilesNamed: filesRead) else {
+            return nil
         }
 
-        return nil
+        do {
+            let fileData = try decode(data: file.read())
+            let batchData = dataFormat.prefixData + fileData + dataFormat.suffixData
+            return Batch(data: batchData, file: file)
+        } catch {
+            internalMonitor?.sdkLogger.error("Failed to read data from file", error: error)
+            return nil
+        }
+    }
+
+    func decode(data: Data) -> Data {
+        guard let encryption = encryption else {
+            return data
+        }
+
+        return data
+            // split data
+            .split(separator: dataFormat.separatorByte)
+            // decode base64 - allow failure
+            .compactMap { Data(base64Encoded: $0) }
+            // decrypt data - allow failure
+            .compactMap { try? encryption.decrypt(data: $0) }
+            // concat data
+            .reduce(Data()) { $0 + $1 + [dataFormat.separatorByte] }
+            // drop last separator
+            .dropLast()
     }
 
     // MARK: - Accepting batches
 
     func markBatchAsRead(_ batch: Batch) {
         orchestrator.delete(readableFile: batch.file)
-        filesRead.append(batch.file)
+        filesRead.insert(batch.file.name)
     }
 }

--- a/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
@@ -14,16 +14,19 @@ internal final class FileWriter: Writer {
     private let orchestrator: FilesOrchestrator
     /// JSON encoder used to encode data.
     private let jsonEncoder: JSONEncoder
+    private let encryption: DataEncryption?
     private let internalMonitor: InternalMonitor?
 
     init(
         dataFormat: DataFormat,
         orchestrator: FilesOrchestrator,
+        encryption: DataEncryption? = nil,
         internalMonitor: InternalMonitor? = nil
     ) {
         self.dataFormat = dataFormat
         self.orchestrator = orchestrator
-        self.jsonEncoder = JSONEncoder.default()
+        self.jsonEncoder = .default()
+        self.encryption = encryption
         self.internalMonitor = internalMonitor
     }
 
@@ -32,18 +35,28 @@ internal final class FileWriter: Writer {
     /// Encodes given value to JSON data and writes it to the file.
     func write<T: Encodable>(value: T) {
         do {
-            let data = try jsonEncoder.encode(value)
+            var data = try encode(value: value)
             let file = try orchestrator.getWritableFile(writeSize: UInt64(data.count))
 
-            if try file.size() == 0 {
-                try file.append(data: data)
-            } else {
-                let atomicData = dataFormat.separatorData + data
-                try file.append(data: atomicData)
+            if try file.size() > 0 {
+                data.insert(dataFormat.separatorByte, at: 0)
             }
+
+            try file.append(data: data)
         } catch {
             userLogger.error("🔥 Failed to write data: \(error)")
             internalMonitor?.sdkLogger.error("Failed to write data to file", error: error)
         }
+    }
+
+    func encode<T: Encodable>(value: T) throws -> Data {
+        let data = try jsonEncoder.encode(value)
+
+        guard let encryption = encryption else {
+            return data
+        }
+
+        return try encryption.encrypt(data: data)
+            .base64EncodedData()
     }
 }

--- a/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
@@ -49,7 +49,13 @@ internal final class FileWriter: Writer {
         }
     }
 
-    func encode<T: Encodable>(value: T) throws -> Data {
+    /// Encodes the given encodable value and encrypt it if encryption is available.
+    ///
+    /// If encryption is available, encryption result is base64 encoded.
+    ///
+    /// - Parameter value: The value to encode.
+    /// - Returns: Data representation of the value.
+    private func encode<T: Encodable>(value: T) throws -> Data {
         let data = try jsonEncoder.encode(value)
 
         guard let encryption = encryption else {

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -227,7 +227,8 @@ public class Datadog {
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider,
             launchTimeProvider: launchTimeProvider,
-            appStateListener: AppStateListener(dateProvider: dateProvider)
+            appStateListener: AppStateListener(dateProvider: dateProvider),
+            encryption: configuration.common.encryption
         )
 
         if let internalMonitoringConfiguration = configuration.internalMonitoring {

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -267,6 +267,7 @@ extension Datadog {
         private(set) var uploadFrequency: UploadFrequency
         private(set) var additionalConfiguration: [String: Any]
         private(set) var proxyConfiguration: [AnyHashable: Any]?
+        private(set) var encryption: DataEncryption?
 
         /// The client token autorizing internal monitoring data to be sent to Datadog org.
         private(set) var internalMonitoringClientToken: String?
@@ -767,6 +768,13 @@ extension Datadog {
             /// - Parameter additionalConfiguration: `[:]` by default.
             public func set(additionalConfiguration: [String: Any]) -> Builder {
                 configuration.additionalConfiguration = additionalConfiguration
+                return self
+            }
+
+            /// Sets data encryption to use for on-disk data persistency.
+            /// - Parameter encryption: An encryption object complying with `DataEncryption` protocol.
+            public func set(encryption: DataEncryption) -> Builder {
+                configuration.encryption = encryption
                 return self
             }
 

--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -30,7 +30,8 @@ extension FeaturesCommonDependencies {
             networkConnectionInfoProvider: NetworkConnectionInfoProvider(),
             carrierInfoProvider: CarrierInfoProvider(),
             launchTimeProvider: LaunchTimeProvider(),
-            appStateListener: AppStateListener(dateProvider: SystemDateProvider())
+            appStateListener: AppStateListener(dateProvider: SystemDateProvider()),
+            encryption: nil
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -59,6 +59,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.batchSize, .medium)
             XCTAssertEqual(configuration.uploadFrequency, .average)
             XCTAssertEqual(configuration.additionalConfiguration.count, 0)
+            XCTAssertNil(configuration.encryption)
         }
     }
 
@@ -108,6 +109,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                     kCFProxyUsernameKey: "proxyuser",
                     kCFProxyPasswordKey: "proxypass",
                 ])
+                .set(encryption: DataEncryptionMock())
 
             return builder
         }
@@ -165,6 +167,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.proxyConfiguration?[kCFNetworkProxiesHTTPProxy] as? String, "www.example.com")
             XCTAssertEqual(configuration.proxyConfiguration?[kCFProxyUsernameKey] as? String, "proxyuser")
             XCTAssertEqual(configuration.proxyConfiguration?[kCFProxyPasswordKey] as? String, "proxypass")
+            XCTAssertTrue(configuration.encryption is DataEncryptionMock)
         }
 
         XCTAssertTrue(rumConfigurationWithDefaultValues.rumUIKitViewsPredicate is DefaultUIKitRUMViewsPredicate)

--- a/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/InternalMonitoring/InternalMonitoringFeatureTests.swift
@@ -35,6 +35,7 @@ class InternalMonitoringFeatureTests: XCTestCase {
         let randomDeviceModel: String = .mockRandom()
         let randomDeviceOSName: String = .mockRandom()
         let randomDeviceOSVersion: String = .mockRandom()
+        let randomEncryption: DataEncryption? = Bool.random() ? DataEncryptionMock() : nil
 
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
@@ -47,7 +48,8 @@ class InternalMonitoringFeatureTests: XCTestCase {
                     applicationVersion: randomApplicationVersion,
                     source: randomSource,
                     origin: randomOrigin,
-                    sdkVersion: randomSDKVersion
+                    sdkVersion: randomSDKVersion,
+                    encryption: randomEncryption
                 ),
                 logsUploadURL: randomUploadURL,
                 clientToken: randomClientToken

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -35,6 +35,7 @@ class LoggingFeatureTests: XCTestCase {
         let randomDeviceModel: String = .mockRandom()
         let randomDeviceOSName: String = .mockRandom()
         let randomDeviceOSVersion: String = .mockRandom()
+        let randomEncryption: DataEncryption? = Bool.random() ? DataEncryptionMock() : nil
 
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
@@ -47,7 +48,8 @@ class LoggingFeatureTests: XCTestCase {
                     applicationVersion: randomApplicationVersion,
                     source: randomSource,
                     origin: randomOrigin,
-                    sdkVersion: randomSDKVersion
+                    sdkVersion: randomSDKVersion,
+                    encryption: randomEncryption
                 ),
                 uploadURL: randomUploadURL,
                 clientToken: randomClientToken

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -580,7 +580,7 @@ extension FeaturesCommonDependencies {
             carrierInfoProvider: carrierInfoProvider ?? self.carrierInfoProvider,
             launchTimeProvider: launchTimeProvider ?? self.launchTimeProvider,
             appStateListener: appStateListener ?? self.appStateListener,
-            encryption: encryption
+            encryption: encryption ?? self.encryption
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -196,7 +196,8 @@ extension FeaturesConfiguration.Common {
         source: String = .mockAny(),
         origin: String? = nil,
         sdkVersion: String = .mockAny(),
-        proxyConfiguration: [AnyHashable: Any]? = nil
+        proxyConfiguration: [AnyHashable: Any]? = nil,
+        encryption: DataEncryption? = nil
     ) -> Self {
         return .init(
             applicationName: applicationName,
@@ -208,7 +209,8 @@ extension FeaturesConfiguration.Common {
             source: source,
             origin: origin,
             sdkVersion: sdkVersion,
-            proxyConfiguration: proxyConfiguration
+            proxyConfiguration: proxyConfiguration,
+            encryption: encryption
         )
     }
 }
@@ -365,6 +367,22 @@ extension AppContext {
     }
 }
 
+struct DataEncryptionMock: DataEncryption {
+    let enc: (Data) throws -> Data
+    let dec: (Data) throws -> Data
+
+    init(
+        encrypt: @escaping (Data) throws -> Data = { $0 },
+        decrypt: @escaping (Data) throws -> Data = { $0 }
+    ) {
+        enc = encrypt
+        dec = decrypt
+    }
+
+    func encrypt(data: Data) throws -> Data { try enc(data) }
+    func decrypt(data: Data) throws -> Data { try dec(data) }
+}
+
 // MARK: - PerformancePreset Mocks
 
 struct StoragePerformanceMock: StoragePerformancePreset {
@@ -492,7 +510,8 @@ extension FeaturesCommonDependencies {
         ),
         carrierInfoProvider: CarrierInfoProviderType = CarrierInfoProviderMock.mockAny(),
         launchTimeProvider: LaunchTimeProviderType = LaunchTimeProviderMock.mockAny(),
-        appStateListener: AppStateListening = AppStateListenerMock.mockAny()
+        appStateListener: AppStateListening = AppStateListenerMock.mockAny(),
+        encryption: DataEncryption? = nil
     ) -> FeaturesCommonDependencies {
         let httpClient: HTTPClient
 
@@ -527,7 +546,8 @@ extension FeaturesCommonDependencies {
             networkConnectionInfoProvider: networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider,
             launchTimeProvider: launchTimeProvider,
-            appStateListener: appStateListener
+            appStateListener: appStateListener,
+            encryption: encryption
         )
     }
 
@@ -544,7 +564,8 @@ extension FeaturesCommonDependencies {
         networkConnectionInfoProvider: NetworkConnectionInfoProviderType? = nil,
         carrierInfoProvider: CarrierInfoProviderType? = nil,
         launchTimeProvider: LaunchTimeProviderType? = nil,
-        appStateListener: AppStateListening? = nil
+        appStateListener: AppStateListening? = nil,
+        encryption: DataEncryption? = nil
     ) -> FeaturesCommonDependencies {
         return FeaturesCommonDependencies(
             consentProvider: consentProvider ?? self.consentProvider,
@@ -558,7 +579,8 @@ extension FeaturesCommonDependencies {
             networkConnectionInfoProvider: networkConnectionInfoProvider ?? self.networkConnectionInfoProvider,
             carrierInfoProvider: carrierInfoProvider ?? self.carrierInfoProvider,
             launchTimeProvider: launchTimeProvider ?? self.launchTimeProvider,
-            appStateListener: appStateListener ?? self.appStateListener
+            appStateListener: appStateListener ?? self.appStateListener,
+            encryption: encryption
         )
     }
 }
@@ -613,7 +635,7 @@ extension DataFormat {
     static func mockWith(
         prefix: String = .mockAny(),
         suffix: String = .mockAny(),
-        separator: String = .mockAny()
+        separator: Character = .mockAny()
     ) -> DataFormat {
         return DataFormat(
             prefix: prefix,

--- a/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/SystemFrameworks/FoundationMocks.swift
@@ -243,6 +243,14 @@ extension String: AnyMockable, RandomMockable {
     static let decimalDigits = "0123456789"
 }
 
+extension Character: AnyMockable, RandomMockable {
+    static func mockAny() -> Character { "c" }
+
+    static func mockRandom() -> Character {
+        String.alphanumerics.randomElement()!
+    }
+}
+
 extension Bool: RandomMockable {
     static func mockRandom() -> Bool {
         return .random()

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -37,6 +37,7 @@ class RUMFeatureTests: XCTestCase {
         let randomDeviceModel: String = .mockRandom()
         let randomDeviceOSName: String = .mockRandom()
         let randomDeviceOSVersion: String = .mockRandom()
+        let randomEncryption: DataEncryption? = Bool.random() ? DataEncryptionMock() : nil
 
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
@@ -51,7 +52,8 @@ class RUMFeatureTests: XCTestCase {
                     environment: randomEnvironmentName,
                     source: randomSource,
                     origin: randomOrigin,
-                    sdkVersion: randomSDKVersion
+                    sdkVersion: randomSDKVersion,
+                    encryption: randomEncryption
                 ),
                 uploadURL: randomUploadURL,
                 clientToken: randomClientToken

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -35,6 +35,7 @@ class TracingFeatureTests: XCTestCase {
         let randomDeviceModel: String = .mockRandom()
         let randomDeviceOSName: String = .mockRandom()
         let randomDeviceOSVersion: String = .mockRandom()
+        let randomEncryption: DataEncryption? = Bool.random() ? DataEncryptionMock() : nil
 
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
@@ -47,7 +48,8 @@ class TracingFeatureTests: XCTestCase {
                     applicationVersion: randomApplicationVersion,
                     source: randomSource,
                     origin: randomOrigin,
-                    sdkVersion: randomSDKVersion
+                    sdkVersion: randomSDKVersion,
+                    encryption: randomEncryption
                 ),
                 uploadURL: randomUploadURL,
                 clientToken: randomClientToken

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -64,6 +64,7 @@ class DDConfigurationTests: XCTestCase {
             XCTAssertNil(configuration.rumActionEventMapper)
             XCTAssertNil(configuration.rumErrorEventMapper)
             XCTAssertEqual(configuration.additionalConfiguration.count, 0)
+            XCTAssertNil(configuration.encryption)
         }
     }
 
@@ -197,6 +198,14 @@ class DDConfigurationTests: XCTestCase {
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFNetworkProxiesHTTPProxy] as? String, "www.example.com")
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFProxyUsernameKey] as? String, "proxyuser")
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.proxyConfiguration?[kCFProxyPasswordKey] as? String, "proxypass")
+
+        class ObjCDataEncryption: DDDataEncryption {
+            func encrypt(data: Data) throws -> Data { data }
+            func decrypt(data: Data) throws -> Data { data }
+        }
+        let dataEncryption = ObjCDataEncryption()
+        objcBuilder.set(encryption: dataEncryption)
+        XCTAssertTrue((objcBuilder.build().sdkConfiguration.encryption as? DDDataEncryptionBridge)?.objcEncryption === dataEncryption)
     }
 
     func testScrubbingRUMEvents() {
@@ -283,6 +292,31 @@ class DDConfigurationTests: XCTestCase {
         XCTAssertNil(configuration.rumActionEventMapper?(.mockRandom()))
         XCTAssertNil(configuration.rumErrorEventMapper?(.mockRandom()))
         XCTAssertNil(configuration.rumLongTaskEventMapper?(.mockRandom()))
+    }
+
+    func testDataEncryption() throws {
+        // Given
+        class ObjCDataEncryption: DDDataEncryption {
+            let encData: Data = .mockRandom()
+            let decData: Data = .mockRandom()
+            func encrypt(data: Data) throws -> Data { encData }
+            func decrypt(data: Data) throws -> Data { decData }
+        }
+
+        let encryption = ObjCDataEncryption()
+
+        // When
+        let objcBuilder = DDConfiguration.builder(
+            rumApplicationID: "rum-app-id",
+            clientToken: "abc-123",
+            environment: "tests"
+        )
+        objcBuilder.set(encryption: encryption)
+        let configuration = objcBuilder.build().sdkConfiguration
+
+        // Then
+        XCTAssertEqual(try configuration.encryption?.encrypt(data: .mockRandom()), encryption.encData)
+        XCTAssertEqual(try configuration.encryption?.decrypt(data: .mockRandom()), encryption.decData)
     }
 
     func testDeprecatedTrackUIActions() {

--- a/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
+++ b/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
@@ -34,6 +34,23 @@
 
 @end
 
+// MARK: - DDDataEncryption
+
+@interface CustomDDDataEncryption: NSObject <DDDataEncryption>
+@end
+
+@implementation CustomDDDataEncryption
+
+- (NSData * _Nullable)decryptWithData:(NSData * _Nonnull)data error:(NSError * _Nullable __autoreleasing * _Nullable)error {
+    return data;
+}
+
+- (NSData * _Nullable)encryptWithData:(NSData * _Nonnull)data error:(NSError * _Nullable __autoreleasing * _Nullable)error {
+    return data;
+}
+
+@end
+
 // MARK: - Tests
 
 @interface DDConfiguration_apiTests : XCTestCase
@@ -112,6 +129,7 @@
     [builder setWithBatchSize:DDBatchSizeMedium];
     [builder setWithUploadFrequency:DDUploadFrequencyAverage];
     [builder setWithAdditionalConfiguration:@{}];
+    [builder setWithEncryption:[CustomDDDataEncryption new]];
     [builder build];
 }
 


### PR DESCRIPTION
### What and why?

Allow users to set custom encryption routines for on-disk data storage.

### How?

Expect an implementation of the following protocol:
```swift 
/// Interface that allows storing data in encrypted format. Encryption/decryption round should
/// return exactly the same data as it given for the encryption originally (even if decryption
/// happens in another process/app launch).
public protocol DataEncryption {
    /// Encrypts given `Data` with user-chosen encryption.
    ///
    /// - Parameter data: Data to encrypt.
    /// - Returns: The encrypted data.
    func encrypt(data: Data) throws -> Data

    /// Decrypts given `Data` with user-chosen encryption.
    ///
    /// Beware that data to decrypt could be encrypted in a previous
    /// app launch, so implementation should be aware of the case when decryption could
    /// fail (for example, key used for encryption is different from key used for decryption, if
    /// they are unique for every app launch).
    ///
    /// - Parameter data: Data to decrypt.
    /// - Returns: The decrypted data.
    func decrypt(data: Data) throws -> Data
}
```

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing change. 
