### PR TITLE
RUMM-1227 DatadogSDKTesting is enabled for Crash tests

### DIFF
--- a/Datadog/TargetSupport/DatadogIntegrationTests/DatadogCrashReportingIntegrationTests.xctestplan
+++ b/Datadog/TargetSupport/DatadogIntegrationTests/DatadogCrashReportingIntegrationTests.xctestplan
@@ -25,6 +25,64 @@
         }
       ]
     },
+    "environmentVariableEntries" : [
+      {
+        "key" : "DD_DISABLE_CRASH_HANDLER",
+        "value" : "1"
+      },
+      {
+        "key" : "DD_TEST_RUNNER",
+        "value" : "$(DD_TEST_RUNNER)"
+      },
+      {
+        "key" : "DD_API_KEY",
+        "value" : "$(DD_SDK_SWIFT_TESTING_APIKEY)"
+      },
+      {
+        "key" : "DD_ENV",
+        "value" : "$(DD_SDK_SWIFT_TESTING_ENV)"
+      },
+      {
+        "key" : "DD_SERVICE",
+        "value" : "$(DD_SDK_SWIFT_TESTING_SERVICE)"
+      },
+      {
+        "key" : "DD_DISABLE_SDKIOS_INTEGRATION",
+        "value" : "1"
+      },
+      {
+        "key" : "DD_DISABLE_HEADERS_INJECTION",
+        "value" : "1"
+      },
+      {
+        "key" : "DD_ENABLE_RECORD_PAYLOAD",
+        "value" : "1"
+      },
+      {
+        "key" : "SRCROOT",
+        "value" : "$(SRCROOT)"
+      },
+      {
+        "key" : "BITRISE_SOURCE_DIR",
+        "value" : "$(BITRISE_SOURCE_DIR)"
+      },
+      {
+        "key" : "BITRISE_TRIGGERED_WORKFLOW_ID",
+        "value" : "$(BITRISE_TRIGGERED_WORKFLOW_ID)"
+      },
+      {
+        "key" : "BITRISE_BUILD_SLUG",
+        "value" : "$(BITRISE_BUILD_SLUG)"
+      },
+      {
+        "key" : "BITRISE_BUILD_NUMBER",
+        "value" : "$(BITRISE_BUILD_NUMBER)"
+      },
+      {
+        "key" : "BITRISE_BUILD_URL",
+        "value" : "$(BITRISE_BUILD_URL)"
+      }
+    ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:Datadog.xcodeproj",
       "identifier" : "61441C2924616F1D003D8BB8",


### PR DESCRIPTION
### What and why?

In order to avoid collision (both `DatadogSDKTesting` and our SDK have their own crash reporters) `DatadogCrashReportingIntegrationTests.xctestplan` disables `DatadogSDKTesting` by leaving env vars blank

### How?

Now `DatadogCrashReportingIntegrationTests.xctestplan` enables `DatadogSDKTesting` by feeding the correct env vars, on top of them it has `DD_DISABLE_CRASH_HANDLER` env var to disable `DatadogSDKTesting`'s crash reporter

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
