### PR TITLE
RUMM-2029 Make integration tests not depend on the number of view updates

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -10,6 +10,11 @@
 		61020C2A2757AD91005EEAEA /* BackgroundLocationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */; };
 		61020C2C2758E853005EEAEA /* DebugBackgroundEventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */; };
 		6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */; };
+		61098D2B27FEE3F00021237A /* MessagePortChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61098D2A27FEE3F00021237A /* MessagePortChannel.swift */; };
+		61098D2C27FEE3F00021237A /* MessagePortChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61098D2A27FEE3F00021237A /* MessagePortChannel.swift */; };
+		61098D2D27FEE4130021237A /* MessagePortChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61098D2A27FEE3F00021237A /* MessagePortChannel.swift */; };
+		61098D2F27FF16A20021237A /* RUMSessionEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61098D2E27FF16A20021237A /* RUMSessionEndView.swift */; };
+		61098D3027FF16A20021237A /* RUMSessionEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61098D2E27FF16A20021237A /* RUMSessionEndView.swift */; };
 		610DE00E26613E990042763D /* PersistenceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111544725C9A88B007C84C9 /* PersistenceHelper.swift */; };
 		6111542525C992F8007C84C9 /* CrashReportingScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111542425C992F8007C84C9 /* CrashReportingScenarios.swift */; };
 		6111543625C993C2007C84C9 /* CrashReportingScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6111543525C993C2007C84C9 /* CrashReportingScenario.storyboard */; };
@@ -1181,6 +1186,8 @@
 		61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundLocationMonitor.swift; sourceTree = "<group>"; };
 		61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBackgroundEventsViewController.swift; sourceTree = "<group>"; };
 		6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingWithActiveSpanIntegration.swift; sourceTree = "<group>"; };
+		61098D2A27FEE3F00021237A /* MessagePortChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagePortChannel.swift; sourceTree = "<group>"; };
+		61098D2E27FF16A20021237A /* RUMSessionEndView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionEndView.swift; sourceTree = "<group>"; };
 		6111542425C992F8007C84C9 /* CrashReportingScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingScenarios.swift; sourceTree = "<group>"; };
 		6111543525C993C2007C84C9 /* CrashReportingScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CrashReportingScenario.storyboard; sourceTree = "<group>"; };
 		6111543E25C996A5007C84C9 /* CrashReportingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingViewController.swift; sourceTree = "<group>"; };
@@ -2872,6 +2879,8 @@
 				61441C912461A648003D8BB8 /* UIButton+Disabling.swift */,
 				61441C922461A648003D8BB8 /* UIViewController+KeyboardControlling.swift */,
 				6111544725C9A88B007C84C9 /* PersistenceHelper.swift */,
+				61098D2A27FEE3F00021237A /* MessagePortChannel.swift */,
+				61098D2E27FF16A20021237A /* RUMSessionEndView.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5350,6 +5359,7 @@
 				6111542525C992F8007C84C9 /* CrashReportingScenarios.swift in Sources */,
 				61F74AF426F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift in Sources */,
 				61441C972461A649003D8BB8 /* UIViewController+KeyboardControlling.swift in Sources */,
+				61098D2B27FEE3F00021237A /* MessagePortChannel.swift in Sources */,
 				61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */,
 				6111543F25C996A5007C84C9 /* CrashReportingViewController.swift in Sources */,
 				61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */,
@@ -5367,6 +5377,7 @@
 				6164AF0E252C9016000D78C4 /* ObjcSendThirdPartyRequestsViewController.m in Sources */,
 				61441C0524616DE9003D8BB8 /* ExampleAppDelegate.swift in Sources */,
 				6193DCCE251B6201009B8011 /* RUMTASScreen1ViewController.swift in Sources */,
+				61098D2F27FF16A20021237A /* RUMSessionEndView.swift in Sources */,
 				61163C3E252E0015007DD5BF /* RUMMVSModalViewController.swift in Sources */,
 				61020C2C2758E853005EEAEA /* DebugBackgroundEventsViewController.swift in Sources */,
 				61441C992461A649003D8BB8 /* DebugLoggingViewController.swift in Sources */,
@@ -5396,6 +5407,7 @@
 				61B9ED212462089600C0DCFF /* TracingManualInstrumentationScenarioTests.swift in Sources */,
 				61B6811F25F0EA860015B4AF /* CrashReportingWithLoggingScenarioTests.swift in Sources */,
 				61C2C20D24C1831700C0321C /* RUMManualInstrumentationScenarioTests.swift in Sources */,
+				61098D2D27FEE4130021237A /* MessagePortChannel.swift in Sources */,
 				9EC2835A26CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift in Sources */,
 				61FF282924B8A31E000B3D9B /* RUMEventMatcher.swift in Sources */,
 				61F7F1DD266F9CB000F9F53B /* CodableValue.swift in Sources */,
@@ -5528,8 +5540,10 @@
 				D240681627CE6C9E00C04F44 /* AppConfiguration.swift in Sources */,
 				D240681E27CE6C9E00C04F44 /* ExampleAppDelegate.swift in Sources */,
 				D240682527CE6C9E00C04F44 /* PersistenceHelper.swift in Sources */,
+				61098D3027FF16A20021237A /* RUMSessionEndView.swift in Sources */,
 				D240682B27CE6C9E00C04F44 /* UIButton+Disabling.swift in Sources */,
 				D240682D27CE6C9E00C04F44 /* Environment.swift in Sources */,
+				61098D2C27FEE3F00021237A /* MessagePortChannel.swift in Sources */,
 				D240684F27CF5CA500C04F44 /* TestScenarios.swift in Sources */,
 				D240686827CF642900C04F44 /* SwiftUI.swift in Sources */,
 			);

--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -95,7 +95,7 @@ struct UITestsAppConfiguration: AppConfiguration {
         }
 
         // Handle messages received from UITest runner:
-        MessagePortChannel.createReceiver()?.startListening { message in
+        try! MessagePortChannel.createReceiver().startListening { message in
             switch message {
             case .endRUMSession: markRUMSessionAsEnded()
             }

--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -93,6 +93,13 @@ struct UITestsAppConfiguration: AppConfiguration {
         if Environment.shouldClearPersistentData() {
             PersistenceHelpers.deleteAllSDKData()
         }
+
+        // Handle messages received from UITest runner:
+        MessagePortChannel.createReceiver()?.startListening { message in
+            switch message {
+            case .endRUMSession: markRUMSessionAsEnded()
+            }
+        }
     }
 
     var initialTrackingConsent: TrackingConsent {

--- a/Datadog/Example/Environment.swift
+++ b/Datadog/Example/Environment.swift
@@ -35,14 +35,21 @@ struct HTTPServerMockConfiguration: Codable {
 }
 
 internal struct Environment {
+    /// ENV variables shared between UITests and Example targets.
     struct Variable {
         static let testScenarioClassName = "DD_TEST_SCENARIO_CLASS_NAME"
         static let serverMockConfiguration = "DD_TEST_SERVER_MOCK_CONFIGURATION"
     }
+    /// Launch arguments shared between UITests and Example targets.
     struct Argument {
         static let isRunningUnitTests       = "IS_RUNNING_UNIT_TESTS"
         static let isRunningUITests         = "IS_RUNNING_UI_TESTS"
         static let doNotClearPersistentData = "DO_NOT_CLEAR_PERSISTENT_DATA"
+    }
+    /// Common constants shared between UITests and Example targets.
+    struct Constants {
+        /// The name of the view indicating the end of RUM session in RUM-related `TestScenarios`.
+        static let rumSessionEndViewName = "RUMSessionEndView"
     }
     struct InfoPlistKey {
         static let clientToken      = "DatadogClientToken"

--- a/Datadog/Example/Utils/MessagePortChannel.swift
+++ b/Datadog/Example/Utils/MessagePortChannel.swift
@@ -1,0 +1,80 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Establishes a communications channel from UITests runner to the app under tests (allows sending messages
+/// from `DatadogIntegrationTests` to `Example` app).
+///
+/// Ref.: https://developer.apple.com/documentation/corefoundation/cfmessageport-rs2
+///
+/// Note: this class is used by two targets: `DatadogIntegrationTests` (sender) and `Example` (receiver).
+internal class MessagePortChannel {
+    private static let portName = "DDExampleAppPort" as CFString
+
+    enum Message: Int32 {
+        case endRUMSession = 0x1111
+    }
+
+    static var createSender: () -> Sender? = { Sender() }
+    static var createReceiver: () -> Receiver? = { Receiver() }
+
+    // MARK: - Sending messages
+
+    /// Sender, obtained in `UITests` runner process. Sends messages to `MessagePortChannel.portName`.
+    internal class Sender {
+        private let remotePort: CFMessagePort
+
+        fileprivate init?() {
+            guard let remotePort = CFMessagePortCreateRemote(nil, MessagePortChannel.portName) else {
+                print("⚠️ `MessagePortChannel.Sender` - failed to instantiate remote port")
+                return nil
+            }
+            self.remotePort = remotePort
+        }
+
+        func send(message: Message) {
+            let timeout: CFTimeInterval = 5.0
+            let replyMode = CFRunLoopMode.defaultMode.rawValue // use `default` mode to avaid delivery confirmation
+            let deliveryStatus = CFMessagePortSendRequest(remotePort, message.rawValue, nil, timeout, timeout, replyMode, nil)
+            if deliveryStatus != kCFMessagePortSuccess {
+                print("⚠️ `MessagePortChannel.Sender` - failed to send '\(message)' message")
+            }
+        }
+    }
+
+    // MARK: - Receiving messages
+
+    /// Receiver, obtained in `Example` app process. Receives messages on `MessagePortChannel.portName`.
+    internal class Receiver {
+        private let localPort: CFMessagePort
+        private static var currentListener: ((Message) -> Void)?
+
+        fileprivate init?() {
+            func callback(port: CFMessagePort?, msgid: Int32, data: CFData?, info: UnsafeMutableRawPointer?) -> Unmanaged<CFData>? {
+                if let message = Message(rawValue: msgid) {
+                    Receiver.currentListener?(message)
+                } else {
+                    print("⚠️ `MessagePortChannel.Receiver` - failed to read message from `msgid`: \(msgid)")
+                }
+                return nil
+            }
+
+            guard let localPort = CFMessagePortCreateLocal(nil, MessagePortChannel.portName, callback, nil, nil) else {
+                print("⚠️ `MessagePortChannel.Receiver` - failed to instantiate local port")
+                return nil
+            }
+            self.localPort = localPort
+        }
+
+        func startListening(_ listener: @escaping (Message) -> Void) {
+            precondition(Receiver.currentListener == nil, "Listener was already started")
+            Receiver.currentListener = listener
+            let runLoopSource = CFMessagePortCreateRunLoopSource(nil, localPort, 0)
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, CFRunLoopMode.commonModes)
+        }
+    }
+}

--- a/Datadog/Example/Utils/RUMSessionEndView.swift
+++ b/Datadog/Example/Utils/RUMSessionEndView.swift
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import SwiftUI
+import Datadog
+
+/// Marks current RUM session as ended by starting and stopping one more RUM View ("end view"):
+/// - starting the "end view" will mark the previous active view in the session as "eventually inactive",
+/// - stopping the "end view" will mark it itself as "inactive".
+///
+/// Note: calling this method does not necessarily mean the end of RUM events processing. Some views in the current RUM session
+/// could be still awaiting their resources completion (ref.: _RUMM-1779 Keep view active as long as we have ongoing resources_).
+/// In result of this call, such views will be marked "eventually inactive" right away and will receive the "inactive" flag upon their last resource completion.
+internal func markRUMSessionAsEnded() {
+    Global.rum.startView(key: Environment.Constants.rumSessionEndViewName)
+    Global.rum.stopView(key: Environment.Constants.rumSessionEndViewName)
+
+    if #available(iOS 13, *) {
+        // Show utility view to indicate  in UI that current RUM session
+        // was marked as ended (`UIHostingController` is excluded from instrumentation by default):
+        UIApplication.shared.keyWindow?.rootViewController = UIHostingController(rootView: RUMSessionEndView())
+    }
+}
+
+@available(iOS 13, *)
+private struct RUMSessionEndView: View {
+    var body: some View {
+        VStack(alignment: .center) {
+            Text("RUM Session has ended")
+                .font(.headline)
+                .fontWeight(.bold)
+            Divider()
+            Text("This view is only displayed to finish the previous RUM view. " +
+                 "Previous views could be still awaiting for their resources completion, but will finish soon.")
+                .font(.subheadline)
+                .fontWeight(.light)
+            Divider()
+        }
+        .padding()
+    }
+}

--- a/Datadog/Example/Utils/RUMSessionEndView.swift
+++ b/Datadog/Example/Utils/RUMSessionEndView.swift
@@ -18,14 +18,14 @@ internal func markRUMSessionAsEnded() {
     Global.rum.startView(key: Environment.Constants.rumSessionEndViewName)
     Global.rum.stopView(key: Environment.Constants.rumSessionEndViewName)
 
-    if #available(iOS 13, *) {
+    if #available(iOS 13, tvOS 13, *) {
         // Show utility view to indicate  in UI that current RUM session
         // was marked as ended (`UIHostingController` is excluded from instrumentation by default):
         UIApplication.shared.keyWindow?.rootViewController = UIHostingController(rootView: RUMSessionEndView())
     }
 }
 
-@available(iOS 13, *)
+@available(iOS 13, tvOS 13, *)
 private struct RUMSessionEndView: View {
     var body: some View {
         VStack(alignment: .center) {

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
@@ -87,4 +87,13 @@ extension RUMSessionMatcher {
     class func assertViewWasEventuallyInactive(_ viewVisit: ViewVisit) {
         XCTAssertFalse(try XCTUnwrap(viewVisit.viewEvents.last?.view.isActive))
     }
+
+    /// Checks if RUM session has ended by:
+    /// - checking if it contains "end view" added in response to `ExampleApplication.endRUMSession()`;
+    /// - checking if all other views are marked as "inactive" (meaning they ended up processing their resources).
+    func hasEnded() -> Bool {
+        let hasEndView = viewVisits.last?.name == Environment.Constants.rumSessionEndViewName
+        let hasSomeActiveView = viewVisits.contains(where: { $0.viewEvents.last?.view.isActive == true })
+        return hasEndView && !hasSomeActiveView
+    }
 }

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -43,9 +43,11 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         let screen2 = screen1.tapPushNextScreen()
         screen2.tapPushNextScreen()
 
+        app.endRUMSession()
+
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 3
+            try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 
         assertRUM(requests: recordedRUMRequests)
@@ -56,7 +58,6 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         let view1 = session.viewVisits[0]
         XCTAssertEqual(view1.name, "SendRUMFixture1View")
         XCTAssertEqual(view1.path, "Example.SendRUMFixture1ViewController")
-        XCTAssertEqual(view1.viewEvents.count, 6, "First view should receive 6 updates")
         XCTAssertEqual(view1.viewEvents.last?.view.action.count, 2)
         XCTAssertEqual(view1.viewEvents.last?.view.resource.count, 1)
         XCTAssertEqual(view1.viewEvents.last?.view.error.count, 1)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -43,7 +43,7 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         let screen2 = screen1.tapPushNextScreen()
         screen2.tapPushNextScreen()
 
-        app.endRUMSession()
+        try app.endRUMSession()
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMMobileVitalsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMMobileVitalsScenarioTests.swift
@@ -38,7 +38,7 @@ class RUMMobileVitalsScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapBlockMainThreadButton()
         app.tapNoOpButton()
 
-        app.endRUMSession()
+        try app.endRUMSession()
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMMobileVitalsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMMobileVitalsScenarioTests.swift
@@ -38,10 +38,11 @@ class RUMMobileVitalsScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapBlockMainThreadButton()
         app.tapNoOpButton()
 
+        app.endRUMSession()
+
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            let eventCount = try RUMSessionMatcher.singleSession(from: requests)?.longTaskEventMatchers.count
-            return eventCount == 2
+            try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 
         assertRUM(requests: recordedRUMRequests)
@@ -49,26 +50,13 @@ class RUMMobileVitalsScenarioTests: IntegrationTests, RUMCommonAsserts {
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
         sendCIAppLog(session)
 
-        XCTAssertEqual(session.viewVisits[0].viewEvents.count, 5)
+        let lastViewEvent = try XCTUnwrap(session.viewVisits[0].viewEvents.last)
 
-        let viewLongTask1 = try XCTUnwrap(session.viewVisits[0].viewEvents[0].view.longTask) // start view
-        let viewLongTask2 = try XCTUnwrap(session.viewVisits[0].viewEvents[1].view.longTask) // no-op action
-        let viewLongTask3 = try XCTUnwrap(session.viewVisits[0].viewEvents[2].view.longTask) // block main thread
-        let viewLongTask4 = try XCTUnwrap(session.viewVisits[0].viewEvents[3].view.longTask) // no-op action
-        let viewLongTask5 = try XCTUnwrap(session.viewVisits[0].viewEvents[4].view.longTask) // block main thread
+        let cpuTicksPerSecond = try XCTUnwrap(lastViewEvent.view.cpuTicksPerSecond)
+        XCTAssertGreaterThan(cpuTicksPerSecond, 0.0)
 
-        XCTAssertEqual(viewLongTask1.count, viewLongTask2.count, "Add action event should NOT increment long task count")
-        XCTAssertEqual(viewLongTask2.count + 1, viewLongTask3.count, "Block main thread button should increment long task count")
-        XCTAssertEqual(viewLongTask3.count, viewLongTask4.count, "Add action event should NOT increment long task count")
-        XCTAssertEqual(viewLongTask4.count + 1, viewLongTask5.count, "Block main thread button should increment long task count")
-
-        let viewEvent = session.viewVisits[0].viewEvents[2].view
-
-        let cpuTicksPerSec2 = try XCTUnwrap(viewEvent.cpuTicksPerSecond)
-        XCTAssertGreaterThan(cpuTicksPerSec2, 0.0)
-
-        let fps2 = try XCTUnwrap(viewEvent.refreshRateAverage)
-        XCTAssertGreaterThan(fps2, 0.0)
+        let refreshRateAverage = try XCTUnwrap(lastViewEvent.view.refreshRateAverage)
+        XCTAssertGreaterThan(refreshRateAverage, 0.0)
 
         let longTaskEvents = session.viewVisits[0].longTaskEvents
         XCTAssertEqual(longTaskEvents.count, 2)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
@@ -51,7 +51,7 @@ class RUMModalViewsScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.swipeToPullModalDownButThenCancel() // interactive and cancelled dismiss, stay on "Modal"
         app.tapButton(titled: "Dismiss by self.dismiss()") // dismiss to "Screen"
 
-        app.endRUMSession()
+        try app.endRUMSession()
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMModalViewsScenarioTests.swift
@@ -51,9 +51,11 @@ class RUMModalViewsScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.swipeToPullModalDownButThenCancel() // interactive and cancelled dismiss, stay on "Modal"
         app.tapButton(titled: "Dismiss by self.dismiss()") // dismiss to "Screen"
 
+        app.endRUMSession()
+
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 9
+            try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 
         assertRUM(requests: recordedRUMRequests)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -48,9 +48,11 @@ class RUMNavigationControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapPushNextScreenButton() // go to "Screen2"
         app.swipeInteractiveBackGesture() // swipe back to "Screen1"
 
+        app.endRUMSession()
+
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 8
+            try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 
         assertRUM(requests: recordedRUMRequests)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMNavigationControllerScenarioTests.swift
@@ -48,7 +48,7 @@ class RUMNavigationControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapPushNextScreenButton() // go to "Screen2"
         app.swipeInteractiveBackGesture() // swipe back to "Screen1"
 
-        app.endRUMSession()
+        try app.endRUMSession()
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -83,7 +83,7 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         app.tapSend3rdPartyRequests()
 
-        app.endRUMSession()
+        try app.endRUMSession()
 
         // Get custom 1st party request sent to the server
         let firstPartyPOSTRequest = try XCTUnwrap(

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -83,6 +83,8 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         app.tapSend3rdPartyRequests()
 
+        app.endRUMSession()
+
         // Get custom 1st party request sent to the server
         let firstPartyPOSTRequest = try XCTUnwrap(
             customFirstPartyServerSession
@@ -113,11 +115,7 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         // Get RUM Sessions with expected number of View visits and Resources
         let rumRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            let session = try RUMSessionMatcher.singleSession(from: requests)
-            let hasAllViews = session?.viewVisits.count == 2
-            let hasAllResources = session?.resourceEventMatchers.count == 4
-            let hasAllErrors = session?.errorEventMatchers.count == 1
-            return hasAllViews && hasAllResources && hasAllErrors
+            try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 
         assertRUM(requests: rumRequests)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
@@ -19,7 +19,7 @@ class RUMScrubbingScenarioTests: IntegrationTests, RUMCommonAsserts {
             )
         )
 
-        app.endRUMSession()
+        try app.endRUMSession()
 
         // Get RUM Session with expected number of RUM Errors
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMScrubbingScenarioTests.swift
@@ -19,9 +19,11 @@ class RUMScrubbingScenarioTests: IntegrationTests, RUMCommonAsserts {
             )
         )
 
+        app.endRUMSession()
+
         // Get RUM Session with expected number of RUM Errors
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.last?.errorEvents.count == 2
+            try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 
         assertRUM(requests: recordedRUMRequests)
@@ -29,7 +31,6 @@ class RUMScrubbingScenarioTests: IntegrationTests, RUMCommonAsserts {
         let session = try XCTUnwrap(RUMSessionMatcher.singleSession(from: recordedRUMRequests))
         sendCIAppLog(session)
 
-        XCTAssertEqual(session.viewVisits.count, 1)
         let viewVisit = session.viewVisits[0]
 
         XCTAssertGreaterThan(viewVisit.viewEvents.count, 0)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMSwiftUIScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMSwiftUIScenarioTests.swift
@@ -63,7 +63,7 @@ class RUMSwiftUIScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.swipeDownInteraction() // go back to "SwiftUI.View 100"
         app.tapTapBar(item: "Navigation View") // go to "SwiftUI.View 3"
 
-        app.endRUMSession()
+        try app.endRUMSession()
 
         // Get RUM Sessions with expected number of View visits
         let requests = try recording.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMSwiftUIScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMSwiftUIScenarioTests.swift
@@ -63,9 +63,11 @@ class RUMSwiftUIScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.swipeDownInteraction() // go back to "SwiftUI.View 100"
         app.tapTapBar(item: "Navigation View") // go to "SwiftUI.View 3"
 
+        app.endRUMSession()
+
         // Get RUM Sessions with expected number of View visits
         let requests = try recording.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 9
+            try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 
         assertRUM(requests: requests)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
@@ -43,9 +43,11 @@ class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapTapBarButton(named: "Tab C") // go to "Screen C2"
         app.tapTapBarButton(named: "Tab C") // go to "Screen C1"
 
+        app.endRUMSession()
+
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 9
+            try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 
         assertRUM(requests: recordedRUMRequests)

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTabBarControllerScenarioTests.swift
@@ -43,7 +43,7 @@ class RUMTabBarControllerScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapTapBarButton(named: "Tab C") // go to "Screen C2"
         app.tapTapBarButton(named: "Tab C") // go to "Screen C1"
 
-        app.endRUMSession()
+        try app.endRUMSession()
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -106,7 +106,7 @@ class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapNavigationBarButton(named: "Share")
         app.tapNavigationBarButton(named: "Back")
 
-        app.endRUMSession()
+        try app.endRUMSession()
 
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMTapActionScenarioTests.swift
@@ -106,9 +106,11 @@ class RUMTapActionScenarioTests: IntegrationTests, RUMCommonAsserts {
         app.tapNavigationBarButton(named: "Share")
         app.tapNavigationBarButton(named: "Back")
 
+        app.endRUMSession()
+
         // Get RUM Sessions with expected number of View visits
         let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
-            try RUMSessionMatcher.singleSession(from: requests)?.viewVisits.count == 7
+            try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 
         assertRUM(requests: recordedRUMRequests)

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -34,6 +34,13 @@ class ExampleApplication: XCUIApplication {
 
         super.launch()
     }
+
+    /// Sends a message to `Example` app under test to start and stop the "end view" in current RUM session.
+    /// Presence of this view can be used to await end of transmitting RUM session to the mock server.
+    func endRUMSession() {
+        Thread.sleep(forTimeInterval: 2) // wait a bit so the app under test can complete its animations and transitions
+        MessagePortChannel.createSender()?.send(message: .endRUMSession)
+    }
 }
 
 extension Array where Element == RUMEventMatcher {

--- a/Tests/DatadogIntegrationTests/UITestsHelpers.swift
+++ b/Tests/DatadogIntegrationTests/UITestsHelpers.swift
@@ -37,9 +37,9 @@ class ExampleApplication: XCUIApplication {
 
     /// Sends a message to `Example` app under test to start and stop the "end view" in current RUM session.
     /// Presence of this view can be used to await end of transmitting RUM session to the mock server.
-    func endRUMSession() {
+    func endRUMSession() throws {
         Thread.sleep(forTimeInterval: 2) // wait a bit so the app under test can complete its animations and transitions
-        MessagePortChannel.createSender()?.send(message: .endRUMSession)
+        try MessagePortChannel.createSender().send(message: .endRUMSession)
     }
 }
 


### PR DESCRIPTION
### What and why?

📦 This PR updates our integration tests so they no longer depend on the number of `RUMViewEvents` sent during each RUM scenario. This is a preliminary enhancement for _"RUMM-2029 Reduce number of view updates"_ coming in next PR.

The old approach of awaiting for certain `view.resource.count` or `view.action.count` in integration tests was too fragile as it strictly depends on the number of view events we send. In upcoming `RUMM-2029` work we can't guarantee presence of every "intermediate" update, so in case of last view being not stopped, we will miss some events in integration tests:

<img width="816" alt="Screenshot 2022-04-11 at 09 35 25" src="https://user-images.githubusercontent.com/2358722/162687387-c218a5bc-50b0-45e3-9da1-87585a689d06.png">

### How?

In upcoming `RUMM-2029` work we will reduce the number of "intermediate" updates, but keep the "initial" and "terminal" ones. With that in mind, and knowing the RUM principle of _"starting a new view stops the previous one"_, integration tests are now updated to always start and stop an "END VIEW" as the final step of a test scenario:

<img width="782" alt="Screenshot 2022-04-11 at 09 38 35" src="https://user-images.githubusercontent.com/2358722/162687938-39820a73-cd64-44c6-9006-aeea41c74d95.png">

This guarantees that "terminal" update for the last important view is always sent and all its counts are set correctly.

To avoid implementing "END VIEW" at the end of each RUM test scenario, I added its invocation logic in UI tests definition:
```swift
// in DatadogIntegrationTests:

let app = ExampleApplication()
app.launchWith(...)

// ...

try app.endRUMSession() // <-- new
```

Because UITests runner (`DatadogIntegrationTests`) and app-under-tests (`Example`) are two separate processes, I use [`CFMessagePort`](https://developer.apple.com/documentation/corefoundation/cfmessageport-rs2) API for doing IPC. It sends a basic message from one process and receives it in another. Upon receiving `endRUMSession = 0x1111` message, the "END VIEW" is started & stopped in the `Example` app.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] ~Add CHANGELOG entry for user facing change.~
