### PR TITLE
RUMM-2079 `time_spent` can't be lower than 1ns

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -368,8 +368,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         // RUMM-1779 Keep view active as long as we have ongoing resources
         let isActive = isActiveView || !resourceScopes.isEmpty
-
-        let timeSpent = command.time.timeIntervalSince(viewStartTime)
+        // RUMM-2079 `time_spent` can't be lower than 1ns
+        let timeSpent = max(1e-9, command.time.timeIntervalSince(viewStartTime))
         let cpuInfo = vitalInfoSampler.cpu
         let memoryInfo = vitalInfoSampler.memory
         let refreshRateInfo = vitalInfoSampler.refreshRate

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -154,7 +154,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.view.name, "ViewName")
         let viewIsActive = try XCTUnwrap(event.view.isActive)
         XCTAssertTrue(viewIsActive)
-        XCTAssertEqual(event.view.timeSpent, 0)
+        XCTAssertEqual(event.view.timeSpent, 1) // Minimum `time_spent of 1 nanosecond
         XCTAssertEqual(event.view.action.count, 1, "The initial view update must have come with `application_start` action sent.")
         XCTAssertEqual(event.view.error.count, 0)
         XCTAssertEqual(event.view.resource.count, 0)
@@ -195,7 +195,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.view.name, "ViewName")
         let viewIsActive = try XCTUnwrap(event.view.isActive)
         XCTAssertTrue(viewIsActive)
-        XCTAssertEqual(event.view.timeSpent, 0)
+        XCTAssertEqual(event.view.timeSpent, 1) // Minimum `time_spent of 1 nanosecond
         XCTAssertEqual(event.view.action.count, isInitialView ? 1 : 0, "It must track application start action only if this is an initial view")
         XCTAssertEqual(event.view.error.count, 0)
         XCTAssertEqual(event.view.resource.count, 0)


### PR DESCRIPTION
### What and why?

Prevent sending negative `view.time_spent`.

### How?

Report `time_spent` with a minimal value of 1 nano second.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] ~~Add CHANGELOG entry for user facing change.~~
