### PR TITLE
RUMM-2133 Register Crash Reporting v1 in `DatadogCore`

### DIFF
--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -8,12 +8,6 @@ import Foundation
 
 /// Creates and owns components enabling Crash Reporting feature.
 internal final class CrashReportingFeature {
-    /// Single, shared instance of `CrashReportingFeature`.
-    static var instance: CrashReportingFeature?
-
-    /// Tells if the feature was enabled by the user in the SDK configuration.
-    static var isEnabled: Bool { instance != nil }
-
     // MARK: - Configuration
 
     let configuration: FeaturesConfiguration.CrashReporting
@@ -53,9 +47,5 @@ internal final class CrashReportingFeature {
         self.rumSessionStateProvider = ValuePublisher(initialValue: nil) // `nil` by default, because there cannot be any RUM session at this ponit
         self.appStateListener = commonDependencies.appStateListener
         self.telemetry = telemetry
-    }
-
-    internal func deinitialize() {
-        CrashReportingFeature.instance = nil
     }
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -289,6 +289,8 @@ public class Datadog {
                 commonDependencies: commonDependencies,
                 telemetry: telemetry
             )
+
+            core.register(feature: crashReporting)
         }
 
         if let urlSessionAutoInstrumentationConfiguration = configuration.urlSessionAutoInstrumentation {
@@ -297,8 +299,6 @@ public class Datadog {
                 commonDependencies: commonDependencies
             )
         }
-
-        CrashReportingFeature.instance = crashReporting
 
         core.feature(RUMInstrumentation.self)?.enable()
 
@@ -309,12 +309,13 @@ public class Datadog {
 
         // After everything is set up, if the Crash Reporting feature was enabled,
         // register crash reporter and send crash report if available:
-        if let crashReportingFeature = CrashReportingFeature.instance {
+        if let crashReportingFeature = core.feature(CrashReportingFeature.self) {
             Global.crashReporter = CrashReporter(
                 crashReportingFeature: crashReportingFeature,
                 loggingFeature: logging,
                 rumFeature: rum
             )
+
             Global.crashReporter?.sendCrashReportIfFound()
         }
     }
@@ -346,7 +347,6 @@ public class Datadog {
         rum?.deinitialize()
         rumInstrumentation?.deinitialize()
 
-        CrashReportingFeature.instance?.deinitialize()
         URLSessionAutoInstrumentation.instance?.deinitialize()
 
         // Reset Globals:

--- a/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMWithCrashContextIntegration.swift
@@ -14,15 +14,11 @@ internal struct RUMWithCrashContextIntegration {
     private weak var rumViewEventProvider: ValuePublisher<RUMViewEvent?>?
     private weak var rumSessionStateProvider: ValuePublisher<RUMSessionState?>?
 
-    init?() {
-        if let crashReportingFeature = CrashReportingFeature.instance {
-            self.init(
-                rumViewEventProvider: crashReportingFeature.rumViewEventProvider,
-                rumSessionStateProvider: crashReportingFeature.rumSessionStateProvider
-            )
-        } else {
-            return nil
-        }
+    init(crashReporting: CrashReportingFeature) {
+        self.init(
+            rumViewEventProvider: crashReporting.rumViewEventProvider,
+            rumSessionStateProvider: crashReporting.rumSessionStateProvider
+        )
     }
 
     init(

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -43,7 +43,7 @@ internal struct RUMScopeDependencies {
 }
 
 internal extension RUMScopeDependencies {
-    init(rumFeature: RUMFeature) {
+    init(rumFeature: RUMFeature, crashReportingFeature: CrashReportingFeature?) {
         self.init(
             rumApplicationID: rumFeature.configuration.applicationID,
             sessionSampler: rumFeature.configuration.sessionSampler,
@@ -67,7 +67,7 @@ internal extension RUMScopeDependencies {
             ),
             rumUUIDGenerator: rumFeature.configuration.uuidGenerator,
             dateCorrector: rumFeature.dateCorrector,
-            crashContextIntegration: RUMWithCrashContextIntegration(),
+            crashContextIntegration: crashReportingFeature.map { .init(crashReporting: $0) },
             ciTest: CITestIntegration.active?.rumCITest,
             viewUpdatesThrottlerFactory: { RUMViewUpdatesThrottler() },
             vitalCPUReader: rumFeature.vitalCPUReader,

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -164,8 +164,10 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                         : "`Datadog.initialize()` must be called prior to `RUMMonitor.initialize()`."
                 )
             }
+
+            let crashReporting = core.feature(CrashReportingFeature.self)
             let monitor = RUMMonitor(
-                dependencies: RUMScopeDependencies(rumFeature: rumFeature),
+                dependencies: RUMScopeDependencies(rumFeature: rumFeature, crashReportingFeature: crashReporting),
                 dateProvider: rumFeature.dateProvider
             )
 

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -116,7 +116,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
-            XCTAssertFalse(CrashReportingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
@@ -128,7 +128,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
-            XCTAssertFalse(CrashReportingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
@@ -141,7 +141,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
-            XCTAssertFalse(CrashReportingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
@@ -154,7 +154,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(TracingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
-            XCTAssertFalse(CrashReportingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
@@ -168,7 +168,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
-            XCTAssertFalse(CrashReportingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
         }
@@ -177,7 +177,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
-            XCTAssertFalse(CrashReportingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
         }
@@ -186,7 +186,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature cannot be enabled")
-            XCTAssertFalse(CrashReportingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
@@ -198,7 +198,7 @@ class DatadogTests: XCTestCase {
             // verify features:
             XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self))
-            XCTAssertFalse(CrashReportingFeature.isEnabled)
+            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
             // verify integrations:
@@ -247,7 +247,7 @@ class DatadogTests: XCTestCase {
                 .enableCrashReporting(using: CrashReportingPluginMock())
                 .build()
         ) {
-            XCTAssertNotNil(CrashReportingFeature.instance)
+            XCTAssertNotNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertTrue(
                 Global.crashReporter?.loggingOrRUMIntegration is CrashReportingWithLoggingIntegration,
                 "When only Logging feature is enabled, the Crash Reporter should send crash reports as Logs"
@@ -261,7 +261,7 @@ class DatadogTests: XCTestCase {
                 .enableCrashReporting(using: CrashReportingPluginMock())
                 .build()
         ) {
-            XCTAssertNotNil(CrashReportingFeature.instance)
+            XCTAssertNotNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertTrue(
                 Global.crashReporter?.loggingOrRUMIntegration is CrashReportingWithRUMIntegration,
                 "When only RUM feature is enabled, the Crash Reporter should send crash reports as RUM Events"
@@ -275,7 +275,7 @@ class DatadogTests: XCTestCase {
                 .enableCrashReporting(using: CrashReportingPluginMock())
                 .build()
         ) {
-            XCTAssertNotNil(CrashReportingFeature.instance)
+            XCTAssertNotNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertTrue(
                 Global.crashReporter?.loggingOrRUMIntegration is CrashReportingWithRUMIntegration,
                 "When both Logging and RUM features are enabled, the Crash Reporter should send crash reports as RUM Events"
@@ -289,7 +289,7 @@ class DatadogTests: XCTestCase {
                 .enableCrashReporting(using: CrashReportingPluginMock())
                 .build()
         ) {
-            XCTAssertNil(CrashReportingFeature.instance)
+            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(
                 Global.crashReporter,
                 "When both Logging and RUM are disabled, Crash Reporter should not be registered"

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMWithCrashContextIntegrationTests.swift
@@ -11,10 +11,8 @@ class RUMWithCrashContextIntegrationTests: XCTestCase {
     func testWhenCrashReportingIsEnabled_itUpdatesCrashContextWithLastRUMView() throws {
         // When
         let crashReporting: CrashReportingFeature = .mockNoOp()
-        CrashReportingFeature.instance = crashReporting
-        defer { CrashReportingFeature.instance?.deinitialize() }
 
-        let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration())
+        let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration(crashReporting: crashReporting))
 
         // Then
         let randomRUMViewEvent: RUMViewEvent = .mockRandom()
@@ -27,22 +25,13 @@ class RUMWithCrashContextIntegrationTests: XCTestCase {
 
     func testWhenCrashReportingIsEnabled_itUpdatesCrashContextWithRUMSessionState() throws {
         // When
-        CrashReportingFeature.instance = .mockNoOp()
-        defer { CrashReportingFeature.instance?.deinitialize() }
+        let crashReporting: CrashReportingFeature = .mockNoOp()
 
         // Then
-        let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration())
+        let rumWithCrashContextIntegration = try XCTUnwrap(RUMWithCrashContextIntegration(crashReporting: crashReporting))
         let randomRUMSessionState: RUMSessionState = .mockRandom()
         rumWithCrashContextIntegration.update(lastRUMSessionState: randomRUMSessionState)
 
-        XCTAssertEqual(CrashReportingFeature.instance?.rumSessionStateProvider.currentValue, randomRUMSessionState)
-    }
-
-    func testWhenCrashReportingIsNotEnabled_itCannotBeInitialized() {
-        // When
-        XCTAssertNil(CrashReportingFeature.instance)
-
-        // Then
-        XCTAssertNil(RUMWithCrashContextIntegration())
+        XCTAssertEqual(crashReporting.rumSessionStateProvider.currentValue, randomRUMSessionState)
     }
 }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -592,7 +592,7 @@ class LoggerTests: XCTestCase {
         // given
         let logger = Logger.builder.build(in: core)
         Global.rum = RUMMonitor(
-            dependencies: RUMScopeDependencies(rumFeature: rum)
+            dependencies: RUMScopeDependencies(rumFeature: rum, crashReportingFeature: nil)
                 .replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
             dateProvider: rum.dateProvider
         )

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -148,7 +148,7 @@ class DDRUMMonitorTests: XCTestCase {
     private func createTestableDDRUMMonitor() throws -> DatadogObjc.DDRUMMonitor {
         let rumFeature: RUMFeature = try XCTUnwrap(core.feature(RUMFeature.self), "RUM feature must be initialized before creating `RUMMonitor`")
         let swiftMonitor = RUMMonitor(
-            dependencies: RUMScopeDependencies(rumFeature: rumFeature)
+            dependencies: RUMScopeDependencies(rumFeature: rumFeature, crashReportingFeature: nil)
                 .replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
             dateProvider: rumFeature.dateProvider
         )

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -48,7 +48,7 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
                 defaultDatadogCore.feature(LoggingFeature.self) == nil
                     && defaultDatadogCore.feature(TracingFeature.self) == nil
                     && defaultDatadogCore.feature(RUMFeature.self) == nil
-                    && CrashReportingFeature.instance == nil
+                    && defaultDatadogCore.feature(CrashReportingFeature.self) == nil
             },
             problem: "All features must not be initialized.",
             solution: """


### PR DESCRIPTION
### What and why?

Register Crash Reporting v1 in `DatadogCore`.

### How?

Remove `CrashReportingFeature.instance` singleton and other static access.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests

