### PR TITLE
RUMM-2133 Register Logs v1 in `DatadogCore`

### DIFF
--- a/Sources/Datadog/Core/Persistence/Files/Directory.swift
+++ b/Sources/Datadog/Core/Persistence/Files/Directory.swift
@@ -82,13 +82,13 @@ internal struct Directory {
 /// * System may delete data in `/Library/Cache` to free up disk space which reduces the impact on devices working under heavy space pressure.
 private func createCachesSubdirectoryIfNotExists(subdirectoryPath: String) throws -> URL {
     guard let cachesDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-        throw ProgrammerError(description: "Cannot obtain `/Library/Caches/` url.")
+        throw InternalError(description: "Cannot obtain `/Library/Caches/` url.")
     }
     let subdirectoryURL = cachesDirectoryURL.appendingPathComponent(subdirectoryPath, isDirectory: true)
     do {
         try FileManager.default.createDirectory(at: subdirectoryURL, withIntermediateDirectories: true, attributes: nil)
     } catch {
-        throw ProgrammerError(description: "Cannot create subdirectory in `/Library/Caches/` folder.")
+        throw InternalError(description: "Cannot create subdirectory in `/Library/Caches/` folder.")
     }
     return subdirectoryURL
 }

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -22,13 +22,16 @@ internal class CrashReporter {
 
     // MARK: - Initialization
 
-    convenience init?(crashReportingFeature: CrashReportingFeature) {
+    convenience init?(
+        crashReportingFeature: CrashReportingFeature,
+        loggingFeature: LoggingFeature?
+    ) {
         let loggingOrRUMIntegration: CrashReportingIntegration?
 
         // If RUM rum is enabled prefer it for sending crash reports, otherwise use Logging feature.
         if let rumFeature = RUMFeature.instance {
             loggingOrRUMIntegration = CrashReportingWithRUMIntegration(rumFeature: rumFeature)
-        } else if let loggingFeature = LoggingFeature.instance {
+        } else if let loggingFeature = loggingFeature {
             loggingOrRUMIntegration = CrashReportingWithLoggingIntegration(loggingFeature: loggingFeature)
         } else {
             loggingOrRUMIntegration = nil

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -95,8 +95,10 @@ public class Datadog {
                 consolePrint("⚠️ Overriding RUM debugging due to \(LaunchArguments.DebugRUM) launch argument")
                 Datadog.debugRUM = true
             }
-        } catch {
+        } catch let error as ProgrammerError {
             consolePrint("\(error)")
+        } catch {
+            defaultDatadogCore = NOOPDatadogCore()
         }
     }
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -34,6 +34,36 @@ internal final class DatadogCore {
         self.consentProvider = consentProvider
         self.userInfoProvider = userInfoProvider
     }
+
+    /// Sets current user information.
+    ///
+    /// Those will be added to logs, traces and RUM events automatically.
+    /// 
+    /// - Parameters:
+    ///   - id: User ID, if any
+    ///   - name: Name representing the user, if any
+    ///   - email: User's email, if any
+    ///   - extraInfo: User's custom attributes, if any
+    func setUserInfo(
+        id: String? = nil,
+        name: String? = nil,
+        email: String? = nil,
+        extraInfo: [AttributeKey: AttributeValue] = [:]
+    ) {
+        userInfoProvider.value = UserInfo(
+            id: id,
+            name: name,
+            email: email,
+            extraInfo: extraInfo
+        )
+    }
+
+    /// Sets the tracking consent regarding the data collection for the Datadog SDK.
+    /// 
+    /// - Parameter trackingConsent: new consent value, which will be applied for all data collected from now on
+    func set(trackingConsent: TrackingConsent) {
+        consentProvider.changeConsent(to: trackingConsent)
+    }
 }
 
 extension DatadogCore: DatadogCoreProtocol {

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -382,9 +382,9 @@ public class Logger {
         }
 
         /// Builds `Logger` object.
-        public func build() -> Logger {
+        public func build(in core: DatadogCoreProtocol = defaultDatadogCore) -> Logger {
             do {
-                return try buildOrThrow()
+                return try buildOrThrow(in: core)
             } catch {
                 consolePrint("\(error)")
                 return Logger(
@@ -398,8 +398,8 @@ public class Logger {
             }
         }
 
-        private func buildOrThrow() throws -> Logger {
-            guard let loggingFeature = LoggingFeature.instance else {
+        private func buildOrThrow(in core: DatadogCoreProtocol) throws -> Logger {
+            guard let loggingFeature = core.feature(LoggingFeature.self, named: LoggingFeature.featureName) else {
                 throw ProgrammerError(
                     description: Datadog.isInitialized
                         ? "`Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -25,12 +25,6 @@ internal func obtainLoggingFeatureDirectories() throws -> FeatureDirectories {
 /// Creates and owns componetns enabling logging feature.
 /// Bundles dependencies for other logging-related components created later at runtime  (i.e. `Logger`).
 internal final class LoggingFeature {
-    /// Single, shared instance of `LoggingFeature`.
-    internal static var instance: LoggingFeature?
-
-    /// Tells if the feature was enabled by the user in the SDK configuration.
-    static var isEnabled: Bool { instance != nil }
-
     // MARK: - Configuration
 
     let configuration: FeaturesConfiguration.Logging
@@ -152,6 +146,5 @@ internal final class LoggingFeature {
     internal func deinitialize() {
         storage.flushAndTearDown()
         upload.flushAndTearDown()
-        LoggingFeature.instance = nil
     }
 }

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -211,9 +211,11 @@ class CrashReporterTests: XCTestCase {
         plugin.pendingCrashReport = .mockAny()
 
         // When
-        XCTAssertNil(LoggingFeature.instance)
         XCTAssertNil(RUMFeature.instance)
-        let crashReporter = CrashReporter(crashReportingFeature: .mockNoOp())
+        let crashReporter = CrashReporter(
+            crashReportingFeature: .mockNoOp(),
+            loggingFeature: nil
+        )
 
         // Then
         XCTAssertNil(crashReporter)

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -37,7 +37,6 @@ class LoggerBuilderTests: XCTestCase {
     }
 
     override func tearDown() {
-        core.all(LoggingFeature.self).forEach { $0.deinitialize() }
         core.flush()
         temporaryFeatureDirectories.delete()
         super.tearDown()

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -8,6 +8,8 @@ import XCTest
 @testable import Datadog
 
 class LoggerBuilderTests: XCTestCase {
+    let core = DatadogCoreMock()
+
     private let networkConnectionInfoProvider: NetworkConnectionInfoProviderMock = .mockAny()
     private let carrierInfoProvider: CarrierInfoProviderMock = .mockAny()
 
@@ -15,7 +17,7 @@ class LoggerBuilderTests: XCTestCase {
         super.setUp()
         temporaryFeatureDirectories.create()
 
-        LoggingFeature.instance = .mockByRecordingLogMatchers(
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
@@ -30,21 +32,24 @@ class LoggerBuilderTests: XCTestCase {
                 carrierInfoProvider: carrierInfoProvider
             )
         )
+
+        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
     }
 
     override func tearDown() {
-        LoggingFeature.instance?.deinitialize()
+        core.all(LoggingFeature.self).forEach { $0.deinitialize() }
+        core.flush()
         temporaryFeatureDirectories.delete()
         super.tearDown()
     }
 
     func testDefaultLogger() throws {
-        let logger = Logger.builder.build()
+        let logger = Logger.builder.build(in: core)
 
         XCTAssertNil(logger.rumContextIntegration)
         XCTAssertNil(logger.activeSpanIntegration)
 
-        let feature = LoggingFeature.instance!
+        let feature = try XCTUnwrap(core.feature(LoggingFeature.self, named: LoggingFeature.featureName))
         XCTAssertTrue(
             logger.logOutput is LogFileOutput,
             "When Logging feature is enabled the Logger should use `LogFileOutput`."
@@ -67,7 +72,7 @@ class LoggerBuilderTests: XCTestCase {
         RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance?.deinitialize() }
 
-        let logger1 = Logger.builder.build()
+        let logger1 = Logger.builder.build(in: core)
         XCTAssertNotNil(logger1.rumContextIntegration)
 
         let logger2 = Logger.builder.bundleWithRUM(false).build()
@@ -78,10 +83,10 @@ class LoggerBuilderTests: XCTestCase {
         TracingFeature.instance = .mockNoOp()
         defer { TracingFeature.instance?.deinitialize() }
 
-        let logger1 = Logger.builder.build()
+        let logger1 = Logger.builder.build(in: core)
         XCTAssertNotNil(logger1.activeSpanIntegration)
 
-        let logger2 = Logger.builder.bundleWithTrace(false).build()
+        let logger2 = Logger.builder.bundleWithTrace(false).build(in: core)
         XCTAssertNil(logger2.activeSpanIntegration)
     }
 
@@ -98,12 +103,12 @@ class LoggerBuilderTests: XCTestCase {
             .sendNetworkInfo(true)
             .bundleWithRUM(false)
             .bundleWithTrace(false)
-            .build()
+            .build(in: core)
 
         XCTAssertNil(logger.rumContextIntegration)
         XCTAssertNil(logger.activeSpanIntegration)
 
-        let feature = LoggingFeature.instance!
+        let feature = try XCTUnwrap(core.feature(LoggingFeature.self, named: LoggingFeature.featureName))
         XCTAssertTrue(
             logger.logOutput is LogFileOutput,
             "When Logging feature is enabled the Logger should use `LogFileOutput`."
@@ -125,45 +130,45 @@ class LoggerBuilderTests: XCTestCase {
     func testUsingDifferentOutputs() throws {
         var logger: Logger
 
-        logger = Logger.builder.build()
+        logger = Logger.builder.build(in: core)
         XCTAssertNotNil(logger.logBuilder)
         XCTAssertTrue(logger.logOutput is LogFileOutput)
 
-        logger = Logger.builder.sendLogsToDatadog(true).build()
+        logger = Logger.builder.sendLogsToDatadog(true).build(in: core)
         XCTAssertNotNil(logger.logBuilder)
         XCTAssertTrue(logger.logOutput is LogFileOutput)
 
-        logger = Logger.builder.sendLogsToDatadog(false).build()
+        logger = Logger.builder.sendLogsToDatadog(false).build(in: core)
         XCTAssertNil(logger.logBuilder)
         XCTAssertNil(logger.logOutput)
 
-        logger = Logger.builder.printLogsToConsole(true).build()
+        logger = Logger.builder.printLogsToConsole(true).build(in: core)
         var combinedOutputs = try (logger.logOutput as? CombinedLogOutput).unwrapOrThrow().combinedOutputs
         XCTAssertNotNil(logger.logBuilder)
         XCTAssertEqual(combinedOutputs.count, 2)
         XCTAssertTrue(combinedOutputs[0] is LogFileOutput)
         XCTAssertTrue(combinedOutputs[1] is LogConsoleOutput)
 
-        logger = Logger.builder.printLogsToConsole(false).build()
+        logger = Logger.builder.printLogsToConsole(false).build(in: core)
         XCTAssertNotNil(logger.logBuilder)
         XCTAssertTrue(logger.logOutput is LogFileOutput)
 
-        logger = Logger.builder.sendLogsToDatadog(true).printLogsToConsole(true).build()
+        logger = Logger.builder.sendLogsToDatadog(true).printLogsToConsole(true).build(in: core)
         combinedOutputs = try (logger.logOutput as? CombinedLogOutput).unwrapOrThrow().combinedOutputs
         XCTAssertNotNil(logger.logBuilder)
         XCTAssertEqual(combinedOutputs.count, 2)
         XCTAssertTrue(combinedOutputs[0] is LogFileOutput)
         XCTAssertTrue(combinedOutputs[1] is LogConsoleOutput)
 
-        logger = Logger.builder.sendLogsToDatadog(false).printLogsToConsole(true).build()
+        logger = Logger.builder.sendLogsToDatadog(false).printLogsToConsole(true).build(in: core)
         XCTAssertNotNil(logger.logBuilder)
         XCTAssertTrue(logger.logOutput is LogConsoleOutput)
 
-        logger = Logger.builder.sendLogsToDatadog(true).printLogsToConsole(false).build()
+        logger = Logger.builder.sendLogsToDatadog(true).printLogsToConsole(false).build(in: core)
         XCTAssertNotNil(logger.logBuilder)
         XCTAssertTrue(logger.logOutput is LogFileOutput)
 
-        logger = Logger.builder.sendLogsToDatadog(false).printLogsToConsole(false).build()
+        logger = Logger.builder.sendLogsToDatadog(false).printLogsToConsole(false).build(in: core)
         XCTAssertNil(logger.logBuilder)
         XCTAssertNil(logger.logOutput)
     }

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -18,7 +18,6 @@ class LoggingFeatureTests: XCTestCase {
 
     override func tearDown() {
         XCTAssertFalse(Datadog.isInitialized)
-        core.all(LoggingFeature.self).forEach { $0.deinitialize() }
         core.flush()
         temporaryFeatureDirectories.delete()
         super.tearDown()

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -8,16 +8,18 @@ import XCTest
 @testable import Datadog
 
 class LoggingFeatureTests: XCTestCase {
+    let core = DatadogCoreMock()
+
     override func setUp() {
         super.setUp()
         XCTAssertFalse(Datadog.isInitialized)
-        XCTAssertNil(LoggingFeature.instance)
         temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
         XCTAssertFalse(Datadog.isInitialized)
-        XCTAssertNil(LoggingFeature.instance)
+        core.all(LoggingFeature.self).forEach { $0.deinitialize() }
+        core.flush()
         temporaryFeatureDirectories.delete()
         super.tearDown()
     }
@@ -40,7 +42,7 @@ class LoggingFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
         // Given
-        LoggingFeature.instance = .mockWith(
+        let feature: LoggingFeature = .mockWith(
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
@@ -58,10 +60,10 @@ class LoggingFeatureTests: XCTestCase {
                 mobileDevice: .mockWith(model: randomDeviceModel, osName: randomDeviceOSName, osVersion: randomDeviceOSVersion)
             )
         )
-        defer { LoggingFeature.instance?.deinitialize() }
+        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
 
         // When
-        let logger = Logger.builder.build()
+        let logger = Logger.builder.build(in: core)
         logger.debug(.mockAny())
 
         // Then
@@ -88,7 +90,7 @@ class LoggingFeatureTests: XCTestCase {
 
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        LoggingFeature.instance = .mockWith(
+        let feature: LoggingFeature = .mockWith(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(
@@ -110,9 +112,9 @@ class LoggingFeatureTests: XCTestCase {
                 )
             )
         )
-        defer { LoggingFeature.instance?.deinitialize() }
+        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
 
-        let logger = Logger.builder.build()
+        let logger = Logger.builder.build(in: core)
         logger.debug("log 1")
         logger.debug("log 2")
         logger.debug("log 3")

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -64,12 +64,21 @@ extension LoggingFeature {
 
     // MARK: - Expecting Logs Data
 
-    static func waitAndReturnLogMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
-        guard let uploadWorker = LoggingFeature.instance?.upload.uploader as? DataUploadWorkerMock else {
+    func waitAndReturnLogMatchers(count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
+        guard let uploadWorker = upload.uploader as? DataUploadWorkerMock else {
             preconditionFailure("Retrieving matchers requires that feature is mocked with `.mockByRecordingLogMatchers()`")
         }
         return try uploadWorker.waitAndReturnBatchedData(count: count, file: file, line: line)
             .flatMap { batchData in try LogMatcher.fromArrayOfJSONObjectsData(batchData, file: file, line: line) }
+    }
+
+    // swiftlint:disable:next function_default_parameter_at_end
+    static func waitAndReturnLogMatchers(in core: DatadogCoreProtocol = defaultDatadogCore, count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
+        guard let logging = core.feature(LoggingFeature.self, named: LoggingFeature.featureName) else {
+            preconditionFailure("LoggingFeature is not registered in core")
+        }
+
+        return try logging.waitAndReturnLogMatchers(count: count, file: file, line: line)
     }
 }
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1139,7 +1139,10 @@ class RUMMonitorTests: XCTestCase {
         defer { CrashReportingFeature.instance?.deinitialize() }
 
         // Given
-        Global.crashReporter = CrashReporter(crashReportingFeature: CrashReportingFeature.instance!)
+        Global.crashReporter = CrashReporter(
+            crashReportingFeature: CrashReportingFeature.instance!,
+            loggingFeature: nil
+        )
         defer { Global.crashReporter = nil }
 
         // When

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -9,16 +9,21 @@ import XCTest
 
 // swiftlint:disable multiline_arguments_brackets
 class TracerTests: XCTestCase {
+    let core = DatadogCoreMock()
+
     override func setUp() {
         super.setUp()
         XCTAssertFalse(Datadog.isInitialized)
-        XCTAssertNil(LoggingFeature.instance)
+        XCTAssertNil(TracingFeature.instance)
         temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
+        core.all(LoggingFeature.self).forEach { $0.deinitialize() }
+        core.flush()
+
         XCTAssertFalse(Datadog.isInitialized)
-        XCTAssertNil(LoggingFeature.instance)
+        XCTAssertNil(TracingFeature.instance)
         temporaryFeatureDirectories.delete()
         super.tearDown()
     }
@@ -600,20 +605,21 @@ class TracerTests: XCTestCase {
     // MARK: - Integration With Logging Feature
 
     func testSendingSpanLogs() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(
+        let loggingFeature: LoggingFeature = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance?.deinitialize() }
+
+        core.registerFeature(named: LoggingFeature.featureName, instance: loggingFeature)
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             ),
-            loggingFeature: LoggingFeature.instance!
+            loggingFeature: loggingFeature
         )
         defer { TracingFeature.instance?.deinitialize() }
 
@@ -623,7 +629,7 @@ class TracerTests: XCTestCase {
         span.log(fields: [OTLogFields.message: "hello", "custom.field": "value"])
         span.log(fields: [OTLogFields.event: "error", OTLogFields.errorKind: "Swift error", OTLogFields.message: "Ops!"])
 
-        let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 2)
+        let logMatchers = try loggingFeature.waitAndReturnLogMatchers(count: 2)
 
         let regularLogMatcher = logMatchers[0]
         let errorLogMatcher = logMatchers[1]
@@ -644,20 +650,20 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(
+        let loggingFeature: LoggingFeature = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance?.deinitialize() }
+        core.registerFeature(named: LoggingFeature.featureName, instance: loggingFeature)
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             ),
-            loggingFeature: LoggingFeature.instance!
+            loggingFeature: loggingFeature
         )
         defer { TracingFeature.instance?.deinitialize() }
 
@@ -667,7 +673,7 @@ class TracerTests: XCTestCase {
         span.log(fields: [OTLogFields.message: "hello", "custom.field": "value"])
         span.setError(kind: "Swift error", message: "Ops!")
 
-        let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 2)
+        let logMatchers = try loggingFeature.waitAndReturnLogMatchers(count: 2)
         let errorLogMatcher = logMatchers[1]
 
         errorLogMatcher.assertStatus(equals: "error")
@@ -680,20 +686,20 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(
+        let loggingFeature: LoggingFeature = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance?.deinitialize() }
+        core.registerFeature(named: LoggingFeature.featureName, instance: loggingFeature)
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             ),
-            loggingFeature: LoggingFeature.instance!
+            loggingFeature: loggingFeature
         )
         defer { TracingFeature.instance?.deinitialize() }
 
@@ -708,7 +714,7 @@ class TracerTests: XCTestCase {
         )
         span.setError(error)
 
-        let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 2)
+        let logMatchers = try loggingFeature.waitAndReturnLogMatchers(count: 2)
 
         let errorLogMatcher = logMatchers[1]
 
@@ -722,20 +728,20 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromSwiftError() throws {
-        LoggingFeature.instance = .mockByRecordingLogMatchers(
+        let loggingFeature: LoggingFeature = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { LoggingFeature.instance?.deinitialize() }
+        core.registerFeature(named: LoggingFeature.featureName, instance: loggingFeature)
 
         TracingFeature.instance = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             ),
-            loggingFeature: LoggingFeature.instance!
+            loggingFeature: loggingFeature
         )
         defer { TracingFeature.instance?.deinitialize() }
 
@@ -745,7 +751,7 @@ class TracerTests: XCTestCase {
         span.log(fields: [OTLogFields.message: "hello", "custom.field": "value"])
         span.setError(ErrorMock("Ops!"))
 
-        let logMatchers = try LoggingFeature.waitAndReturnLogMatchers(count: 2)
+        let logMatchers = try loggingFeature.waitAndReturnLogMatchers(count: 2)
 
         let errorLogMatcher = logMatchers[1]
 

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -19,7 +19,6 @@ class TracerTests: XCTestCase {
     }
 
     override func tearDown() {
-        core.all(LoggingFeature.self).forEach { $0.deinitialize() }
         core.flush()
 
         XCTAssertFalse(Datadog.isInitialized)

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -13,13 +13,15 @@ class DDDatadogTests: XCTestCase {
     override func setUp() {
         super.setUp()
         XCTAssertFalse(Datadog.isInitialized)
-        XCTAssertNil(LoggingFeature.instance)
+        let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
+        XCTAssertNil(logging)
         XCTAssertNil(URLSessionAutoInstrumentation.instance)
     }
 
     override func tearDown() {
         XCTAssertFalse(Datadog.isInitialized)
-        XCTAssertNil(LoggingFeature.instance)
+        let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
+        XCTAssertNil(logging)
         XCTAssertNil(URLSessionAutoInstrumentation.instance)
         super.tearDown()
     }
@@ -37,8 +39,10 @@ class DDDatadogTests: XCTestCase {
         )
 
         XCTAssertTrue(Datadog.isInitialized)
-        XCTAssertEqual(LoggingFeature.instance?.configuration.common.applicationName, "app-name")
-        XCTAssertEqual(LoggingFeature.instance?.configuration.common.environment, "tests")
+
+        let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
+        XCTAssertEqual(logging?.configuration.common.applicationName, "app-name")
+        XCTAssertEqual(logging?.configuration.common.environment, "tests")
         XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
 
         URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -45,7 +45,7 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
         ),
         .init(
             assert: {
-                LoggingFeature.instance == nil
+                defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName) == nil
                     && TracingFeature.instance == nil
                     && RUMFeature.instance == nil
                     && CrashReportingFeature.instance == nil


### PR DESCRIPTION
### What and why?

Register Logs v1 in `DatadogCore`.

### How?

Remove `LoggingFeature.instance` singleton and other static access and expect a `DatadogCoreProtocol` complying instance when creating a `Logger`, `defaultDatadogCore` is used by default.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
