### PR TITLE
Fix RUM events to support sending correctly configured `source` value

### DIFF
--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -226,6 +226,7 @@ public class Datadog {
             telemetry = RUMTelemetry(
                 sdkVersion: configuration.common.sdkVersion,
                 applicationID: rumConfiguration.applicationID,
+                source: rumConfiguration.common.source,
                 dateProvider: dateProvider,
                 dateCorrector: dateCorrector
             )

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -253,7 +253,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 id: lastRUMView.session.id,
                 type: lastRUMView.ciTest != nil ? .ciTest : .user
             ),
-            source: .ios,
+            source: lastRUMView.source?.toErrorEventSource ?? .ios,
             synthetics: nil,
             usr: lastRUMView.usr,
             version: lastRUMView.version,
@@ -286,7 +286,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds - 1, // -1ms to put the crash after view in RUM session
             service: original.service,
             session: original.session,
-            source: .ios,
+            source: original.source ?? .ios,
             synthetics: nil,
             usr: original.usr,
             version: original.version,
@@ -359,7 +359,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 id: sessionUUID.toRUMDataFormat,
                 type: CITestIntegration.active != nil ? .ciTest : .user
             ),
-            source: .ios,
+            source: .init(rawValue: rumConfiguration.common.source) ?? .ios,
             synthetics: nil,
             usr: crashContext.lastUserInfo.flatMap { RUMUser(userInfo: $0) },
             version: rumConfiguration.common.applicationVersion,

--- a/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModelsMapping.swift
@@ -44,3 +44,15 @@ internal extension RUMUserActionType {
         }
     }
 }
+
+internal extension RUMViewEvent.Source {
+    var toErrorEventSource: RUMErrorEvent.Source {
+        switch self {
+        case .ios: return .ios
+        case .android: return .android
+        case .browser: return .browser
+        case .reactNative: return .reactNative
+        case .flutter: return .flutter
+        }
+    }
+}

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -195,7 +195,7 @@ internal class RUMResourceScope: RUMScope {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .ios,
+            source: .init(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,
@@ -253,7 +253,7 @@ internal class RUMResourceScope: RUMScope {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .ios,
+            source: .init(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -22,6 +22,7 @@ internal struct RUMScopeDependencies {
     let serviceName: String
     let applicationVersion: String
     let sdkVersion: String
+    let source: String
     let eventBuilder: RUMEventBuilder
     let eventOutput: RUMEventOutput
     let rumUUIDGenerator: RUMUUIDGenerator
@@ -59,6 +60,7 @@ internal extension RUMScopeDependencies {
             serviceName: rumFeature.configuration.common.serviceName,
             applicationVersion: rumFeature.configuration.common.applicationVersion,
             sdkVersion: rumFeature.configuration.common.sdkVersion,
+            source: rumFeature.configuration.common.source,
             eventBuilder: RUMEventBuilder(
                 eventsMapper: rumFeature.eventsMapper
             ),

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -159,7 +159,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .ios,
+            source: .init(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -348,7 +348,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .ios,
+            source: .init(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,
@@ -398,7 +398,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .ios,
+            source: .init(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,
@@ -489,7 +489,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .ios,
+            source: .init(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,
@@ -532,7 +532,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .ios,
+            source: .init(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,

--- a/Sources/Datadog/RUM/RUMTelemetry.swift
+++ b/Sources/Datadog/RUM/RUMTelemetry.swift
@@ -13,6 +13,7 @@ import Foundation
 internal final class RUMTelemetry: Telemetry {
     let sdkVersion: String
     let applicationID: String
+    let source: String
     let dateProvider: DateProvider
     let dateCorrector: DateCorrectorType
 
@@ -26,11 +27,13 @@ internal final class RUMTelemetry: Telemetry {
     init(
         sdkVersion: String,
         applicationID: String,
+        source: String,
         dateProvider: DateProvider,
         dateCorrector: DateCorrectorType
     ) {
         self.sdkVersion = sdkVersion
         self.applicationID = applicationID
+        self.source = source
         self.dateProvider = dateProvider
         self.dateCorrector = dateCorrector
     }
@@ -64,7 +67,7 @@ internal final class RUMTelemetry: Telemetry {
                 date: date.timeIntervalSince1970.toInt64Milliseconds,
                 service: "dd-sdk-ios",
                 session: sessionId.map { .init(id: $0) },
-                source: .ios,
+                source: .init(rawValue: self.source) ?? .ios,
                 telemetry: .init(message: message),
                 version: self.sdkVersion,
                 view: viewId.map { .init(id: $0) }
@@ -106,7 +109,7 @@ internal final class RUMTelemetry: Telemetry {
                 date: date.timeIntervalSince1970.toInt64Milliseconds,
                 service: "dd-sdk-ios",
                 session: sessionId.map { .init(id: $0) },
-                source: .ios,
+                source: .init(rawValue: self.source) ?? .ios,
                 telemetry: .init(error: .init(kind: kind, stack: stack), message: message),
                 version: self.sdkVersion,
                 view: viewId.map { .init(id: $0) }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -319,3 +319,9 @@ extension RUMLongTaskEvent: RandomMockable {
         )
     }
 }
+
+extension String {
+    static func mockAnySource() -> String {
+        return ["ios", "android", "browser", "ios", "react-native", "flutter"].randomElement()!
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -102,12 +102,14 @@ extension RUMTelemetry: AnyMockable {
     static func mockWith(
         sdkVersion: String = .mockAny(),
         applicationID: String = .mockAny(),
+        source: String = .mockAnySource(),
         dateProvider: DateProvider = SystemDateProvider(),
         dateCorrector: DateCorrectorType = DateCorrectorMock()
     ) -> Self {
         .init(
             sdkVersion: sdkVersion,
             applicationID: applicationID,
+            source: source,
             dateProvider: dateProvider,
             dateCorrector: dateCorrector
         )
@@ -659,6 +661,7 @@ extension RUMScopeDependencies {
         serviceName: String = .mockAny(),
         applicationVersion: String = .mockAny(),
         sdkVersion: String = .mockAny(),
+        source: String = "ios",
         eventBuilder: RUMEventBuilder = RUMEventBuilder(eventsMapper: .mockNoOp()),
         eventOutput: RUMEventOutput = RUMEventOutputMock(),
         rumUUIDGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
@@ -680,6 +683,7 @@ extension RUMScopeDependencies {
             serviceName: serviceName,
             applicationVersion: applicationVersion,
             sdkVersion: sdkVersion,
+            source: source,
             eventBuilder: eventBuilder,
             eventOutput: eventOutput,
             rumUUIDGenerator: rumUUIDGenerator,
@@ -707,6 +711,7 @@ extension RUMScopeDependencies {
         serviceName: String? = nil,
         applicationVersion: String? = nil,
         sdkVersion: String? = nil,
+        source: String? = nil,
         eventBuilder: RUMEventBuilder? = nil,
         eventOutput: RUMEventOutput? = nil,
         rumUUIDGenerator: RUMUUIDGenerator? = nil,
@@ -728,6 +733,7 @@ extension RUMScopeDependencies {
             serviceName: serviceName ?? self.serviceName,
             applicationVersion: applicationVersion ?? self.applicationVersion,
             sdkVersion: sdkVersion ?? self.sdkVersion,
+            source: source ?? self.source,
             eventBuilder: eventBuilder ?? self.eventBuilder,
             eventOutput: eventOutput ?? self.eventOutput,
             rumUUIDGenerator: rumUUIDGenerator ?? self.rumUUIDGenerator,

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -66,6 +66,27 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertEqual(recordedAction.service, randomServiceName)
     }
 
+    func testGivenCustomSource_whenActionIsSent_itSendsCustomSource() throws {
+        let customSource = String.mockAnySource()
+        let scope = RUMViewScope.mockWith(
+            parent: parent,
+            dependencies: dependencies.replacing(
+                source: customSource
+            ),
+            identity: mockView,
+            attributes: [:],
+            startTime: Date()
+        )
+        XCTAssertTrue(scope.process(command: RUMStartViewCommand.mockWith(identity: mockView)))
+        let mockUserActionCmd = RUMAddUserActionCommand.mockAny()
+        XCTAssertTrue(scope.process(command: mockUserActionCmd))
+        XCTAssertFalse(scope.process(command: RUMStopViewCommand.mockWith(identity: mockView)))
+
+        let recordedActionEvents = try output.recordedEvents(ofType: RUMActionEvent.self)
+        let recordedAction = try XCTUnwrap(recordedActionEvents.last)
+        XCTAssertEqual(recordedAction.source, RUMActionEvent.Source(rawValue: customSource))
+    }
+
     // MARK: - Continuous User Action
 
     func testWhenContinuousUserActionEnds_itSendsActionEvent() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -27,7 +27,9 @@ class RUMTelemetryTests: XCTestCase {
     // MARK: - Sending Telemetry events
 
     func testSendTelemetryDebug() throws {
+        let configuredSource = String.mockAnySource()
         let telemetry: RUMTelemetry = .mockWith(
+            source: configuredSource,
             dateProvider: RelativeDateProvider(
                 using: .init(timeIntervalSince1970: 0)
             )
@@ -41,13 +43,15 @@ class RUMTelemetryTests: XCTestCase {
             XCTAssertEqual(event.application?.id, telemetry.applicationID)
             XCTAssertEqual(event.version, telemetry.sdkVersion)
             XCTAssertEqual(event.service, "dd-sdk-ios")
-            XCTAssertEqual(event.source, .ios)
+            XCTAssertEqual(event.source, TelemetryDebugEvent.Source(rawValue: configuredSource))
             XCTAssertEqual(event.telemetry.message, "Hello world!")
         }
     }
 
     func testSendTelemetryError() throws {
+        let configuredSource = String.mockAnySource()
         let telemetry: RUMTelemetry = .mockWith(
+            source: configuredSource,
             dateProvider: RelativeDateProvider(
                 using: .init(timeIntervalSince1970: 0)
             )
@@ -60,7 +64,7 @@ class RUMTelemetryTests: XCTestCase {
             XCTAssertEqual(event.application?.id, telemetry.applicationID)
             XCTAssertEqual(event.version, telemetry.sdkVersion)
             XCTAssertEqual(event.service, "dd-sdk-ios")
-            XCTAssertEqual(event.source, .ios)
+            XCTAssertEqual(event.source, TelemetryErrorEvent.Source(rawValue: configuredSource))
             XCTAssertEqual(event.telemetry.message, "Oops")
             XCTAssertEqual(event.telemetry.error?.kind, "OutOfMemory")
             XCTAssertEqual(event.telemetry.error?.stack, "a\nhay\nneedle\nstack")


### PR DESCRIPTION
### What and why?

The React Native and Flutter SDKs set the `_dd.source` additional property to have that change the `source` property of events. However, all of the RUM events were still only even using `ios` as the source. This should fix it so that, if a value is provided to the the `_dd.source` attribute map, that source is sent to RUMM 

Fixes RUMM-2162

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
