### PR TITLE
RUMM-2027 Add RUM Telemetry sampling

### DIFF
--- a/Datadog/E2ETests/Helpers/DatadogE2EHelpers.swift
+++ b/Datadog/E2ETests/Helpers/DatadogE2EHelpers.swift
@@ -12,6 +12,6 @@ extension Datadog.Configuration {
             rumApplicationID: E2EConfig.readRUMApplicationID(),
             clientToken: E2EConfig.readClientToken(),
             environment: E2EConfig.readEnv()
-        )
+        ).set(sampleTelemetry: 100)
     }
 }

--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -40,6 +40,7 @@ struct ExampleAppConfiguration: AppConfiguration {
             .set(serviceName: serviceName)
             .set(batchSize: .small)
             .set(uploadFrequency: .frequent)
+            .set(sampleTelemetry: 100)
 
         if let customLogsURL = Environment.readCustomLogsURL() {
             _ = configuration.set(customLogsEndpoint: customLogsURL)

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -51,6 +51,7 @@ internal struct FeaturesConfiguration {
         let clientToken: String
         let applicationID: String
         let sessionSampler: Sampler
+        let telemetrySampler: Sampler
         let uuidGenerator: RUMUUIDGenerator
         let viewEventMapper: RUMViewEventMapper?
         let resourceEventMapper: RUMResourceEventMapper?
@@ -197,6 +198,7 @@ extension FeaturesConfiguration {
                     clientToken: try ifValid(clientToken: configuration.clientToken),
                     applicationID: rumApplicationID,
                     sessionSampler: Sampler(samplingRate: debugOverride ? 100.0 : configuration.rumSessionsSamplingRate),
+                    telemetrySampler: Sampler(samplingRate: configuration.rumTelemetrySamplingRate),
                     uuidGenerator: DefaultRUMUUIDGenerator(),
                     viewEventMapper: configuration.rumViewEventMapper,
                     resourceEventMapper: configuration.rumResourceEventMapper,

--- a/Sources/Datadog/Core/Telemetry.swift
+++ b/Sources/Datadog/Core/Telemetry.swift
@@ -33,7 +33,7 @@ extension Telemetry {
     ///   - message: The debug message.
     ///   - file: The current file name.
     ///   - line: The line number in file.
-    func debug(_ message: String, file: String = #fileID, line: Int = #line) {
+    func debug(_ message: String, file: String = #file, line: Int = #line) {
         debug(id: "\(file):\(line):\(message)", message: message)
     }
 
@@ -44,7 +44,9 @@ extension Telemetry {
     ///   - stack: The stack trace.
     ///   - file: The current file name.
     ///   - line: The line number in file.
-    func error(_ message: String, kind: String? = nil, stack: String? = nil, file: String = #fileID, line: Int = #line) {
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    func error(_ message: String, kind: String? = nil, stack: String? = nil, file: String = #file, line: Int = #line) {
         error(id: "\(file):\(line):\(message)", message: message, kind: kind, stack: stack)
     }
 
@@ -52,8 +54,10 @@ extension Telemetry {
     ///
     /// - Parameters:
     ///   - error: The error.
-    func error(_ error: DDError) {
-        self.error(error.message, kind: error.type, stack: error.stack)
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    func error(_ error: DDError, file: String = #file, line: Int = #line) {
+        self.error(error.message, kind: error.type, stack: error.stack, file: file, line: line)
     }
 
     /// Collect execution error.
@@ -61,16 +65,20 @@ extension Telemetry {
     /// - Parameters:
     ///   - message: The error message.
     ///   - error: The error.
-    func error(_ message: String, error: DDError) {
-        self.error("\(message) - \(error.message)", kind: error.type, stack: error.stack)
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    func error(_ message: String, error: DDError, file: String = #file, line: Int = #line) {
+        self.error("\(message) - \(error.message)", kind: error.type, stack: error.stack, file: file, line: line)
     }
 
     /// Collect execution error.
     ///
     /// - Parameters:
     ///   - error: The error.
-    func error(_ error: Error) {
-        self.error(DDError(error: error))
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    func error(_ error: Error, file: String = #file, line: Int = #line) {
+        self.error(DDError(error: error), file: file, line: line)
     }
 
     /// Collect execution error.
@@ -78,7 +86,9 @@ extension Telemetry {
     /// - Parameters:
     ///   - message: The error message.
     ///   - error: The error.
-    func error(_ message: String, error: Error) {
-        self.error(message, error: DDError(error: error))
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    func error(_ message: String, error: Error, file: String = #file, line: Int = #line) {
+        self.error(message, error: DDError(error: error), file: file, line: line)
     }
 }

--- a/Sources/Datadog/Core/Telemetry.swift
+++ b/Sources/Datadog/Core/Telemetry.swift
@@ -11,26 +11,30 @@ import Foundation
 internal protocol Telemetry {
     /// Collects debug information.
     ///
-    /// - Parameter message: The debug message.
-    func debug(_ message: String)
+    /// - Parameters:
+    ///   - id: Identity of the debug log, this can be used to prevent duplicates.
+    ///   - message: The debug message.
+    func debug(id: String, message: String)
 
     /// Collect execution error.
     /// 
     /// - Parameters:
+    ///   - id: Identity of the debug log, this can be used to prevent duplicates.
     ///   - message: The error message.
     ///   - kind: The kind of error.
     ///   - stack: The stack trace.
-    func error(_ message: String, kind: String?, stack: String?)
+    func error(id: String, message: String, kind: String?, stack: String?)
 }
 
 extension Telemetry {
-    /// Collect execution error.
+    /// Collects debug information.
     ///
     /// - Parameters:
-    ///   - message: The error message.
-    ///   - kind: The kind of error.
-    func error(_ message: String, kind: String) {
-        error(message, kind: kind, stack: nil)
+    ///   - message: The debug message.
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    func debug(_ message: String, file: String = #fileID, line: Int = #line) {
+        debug(id: "\(file):\(line):\(message)", message: message)
     }
 
     /// Collect execution error.
@@ -38,8 +42,10 @@ extension Telemetry {
     /// - Parameters:
     ///   - message: The error message.
     ///   - stack: The stack trace.
-    func error(_ message: String, stack: String? = nil) {
-        error(message, kind: nil, stack: stack)
+    ///   - file: The current file name.
+    ///   - line: The line number in file.
+    func error(_ message: String, kind: String? = nil, stack: String? = nil, file: String = #fileID, line: Int = #line) {
+        error(id: "\(file):\(line):\(message)", message: message, kind: kind, stack: stack)
     }
 
     /// Collect execution error.

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -228,7 +228,8 @@ public class Datadog {
                 applicationID: rumConfiguration.applicationID,
                 source: rumConfiguration.common.source,
                 dateProvider: dateProvider,
-                dateCorrector: dateCorrector
+                dateCorrector: dateCorrector,
+                sampler: rumConfiguration.telemetrySampler
             )
 
             rum = RUMFeature(

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -263,6 +263,7 @@ extension Datadog {
         private(set) var rumLongTaskEventMapper: RUMLongTaskEventMapper?
         private(set) var rumResourceAttributesProvider: URLSessionRUMAttributesProvider?
         private(set) var rumBackgroundEventTrackingEnabled: Bool
+        private(set) var rumTelemetrySamplingRate: Float
         private(set) var batchSize: BatchSize
         private(set) var uploadFrequency: UploadFrequency
         private(set) var additionalConfiguration: [String: Any]
@@ -335,6 +336,7 @@ extension Datadog {
                     rumErrorEventMapper: nil,
                     rumResourceAttributesProvider: nil,
                     rumBackgroundEventTrackingEnabled: false,
+                    rumTelemetrySamplingRate: 20,
                     batchSize: .medium,
                     uploadFrequency: .average,
                     additionalConfiguration: [:],
@@ -683,6 +685,15 @@ extension Datadog {
             /// - Parameter enabled: `true` by default
             public func trackBackgroundEvents(_ enabled: Bool = true) -> Builder {
                 configuration.rumBackgroundEventTrackingEnabled = enabled
+                return self
+            }
+
+            /// Sets the sampling rate for Internal Telemetry (info related to the work of the SDK internals). Default value is 20.
+            ///
+            /// - Parameter rate: the sampling rate must be a value between 0 and 100. A value of 0
+            ///                   means no telemetry will be sent, 100 means all telemetry will be kept.
+            public func set(sampleTelemetry rate: Float) -> Builder {
+                configuration.rumTelemetrySamplingRate = rate
                 return self
             }
 

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -147,7 +147,7 @@ internal final class RUMFeature {
             upload: upload,
             configuration: configuration,
             commonDependencies: commonDependencies,
-            vitalCPUReader: VitalCPUReader(),
+            vitalCPUReader: VitalCPUReader(telemetry: telemetry),
             vitalMemoryReader: VitalMemoryReader(),
             vitalRefreshRateReader: VitalRefreshRateReader(),
             onSessionStart: configuration.onSessionStart

--- a/Sources/Datadog/RUM/RUMTelemetry.swift
+++ b/Sources/Datadog/RUM/RUMTelemetry.swift
@@ -28,7 +28,7 @@ internal final class RUMTelemetry: Telemetry {
     private var currentSessionID: RUMUUID = .nullUUID
 
     /// Keeps track of event's ids recorded during a user session.
-    private var eventIDs: [String] = []
+    private var eventIDs: Set<String> = []
 
     /// Creates a RUM Telemetry instance.
     ///
@@ -142,7 +142,7 @@ internal final class RUMTelemetry: Telemetry {
 
             // record up de `MaxEventsPerSessions`, discard duplicates
             if self.eventIDs.count < RUMTelemetry.MaxEventsPerSessions, !self.eventIDs.contains(id) {
-                self.eventIDs.append(id)
+                self.eventIDs.insert(id)
                 operation(context, writer)
             }
         }

--- a/Sources/Datadog/RUM/RUMVitals/VitalCPUReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalCPUReader.swift
@@ -14,7 +14,13 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
     private var totalInactiveTicks: natural_t = 0
     private var utilizedTicksWhenResigningActive: natural_t? = nil
 
-    init(notificationCenter: NotificationCenter = .default) {
+    let telemetry: Telemetry?
+
+    init(
+        notificationCenter: NotificationCenter = .default,
+        telemetry: Telemetry? = nil
+    ) {
+        self.telemetry = telemetry
         notificationCenter.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
@@ -65,11 +71,7 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
         if result != KERN_SUCCESS {
             // in case of error, refer to `kern_return.h` (Objc)
             // as its Swift interface doesn't have integer values
-            //
-            // NOTE: RUMM-1276 consider using sdkLogger.errorOnce(...) to avoid flooding
-//            InternalMonitoringFeature.instance?.monitor.sdkLogger.error(
-//                "CPU Vital cannot be read! Error code: \(result)"
-//            )
+            telemetry?.error("CPU Vital cannot be read! Error code: \(result)")
             return nil
         }
 

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -146,6 +146,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.firstPartyHosts, ["example.com"])
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 42.5)
             XCTAssertNotNil(configuration.rumSessionsListener)
+            XCTAssertEqual(configuration.rumTelemetrySamplingRate, 20)
             XCTAssertTrue(configuration.rumUIKitViewsPredicate is UIKitRUMViewsPredicateMock)
             XCTAssertTrue(configuration.rumUIKitUserActionsPredicate is UIKitRUMUserActionsPredicateMock)
             XCTAssertEqual(configuration.rumLongTaskDurationThreshold, 100.0)

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -55,6 +55,7 @@ extension Datadog.Configuration {
         rumLongTaskDurationThreshold: TimeInterval? = nil,
         rumResourceAttributesProvider: URLSessionRUMAttributesProvider? = nil,
         rumBackgroundEventTrackingEnabled: Bool = false,
+        rumTelemetrySamplingRate: Float = 100.0,
         batchSize: BatchSize = .medium,
         uploadFrequency: UploadFrequency = .average,
         additionalConfiguration: [String: Any] = [:],
@@ -84,6 +85,7 @@ extension Datadog.Configuration {
             rumLongTaskDurationThreshold: rumLongTaskDurationThreshold,
             rumResourceAttributesProvider: rumResourceAttributesProvider,
             rumBackgroundEventTrackingEnabled: rumBackgroundEventTrackingEnabled,
+            rumTelemetrySamplingRate: rumTelemetrySamplingRate,
             batchSize: batchSize,
             uploadFrequency: uploadFrequency,
             additionalConfiguration: additionalConfiguration,
@@ -257,6 +259,7 @@ extension FeaturesConfiguration.RUM {
         clientToken: String = .mockAny(),
         applicationID: String = .mockAny(),
         sessionSampler: Sampler = Sampler(samplingRate: 100),
+        telemetrySampler: Sampler = Sampler(samplingRate: 100),
         uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
         viewEventMapper: RUMViewEventMapper? = nil,
         resourceEventMapper: RUMResourceEventMapper? = nil,
@@ -265,7 +268,7 @@ extension FeaturesConfiguration.RUM {
         longTaskEventMapper: RUMLongTaskEventMapper? = nil,
         instrumentation: FeaturesConfiguration.RUM.Instrumentation? = nil,
         backgroundEventTrackingEnabled: Bool = false,
-        onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListerner()
+        onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListener()
     ) -> Self {
         return .init(
             common: common,
@@ -273,6 +276,7 @@ extension FeaturesConfiguration.RUM {
             clientToken: clientToken,
             applicationID: applicationID,
             sessionSampler: sessionSampler,
+            telemetrySampler: telemetrySampler,
             uuidGenerator: uuidGenerator,
             viewEventMapper: viewEventMapper,
             resourceEventMapper: resourceEventMapper,

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -298,12 +298,12 @@ class TelemetryMock: Telemetry, CustomStringConvertible {
     private(set) var errors: [(message: String, kind: String?, stack: String?)] = []
     private(set) var description: String = "Telemetry logs:"
 
-    func debug(_ message: String) {
+    func debug(id: String, message: String) {
         debugs.append(message)
         description.append("\n- [debug] \(message)")
     }
 
-    func error(_ message: String, kind: String?, stack: String?) {
+    func error(id: String, message: String, kind: String?, stack: String?) {
         errors.append((message: message, kind: kind, stack: stack))
         description.append("\n - [error] \(message), kind: \(kind ?? "nil"), stack: \(stack ?? "nil")")
     }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -104,14 +104,16 @@ extension RUMTelemetry: AnyMockable {
         applicationID: String = .mockAny(),
         source: String = .mockAnySource(),
         dateProvider: DateProvider = SystemDateProvider(),
-        dateCorrector: DateCorrectorType = DateCorrectorMock()
+        dateCorrector: DateCorrectorType = DateCorrectorMock(),
+        sampler: Sampler = .init(samplingRate: 100)
     ) -> Self {
         .init(
             sdkVersion: sdkVersion,
             applicationID: applicationID,
             source: source,
             dateProvider: dateProvider,
-            dateCorrector: dateCorrector
+            dateCorrector: dateCorrector,
+            sampler: sampler
         )
     }
 }
@@ -637,7 +639,7 @@ internal struct NoOpRUMViewUpdatesThrottler: RUMViewUpdatesThrottlerType {
     }
 }
 
-func mockNoOpSessionListerner() -> RUMSessionListener {
+func mockNoOpSessionListener() -> RUMSessionListener {
     return { _, _ in }
 }
 
@@ -669,7 +671,7 @@ extension RUMScopeDependencies {
         crashContextIntegration: RUMWithCrashContextIntegration? = nil,
         ciTest: RUMCITest? = nil,
         viewUpdatesThrottlerFactory: @escaping () -> RUMViewUpdatesThrottlerType = { NoOpRUMViewUpdatesThrottler() },
-        onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListerner()
+        onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListener()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
             rumApplicationID: rumApplicationID,

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -118,12 +118,12 @@ class RUMTelemetryTests: XCTestCase {
 
     func testTelemetryErrorFormatting() {
         class TelemetryTest: Telemetry {
-            var record: (message: String, kind: String?, stack: String?)?
+            var record: (id: String, message: String, kind: String?, stack: String?)?
 
             func debug(id: String, message: String) { }
 
             func error(id: String, message: String, kind: String?, stack: String?) {
-                record = (message: message, kind: kind, stack: stack)
+                record = (id: id, message: message, kind: kind, stack: stack)
             }
         }
 
@@ -143,12 +143,20 @@ class RUMTelemetryTests: XCTestCase {
             ]
         )
 
+        #sourceLocation(file: "File.swift", line: 1)
         telemetry.error(swiftError)
+        #sourceLocation()
+
+        XCTAssertEqual(telemetry.record?.id, #"File.swift:1:SwiftError(description: "error description")"#)
         XCTAssertEqual(telemetry.record?.message, #"SwiftError(description: "error description")"#)
         XCTAssertEqual(telemetry.record?.kind, "SwiftError")
         XCTAssertEqual(telemetry.record?.stack, #"SwiftError(description: "error description")"#)
 
+        #sourceLocation(file: "File.swift", line: 2)
         telemetry.error(nsError)
+        #sourceLocation()
+
+        XCTAssertEqual(telemetry.record?.id, "File.swift:2:error description")
         XCTAssertEqual(telemetry.record?.message, "error description")
         XCTAssertEqual(telemetry.record?.kind, "custom-domain - 10")
         XCTAssertEqual(

--- a/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMEventMatcher.swift
@@ -138,6 +138,10 @@ extension Array where Element == RUMEventMatcher {
         return try filter { matcher in matcher.model(isTypeOf: type) }
             .forEach { matcher in body(try matcher.model()) }
     }
+
+    func compactMap<DM: Decodable>(_ type: DM.Type) throws -> [DM] {
+        return try filter { $0.model(isTypeOf: type) }.map { try $0.model() }
+    }
 }
 
 func XCTAssertValidRumUUID(_ string: String?, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
### What and why?

Add RUM telemetry event sampling, discard duplicates, and report up to 100 events per sessions.

### How?

`RUMTelemetry` class now takes a sampler parameter and implement a log validation before recording the telemetry event.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] ~~Add CHANGELOG entry for user facing changes~~

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
