### PR TITLE
RUMM-2133 Register Tracing v1 in `DatadogCore`

### DIFF
--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -155,7 +155,8 @@ public class Datadog {
     public static func clearAllData() {
         let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
         logging?.storage.clearAllData()
-        TracingFeature.instance?.storage.clearAllData()
+        let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+        tracing?.storage.clearAllData()
         RUMFeature.instance?.storage.clearAllData()
     }
 
@@ -270,10 +271,12 @@ public class Datadog {
                 directories: try obtainTracingFeatureDirectories(),
                 configuration: tracingConfiguration,
                 commonDependencies: commonDependencies,
-                loggingFeatureAdapter: logging.flatMap { LoggingForTracingAdapter(loggingFeature: $0) },
+                loggingFeatureAdapter: logging.map { LoggingForTracingAdapter(loggingFeature: $0) },
                 tracingUUIDGenerator: DefaultTracingUUIDGenerator(),
                 telemetry: telemetry
             )
+
+            defaultDatadogCore.registerFeature(named: TracingFeature.featureName, instance: tracing)
         }
 
         if let crashReportingConfiguration = configuration.crashReporting {
@@ -291,7 +294,6 @@ public class Datadog {
             )
         }
 
-        TracingFeature.instance = tracing
         RUMFeature.instance = rum
         CrashReportingFeature.instance = crashReporting
 
@@ -332,8 +334,8 @@ public class Datadog {
         // Tear down and deinitialize all features:
         let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
         logging?.deinitialize()
-
-        TracingFeature.instance?.deinitialize()
+        let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+        tracing?.deinitialize()
         RUMFeature.instance?.deinitialize()
         CrashReportingFeature.instance?.deinitialize()
 

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -409,13 +409,17 @@ public class Logger {
 
             let (logBuilder, logOutput) = resolveLogBuilderAndOutput(for: loggingFeature) ?? (nil, nil)
 
+            // RUMM-2133 Note: strong feature coupling while migrating to v2.
+            // In v2 active span will be provided in context from feature scope.
+            let tracingEnabled = core.feature(TracingFeature.self, named: TracingFeature.featureName) != nil
+
             return Logger(
                 logBuilder: logBuilder,
                 logOutput: logOutput,
                 dateProvider: loggingFeature.dateProvider,
                 identifier: resolveLoggerName(for: loggingFeature),
                 rumContextIntegration: (RUMFeature.isEnabled && bundleWithRUM) ? LoggingWithRUMContextIntegration() : nil,
-                activeSpanIntegration: (TracingFeature.isEnabled && bundleWithTrace) ? LoggingWithActiveSpanIntegration() : nil
+                activeSpanIntegration: (tracingEnabled && bundleWithTrace) ? LoggingWithActiveSpanIntegration() : nil
             )
         }
 

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -69,7 +69,7 @@ public class Tracer: OTTracer {
     /// Initializes the Datadog Tracer.
     /// - Parameters:
     ///   - configuration: the tracer configuration obtained using `Tracer.Configuration()`.
-    public static func initialize(configuration: Configuration) -> OTTracer {
+    public static func initialize(configuration: Configuration, in core: DatadogCoreProtocol = defaultDatadogCore) -> OTTracer {
         do {
             if Global.sharedTracer is Tracer {
                 throw ProgrammerError(
@@ -78,7 +78,7 @@ public class Tracer: OTTracer {
                     """
                 )
             }
-            guard let tracingFeature = TracingFeature.instance else {
+            guard let tracingFeature = core.feature(TracingFeature.self, named: TracingFeature.featureName) else {
                 throw ProgrammerError(
                     description: Datadog.isInitialized
                         ? "`Tracer.initialize(configuration:)` produces a non-functional tracer, as the tracing feature is disabled."

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -25,12 +25,6 @@ internal func obtainTracingFeatureDirectories() throws -> FeatureDirectories {
 /// Creates and owns componetns enabling tracing feature.
 /// Bundles dependencies for other tracing-related components created later at runtime  (i.e. `Tracer`).
 internal final class TracingFeature {
-    /// Single, shared instance of `TracingFeatureFeature`.
-    internal static var instance: TracingFeature?
-
-    /// Tells if the feature was enabled by the user in the SDK configuration.
-    static var isEnabled: Bool { instance != nil }
-
     // MARK: - Configuration
 
     let configuration: FeaturesConfiguration.Tracing
@@ -171,6 +165,5 @@ internal final class TracingFeature {
     internal func deinitialize() {
         storage.flushAndTearDown()
         upload.flushAndTearDown()
-        TracingFeature.instance = nil
     }
 }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -115,53 +115,58 @@ class DatadogTests: XCTestCase {
         verify(configuration: defaultBuilder.build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertTrue(TracingFeature.isEnabled)
             XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            XCTAssertNotNil(tracing)
+            XCTAssertNotNil(tracing?.loggingFeatureAdapter)
         }
         verify(configuration: rumBuilder.build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertTrue(TracingFeature.isEnabled)
             XCTAssertTrue(RUMFeature.isEnabled, "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            XCTAssertNotNil(tracing)
+            XCTAssertNotNil(tracing?.loggingFeatureAdapter)
         }
 
         verify(configuration: defaultBuilder.enableLogging(false).build()) {
             // verify features:
             XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertTrue(TracingFeature.isEnabled)
             XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            XCTAssertNil(TracingFeature.instance?.loggingFeatureAdapter)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            XCTAssertNotNil(tracing)
+            XCTAssertNil(tracing?.loggingFeatureAdapter)
         }
         verify(configuration: rumBuilder.enableLogging(false).build()) {
             // verify features:
             XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertTrue(TracingFeature.isEnabled)
+            XCTAssertNotNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
             XCTAssertTrue(RUMFeature.isEnabled, "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            XCTAssertNil(TracingFeature.instance?.loggingFeatureAdapter)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            XCTAssertNotNil(tracing)
+            XCTAssertNil(tracing?.loggingFeatureAdapter)
         }
 
         verify(configuration: defaultBuilder.enableTracing(false).build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertFalse(TracingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
             XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
@@ -170,7 +175,7 @@ class DatadogTests: XCTestCase {
         verify(configuration: rumBuilder.enableTracing(false).build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertFalse(TracingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
             XCTAssertTrue(RUMFeature.isEnabled, "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(RUMInstrumentation.instance)
@@ -180,24 +185,26 @@ class DatadogTests: XCTestCase {
         verify(configuration: defaultBuilder.enableRUM(true).build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertTrue(TracingFeature.isEnabled)
             XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature cannot be enabled")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            XCTAssertNotNil(tracing)
+            XCTAssertNotNil(tracing?.loggingFeatureAdapter)
         }
         verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertTrue(TracingFeature.isEnabled)
             XCTAssertFalse(RUMFeature.isEnabled)
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            XCTAssertNotNil(TracingFeature.instance?.loggingFeatureAdapter)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            XCTAssertNotNil(tracing)
+            XCTAssertNotNil(tracing?.loggingFeatureAdapter)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMViews().build()) {
@@ -317,9 +324,10 @@ class DatadogTests: XCTestCase {
 
         let core = defaultDatadogCore
         let logging = core.feature(LoggingFeature.self, named: LoggingFeature.featureName)
+        let tracing = core.feature(TracingFeature.self, named: TracingFeature.featureName)
         XCTAssertEqual(logging?.configuration.common.performance, expectedPerformancePreset)
         XCTAssertEqual(RUMFeature.instance?.configuration.sessionSampler.samplingRate, 100)
-        XCTAssertEqual(TracingFeature.instance?.configuration.common.performance, expectedPerformancePreset)
+        XCTAssertEqual(tracing?.configuration.common.performance, expectedPerformancePreset)
         XCTAssertEqual(Datadog.verbosityLevel, .debug)
 
         // Clear default verbosity after this test
@@ -440,12 +448,13 @@ class DatadogTests: XCTestCase {
 
         let core = defaultDatadogCore
         let logging = core.feature(LoggingFeature.self, named: LoggingFeature.featureName)
+        let tracing = core.feature(TracingFeature.self, named: TracingFeature.featureName)
 
         // On SDK init, underlying `ConsentAwareDataWriter` performs data migration for each feature, which includes
         // data removal in `unauthorised` (`.pending`) directory. To not cause test flakiness, we must ensure that
         // mock data is written only after this operation completes - otherwise, migration may delete mocked files.
         let loggingWriter = try XCTUnwrap(logging?.storage.writer as? ConsentAwareDataWriter)
-        let tracingWriter = try XCTUnwrap(TracingFeature.instance?.storage.writer as? ConsentAwareDataWriter)
+        let tracingWriter = try XCTUnwrap(tracing?.storage.writer as? ConsentAwareDataWriter)
         let rumWriter = try XCTUnwrap(RUMFeature.instance?.storage.writer as? ConsentAwareDataWriter)
         loggingWriter.queue.sync {}
         tracingWriter.queue.sync {}
@@ -469,7 +478,7 @@ class DatadogTests: XCTestCase {
 
         // Wait for async clear completion in all features:
         (logging?.storage.dataOrchestrator as? DataOrchestrator)?.queue.sync {}
-        (TracingFeature.instance?.storage.dataOrchestrator as? DataOrchestrator)?.queue.sync {}
+        (tracing?.storage.dataOrchestrator as? DataOrchestrator)?.queue.sync {}
         (RUMFeature.instance?.storage.dataOrchestrator as? DataOrchestrator)?.queue.sync {}
 
         // Then

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -79,8 +79,8 @@ class LoggerBuilderTests: XCTestCase {
     }
 
     func testDefaultLoggerWithTracingEnabled() throws {
-        TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance?.deinitialize() }
+        let tracing: TracingFeature = .mockNoOp()
+        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
 
         let logger1 = Logger.builder.build(in: core)
         XCTAssertNotNil(logger1.activeSpanIntegration)
@@ -93,8 +93,8 @@ class LoggerBuilderTests: XCTestCase {
         RUMFeature.instance = .mockNoOp()
         defer { RUMFeature.instance?.deinitialize() }
 
-        TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance?.deinitialize() }
+        let tracing: TracingFeature = .mockNoOp()
+        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
 
         let logger = Logger.builder
             .set(serviceName: "custom-service-name")

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -632,15 +632,13 @@ class LoggerTests: XCTestCase {
 
     func testGivenBundlingWithTraceEnabledAndTracerRegistered_whenSendingLog_itContainsActiveSpanAttributes() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { feature.deinitialize() }
+        let tracing: TracingFeature = .mockNoOp()
         core.registerFeature(named: LoggingFeature.featureName, instance: feature)
-
-        TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance?.deinitialize() }
+        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
 
         // given
         let logger = Logger.builder.build(in: core)
-        Global.sharedTracer = Tracer.initialize(configuration: .init())
+        Global.sharedTracer = Tracer.initialize(configuration: .init(), in: core)
         defer { Global.sharedTracer = DDNoopGlobals.tracer }
 
         // when
@@ -665,11 +663,9 @@ class LoggerTests: XCTestCase {
 
     func testGivenBundlingWithTraceEnabledButTracerNotRegistered_whenSendingLog_itPrintsWarning() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { feature.deinitialize() }
+        let tracing: TracingFeature = .mockNoOp()
         core.registerFeature(named: LoggingFeature.featureName, instance: feature)
-
-        TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance?.deinitialize() }
+        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
 
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -60,3 +60,9 @@ extension LoggingFeature: Flushable {
         deinitialize()
     }
 }
+
+extension TracingFeature: Flushable {
+    func flush() {
+        deinitialize()
+    }
+}

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -13,16 +13,10 @@ class DDDatadogTests: XCTestCase {
     override func setUp() {
         super.setUp()
         XCTAssertFalse(Datadog.isInitialized)
-        let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
-        XCTAssertNil(logging)
-        XCTAssertNil(URLSessionAutoInstrumentation.instance)
     }
 
     override func tearDown() {
         XCTAssertFalse(Datadog.isInitialized)
-        let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
-        XCTAssertNil(logging)
-        XCTAssertNil(URLSessionAutoInstrumentation.instance)
         super.tearDown()
     }
 
@@ -47,6 +41,9 @@ class DDDatadogTests: XCTestCase {
 
         URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
         Datadog.flushAndDeinitialize()
+
+        XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
+        XCTAssertNil(URLSessionAutoInstrumentation.instance)
     }
 
     // MARK: - Changing Tracking Consent

--- a/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
@@ -5,48 +5,55 @@
 */
 
 import XCTest
-@testable import struct Datadog.DDGlobal
-@testable import class Datadog.TracingFeature
-@testable import class Datadog.DDNoopRUMMonitor
-@testable import class Datadog.Tracer
-@testable import struct Datadog.DDNoopTracer
-@testable import class Datadog.RUMFeature
-@testable import class Datadog.RUMMonitor
+@testable import  Datadog
 @testable import DatadogObjc
 
 class DDGlobalTests: XCTestCase {
+    let core = DatadogCoreMock()
+
+    override func setUp() {
+        super.setUp()
+        defaultDatadogCore = core
+    }
+
+    override func tearDown() {
+        core.flush()
+        defaultDatadogCore = NOOPDatadogCore()
+        super.tearDown()
+    }
     // MARK: - Test Global Tracer
 
     func testWhenTracerIsNotSet_itReturnsNoOpImplementation() {
-        XCTAssertTrue(DatadogObjc.DDGlobal.sharedTracer.swiftTracer is Datadog.DDNoopTracer)
-        XCTAssertTrue(Datadog.DDGlobal.sharedTracer is Datadog.DDNoopTracer)
+        XCTAssertTrue(DatadogObjc.DDGlobal.sharedTracer.swiftTracer is DDNoopTracer)
+        XCTAssertTrue(Global.sharedTracer is DDNoopTracer)
     }
 
     func testWhenTracerIsSet_itSetsSwiftImplementation() {
-        TracingFeature.instance = .mockNoOp()
-        defer { TracingFeature.instance?.deinitialize() }
+        let tracing: TracingFeature = .mockNoOp()
+        defaultDatadogCore.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        defer { tracing.deinitialize() }
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.sharedTracer,
-            swift: Datadog.DDGlobal.sharedTracer
+            swift: Global.sharedTracer
         )
         defer {
             DatadogObjc.DDGlobal.sharedTracer = previousGlobal.objc
-            Datadog.DDGlobal.sharedTracer = previousGlobal.swift
+            Global.sharedTracer = previousGlobal.swift
         }
 
         // When
         DatadogObjc.DDGlobal.sharedTracer = DatadogObjc.DDTracer(configuration: DDTracerConfiguration())
 
         // Then
-        XCTAssertTrue(Datadog.DDGlobal.sharedTracer is Datadog.Tracer)
+        XCTAssertTrue(Global.sharedTracer is Tracer)
     }
 
     // MARK: - Test Global RUMMonitor
 
     func testWhenRUMMonitorIsNotSet_itReturnsNoOpImplementation() {
-        XCTAssertTrue(DatadogObjc.DDGlobal.rum.swiftRUMMonitor is Datadog.DDNoopRUMMonitor)
-        XCTAssertTrue(Datadog.DDGlobal.rum is Datadog.DDNoopRUMMonitor)
+        XCTAssertTrue(DatadogObjc.DDGlobal.rum.swiftRUMMonitor is DDNoopRUMMonitor)
+        XCTAssertTrue(Global.rum is DDNoopRUMMonitor)
     }
 
     func testWhenRUMMonitorIsSet_itSetsSwiftImplementation() {
@@ -55,17 +62,17 @@ class DDGlobalTests: XCTestCase {
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.rum,
-            swift: Datadog.DDGlobal.rum
+            swift: Global.rum
         )
         defer {
             DatadogObjc.DDGlobal.rum = previousGlobal.objc
-            Datadog.DDGlobal.rum = previousGlobal.swift
+            Global.rum = previousGlobal.swift
         }
 
         // When
         DatadogObjc.DDGlobal.rum = DatadogObjc.DDRUMMonitor()
 
         // Then
-        XCTAssertTrue(Datadog.DDGlobal.rum is Datadog.RUMMonitor)
+        XCTAssertTrue(Global.rum is RUMMonitor)
     }
 }

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -46,7 +46,7 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
         .init(
             assert: {
                 defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName) == nil
-                    && TracingFeature.instance == nil
+                    && defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName) == nil
                     && RUMFeature.instance == nil
                     && CrashReportingFeature.instance == nil
             },


### PR DESCRIPTION
### What and why?

Register Tracing v1 in `DatadogCore`.

### How?

Remove `TracingFeature.instance` singleton and other static access and expect a `DatadogCoreProtocol` complying instance when creating a `Tracer`, `defaultDatadogCore` is used by default.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests