### PR TITLE
Migrate http-server-mock to python3

### DIFF
--- a/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerMock.swift
+++ b/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerMock.swift
@@ -36,7 +36,7 @@ fileprivate extension Request {
         self.path = intermediateRequest.path
         self.httpMethod = intermediateRequest.method
         self.httpHeaders = headersString
-            .split(separator: "\r\n")
+            .split(separator: "\n")
             .map { String($0) }
         self.httpBody = bodyData
     }

--- a/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerProcessRunner.swift
+++ b/instrumented-tests/http-server-mock/Sources/HTTPServerMock/ServerProcessRunner.swift
@@ -22,12 +22,13 @@ public class ServerProcessRunner {
     /// Waits until server is reachable.
     /// Returns `ServerProcess` instance if the server is running, `nil` otherwise.
     public func waitUntilServerIsReachable() -> ServerProcess? {
-        let deadline = Date(timeIntervalSinceNow: 5)
+        let deadline = Date(timeIntervalSinceNow: 10)
 
         while Date() < deadline {
             if ping() {
                 return ServerProcess(serverURL: serverURL)
             }
+            Thread.sleep(forTimeInterval: 0.5)
         }
 
         return nil

--- a/instrumented-tests/http-server-mock/Tests/HTTPServerMockTests/HTTPServerMockTests.swift
+++ b/instrumented-tests/http-server-mock/Tests/HTTPServerMockTests/HTTPServerMockTests.swift
@@ -14,7 +14,7 @@ final class HTTPServerMockTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.process = Process()
-        self.process.launchPath = "/usr/bin/python"
+        self.process.launchPath = "/usr/bin/python3"
         self.process.arguments = [serverPythonScriptPath(), "--prefer-localhost"]
         self.process.launch()
     }
@@ -128,7 +128,7 @@ private func resolveSwiftPackageFolder() -> URL {
         }
     }
 
-    fatalError("Cannot resolve the URL to folder containing `Package.swif`.")
+    fatalError("Cannot resolve the URL to folder containing `Package.swift`.")
 }
 
 private func sendPOSTRequestSynchronouslyTo(url: URL, body: Data) {

--- a/instrumented-tests/http-server-mock/python/server_address.py
+++ b/instrumented-tests/http-server-mock/python/server_address.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # -----------------------------------------------------------
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
@@ -9,9 +9,9 @@
 import socket
 
 class ServerAddress():
-    def __init__(self, ip, port):
-    	self.ip = ip
-    	self.port = port
+	def __init__(self, ip, port):
+		self.ip = ip
+		self.port = port
 
 def get_private_IP():
 	"""

--- a/instrumented-tests/http-server-mock/python/start_mock_server.py
+++ b/instrumented-tests/http-server-mock/python/start_mock_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # -----------------------------------------------------------
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
@@ -6,7 +6,7 @@
 # Copyright 2019-2020 Datadog, Inc.
 # -----------------------------------------------------------
 
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from http.server import HTTPServer, BaseHTTPRequestHandler
 from server_address import get_localhost, get_best_server_address
 import re
 import json
@@ -61,9 +61,9 @@ class HTTPMockServer(BaseHTTPRequestHandler):
         if 'Content-Encoding' in self.headers and self.headers['Content-Encoding'] == 'deflate':
             request_body = zlib.decompress(request_body)
         
-        request = GenericRequest("POST", request_path, self.headers, request_body)
+        request = GenericRequest("POST", request_path, self.headers.as_bytes(), request_body)
         history.add_request(request)
-        return "{}"
+        return bytes()
 
     def __GET_inspect(self, parameters):
         """
@@ -77,10 +77,11 @@ class HTTPMockServer(BaseHTTPRequestHandler):
             inspection_info.append({
                 "method": request.http_method,
                 "path": request.path,
-                "body": base64.b64encode(request.http_body), # use Base64 to not corrupt the JSON
-                "headers": base64.b64encode(str(request.http_headers)) # use Base64 to not corrupt the JSON
+                "body": base64.b64encode(request.http_body).decode("utf-8") , # use Base64 string to not corrupt the JSON
+                "headers": base64.b64encode(request.http_headers).decode("utf-8") # use Base64 string to not corrupt the JSON
             })
-        return json.dumps(inspection_info)
+
+        return json.dumps(inspection_info).encode("utf-8")
 
     def __route(self, routes):
         try:


### PR DESCRIPTION
### What and why?

`http-server-mock` was the last script still in py 2.

### How?

`BaseHTTPRequestHandler` now write `bytes` instead of `string` to fd.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
