### PR TITLE
Update `dogfood` tool to support new format of `package.resolved`

### DIFF
--- a/tools/distribution/dogfood.py
+++ b/tools/distribution/dogfood.py
@@ -11,7 +11,7 @@ import sys
 import os
 import traceback
 from tempfile import TemporaryDirectory
-from src.dogfood.package_resolved import PackageResolvedFile
+from src.dogfood.package_resolved import PackageResolvedFile, PackageID
 from src.dogfood.dogfooded_commit import DogfoodedCommit
 from src.dogfood.repository import Repository
 from src.utils import remember_cwd
@@ -52,26 +52,26 @@ def dogfood(dry_run: bool, repository_url: str, repository_name: str, repository
             # Update version of `dd-sdk-ios`:
             for package in packages:
                 package.update_dependency(
-                    package_name='DatadogSDK',
+                    package_id=PackageID(v1='DatadogSDK', v2='dd-sdk-ios'),
                     new_branch='dogfooding',
                     new_revision=dd_sdk_ios_commit.hash,
                     new_version=None
                 )
 
                 # Add or update `dd-sdk-ios` dependencies
-                for dependency_name in dd_sdk_ios_package.read_dependency_names():
-                    dependency = dd_sdk_ios_package.read_dependency(package_name=dependency_name)
+                for dependency_id in dd_sdk_ios_package.read_dependency_ids():
+                    dependency = dd_sdk_ios_package.read_dependency(package_id=dependency_id)
 
-                    if package.has_dependency(package_name=dependency_name):
+                    if package.has_dependency(package_id=dependency_id):
                         package.update_dependency(
-                            package_name=dependency_name,
+                            package_id=dependency_id,
                             new_branch=dependency['state']['branch'],
                             new_revision=dependency['state']['revision'],
                             new_version=dependency['state']['version'],
                         )
                     else:
                         package.add_dependency(
-                            package_name=dependency_name,
+                            package_id=dependency_id,
                             repository_url=dependency['repositoryURL'],
                             branch=dependency['state']['branch'],
                             revision=dependency['state']['revision'],

--- a/tools/distribution/dogfood.py
+++ b/tools/distribution/dogfood.py
@@ -28,6 +28,12 @@ def dogfood(dry_run: bool, repository_url: str, repository_name: str, repository
     os.system(f'swift package --package-path {dd_sdk_package_path} resolve')
     dd_sdk_ios_package = PackageResolvedFile(path=f'{dd_sdk_package_path}/Package.resolved')
 
+    if dd_sdk_ios_package.version != 1:
+        raise Exception(
+            f'`dogfood.py` expects the `package.resolved` in `dd-sdk-ios` to use version 1 ' +
+            f'but version {dd_sdk_ios_package.version} was detected. Update `dogfood.py` to use this version.'
+        )
+
     # Clone dependant repo to temporary location and update its `Package.resolved` (one or many) so it points
     # to the current `dd-sdk-ios` commit. After that, push changes to dependant repo and create dogfooding PR.
     with TemporaryDirectory() as temp_dir:

--- a/tools/distribution/src/dogfood/package_resolved.py
+++ b/tools/distribution/src/dogfood/package_resolved.py
@@ -104,6 +104,7 @@ class PackageResolvedFile(PackageResolvedContent):
                 self.packages,
                 fp=file,
                 indent=2,  # preserve `swift package` indentation
+                separators=(',', ': ' if self.version == 1 else ' : '),  # v1: `"key": "value"`, v2: `"key" : "value"`
                 sort_keys=True  # preserve `swift package` packages sorting
             )
             file.write('\n')  # add new line to the EOF
@@ -235,19 +236,19 @@ class PackageResolvedContentV2(PackageResolvedContent):
     Example of `package.resolved` in version `2` looks this::
 
         {
-            "pins": [
+            "pins" : [
                 {
                     "identity" : "dd-sdk-ios",
                     "kind" : "remoteSourceControl",
                     "location" : "https://github.com/DataDog/dd-sdk-ios",
-                    "state": {
-                        "branch": "dogfooding",
+                    "state" : {
+                        "branch" : "dogfooding",
                         "revision" : "6f662103771eb4523164e64f7f936bf9276f6bd0"
                     }
                 },
                 ...
             ]
-            "version": 2
+            "version" : 2
         }
 
     In v2 `branch` and `version` are mutually exclusive: if one is set, the other

--- a/tools/distribution/src/dogfood/package_resolved.py
+++ b/tools/distribution/src/dogfood/package_resolved.py
@@ -9,6 +9,17 @@ from copy import deepcopy
 from typing import Optional
 
 
+class PackageID:
+    """Identifies package in `package.resolved` file."""
+
+    v1: str  # used in `package.resolved` version 1
+    v2: str  # used in `package.resolved` version 2
+
+    def __init__(self, package_name: str, repository_url: str):
+        self.v1 = package_name
+        self.v2 = package_name
+
+
 class PackageResolvedContent:
     """An interface for manipulating `package.resolved` content."""
 

--- a/tools/distribution/tests/dogfood/test_package_resolved.py
+++ b/tools/distribution/tests/dogfood/test_package_resolved.py
@@ -41,7 +41,7 @@ class PackageResolvedFileTestCase(unittest.TestCase):
 
     v2_file_content = b'''
     {
-      "pins": [
+      "pins" : [
         {
           "identity" : "a",
           "kind" : "remoteSourceControl",
@@ -61,7 +61,7 @@ class PackageResolvedFileTestCase(unittest.TestCase):
           }
         }
       ],
-      "version": 2
+      "version" : 2
     }
     '''
 
@@ -216,45 +216,45 @@ class PackageResolvedFileTestCase(unittest.TestCase):
 
             actual_new_content = file.read().decode('utf-8')
             expected_new_content = '''{
-  "pins": [
+  "pins" : [
     {
-      "identity": "a",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/A-org/a",
-      "state": {
-        "branch": "a-branch",
-        "revision": "a-revision"
+      "identity" : "a",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/A-org/a",
+      "state" : {
+        "branch" : "a-branch",
+        "revision" : "a-revision"
       }
     },
     {
-      "identity": "b",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/B-org/b.git",
-      "state": {
-        "branch": "b-branch-new",
-        "revision": "b-revision-new"
+      "identity" : "b",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/B-org/b.git",
+      "state" : {
+        "branch" : "b-branch-new",
+        "revision" : "b-revision-new"
       }
     },
     {
-      "identity": "c",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/C-org/c.git",
-      "state": {
-        "branch": "c-branch",
-        "revision": "c-revision"
+      "identity" : "c",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/C-org/c.git",
+      "state" : {
+        "branch" : "c-branch",
+        "revision" : "c-revision"
       }
     },
     {
-      "identity": "d",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/D-org/d.git",
-      "state": {
-        "revision": "d-revision",
-        "version": "1.1.0"
+      "identity" : "d",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/D-org/d.git",
+      "state" : {
+        "revision" : "d-revision",
+        "version" : "1.1.0"
       }
     }
   ],
-  "version": 2
+  "version" : 2
 }
 '''
             self.assertEqual(expected_new_content, actual_new_content)

--- a/tools/distribution/tests/dogfood/test_package_resolved.py
+++ b/tools/distribution/tests/dogfood/test_package_resolved.py
@@ -1,0 +1,256 @@
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-2020 Datadog, Inc.
+# -----------------------------------------------------------
+
+
+import unittest
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+from src.dogfood.package_resolved import PackageResolvedFile
+
+
+class PackageResolvedFileTestCase(unittest.TestCase):
+    v1_file_content = b'''
+    {
+      "object": {
+        "pins": [
+          {
+            "package": "A",
+            "repositoryURL": "https://github.com/A-org/a.git",
+            "state": {
+              "branch": "a-branch",
+              "revision": "a-revision",
+              "version": null
+            }
+          },
+          {
+            "package": "B",
+            "repositoryURL": "https://github.com/B-org/b.git",
+            "state": {
+              "branch": null,
+              "revision": "b-revision",
+              "version": "1.0.0"
+            }
+          }
+        ]
+      },
+      "version": 1
+    }
+    '''
+
+    v2_file_content = b'''
+    {
+      "object": {
+        "pins": [
+          {
+            "identity" : "a",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/A-org/a",
+            "state" : {
+              "branch" : "a-branch",
+              "revision" : "a-revision"
+            }
+          },
+          {
+            "identity" : "b",
+            "kind" : "remoteSourceControl",
+            "location" : "https://github.com/B-org/b.git",
+            "state" : {
+              "revision" : "b-revision",
+              "version" : "1.0.0"
+            }
+          }
+        ]
+      },
+      "version": 2
+    }
+    '''
+
+    def test_it_reads_version1_files(self):
+        with NamedTemporaryFile() as file:
+            file.write(self.v1_file_content)
+            file.seek(0)
+
+            package_resolved = PackageResolvedFile(path=file.name)
+            self.assertTrue(package_resolved.has_dependency(package_name='A'))
+            self.assertTrue(package_resolved.has_dependency(package_name='B'))
+            self.assertFalse(package_resolved.has_dependency(package_name='C'))
+            self.assertListEqual(['A', 'B'], package_resolved.read_dependency_names())
+            self.assertDictEqual(
+                {
+                    'package': 'A',
+                    'repositoryURL': 'https://github.com/A-org/a.git',
+                    'state': {'branch': 'a-branch', 'revision': 'a-revision', 'version': None}
+                },
+                package_resolved.read_dependency(package_name='A')
+            )
+            self.assertDictEqual(
+                {
+                    'package': 'B',
+                    'repositoryURL': 'https://github.com/B-org/b.git',
+                    'state': {'branch': None, 'revision': 'b-revision', 'version': '1.0.0'}
+                },
+                package_resolved.read_dependency(package_name='B')
+            )
+
+    def test_it_changes_version1_files(self):
+        with NamedTemporaryFile() as file:
+            file.write(self.v1_file_content)
+            file.seek(0)
+
+            package_resolved = PackageResolvedFile(path=file.name)
+            package_resolved.update_dependency(
+                package_name='B', new_branch='b-branch-new', new_revision='b-revision-new', new_version=None
+            )
+            package_resolved.add_dependency(
+                package_name='C', repository_url='https://github.com/C-org/c.git',
+                branch='c-branch', revision='c-revision', version=None
+            )
+            package_resolved.add_dependency(
+                package_name='D', repository_url='https://github.com/D-org/d.git',
+                branch=None, revision='d-revision', version='1.1.0'
+            )
+            package_resolved.save()
+
+            actual_new_content = file.read().decode('utf-8')
+            expected_new_content = '''{
+  "object": {
+    "pins": [
+      {
+        "package": "A",
+        "repositoryURL": "https://github.com/A-org/a.git",
+        "state": {
+          "branch": "a-branch",
+          "revision": "a-revision",
+          "version": null
+        }
+      },
+      {
+        "package": "B",
+        "repositoryURL": "https://github.com/B-org/b.git",
+        "state": {
+          "branch": "b-branch-new",
+          "revision": "b-revision-new",
+          "version": null
+        }
+      },
+      {
+        "package": "C",
+        "repositoryURL": "https://github.com/C-org/c.git",
+        "state": {
+          "branch": "c-branch",
+          "revision": "c-revision",
+          "version": null
+        }
+      },
+      {
+        "package": "D",
+        "repositoryURL": "https://github.com/D-org/d.git",
+        "state": {
+          "branch": null,
+          "revision": "d-revision",
+          "version": "1.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}
+'''
+            self.assertEqual(expected_new_content, actual_new_content)
+
+    def test_it_reads_version2_files(self):
+        with NamedTemporaryFile() as file:
+            file.write(self.v2_file_content)
+            file.seek(0)
+
+            package_resolved = PackageResolvedFile(path=file.name)
+            self.assertTrue(package_resolved.has_dependency(package_name='a'))
+            self.assertTrue(package_resolved.has_dependency(package_name='b'))
+            self.assertFalse(package_resolved.has_dependency(package_name='c'))
+            self.assertListEqual(['a', 'b'], package_resolved.read_dependency_names())
+            self.assertDictEqual(
+                {
+                    'identity': 'a',
+                    'kind': 'remoteSourceControl',
+                    'location': 'https://github.com/A-org/a',
+                    'state': {'branch': 'a-branch', 'revision': 'a-revision'}
+                },
+                package_resolved.read_dependency(package_name='a')
+            )
+            self.assertDictEqual(
+                {
+                    'identity': 'b',
+                    'kind': 'remoteSourceControl',
+                    'location': 'https://github.com/B-org/b.git',
+                    'state': {'revision': 'b-revision', 'version': '1.0.0'}
+                },
+                package_resolved.read_dependency(package_name='b')
+            )
+
+    def test_it_changes_version2_files(self):
+        with NamedTemporaryFile() as file:
+            file.write(self.v2_file_content)
+            file.seek(0)
+
+            package_resolved = PackageResolvedFile(path=file.name)
+            package_resolved.update_dependency(
+                package_name='b', new_branch='b-branch-new', new_revision='b-revision-new', new_version=None
+            )
+            package_resolved.add_dependency(
+                package_name='c', repository_url='https://github.com/C-org/c.git',
+                branch='c-branch', revision='c-revision', version=None
+            )
+            package_resolved.add_dependency(
+                package_name='d', repository_url='https://github.com/D-org/d.git',
+                branch=None, revision='d-revision', version='1.1.0'
+            )
+            package_resolved.save()
+
+            actual_new_content = file.read().decode('utf-8')
+            expected_new_content = '''{
+  "object": {
+    "pins": [
+      {
+        "identity": "a",
+        "kind": "remoteSourceControl",
+        "location": "https://github.com/A-org/a",
+        "state": {
+          "branch": "a-branch",
+          "revision": "a-revision"
+        }
+      },
+      {
+        "identity": "b",
+        "kind": "remoteSourceControl",
+        "location": "https://github.com/B-org/b.git",
+        "state": {
+          "branch": "b-branch-new",
+          "revision": "b-revision-new"
+        }
+      },
+      {
+        "identity": "c",
+        "kind": "remoteSourceControl",
+        "location": "https://github.com/C-org/c.git",
+        "state": {
+          "branch": "c-branch",
+          "revision": "c-revision"
+        }
+      },
+      {
+        "identity": "d",
+        "kind": "remoteSourceControl",
+        "location": "https://github.com/D-org/d.git",
+        "state": {
+          "revision": "d-revision",
+          "version": "1.1.0"
+        }
+      }
+    ]
+  },
+  "version": 2
+}
+'''
+            self.assertEqual(expected_new_content, actual_new_content)


### PR DESCRIPTION
### What and why?

⚙️ This PR fixes the problem of the recent dogfooding automation [failure](https://github.com/DataDog/dd-sdk-ios/runs/5816985836):
```
❌ Failed to dogfood: .package.resolved uses version 2 but `package_resolved.py` supports version 1. Update `package_resolved.py` to new format.
```

https://github.com/apple/swift-package-manager/pull/3717 introduced a new format of `package.resolved` in Swfit 5.6 toolchain ([CHANGELOG](https://github.com/apple/swift-package-manager/pull/3717)). Before, both `dd-sdk-ios` and its dependant projects (Shopist iOS and Datadog iOS app) were using `package.resolved` in `version: 1`. Recently, Datadog iOS app's build was upgraded to new toolchain and it uses `version: 2`.

This PR enhances `dogfood` script to support both formats, so we can freely use different toolchains in different repositories.

#### V1's `package.resolved` example:
```js
{
    "object": {
        "pins": [
            {
                "package": "DatadogSDK",
                "repositoryURL": "https://github.com/DataDog/dd-sdk-ios",
                "state": {
                    "branch": "dogfooding",
                    "revision": "6f662103771eb4523164e64f7f936bf9276f6bd0",
                    "version": null
                }
            },
            // ...
        ]
    },
    "version": 1
}
```

#### V2's `package.resolved` example:
```js
{
    "pins" : [
        {
            "identity" : "dd-sdk-ios",
            "kind" : "remoteSourceControl",
            "location" : "https://github.com/DataDog/dd-sdk-ios",
            "state" : {
                "branch" : "dogfooding",
                "revision" : "6f662103771eb4523164e64f7f936bf9276f6bd0"
            }
        },
        ...
    ]
    "version" : 2
}
```

### How?

The `PackageResolvedFile` now uses one of 2 wrapped types:
* `PackageResolvedContentV1` - for manipulating `version: 1` structure,
* `PackageResolvedContentV2` - for manipulating `version: 2` structure.

Because dependencies now need to be identified differently, e.g.:
* `"package": "DatadogSDK"` - in v1
* `"identity" : "dd-sdk-ios"` - in v2

I introduced `PackageID` concept, which manages ID for both formats (through `id.v1` and `id.v2`).

This isolation is to simplify migration once we drop `version: 1` in all projects. To avoid mistakes, I added full tests coverage for `PackageResolvedFile` and both formats.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] ~Make sure each commit and the PR mention the Issue number or JIRA reference~
- [ ] ~Add CHANGELOG entry for user facing change.~
