### PR TITLE
RUMM-2024 Isolate telemetry apis

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -564,6 +564,12 @@
 		D240688627CFA64A00C04F44 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D240688427CFA64A00C04F44 /* LaunchScreen.storyboard */; };
 		D243BBC0276C9D640019C857 /* PLCrashReporterIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D243BBBF276C9D640019C857 /* PLCrashReporterIntegrationTests.swift */; };
 		D244B3A3271EDACD003E1B29 /* SwiftUIExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D244B3A2271EDACD003E1B29 /* SwiftUIExtensionsTests.swift */; };
+		D248ED4228070E2B00B315B4 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D248ED4128070E2B00B315B4 /* Telemetry.swift */; };
+		D248ED4328070E2B00B315B4 /* Telemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D248ED4128070E2B00B315B4 /* Telemetry.swift */; };
+		D248ED452807193B00B315B4 /* RUMTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D248ED442807193B00B315B4 /* RUMTelemetry.swift */; };
+		D248ED462807193B00B315B4 /* RUMTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D248ED442807193B00B315B4 /* RUMTelemetry.swift */; };
+		D248ED4A28081D7500B315B4 /* RUMTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D248ED4728081B9B00B315B4 /* RUMTelemetryTests.swift */; };
+		D248ED4B28081D7E00B315B4 /* RUMTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D248ED4728081B9B00B315B4 /* RUMTelemetryTests.swift */; };
 		D24985A22728048B00B4F72D /* SwiftUIViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24985A12728048B00B4F72D /* SwiftUIViewHandler.swift */; };
 		D24985A327280FD100B4F72D /* SwiftUIViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D249859F2728042200B4F72D /* SwiftUIViewModifier.swift */; };
 		D24C27EA270C8BEE005DE596 /* DataCompression.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24C27E9270C8BEE005DE596 /* DataCompression.swift */; };
@@ -1727,6 +1733,9 @@
 		D240688527CFA64A00C04F44 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D243BBBF276C9D640019C857 /* PLCrashReporterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLCrashReporterIntegrationTests.swift; sourceTree = "<group>"; };
 		D244B3A2271EDACD003E1B29 /* SwiftUIExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExtensionsTests.swift; sourceTree = "<group>"; };
+		D248ED4128070E2B00B315B4 /* Telemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Telemetry.swift; sourceTree = "<group>"; };
+		D248ED442807193B00B315B4 /* RUMTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTelemetry.swift; sourceTree = "<group>"; };
+		D248ED4728081B9B00B315B4 /* RUMTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMTelemetryTests.swift; sourceTree = "<group>"; };
 		D249859F2728042200B4F72D /* SwiftUIViewModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIViewModifier.swift; sourceTree = "<group>"; };
 		D24985A12728048B00B4F72D /* SwiftUIViewHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIViewHandler.swift; sourceTree = "<group>"; };
 		D24C27E9270C8BEE005DE596 /* DataCompression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompression.swift; sourceTree = "<group>"; };
@@ -2057,6 +2066,7 @@
 				61BBD19424ED4E9E0023E65F /* FeaturesConfiguration.swift */,
 				614E9EB2244719FA007EE3E1 /* BundleType.swift */,
 				61BB2B1A244A185D009F3F56 /* PerformancePreset.swift */,
+				D248ED4128070E2B00B315B4 /* Telemetry.swift */,
 				9E5D2D4A249137E900763FE4 /* Swizzling */,
 				61133BBF2423979B00786299 /* Attributes */,
 				61133B9F2423979B00786299 /* Utils */,
@@ -3608,8 +3618,9 @@
 		61E5332A24B75C3B003D6C4E /* RUM */ = {
 			isa = PBXGroup;
 			children = (
-				B3FC3C0426526EE900DEED9E /* RUMVitals */,
 				61E5332B24B75C51003D6C4E /* RUMFeature.swift */,
+				D248ED442807193B00B315B4 /* RUMTelemetry.swift */,
+				B3FC3C0426526EE900DEED9E /* RUMVitals */,
 				61E5333224B7A504003D6C4E /* DataModels */,
 				61C3E63124BF143C008053F2 /* RUMMonitor */,
 				6156CB8A24DDA186008CB2B2 /* RUMContext */,
@@ -3626,9 +3637,10 @@
 		61E5332D24B75DC7003D6C4E /* RUM */ = {
 			isa = PBXGroup;
 			children = (
+				61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */,
+				D248ED4728081B9B00B315B4 /* RUMTelemetryTests.swift */,
 				9EB4B86A27510AC80041CD03 /* WebView */,
 				B3FC3C1226526F4100DEED9E /* RUMVitals */,
-				61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */,
 				618715FA24DC5EE700FC0F69 /* DataModels */,
 				617B953B24BF4D7300E6F443 /* RUMMonitor */,
 				6156CB9124DDAA13008CB2B2 /* RUMContext */,
@@ -4953,6 +4965,7 @@
 				D2EFF3D32731822A00D09F33 /* RUMViewsHandler.swift in Sources */,
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,
 				6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */,
+				D248ED4228070E2B00B315B4 /* Telemetry.swift in Sources */,
 				9EB4B864274FAB410041CD03 /* WebLogEventConsumer.swift in Sources */,
 				61EF78B1257E2E7A00EDCCB3 /* MoveDataMigrator.swift in Sources */,
 				61133BDC2423979B00786299 /* Logger.swift in Sources */,
@@ -5037,6 +5050,7 @@
 				61E909EE24A24DD3005EA2DE /* OTFormat.swift in Sources */,
 				9E26E6B924C87693000B3270 /* RUMDataModels.swift in Sources */,
 				61D3E0D6277B23F1008BE766 /* KronosClock.swift in Sources */,
+				D248ED452807193B00B315B4 /* RUMTelemetry.swift in Sources */,
 				613E793B2577B6EE00DFCC17 /* DataReader.swift in Sources */,
 				614B0A5324EBFE5500A2A780 /* DDRUMMonitor.swift in Sources */,
 				61133BE32423979B00786299 /* UserInfoProvider.swift in Sources */,
@@ -5126,6 +5140,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D248ED4A28081D7500B315B4 /* RUMTelemetryTests.swift in Sources */,
 				61B0387D252724AB00518F3C /* URLSessionSwizzlerTests.swift in Sources */,
 				617CD0DD24CEDDD300B0B557 /* RUMUserActionScopeTests.swift in Sources */,
 				D29889C9273413ED00A4D1A9 /* RUMViewsHandlerTests.swift in Sources */,
@@ -5591,6 +5606,7 @@
 				D2CB6E4027C50EAE00A62B57 /* UIViewControllerSwizzler.swift in Sources */,
 				D2CB6E4127C50EAE00A62B57 /* RUMCurrentContext.swift in Sources */,
 				D2CB6E4227C50EAE00A62B57 /* RUMConnectivityInfoProvider.swift in Sources */,
+				D248ED462807193B00B315B4 /* RUMTelemetry.swift in Sources */,
 				D2CB6E4327C50EAE00A62B57 /* ObjcExceptionHandler.m in Sources */,
 				D2CB6E4427C50EAE00A62B57 /* UIApplicationSwizzler.swift in Sources */,
 				D2CB6E4527C50EAE00A62B57 /* RUMResourceScope.swift in Sources */,
@@ -5657,6 +5673,7 @@
 				D2CB6E8127C50EAE00A62B57 /* DataUploader.swift in Sources */,
 				D2CB6E8227C50EAE00A62B57 /* DeleteAllDataMigrator.swift in Sources */,
 				D2CB6E8327C50EAE00A62B57 /* RUMUserActionScope.swift in Sources */,
+				D248ED4328070E2B00B315B4 /* Telemetry.swift in Sources */,
 				D2CB6E8427C50EAE00A62B57 /* DDNoopRUMMonitor.swift in Sources */,
 				D2CB6E8527C50EAE00A62B57 /* Casting.swift in Sources */,
 				D2CB6E8627C50EAE00A62B57 /* RUMScope.swift in Sources */,
@@ -5735,6 +5752,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D2CB6ED727C520D400A62B57 /* URLSessionSwizzlerTests.swift in Sources */,
+				D248ED4B28081D7E00B315B4 /* RUMTelemetryTests.swift in Sources */,
 				D2CB6ED827C520D400A62B57 /* RUMUserActionScopeTests.swift in Sources */,
 				D2CB6ED927C520D400A62B57 /* RUMViewsHandlerTests.swift in Sources */,
 				D2CB6EDA27C520D400A62B57 /* Casting+Tracing.swift in Sources */,

--- a/Sources/Datadog/Core/Telemetry.swift
+++ b/Sources/Datadog/Core/Telemetry.swift
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2022 Datadog, Inc.
+ */
+
+import Foundation
+
+/// The `Telemetry` protocol defines methods to collect debug information
+/// and detect execution errors of the Datadog SDK.
+internal protocol Telemetry {
+    /// Collects debug information.
+    ///
+    /// - Parameter message: The debug message.
+    func debug(_ message: String)
+
+    /// Collect execution error.
+    /// 
+    /// - Parameters:
+    ///   - message: The error message.
+    ///   - kind: The kind of error.
+    ///   - stack: The stack trace.
+    func error(_ message: String, kind: String?, stack: String?)
+}
+
+extension Telemetry {
+    /// Collect execution error.
+    ///
+    /// - Parameters:
+    ///   - message: The error message.
+    ///   - kind: The kind of error.
+    func error(_ message: String, kind: String) {
+        error(message, kind: kind, stack: nil)
+    }
+
+    /// Collect execution error.
+    ///
+    /// - Parameters:
+    ///   - message: The error message.
+    ///   - stack: The stack trace.
+    func error(_ message: String, stack: String? = nil) {
+        error(message, kind: nil, stack: stack)
+    }
+}

--- a/Sources/Datadog/DDRUMMonitor.swift
+++ b/Sources/Datadog/DDRUMMonitor.swift
@@ -286,11 +286,6 @@ public class DDRUMMonitor {
     /// - Parameter key: key for the attribute that will be removed.
     public func removeAttribute(forKey key: AttributeKey) {}
 
-    // MARK: - RUM Telemetry
-    internal func addTelemetryDebug(withMessage message: String) {}
-
-    internal func addTelemetryError(withMessage message: String, kind: String? = nil, stack: String? = nil) {}
-
     // MARK: - Internal
 
     internal init() {}

--- a/Sources/Datadog/RUM/RUMContext/RUMCurrentContext.swift
+++ b/Sources/Datadog/RUM/RUMContext/RUMCurrentContext.swift
@@ -25,6 +25,14 @@ internal class RUMCurrentContext: RUMContextProvider {
         }
     }
 
+    // MARK: - Internal
+
+    func async(execute work: @escaping (RUMContext) -> Void) {
+        queue.async {
+            work(self.activeViewContext ?? self.sessionContext ?? self.applicationContext)
+        }
+    }
+
     // MARK: - Private
 
     private var applicationContext: RUMContext {

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -315,27 +315,3 @@ internal struct RUMKeepSessionAliveCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
 }
-
-// MARK: - RUM Telemetry Events related commands
-
-/// RUM Telemetry Debug event provides observability on the behavior of the SDK at runtime.
-internal struct RUMTelemetryDebugCommand: RUMCommand {
-    let canStartBackgroundView = false
-    let canStartApplicationLaunchView = false
-    var time: Date
-    var attributes: [AttributeKey: AttributeValue]
-
-    let message: String
-}
-
-/// RUM Telemetry Error event provides observability on Errors happening in the SDK at runtime.
-internal struct RUMTelemetryErrorCommand: RUMCommand {
-    let canStartBackgroundView = false
-    let canStartApplicationLaunchView = false
-    var time: Date
-    var attributes: [AttributeKey: AttributeValue]
-
-    let message: String
-    let kind: String?
-    let stack: String?
-}

--- a/Sources/Datadog/RUM/RUMTelemetry.swift
+++ b/Sources/Datadog/RUM/RUMTelemetry.swift
@@ -1,0 +1,118 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Sends Telemetry events to RUM.
+///
+/// `RUMTelemetry` complies to `Telemetry` protocol allowing
+/// sending telemetry events accross features.
+internal final class RUMTelemetry: Telemetry {
+    let sdkVersion: String
+    let applicationID: String
+    let dateProvider: DateProvider
+    let dateCorrector: DateCorrectorType
+
+    /// Creates a RUM Telemetry instance.
+    ///
+    /// - Parameters:
+    ///   - sdkVersion: The Datadog SDK version.
+    ///   - applicationID: The application ID.
+    ///   - dateProvider: Current device time provider.
+    ///   - dateCorrector: Date correction for adjusting device time to server time.
+    init(
+        sdkVersion: String,
+        applicationID: String,
+        dateProvider: DateProvider,
+        dateCorrector: DateCorrectorType
+    ) {
+        self.sdkVersion = sdkVersion
+        self.applicationID = applicationID
+        self.dateProvider = dateProvider
+        self.dateCorrector = dateCorrector
+    }
+
+    /// Sends a `TelemetryDebugEvent` event.
+    /// see. https://github.com/DataDog/rum-events-format/blob/master/schemas/telemetry/debug-schema.json
+    ///
+    /// The current RUM context info is applied if available, including session ID, view ID,
+    /// and action ID.
+    ///
+    /// - Parameter message: Body of the log
+    func debug(_ message: String) {
+        guard
+            let monitor = Global.rum as? RUMMonitor,
+            let writer = RUMFeature.instance?.storage.writer
+        else {
+            return
+        }
+
+        let date = dateCorrector.currentCorrection.applying(to: dateProvider.currentDate())
+
+        monitor.contextProvider.async { context in
+            let actionId = context.activeUserActionID?.toRUMDataFormat
+            let viewId = context.activeViewID?.toRUMDataFormat
+            let sessionId = context.sessionID == RUMUUID.nullUUID ? nil :context.sessionID.toRUMDataFormat
+
+            let event = TelemetryDebugEvent(
+                dd: .init(),
+                action: actionId.map { .init(id: $0) },
+                application: .init(id: self.applicationID),
+                date: date.timeIntervalSince1970.toInt64Milliseconds,
+                service: "dd-sdk-ios",
+                session: sessionId.map { .init(id: $0) },
+                source: .ios,
+                telemetry: .init(message: message),
+                version: self.sdkVersion,
+                view: viewId.map { .init(id: $0) }
+            )
+
+            writer.write(value: event)
+        }
+    }
+
+    /// Sends a `TelemetryErrorEvent` event.
+    /// see. https://github.com/DataDog/rum-events-format/blob/master/schemas/telemetry/error-schema.json
+    ///
+    /// The current RUM context info is applied if available, including session ID, view ID,
+    /// and action ID.
+    ///
+    /// - Parameters:
+    ///   - message: Body of the log
+    ///   - kind: The error type or kind (or code in some cases).
+    ///   - stack: The stack trace or the complementary information about the error.
+    func error(_ message: String, kind: String?, stack: String?) {
+        guard
+            let monitor = Global.rum as? RUMMonitor,
+            let writer = RUMFeature.instance?.storage.writer
+        else {
+            return
+        }
+
+        let date = dateCorrector.currentCorrection.applying(to: dateProvider.currentDate())
+
+        monitor.contextProvider.async { context in
+            let actionId = context.activeUserActionID?.toRUMDataFormat
+            let viewId = context.activeViewID?.toRUMDataFormat
+            let sessionId = context.sessionID == RUMUUID.nullUUID ? nil :context.sessionID.toRUMDataFormat
+
+            let event = TelemetryErrorEvent(
+                dd: .init(),
+                action: actionId.map { .init(id: $0) },
+                application: .init(id: self.applicationID),
+                date: date.timeIntervalSince1970.toInt64Milliseconds,
+                service: "dd-sdk-ios",
+                session: sessionId.map { .init(id: $0) },
+                source: .ios,
+                telemetry: .init(error: .init(kind: kind, stack: stack), message: message),
+                version: self.sdkVersion,
+                view: viewId.map { .init(id: $0) }
+            )
+
+            writer.write(value: event)
+        }
+    }
+}

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -593,30 +593,6 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         )
     }
 
-    // MARK: - RUM Telemetry
-
-    override internal func addTelemetryDebug(withMessage message: String) {
-        process(
-            command: RUMTelemetryDebugCommand(
-                time: dateProvider.currentDate(),
-                attributes: [:],
-                message: message
-            )
-        )
-    }
-
-    override internal func addTelemetryError(withMessage message: String, kind: String? = nil, stack: String? = nil) {
-        process(
-            command: RUMTelemetryErrorCommand(
-                time: dateProvider.currentDate(),
-                attributes: [:],
-                message: message,
-                kind: kind,
-                stack: stack
-            )
-        )
-    }
-
     // MARK: - Attributes
 
     override public func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
@@ -644,12 +620,8 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
 
     func process(command: RUMCommand) {
         queue.async {
-            if (command is RUMTelemetryDebugCommand) || (command is RUMTelemetryErrorCommand) {
-                _ = self.applicationScope.process(command: command)
-            } else {
-                let transformedCommand = self.transform(command: command)
-                _ = self.applicationScope.process(command: transformedCommand)
-            }
+            let transformedCommand = self.transform(command: command)
+            _ = self.applicationScope.process(command: transformedCommand)
 
             if let debugging = self.debugging {
                 debugging.debug(applicationScope: self.applicationScope)

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -86,6 +86,26 @@ extension RUMResourceType {
     static func mockAny() -> RUMResourceType { .image }
 }
 
+// MARK: - RUMTelemetry Mocks
+
+extension RUMTelemetry: AnyMockable {
+    static func mockAny() -> Self { .mockWith() }
+
+    static func mockWith(
+        sdkVersion: String = .mockAny(),
+        applicationID: String = .mockAny(),
+        dateProvider: DateProvider = SystemDateProvider(),
+        dateCorrector: DateCorrectorType = DateCorrectorMock()
+    ) -> Self {
+        .init(
+            sdkVersion: sdkVersion,
+            applicationID: applicationID,
+            dateProvider: dateProvider,
+            dateCorrector: dateCorrector
+        )
+    }
+}
+
 // MARK: - RUMDataModel Mocks
 
 struct RUMDataModelMock: RUMDataModel, RUMSanitizableEvent, EquatableInTests {

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2022 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class RUMTelemetryTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        temporaryFeatureDirectories.create()
+
+        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        Global.rum = RUMMonitor.initialize()
+    }
+
+    override func tearDown() {
+        RUMFeature.instance?.deinitialize()
+        Global.rum = DDNoopRUMMonitor()
+
+        temporaryFeatureDirectories.delete()
+        super.tearDown()
+    }
+
+    // MARK: - Sending Telemetry events
+
+    func testSendTelemetryDebug() throws {
+        let telemetry: RUMTelemetry = .mockWith(
+            dateProvider: RelativeDateProvider(
+                using: .init(timeIntervalSince1970: 0)
+            )
+        )
+
+        telemetry.debug("Hello world!")
+
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 1)
+        try rumEventMatchers.lastRUMEvent(ofType: TelemetryDebugEvent.self).model(ofType: TelemetryDebugEvent.self) { event in
+            XCTAssertEqual(event.date, 0)
+            XCTAssertEqual(event.application?.id, telemetry.applicationID)
+            XCTAssertEqual(event.version, telemetry.sdkVersion)
+            XCTAssertEqual(event.service, "dd-sdk-ios")
+            XCTAssertEqual(event.source, .ios)
+            XCTAssertEqual(event.telemetry.message, "Hello world!")
+        }
+    }
+
+    func testSendTelemetryError() throws {
+        let telemetry: RUMTelemetry = .mockWith(
+            dateProvider: RelativeDateProvider(
+                using: .init(timeIntervalSince1970: 0)
+            )
+        )
+        telemetry.error("Oops", kind: "OutOfMemory", stack: "a\nhay\nneedle\nstack")
+
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 1)
+        try rumEventMatchers.lastRUMEvent(ofType: TelemetryErrorEvent.self).model(ofType: TelemetryErrorEvent.self) { event in
+            XCTAssertEqual(event.date, 0)
+            XCTAssertEqual(event.application?.id, telemetry.applicationID)
+            XCTAssertEqual(event.version, telemetry.sdkVersion)
+            XCTAssertEqual(event.service, "dd-sdk-ios")
+            XCTAssertEqual(event.source, .ios)
+            XCTAssertEqual(event.telemetry.message, "Oops")
+            XCTAssertEqual(event.telemetry.error?.kind, "OutOfMemory")
+            XCTAssertEqual(event.telemetry.error?.stack, "a\nhay\nneedle\nstack")
+        }
+    }
+
+    func testSendTelemetryDebug_withRUMContext() throws {
+        let telemetry: RUMTelemetry = .mockAny()
+
+        Global.rum.startView(viewController: mockView)
+        Global.rum.startUserAction(type: .scroll, name: .mockAny())
+        telemetry.debug("telemetry debug")
+
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
+        try rumEventMatchers.lastRUMEvent(ofType: TelemetryDebugEvent.self).model(ofType: TelemetryDebugEvent.self) { event in
+            XCTAssertEqual(event.telemetry.message, "telemetry debug")
+            XCTAssertValidRumUUID(event.action?.id)
+            XCTAssertValidRumUUID(event.view?.id)
+            XCTAssertValidRumUUID(event.session?.id)
+        }
+    }
+
+    func testSendTelemetryError_withRUMContext() throws {
+        let telemetry: RUMTelemetry = .mockAny()
+
+        Global.rum.startView(viewController: mockView)
+        Global.rum.startUserAction(type: .scroll, name: .mockAny())
+        telemetry.error("telemetry error")
+
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
+        try rumEventMatchers.lastRUMEvent(ofType: TelemetryErrorEvent.self).model(ofType: TelemetryErrorEvent.self) { event in
+            XCTAssertEqual(event.telemetry.message, "telemetry error")
+            XCTAssertValidRumUUID(event.action?.id)
+            XCTAssertValidRumUUID(event.view?.id)
+            XCTAssertValidRumUUID(event.session?.id)
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -584,54 +584,6 @@ class RUMMonitorTests: XCTestCase {
             }
     }
 
-    // MARK: - Sending Telemetry events
-
-    func testStartingView_thenTelemetryDebug() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
-            dependencies: .mockWith(
-                dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
-            )
-        )
-        defer { RUMFeature.instance?.deinitialize() }
-
-        let monitor = RUMMonitor.initialize()
-        setGlobalAttributes(of: monitor)
-
-        monitor.startView(viewController: mockView)
-        monitor.addTelemetryDebug(withMessage: "Hello world!")
-        monitor.stopView(viewController: mockView)
-
-        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
-        try rumEventMatchers.lastRUMEvent(ofType: TelemetryDebugEvent.self).model(ofType: TelemetryDebugEvent.self) { telemetryDebug in
-            XCTAssertEqual(telemetryDebug.telemetry.message, "Hello world!")
-        }
-    }
-
-    func testStartingView_thenTelemetryError() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
-            dependencies: .mockWith(
-                dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
-            )
-        )
-        defer { RUMFeature.instance?.deinitialize() }
-
-        let monitor = RUMMonitor.initialize()
-        setGlobalAttributes(of: monitor)
-
-        monitor.startView(viewController: mockView)
-        monitor.addTelemetryError(withMessage: "Oops", kind: "OutOfMemory", stack: "a\nhay\nneedle\nstack")
-        monitor.stopView(viewController: mockView)
-
-        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 4)
-        try rumEventMatchers.lastRUMEvent(ofType: TelemetryErrorEvent.self).model(ofType: TelemetryErrorEvent.self) { telemetryError in
-            XCTAssertEqual(telemetryError.telemetry.message, "Oops")
-            XCTAssertEqual(telemetryError.telemetry.error?.kind, "OutOfMemory")
-            XCTAssertEqual(telemetryError.telemetry.error?.stack, "a\nhay\nneedle\nstack")
-        }
-    }
-
     // MARK: - Sending user info
 
     func testWhenUserInfoIsProvided_itIsSendWithAllEvents() throws {


### PR DESCRIPTION
### What and why?

Isolate RUM Telemetry apis for cross feature usage.

### How?

Creates a `Telemetry` protocol to be used across features and in core layer of the SDK. RUM then complies to the protocol through `RUMTelemetry` to send debug and error messages as RUM Telemetry events.

### Review checklist

- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] ~~Add CHANGELOG entry for user facing change.~~
