### PR TITLE
RUMM-2105 RUMResourceScope converts negative duration to positive

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -162,7 +162,7 @@ internal class RUMResourceScope: RUMScope {
                         start: metric.start.timeIntervalSince(resourceStartTime).toInt64Nanoseconds
                     )
                 },
-                duration: resourceDuration.toInt64Nanoseconds,
+                duration: resolveResourceDuration(resourceDuration),
                 firstByte: resourceMetrics?.firstByte.flatMap { metric in
                     .init(
                         duration: metric.duration.toInt64Nanoseconds,
@@ -301,5 +301,17 @@ internal class RUMResourceScope: RUMScope {
 
     private func providerDomain(from url: String) -> String? {
         return URL(string: url)?.host ?? url
+    }
+
+    private func resolveResourceDuration(_ duration: TimeInterval) -> Int64 {
+        if duration <= 0.0 {
+            let negativeDurationWarningMessage =
+            """
+            The computed duration for your resource: \(resourceURL) was 0 or negative. In order to keep the resource event we forced it to 1ns.
+            """
+            userLogger.warn(negativeDurationWarningMessage)
+            return 1 // 1ns
+        }
+        return duration.toInt64Nanoseconds
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -106,6 +106,72 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.service, randomServiceName)
     }
 
+    func testGivenStartedResource_whenResourceLoadingEndsWithNegativeDuration_itSendsResourceEventWithPositiveDuration() throws {
+        var currentTime: Date = .mockDecember15th2019At10AMUTC()
+
+        // Given
+        let scope = RUMResourceScope.mockWith(
+            context: context,
+            dependencies: dependencies,
+            resourceKey: "/resource/1",
+            attributes: [:],
+            startTime: currentTime,
+            dateCorrection: .zero,
+            url: "https://foo.com/resource/1",
+            httpMethod: .post,
+            isFirstPartyResource: nil,
+            resourceKindBasedOnRequest: nil,
+            spanContext: .init(traceID: "100", spanID: "200")
+        )
+
+        currentTime.addTimeInterval(-1)
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopResourceCommand(
+                    resourceKey: "/resource/1",
+                    time: currentTime,
+                    attributes: ["foo": "bar"],
+                    kind: .image,
+                    httpStatusCode: 200,
+                    size: 1_024
+                )
+            )
+        )
+
+        // Then
+        let event = try XCTUnwrap(output.recordedEvents(ofType: RUMResourceEvent.self).first)
+        XCTAssertEqual(event.date, Date.mockDecember15th2019At10AMUTC().timeIntervalSince1970.toInt64Milliseconds)
+        XCTAssertEqual(event.application.id, scope.context.rumApplicationID)
+        XCTAssertEqual(event.session.id, scope.context.sessionID.toRUMDataFormat)
+        XCTAssertEqual(event.session.type, .user)
+        XCTAssertEqual(event.source, .ios)
+        XCTAssertEqual(event.view.id, context.activeViewID?.toRUMDataFormat)
+        XCTAssertEqual(event.view.url, "FooViewController")
+        XCTAssertEqual(event.view.name, "FooViewName")
+        XCTAssertValidRumUUID(event.resource.id)
+        XCTAssertEqual(event.resource.type, .image)
+        XCTAssertEqual(event.resource.method, .post)
+        XCTAssertNil(event.resource.provider)
+        XCTAssertEqual(event.resource.url, "https://foo.com/resource/1")
+        XCTAssertEqual(event.resource.statusCode, 200)
+        XCTAssertEqual(event.resource.duration, 1)
+        XCTAssertEqual(event.resource.size, 1_024)
+        XCTAssertNil(event.resource.redirect)
+        XCTAssertNil(event.resource.dns)
+        XCTAssertNil(event.resource.connect)
+        XCTAssertNil(event.resource.ssl)
+        XCTAssertNil(event.resource.firstByte)
+        XCTAssertNil(event.resource.download)
+        XCTAssertEqual(try XCTUnwrap(event.action?.id), context.activeUserActionID?.toRUMDataFormat)
+        XCTAssertEqual(event.context?.contextInfo as? [String: String], ["foo": "bar"])
+        XCTAssertEqual(event.dd.traceId, "100")
+        XCTAssertEqual(event.dd.spanId, "200")
+        XCTAssertEqual(event.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
+        XCTAssertEqual(event.service, randomServiceName)
+    }
+
     func testGivenStartedResource_whenResourceLoadingEnds_itSendsResourceEventWithCustomSpanAndTraceId() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 


### PR DESCRIPTION
### What and why?

iOS port of https://github.com/DataDog/dd-sdk-android/pull/900

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
