### PR TITLE
Fix CI Visiblity testing

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog tvOS.xcscheme
@@ -30,6 +30,15 @@
       enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D2CB6ED327C520D400A62B57"
+            BuildableName = "DatadogTests.xctest"
+            BlueprintName = "DatadogTests tvOS"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
             argument = "IS_RUNNING_UNIT_TESTS"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
@@ -30,6 +30,15 @@
       enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D2CB6FD327C5352300A62B57"
+            BuildableName = "DatadogCrashReportingTests.xctest"
+            BlueprintName = "DatadogCrashReportingTests tvOS"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
             argument = "IS_RUNNING_UNIT_TESTS"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc tvOS.xcscheme
@@ -43,6 +43,15 @@
       shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D2CB6ED327C520D400A62B57"
+            BuildableName = "DatadogTests.xctest"
+            BlueprintName = "DatadogTests tvOS"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
             argument = "IS_RUNNING_UNIT_TESTS"

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ all: dependencies xcodeproj-httpservermock templates
 DD_SDK_SWIFT_TESTING_VERSION = 1.1.1
 
 define DD_SDK_TESTING_XCCONFIG_CI
-FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$(inherited) $(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
-LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]=$(inherited) $(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
-FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]==$(inherited) $(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
-LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*]=$(inherited) $(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
+FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
+LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
+FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]==$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
+LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
 OTHER_LDFLAGS=$$(inherited) -framework DatadogSDKTesting\n
 DD_TEST_RUNNER=1\n
 DD_SDK_SWIFT_TESTING_SERVICE=dd-sdk-ios\n

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ all: dependencies xcodeproj-httpservermock templates
 DD_SDK_SWIFT_TESTING_VERSION = 1.1.1
 
 define DD_SDK_TESTING_XCCONFIG_CI
-FRAMEWORK_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/**\n
-LD_RUNPATH_SEARCH_PATHS=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/**\n
+FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$(inherited) $(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
+LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]=$(inherited) $(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
+FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]==$(inherited) $(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
+LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*]=$(inherited) $(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
 OTHER_LDFLAGS=$$(inherited) -framework DatadogSDKTesting\n
 DD_TEST_RUNNER=1\n
 DD_SDK_SWIFT_TESTING_SERVICE=dd-sdk-ios\n


### PR DESCRIPTION
### What and why?

Fix CI Visiblity testing. 

### How?

FRAMEWORK_SEARCH_PATHS and LD_RUNPATH_SEARCH_PATHS were not properly set 
Expand test environment variables in tvOS targets 

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing change. 
