### PR TITLE
Update crash_reporting.md

### DIFF
--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -18,7 +18,7 @@ Enable iOS Crash Reporting and Error Tracking to get comprehensive crash reports
  - Symbolicated iOS crash reports
  - Trend analysis with iOS error tracking
 
-In order to symbolicate your stack traces, find and upload your dYSM files to Datadog. Then, verify your configuration by running a test crash and restarting your application. 
+In order to symbolicate your stack traces, find and upload your .dSYM files to Datadog. Then, verify your configuration by running a test crash and restarting your application. 
 
 Your crash reports appear in [**Error Tracking**][8].
 
@@ -77,18 +77,18 @@ Global.rum = RUMMonitor.initialize()
 
 ## Symbolicate crash reports
 
-Crash reports are collected in a raw format and mostly contain memory addresses. To map these addresses into legible symbol information, Datadog requires dYSM files, which are generated in your application's build or distribution process.
+Crash reports are collected in a raw format and mostly contain memory addresses. To map these addresses into legible symbol information, Datadog requires .dSYM files, which are generated in your application's build or distribution process.
 
-### Find your dYSM file
+### Find your .dSYM file
 
-Every iOS application produces dYSM files for each application module. These files minimize an application's binary size and enable faster download speed. Each application version contains a set of dYSM files. 
+Every iOS application produces .dSYM files for each application module. These files minimize an application's binary size and enable faster download speed. Each application version contains a set of .dSYM files. 
 
-Depending on your setup, you may need to download dSYM files from App Store Connect or find them on your local machine. 
+Depending on your setup, you may need to download .dSYM files from App Store Connect or find them on your local machine. 
 
 | Bitcode Enabled | Description                                                                                                                                                                                                                                                                                       |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Yes             | dSYM files are available once [App Store Connect][6] completes processing your application's build.                                                                                                                                                                                                    |
-| No              | Xcode exports dSYM files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with dYSM File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** for the Release project configuration. |
+| No              | Xcode exports dSYM files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with .d File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** for the Release project configuration. |
 
 ### Upload your dYSM file
 

--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -88,11 +88,11 @@ Depending on your setup, you may need to download .dSYM files from App Store Con
 | Bitcode Enabled | Description                                                                                                                                                                                                                                                                                       |
 |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Yes             | dSYM files are available once [App Store Connect][6] completes processing your application's build.                                                                                                                                                                                                    |
-| No              | Xcode exports dSYM files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with .d File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** for the Release project configuration. |
+| No              | Xcode exports .dSYM files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with dSYM File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** for the Release project configuration. |
 
-### Upload your dYSM file
+### Upload your dSYM file
 
-By uploading your dYSM file to Datadog, you gain access to the file path and line number of each frame in an error's related stack trace.
+By uploading your .dSYM file to Datadog, you gain access to the file path and line number of each frame in an error's related stack trace.
 
 Once your application crashes and you restart the application, the iOS SDK uploads a crash report to Datadog. 
 

--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -79,7 +79,7 @@ Global.rum = RUMMonitor.initialize()
 
 Crash reports are collected in a raw format and mostly contain memory addresses. To map these addresses into legible symbol information, Datadog requires .dSYM files, which are generated in your application's build or distribution process.
 
-### Find your .dSYM file
+### Find your dSYM file
 
 Every iOS application produces .dSYM files for each application module. These files minimize an application's binary size and enable faster download speed. Each application version contains a set of .dSYM files. 
 

--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -92,7 +92,7 @@ Depending on your setup, you may need to download dSYM files from App Store Conn
 
 ### Upload your dYSM file
 
-By uploading your dYSM file to Datadog, you gain access to the file path, line number, and code snippet of each frame in an error's related stack trace.
+By uploading your dYSM file to Datadog, you gain access to the file path and line number of each frame in an error's related stack trace.
 
 Once your application crashes and you restart the application, the iOS SDK uploads a crash report to Datadog. 
 


### PR DESCRIPTION
### What and why?

A small update to the `Upload your dSYM file` section of:
https://docs.datadoghq.com/real_user_monitoring/ios/crash_reporting/?tab=cocoapods#upload-your-dsym-file

Today we do not display code snippet so remove the wording.
