### PR TITLE
Update to version 2.0.0 of the testing framework

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog iOS.xcscheme
@@ -52,8 +52,8 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "DATADOG_CLIENT_TOKEN"
-            value = "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+            key = "DD_API_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APIKEY)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog tvOS.xcscheme
@@ -52,8 +52,8 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "DATADOG_CLIENT_TOKEN"
-            value = "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+            key = "DD_API_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APIKEY)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
@@ -87,8 +87,8 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "DATADOG_CLIENT_TOKEN"
-            value = "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+            key = "DD_API_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APIKEY)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
@@ -52,8 +52,8 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "DATADOG_CLIENT_TOKEN"
-            value = "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+            key = "DD_API_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APIKEY)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
@@ -52,8 +52,8 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "DATADOG_CLIENT_TOKEN"
-            value = "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+            key = "DD_API_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APIKEY)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc iOS.xcscheme
@@ -51,8 +51,8 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "DATADOG_CLIENT_TOKEN"
-            value = "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+            key = "DD_API_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APIKEY)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc tvOS.xcscheme
@@ -65,8 +65,8 @@
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "DATADOG_CLIENT_TOKEN"
-            value = "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+            key = "DD_API_KEY"
+            value = "$(DD_SDK_SWIFT_TESTING_APIKEY)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/Datadog/TargetSupport/DatadogIntegrationTests/DatadogIntegrationTests.xctestplan
+++ b/Datadog/TargetSupport/DatadogIntegrationTests/DatadogIntegrationTests.xctestplan
@@ -10,8 +10,8 @@
             "value" : "$(DD_TEST_RUNNER)"
           },
           {
-            "key" : "DATADOG_CLIENT_TOKEN",
-            "value" : "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+            "key" : "DD_API_KEY",
+            "value" : "$(DD_SDK_SWIFT_TESTING_APIKEY)"
           },
           {
             "key" : "DD_ENV",
@@ -91,8 +91,8 @@
         "value" : "$(DD_TEST_RUNNER)"
       },
       {
-        "key" : "DATADOG_CLIENT_TOKEN",
-        "value" : "$(DD_SDK_SWIFT_TESTING_CLIENT_TOKEN)"
+        "key" : "DD_API_KEY",
+        "value" : "$(DD_SDK_SWIFT_TESTING_APIKEY)"
       },
       {
         "key" : "DD_ENV",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: dependencies xcodeproj-httpservermock templates
 
 # The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
-DD_SDK_SWIFT_TESTING_VERSION = 1.1.1
+DD_SDK_SWIFT_TESTING_VERSION = 2.0.0
 
 define DD_SDK_TESTING_XCCONFIG_CI
 FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
@@ -11,7 +11,7 @@ LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(SRCROOT)/../inst
 OTHER_LDFLAGS=$$(inherited) -framework DatadogSDKTesting\n
 DD_TEST_RUNNER=1\n
 DD_SDK_SWIFT_TESTING_SERVICE=dd-sdk-ios\n
-DD_SDK_SWIFT_TESTING_CLIENT_TOKEN=${DD_SDK_SWIFT_TESTING_CLIENT_TOKEN}\n
+DD_SDK_SWIFT_TESTING_APIKEY=${DD_SDK_SWIFT_TESTING_APIKEY}\n
 DD_SDK_SWIFT_TESTING_ENV=ci\n
 endef
 export DD_SDK_TESTING_XCCONFIG_CI


### PR DESCRIPTION
### What and why?

Update to version 2.0.0 of the testing framework

### How?

Update DD_SDK_SWIFT_TESTING_VERSION to 2.0.0 in Makefile
Use DD_API_KEY instead of DATADOG_CLIENT_TOKEN

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing change. 
