### PR TITLE
RUMM-2134 Remove deprecated feature directories

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -588,6 +588,8 @@
 		D29D5A4D273BF8B400A687C1 /* SwiftUIActionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */; };
 		D2B3F0442823EE8400C2B5EE /* DataBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */; };
 		D2B3F0452823EE8400C2B5EE /* DataBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */; };
+		D2B3F04728292D6E00C2B5EE /* DataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F04628292D6E00C2B5EE /* DataMigratorTests.swift */; };
+		D2B3F04828292D6E00C2B5EE /* DataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F04628292D6E00C2B5EE /* DataMigratorTests.swift */; };
 		D2CB6E0C27C50EAE00A62B57 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2CB6E0D27C50EAE00A62B57 /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2CB6E0E27C50EAE00A62B57 /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1749,6 +1751,7 @@
 		D29CDD3128211A2200F7DAA5 /* DataBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlock.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
 		D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlockTests.swift; sourceTree = "<group>"; };
+		D2B3F04628292D6E00C2B5EE /* DataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorTests.swift; sourceTree = "<group>"; };
 		D2CB6ED127C50EAE00A62B57 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6F8F27C520D400A62B57 /* DatadogTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FB027C5217A00A62B57 /* DatadogObjc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogObjc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3720,6 +3723,7 @@
 		61EF788E257E287B00EDCCB3 /* Migrating */ = {
 			isa = PBXGroup;
 			children = (
+				D2B3F04628292D6E00C2B5EE /* DataMigratorTests.swift */,
 				61EF788F257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift */,
 				61EF78B6257E37D500EDCCB3 /* MoveDataMigratorTests.swift */,
 			);
@@ -5269,6 +5273,7 @@
 				61C5A89E24509C1100DA608C /* WarningsTests.swift in Sources */,
 				9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */,
 				61122EEE25B1D75B00F9C7F5 /* RUMEventSanitizerTests.swift in Sources */,
+				D2B3F04728292D6E00C2B5EE /* DataMigratorTests.swift in Sources */,
 				614B0A5124EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift in Sources */,
 				611F82032563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift in Sources */,
 				61133C652423990D00786299 /* LogBuilderTests.swift in Sources */,
@@ -5885,6 +5890,7 @@
 				D2CB6F5927C520D400A62B57 /* WarningsTests.swift in Sources */,
 				D2CB6F5A27C520D400A62B57 /* SwiftExtensionsTests.swift in Sources */,
 				D2CB6F5B27C520D400A62B57 /* RUMEventSanitizerTests.swift in Sources */,
+				D2B3F04828292D6E00C2B5EE /* DataMigratorTests.swift in Sources */,
 				D2CB6F5C27C520D400A62B57 /* RUMConnectivityInfoProviderTests.swift in Sources */,
 				D2CB6F5D27C520D400A62B57 /* UIKitRUMViewsPredicateTests.swift in Sources */,
 				D2CB6F5E27C520D400A62B57 /* LogBuilderTests.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Lists different types of data directories used by the feature.
 internal struct FeatureDirectories {
+    /// Deprecated data directory that can be deleted safely.
+    let deprecated: [Directory]
     /// Data directory for storing unauthorized data collected without knowing the tracking consent value.
     /// Due to the consent change, data in this directory may be either moved to `authorized` folder or entirely deleted.
     let unauthorized: Directory

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -231,7 +231,7 @@ public class Datadog {
             )
 
             rum = RUMFeature(
-                directories: try obtainRUMFeatureDirectories(version: "v2"),
+                directories: try obtainRUMFeatureDirectories(),
                 configuration: rumConfiguration,
                 commonDependencies: commonDependencies,
                 telemetry: telemetry
@@ -247,7 +247,7 @@ public class Datadog {
 
         if let loggingConfiguration = configuration.logging {
             logging = LoggingFeature(
-                directories: try obtainLoggingFeatureDirectories(version: "v2"),
+                directories: try obtainLoggingFeatureDirectories(),
                 configuration: loggingConfiguration,
                 commonDependencies: commonDependencies,
                 telemetry: telemetry
@@ -256,7 +256,7 @@ public class Datadog {
 
         if let tracingConfiguration = configuration.tracing {
             tracing = TracingFeature(
-                directories: try obtainTracingFeatureDirectories(version: "v2"),
+                directories: try obtainTracingFeatureDirectories(),
                 configuration: tracingConfiguration,
                 commonDependencies: commonDependencies,
                 loggingFeatureAdapter: logging.flatMap { LoggingForTracingAdapter(loggingFeature: $0) },

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -7,8 +7,16 @@
 import Foundation
 
 /// Obtains subdirectories in `/Library/Caches` where logging data is stored.
-internal func obtainLoggingFeatureDirectories(version: String) throws -> FeatureDirectories {
+internal func obtainLoggingFeatureDirectories() throws -> FeatureDirectories {
+    var version = "v1"
+    let deprecated = [
+        try Directory(withSubdirectoryPath: "com.datadoghq.logs/intermediate-\(version)"),
+        try Directory(withSubdirectoryPath: "com.datadoghq.logs/\(version)")
+    ]
+
+    version = "v2"
     return FeatureDirectories(
+        deprecated: deprecated,
         unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.logs/intermediate-\(version)"),
         authorized: try Directory(withSubdirectoryPath: "com.datadoghq.logs/\(version)")
     )

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -7,8 +7,16 @@
 import Foundation
 
 /// Obtains subdirectories in `/Library/Caches` where RUM data is stored.
-internal func obtainRUMFeatureDirectories(version: String) throws -> FeatureDirectories {
+internal func obtainRUMFeatureDirectories() throws -> FeatureDirectories {
+    var version = "v1"
+    let deprecated = [
+        try Directory(withSubdirectoryPath: "com.datadoghq.rum/intermediate-\(version)"),
+        try Directory(withSubdirectoryPath: "com.datadoghq.rum/\(version)")
+    ]
+
+    version = "v2"
     return FeatureDirectories(
+        deprecated: deprecated,
         unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.rum/intermediate-\(version)"),
         authorized: try Directory(withSubdirectoryPath: "com.datadoghq.rum/\(version)")
     )

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -7,8 +7,16 @@
 import Foundation
 
 /// Obtains subdirectories in `/Library/Caches` where tracing data is stored.
-internal func obtainTracingFeatureDirectories(version: String) throws -> FeatureDirectories {
+internal func obtainTracingFeatureDirectories() throws -> FeatureDirectories {
+    var version = "v1"
+    let deprecated = [
+        try Directory(withSubdirectoryPath: "com.datadoghq.traces/intermediate-\(version)"),
+        try Directory(withSubdirectoryPath: "com.datadoghq.traces/\(version)")
+    ]
+
+    version = "v2"
     return FeatureDirectories(
+        deprecated: deprecated,
         unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.traces/intermediate-\(version)"),
         authorized: try Directory(withSubdirectoryPath: "com.datadoghq.traces/\(version)")
     )

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Migrating/DataMigratorTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Migrating/DataMigratorTests.swift
@@ -1,0 +1,106 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class DataMigratorTests: XCTestCase {
+    func testMultiDataMigrator() {
+        // Given
+        struct Migrator: DataMigrator {
+            let expectation: XCTestExpectation
+            func migrate() {
+                expectation.fulfill()
+            }
+        }
+
+        let expectation = XCTestExpectation(description: "Invoke migration")
+        expectation.expectedFulfillmentCount = 10
+
+        let migrators = (0..<expectation.expectedFulfillmentCount).map { _ in
+            Migrator(expectation: expectation)
+        }
+
+        // When
+        let multiMigrator: DataMigrator = MultiDataMigrator(migrators: migrators)
+        multiMigrator.migrate()
+
+        // Then
+        wait(for: [expectation], timeout: 0)
+    }
+
+    func testDataMigrationFactory_initialMigration() throws {
+        // Given
+        let deprecated = try Directory(withSubdirectoryPath: UUID().uuidString)
+        defer { deprecated.delete() }
+        let unauthorized = try Directory(withSubdirectoryPath: UUID().uuidString)
+        defer { unauthorized.delete() }
+        let authorized = try Directory(withSubdirectoryPath: UUID().uuidString)
+        defer { authorized.delete() }
+
+        _ = try deprecated.createFile(named: "deprecated")
+        _ = try unauthorized.createFile(named: "unauthorized")
+        XCTAssertEqual(try deprecated.files().count, 1)
+        XCTAssertEqual(try unauthorized.files().count, 1)
+
+        let directories = FeatureDirectories(deprecated: [deprecated], unauthorized: unauthorized, authorized: authorized)
+        let factory = DataMigratorFactory(directories: directories)
+
+        // When
+        let migrator = factory.resolveInitialMigrator()
+        migrator.migrate()
+
+        // Then
+        XCTAssertEqual(try deprecated.files().count, 0)
+        XCTAssertEqual(try unauthorized.files().count, 0)
+    }
+
+    func testDataMigrationFactory_ConsentPendingToGrantedMigration() throws {
+        // Given
+        let unauthorized = try Directory(withSubdirectoryPath: UUID().uuidString)
+        defer { unauthorized.delete() }
+        let authorized = try Directory(withSubdirectoryPath: UUID().uuidString)
+        defer { authorized.delete() }
+
+        _ = try unauthorized.createFile(named: "unauthorized")
+        XCTAssertEqual(try unauthorized.files().count, 1)
+        XCTAssertEqual(try authorized.files().count, 0)
+
+        let directories = FeatureDirectories(deprecated: [], unauthorized: unauthorized, authorized: authorized)
+        let factory = DataMigratorFactory(directories: directories)
+
+        // When
+        let migrator = factory.resolveMigratorForConsentChange(from: .pending, to: .granted)
+        migrator?.migrate()
+
+        // Then
+        XCTAssertEqual(try unauthorized.files().count, 0)
+        XCTAssertEqual(try authorized.files().count, 1)
+    }
+
+    func testDataMigrationFactory_ConsentPendingToNotGrantedMigration() throws {
+        // Given
+        let unauthorized = try Directory(withSubdirectoryPath: UUID().uuidString)
+        defer { unauthorized.delete() }
+        let authorized = try Directory(withSubdirectoryPath: UUID().uuidString)
+        defer { authorized.delete() }
+
+        _ = try unauthorized.createFile(named: "unauthorized")
+        XCTAssertEqual(try unauthorized.files().count, 1)
+        XCTAssertEqual(try authorized.files().count, 0)
+
+        let directories = FeatureDirectories(deprecated: [], unauthorized: unauthorized, authorized: authorized)
+        let factory = DataMigratorFactory(directories: directories)
+
+        // When
+        let migrator = factory.resolveMigratorForConsentChange(from: .pending, to: .notGranted)
+        migrator?.migrate()
+
+        // Then
+        XCTAssertEqual(try unauthorized.files().count, 0)
+        XCTAssertEqual(try authorized.files().count, 0)
+    }
+}

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -441,9 +441,9 @@ class DatadogTests: XCTestCase {
         rumWriter.queue.sync {}
 
         let featureDirectories: [FeatureDirectories] = [
-            try obtainLoggingFeatureDirectories(version: "v2"),
-            try obtainTracingFeatureDirectories(version: "v2"),
-            try obtainRUMFeatureDirectories(version: "v2")
+            try obtainLoggingFeatureDirectories(),
+            try obtainTracingFeatureDirectories(),
+            try obtainRUMFeatureDirectories()
         ]
 
         let allDirectories: [Directory] = featureDirectories.flatMap { [$0.authorized, $0.unauthorized] }

--- a/Tests/DatadogTests/Datadog/Mocks/FeatureDirectoriesMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/FeatureDirectoriesMock.swift
@@ -10,6 +10,7 @@
 /// Those subfolders do not exist by default and should be created and deleted by calling `.create()` and `.delete()` in each test,
 /// which guarantees clear state before and after test.
 let temporaryFeatureDirectories = FeatureDirectories(
+    deprecated: [],
     unauthorized: obtainUniqueTemporaryDirectory(),
     authorized: obtainUniqueTemporaryDirectory()
 )


### PR DESCRIPTION
### What and why?

Remove v1 feature folders when migrating to v2 storage.

### How?

Any `deprecated` directories defined in `FeatureDirectories` will be removed as part of the initial migration step.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] ~~Add CHANGELOG entry for user facing changes~~

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
