### PR TITLE
RUMM-2162 Fix compilation issue in Xcode 12.x

### DIFF
--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -359,7 +359,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 id: sessionUUID.toRUMDataFormat,
                 type: CITestIntegration.active != nil ? .ciTest : .user
             ),
-            source: .init(rawValue: rumConfiguration.common.source) ?? .ios,
+            source: RUMViewEvent.Source(rawValue: rumConfiguration.common.source) ?? .ios,
             synthetics: nil,
             usr: crashContext.lastUserInfo.flatMap { RUMUser(userInfo: $0) },
             version: rumConfiguration.common.applicationVersion,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -195,7 +195,7 @@ internal class RUMResourceScope: RUMScope {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .init(rawValue: dependencies.source) ?? .ios,
+            source: RUMResourceEvent.Source(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,
@@ -253,7 +253,7 @@ internal class RUMResourceScope: RUMScope {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .init(rawValue: dependencies.source) ?? .ios,
+            source: RUMErrorEvent.Source(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -159,7 +159,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .init(rawValue: dependencies.source) ?? .ios,
+            source: RUMActionEvent.Source(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -348,7 +348,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .init(rawValue: dependencies.source) ?? .ios,
+            source: RUMActionEvent.Source(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,
@@ -398,7 +398,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .init(rawValue: dependencies.source) ?? .ios,
+            source: RUMViewEvent.Source(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,
@@ -489,7 +489,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .init(rawValue: dependencies.source) ?? .ios,
+            source: RUMErrorEvent.Source(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,
@@ -532,7 +532,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 id: context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
-            source: .init(rawValue: dependencies.source) ?? .ios,
+            source: RUMLongTaskEvent.Source(rawValue: dependencies.source) ?? .ios,
             synthetics: nil,
             usr: dependencies.userInfoProvider.current,
             version: dependencies.applicationVersion,

--- a/Sources/Datadog/RUM/RUMTelemetry.swift
+++ b/Sources/Datadog/RUM/RUMTelemetry.swift
@@ -67,7 +67,7 @@ internal final class RUMTelemetry: Telemetry {
                 date: date.timeIntervalSince1970.toInt64Milliseconds,
                 service: "dd-sdk-ios",
                 session: sessionId.map { .init(id: $0) },
-                source: .init(rawValue: self.source) ?? .ios,
+                source: TelemetryDebugEvent.Source(rawValue: self.source) ?? .ios,
                 telemetry: .init(message: message),
                 version: self.sdkVersion,
                 view: viewId.map { .init(id: $0) }
@@ -109,7 +109,7 @@ internal final class RUMTelemetry: Telemetry {
                 date: date.timeIntervalSince1970.toInt64Milliseconds,
                 service: "dd-sdk-ios",
                 session: sessionId.map { .init(id: $0) },
-                source: .init(rawValue: self.source) ?? .ios,
+                source: TelemetryErrorEvent.Source(rawValue: self.source) ?? .ios,
                 telemetry: .init(error: .init(kind: kind, stack: stack), message: message),
                 version: self.sdkVersion,
                 view: viewId.map { .init(id: $0) }


### PR DESCRIPTION
### What and why?

⚙️ Fixes recent nightly tests failure (on Xcode 12.x stack):
```
❌ /Users/vagrant/git/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift:198:22: value of optional type 'RUMResourceEvent.Source?' must be unwrapped to a value of type 'RUMResourceEvent.Source'
            source: .init(rawValue: dependencies.source) ?? .ios,
```

### How?

Xcode 12.x compiler wasn't yet smart enough to infer type in such expressions:
```diff
- source: .init(rawValue: dependencies.source) ?? .ios,
```
I had to add the type information by hand:
```diff
+ source: RUMResourceEvent.Source(rawValue: dependencies.source) ?? .ios,
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
