### PR TITLE
DOCS-3269 tvOS and iOS Support in iOS Monitoring Documentation

### DIFF
--- a/docs/rum_collection/_index.md
+++ b/docs/rum_collection/_index.md
@@ -2,7 +2,7 @@
 title: RUM iOS Monitoring
 kind: documentation
 beta: true
-description: "Collect RUM data from your iOS applications."
+description: "Collect RUM data from your iOS and tvOS applications."
 aliases:
     - /real_user_monitoring/ios/getting_started
 further_reading:
@@ -23,7 +23,7 @@ Datadog Real User Monitoring (RUM) enables you to visualize and analyze the real
 3. Initialize the library.
 4. Initialize the RUM Monitor, `DDURLSessionDelegate`, and start sending data.
 
-**Note:** The minimum supported version for the Datadog iOS SDK is iOS v11+.
+**Note:** The minimum supported version for the Datadog iOS SDK is iOS v11+. The iOS SDK also supports tvOS. 
 
 ### Declare SDK as dependency
 

--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -12,9 +12,6 @@ further_reading:
 ---
 ## Overview
 
-<div class="alert alert-info"><p>iOS Crash Reporting and Error Tracking is in beta. Upgrade to <a href="https://github.com/DataDog/dd-sdk-ios/releases">dd-sdk-ios v1.7.0+</a> to get access.</p>
-</div>
-
 Enable iOS Crash Reporting and Error Tracking to get comprehensive crash reports and error trends with Real User Monitoring. With this feature, you can access:
 
  - Aggregated iOS crash dashboards and attributes


### PR DESCRIPTION
### What and why?

Updates the iOS Monitoring doc page announcing that the SDK now supports tvOS and iOS.

### How?

Slack convo with Maxime.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing change. 
