### PR TITLE
RUMM-2133 Add v1 feature registry

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -544,6 +544,8 @@
 		B3FC3C3C2653A97700DEED9E /* VitalInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FC3C3B2653A97700DEED9E /* VitalInfoTests.swift */; };
 		D2135330270CA722000315AD /* DataCompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213532F270CA722000315AD /* DataCompressionTests.swift */; };
 		D22C1F5C271484B400922024 /* LogEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C1F5B271484B400922024 /* LogEventMapper.swift */; };
+		D232CAD52832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
+		D232CAD62832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
 		D240680827CE6C9E00C04F44 /* ConsoleOutputInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C902461A648003D8BB8 /* ConsoleOutputInterceptor.swift */; };
 		D240680E27CE6C9E00C04F44 /* UIViewController+KeyboardControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C922461A648003D8BB8 /* UIViewController+KeyboardControlling.swift */; };
 		D240681627CE6C9E00C04F44 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61441C9C2461A796003D8BB8 /* AppConfiguration.swift */; };
@@ -1740,6 +1742,7 @@
 		B3FC3C3B2653A97700DEED9E /* VitalInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VitalInfoTests.swift; sourceTree = "<group>"; };
 		D213532F270CA722000315AD /* DataCompressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompressionTests.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
+		D232CAD42832D762001B262C /* DatadogCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreMock.swift; sourceTree = "<group>"; };
 		D240684D27CE6C9E00C04F44 /* Example tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D240688527CFA64A00C04F44 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D243BBBF276C9D640019C857 /* PLCrashReporterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLCrashReporterIntegrationTests.swift; sourceTree = "<group>"; };
@@ -2349,6 +2352,7 @@
 				61C3638224361BE200C4D4E6 /* DatadogPrivateMocks.swift */,
 				61F1A61B2498AD2C00075390 /* SystemFrameworks */,
 				614BF37D2670AE9D002379C8 /* AttributesMocks.swift */,
+				D232CAD42832D762001B262C /* DatadogCoreMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -5339,6 +5343,7 @@
 				61133C532423990D00786299 /* MobileDeviceTests.swift in Sources */,
 				61FF282124B8981D000B3D9B /* RUMEventBuilderTests.swift in Sources */,
 				61B5E42926DFB60A000B0A5F /* DDConfiguration+apiTests.m in Sources */,
+				D232CAD52832D762001B262C /* DatadogCoreMock.swift in Sources */,
 				6184751826EFD03400C7C9C5 /* DatadogTestsObserverLoader.m in Sources */,
 				61345613244756E300E7DA6B /* PerformancePresetTests.swift in Sources */,
 			);
@@ -5958,6 +5963,7 @@
 				D2CB6F8127C520D400A62B57 /* MobileDeviceTests.swift in Sources */,
 				D2CB6F8227C520D400A62B57 /* RUMEventBuilderTests.swift in Sources */,
 				D2CB6F8327C520D400A62B57 /* DDConfiguration+apiTests.m in Sources */,
+				D232CAD62832D762001B262C /* DatadogCoreMock.swift in Sources */,
 				D2CB6F8427C520D400A62B57 /* DatadogTestsObserverLoader.m in Sources */,
 				D2CB6F8527C520D400A62B57 /* PerformancePresetTests.swift in Sources */,
 			);

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -20,6 +20,8 @@ internal final class DatadogCore {
     /// User PII.
     let userInfoProvider: UserInfoProvider
 
+    private var v1Features: [String: Any] = [:]
+
     /// Creates a core instance.
     ///
     /// - Parameters:
@@ -42,5 +44,15 @@ extension DatadogCore: DatadogCoreProtocol {
     func scope(forFeature featureName: String) -> FeatureScope? {
         // no-op
         return nil
+    }
+
+    // MARK: V1 interface
+
+    func registerFeature(named featureName: String, instance: Any?) {
+        v1Features[featureName] = instance
+    }
+
+    func feature<T>(_ type: T.Type, named featureName: String) -> T? {
+        return v1Features[featureName] as? T
     }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal var defaultDatadogCore: DatadogCoreProtocol = NOOPDatadogCore()
+public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOOPDatadogCore()
 
 /// A Datadog Core holds a set of features and is responsible of managing their storage
 /// and upload mechanism. It also provides a thread-safe scope for writing events.
@@ -24,6 +24,35 @@ public protocol DatadogCoreProtocol {
     /// - Parameter featureName: The feature's name.
     /// - Returns: The scope for feature that previously registered, `nil` otherwise.
     func scope(forFeature featureName: String) -> FeatureScope?
+
+    // MARK: V1 interface
+
+    /// Registers a feature instance by its name.
+    ///
+    /// Passing `nil` will unregister the feature.
+    ///
+    /// - Parameters:
+    ///   - featureName: The feature name.
+    ///   - instance: The feature instance.
+    func registerFeature(named featureName: String, instance: Any?)
+
+    /// Returns a Feature instance by its name.
+    /// 
+    /// - Parameters:
+    ///   - type: The feature instance type.
+    ///   - featureName: The feature's name.
+    /// - Returns: The feature if any.
+    func feature<T>(_ type: T.Type, named featureName: String) -> T?
+}
+
+extension DatadogCoreProtocol {
+    /// Returns a Feature instance by its name.
+    ///
+    /// - Parameter featureName: The feature's name.
+    /// - Returns: The feature if any.
+    func feature<T>(named featureName: String) -> T? {
+        return feature(T.self, named: featureName)
+    }
 }
 
 /// Provide feature specific storage configuration.
@@ -48,6 +77,16 @@ internal struct NOOPDatadogCore: DatadogCoreProtocol {
 
     /// no-op
     func scope(forFeature featureName: String) -> FeatureScope? {
+        return nil
+    }
+
+    // MARK: V1 interface
+
+    /// no-op
+    func registerFeature(named featureName: String, instance: Any?) {}
+
+    /// no-op
+    func feature<T>(_ type: T.Type, named featureName: String) -> T? {
         return nil
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import Datadog
+
+internal final class DatadogCoreMock: DatadogCoreProtocol {
+    private var v1Features: [String: Any] = [:]
+
+    func flush() {
+        v1Features = [:]
+    }
+
+    func all<T>(_ type: T.Type) -> [T] {
+        v1Features.values.compactMap { $0 as? T }
+    }
+
+    /// no-op
+    func registerFeature(named featureName: String, storage: FeatureStorageConfiguration, upload: FeatureUploadConfiguration) {}
+
+    /// no-op
+    func scope(forFeature featureName: String) -> FeatureScope? {
+        return nil
+    }
+
+    // MARK: V1 interface
+
+    func registerFeature(named featureName: String, instance: Any?) {
+        v1Features[featureName] = instance
+    }
+
+    func feature<T>(_ type: T.Type, named featureName: String) -> T? {
+        return v1Features[featureName] as? T
+    }
+}


### PR DESCRIPTION
### What and why?

Creates a v1 feature registry in `DatadogCore` to use while migrating to v2 architecture.

### How?

`DatadogCoreProtocol` now expect 2 methods specific to v1 features registering.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
