### PR TITLE
Merge 1.10.0 to `develop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 1.10.0 / 04-12-2022
+
+### Changes
+
 * [FEATURE] Web-view tracking. See [#729][]
 * [BUGFIX] Strip query parameters from span resource. See [#728][]
 

--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
   s.module_name  = "Datadog"
-  s.version      = "1.10.0-beta1"
+  s.version      = "1.10.0"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKAlamofireExtension.podspec
+++ b/DatadogSDKAlamofireExtension.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKAlamofireExtension"
   s.module_name  = "DatadogAlamofireExtension"
-  s.version      = "1.10.0-beta1"
+  s.version      = "1.10.0"
   s.summary      = "An Official Extensions of Datadog Swift SDK for Alamofire."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKCrashReporting"
   s.module_name  = "DatadogCrashReporting"
-  s.version      = "1.10.0-beta1"
+  s.version      = "1.10.0"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
-  s.dependency 'DatadogSDK', '1.10.0-beta1'
+  s.dependency 'DatadogSDK', '1.10.0'
   s.dependency 'PLCrashReporter', '~> 1.10.1'
 end

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKObjc"
   s.module_name  = "DatadogObjc"
-  s.version      = "1.10.0-beta1"
+  s.version      = "1.10.0"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
 
   s.source_files = "Sources/DatadogObjc/**/*.swift"
-  s.dependency 'DatadogSDK', '1.10.0-beta1'
+  s.dependency 'DatadogSDK', '1.10.0'
 end

--- a/Sources/Datadog/Versioning.swift
+++ b/Sources/Datadog/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let __sdkVersion = "1.10.0-beta1"
+internal let __sdkVersion = "1.10.0"


### PR DESCRIPTION
### What and why?

Merging `release/1.10.0` into `develop`.

⚠️ The CI failure in this PR is expected and not dangerous - it fails in package manager tests, where we assert `tvOS` compatibility for current branch. This compatibility is implemented on `develop` but not yet provided on `release/1.10.0`, so _"does `release/1.10.0` compile fine for `tvOS`"_ assertion must fail. There is no easy workaround. This won't happen in next and further releases.

⚠️⚠️ Actually, there seems to be a bug in Bitrise Checks for GH. If one branch (`release/1.10.0`) has 2 open PRs, then both receive the same status. I restarted the `release/1.10.0` → `master` job and it overwrited the status in this PR 😞.

<img width="1571" alt="Screenshot 2022-04-12 at 17 46 42" src="https://user-images.githubusercontent.com/2358722/163002116-df816cb7-a752-41a3-a068-e07d724ecfa1.png">


### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing change. 
