### PR TITLE
RUMM-2110 Improve CI performance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,11 @@ A short description of what changes this PR introduces and why.
 A brief description of implementation details of this PR.
 
 ### Review checklist
-
 - [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
-- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
-- [ ] Add CHANGELOG entry for user facing change. 
+- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
+- [ ] Add CHANGELOG entry for user facing changes
+
+### Custom CI job configuration (optional)
+- [ ] Run unit tests
+- [ ] Run integration tests
+- [ ] Run smoke tests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,5 +1,4 @@
----
-format_version: '8'
+format_version: 11
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: other
 
@@ -7,14 +6,61 @@ project_type: other
 # go to Workflow Editor on Bitrise.io.
 
 workflows:
-  push_to_any_branch:
+  push_to_pull_request:
+    description: |-
+        This workflow is triggered on starting new PR or pushing new changes to existing PRs.
+        By default, it doesn't run any test phases, but this behaviour is overwritten in `choose_workflows.py` when:
+        - one or more `DD_OVERWRITE_RUN_(phase)_TESTS` ENVs are passed to the current CI job:
+            - DD_OVERRIDE_RUN_UNIT_TESTS='1' to run unit tests phase
+            - DD_OVERRIDE_RUN_INTEGRATION_TESTS='1' to run integration tests phase
+            - DD_OVERRIDE_RUN_SMOKE_TESTS='1' to run smoke tests phase
+            - DD_OVERRIDE_TOOLS_TESTS='1' to run tools tests phase
+        - a phase is selected on the checklist in the PR description,
+        - the PR changes a file which matches phase filter (e.g. changing a file in `Sources/*` will trigger unit tests phase)
+    envs:
+      - DD_RUN_UNIT_TESTS: '0'
+      - DD_RUN_INTEGRATION_TESTS: '0'
+      - DD_RUN_SMOKE_TESTS: '0'
+      - DD_RUN_TOOLS_TESTS: '0'
     after_run:
     - _make_dependencies
-    - run_linter
-    - run_unit_tests
-    - run_integration_tests
-    - check_dependency_managers
+    - run_conditioned_workflows
     - _deploy_artifacts
+
+  push_to_develop_or_master:
+    description: |-
+        This workflow is triggered for each new commit pushed to `develop` or `master` branch.
+    envs:
+      - DD_RUN_UNIT_TESTS: '1'
+      - DD_RUN_INTEGRATION_TESTS: '1'
+      - DD_RUN_SMOKE_TESTS: '0'
+      - DD_RUN_TOOLS_TESTS: '0'
+    after_run:
+    - _make_dependencies
+    - run_conditioned_workflows
+    - _deploy_artifacts
+    - _notify_failure_on_slack
+
+  run_nightly_smoke_and_tools_tests:
+    description: |-
+        This workflow is triggered every night.
+    envs:
+      - DD_RUN_UNIT_TESTS: '0'
+      - DD_RUN_INTEGRATION_TESTS: '0'
+      - DD_RUN_SMOKE_TESTS: '1'
+      - DD_RUN_TOOLS_TESTS: '1'
+    after_run:
+    - _make_dependencies
+    - run_conditioned_workflows
+    - _deploy_artifacts
+    - _notify_failure_on_slack
+
+
+  # Temporary workflow for enabling backward compatibility for pre- RUMM-2110 triggers.
+  # TODO: remove this workflow and clean-up triggers when RUMM-2110 is merged into `master` with `1.11.0`.
+  push_to_any_branch:
+    after_run:
+    - push_to_pull_request
 
   push_to_dogfooding:
     after_run:
@@ -28,12 +74,16 @@ workflows:
     - _notify_failure_on_slack
 
   tagged_commit:
+    description: |-
+        This workflow is triggered on pushing a new release tag.
+    envs:
+      - DD_RUN_UNIT_TESTS: '1'
+      - DD_RUN_INTEGRATION_TESTS: '1'
+      - DD_RUN_SMOKE_TESTS: '1'
+      - DD_RUN_TOOLS_TESTS: '0'
     after_run:
     - _make_dependencies
-    - run_linter
-    - run_unit_tests
-    - run_integration_tests
-    - check_dependency_managers
+    - run_conditioned_workflows
     - _deploy_artifacts
     - start_async_release_jobs
     - _notify_failure_on_slack
@@ -77,6 +127,27 @@ workflows:
         - icon_url: 'https://avatars.githubusercontent.com/t/3555052?s=128&v=4'
         - webhook_url: '${SLACK_INCOMING_WEBHOOK_MOBILE_CI}'
 
+  run_conditioned_workflows:
+    steps:
+    - script:
+        title: Choose which workflows to run
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+
+            cd tools/ci && make
+
+            # The `choose_workflows.py` inspects current ENV variables and Pull Request metadata (if running in PR)
+            # and decides on which from the workflows in `after_run` should be ran. Workflows are opted-in
+            # by modifying `DD_RUN_*` ENV variables with `envman` (ref.: https://github.com/bitrise-io/envman).
+            venv/bin/python3 choose_workflows.py
+    after_run:
+      - run_linter
+      - run_unit_tests
+      - run_integration_tests
+      - run_smoke_tests
+      - run_tools_tests
+
   run_linter:
     description: |-
         Runs swiftlint and license check for all source and test files.
@@ -111,24 +182,24 @@ workflows:
             #!/usr/bin/env bash
             set -e
             ./tools/license/check-license.sh
-    - script:
-        title: Verify RUM data models
-        is_always_run: true
-        inputs:
-        - content: |-
-            #!/usr/bin/env zsh
-            set -e
-            make rum-models-verify ci=${CI}
 
   run_unit_tests:
     description: |-
         Runs unit tests for SDK on iOS Simulator.
         Runs unit tests for SDK on tvOS Simulator.
-        Runs benchmarks for SDK on iOS Simulator.
-        Runs unit tests for HTTPServerMock package on macOS.
+        Only ran if 'DD_RUN_UNIT_TESTS' is '1'.
     steps:
+    - script:
+        title: Verify RUM data models
+        run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
+        inputs:
+        - content: |-
+            #!/usr/bin/env zsh
+            set -e
+            make rum-models-verify ci=${CI}
     - xcode-test:
         title: Run unit tests for Datadog - iOS Simulator
+        run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         inputs:
         - scheme: Datadog iOS
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
@@ -140,6 +211,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Datadog-ios-unit-tests.html"
     - xcode-test:
         title: Run unit tests for DatadogCrashReporting - iOS Simulator
+        run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         inputs:
         - scheme: DatadogCrashReporting iOS
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
@@ -148,6 +220,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogCrashReporting-ios-unit-tests.html"
     - xcode-test:
         title: Run unit tests for Datadog - tvOS Simulator
+        run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         inputs:
         - scheme: Datadog tvOS
         - destination: platform=tvOS Simulator,name=Apple TV,OS=latest
@@ -159,14 +232,23 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Datadog-tvos-unit-tests.html"
     - xcode-test:
         title: Run unit tests for DatadogCrashReporting - tvOS Simulator
+        run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         inputs:
         - scheme: DatadogCrashReporting tvOS
         - destination: platform=tvOS Simulator,name=Apple TV,OS=latest
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogCrashReporting-tvos-unit-tests.html"
+
+  run_integration_tests:
+    description: |-
+        Build benchmarks for SDK on iOS Simulator.
+        Runs integration tests from Datadog.xcworkspace.
+        Only ran if 'DD_RUN_INTEGRATION_TESTS' is '1'.
+    steps:
     - xcode-test:
         title: Run benchmarks - DatadogBenchmarkTests on iOS Simulator
+        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         inputs:
         - scheme: DatadogBenchmarkTests
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
@@ -175,26 +257,9 @@ workflows:
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Benchmark-tests.html"
-    - script:
-        title: Generate HTTPServerMock.xcodeproj
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -e
-            make xcodeproj-httpservermock
-    - xcode-test-mac:
-        title: Run unit tests for HTTPServerMock.xcodeproj - macOS
-        inputs:
-        - scheme: HTTPServerMock-Package
-        - destination: platform=OS X,arch=x86_64
-        - project_path: instrumented-tests/http-server-mock/HTTPServerMock.xcodeproj
-
-  run_integration_tests:
-    description: |-
-        Runs integration tests from Datadog.xcworkspace.
-    steps:
     - xcode-test:
         title: Run integration tests for RUM, Logging and Tracing (on iOS Simulator)
+        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         inputs:
         - scheme: DatadogIntegrationTests
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
@@ -206,6 +271,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogIntegration-tests.html"
     - xcode-test:
         title: Run integration tests for Crash Reporting (on iOS Simulator)
+        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         inputs:
         - scheme: DatadogIntegrationTests
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
@@ -216,13 +282,15 @@ workflows:
         - xcodebuild_options: -testPlan DatadogCrashReportingIntegrationTests
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogCrashReportingIntegration-tests.html"
 
-  check_dependency_managers:
+  run_smoke_tests:
     description: |-
         Uses supported dependency managers to fetch, install and link the SDK
         to test projects.
+        Only ran if 'DD_RUN_SMOKE_TESTS' is '1'.
     steps:
     - script:
         title: Test SPM compatibility
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -230,6 +298,7 @@ workflows:
             make test-spm ci=${CI}
     - xcodebuild:
         title: Check Mac Catalyst compatibility (build SPMProject for Catalyst)
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - scheme: App iOS
         - destination: platform=macOS,variant=Mac Catalyst
@@ -237,6 +306,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPMProject-catalyst-sanity-check.html"
     - xcode-test:
         title: Run SPMProject iOS tests
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - scheme: App iOS
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
@@ -246,6 +316,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPMProject-ios-tests.html"
     - xcode-test:
         title: Run SPMProject tvOS tests
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - scheme: App tvOS
         - destination: platform=tvOS Simulator,name=Apple TV,OS=latest
@@ -255,6 +326,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPMProject-tvos-tests.html"
     - script:
         title: Test Carthage compatibility
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -262,6 +334,7 @@ workflows:
             make test-carthage ci=${CI}
     - xcode-test:
         title: Run CTProject iOS tests
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - scheme: App iOS
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
@@ -271,6 +344,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CTProject-ios-tests.html"
     - xcode-test:
         title: Run CTProject tvOS tests
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - scheme: App tvOS
         - destination: platform=tvOS Simulator,name=Apple TV,OS=latest
@@ -280,6 +354,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CTProject-tvos-tests.html"
     - script:
         title: Test Cocoapods compatibility
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - content: |-
             #!/usr/bin/env bash
@@ -287,6 +362,7 @@ workflows:
             make test-cocoapods ci=${CI}
     - xcode-test:
         title: Run CPProject tests iOS with 'use_frameworks!'
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - scheme: App Dynamic iOS
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
@@ -296,6 +372,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CPProject-ios-dynamic-tests.html"
     - xcode-test:
         title: Run CPProject tests iOS with no 'use_frameworks!'
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - scheme: App Static iOS
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
@@ -305,6 +382,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CPProject-ios-static-tests.html"
     - xcode-test:
         title: Run CPProject tests tvOS with 'use_frameworks!'
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - scheme: App Dynamic tvOS
         - destination: platform=tvOS Simulator,name=Apple TV,OS=latest
@@ -314,6 +392,7 @@ workflows:
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CPProject-tvos-dynamic-tests.html"
     - xcode-test:
         title: Run CPProject tests tvOS with no 'use_frameworks!'
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
         - scheme: App Static tvOS
         - destination: platform=tvOS Simulator,name=Apple TV,OS=latest
@@ -321,6 +400,27 @@ workflows:
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/cocoapods/CPProject.xcworkspace"
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CPProject-tvos-static-tests.html"
+
+  run_tools_tests:
+    description: |-
+        Runs tests for internal tools.
+        Only ran if 'DD_RUN_TOOLS_TESTS' is '1'.
+    steps:
+    - script:
+        title: Generate HTTPServerMock.xcodeproj
+        run_if: '{{enveq "DD_RUN_TOOLS_TESTS" "1"}}'
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make xcodeproj-httpservermock
+    - xcode-test-mac:
+        title: Run unit tests for HTTPServerMock.xcodeproj - macOS
+        run_if: '{{enveq "DD_RUN_TOOLS_TESTS" "1"}}'
+        inputs:
+        - scheme: HTTPServerMock-Package
+        - destination: platform=OS X,arch=x86_64
+        - project_path: instrumented-tests/http-server-mock/HTTPServerMock.xcodeproj
 
   create_dogfooding_pr:
     description: |-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -55,13 +55,6 @@ workflows:
     - _deploy_artifacts
     - _notify_failure_on_slack
 
-
-  # Temporary workflow for enabling backward compatibility for pre- RUMM-2110 triggers.
-  # TODO: remove this workflow and clean-up triggers when RUMM-2110 is merged into `master` with `1.11.0`.
-  push_to_any_branch:
-    after_run:
-    - push_to_pull_request
-
   push_to_dogfooding:
     after_run:
     - create_dogfooding_pr

--- a/tools/ci/Makefile
+++ b/tools/ci/Makefile
@@ -1,0 +1,9 @@
+.PHONY: all
+
+all:
+	@echo "⚙️  Ensuring that GitHub CLI is installed $(PWD)"
+	@brew list gh &>/dev/null || brew install gh
+ifeq ($(wildcard venv),)
+	@echo "⚙️  Creating Python venv in $(PWD)"
+	python3 -m venv venv
+endif

--- a/tools/ci/choose_workflows.py
+++ b/tools/ci/choose_workflows.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-2020 Datadog, Inc.
+# -----------------------------------------------------------
+
+import sys
+import argparse
+import traceback
+from typing import Optional
+from src.utils import export_env
+from src.ci_context import get_ci_context, CIContext
+
+
+def should_run_unit_tests(ctx: CIContext) -> bool:
+    print('⚙️ Resolving `unit tests` phase:')
+    return should_run_phase(
+        ctx=ctx,
+        trigger_env=context.trigger_env.DD_RUN_UNIT_TESTS,
+        build_env=context.build_env.DD_OVERRIDE_RUN_UNIT_TESTS,
+        pr_keyword='[x] Run unit tests',
+        pr_path_prefixes=[
+            'Sources/',
+            'Tests/DatadogTests',
+            'Tests/DatadogCrashReportingTests',
+            'Datadog/Datadog.xcodeproj/',
+        ],
+        pr_file_extensions=[]
+    )
+
+
+def should_run_integration_tests(ctx: CIContext) -> bool:
+    print('⚙️ Resolving `integration tests` phase:')
+    return should_run_phase(
+        ctx=ctx,
+        trigger_env=context.trigger_env.DD_RUN_INTEGRATION_TESTS,
+        build_env=context.build_env.DD_OVERRIDE_RUN_INTEGRATION_TESTS,
+        pr_keyword='[x] Run integration tests',
+        pr_path_prefixes=[
+            'Datadog/Example/',
+            'Tests/DatadogIntegrationTests/',
+        ],
+        pr_file_extensions=[]
+    )
+
+
+def should_run_smoke_tests(ctx: CIContext) -> bool:
+    print('⚙️ Resolving `smoke tests` phase:')
+    return should_run_phase(
+        ctx=ctx,
+        trigger_env=context.trigger_env.DD_RUN_SMOKE_TESTS,
+        build_env=context.build_env.DD_OVERRIDE_RUN_SMOKE_TESTS,
+        pr_keyword='[x] Run smoke tests',
+        pr_path_prefixes=[
+            'dependency-manager-tests/',
+        ],
+        pr_file_extensions=[
+            '.podspec',
+            '.podspec.src',
+            'Cartfile',
+            'Cartfile.resolved',
+            'Package.swift',
+        ]
+    )
+
+
+def should_run_tools_tests(ctx: CIContext) -> bool:
+    print('⚙️ Resolving `tools tests` phase:')
+    return should_run_phase(
+        ctx=ctx,
+        trigger_env=context.trigger_env.DD_RUN_TOOLS_TESTS,
+        build_env=context.build_env.DD_OVERRIDE_RUN_TOOLS_TESTS,
+        pr_keyword=None,
+        pr_path_prefixes=[
+            'instrumented-tests/',
+            'tools/',
+        ],
+        pr_file_extensions=[]
+    )
+
+
+def should_run_phase(
+    ctx: CIContext, trigger_env: str, build_env: Optional[str],
+    pr_keyword: Optional[str], pr_path_prefixes: [str], pr_file_extensions: [str]
+) -> bool:
+    """
+    Resolves CI do determine if a phase should be ran as part of the workflow.
+
+    :param ctx: CI context (ENVs and optional Pull Request information)
+    :param trigger_env: the name of a trigger-level ENV which decides on running this phase
+    :param build_env: the name of a build-level ENV which decides on running this phase
+    :param pr_keyword: the magic word to lookup in PR's description (or `None`) - if found, it will trigger this phase
+    :param pr_path_prefixes: the list of prefixes to match against PR's modified files (any match triggers this phase)
+    :param pr_file_extensions: the list of suffixes to match against PR's modified files (any match triggers this phase)
+    :return: True if a phase should be ran for given CI context
+    """
+    # First, respect trigger ENV:
+    if trigger_env == '1':
+        print('→ opted-in by trigger ENV')
+        return True
+
+    # Second, check build ENV:
+    if build_env == '1':
+        print('→ opted-in by build ENV')
+        return True
+
+    # Last, infer from Pull Request (if running for PR):
+    if ctx.pull_request:
+        if pr_keyword and ctx.pull_request.description.contains(pr_keyword):
+            print(f'→ opted-in by matching keyword ("{pr_keyword}") in PR description ▶️')
+            return True
+
+        if ctx.pull_request.modified_files.contains_paths(path_prefixes=pr_path_prefixes):
+            print(f'→ opted-in by matching one or more path prefixes ({pr_path_prefixes}) in PR files ▶️')
+            return True
+
+        if ctx.pull_request.modified_files.contains_extensions(file_extensions=pr_file_extensions):
+            print(f'→ opted-in by matching one or more file extensions ({pr_file_extensions}) in PR files ▶️')
+            return True
+
+    print(f'→ will be skipped ⏩')
+    return False
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dry-run",
+        action='store_true',
+        help="Run without exporting ENVs to `envman`."
+    )
+    args = parser.parse_args()
+
+    try:
+        dry_run = True if args.dry_run else False
+
+        context = get_ci_context()
+
+        print(f'🛠️️ CI Context:\n'
+              f'- trigger ENVs = {context.trigger_env}\n'
+              f'- build ENVs   = {context.build_env}\n'
+              f'- PR files     = {context.pull_request.modified_files.paths if context.pull_request else "(no PR)"}')
+
+        if should_run_unit_tests(context):
+            export_env('DD_RUN_UNIT_TESTS', '1', dry_run=dry_run)
+
+        if should_run_integration_tests(context):
+            export_env('DD_RUN_INTEGRATION_TESTS', '1', dry_run=dry_run)
+
+        if should_run_smoke_tests(context):
+            export_env('DD_RUN_SMOKE_TESTS', '1', dry_run=dry_run)
+
+        if should_run_tools_tests(context):
+            export_env('DD_RUN_TOOLS_TESTS', '1', dry_run=dry_run)
+
+    except Exception as error:
+        print(f'❌ Failed with: {error}')
+        print('-' * 60)
+        traceback.print_exc(file=sys.stdout)
+        print('-' * 60)
+        sys.exit(1)
+
+    sys.exit(0)

--- a/tools/ci/src/ci_context.py
+++ b/tools/ci/src/ci_context.py
@@ -1,0 +1,115 @@
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-2020 Datadog, Inc.
+# -----------------------------------------------------------
+
+import json
+import os
+from typing import Optional
+from dataclasses import dataclass
+from src.utils import shell_output
+
+
+@dataclass
+class CIContext:
+    trigger_env: 'TriggerENVs'
+    build_env: 'BuildENVs'
+    pull_request: Optional['PullRequest']
+
+
+@dataclass
+class TriggerENVs:
+    """
+    ENVs defined for a trigger in `bitrise.yml`.
+    """
+    DD_RUN_UNIT_TESTS: str
+    DD_RUN_INTEGRATION_TESTS: str
+    DD_RUN_SMOKE_TESTS: str
+    DD_RUN_TOOLS_TESTS: str
+
+
+@dataclass
+class BuildENVs:
+    """
+    Optional ENVs passed from outside (when starting build manually).
+    """
+    DD_OVERRIDE_RUN_UNIT_TESTS: Optional[str]
+    DD_OVERRIDE_RUN_INTEGRATION_TESTS: Optional[str]
+    DD_OVERRIDE_RUN_SMOKE_TESTS: Optional[str]
+    DD_OVERRIDE_RUN_TOOLS_TESTS: Optional[str]
+
+
+@dataclass
+class PullRequest:
+    """
+    Pull request context fetched from GH (available only for pull request builds).
+    """
+    description: 'PullRequestDescription'
+    modified_files: 'PullRequestFiles'
+
+
+@dataclass
+class PullRequestDescription:
+    """
+    Description of the PR.
+    """
+    description: str
+
+    def contains(self, word: str) -> bool:
+        return word in self.description
+
+
+@dataclass
+class PullRequestFiles:
+    """
+    List of files modified by the PR.
+    """
+    paths: [str]
+
+    def contains_paths(self, path_prefixes: [str]) -> bool:
+        for path in self.paths:
+            for path_prefix in path_prefixes:
+                if path.startswith(path_prefix):
+                    return True
+        return False
+
+    def contains_extensions(self, file_extensions: [str]) -> bool:
+        for path in self.paths:
+            for file_extension in file_extensions:
+                if path.endswith(file_extension):
+                    return True
+        return False
+
+
+def get_ci_context() -> CIContext:
+    trigger_env = TriggerENVs(
+        DD_RUN_UNIT_TESTS=os.environ.get('DD_RUN_UNIT_TESTS') or "0",
+        DD_RUN_INTEGRATION_TESTS=os.environ.get('DD_RUN_INTEGRATION_TESTS') or "0",
+        DD_RUN_SMOKE_TESTS=os.environ.get('DD_RUN_SMOKE_TESTS') or "0",
+        DD_RUN_TOOLS_TESTS=os.environ.get('DD_RUN_TOOLS_TESTS') or "0"
+    )
+
+    build_env = BuildENVs(
+        DD_OVERRIDE_RUN_UNIT_TESTS=os.environ.get('DD_OVERRIDE_RUN_UNIT_TESTS'),
+        DD_OVERRIDE_RUN_INTEGRATION_TESTS=os.environ.get('DD_OVERRIDE_RUN_INTEGRATION_TESTS'),
+        DD_OVERRIDE_RUN_SMOKE_TESTS=os.environ.get('DD_OVERRIDE_RUN_SMOKE_TESTS'),
+        DD_OVERRIDE_RUN_TOOLS_TESTS=os.environ.get('DD_OVERRIDE_RUN_TOOLS_TESTS')
+    )
+
+    if pull_request_id := os.environ.get('BITRISE_PULL_REQUEST'):
+        # Fetch PR details with GH CLI (ref.: https://cli.github.com/manual/gh_pr_view)
+        gh_cli_output = shell_output(f'gh pr view {pull_request_id} --json body,files')
+        pr_json = json.loads(gh_cli_output)
+        pull_request = PullRequest(
+            description=PullRequestDescription(pr_json['body']),
+            modified_files=PullRequestFiles(list(map(lambda file: file['path'], pr_json['files'])))
+        )
+    else:
+        pull_request = None
+
+    return CIContext(
+        trigger_env=trigger_env,
+        build_env=build_env,
+        pull_request=pull_request
+    )

--- a/tools/ci/src/utils.py
+++ b/tools/ci/src/utils.py
@@ -1,0 +1,43 @@
+# -----------------------------------------------------------
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-2020 Datadog, Inc.
+# -----------------------------------------------------------
+
+import subprocess
+
+
+def export_env(key: str, value: str, dry_run: bool):
+    """
+    Exports ENV to other process using `envman` (ref.: https://github.com/bitrise-io/envman).
+    Once set, the ENV will be available to `envman` running in caller process.
+    """
+    if not dry_run:
+        shell_output(f'envman add --key {key} --value "{value}"')
+    else:
+        print(f'[DRY-RUN] calling: `envman add --key {key} --value "{value}"`')
+
+
+# Copied from `tools/nightly-unit-tests/src/utils.py`
+# TODO: RUMM-1860 Share this code between both tools
+def shell_output(command: str):
+    """
+    Runs shell command and returns its output.
+    Fails on exit code != 0.
+    """
+    process = subprocess.run(
+        args=[command],
+        capture_output=True,
+        shell=True,
+        text=True  # capture STDOUT as text
+    )
+    if process.returncode == 0:
+        return process.stdout
+    else:
+        raise Exception(
+            f'''
+            Command {command} exited with status code {process.returncode}
+            - STDOUT: {process.stdout if process.stdout != '' else '""'}
+            - STDERR: {process.stderr if process.stderr != '' else '""'}
+            '''
+        )

--- a/tools/license/check-license.sh
+++ b/tools/license/check-license.sh
@@ -18,6 +18,7 @@ function files {
 		-not -path "*Carthage/Checkouts/*" \
 		-not -path "./tools/rum-models-generator/rum-events-format/*" \
 		-not -path "*/tools/distribution/venv/*" \
+		-not -path "*/tools/ci/venv/*" \
 		-not -path "./instrumented-tests/DatadogSDKTesting.xcframework/*" \
 		-not -name "OTSpan.swift" \
 		-not -name "OTFormat.swift" \


### PR DESCRIPTION
### What and why?

⚙️🔨  This PR proposes an improvement to our CI pipelines configuration. The goal is to reduce the duration of CI builds for different triggers. Recently this duration crossed the bar of 60 minutes, which clearly becomes a bottleneck in our workflow.

Average build duration (p95) for last 60 days (by "phases"):

<img width="553" alt="Screenshot 2022-04-14 at 13 24 54" src="https://user-images.githubusercontent.com/2358722/164260904-fdd4802b-9691-40c2-bc38-650a47a76227.png">

Significant phases are:
* "setup" (~3 minutes) - preparing CI environment (installing PLCR, `dd-swift-testing` and CLIs),
* "unit tests" (~12.5 minutes) - running unit tests for iOS and tvOS (all products),
* "integration tests" (~18 minutes) - running integration tests for all products,
* "smoke tests" (~30 minutes) - testing SDK compatibility with Cocoapods, Carthage and SPM.

**Before**, these phases were always ran one after another for every pull request. Even if the PR was only about docs update, its overall duration had to be ~60 minutes.

**Now**, these phases are selectively enabled/disabled, depending on the PR configuration and content. For example, if a pull request includes only docs update, none of tests will be ran, limiting its CI duration to ~5 minutes. On merges to `develop` and `master` it will always run unit and integration tests (~30 minutes). The heaviest phase (smoke tests) will be ran nightly. For all PRs the automation will enable phases based on the _"Custom CI job"_ checklist in the PR description and / or infer it from the list of files changed in the PR.

### How?

When it comes to enabling phases based on the change context, we need:
* wisely chosen **default phases for each trigger** (pull requests / commits on `develop` / release tags / ...);
* ability to **override default phases for pull requests** (e.g. for maintenance of given phase);
* a mechanism to **enable phases automatically** on certain changes (to spot issues early in PRs, not in nightly builds).

Unfortunately, Bitrise CI is yet limited when it comes to last two points. Although it offers the [Selective Builds feature](https://devcenter.bitrise.io/en/builds/configuring-build-settings/selective-builds.html#ot-lst-cnt) that could be used to enable workflows if matching a pattern in the file path, it needs to be configured globally on bitrise.io, not in `bitrise.yml`. Even if using Selective Builds, it won't solve the problem of running particular phase for maintenance purpose or bypassing file patterns for other reason. [Unlike GitLab](https://docs.gitlab.com/ee/ci/pipelines/#add-manual-interaction-to-your-pipeline) and some other providers, Bitrise doesn't support manual triggers and we need to [start builds manually](https://devcenter.bitrise.io/en/builds/starting-builds/starting-builds-manually.html#ot-lst-cnt) or use 3rd party integrations (Slack/CLI) to customise build phases.

Given these limitations, I had to add a custom script for enabling `bitrise.yml` workflows conditionally.

I introduced a new workflow (named: `run_conditioned_workflows`) which first resolves conditions for enabling further build phases. After ENV flags are set, it runs child workflows sequentially and each workflow has the ability to skip its steps:

<img width="1395" alt="Screenshot 2022-04-20 at 18 34 39" src="https://user-images.githubusercontent.com/2358722/164279698-3aae3f6c-4fa1-4e73-a24e-f1a445dd0c51.png">

The `choose_workflows.py` script toggles `DD_RUN_(phase)_TESTS` ENVs by resolving conditions in following order:
* 1/ It checks if the `DD_RUN_(phase)_TESTS` ENV value defined in `bitrise.yml` is `1`.
* 2/ If not, it checks if the `DD_OVERRIDE_RUN_(phase)_TESTS` ENV value passed from outside is `1`.
* 3/ If not, only if the build is started for a pull request:
   * 3a/ it checks if corresponding `[ ] Run (phase) tests` checkbox is selected in PR description,
   * 3b/ last, it checks if PR modifies files which match the pattern defined for given phase.

This should give us enough flexibility and safety when running CI builds for different changes, e.g.:
* When starting a new PR we don't need to do anything - we can leverage the auto configuration from 3a/ and 3b/.
* If the PR requires running a phase which is not enabled by 3/ we can do it by selecting the checkbox in PR description.
* Any PR build can be restarted with selecting different phases than originally.
* If we need to run a phase for arbitrary commit (without PR), we can [start build manually](https://devcenter.bitrise.io/en/builds/starting-builds/starting-builds-manually.html#ot-lst-cnt) and pass override ENVs (2/).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests