### PR TITLE
RUMM-2133 Register RUM v1 in `DatadogCore`

### DIFF
--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -24,12 +24,13 @@ internal class CrashReporter {
 
     convenience init?(
         crashReportingFeature: CrashReportingFeature,
-        loggingFeature: LoggingFeature?
+        loggingFeature: LoggingFeature?,
+        rumFeature: RUMFeature?
     ) {
         let loggingOrRUMIntegration: CrashReportingIntegration?
 
         // If RUM rum is enabled prefer it for sending crash reports, otherwise use Logging feature.
-        if let rumFeature = RUMFeature.instance {
+        if let rumFeature = rumFeature {
             loggingOrRUMIntegration = CrashReportingWithRUMIntegration(rumFeature: rumFeature)
         } else if let loggingFeature = loggingFeature {
             loggingOrRUMIntegration = CrashReportingWithLoggingIntegration(loggingFeature: loggingFeature)

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -254,6 +254,8 @@ public class Datadog {
                     configuration: instrumentationConfiguration,
                     dateProvider: dateProvider
                 )
+
+                core.register(feature: rumInstrumentation)
             }
         }
 
@@ -298,8 +300,7 @@ public class Datadog {
 
         CrashReportingFeature.instance = crashReporting
 
-        RUMInstrumentation.instance = rumInstrumentation
-        RUMInstrumentation.instance?.enable()
+        core.feature(RUMInstrumentation.self)?.enable()
 
         URLSessionAutoInstrumentation.instance = urlSessionAutoInstrumentation
         URLSessionAutoInstrumentation.instance?.enable()
@@ -339,12 +340,13 @@ public class Datadog {
         let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
         let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
         let rum = defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName)
+        let rumInstrumentation = defaultDatadogCore.feature(RUMInstrumentation.self)
         logging?.deinitialize()
         tracing?.deinitialize()
         rum?.deinitialize()
+        rumInstrumentation?.deinitialize()
 
         CrashReportingFeature.instance?.deinitialize()
-        RUMInstrumentation.instance?.deinitialize()
         URLSessionAutoInstrumentation.instance?.deinitialize()
 
         // Reset Globals:

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -151,9 +151,9 @@ public class Datadog {
 
     /// Clears all data that has not already been sent to Datadog servers.
     public static func clearAllData() {
-        let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
-        let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
-        let rum = defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName)
+        let logging = defaultDatadogCore.feature(LoggingFeature.self)
+        let tracing = defaultDatadogCore.feature(TracingFeature.self)
+        let rum = defaultDatadogCore.feature(RUMFeature.self)
         logging?.storage.clearAllData()
         tracing?.storage.clearAllData()
         rum?.storage.clearAllData()
@@ -247,7 +247,7 @@ public class Datadog {
                 telemetry: telemetry
             )
 
-            core.registerFeature(named: RUMFeature.featureName, instance: rum)
+            core.register(feature: rum)
 
             if let instrumentationConfiguration = rumConfiguration.instrumentation {
                 rumInstrumentation = RUMInstrumentation(
@@ -267,7 +267,7 @@ public class Datadog {
                 telemetry: telemetry
             )
 
-            core.registerFeature(named: LoggingFeature.featureName, instance: logging)
+            core.register(feature: logging)
         }
 
         if let tracingConfiguration = configuration.tracing {
@@ -280,7 +280,7 @@ public class Datadog {
                 telemetry: telemetry
             )
 
-            core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+            core.register(feature: tracing)
         }
 
         if let crashReportingConfiguration = configuration.crashReporting {
@@ -337,9 +337,9 @@ public class Datadog {
         assert(Datadog.isInitialized, "SDK must be first initialized.")
 
         // Tear down and deinitialize all features:
-        let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
-        let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
-        let rum = defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName)
+        let logging = defaultDatadogCore.feature(LoggingFeature.self)
+        let tracing = defaultDatadogCore.feature(TracingFeature.self)
+        let rum = defaultDatadogCore.feature(RUMFeature.self)
         let rumInstrumentation = defaultDatadogCore.feature(RUMInstrumentation.self)
         logging?.deinitialize()
         tracing?.deinitialize()

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -78,11 +78,13 @@ extension DatadogCore: DatadogCoreProtocol {
 
     // MARK: V1 interface
 
-    func registerFeature(named featureName: String, instance: Any?) {
-        v1Features[featureName] = instance
+    func register<T>(feature instance: T?) {
+        let key = String(describing: T.self)
+        v1Features[key] = instance
     }
 
-    func feature<T>(_ type: T.Type, named featureName: String) -> T? {
-        return v1Features[featureName] as? T
+    func feature<T>(_ type: T.Type) -> T? {
+        let key = String(describing: T.self)
+        return v1Features[key] as? T
     }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -46,6 +46,22 @@ public protocol DatadogCoreProtocol {
 }
 
 extension DatadogCoreProtocol {
+    /// Registers a feature instance by its type description.
+    ///
+    /// - Parameter instance: The feaure instance to register
+    func register<T>(feature instance: T?) {
+        registerFeature(named: String(describing: T.self), instance: instance)
+    }
+
+    /// Returns a Feature instance by its type.
+    ///
+    /// - Parameters:
+    ///   - type: The feature instance type.
+    /// - Returns: The feature if any.
+    func feature<T>(_ type: T.Type) -> T? {
+        return feature(T.self, named: String(describing: T.self))
+    }
+
     /// Returns a Feature instance by its name.
     ///
     /// - Parameter featureName: The feature's name.

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -27,48 +27,17 @@ public protocol DatadogCoreProtocol {
 
     // MARK: V1 interface
 
-    /// Registers a feature instance by its name.
-    ///
-    /// Passing `nil` will unregister the feature.
-    ///
-    /// - Parameters:
-    ///   - featureName: The feature name.
-    ///   - instance: The feature instance.
-    func registerFeature(named featureName: String, instance: Any?)
-
-    /// Returns a Feature instance by its name.
-    /// 
-    /// - Parameters:
-    ///   - type: The feature instance type.
-    ///   - featureName: The feature's name.
-    /// - Returns: The feature if any.
-    func feature<T>(_ type: T.Type, named featureName: String) -> T?
-}
-
-extension DatadogCoreProtocol {
     /// Registers a feature instance by its type description.
     ///
     /// - Parameter instance: The feaure instance to register
-    func register<T>(feature instance: T?) {
-        registerFeature(named: String(describing: T.self), instance: instance)
-    }
+    func register<T>(feature instance: T?)
 
     /// Returns a Feature instance by its type.
     ///
     /// - Parameters:
     ///   - type: The feature instance type.
     /// - Returns: The feature if any.
-    func feature<T>(_ type: T.Type) -> T? {
-        return feature(T.self, named: String(describing: T.self))
-    }
-
-    /// Returns a Feature instance by its name.
-    ///
-    /// - Parameter featureName: The feature's name.
-    /// - Returns: The feature if any.
-    func feature<T>(named featureName: String) -> T? {
-        return feature(T.self, named: featureName)
-    }
+    func feature<T>(_ type: T.Type) -> T?
 }
 
 /// Provide feature specific storage configuration.
@@ -99,10 +68,10 @@ internal struct NOOPDatadogCore: DatadogCoreProtocol {
     // MARK: V1 interface
 
     /// no-op
-    func registerFeature(named featureName: String, instance: Any?) {}
+    func register<T>(feature instance: T?) {}
 
     /// no-op
-    func feature<T>(_ type: T.Type, named featureName: String) -> T? {
+    func feature<T>(_ type: T.Type) -> T? {
         return nil
     }
 }

--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -28,8 +28,8 @@ public extension WKUserContentController {
         addDatadogMessageHandler(
             allowedWebViewHosts: hosts,
             hostsSanitizer: HostsSanitizer(),
-            loggingFeature: core.feature(named: LoggingFeature.featureName),
-            rumFeature: core.feature(named: RUMFeature.featureName)
+            loggingFeature: core.feature(LoggingFeature.self),
+            rumFeature: core.feature(RUMFeature.self)
         )
     }
 

--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -28,7 +28,8 @@ public extension WKUserContentController {
         addDatadogMessageHandler(
             allowedWebViewHosts: hosts,
             hostsSanitizer: HostsSanitizer(),
-            loggingFeature: core.feature(named: LoggingFeature.featureName)
+            loggingFeature: core.feature(named: LoggingFeature.featureName),
+            rumFeature: core.feature(named: RUMFeature.featureName)
         )
     }
 
@@ -51,7 +52,8 @@ public extension WKUserContentController {
     internal func addDatadogMessageHandler(
         allowedWebViewHosts: Set<String>,
         hostsSanitizer: HostsSanitizing,
-        loggingFeature: LoggingFeature?
+        loggingFeature: LoggingFeature?,
+        rumFeature: RUMFeature?
     ) {
         guard !isTracking else {
               userLogger.warn("`trackDatadogEvents(in:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.")
@@ -74,7 +76,7 @@ public extension WKUserContentController {
         }
 
         var rumEventConsumer: DefaultWebRUMEventConsumer? = nil
-        if let rumFeature = RUMFeature.instance {
+        if let rumFeature = rumFeature {
             rumEventConsumer = DefaultWebRUMEventConsumer(
                 dataWriter: rumFeature.storage.writer,
                 dateCorrector: rumFeature.dateCorrector,

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -399,7 +399,7 @@ public class Logger {
         }
 
         private func buildOrThrow(in core: DatadogCoreProtocol) throws -> Logger {
-            guard let loggingFeature = core.feature(LoggingFeature.self, named: LoggingFeature.featureName) else {
+            guard let loggingFeature = core.feature(LoggingFeature.self) else {
                 throw ProgrammerError(
                     description: Datadog.isInitialized
                         ? "`Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."
@@ -411,8 +411,8 @@ public class Logger {
 
             // RUMM-2133 Note: strong feature coupling while migrating to v2.
             // In v2 active span will be provided in context from feature scope.
-            let rumEnabled = core.feature(RUMFeature.self, named: RUMFeature.featureName) != nil
-            let tracingEnabled = core.feature(TracingFeature.self, named: TracingFeature.featureName) != nil
+            let rumEnabled = core.feature(RUMFeature.self) != nil
+            let tracingEnabled = core.feature(TracingFeature.self) != nil
 
             return Logger(
                 logBuilder: logBuilder,

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -411,6 +411,7 @@ public class Logger {
 
             // RUMM-2133 Note: strong feature coupling while migrating to v2.
             // In v2 active span will be provided in context from feature scope.
+            let rumEnabled = core.feature(RUMFeature.self, named: RUMFeature.featureName) != nil
             let tracingEnabled = core.feature(TracingFeature.self, named: TracingFeature.featureName) != nil
 
             return Logger(
@@ -418,7 +419,7 @@ public class Logger {
                 logOutput: logOutput,
                 dateProvider: loggingFeature.dateProvider,
                 identifier: resolveLoggerName(for: loggingFeature),
-                rumContextIntegration: (RUMFeature.isEnabled && bundleWithRUM) ? LoggingWithRUMContextIntegration() : nil,
+                rumContextIntegration: (rumEnabled && bundleWithRUM) ? LoggingWithRUMContextIntegration() : nil,
                 activeSpanIntegration: (tracingEnabled && bundleWithTrace) ? LoggingWithActiveSpanIntegration() : nil
             )
         }

--- a/Sources/Datadog/RUM/Instrumentation/RUMInstrumentation.swift
+++ b/Sources/Datadog/RUM/Instrumentation/RUMInstrumentation.swift
@@ -8,8 +8,6 @@ import Foundation
 
 /// RUM Auto Instrumentation feature.
 internal final class RUMInstrumentation: RUMCommandPublisher {
-    static var instance: RUMInstrumentation?
-
     /// RUM User Actions auto instrumentation.
     class UserActionsAutoInstrumentation {
         let swizzler: UIApplicationSwizzler
@@ -88,6 +86,5 @@ internal final class RUMInstrumentation: RUMCommandPublisher {
     internal func deinitialize() {
         viewControllerSwizzler?.unswizzle()
         userActionsAutoInstrumentation?.swizzler.unswizzle()
-        RUMInstrumentation.instance = nil
     }
 }

--- a/Sources/Datadog/RUM/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
+++ b/Sources/Datadog/RUM/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
@@ -11,6 +11,9 @@ import SwiftUI
 /// global RUM Monitor when the modified view appears and disappears.
 @available(iOS 13, tvOS 13, *)
 internal struct RUMViewModifier: SwiftUI.ViewModifier {
+    /// Datadog RUM instrumentation instance
+    let instrumentation: RUMInstrumentation?
+
     /// The Content View identifier.
     /// The id will be unique per modified view.
     let identity: String = UUID().uuidString
@@ -26,7 +29,7 @@ internal struct RUMViewModifier: SwiftUI.ViewModifier {
 
     func body(content: Content) -> some View {
         content.onAppear {
-            RUMInstrumentation.instance?.viewsHandler
+            instrumentation?.viewsHandler
                 .notify_onAppear(
                     identity: identity,
                     name: name,
@@ -35,7 +38,7 @@ internal struct RUMViewModifier: SwiftUI.ViewModifier {
                 )
         }
         .onDisappear {
-            RUMInstrumentation.instance?.viewsHandler
+            instrumentation?.viewsHandler
                 .notify_onDisappear(identity: identity)
         }
     }
@@ -52,10 +55,19 @@ public extension SwiftUI.View {
     /// - Returns: This view after applying a `ViewModifier` for monitoring the view.
     func trackRUMView(
         name: String,
-        attributes: [AttributeKey: AttributeValue] = [:]
+        attributes: [AttributeKey: AttributeValue] = [:],
+        in core: DatadogCoreProtocol = defaultDatadogCore
     ) -> some View {
         let path = "\(name)/\(typeDescription.hashValue)"
-        return modifier(RUMViewModifier(name: name, path: path, attributes: attributes))
+        let instrumentation = core.feature(RUMInstrumentation.self)
+        return modifier(
+            RUMViewModifier(
+                instrumentation: instrumentation,
+                name: name,
+                path: path,
+                attributes: attributes
+            )
+        )
     }
 }
 

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -25,12 +25,6 @@ internal func obtainRUMFeatureDirectories() throws -> FeatureDirectories {
 /// Creates and owns componetns enabling RUM feature.
 /// Bundles dependencies for other RUM-related components created later at runtime  (i.e. `RUMMonitor`).
 internal final class RUMFeature {
-    /// Single, shared instance of `RUMFeature`.
-    internal static var instance: RUMFeature?
-
-    /// Tells if the feature was enabled by the user in the SDK configuration.
-    static var isEnabled: Bool { instance != nil }
-
     // MARK: - Configuration
 
     let configuration: FeaturesConfiguration.RUM
@@ -199,6 +193,5 @@ internal final class RUMFeature {
     internal func deinitialize() {
         storage.flushAndTearDown()
         upload.flushAndTearDown()
-        RUMFeature.instance = nil
     }
 }

--- a/Sources/Datadog/RUM/RUMTelemetry.swift
+++ b/Sources/Datadog/RUM/RUMTelemetry.swift
@@ -11,6 +11,7 @@ import Foundation
 /// `RUMTelemetry` complies to `Telemetry` protocol allowing
 /// sending telemetry events accross features.
 internal final class RUMTelemetry: Telemetry {
+    let core: DatadogCoreProtocol
     let sdkVersion: String
     let applicationID: String
     let dateProvider: DateProvider
@@ -19,16 +20,19 @@ internal final class RUMTelemetry: Telemetry {
     /// Creates a RUM Telemetry instance.
     ///
     /// - Parameters:
+    ///   - core: Datadog core instance.
     ///   - sdkVersion: The Datadog SDK version.
     ///   - applicationID: The application ID.
     ///   - dateProvider: Current device time provider.
     ///   - dateCorrector: Date correction for adjusting device time to server time.
     init(
+        in core: DatadogCoreProtocol,
         sdkVersion: String,
         applicationID: String,
         dateProvider: DateProvider,
         dateCorrector: DateCorrectorType
     ) {
+        self.core = core
         self.sdkVersion = sdkVersion
         self.applicationID = applicationID
         self.dateProvider = dateProvider
@@ -43,9 +47,11 @@ internal final class RUMTelemetry: Telemetry {
     ///
     /// - Parameter message: Body of the log
     func debug(_ message: String) {
+        let rum = core.feature(RUMFeature.self, named: RUMFeature.featureName)
+
         guard
             let monitor = Global.rum as? RUMMonitor,
-            let writer = RUMFeature.instance?.storage.writer
+            let writer = rum?.storage.writer
         else {
             return
         }
@@ -85,9 +91,11 @@ internal final class RUMTelemetry: Telemetry {
     ///   - kind: The error type or kind (or code in some cases).
     ///   - stack: The stack trace or the complementary information about the error.
     func error(_ message: String, kind: String?, stack: String?) {
+        let rum = core.feature(RUMFeature.self, named: RUMFeature.featureName)
+
         guard
             let monitor = Global.rum as? RUMMonitor,
-            let writer = RUMFeature.instance?.storage.writer
+            let writer = rum?.storage.writer
         else {
             return
         }

--- a/Sources/Datadog/RUM/RUMTelemetry.swift
+++ b/Sources/Datadog/RUM/RUMTelemetry.swift
@@ -47,7 +47,7 @@ internal final class RUMTelemetry: Telemetry {
     ///
     /// - Parameter message: Body of the log
     func debug(_ message: String) {
-        let rum = core.feature(RUMFeature.self, named: RUMFeature.featureName)
+        let rum = core.feature(RUMFeature.self)
 
         guard
             let monitor = Global.rum as? RUMMonitor,
@@ -91,7 +91,7 @@ internal final class RUMTelemetry: Telemetry {
     ///   - kind: The error type or kind (or code in some cases).
     ///   - stack: The stack trace or the complementary information about the error.
     func error(_ message: String, kind: String?, stack: String?) {
-        let rum = core.feature(RUMFeature.self, named: RUMFeature.featureName)
+        let rum = core.feature(RUMFeature.self)
 
         guard
             let monitor = Global.rum as? RUMMonitor,

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -148,7 +148,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
     // MARK: - Initialization
 
     /// Initializes the Datadog RUM Monitor.
-    public static func initialize() -> DDRUMMonitor {
+    public static func initialize(in core: DatadogCoreProtocol = defaultDatadogCore) -> DDRUMMonitor {
         do {
             if Global.rum is RUMMonitor {
                 throw ProgrammerError(
@@ -157,7 +157,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     """
                 )
             }
-            guard let rumFeature = RUMFeature.instance else {
+            guard let rumFeature = core.feature(RUMFeature.self, named: RUMFeature.featureName) else {
                 throw ProgrammerError(
                     description: Datadog.isInitialized
                         ? "`RUMMonitor.initialize()` produces a non-functional monitor, as the RUM feature is disabled."

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -157,7 +157,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     """
                 )
             }
-            guard let rumFeature = core.feature(RUMFeature.self, named: RUMFeature.featureName) else {
+            guard let rumFeature = core.feature(RUMFeature.self) else {
                 throw ProgrammerError(
                     description: Datadog.isInitialized
                         ? "`RUMMonitor.initialize()` produces a non-functional monitor, as the RUM feature is disabled."

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -168,7 +168,8 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 dependencies: RUMScopeDependencies(rumFeature: rumFeature),
                 dateProvider: rumFeature.dateProvider
             )
-            RUMInstrumentation.instance?.publish(to: monitor)
+
+            core.feature(RUMInstrumentation.self)?.publish(to: monitor)
             URLSessionAutoInstrumentation.instance?.publish(to: monitor)
             return monitor
         } catch {

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -78,7 +78,7 @@ public class Tracer: OTTracer {
                     """
                 )
             }
-            guard let tracingFeature = core.feature(TracingFeature.self, named: TracingFeature.featureName) else {
+            guard let tracingFeature = core.feature(TracingFeature.self) else {
                 throw ProgrammerError(
                     description: Datadog.isInitialized
                         ? "`Tracer.initialize(configuration:)` produces a non-functional tracer, as the tracing feature is disabled."
@@ -88,7 +88,7 @@ public class Tracer: OTTracer {
             return DDTracer(
                 tracingFeature: tracingFeature,
                 tracerConfiguration: configuration,
-                rumEnabled: core.feature(RUMFeature.self, named: RUMFeature.featureName) != nil
+                rumEnabled: core.feature(RUMFeature.self) != nil
             )
         } catch {
             consolePrint("\(error)")

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -87,7 +87,8 @@ public class Tracer: OTTracer {
             }
             return DDTracer(
                 tracingFeature: tracingFeature,
-                tracerConfiguration: configuration
+                tracerConfiguration: configuration,
+                rumEnabled: core.feature(RUMFeature.self, named: RUMFeature.featureName) != nil
             )
         } catch {
             consolePrint("\(error)")
@@ -95,7 +96,7 @@ public class Tracer: OTTracer {
         }
     }
 
-    internal convenience init(tracingFeature: TracingFeature, tracerConfiguration: Configuration) {
+    internal convenience init(tracingFeature: TracingFeature, tracerConfiguration: Configuration, rumEnabled: Bool) {
         self.init(
             spanBuilder: SpanEventBuilder(
                 sdkVersion: tracingFeature.configuration.common.sdkVersion,
@@ -120,7 +121,7 @@ public class Tracer: OTTracer {
             dateProvider: tracingFeature.dateProvider,
             tracingUUIDGenerator: tracingFeature.tracingUUIDGenerator,
             globalTags: tracerConfiguration.globalTags,
-            rumContextIntegration: (RUMFeature.isEnabled && tracerConfiguration.bundleWithRUM) ? TracingWithRUMContextIntegration() : nil
+            rumContextIntegration: (rumEnabled && tracerConfiguration.bundleWithRUM) ? TracingWithRUMContextIntegration() : nil
         )
     }
 

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -211,10 +211,10 @@ class CrashReporterTests: XCTestCase {
         plugin.pendingCrashReport = .mockAny()
 
         // When
-        XCTAssertNil(RUMFeature.instance)
         let crashReporter = CrashReporter(
             crashReportingFeature: .mockNoOp(),
-            loggingFeature: nil
+            loggingFeature: nil,
+            rumFeature: nil
         )
 
         // Then

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -114,69 +114,69 @@ class DatadogTests: XCTestCase {
 
         verify(configuration: defaultBuilder.build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNotNil(tracing?.loggingFeatureAdapter)
         }
         verify(configuration: rumBuilder.build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNotNil(tracing?.loggingFeatureAdapter)
         }
 
         verify(configuration: defaultBuilder.enableLogging(false).build()) {
             // verify features:
-            XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNil(tracing?.loggingFeatureAdapter)
         }
         verify(configuration: rumBuilder.enableLogging(false).build()) {
             // verify features:
-            XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertNotNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.feature(TracingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNil(tracing?.loggingFeatureAdapter)
         }
 
         verify(configuration: defaultBuilder.enableTracing(false).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self))
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
         }
         verify(configuration: rumBuilder.enableTracing(false).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
@@ -184,51 +184,51 @@ class DatadogTests: XCTestCase {
 
         verify(configuration: defaultBuilder.enableRUM(true).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature cannot be enabled")
+            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature cannot be enabled")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNotNil(tracing?.loggingFeatureAdapter)
         }
         verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
+            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self))
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
-            let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
+            let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNotNil(tracing?.loggingFeatureAdapter)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMViews().build()) {
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
         verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitRUMViews().build()
         ) {
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMActions().build()) {
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
         verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitRUMActions().build()
         ) {
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
@@ -323,9 +323,9 @@ class DatadogTests: XCTestCase {
         )
 
         let core = defaultDatadogCore
-        let logging = core.feature(LoggingFeature.self, named: LoggingFeature.featureName)
-        let tracing = core.feature(TracingFeature.self, named: TracingFeature.featureName)
-        let rum = core.feature(RUMFeature.self, named: RUMFeature.featureName)
+        let logging = core.feature(LoggingFeature.self)
+        let tracing = core.feature(TracingFeature.self)
+        let rum = core.feature(RUMFeature.self)
         XCTAssertEqual(logging?.configuration.common.performance, expectedPerformancePreset)
         XCTAssertEqual(rum?.configuration.sessionSampler.samplingRate, 100)
         XCTAssertEqual(tracing?.configuration.common.performance, expectedPerformancePreset)
@@ -448,9 +448,9 @@ class DatadogTests: XCTestCase {
         )
 
         let core = defaultDatadogCore
-        let logging = core.feature(LoggingFeature.self, named: LoggingFeature.featureName)
-        let tracing = core.feature(TracingFeature.self, named: TracingFeature.featureName)
-        let rum = core.feature(RUMFeature.self, named: RUMFeature.featureName)
+        let logging = core.feature(LoggingFeature.self)
+        let tracing = core.feature(TracingFeature.self)
+        let rum = core.feature(RUMFeature.self)
 
         // On SDK init, underlying `ConsentAwareDataWriter` performs data migration for each feature, which includes
         // data removal in `unauthorised` (`.pending`) directory. To not cause test flakiness, we must ensure that

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -102,13 +102,13 @@ class DatadogTests: XCTestCase {
             )
             verificationBlock()
 
-            RUMInstrumentation.instance?.viewControllerSwizzler?.unswizzle()
+            defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler?.unswizzle()
             URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
             Datadog.flushAndDeinitialize()
         }
 
         defer {
-            RUMInstrumentation.instance?.viewControllerSwizzler?.unswizzle()
+            defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler?.unswizzle()
             URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
         }
 
@@ -117,7 +117,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
-            XCTAssertNil(RUMInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
@@ -129,7 +129,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
-            XCTAssertNotNil(RUMInstrumentation.instance)
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
@@ -142,7 +142,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
-            XCTAssertNil(RUMInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
@@ -155,7 +155,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
-            XCTAssertNotNil(RUMInstrumentation.instance)
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
@@ -169,7 +169,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
-            XCTAssertNil(RUMInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
         }
         verify(configuration: rumBuilder.enableTracing(false).build()) {
@@ -178,7 +178,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
-            XCTAssertNotNil(RUMInstrumentation.instance)
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
         }
 
@@ -187,7 +187,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature cannot be enabled")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
-            XCTAssertNil(RUMInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
@@ -199,7 +199,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
             XCTAssertFalse(CrashReportingFeature.isEnabled)
-            XCTAssertNil(RUMInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName)
@@ -209,28 +209,28 @@ class DatadogTests: XCTestCase {
 
         verify(configuration: rumBuilder.trackUIKitRUMViews().build()) {
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
-            XCTAssertNotNil(RUMInstrumentation.instance?.viewControllerSwizzler)
-            XCTAssertNil(RUMInstrumentation.instance?.userActionsAutoInstrumentation)
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
         verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitRUMViews().build()
         ) {
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
-            XCTAssertNil(RUMInstrumentation.instance?.viewControllerSwizzler)
-            XCTAssertNil(RUMInstrumentation.instance?.userActionsAutoInstrumentation)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMActions().build()) {
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
-            XCTAssertNil(RUMInstrumentation.instance?.viewControllerSwizzler)
-            XCTAssertNotNil(RUMInstrumentation.instance?.userActionsAutoInstrumentation)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
         verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitRUMActions().build()
         ) {
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
-            XCTAssertNil(RUMInstrumentation.instance?.viewControllerSwizzler)
-            XCTAssertNil(RUMInstrumentation.instance?.userActionsAutoInstrumentation)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
+            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
 
         verify(configuration: defaultBuilder.trackURLSession(firstPartyHosts: ["example.com"]).build()) {

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -115,7 +115,7 @@ class DatadogTests: XCTestCase {
         verify(configuration: defaultBuilder.build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
@@ -127,7 +127,7 @@ class DatadogTests: XCTestCase {
         verify(configuration: rumBuilder.build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertTrue(RUMFeature.isEnabled, "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
@@ -140,7 +140,7 @@ class DatadogTests: XCTestCase {
         verify(configuration: defaultBuilder.enableLogging(false).build()) {
             // verify features:
             XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
@@ -153,7 +153,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
             XCTAssertNotNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
-            XCTAssertTrue(RUMFeature.isEnabled, "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
@@ -167,7 +167,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
             XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
-            XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
@@ -176,7 +176,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
             XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName))
-            XCTAssertTrue(RUMFeature.isEnabled, "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
@@ -185,7 +185,7 @@ class DatadogTests: XCTestCase {
         verify(configuration: defaultBuilder.enableRUM(true).build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertFalse(RUMFeature.isEnabled, "When using `defaultBuilder` RUM feature cannot be enabled")
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName), "When using `defaultBuilder` RUM feature cannot be enabled")
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
@@ -197,7 +197,7 @@ class DatadogTests: XCTestCase {
         verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
-            XCTAssertFalse(RUMFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(RUMInstrumentation.instance)
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
@@ -208,27 +208,27 @@ class DatadogTests: XCTestCase {
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMViews().build()) {
-            XCTAssertTrue(RUMFeature.isEnabled)
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
             XCTAssertNotNil(RUMInstrumentation.instance?.viewControllerSwizzler)
             XCTAssertNil(RUMInstrumentation.instance?.userActionsAutoInstrumentation)
         }
         verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitRUMViews().build()
         ) {
-            XCTAssertFalse(RUMFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
             XCTAssertNil(RUMInstrumentation.instance?.viewControllerSwizzler)
             XCTAssertNil(RUMInstrumentation.instance?.userActionsAutoInstrumentation)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMActions().build()) {
-            XCTAssertTrue(RUMFeature.isEnabled)
+            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
             XCTAssertNil(RUMInstrumentation.instance?.viewControllerSwizzler)
             XCTAssertNotNil(RUMInstrumentation.instance?.userActionsAutoInstrumentation)
         }
         verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitRUMActions().build()
         ) {
-            XCTAssertFalse(RUMFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName))
             XCTAssertNil(RUMInstrumentation.instance?.viewControllerSwizzler)
             XCTAssertNil(RUMInstrumentation.instance?.userActionsAutoInstrumentation)
         }
@@ -325,8 +325,9 @@ class DatadogTests: XCTestCase {
         let core = defaultDatadogCore
         let logging = core.feature(LoggingFeature.self, named: LoggingFeature.featureName)
         let tracing = core.feature(TracingFeature.self, named: TracingFeature.featureName)
+        let rum = core.feature(RUMFeature.self, named: RUMFeature.featureName)
         XCTAssertEqual(logging?.configuration.common.performance, expectedPerformancePreset)
-        XCTAssertEqual(RUMFeature.instance?.configuration.sessionSampler.samplingRate, 100)
+        XCTAssertEqual(rum?.configuration.sessionSampler.samplingRate, 100)
         XCTAssertEqual(tracing?.configuration.common.performance, expectedPerformancePreset)
         XCTAssertEqual(Datadog.verbosityLevel, .debug)
 
@@ -449,13 +450,14 @@ class DatadogTests: XCTestCase {
         let core = defaultDatadogCore
         let logging = core.feature(LoggingFeature.self, named: LoggingFeature.featureName)
         let tracing = core.feature(TracingFeature.self, named: TracingFeature.featureName)
+        let rum = core.feature(RUMFeature.self, named: RUMFeature.featureName)
 
         // On SDK init, underlying `ConsentAwareDataWriter` performs data migration for each feature, which includes
         // data removal in `unauthorised` (`.pending`) directory. To not cause test flakiness, we must ensure that
         // mock data is written only after this operation completes - otherwise, migration may delete mocked files.
         let loggingWriter = try XCTUnwrap(logging?.storage.writer as? ConsentAwareDataWriter)
         let tracingWriter = try XCTUnwrap(tracing?.storage.writer as? ConsentAwareDataWriter)
-        let rumWriter = try XCTUnwrap(RUMFeature.instance?.storage.writer as? ConsentAwareDataWriter)
+        let rumWriter = try XCTUnwrap(rum?.storage.writer as? ConsentAwareDataWriter)
         loggingWriter.queue.sync {}
         tracingWriter.queue.sync {}
         rumWriter.queue.sync {}
@@ -479,7 +481,7 @@ class DatadogTests: XCTestCase {
         // Wait for async clear completion in all features:
         (logging?.storage.dataOrchestrator as? DataOrchestrator)?.queue.sync {}
         (tracing?.storage.dataOrchestrator as? DataOrchestrator)?.queue.sync {}
-        (RUMFeature.instance?.storage.dataOrchestrator as? DataOrchestrator)?.queue.sync {}
+        (rum?.storage.dataOrchestrator as? DataOrchestrator)?.queue.sync {}
 
         // Then
         let newNumberOfFiles = try allDirectories.reduce(0, { acc, nextDirectory in return try acc + nextDirectory.files().count })

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -8,14 +8,21 @@ import XCTest
 @testable import Datadog
 
 class RUMIntegrationsTests: XCTestCase {
+    let core = DatadogCoreMock()
+
     private let integration = RUMContextIntegration()
 
+    override func tearDown() {
+        core.flush()
+        super.tearDown()
+    }
+
     func testGivenRUMMonitorRegistered_itProvidesRUMContextAttributes() throws {
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         // given
-        Global.rum = RUMMonitor.initialize()
+        Global.rum = RUMMonitor.initialize(in: core)
         Global.rum.startView(viewController: mockView)
         Global.rum.startUserAction(type: .tap, name: .mockAny())
         defer { Global.rum = DDNoopRUMMonitor() }
@@ -26,7 +33,7 @@ class RUMIntegrationsTests: XCTestCase {
         XCTAssertEqual(attributes.count, 4)
         XCTAssertEqual(
             attributes["application_id"] as? String,
-            try XCTUnwrap(RUMFeature.instance?.configuration.applicationID)
+            rum.configuration.applicationID
         )
         XCTAssertValidRumUUID(attributes["session_id"] as? String)
         XCTAssertValidRumUUID(attributes["view.id"] as? String)
@@ -34,7 +41,7 @@ class RUMIntegrationsTests: XCTestCase {
     }
 
     func testGivenRUMMonitorRegistered_whenSessionIsRejectedBySampler_itProvidesEmptyRUMContextAttributes() throws {
-        RUMFeature.instance = RUMFeature(
+        let rum = RUMFeature(
             eventsMapper: .mockNoOp(),
             storage: .mockNoOp(),
             upload: .mockNoOp(),
@@ -45,10 +52,10 @@ class RUMIntegrationsTests: XCTestCase {
             vitalRefreshRateReader: ContinuousVitalReaderMock(),
             onSessionStart: nil
         )
-        defer { RUMFeature.instance?.deinitialize() }
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         // given
-        Global.rum = RUMMonitor.initialize()
+        Global.rum = RUMMonitor.initialize(in: core)
         Global.rum.startView(viewController: mockView)
         defer { Global.rum = DDNoopRUMMonitor() }
 
@@ -59,9 +66,6 @@ class RUMIntegrationsTests: XCTestCase {
     }
 
     func testWhenRUMMonitorIsNotRegistered_itReturnsNil() throws {
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
-
         // when
         XCTAssertTrue(Global.rum is DDNoopRUMMonitor)
 
@@ -71,6 +75,7 @@ class RUMIntegrationsTests: XCTestCase {
 }
 
 class RUMErrorsIntegrationTests: XCTestCase {
+    let core = DatadogCoreMock()
     private let integration = RUMErrorsIntegration()
 
     override func setUp() {
@@ -79,16 +84,17 @@ class RUMErrorsIntegrationTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
+        core.flush()
         temporaryFeatureDirectories.delete()
+        super.tearDown()
     }
 
     func testGivenRUMMonitorRegistered_whenAddingErrorMessage_itSendsRUMErrorForCurrentView() throws {
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         // given
-        Global.rum = RUMMonitor.initialize()
+        Global.rum = RUMMonitor.initialize(in: core)
         Global.rum.startView(viewController: mockView)
         defer { Global.rum = DDNoopRUMMonitor() }
 
@@ -96,7 +102,7 @@ class RUMErrorsIntegrationTests: XCTestCase {
         integration.addError(with: "error message", type: "Error type", stack: "Foo.swift:10", source: .logger)
 
         // then
-        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3) // [RUMView, RUMAction, RUMError] events sent
+        let rumEventMatchers = try rum.waitAndReturnRUMEventMatchers(count: 3) // [RUMView, RUMAction, RUMError] events sent
         let rumErrorMatcher = rumEventMatchers.first { $0.model(isTypeOf: RUMErrorEvent.self) }
         try XCTUnwrap(rumErrorMatcher).model(ofType: RUMErrorEvent.self) { rumModel in
             XCTAssertEqual(rumModel.error.message, "error message")

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -19,7 +19,7 @@ class RUMIntegrationsTests: XCTestCase {
 
     func testGivenRUMMonitorRegistered_itProvidesRUMContextAttributes() throws {
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         // given
         Global.rum = RUMMonitor.initialize(in: core)
@@ -52,7 +52,7 @@ class RUMIntegrationsTests: XCTestCase {
             vitalRefreshRateReader: ContinuousVitalReaderMock(),
             onSessionStart: nil
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         // given
         Global.rum = RUMMonitor.initialize(in: core)
@@ -91,7 +91,7 @@ class RUMErrorsIntegrationTests: XCTestCase {
 
     func testGivenRUMMonitorRegistered_whenAddingErrorMessage_itSendsRUMErrorForCurrentView() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         // given
         Global.rum = RUMMonitor.initialize(in: core)

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -68,8 +68,8 @@ class LoggerBuilderTests: XCTestCase {
     }
 
     func testDefaultLoggerWithRUMEnabled() throws {
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         let logger1 = Logger.builder.build(in: core)
         XCTAssertNotNil(logger1.rumContextIntegration)
@@ -90,8 +90,8 @@ class LoggerBuilderTests: XCTestCase {
     }
 
     func testCustomizedLogger() throws {
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         let tracing: TracingFeature = .mockNoOp()
         core.registerFeature(named: TracingFeature.featureName, instance: tracing)

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -33,7 +33,7 @@ class LoggerBuilderTests: XCTestCase {
             )
         )
 
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
     }
 
     override func tearDown() {
@@ -48,7 +48,7 @@ class LoggerBuilderTests: XCTestCase {
         XCTAssertNil(logger.rumContextIntegration)
         XCTAssertNil(logger.activeSpanIntegration)
 
-        let feature = try XCTUnwrap(core.feature(LoggingFeature.self, named: LoggingFeature.featureName))
+        let feature = try XCTUnwrap(core.feature(LoggingFeature.self))
         XCTAssertTrue(
             logger.logOutput is LogFileOutput,
             "When Logging feature is enabled the Logger should use `LogFileOutput`."
@@ -69,7 +69,7 @@ class LoggerBuilderTests: XCTestCase {
 
     func testDefaultLoggerWithRUMEnabled() throws {
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let logger1 = Logger.builder.build(in: core)
         XCTAssertNotNil(logger1.rumContextIntegration)
@@ -80,7 +80,7 @@ class LoggerBuilderTests: XCTestCase {
 
     func testDefaultLoggerWithTracingEnabled() throws {
         let tracing: TracingFeature = .mockNoOp()
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: tracing)
 
         let logger1 = Logger.builder.build(in: core)
         XCTAssertNotNil(logger1.activeSpanIntegration)
@@ -91,10 +91,10 @@ class LoggerBuilderTests: XCTestCase {
 
     func testCustomizedLogger() throws {
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let tracing: TracingFeature = .mockNoOp()
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: tracing)
 
         let logger = Logger.builder
             .set(serviceName: "custom-service-name")
@@ -107,7 +107,7 @@ class LoggerBuilderTests: XCTestCase {
         XCTAssertNil(logger.rumContextIntegration)
         XCTAssertNil(logger.activeSpanIntegration)
 
-        let feature = try XCTUnwrap(core.feature(LoggingFeature.self, named: LoggingFeature.featureName))
+        let feature = try XCTUnwrap(core.feature(LoggingFeature.self))
         XCTAssertTrue(
             logger.logOutput is LogFileOutput,
             "When Logging feature is enabled the Logger should use `LogFileOutput`."

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -42,7 +42,7 @@ class LoggerTests: XCTestCase {
         )
         defer { feature.deinitialize() }
 
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
         logger.debug("message")
@@ -66,7 +66,7 @@ class LoggerTests: XCTestCase {
     func testSendingLogWithCustomizedLogger() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder
             .set(serviceName: "custom-service-name")
@@ -103,7 +103,7 @@ class LoggerTests: XCTestCase {
             )
         )
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
         logger.info("message 1")
@@ -119,7 +119,7 @@ class LoggerTests: XCTestCase {
     func testSendingLogsWithDifferentLevels() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
         logger.debug("message")
@@ -143,7 +143,7 @@ class LoggerTests: XCTestCase {
     func testLoggingError() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         struct TestError: Error {
             var description = "Test description"
@@ -182,7 +182,7 @@ class LoggerTests: XCTestCase {
         )
         defer { feature.deinitialize() }
 
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
         logger.debug("message with no user info")
@@ -235,7 +235,7 @@ class LoggerTests: XCTestCase {
             )
         )
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder
             .sendNetworkInfo(true)
@@ -277,7 +277,7 @@ class LoggerTests: XCTestCase {
             )
         )
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder
             .sendNetworkInfo(true)
@@ -332,7 +332,7 @@ class LoggerTests: XCTestCase {
     func testSendingLoggerAttributesOfDifferentEncodableValues() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
 
@@ -397,7 +397,7 @@ class LoggerTests: XCTestCase {
     func testSendingMessageAttributes() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
 
@@ -430,7 +430,7 @@ class LoggerTests: XCTestCase {
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
 
@@ -476,7 +476,7 @@ class LoggerTests: XCTestCase {
             )
         )
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
         logger.debug("message")
@@ -495,7 +495,7 @@ class LoggerTests: XCTestCase {
             )
         )
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
         logger.debug("message")
@@ -510,10 +510,10 @@ class LoggerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
+        core.register(feature: logging)
 
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         // given
         let logger = Logger.builder.build(in: core)
@@ -550,10 +550,10 @@ class LoggerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
+        core.register(feature: logging)
 
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }
@@ -584,10 +584,10 @@ class LoggerTests: XCTestCase {
 
     func testWhenSendingErrorOrCriticalLogs_itCreatesRUMErrorForCurrentView() throws {
         let logging: LoggingFeature = .mockNoOp()
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
+        core.register(feature: logging)
 
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         // given
         let logger = Logger.builder.build(in: core)
@@ -629,8 +629,8 @@ class LoggerTests: XCTestCase {
     func testGivenBundlingWithTraceEnabledAndTracerRegistered_whenSendingLog_itContainsActiveSpanAttributes() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         let tracing: TracingFeature = .mockNoOp()
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: logging)
+        core.register(feature: tracing)
 
         // given
         let logger = Logger.builder.build(in: core)
@@ -660,8 +660,8 @@ class LoggerTests: XCTestCase {
     func testGivenBundlingWithTraceEnabledButTracerNotRegistered_whenSendingLog_itPrintsWarning() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
         let tracing: TracingFeature = .mockNoOp()
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: feature)
+        core.register(feature: tracing)
 
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }
@@ -704,7 +704,7 @@ class LoggerTests: XCTestCase {
             )
         )
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
         logger.debug("message")
@@ -727,7 +727,7 @@ class LoggerTests: XCTestCase {
             dependencies: .mockWith(consentProvider: consentProvider)
         )
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
 
@@ -753,7 +753,7 @@ class LoggerTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let feature: LoggingFeature = .mockNoOp()
         defer { feature.deinitialize() }
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder
             .sendLogsToDatadog(false)

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -59,7 +59,7 @@ class LoggingFeatureTests: XCTestCase {
                 mobileDevice: .mockWith(model: randomDeviceModel, osName: randomDeviceOSName, osVersion: randomDeviceOSVersion)
             )
         )
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         // When
         let logger = Logger.builder.build(in: core)
@@ -111,7 +111,7 @@ class LoggingFeatureTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let logger = Logger.builder.build(in: core)
         logger.debug("log 1")

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -37,12 +37,14 @@ internal final class DatadogCoreMock: DatadogCoreProtocol, Flushable {
 
     // MARK: V1 interface
 
-    func registerFeature(named featureName: String, instance: Any?) {
-        v1Features[featureName] = instance
+    func register<T>(feature instance: T?) {
+        let key = String(describing: T.self)
+        v1Features[key] = instance
     }
 
-    func feature<T>(_ type: T.Type, named featureName: String) -> T? {
-        return v1Features[featureName] as? T
+    func feature<T>(_ type: T.Type) -> T? {
+        let key = String(describing: T.self)
+        return v1Features[key] as? T
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -66,3 +66,9 @@ extension TracingFeature: Flushable {
         deinitialize()
     }
 }
+
+extension RUMFeature: Flushable {
+    func flush() {
+        deinitialize()
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -72,3 +72,9 @@ extension RUMFeature: Flushable {
         deinitialize()
     }
 }
+
+extension RUMInstrumentation: Flushable {
+    func flush() {
+        deinitialize()
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -74,7 +74,7 @@ extension LoggingFeature {
 
     // swiftlint:disable:next function_default_parameter_at_end
     static func waitAndReturnLogMatchers(in core: DatadogCoreProtocol = defaultDatadogCore, count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
-        guard let logging = core.feature(LoggingFeature.self, named: LoggingFeature.featureName) else {
+        guard let logging = core.feature(LoggingFeature.self) else {
             preconditionFailure("LoggingFeature is not registered in core")
         }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -85,7 +85,7 @@ extension RUMFeature {
 
     // swiftlint:disable:next function_default_parameter_at_end
     static func waitAndReturnRUMEventMatchers(in core: DatadogCoreProtocol = defaultDatadogCore, count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [RUMEventMatcher] {
-        guard let rum = core.feature(RUMFeature.self, named: RUMFeature.featureName) else {
+        guard let rum = core.feature(RUMFeature.self) else {
             preconditionFailure("RUMFeature is not registered in core")
         }
         return try rum.waitAndReturnRUMEventMatchers(count: count, file: file, line: line)

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -89,7 +89,7 @@ extension TracingFeature {
 
     // swiftlint:disable:next function_default_parameter_at_end
     static func waitAndReturnSpanMatchers(in core: DatadogCoreProtocol = defaultDatadogCore, count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [SpanMatcher] {
-        guard let tracing = core.feature(TracingFeature.self, named: TracingFeature.featureName) else {
+        guard let tracing = core.feature(TracingFeature.self) else {
             preconditionFailure("TracingFeature is not registered in core")
         }
 

--- a/Tests/DatadogTests/Datadog/RUM/Instrumentation/RUMInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Instrumentation/RUMInstrumentationTests.swift
@@ -8,22 +8,23 @@ import XCTest
 @testable import Datadog
 
 class RUMInstrumentationTests: XCTestCase {
+    let core = DatadogCoreMock()
+
     override func setUp() {
         super.setUp()
-        XCTAssertNil(RUMFeature.instance)
         XCTAssertNil(RUMInstrumentation.instance)
     }
 
     override func tearDown() {
+        core.flush()
         XCTAssertNil(RUMInstrumentation.instance)
-        XCTAssertNil(RUMFeature.instance)
         super.tearDown()
     }
 
     func testGivenRUMViewsAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsViewsHandler() throws {
         // Given
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         RUMInstrumentation.instance = RUMInstrumentation(
             configuration: .init(
@@ -36,7 +37,7 @@ class RUMInstrumentationTests: XCTestCase {
         defer { RUMInstrumentation.instance?.deinitialize() }
 
         // When
-        Global.rum = RUMMonitor.initialize()
+        Global.rum = RUMMonitor.initialize(in: core)
         defer { Global.rum = DDNoopRUMMonitor() }
 
         // Then
@@ -46,8 +47,8 @@ class RUMInstrumentationTests: XCTestCase {
 
     func testGivenRUMUserActionsAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsUserActionsHandler() throws {
         // Given
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         RUMInstrumentation.instance = RUMInstrumentation(
             configuration: .init(
@@ -60,7 +61,7 @@ class RUMInstrumentationTests: XCTestCase {
         defer { RUMInstrumentation.instance?.deinitialize() }
 
         // When
-        Global.rum = RUMMonitor.initialize()
+        Global.rum = RUMMonitor.initialize(in: core)
         defer { Global.rum = DDNoopRUMMonitor() }
 
         // Then
@@ -70,8 +71,8 @@ class RUMInstrumentationTests: XCTestCase {
 
     func testGivenRUMLongTasksAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsLongTaskObserver() throws {
         // Given
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         RUMInstrumentation.instance = RUMInstrumentation(
             configuration: .init(
@@ -84,7 +85,7 @@ class RUMInstrumentationTests: XCTestCase {
         defer { RUMInstrumentation.instance?.deinitialize() }
 
         // When
-        Global.rum = RUMMonitor.initialize()
+        Global.rum = RUMMonitor.initialize(in: core)
         defer { Global.rum = DDNoopRUMMonitor() }
 
         // Then
@@ -94,8 +95,8 @@ class RUMInstrumentationTests: XCTestCase {
     /// Sanity check for not-allowed configuration.
     func testWhenAllRUMAutoInstrumentationsDisabled_itDoesNotCreateInstrumentationComponents() throws {
         // Given
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         /// This configuration is not allowed by `FeaturesConfiguration` logic. We test it for sanity.
         let notAllowedConfiguration = FeaturesConfiguration.RUM.Instrumentation(

--- a/Tests/DatadogTests/Datadog/RUM/Instrumentation/RUMInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Instrumentation/RUMInstrumentationTests.swift
@@ -31,7 +31,7 @@ class RUMInstrumentationTests: XCTestCase {
             ),
             dateProvider: SystemDateProvider()
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
         core.register(feature: instrumentation)
 
         // When
@@ -55,7 +55,7 @@ class RUMInstrumentationTests: XCTestCase {
             ),
             dateProvider: SystemDateProvider()
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
         core.register(feature: instrumentation)
 
         // When
@@ -79,7 +79,7 @@ class RUMInstrumentationTests: XCTestCase {
             dateProvider: SystemDateProvider()
         )
 
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
         core.register(feature: instrumentation)
 
         // When
@@ -107,7 +107,7 @@ class RUMInstrumentationTests: XCTestCase {
             dateProvider: SystemDateProvider()
         )
 
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
         core.register(feature: instrumentation)
 
         // Then

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -60,7 +60,7 @@ class RUMFeatureTests: XCTestCase {
                 mobileDevice: .mockWith(model: randomDeviceModel, osName: randomDeviceOSName, osVersion: randomDeviceOSVersion)
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         // When
         let monitor = RUMMonitor.initialize(in: core)
@@ -120,7 +120,7 @@ class RUMFeatureTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let fileWriter = feature.storage.writer
         fileWriter.write(value: RUMDataModelMock(attribute: "1st event"))

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -10,14 +10,10 @@ import XCTest
 class RUMFeatureTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        XCTAssertFalse(Datadog.isInitialized)
-        XCTAssertNil(RUMFeature.instance)
         temporaryFeatureDirectories.create()
     }
 
     override func tearDown() {
-        XCTAssertFalse(Datadog.isInitialized)
-        XCTAssertNil(RUMFeature.instance)
         temporaryFeatureDirectories.delete()
         super.tearDown()
     }
@@ -39,10 +35,12 @@ class RUMFeatureTests: XCTestCase {
         let randomDeviceOSVersion: String = .mockRandom()
         let randomEncryption: DataEncryption? = Bool.random() ? DataEncryptionMock() : nil
 
+        let core = DatadogCoreMock()
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
+        defer { core.flush() }
 
         // Given
-        RUMFeature.instance = .mockWith(
+        let feature: RUMFeature = .mockWith(
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
@@ -62,10 +60,10 @@ class RUMFeatureTests: XCTestCase {
                 mobileDevice: .mockWith(model: randomDeviceModel, osName: randomDeviceOSName, osVersion: randomDeviceOSVersion)
             )
         )
-        defer { RUMFeature.instance?.deinitialize() }
+        core.registerFeature(named: RUMFeature.featureName, instance: feature)
 
         // When
-        let monitor = RUMMonitor.initialize()
+        let monitor = RUMMonitor.initialize(in: core)
         monitor.startView(viewController: mockView) // on starting the first view we sends `application_start` action event
 
         // Then
@@ -96,8 +94,11 @@ class RUMFeatureTests: XCTestCase {
     // MARK: - HTTP Payload
 
     func testItUsesExpectedPayloadFormatForUploads() throws {
+        let core = DatadogCoreMock()
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-        RUMFeature.instance = .mockWith(
+        defer { core.flush() }
+
+        let feature: RUMFeature = .mockWith(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
                 performance: .combining(
@@ -119,9 +120,9 @@ class RUMFeatureTests: XCTestCase {
                 )
             )
         )
-        defer { RUMFeature.instance?.deinitialize() }
+        core.registerFeature(named: RUMFeature.featureName, instance: feature)
 
-        let fileWriter = try XCTUnwrap(RUMFeature.instance?.storage.writer)
+        let fileWriter = feature.storage.writer
         fileWriter.write(value: RUMDataModelMock(attribute: "1st event"))
         fileWriter.write(value: RUMDataModelMock(attribute: "2nd event"))
         fileWriter.write(value: RUMDataModelMock(attribute: "3rd event"))

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -15,7 +15,7 @@ class RUMTelemetryTests: XCTestCase {
         temporaryFeatureDirectories.create()
 
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
         Global.rum = RUMMonitor.initialize(in: core)
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -8,18 +8,20 @@ import XCTest
 @testable import Datadog
 
 class RUMTelemetryTests: XCTestCase {
+    let core = DatadogCoreMock()
+
     override func setUp() {
         super.setUp()
         temporaryFeatureDirectories.create()
 
-        RUMFeature.instance = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        Global.rum = RUMMonitor.initialize()
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        Global.rum = RUMMonitor.initialize(in: core)
     }
 
     override func tearDown() {
-        RUMFeature.instance?.deinitialize()
+        core.flush()
         Global.rum = DDNoopRUMMonitor()
-
         temporaryFeatureDirectories.delete()
         super.tearDown()
     }
@@ -28,6 +30,7 @@ class RUMTelemetryTests: XCTestCase {
 
     func testSendTelemetryDebug() throws {
         let telemetry: RUMTelemetry = .mockWith(
+            core: core,
             dateProvider: RelativeDateProvider(
                 using: .init(timeIntervalSince1970: 0)
             )
@@ -35,7 +38,7 @@ class RUMTelemetryTests: XCTestCase {
 
         telemetry.debug("Hello world!")
 
-        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 1)
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(in: core, count: 1)
         try rumEventMatchers.lastRUMEvent(ofType: TelemetryDebugEvent.self).model(ofType: TelemetryDebugEvent.self) { event in
             XCTAssertEqual(event.date, 0)
             XCTAssertEqual(event.application?.id, telemetry.applicationID)
@@ -48,13 +51,14 @@ class RUMTelemetryTests: XCTestCase {
 
     func testSendTelemetryError() throws {
         let telemetry: RUMTelemetry = .mockWith(
+            core: core,
             dateProvider: RelativeDateProvider(
                 using: .init(timeIntervalSince1970: 0)
             )
         )
         telemetry.error("Oops", kind: "OutOfMemory", stack: "a\nhay\nneedle\nstack")
 
-        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 1)
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(in: core, count: 1)
         try rumEventMatchers.lastRUMEvent(ofType: TelemetryErrorEvent.self).model(ofType: TelemetryErrorEvent.self) { event in
             XCTAssertEqual(event.date, 0)
             XCTAssertEqual(event.application?.id, telemetry.applicationID)
@@ -68,13 +72,13 @@ class RUMTelemetryTests: XCTestCase {
     }
 
     func testSendTelemetryDebug_withRUMContext() throws {
-        let telemetry: RUMTelemetry = .mockAny()
+        let telemetry: RUMTelemetry = .mockAny(in: core)
 
         Global.rum.startView(viewController: mockView)
         Global.rum.startUserAction(type: .scroll, name: .mockAny())
         telemetry.debug("telemetry debug")
 
-        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(in: core, count: 3)
         try rumEventMatchers.lastRUMEvent(ofType: TelemetryDebugEvent.self).model(ofType: TelemetryDebugEvent.self) { event in
             XCTAssertEqual(event.telemetry.message, "telemetry debug")
             XCTAssertValidRumUUID(event.action?.id)
@@ -84,13 +88,13 @@ class RUMTelemetryTests: XCTestCase {
     }
 
     func testSendTelemetryError_withRUMContext() throws {
-        let telemetry: RUMTelemetry = .mockAny()
+        let telemetry: RUMTelemetry = .mockAny(in: core)
 
         Global.rum.startView(viewController: mockView)
         Global.rum.startUserAction(type: .scroll, name: .mockAny())
         telemetry.error("telemetry error")
 
-        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(count: 3)
+        let rumEventMatchers = try RUMFeature.waitAndReturnRUMEventMatchers(in: core, count: 3)
         try rumEventMatchers.lastRUMEvent(ofType: TelemetryErrorEvent.self).model(ofType: TelemetryErrorEvent.self) { event in
             XCTAssertEqual(event.telemetry.message, "telemetry error")
             XCTAssertValidRumUUID(event.action?.id)

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -184,8 +184,8 @@ class WKUserContentController_DatadogTests: XCTestCase {
             )
         )
 
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: logging)
+        core.register(feature: rum)
 
         Global.rum = RUMMonitor.initialize(in: core)
         defer { Global.rum = DDNoopRUMMonitor() }

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -36,7 +36,7 @@ class RUMMonitorConfigurationTests: XCTestCase {
             )
         )
 
-        core.registerFeature(named: RUMFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let monitor = RUMMonitor.initialize(in: core).dd
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -31,7 +31,7 @@ class RUMMonitorTests: XCTestCase {
     /// Creates `RUMMonitor` instance for tests.
     /// The only difference vs. `RUMMonitor.initialize()` is that we disable RUM view updates sampling to get deterministic behaviour.
     private func createTestableRUMMonitor(in core: DatadogCoreProtocol) throws -> DDRUMMonitor {
-        let rumFeature: RUMFeature = try XCTUnwrap(core.feature(named: RUMFeature.featureName), "RUM feature must be initialized before creating `RUMMonitor`")
+        let rumFeature: RUMFeature = try XCTUnwrap(core.feature(RUMFeature.self), "RUM feature must be initialized before creating `RUMMonitor`")
         return RUMMonitor(
             dependencies: RUMScopeDependencies(rumFeature: rumFeature)
                 .replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
@@ -53,7 +53,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: dateProvider
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -91,7 +91,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: dateProvider
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -113,7 +113,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingImageResourceWithRequest() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -147,7 +147,7 @@ class RUMMonitorTests: XCTestCase {
         }
 
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -182,7 +182,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingNativeResourceWithRequestWithExternalMetrics() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -250,7 +250,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingResourceWithURL() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -271,7 +271,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingResourceWithURLString() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -298,7 +298,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -329,7 +329,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenLoadingResources_whileScrolling() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -392,7 +392,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0.01)
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -457,7 +457,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -507,7 +507,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingLoadingResourcesFromTheFirstView_thenStartingAnotherViewWhichAlsoLoadsResources() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -576,7 +576,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
 
@@ -620,7 +620,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
 
@@ -673,7 +673,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
 
@@ -711,7 +711,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testSendingAttributes() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let view1 = createMockView(viewControllerClassName: "FirstViewController")
         let view2 = createMockView(viewControllerClassName: "SecondViewController")
@@ -754,7 +754,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testWhenViewIsStarted_attributesCanBeAddedOrUpdatedButNotRemoved() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
 
@@ -792,7 +792,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
         setGlobalAttributes(of: monitor)
@@ -833,7 +833,7 @@ class RUMMonitorTests: XCTestCase {
                 onSessionStart: onSessionStart
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor(in: core)
         monitor.startView(viewController: mockView)
@@ -863,7 +863,7 @@ class RUMMonitorTests: XCTestCase {
                 dateCorrector: DateCorrectorMock(correctionOffset: serverTimeDifference)
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
 
@@ -922,7 +922,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
 
@@ -968,7 +968,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
 
@@ -1048,7 +1048,7 @@ class RUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
 
@@ -1092,7 +1092,7 @@ class RUMMonitorTests: XCTestCase {
                 longTaskEventMapper: { _ in nil }
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
 
@@ -1141,7 +1141,7 @@ class RUMMonitorTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         CrashReportingFeature.instance = .mockNoOp()
         defer { CrashReportingFeature.instance?.deinitialize() }
@@ -1172,7 +1172,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let monitor = RUMMonitor.initialize(in: core)
         let view = mockView
@@ -1379,7 +1379,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testHandlingInternalTimestampAttribute() throws {
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         var mockCommand = RUMCommandMock()
         mockCommand.attributes = [

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1312,14 +1312,16 @@ class RUMMonitorTests: XCTestCase {
                 .trackUIKitRUMActions()
                 .build()
         )
+        defer { Datadog.flushAndDeinitialize() }
 
         let output = LogOutputMock()
         userLogger = .mockWith(logOutput: output)
 
         // Given
         let resourcesHandler = try XCTUnwrap(URLSessionAutoInstrumentation.instance?.interceptor.handler)
-        let viewsHandler = try XCTUnwrap(RUMInstrumentation.instance?.viewsHandler)
-        let userActionsHandler = try XCTUnwrap(RUMInstrumentation.instance?.userActionsAutoInstrumentation?.handler)
+        let rumInstrumentation = try XCTUnwrap(defaultDatadogCore.feature(RUMInstrumentation.self))
+        let viewsHandler = rumInstrumentation.viewsHandler
+        let userActionsHandler = try XCTUnwrap(rumInstrumentation.userActionsAutoInstrumentation?.handler)
 
         // When
         XCTAssertTrue(Global.rum is DDNoopRUMMonitor)
@@ -1369,10 +1371,8 @@ class RUMMonitorTests: XCTestCase {
         )
 
         URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
-        RUMInstrumentation.instance?.viewControllerSwizzler?.unswizzle()
-        RUMInstrumentation.instance?.userActionsAutoInstrumentation?.swizzler.unswizzle()
-
-        Datadog.flushAndDeinitialize()
+        rumInstrumentation.viewControllerSwizzler?.unswizzle()
+        rumInstrumentation.userActionsAutoInstrumentation?.swizzler.unswizzle()
     }
 
     // MARK: - Internal attributes

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -70,8 +70,8 @@ class TracerConfigurationTests: XCTestCase {
     }
 
     func testDefaultTracerWithRUMEnabled() {
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         let tracer1 = Tracer.initialize(configuration: .init(), in: core).dd
         XCTAssertNotNil(tracer1.rumContextIntegration)

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -33,7 +33,7 @@ class TracerConfigurationTests: XCTestCase {
             loggingFeature: .mockNoOp()
         )
 
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
     }
 
     override func tearDown() {
@@ -47,7 +47,7 @@ class TracerConfigurationTests: XCTestCase {
 
         XCTAssertNil(tracer.rumContextIntegration)
 
-        let feature = try XCTUnwrap(core.feature(TracingFeature.self, named: TracingFeature.featureName))
+        let feature = try XCTUnwrap(core.feature(TracingFeature.self))
         XCTAssertEqual((tracer.spanOutput as? SpanFileOutput)?.environment, "tests")
         XCTAssertEqual(tracer.spanBuilder.applicationVersion, "1.2.3")
         XCTAssertEqual(tracer.spanBuilder.serviceName, "service-name")
@@ -71,7 +71,7 @@ class TracerConfigurationTests: XCTestCase {
 
     func testDefaultTracerWithRUMEnabled() {
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let tracer1 = Tracer.initialize(configuration: .init(), in: core).dd
         XCTAssertNotNil(tracer1.rumContextIntegration)
@@ -92,7 +92,7 @@ class TracerConfigurationTests: XCTestCase {
 
         XCTAssertNil(tracer.rumContextIntegration)
 
-        let feature = try XCTUnwrap(core.feature(TracingFeature.self, named: TracingFeature.featureName))
+        let feature = try XCTUnwrap(core.feature(TracingFeature.self))
         XCTAssertEqual((tracer.spanOutput as? SpanFileOutput)?.environment, "tests")
         XCTAssertEqual(tracer.spanBuilder.applicationVersion, "1.2.3")
         XCTAssertEqual(tracer.spanBuilder.serviceName, "custom-service-name")

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -42,7 +42,7 @@ class TracerTests: XCTestCase {
             ),
             tracingUUIDGenerator: RelativeTracingUUIDGenerator(startingFrom: 1)
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core)
 
@@ -78,7 +78,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithCustomizedTracer() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(
             configuration: .init(
@@ -109,7 +109,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithGlobalTags() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(
             configuration: .init(
@@ -136,7 +136,7 @@ class TracerTests: XCTestCase {
 
     func testSendingCustomizedSpan() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
 
@@ -164,7 +164,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithParentAndBaggageItems() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
 
@@ -224,7 +224,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanWithActiveSpanAsAParent() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
         let queue1 = DispatchQueue(label: "\(#function)-queue1")
@@ -256,7 +256,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpansWithNoParent() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
         let queue = DispatchQueue(label: "\(#function)-queue")
@@ -285,7 +285,7 @@ class TracerTests: XCTestCase {
 
     func testStartingRootActiveSpanInAsynchronousJobs() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core)
         let queue = DispatchQueue(label: "\(#function)")
@@ -332,7 +332,7 @@ class TracerTests: XCTestCase {
             )
         )
         defer { feature.deinitialize() }
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
 
@@ -390,7 +390,7 @@ class TracerTests: XCTestCase {
                 carrierInfoProvider: carrierInfoProvider
             )
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(
             configuration: .init(sendNetworkInfo: true),
@@ -437,7 +437,7 @@ class TracerTests: XCTestCase {
                 networkConnectionInfoProvider: networkConnectionInfoProvider
             )
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(
             configuration: .init(sendNetworkInfo: true),
@@ -504,7 +504,7 @@ class TracerTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
 
@@ -526,7 +526,7 @@ class TracerTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
 
@@ -541,7 +541,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanTagsOfDifferentEncodableValues() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
 
@@ -617,7 +617,7 @@ class TracerTests: XCTestCase {
             )
         )
 
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
+        core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -626,7 +626,7 @@ class TracerTests: XCTestCase {
             ),
             loggingFeature: logging
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: tracing)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core)
 
@@ -661,7 +661,7 @@ class TracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
+        core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -670,7 +670,7 @@ class TracerTests: XCTestCase {
             ),
             loggingFeature: logging
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: tracing)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core)
 
@@ -697,7 +697,7 @@ class TracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
+        core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -706,7 +706,7 @@ class TracerTests: XCTestCase {
             ),
             loggingFeature: logging
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: tracing)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core)
 
@@ -739,7 +739,7 @@ class TracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
+        core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
@@ -748,7 +748,7 @@ class TracerTests: XCTestCase {
             ),
             loggingFeature: logging
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: tracing)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core)
 
@@ -773,9 +773,9 @@ class TracerTests: XCTestCase {
 
     func testGivenBundlingWithRUMEnabledAndRUMMonitorRegistered_whenSendingSpan_itContainsCurrentRUMContext() throws {
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: tracing)
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         // given
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
@@ -799,9 +799,9 @@ class TracerTests: XCTestCase {
 
     func testGivenBundlingWithRUMEnabledButRUMMonitorNotRegistered_whenSendingSpan_itPrintsWarning() throws {
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: tracing)
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }
@@ -897,7 +897,7 @@ class TracerTests: XCTestCase {
                 dateCorrector: DateCorrectorMock(correctionOffset: serverTimeDifference)
             )
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core)
 
@@ -928,7 +928,7 @@ class TracerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(consentProvider: consentProvider)
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
 
@@ -958,7 +958,7 @@ class TracerTests: XCTestCase {
 
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() {
         let feature: TracingFeature = .mockNoOp()
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core)
         var spans: [DDSpan] = []

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -59,7 +59,7 @@ class TracingFeatureTests: XCTestCase {
                 mobileDevice: .mockWith(model: randomDeviceModel, osName: randomDeviceOSName, osVersion: randomDeviceOSVersion)
             )
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         // When
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
@@ -112,7 +112,7 @@ class TracingFeatureTests: XCTestCase {
                 )
             )
         )
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
@@ -40,7 +40,7 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
     func testGivenURLSessionAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsResourcesHandler() throws {
         // Given
         let rum: RUMFeature = .mockNoOp()
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
             configuration: .mockAny(),

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
@@ -8,12 +8,15 @@ import XCTest
 @testable import Datadog
 
 class URLSessionAutoInstrumentationTests: XCTestCase {
+    let core = DatadogCoreMock()
+
     override func setUp() {
         super.setUp()
         XCTAssertNil(URLSessionAutoInstrumentation.instance)
     }
 
     override func tearDown() {
+        core.flush()
         XCTAssertNil(URLSessionAutoInstrumentation.instance)
         super.tearDown()
     }
@@ -36,19 +39,17 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
 
     func testGivenURLSessionAutoInstrumentationEnabled_whenRUMMonitorIsRegistered_itSubscribesAsResourcesHandler() throws {
         // Given
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        core.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         URLSessionAutoInstrumentation.instance = URLSessionAutoInstrumentation(
             configuration: .mockAny(),
             commonDependencies: .mockAny()
         )
-        defer {
-            URLSessionAutoInstrumentation.instance?.deinitialize()
-        }
+        defer { URLSessionAutoInstrumentation.instance?.deinitialize() }
 
         // When
-        Global.rum = RUMMonitor.initialize()
+        Global.rum = RUMMonitor.initialize(in: core)
         defer { Global.rum = DDNoopRUMMonitor() }
 
         // Then

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -34,7 +34,7 @@ class DDDatadogTests: XCTestCase {
 
         XCTAssertTrue(Datadog.isInitialized)
 
-        let logging = defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName)
+        let logging = defaultDatadogCore.feature(LoggingFeature.self)
         XCTAssertEqual(logging?.configuration.common.applicationName, "app-name")
         XCTAssertEqual(logging?.configuration.common.environment, "tests")
         XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
@@ -42,7 +42,7 @@ class DDDatadogTests: XCTestCase {
         URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
         Datadog.flushAndDeinitialize()
 
-        XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName))
+        XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self))
         XCTAssertNil(URLSessionAutoInstrumentation.instance)
     }
 

--- a/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
@@ -30,7 +30,7 @@ class DDGlobalTests: XCTestCase {
 
     func testWhenTracerIsSet_itSetsSwiftImplementation() {
         let tracing: TracingFeature = .mockNoOp()
-        defaultDatadogCore.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        defaultDatadogCore.register(feature: tracing)
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.sharedTracer,
@@ -57,7 +57,7 @@ class DDGlobalTests: XCTestCase {
 
     func testWhenRUMMonitorIsSet_itSetsSwiftImplementation() {
         let rum: RUMFeature = .mockNoOp()
-        defaultDatadogCore.registerFeature(named: RUMFeature.featureName, instance: rum)
+        defaultDatadogCore.register(feature: rum)
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.rum,

--- a/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
@@ -31,7 +31,6 @@ class DDGlobalTests: XCTestCase {
     func testWhenTracerIsSet_itSetsSwiftImplementation() {
         let tracing: TracingFeature = .mockNoOp()
         defaultDatadogCore.registerFeature(named: TracingFeature.featureName, instance: tracing)
-        defer { tracing.deinitialize() }
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.sharedTracer,
@@ -57,8 +56,8 @@ class DDGlobalTests: XCTestCase {
     }
 
     func testWhenRUMMonitorIsSet_itSetsSwiftImplementation() {
-        RUMFeature.instance = .mockNoOp()
-        defer { RUMFeature.instance?.deinitialize() }
+        let rum: RUMFeature = .mockNoOp()
+        defaultDatadogCore.registerFeature(named: RUMFeature.featureName, instance: rum)
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.rum,

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -29,7 +29,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingLogsWithDifferentLevels() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defaultDatadogCore.registerFeature(named: LoggingFeature.featureName, instance: feature)
+        defaultDatadogCore.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 
@@ -51,9 +51,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingNSError() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { feature.deinitialize() }
-        defaultDatadogCore.registerFeature(named: LoggingFeature.featureName, instance: feature)
-        defer { defaultDatadogCore.registerFeature(named: LoggingFeature.featureName, instance: nil) }
+        defaultDatadogCore.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 
@@ -85,9 +83,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingMessageAttributes() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { feature.deinitialize() }
-        defaultDatadogCore.registerFeature(named: LoggingFeature.featureName, instance: feature)
-        defer { defaultDatadogCore.registerFeature(named: LoggingFeature.featureName, instance: nil) }
+        defaultDatadogCore.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 
@@ -112,9 +108,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingLoggerAttributes() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
-        defer { feature.deinitialize() }
-        defaultDatadogCore.registerFeature(named: LoggingFeature.featureName, instance: feature)
-        defer { defaultDatadogCore.registerFeature(named: LoggingFeature.featureName, instance: nil) }
+        defaultDatadogCore.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 
@@ -154,9 +148,7 @@ class DDLoggerTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(common: .mockWith(environment: "test"))
         )
-        defer { feature.deinitialize() }
-        defaultDatadogCore.registerFeature(named: LoggingFeature.featureName, instance: feature)
-        defer { defaultDatadogCore.registerFeature(named: LoggingFeature.featureName, instance: nil) }
+        defaultDatadogCore.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -146,7 +146,7 @@ class DDRUMMonitorTests: XCTestCase {
     /// Creates `DDRUMMonitor` instance for tests.
     /// The only difference vs. `DDRUMMonitor.initialize()` is that we disable RUM view updates sampling to get deterministic behaviour.
     private func createTestableDDRUMMonitor() throws -> DatadogObjc.DDRUMMonitor {
-        let rumFeature: RUMFeature = try XCTUnwrap(core.feature(named: RUMFeature.featureName), "RUM feature must be initialized before creating `RUMMonitor`")
+        let rumFeature: RUMFeature = try XCTUnwrap(core.feature(RUMFeature.self), "RUM feature must be initialized before creating `RUMMonitor`")
         let swiftMonitor = RUMMonitor(
             dependencies: RUMScopeDependencies(rumFeature: rumFeature)
                 .replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
@@ -157,7 +157,7 @@ class DDRUMMonitorTests: XCTestCase {
 
     func testSendingViewEvents() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
         let mockView = createMockView(viewControllerClassName: "FirstViewController")
@@ -192,7 +192,7 @@ class DDRUMMonitorTests: XCTestCase {
 
     func testSendingViewEventsWithTiming() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
 
@@ -221,7 +221,7 @@ class DDRUMMonitorTests: XCTestCase {
         }
 
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
 
@@ -274,7 +274,7 @@ class DDRUMMonitorTests: XCTestCase {
 
     func testSendingErrorEvents() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
 
@@ -342,7 +342,7 @@ class DDRUMMonitorTests: XCTestCase {
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
 
@@ -376,7 +376,7 @@ class DDRUMMonitorTests: XCTestCase {
 
     func testSendingGlobalAttributes() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: RUMFeature.featureName, instance: rum)
+        core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
         objcRUMMonitor.addAttribute(forKey: "global-attribute1", value: "foo1")

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -25,7 +25,7 @@ class DDTracerTests: XCTestCase {
 
     func testSendingCustomizedSpans() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration()).dd!
 
@@ -131,8 +131,8 @@ class DDTracerTests: XCTestCase {
             loggingFeature: logging
         )
 
-        core.registerFeature(named: TracingFeature.featureName, instance: logging)
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: logging)
+        core.register(feature: tracing)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
 
@@ -165,8 +165,8 @@ class DDTracerTests: XCTestCase {
             loggingFeature: logging
         )
 
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: logging)
+        core.register(feature: tracing)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
 
@@ -202,8 +202,8 @@ class DDTracerTests: XCTestCase {
             loggingFeature: logging
         )
 
-        core.registerFeature(named: LoggingFeature.featureName, instance: logging)
-        core.registerFeature(named: TracingFeature.featureName, instance: tracing)
+        core.register(feature: logging)
+        core.register(feature: tracing)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
 
@@ -267,7 +267,7 @@ class DDTracerTests: XCTestCase {
 
     func testsWhenTagsDictionaryContainsInvalidKeys_thenThosesTagsAreDropped() throws {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(directories: temporaryFeatureDirectories)
-        core.registerFeature(named: TracingFeature.featureName, instance: feature)
+        core.register(feature: feature)
 
         // Given
         let objcTracer = DDTracer(configuration: DDTracerConfiguration()).dd!

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -47,7 +47,7 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
             assert: {
                 defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName) == nil
                     && defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName) == nil
-                    && RUMFeature.instance == nil
+                    && defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName) == nil
                     && CrashReportingFeature.instance == nil
             },
             problem: "All features must not be initialized.",

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -57,7 +57,7 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
         ),
         .init(
             assert: {
-                RUMInstrumentation.instance == nil && URLSessionAutoInstrumentation.instance == nil
+                defaultDatadogCore.feature(RUMInstrumentation.self) == nil && URLSessionAutoInstrumentation.instance == nil
             },
             problem: "All auto-instrumentation features must not be initialized.",
             solution: """

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -45,9 +45,9 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
         ),
         .init(
             assert: {
-                defaultDatadogCore.feature(LoggingFeature.self, named: LoggingFeature.featureName) == nil
-                    && defaultDatadogCore.feature(TracingFeature.self, named: TracingFeature.featureName) == nil
-                    && defaultDatadogCore.feature(RUMFeature.self, named: RUMFeature.featureName) == nil
+                defaultDatadogCore.feature(LoggingFeature.self) == nil
+                    && defaultDatadogCore.feature(TracingFeature.self) == nil
+                    && defaultDatadogCore.feature(RUMFeature.self) == nil
                     && CrashReportingFeature.instance == nil
             },
             problem: "All features must not be initialized.",


### PR DESCRIPTION
### What and why?

Register RUM v1 in `DatadogCore`.

### How?

Remove `RUMFeature.instance` singleton and other static access and expect a `DatadogCoreProtocol` complying instance when creating a `RUMMonitor`, `defaultDatadogCore` is used by default.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
