### PR TITLE
RUMM-2134 Write events to files in TLV format

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -586,6 +586,8 @@
 		D29CDD3228211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
 		D29CDD3328211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
 		D29D5A4D273BF8B400A687C1 /* SwiftUIActionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */; };
+		D2B3F0442823EE8400C2B5EE /* DataBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */; };
+		D2B3F0452823EE8400C2B5EE /* DataBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */; };
 		D2CB6E0C27C50EAE00A62B57 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2CB6E0D27C50EAE00A62B57 /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2CB6E0E27C50EAE00A62B57 /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1746,6 +1748,7 @@
 		D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandlerTests.swift; sourceTree = "<group>"; };
 		D29CDD3128211A2200F7DAA5 /* DataBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlock.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
+		D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlockTests.swift; sourceTree = "<group>"; };
 		D2CB6ED127C50EAE00A62B57 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6F8F27C520D400A62B57 /* DatadogTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FB027C5217A00A62B57 /* DatadogObjc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogObjc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2373,6 +2376,7 @@
 			children = (
 				6137C573271DBF4800EFC4A1 /* DataOrchestratorTests.swift */,
 				61133C2A2423990D00786299 /* FilesOrchestratorTests.swift */,
+				D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */,
 				619E16D42577C11B00B2516B /* Writing */,
 				619E16D52577C12100B2516B /* Reading */,
 				61EF788E257E287B00EDCCB3 /* Migrating */,
@@ -5255,6 +5259,7 @@
 				61133C482423990D00786299 /* DDDatadogTests.swift in Sources */,
 				613F23FD252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift in Sources */,
 				61133C522423990D00786299 /* FoundationMocks.swift in Sources */,
+				D2B3F0442823EE8400C2B5EE /* DataBlockTests.swift in Sources */,
 				61133C5B2423990D00786299 /* DirectoryTests.swift in Sources */,
 				61E5332F24B75DE2003D6C4E /* RUMFeatureTests.swift in Sources */,
 				E1D203FD24C1885C00D1AF3A /* ActiveSpansPoolTests.swift in Sources */,
@@ -5870,6 +5875,7 @@
 				D2CB6F5027C520D400A62B57 /* DDDatadogTests.swift in Sources */,
 				D2CB6F5127C520D400A62B57 /* URLSessionAutoInstrumentationTests.swift in Sources */,
 				D2CB6F5227C520D400A62B57 /* FoundationMocks.swift in Sources */,
+				D2B3F0452823EE8400C2B5EE /* DataBlockTests.swift in Sources */,
 				D2CB6F5327C520D400A62B57 /* DirectoryTests.swift in Sources */,
 				D2CB6F5427C520D400A62B57 /* RUMFeatureTests.swift in Sources */,
 				D2CB6F5527C520D400A62B57 /* ActiveSpansPoolTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -583,6 +583,8 @@
 		D2791EF927170A760046E07A /* RUMSwiftUIScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2791EF827170A760046E07A /* RUMSwiftUIScenarioTests.swift */; };
 		D28D5D5527C54B30008E72D0 /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */; };
 		D29889C9273413ED00A4D1A9 /* RUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */; };
+		D29CDD3228211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
+		D29CDD3328211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
 		D29D5A4D273BF8B400A687C1 /* SwiftUIActionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */; };
 		D2CB6E0C27C50EAE00A62B57 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2CB6E0D27C50EAE00A62B57 /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1742,6 +1744,7 @@
 		D24C27E9270C8BEE005DE596 /* DataCompression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompression.swift; sourceTree = "<group>"; };
 		D2791EF827170A760046E07A /* RUMSwiftUIScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSwiftUIScenarioTests.swift; sourceTree = "<group>"; };
 		D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandlerTests.swift; sourceTree = "<group>"; };
+		D29CDD3128211A2200F7DAA5 /* DataBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlock.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
 		D2CB6ED127C50EAE00A62B57 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6F8F27C520D400A62B57 /* DatadogTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2110,6 +2113,7 @@
 			isa = PBXGroup;
 			children = (
 				61AD4E3724531500006E34EA /* DataFormat.swift */,
+				D29CDD3128211A2200F7DAA5 /* DataBlock.swift */,
 				6137C571271DAD4B00EFC4A1 /* DataOrchestrator.swift */,
 				D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */,
 				61133BA92423979B00786299 /* FilesOrchestrator.swift */,
@@ -4971,6 +4975,7 @@
 				61C5A8A724509FAA00DA608C /* SpanEventBuilder.swift in Sources */,
 				6179FFD3254ADB1700556A0B /* ObjcAppLaunchHandler.m in Sources */,
 				F637AED22697404200516F32 /* UIKitRUMUserActionsPredicate.swift in Sources */,
+				D29CDD3228211A2200F7DAA5 /* DataBlock.swift in Sources */,
 				61AD4E3824531500006E34EA /* DataFormat.swift in Sources */,
 				9E58E8E124615C75008E5063 /* JSONEncoder.swift in Sources */,
 				61133BCA2423979B00786299 /* CodableValue.swift in Sources */,
@@ -5546,6 +5551,7 @@
 				D2DC4BBC27F234D600E4FB96 /* CITestIntegration.swift in Sources */,
 				D2CB6E1127C50EAE00A62B57 /* TracerConfiguration.swift in Sources */,
 				D2CB6E1227C50EAE00A62B57 /* SwiftUIViewHandler.swift in Sources */,
+				D29CDD3328211A2200F7DAA5 /* DataBlock.swift in Sources */,
 				D2CB6E1327C50EAE00A62B57 /* SwiftUIViewModifier.swift in Sources */,
 				D2CB6E1427C50EAE00A62B57 /* SwiftUIExtensions.swift in Sources */,
 				D2CB6E1527C50EAE00A62B57 /* DateCorrector.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -81,14 +81,12 @@ internal struct FeatureStorage {
         )
 
         let unauthorizedFileWriter = FileWriter(
-            dataFormat: dataFormat,
             orchestrator: unauthorizedFilesOrchestrator,
             encryption: commonDependencies.encryption,
             telemetry: telemetry
         )
 
         let authorizedFileWriter = FileWriter(
-            dataFormat: dataFormat,
             orchestrator: authorizedFilesOrchestrator,
             encryption: commonDependencies.encryption,
             telemetry: telemetry

--- a/Sources/Datadog/Core/Persistence/DataBlock.swift
+++ b/Sources/Datadog/Core/Persistence/DataBlock.swift
@@ -1,0 +1,193 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Block size binary type
+internal typealias BlockSize = UInt32
+
+/// Block type supported in data stream
+internal enum BlockType: UInt16 {
+    case event = 0x00
+    case headerV1 = 0x01
+}
+
+/// Reported errors while manipulateing data blocks.
+internal enum DataBlockError: Error {
+    case readOperationFailed(streamError: Error?)
+    case invalidByteSequence
+}
+
+/// A data block in defined by its type and a byte sequence.
+///
+/// A block can be serialized in data stream by following TLV format.
+internal struct DataBlock {
+    /// Type describing the data block.
+    let type: BlockType
+
+    /// The data.
+    var data: Data
+
+    /// Returns a Data block in Type-Lenght-Value format.
+    ///
+    /// A block follow TLV with bytes aligned such as:
+    ///
+    ///     +-  2 bytes -+-   4 bytes   -+- n bytes -|
+    ///     | block type | data size (n) |    data   |
+    ///     +------------+---------------+-----------+
+    ///
+    /// - Returns: a data block in TLV.
+    func serialize() -> Data {
+        var buffer = Data()
+        // T
+        withUnsafeBytes(of: type.rawValue) { buffer.append(contentsOf: $0) }
+        // L
+        withUnsafeBytes(of: BlockSize(data.count)) { buffer.append(contentsOf: $0) }
+        // V
+        buffer += data
+        return buffer
+    }
+}
+
+internal extension Data {
+    /// Returns a Data block in Type-Lenght-Value format.
+    ///
+    /// A block follow TLV with bytes aligned such as:
+    ///
+    ///     +-  2 bytes -+-   4 bytes    -+- n bytes  -|
+    ///     | block type | block size (n) | block data |
+    ///     +------------+----------------+------------+
+    ///
+    /// - Parameters:
+    ///   - type: The data type
+    ///   - data: The data
+    /// - Returns: a byte sequence in TLV format.
+    static func block(_ type: BlockType, data: Data) -> Data {
+        return DataBlock(type: type, data: data).serialize()
+    }
+}
+
+/// A block reader can read TLV formatted blocks from a data input.
+///
+///
+internal final class DataBlockReader {
+    /// The input data stream.
+    private let stream: InputStream
+
+    /// Reads block from data input.
+    ///
+    /// - Parameter data: The data input
+    init(data: Data) {
+        stream = InputStream(data: data)
+        stream.open()
+    }
+
+    /// Reads block from url input.
+    ///
+    /// At initilization, the reader will open a stream targeting the input
+    /// url. The stream will be closed when the reader instance is deallocated.
+    ///
+    /// - Parameter url: Data url.
+    init?(url: URL) {
+        guard let stream = InputStream(url: url) else {
+            return nil
+        }
+
+        stream.open()
+        self.stream = stream
+    }
+
+    deinit {
+        stream.close()
+    }
+
+    /// Reads the next data block started at current index in data input.
+    ///
+    /// This method returns `nil` when the entire data was traversed but no more
+    /// block could be found.
+    ///
+    /// - Throws: `DataBlockError` while reading the input stream.
+    /// - Returns: The next block or nil if none could be found.
+    func next() throws -> DataBlock? {
+        // look for the next known block
+        while stream.hasBytesAvailable {
+            // read an entire block before inferring the data type
+            // to leave the stream in a usuable state if an unkown
+            // type was encountered.
+            let type = try readType()
+            let size = try readSize()
+            let data = try readData(size: size)
+
+            if let type = BlockType(rawValue: type) {
+                return DataBlock(type: type, data: data)
+            }
+        }
+
+        return nil
+    }
+
+    /// Reads all data blocks from current index in the stream.
+    ///
+    /// - Throws: `DataBlockError` while reading the input stream.
+    /// - Returns: The block sequence found in the input
+    func all() throws -> [DataBlock] {
+        var blocks: [DataBlock] = []
+
+        while let block = try next() {
+            blocks.append(block)
+        }
+
+        return blocks
+    }
+
+    private func readType() throws -> BlockType.RawValue {
+        let lenght = MemoryLayout<BlockType.RawValue>.size
+        var bytes = [UInt8](repeating: 0, count: lenght)
+        let count = stream.read(&bytes, maxLength: lenght)
+
+        if count < 0 {
+            throw DataBlockError.readOperationFailed(streamError: stream.streamError)
+        }
+
+        guard count == lenght else {
+            throw DataBlockError.invalidByteSequence
+        }
+
+        return bytes.withUnsafeBytes { $0.load(as: UInt16.self) }
+    }
+
+    private func readSize() throws -> BlockSize {
+        let lenght = MemoryLayout<BlockSize>.size
+        var bytes = [UInt8](repeating: 0, count: lenght)
+        let count = stream.read(&bytes, maxLength: lenght)
+
+        if count < 0 {
+            throw DataBlockError.readOperationFailed(streamError: stream.streamError)
+        }
+
+        guard count == lenght else {
+            throw DataBlockError.invalidByteSequence
+        }
+
+        return bytes.withUnsafeBytes { $0.load(as: BlockSize.self) }
+    }
+
+    private func readData(size: BlockSize) throws -> Data {
+        let lenght = Int(size)
+        var bytes = [UInt8](repeating: 0, count: lenght)
+        let count = stream.read(&bytes, maxLength: lenght)
+
+        if count < 0 {
+            throw DataBlockError.readOperationFailed(streamError: stream.streamError)
+        }
+
+        guard count == lenght else {
+            throw DataBlockError.invalidByteSequence
+        }
+
+        return Data(bytes)
+    }
+}

--- a/Sources/Datadog/Core/Persistence/DataBlock.swift
+++ b/Sources/Datadog/Core/Persistence/DataBlock.swift
@@ -12,7 +12,6 @@ internal typealias BlockSize = UInt32
 /// Block type supported in data stream
 internal enum BlockType: UInt16 {
     case event = 0x00
-    case headerV1 = 0x01
 }
 
 /// Reported errors while manipulateing data blocks.

--- a/Sources/Datadog/Core/Persistence/DataBlock.swift
+++ b/Sources/Datadog/Core/Persistence/DataBlock.swift
@@ -14,10 +14,11 @@ internal enum BlockType: UInt16 {
     case event = 0x00
 }
 
-/// Reported errors while manipulateing data blocks.
+/// Reported errors while manipulating data blocks.
 internal enum DataBlockError: Error {
     case readOperationFailed(streamError: Error?)
     case invalidByteSequence
+    case dataLenghtExceedsLimit
 }
 
 /// A data block in defined by its type and a byte sequence.
@@ -39,12 +40,15 @@ internal struct DataBlock {
     ///     +------------+---------------+-----------+
     ///
     /// - Returns: a data block in TLV.
-    func serialize() -> Data {
+    func serialize() throws -> Data {
         var buffer = Data()
         // T
         withUnsafeBytes(of: type.rawValue) { buffer.append(contentsOf: $0) }
         // L
-        withUnsafeBytes(of: BlockSize(data.count)) { buffer.append(contentsOf: $0) }
+        guard let length = BlockSize(exactly: data.count) else {
+            throw DataBlockError.dataLenghtExceedsLimit
+        }
+        withUnsafeBytes(of: length) { buffer.append(contentsOf: $0) }
         // V
         buffer += data
         return buffer
@@ -61,12 +65,22 @@ internal final class DataBlockReader {
 
     /// Reads block from data input.
     ///
-    /// At initilization, the reader will open a stream targeting the input
-    /// data. The stream will be closed when the reader instance is deallocated.
+    /// At initilization, the reader will open a stream targeting the input data.
+    /// The stream will be closed when the reader instance is deallocated.
     ///
     /// - Parameter data: The data input
-    init(data: Data) {
-        stream = InputStream(data: data)
+    convenience init(data: Data) {
+        self.init(input: InputStream(data: data))
+    }
+
+    /// Reads block from an input stream.
+    ///
+    /// At initilization, the reader will open the stream, it will be closed
+    /// when the reader instance is deallocated.
+    ///
+    /// - Parameter stream: The input stream
+    init(input stream: InputStream) {
+        self.stream = stream
         stream.open()
     }
 
@@ -112,20 +126,20 @@ internal final class DataBlockReader {
         return blocks
     }
 
-    /// Reads `lenght` bytes from stream.
+    /// Reads `length` bytes from stream.
     ///
-    /// - Parameter lenght: The number of byte to read
+    /// - Parameter length: The number of byte to read
     /// - Throws: `DataBlockError` while reading the input stream.
     /// - Returns: Data bytes from stream.
-    private func read(lenght: Int) throws -> Data {
-        var bytes = [UInt8](repeating: 0, count: lenght)
-        let count = stream.read(&bytes, maxLength: lenght)
+    private func read(length: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: length)
+        let count = stream.read(&bytes, maxLength: length)
 
         if count < 0 {
             throw DataBlockError.readOperationFailed(streamError: stream.streamError)
         }
 
-        guard count == lenght else {
+        guard count == length else {
             throw DataBlockError.invalidByteSequence
         }
 
@@ -134,14 +148,22 @@ internal final class DataBlockReader {
 
     /// Reads a block type.
     private func readType() throws -> BlockType.RawValue {
-        let data = try read(lenght: MemoryLayout<BlockType.RawValue>.size)
+        let data = try read(length: MemoryLayout<BlockType.RawValue>.size)
         return data.withUnsafeBytes { $0.load(as: BlockType.RawValue.self) }
     }
 
-    /// Reads  block data.
+    /// Reads block data.
     private func readData() throws -> Data {
-        let data = try read(lenght: MemoryLayout<BlockSize>.size)
+        let data = try read(length: MemoryLayout<BlockSize>.size)
         let size = data.withUnsafeBytes { $0.load(as: BlockSize.self) }
-        return try read(lenght: Int(size))
+
+        // even if `Int` is able to represent all `BlockSize` on 64 bit
+        // arch, we make sure to avoid overflow and get the exact data
+        // length.
+        guard let length = Int(exactly: size) else {
+            throw DataBlockError.dataLenghtExceedsLimit
+        }
+
+        return try read(length: length)
     }
 }

--- a/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
@@ -38,7 +38,7 @@ internal final class FileReader: Reader {
         }
 
         do {
-            let fileData = try decrypt(data: file.read())
+            let fileData = try decode(data: file.read())
             let batchData = dataFormat.prefixData + fileData + dataFormat.suffixData
             return Batch(data: batchData, file: file)
         } catch {
@@ -47,50 +47,64 @@ internal final class FileReader: Reader {
         }
     }
 
-    /// Decrypts data if encryption is available.
+    /// Decodes input data
     ///
-    /// When encryption is provided, the data is splitted using data-format separator, each slices
-    /// is then decoded from base64 and decrypted. Data is finally re-joined with data-format separator.
+    /// The input data is expected to be a stream of `DataBlock`. Only block of type `event` are
+    /// consumed and decrypted if encryptio is available. Decrypted events data are finally joined with
+    /// data-format separator.
     ///
-    /// If no encryption, the data is returned.
-    ///
-    /// - Parameter data: The data to decrypt.
-    /// - Returns: Decrypted data.
-    private func decrypt(data: Data) -> Data {
-        guard let encryption = encryption else {
-            return data
-        }
+    /// - Parameter data: The data to decode.
+    /// - Returns: The decoded and formatted data.
+    private func decode(data: Data) throws -> Data {
+        let reader = DataBlockReader(data: data)
 
         var failure: String? = nil
         defer {
             failure.map { userLogger.error($0) }
         }
 
-        return data
-            // split data
-            .split(separator: dataFormat.separatorByte)
-            // decode base64 - report failure
+        // get event blocks only
+        return try reader.all()
             .compactMap {
-                if let data = Data(base64Encoded: $0) {
-                    return data
+                switch $0.type {
+                case .event:
+                    return $0.data
+                default:
+                    return nil
                 }
-
-                failure = "🔥 Failed to decode base64 data before decryption"
-                return nil
             }
             // decrypt data - report failure
             .compactMap { (data: Data) in
                 do {
-                    return try encryption.decrypt(data: data)
+                    return try decrypt(data: data)
                 } catch {
                     failure = "🔥 Failed to decrypt data with error: \(error)"
-                    return nil
                 }
+
+                return nil
             }
             // concat data
             .reduce(Data()) { $0 + $1 + [dataFormat.separatorByte] }
             // drop last separator
             .dropLast()
+    }
+
+    /// Decrypts data if encryption is available.
+    ///
+    /// If no encryption, the data is returned.
+    ///
+    /// - Parameter data: The data to decrypt.
+    /// - Returns: Decrypted data.
+    private func decrypt(data: Data) throws -> Data {
+        guard let encryption = encryption else {
+            return data
+        }
+
+        guard let data = Data(base64Encoded: data) else {
+            throw ProgrammerError(description: "Failed to decode base64")
+        }
+
+        return try encryption.decrypt(data: data)
     }
 
     // MARK: - Accepting batches

--- a/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
@@ -69,8 +69,6 @@ internal final class FileReader: Reader {
                 switch $0.type {
                 case .event:
                     return $0.data
-                default:
-                    return nil
                 }
             }
             // decrypt data - report failure

--- a/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
@@ -50,7 +50,7 @@ internal final class FileReader: Reader {
     /// Decodes input data
     ///
     /// The input data is expected to be a stream of `DataBlock`. Only block of type `event` are
-    /// consumed and decrypted if encryptio is available. Decrypted events data are finally joined with
+    /// consumed and decrypted if encryption is available. Decrypted events are finally joined with
     /// data-format separator.
     ///
     /// - Parameter data: The data to decode.
@@ -63,8 +63,8 @@ internal final class FileReader: Reader {
             failure.map { userLogger.error($0) }
         }
 
-        // get event blocks only
         return try reader.all()
+            // get event blocks only
             .compactMap {
                 switch $0.type {
                 case .event:
@@ -77,9 +77,8 @@ internal final class FileReader: Reader {
                     return try decrypt(data: data)
                 } catch {
                     failure = "🔥 Failed to decrypt data with error: \(error)"
+                    return nil
                 }
-
-                return nil
             }
             // concat data
             .reduce(Data()) { $0 + $1 + [dataFormat.separatorByte] }
@@ -96,10 +95,6 @@ internal final class FileReader: Reader {
     private func decrypt(data: Data) throws -> Data {
         guard let encryption = encryption else {
             return data
-        }
-
-        guard let data = Data(base64Encoded: data) else {
-            throw ProgrammerError(description: "Failed to decode base64")
         }
 
         return try encryption.decrypt(data: data)

--- a/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
@@ -8,8 +8,6 @@ import Foundation
 
 /// Writes data to files.
 internal final class FileWriter: Writer {
-    /// Data writing format.
-    private let dataFormat: DataFormat
     /// Orchestrator producing reference to writable file.
     private let orchestrator: FilesOrchestrator
     /// JSON encoder used to encode data.
@@ -18,12 +16,10 @@ internal final class FileWriter: Writer {
     private let telemetry: Telemetry?
 
     init(
-        dataFormat: DataFormat,
         orchestrator: FilesOrchestrator,
         encryption: DataEncryption? = nil,
         telemetry: Telemetry? = nil
     ) {
-        self.dataFormat = dataFormat
         self.orchestrator = orchestrator
         self.jsonEncoder = .default()
         self.encryption = encryption
@@ -35,13 +31,8 @@ internal final class FileWriter: Writer {
     /// Encodes given value to JSON data and writes it to the file.
     func write<T: Encodable>(value: T) {
         do {
-            var data = try encode(value: value)
+            let data = try encode(event: value)
             let file = try orchestrator.getWritableFile(writeSize: UInt64(data.count))
-
-            if try file.size() > 0 {
-                data.insert(dataFormat.separatorByte, at: 0)
-            }
-
             try file.append(data: data)
         } catch {
             userLogger.error("🔥 Failed to write data: \(error)")
@@ -53,11 +44,32 @@ internal final class FileWriter: Writer {
     ///
     /// If encryption is available, encryption result is base64 encoded.
     ///
-    /// - Parameter value: The value to encode.
+    /// The returned data format:
+    ///
+    ///     +- 2 bytes -+-  4 bytes -+- n bytes  -|
+    ///     |    0x00   | block size | block data |
+    ///     +-----------+------------+------------+
+    ///
+    /// Where the 2 first bytes represents the `block type` of
+    /// an event.
+    ///
+    /// - Parameter event: The value to encode.
     /// - Returns: Data representation of the value.
-    private func encode<T: Encodable>(value: T) throws -> Data {
-        let data = try jsonEncoder.encode(value)
+    private func encode<T: Encodable>(event: T) throws -> Data {
+        let data = try jsonEncoder.encode(event)
+        return try DataBlock(
+            type: .event,
+            data: encrypt(data: data)
+        ).serialize()
+    }
 
+    /// Encrypts data if encryption is available.
+    ///
+    /// If no encryption, the data is returned.
+    ///
+    /// - Parameter data: The data to encrypt.
+    /// - Returns: Encrypted data.
+    private func encrypt(data: Data) throws -> Data {
         guard let encryption = encryption else {
             return data
         }

--- a/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
@@ -42,8 +42,6 @@ internal final class FileWriter: Writer {
 
     /// Encodes the given encodable value and encrypt it if encryption is available.
     ///
-    /// If encryption is available, encryption result is base64 encoded.
-    ///
     /// The returned data format:
     ///
     ///     +- 2 bytes -+-  4 bytes -+- n bytes  -|
@@ -75,6 +73,5 @@ internal final class FileWriter: Writer {
         }
 
         return try encryption.encrypt(data: data)
-            .base64EncodedData()
     }
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -231,7 +231,7 @@ public class Datadog {
             )
 
             rum = RUMFeature(
-                directories: try obtainRUMFeatureDirectories(),
+                directories: try obtainRUMFeatureDirectories(version: "v2"),
                 configuration: rumConfiguration,
                 commonDependencies: commonDependencies,
                 telemetry: telemetry
@@ -247,7 +247,7 @@ public class Datadog {
 
         if let loggingConfiguration = configuration.logging {
             logging = LoggingFeature(
-                directories: try obtainLoggingFeatureDirectories(),
+                directories: try obtainLoggingFeatureDirectories(version: "v2"),
                 configuration: loggingConfiguration,
                 commonDependencies: commonDependencies,
                 telemetry: telemetry
@@ -256,7 +256,7 @@ public class Datadog {
 
         if let tracingConfiguration = configuration.tracing {
             tracing = TracingFeature(
-                directories: try obtainTracingFeatureDirectories(),
+                directories: try obtainTracingFeatureDirectories(version: "v2"),
                 configuration: tracingConfiguration,
                 commonDependencies: commonDependencies,
                 loggingFeatureAdapter: logging.flatMap { LoggingForTracingAdapter(loggingFeature: $0) },

--- a/Sources/Datadog/Logging/Log/LogEventSanitizer.swift
+++ b/Sources/Datadog/Logging/Log/LogEventSanitizer.swift
@@ -24,8 +24,8 @@ internal struct LogEventSanitizer {
         /// Allowed first character of a tag name (given as ASCII values ranging from lowercased `a` to `z`) .
         /// Tags with name starting with different character will be dropped.
         static let allowedTagNameFirstCharacterASCIIRange: [UInt8] = Array(97...122)
-        /// Maximum lenght of the tag.
-        /// Tags exceeting this lenght will be trunkated.
+        /// Maximum length of the tag.
+        /// Tags exceeting this length will be trunkated.
         static let maxTagLength: Int = 200
         /// Tag keys reserved for Datadog.
         /// If any of those is used by user, the tag will be ignored.

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -7,8 +7,7 @@
 import Foundation
 
 /// Obtains subdirectories in `/Library/Caches` where logging data is stored.
-internal func obtainLoggingFeatureDirectories() throws -> FeatureDirectories {
-    let version = "v1"
+internal func obtainLoggingFeatureDirectories(version: String) throws -> FeatureDirectories {
     return FeatureDirectories(
         unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.logs/intermediate-\(version)"),
         authorized: try Directory(withSubdirectoryPath: "com.datadoghq.logs/\(version)")

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -7,8 +7,7 @@
 import Foundation
 
 /// Obtains subdirectories in `/Library/Caches` where RUM data is stored.
-internal func obtainRUMFeatureDirectories() throws -> FeatureDirectories {
-    let version = "v1"
+internal func obtainRUMFeatureDirectories(version: String) throws -> FeatureDirectories {
     return FeatureDirectories(
         unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.rum/intermediate-\(version)"),
         authorized: try Directory(withSubdirectoryPath: "com.datadoghq.rum/\(version)")

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -7,8 +7,7 @@
 import Foundation
 
 /// Obtains subdirectories in `/Library/Caches` where tracing data is stored.
-internal func obtainTracingFeatureDirectories() throws -> FeatureDirectories {
-    let version = "v1"
+internal func obtainTracingFeatureDirectories(version: String) throws -> FeatureDirectories {
     return FeatureDirectories(
         unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.traces/intermediate-\(version)"),
         authorized: try Directory(withSubdirectoryPath: "com.datadoghq.traces/\(version)")

--- a/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class DataBlockTests: XCTestCase {
+    func testSerializeDataBlock() throws {
+        XCTAssertEqual(
+            DataBlock(type: .event, data: Data([0xFF])).serialize(),
+            Data([0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xFF])
+        )
+    }
+
+    func testDataBlockReader_withSingleBlock() throws {
+        let data = Data([0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xFF])
+        let reader = DataBlockReader(data: data)
+        let block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, Data([0xFF]))
+    }
+
+    func testDataBlockReader_withMultipleBlock() throws {
+        let data = (0..<100).map { size in
+            DataBlock(
+                type: .event,
+                data: .mock(ofSize: size)
+            ).serialize()
+        }
+        .reduce(Data(), +)
+
+        let reader = DataBlockReader(data: data)
+        let blocks = try reader.all()
+
+        XCTAssertEqual(blocks.count, 100)
+        XCTAssertEqual(blocks.first?.data.count, 0)
+        XCTAssertEqual(blocks.last?.data.count, 99)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
@@ -10,9 +10,27 @@ import XCTest
 class DataBlockTests: XCTestCase {
     func testSerializeDataBlock() throws {
         XCTAssertEqual(
-            DataBlock(type: .event, data: Data([0xFF])).serialize(),
+            try DataBlock(type: .event, data: Data([0xFF])).serialize(),
             Data([0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xFF])
         )
+    }
+
+    func testSerialize_zeroBytesBlock() throws {
+        XCTAssertEqual(
+            try DataBlock(type: .event, data: Data()).serialize(),
+            Data([0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        )
+    }
+
+    func testSerialize_largeBytesBlock() throws {
+        let data = try DataBlock(
+            type: .event,
+            data: .mockRepeating(byte: 0xFF, times: 10_000_000) // 10MB
+        ).serialize()
+
+        XCTAssertEqual(data.count, 10_000_006)
+        // TLV representation: T=0x0000, L=0x00989680, V[0]=0xFF
+        XCTAssertEqual(data.prefix(7), Data([0x00, 0x00, 0x80, 0x96, 0x98, 0x00, 0xFF]))
     }
 
     func testDataBlockReader_withSingleBlock() throws {
@@ -24,8 +42,8 @@ class DataBlockTests: XCTestCase {
     }
 
     func testDataBlockReader_withMultipleBlock() throws {
-        let data = (0..<100).map { size in
-            DataBlock(
+        let data = try (0..<100).map { size in
+            try DataBlock(
                 type: .event,
                 data: .mock(ofSize: size)
             ).serialize()
@@ -38,5 +56,53 @@ class DataBlockTests: XCTestCase {
         XCTAssertEqual(blocks.count, 100)
         XCTAssertEqual(blocks.first?.data.count, 0)
         XCTAssertEqual(blocks.last?.data.count, 99)
+    }
+
+    func testDataBlockReader_skipUnknownType() throws {
+        let data = Data(
+            [
+                0x00, 0xFF, 0x01, 0x00, 0x00, 0x00, 0xFF,
+                0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xFF,
+                0x00, 0xFF, 0x01, 0x00, 0x00, 0x00, 0xFF
+            ]
+        )
+        let reader = DataBlockReader(data: data)
+        let block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, Data([0xFF]))
+        XCTAssertNil(try reader.next())
+    }
+
+    func testDataBlockReader_readsZeroBytesBlock() throws {
+        let data = Data(
+            [
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0xFF,
+                0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0xFF, 0xFF
+            ]
+        )
+        let reader = DataBlockReader(data: data)
+
+        var block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, Data())
+
+        block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, Data([0xFF]))
+
+        block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, Data([0xFF, 0xFF]))
+    }
+
+    func testDataBlockReader_readsLargeBytesBlock() throws {
+        let data = Data([0x00, 0x00, 0x80, 0x96, 0x98, 0x00]) + Data.mockRepeating(byte: 0xFF, times: 10_000_000) // 10MB
+        let reader = DataBlockReader(data: data)
+
+        let block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data.first, 0xFF)
+        XCTAssertEqual(block?.data.count, 10_000_000)
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -29,7 +29,7 @@ class FileReaderTests: XCTestCase {
         )
         _ = try temporaryDirectory
             .createFile(named: Date.mockAny().toFileName)
-            .append(data: .block(.event, data: "ABCD".utf8Data))
+            .append(data: DataBlock(type: .event, data: "ABCD".utf8Data).serialize())
 
         XCTAssertEqual(try temporaryDirectory.files().count, 1)
         let batch = reader.readNextBatch()
@@ -40,7 +40,7 @@ class FileReaderTests: XCTestCase {
         // Given
         // base64(foo) = Zm9v
         let data = Array(repeating: "Zm9v".utf8Data, count: 3)
-            .map { Data.block(.event, data: $0) }
+            .map { DataBlock(type: .event, data: $0).serialize() }
             .reduce(.init(), +)
 
         _ = try temporaryDirectory
@@ -77,13 +77,13 @@ class FileReaderTests: XCTestCase {
             )
         )
         let file1 = try temporaryDirectory.createFile(named: dateProvider.currentDate().toFileName)
-        try file1.append(data: .block(.event, data: "1".utf8Data))
+        try file1.append(data: DataBlock(type: .event, data: "1".utf8Data).serialize())
 
         let file2 = try temporaryDirectory.createFile(named: dateProvider.currentDate().toFileName)
-        try file2.append(data: .block(.event, data: "2".utf8Data))
+        try file2.append(data: DataBlock(type: .event, data: "2".utf8Data).serialize())
 
         let file3 = try temporaryDirectory.createFile(named: dateProvider.currentDate().toFileName)
-        try file3.append(data: .block(.event, data: "3".utf8Data))
+        try file3.append(data: DataBlock(type: .event, data: "3".utf8Data).serialize())
 
         var batch: Batch
         batch = try reader.readNextBatch().unwrapOrThrow()

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -29,20 +29,23 @@ class FileReaderTests: XCTestCase {
         )
         _ = try temporaryDirectory
             .createFile(named: Date.mockAny().toFileName)
-            .append(data: "ABCD".utf8Data)
+            .append(data: .block(.event, data: "ABCD".utf8Data))
 
         XCTAssertEqual(try temporaryDirectory.files().count, 1)
         let batch = reader.readNextBatch()
-
         XCTAssertEqual(batch?.data, "[ABCD]".utf8Data)
     }
 
     func testItReadsSingleEncryptedBatch() throws {
         // Given
+        // base64(foo) = Zm9v
+        let data = Array(repeating: "Zm9v".utf8Data, count: 3)
+            .map { Data.block(.event, data: $0) }
+            .reduce(.init(), +)
+
         _ = try temporaryDirectory
             .createFile(named: Date.mockAny().toFileName)
-            // base64(foo) = Zm9v
-            .append(data: "Zm9v,Zm9v,Zm9v".utf8Data)
+            .append(data: data)
 
         let reader = FileReader(
             dataFormat: .mockWith(prefix: "[", suffix: "]", separator: ","),
@@ -74,13 +77,13 @@ class FileReaderTests: XCTestCase {
             )
         )
         let file1 = try temporaryDirectory.createFile(named: dateProvider.currentDate().toFileName)
-        try file1.append(data: "1".utf8Data)
+        try file1.append(data: .block(.event, data: "1".utf8Data))
 
         let file2 = try temporaryDirectory.createFile(named: dateProvider.currentDate().toFileName)
-        try file2.append(data: "2".utf8Data)
+        try file2.append(data: .block(.event, data: "2".utf8Data))
 
         let file3 = try temporaryDirectory.createFile(named: dateProvider.currentDate().toFileName)
-        try file3.append(data: "3".utf8Data)
+        try file3.append(data: .block(.event, data: "3".utf8Data))
 
         var batch: Batch
         batch = try reader.readNextBatch().unwrapOrThrow()

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Reading/FileReaderTests.swift
@@ -38,9 +38,8 @@ class FileReaderTests: XCTestCase {
 
     func testItReadsSingleEncryptedBatch() throws {
         // Given
-        // base64(foo) = Zm9v
-        let data = Array(repeating: "Zm9v".utf8Data, count: 3)
-            .map { DataBlock(type: .event, data: $0).serialize() }
+        let data = try Array(repeating: "foo".utf8Data, count: 3)
+            .map { try DataBlock(type: .event, data: $0).serialize() }
             .reduce(.init(), +)
 
         _ = try temporaryDirectory

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -208,12 +208,12 @@ class FileWriterTests: XCTestCase {
         let reader = DataBlockReader(data: data)
         var block = try reader.next()
         XCTAssertEqual(block?.type, .event)
-        XCTAssertEqual(block?.data, "Zm9v".utf8Data)
+        XCTAssertEqual(block?.data, "foo".utf8Data)
         block = try reader.next()
         XCTAssertEqual(block?.type, .event)
-        XCTAssertEqual(block?.data, "Zm9v".utf8Data)
+        XCTAssertEqual(block?.data, "foo".utf8Data)
         block = try reader.next()
         XCTAssertEqual(block?.type, .event)
-        XCTAssertEqual(block?.data, "Zm9v".utf8Data)
+        XCTAssertEqual(block?.data, "foo".utf8Data)
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -20,7 +20,6 @@ class FileWriterTests: XCTestCase {
 
     func testItWritesDataToSingleFile() throws {
         let writer = FileWriter(
-            dataFormat: DataFormat(prefix: "[", suffix: "]", separator: ","),
             orchestrator: FilesOrchestrator(
                 directory: temporaryDirectory,
                 performance: PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
@@ -29,14 +28,22 @@ class FileWriterTests: XCTestCase {
         )
 
         writer.write(value: ["key1": "value1"])
-        writer.write(value: ["key2": "value3"])
+        writer.write(value: ["key2": "value2"])
         writer.write(value: ["key3": "value3"])
 
         XCTAssertEqual(try temporaryDirectory.files().count, 1)
-        XCTAssertEqual(
-            try temporaryDirectory.files()[0].read(),
-            #"{"key1":"value1"},{"key2":"value3"},{"key3":"value3"}"#.utf8Data
-        )
+        let data = try temporaryDirectory.files()[0].read()
+
+        let reader = DataBlockReader(data: data)
+        var block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, #"{"key1":"value1"}"#.utf8Data)
+        block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, #"{"key2":"value2"}"#.utf8Data)
+        block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, #"{"key3":"value3"}"#.utf8Data)
     }
 
     func testGivenErrorVerbosity_whenIndividualDataExceedsMaxWriteSize_itDropsDataAndPrintsError() throws {
@@ -47,7 +54,6 @@ class FileWriterTests: XCTestCase {
         userLogger = .mockWith(logOutput: output)
 
         let writer = FileWriter(
-            dataFormat: .mockWith(prefix: "[", suffix: "]"),
             orchestrator: FilesOrchestrator(
                 directory: temporaryDirectory,
                 performance: StoragePerformanceMock(
@@ -57,7 +63,7 @@ class FileWriterTests: XCTestCase {
                     minFileAgeForRead: .mockAny(),
                     maxFileAgeForRead: .mockAny(),
                     maxObjectsInFile: .max,
-                    maxObjectSize: 17 // 17 bytes is enough to write {"key1":"value1"} JSON
+                    maxObjectSize: 23 // 23 bytes is enough for TLV with {"key1":"value1"} JSON
                 ),
                 dateProvider: SystemDateProvider()
             )
@@ -65,13 +71,19 @@ class FileWriterTests: XCTestCase {
 
         writer.write(value: ["key1": "value1"]) // will be written
 
-        XCTAssertEqual(try temporaryDirectory.files()[0].read(), #"{"key1":"value1"}"#.utf8Data)
+        XCTAssertEqual(try temporaryDirectory.files().count, 1)
+        var reader = try DataBlockReader(data: temporaryDirectory.files()[0].read())
+        var blocks = try XCTUnwrap(reader.all())
+        XCTAssertEqual(blocks.count, 1)
+        XCTAssertEqual(blocks[0].data, #"{"key1":"value1"}"#.utf8Data)
 
-        writer.write(value: ["key2": "value3 that makes it exceed 17 bytes"]) // will be dropped
+        writer.write(value: ["key2": "value3 that makes it exceed 23 bytes"]) // will be dropped
 
-        XCTAssertEqual(try temporaryDirectory.files()[0].read(), #"{"key1":"value1"}"#.utf8Data) // same content as before
+        reader = try DataBlockReader(data: temporaryDirectory.files()[0].read())
+        blocks = try XCTUnwrap(reader.all())
+        XCTAssertEqual(blocks.count, 1) // same content as before
         XCTAssertEqual(output.recordedLog?.status, .error)
-        XCTAssertEqual(output.recordedLog?.message, "🔥 Failed to write data: data exceeds the maximum size of 17 bytes.")
+        XCTAssertEqual(output.recordedLog?.message, "🔥 Failed to write data: data exceeds the maximum size of 23 bytes.")
     }
 
     func testGivenErrorVerbosity_whenDataCannotBeEncoded_itPrintsError() throws {
@@ -82,7 +94,6 @@ class FileWriterTests: XCTestCase {
         userLogger = .mockWith(logOutput: output)
 
         let writer = FileWriter(
-            dataFormat: .mockAny(),
             orchestrator: FilesOrchestrator(
                 directory: temporaryDirectory,
                 performance: PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
@@ -104,7 +115,6 @@ class FileWriterTests: XCTestCase {
         userLogger = .mockWith(logOutput: output)
 
         let writer = FileWriter(
-            dataFormat: .mockAny(),
             orchestrator: FilesOrchestrator(
                 directory: temporaryDirectory,
                 performance: PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
@@ -125,7 +135,6 @@ class FileWriterTests: XCTestCase {
     /// NOTE: Test added after incident-4797
     func testWhenIOExceptionsHappenRandomly_theFileIsNeverMalformed() throws {
         let writer = FileWriter(
-            dataFormat: DataFormat(prefix: "[", suffix: "]", separator: ","),
             orchestrator: FilesOrchestrator(
                 directory: temporaryDirectory,
                 performance: StoragePerformanceMock(
@@ -162,20 +171,21 @@ class FileWriterTests: XCTestCase {
 
         XCTAssertEqual(try temporaryDirectory.files().count, 1)
 
-        let fileData = try temporaryDirectory.files()[0].read()
-        let jsonDecoder = JSONDecoder()
+        let data = try temporaryDirectory.files()[0].read()
+        let blocks = try DataBlockReader(data: data).all()
 
         // Assert that data written is not malformed
-        let writtenData = try jsonDecoder.decode([Foo].self, from: "[".utf8Data + fileData + "]".utf8Data)
+        let jsonDecoder = JSONDecoder()
+        let events = try blocks.map { try jsonDecoder.decode(Foo.self, from: $0.data) }
+
         // Assert that some (including all) `Foo`s were written
-        XCTAssertGreaterThan(writtenData.count, 0)
-        XCTAssertLessThanOrEqual(writtenData.count, 300)
+        XCTAssertGreaterThan(events.count, 0)
+        XCTAssertLessThanOrEqual(events.count, 300)
     }
 
     func testItWritesEncryptedDataToSingleFile() throws {
         // Given 
         let writer = FileWriter(
-            dataFormat: DataFormat(prefix: "[", suffix: "]", separator: ","),
             orchestrator: FilesOrchestrator(
                 directory: temporaryDirectory,
                 performance: PerformancePreset(batchSize: .medium, uploadFrequency: .average, bundleType: .iOSApp),
@@ -193,9 +203,17 @@ class FileWriterTests: XCTestCase {
 
         // Then
         XCTAssertEqual(try temporaryDirectory.files().count, 1)
-        XCTAssertEqual(
-            try temporaryDirectory.files()[0].read(),
-            "Zm9v,Zm9v,Zm9v".utf8Data // base64(foo) = Zm9v
-        )
+        let data = try temporaryDirectory.files()[0].read()
+
+        let reader = DataBlockReader(data: data)
+        var block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, "Zm9v".utf8Data)
+        block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, "Zm9v".utf8Data)
+        block = try reader.next()
+        XCTAssertEqual(block?.type, .event)
+        XCTAssertEqual(block?.data, "Zm9v".utf8Data)
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -17,7 +17,6 @@ class DataUploadWorkerTests: XCTestCase {
         dateProvider: dateProvider
     )
     lazy var writer = FileWriter(
-        dataFormat: .mockWith(prefix: "[", suffix: "]"),
         orchestrator: orchestrator
     )
     lazy var reader = FileReader(

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -441,9 +441,9 @@ class DatadogTests: XCTestCase {
         rumWriter.queue.sync {}
 
         let featureDirectories: [FeatureDirectories] = [
-            try obtainLoggingFeatureDirectories(),
-            try obtainTracingFeatureDirectories(),
-            try obtainRUMFeatureDirectories()
+            try obtainLoggingFeatureDirectories(version: "v2"),
+            try obtainTracingFeatureDirectories(version: "v2"),
+            try obtainRUMFeatureDirectories(version: "v2")
         ]
 
         let allDirectories: [Directory] = featureDirectories.flatMap { [$0.authorized, $0.unauthorized] }

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
@@ -22,7 +22,6 @@ class LogFileOutputTests: XCTestCase {
         let fileCreationDateProvider = RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC())
         let output = LogFileOutput(
             fileWriter: FileWriter(
-                dataFormat: LoggingFeature.dataFormat,
                 orchestrator: FilesOrchestrator(
                     directory: temporaryDirectory,
                     performance: PerformancePreset.combining(
@@ -44,14 +43,22 @@ class LogFileOutputTests: XCTestCase {
         output.write(log: log2)
 
         let log1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())
-        let log1Data = try temporaryDirectory.file(named: log1FileName).read()
-        let log1Matcher = try LogMatcher.fromJSONObjectData(log1Data)
+        let log1FileData = try temporaryDirectory.file(named: log1FileName).read()
+        var reader = DataBlockReader(data: log1FileData)
+        let logBlock1 = try XCTUnwrap(reader.next())
+        XCTAssertEqual(logBlock1.type, .event)
+
+        let log1Matcher = try LogMatcher.fromJSONObjectData(logBlock1.data)
         log1Matcher.assertStatus(equals: "info")
         log1Matcher.assertMessage(equals: "log message 1")
 
         let log2FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
-        let log2Data = try temporaryDirectory.file(named: log2FileName).read()
-        let log2Matcher = try LogMatcher.fromJSONObjectData(log2Data)
+        let log2FileData = try temporaryDirectory.file(named: log2FileName).read()
+        reader = DataBlockReader(data: log2FileData)
+        let logBlock2 = try XCTUnwrap(reader.next())
+        XCTAssertEqual(logBlock2.type, .event)
+
+        let log2Matcher = try LogMatcher.fromJSONObjectData(logBlock2.data)
         log2Matcher.assertStatus(equals: "warn")
         log2Matcher.assertMessage(equals: "log message 2")
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -23,7 +23,6 @@ class RUMEventFileOutputTests: XCTestCase {
         let builder = RUMEventBuilder(eventsMapper: .mockNoOp())
         let output = RUMEventFileOutput(
             fileWriter: FileWriter(
-                dataFormat: RUMFeature.dataFormat,
                 orchestrator: FilesOrchestrator(
                     directory: temporaryDirectory,
                     performance: PerformancePreset.combining(
@@ -47,15 +46,23 @@ class RUMEventFileOutputTests: XCTestCase {
         output.write(event: event2)
 
         let event1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())
-        let event1Data = try temporaryDirectory.file(named: event1FileName).read()
-        let event1Matcher = try RUMEventMatcher.fromJSONObjectData(event1Data)
+        let event1FileData = try temporaryDirectory.file(named: event1FileName).read()
+        var reader = DataBlockReader(data: event1FileData)
+        let eventBlock1 = try XCTUnwrap(reader.next())
+        XCTAssertEqual(eventBlock1.type, .event)
+
+        let event1Matcher = try RUMEventMatcher.fromJSONObjectData(eventBlock1.data)
 
         let expectedDatamodel1 = RUMDataModelMock(attribute: "foo", context: RUMEventAttributes(contextInfo: ["custom.attribute": CodableValue("value")]))
         XCTAssertEqual(try event1Matcher.model(), expectedDatamodel1)
 
         let event2FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
-        let event2Data = try temporaryDirectory.file(named: event2FileName).read()
-        let event2Matcher = try RUMEventMatcher.fromJSONObjectData(event2Data)
+        let event2FileData = try temporaryDirectory.file(named: event2FileName).read()
+        reader = DataBlockReader(data: event2FileData)
+        let eventBlock2 = try XCTUnwrap(reader.next())
+        XCTAssertEqual(eventBlock2.type, .event)
+
+        let event2Matcher = try RUMEventMatcher.fromJSONObjectData(eventBlock2.data)
         XCTAssertEqual(try event2Matcher.model(), dataModel2)
 
         // TODO: RUMM-585 Move assertion of full-json to `RUMMonitorTests`


### PR DESCRIPTION
### What and why?

Write event to files in TLV format. This change prepares the introduction of event metadata to batches.

### How?

All events will be serialised in TLV format using the following byte alignment:
```
+-  2 bytes -+-   4 bytes   -+- n bytes -|
| block type | data size (n) |    data   |
+------------+---------------+-----------+
```
This `block type` is a 2 bytes value describing how to decode the data. In this PR, only code `0x00` identifying an event is used.

The `data size` is written in 4 bytes so we are more flexible in term of size limit.

### Note

By using TLV, the format differs from the RFC so we are more resilient to header (metadata) decoding failure.
Batches will be written in `v2` folders, this PR does not remove any `v1` folder, it will be dealt in another PR.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
