### PR TITLE
RUMM-2133 Register `URLSession` Instrumentation v1 in `DatadogCore`

### DIFF
--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -300,12 +300,12 @@ public class Datadog {
                 configuration: urlSessionAutoInstrumentationConfiguration,
                 commonDependencies: commonDependencies
             )
+
+            core.register(feature: urlSessionAutoInstrumentation)
         }
 
         core.feature(RUMInstrumentation.self)?.enable()
-
-        URLSessionAutoInstrumentation.instance = urlSessionAutoInstrumentation
-        URLSessionAutoInstrumentation.instance?.enable()
+        core.feature(URLSessionAutoInstrumentation.self)?.enable()
 
         defaultDatadogCore = core
 
@@ -344,12 +344,12 @@ public class Datadog {
         let tracing = defaultDatadogCore.feature(TracingFeature.self)
         let rum = defaultDatadogCore.feature(RUMFeature.self)
         let rumInstrumentation = defaultDatadogCore.feature(RUMInstrumentation.self)
+        let urlSessionInstrumentation = defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)
         logging?.deinitialize()
         tracing?.deinitialize()
         rum?.deinitialize()
         rumInstrumentation?.deinitialize()
-
-        URLSessionAutoInstrumentation.instance?.deinitialize()
+        urlSessionInstrumentation?.deinitialize()
 
         // Reset Globals:
         Global.sharedTracer = DDNoopGlobals.tracer

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -172,7 +172,8 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
             )
 
             core.feature(RUMInstrumentation.self)?.publish(to: monitor)
-            URLSessionAutoInstrumentation.instance?.publish(to: monitor)
+            core.feature(URLSessionAutoInstrumentation.self)?.publish(to: monitor)
+
             return monitor
         } catch {
             consolePrint("\(error)")

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -29,16 +29,16 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
     }
 
     var instrumentation: URLSessionAutoInstrumentation? {
-        core.feature(URLSessionAutoInstrumentation.self)
+        core().feature(URLSessionAutoInstrumentation.self)
     }
 
     let firstPartyURLsFilter: FirstPartyURLsFilter
 
-    private let core: DatadogCoreProtocol
+    private let core: () -> DatadogCoreProtocol
 
     @objc
     override public init() {
-        core = defaultDatadogCore
+        core = { defaultDatadogCore }
         firstPartyURLsFilter = FirstPartyURLsFilter(hosts: [])
         super.init()
     }
@@ -64,7 +64,7 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
     ///   - core: Datadog SDK core.
     ///   - additionalFirstPartyHosts: additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
     ///                                passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
-    public init(in core: DatadogCoreProtocol, additionalFirstPartyHosts: Set<String>) {
+    public init(in core: @autoclosure @escaping () -> DatadogCoreProtocol, additionalFirstPartyHosts: Set<String>) {
         self.core = core
         self.firstPartyURLsFilter = FirstPartyURLsFilter(hosts: additionalFirstPartyHosts)
         super.init()

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -28,37 +28,59 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
         return self
     }
 
-    var interceptor: URLSessionInterceptorType? { URLSessionAutoInstrumentation.instance?.interceptor }
-    let firstPartyURLsFilter: FirstPartyURLsFilter?
+    var instrumentation: URLSessionAutoInstrumentation? {
+        core.feature(URLSessionAutoInstrumentation.self)
+    }
+
+    let firstPartyURLsFilter: FirstPartyURLsFilter
+
+    private let core: DatadogCoreProtocol
 
     @objc
     override public init() {
-        firstPartyURLsFilter = nil
+        core = defaultDatadogCore
+        firstPartyURLsFilter = FirstPartyURLsFilter(hosts: [])
+        super.init()
     }
 
-    /// Automatically tracked hosts can be customized per instance with this initializer
-    /// - Parameter additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
-    /// passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
+    public convenience init(in core: DatadogCoreProtocol) {
+        self.init(in: core, additionalFirstPartyHosts: [])
+    }
+
+    /// Automatically tracked hosts can be customized per instance with this initializer.
     ///
-    /// **NOTE:** If `trackURLSession(firstPartyHosts:)` is never called, automatic tracking will **not** take place
+    /// **NOTE:** If `trackURLSession(firstPartyHosts:)` is never called, automatic tracking will **not** take place.
+    ///
+    /// - Parameter additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
+    ///             passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
     @objc
-    public init(additionalFirstPartyHosts: Set<String>) {
-        firstPartyURLsFilter = FirstPartyURLsFilter(hosts: additionalFirstPartyHosts)
+    public convenience init(additionalFirstPartyHosts: Set<String>) {
+        self.init(in: defaultDatadogCore, additionalFirstPartyHosts: additionalFirstPartyHosts)
+    }
+
+    /// Automatically tracked hosts can be customized per instance with this initializer.
+    ///
+    /// - Parameters:
+    ///   - core: Datadog SDK core.
+    ///   - additionalFirstPartyHosts: additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
+    ///                                passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
+    public init(in core: DatadogCoreProtocol, additionalFirstPartyHosts: Set<String>) {
+        self.core = core
+        self.firstPartyURLsFilter = FirstPartyURLsFilter(hosts: additionalFirstPartyHosts)
+        super.init()
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        interceptor?.taskMetricsCollected(task: task, metrics: metrics)
+        instrumentation?.interceptor.taskMetricsCollected(task: task, metrics: metrics)
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
-
-        interceptor?.taskCompleted(task: task, error: error)
+        instrumentation?.interceptor.taskCompleted(task: task, error: error)
     }
 
     open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
-
-        interceptor?.taskReceivedData(task: dataTask, data: data)
+        instrumentation?.interceptor.taskReceivedData(task: dataTask, data: data)
     }
 }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -222,7 +222,7 @@ public class URLSessionInterceptor: URLSessionInterceptorType {
             return defaultFirstPartyURLsFilter.isFirstParty(url: request.url)
         }
 
-        return  delegate.firstPartyURLsFilter.isFirstParty(url: request.url) ||
+        return delegate.firstPartyURLsFilter.isFirstParty(url: request.url) ||
                 defaultFirstPartyURLsFilter.isFirstParty(url: request.url)
     }
 

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -28,7 +28,8 @@ internal protocol URLSessionInterceptorType: AnyObject {
 /// An object performing interception of requests sent with `URLSession`.
 public class URLSessionInterceptor: URLSessionInterceptorType {
     public static var shared: URLSessionInterceptor? {
-        URLSessionAutoInstrumentation.instance?.interceptor as? URLSessionInterceptor
+        let instrumentation = defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)
+        return instrumentation?.interceptor as? URLSessionInterceptor
     }
 
     /// Filters first party `URLs` defined by the user.
@@ -217,10 +218,12 @@ public class URLSessionInterceptor: URLSessionInterceptorType {
     // MARK: - Private
 
     private func isFirstParty(request: URLRequest, for session: URLSession?) -> Bool {
-        let delegateURLFilter = (session?.delegate as? DDURLSessionDelegate)?.firstPartyURLsFilter
-        let isFirstPartyForDelegate = (delegateURLFilter?.isFirstParty(url: request.url)) ?? false
-        let isFirstPartyForInterceptor = self.defaultFirstPartyURLsFilter.isFirstParty(url: request.url)
-        return isFirstPartyForDelegate || isFirstPartyForInterceptor
+        guard let delegate = session?.delegate as? DDURLSessionDelegate else {
+            return defaultFirstPartyURLsFilter.isFirstParty(url: request.url)
+        }
+
+        return  delegate.firstPartyURLsFilter.isFirstParty(url: request.url) ||
+                defaultFirstPartyURLsFilter.isFirstParty(url: request.url)
     }
 
     private func finishInterception(task: URLSessionTask, interception: TaskInterception) {

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentation.swift
@@ -8,8 +8,6 @@ import Foundation
 
 /// `URLSession` Auto Instrumentation feature.
 internal final class URLSessionAutoInstrumentation: RUMCommandPublisher {
-    static var instance: URLSessionAutoInstrumentation?
-
     let swizzler: URLSessionSwizzler
     let interceptor: URLSessionInterceptorType
 
@@ -51,6 +49,5 @@ internal final class URLSessionAutoInstrumentation: RUMCommandPublisher {
     /// Removes `URLSession` swizzling and deinitializes this component.
     internal func deinitialize() {
         swizzler.unswizzle()
-        URLSessionAutoInstrumentation.instance = nil
     }
 }

--- a/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzler.swift
@@ -77,7 +77,10 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URLRequest, CompletionHandler?) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, urlRequest, completionHandler -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
+                    guard
+                        let delegate = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate,
+                        let interceptor = delegate.instrumentation?.interceptor
+                    else {
                         return previousImplementation(session, Self.selector, urlRequest, completionHandler)
                     }
                     let task: URLSessionDataTask
@@ -139,7 +142,10 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URL, CompletionHandler?) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, url, completionHandler -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
+                    guard
+                        let delegate = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate,
+                        let interceptor = delegate.instrumentation?.interceptor
+                    else {
                         return previousImplementation(session, Self.selector, url, completionHandler)
                     }
                     let task: URLSessionDataTask
@@ -196,7 +202,10 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URLRequest) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, urlRequest -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
+                    guard
+                        let delegate = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate,
+                        let interceptor = delegate.instrumentation?.interceptor
+                    else {
                         return previousImplementation(session, Self.selector, urlRequest)
                     }
                     let newRequest = interceptor.modify(request: urlRequest, session: session)
@@ -240,7 +249,10 @@ internal class URLSessionSwizzler {
             typealias Signature = @convention(block) (URLSession, URL) -> URLSessionDataTask
             swizzle(method) { previousImplementation -> Signature in
                 return { session, url -> URLSessionDataTask in
-                    guard let interceptor = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate.interceptor else {
+                    guard
+                        let delegate = (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate,
+                        let interceptor = delegate.instrumentation?.interceptor
+                    else {
                         return previousImplementation(session, Self.selector, url)
                     }
                     let task = previousImplementation(session, Self.selector, url)

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -103,13 +103,13 @@ class DatadogTests: XCTestCase {
             verificationBlock()
 
             defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler?.unswizzle()
-            URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
+            defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)?.swizzler.unswizzle()
             Datadog.flushAndDeinitialize()
         }
 
         defer {
             defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler?.unswizzle()
-            URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
+            defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)?.swizzler.unswizzle()
         }
 
         verify(configuration: defaultBuilder.build()) {
@@ -118,7 +118,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
@@ -131,7 +131,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
@@ -145,7 +145,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
@@ -159,7 +159,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
@@ -174,7 +174,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
             XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
         verify(configuration: rumBuilder.enableTracing(false).build()) {
@@ -184,7 +184,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
             XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
 
@@ -194,7 +194,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature cannot be enabled")
             XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
@@ -207,7 +207,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
@@ -242,10 +242,10 @@ class DatadogTests: XCTestCase {
         }
 
         verify(configuration: defaultBuilder.trackURLSession(firstPartyHosts: ["example.com"]).build()) {
-            XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNotNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
         }
         verify(configuration: defaultBuilder.trackURLSession().build()) {
-            XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNotNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
         }
 
         verify(

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -72,3 +72,9 @@ extension RUMInstrumentation: Flushable {
         deinitialize()
     }
 }
+
+extension URLSessionAutoInstrumentation: Flushable {
+    func flush() {
+        deinitialize()
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1371,7 +1371,8 @@ class RUMMonitorTests: XCTestCase {
         userLogger = .mockWith(logOutput: output)
 
         // Given
-        let resourcesHandler = try XCTUnwrap(URLSessionAutoInstrumentation.instance?.interceptor.handler)
+        let urlInstrumentation = try XCTUnwrap(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+        let resourcesHandler = urlInstrumentation.interceptor.handler
         let rumInstrumentation = try XCTUnwrap(defaultDatadogCore.feature(RUMInstrumentation.self))
         let viewsHandler = rumInstrumentation.viewsHandler
         let userActionsHandler = try XCTUnwrap(rumInstrumentation.userActionsAutoInstrumentation?.handler)
@@ -1422,10 +1423,6 @@ class RUMMonitorTests: XCTestCase {
             Make sure `Global.rum = RUMMonitor.initialize()` is called before any action happens.
             """
         )
-
-        URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
-        rumInstrumentation.viewControllerSwizzler?.unswizzle()
-        rumInstrumentation.userActionsAutoInstrumentation?.swizzler.unswizzle()
     }
 
     // MARK: - Internal attributes

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -1128,12 +1128,14 @@ class TracerTests: XCTestCase {
                 .trackURLSession(firstPartyHosts: [.mockAny()])
                 .build()
         )
+        defer { Datadog.flushAndDeinitialize() }
 
         let output = LogOutputMock()
         userLogger = .mockWith(logOutput: output)
 
         // Given
-        let tracingHandler = try XCTUnwrap(URLSessionAutoInstrumentation.instance?.interceptor.handler)
+        let instrumentation = defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)
+        let tracingHandler = try XCTUnwrap(instrumentation?.interceptor.handler)
 
         // When
         XCTAssertTrue(Global.sharedTracer is DDNoopTracer)
@@ -1148,10 +1150,6 @@ class TracerTests: XCTestCase {
             Make sure `Global.sharedTracer = Tracer.initialize()` is called before any network request is send.
             """
         )
-
-        URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
-
-        Datadog.flushAndDeinitialize()
     }
 }
 // swiftlint:enable multiline_arguments_brackets

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
@@ -8,19 +8,22 @@ import XCTest
 @testable import Datadog
 
 class DDURLSessionDelegateTests: XCTestCase {
+    let core = DatadogCoreMock()
     private let interceptor = URLSessionInterceptorMock()
-    private let delegate = DDURLSessionDelegate()
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        URLSessionAutoInstrumentation.instance = .init(
+        let instrumentation = URLSessionAutoInstrumentation(
             swizzler: try URLSessionSwizzler(),
             interceptor: interceptor
         )
+
+        instrumentation.enable() // swizzle `URLSession`
+        core.register(feature: instrumentation)
     }
 
     override func tearDown() {
-        URLSessionAutoInstrumentation.instance?.deinitialize()
+        core.flush()
         super.tearDown()
     }
 
@@ -37,6 +40,7 @@ class DDURLSessionDelegateTests: XCTestCase {
         interceptor.onTaskMetricsCollected = { _, _ in notifyTaskMetricsCollected.fulfill() }
 
         // Given
+        let delegate = DDURLSessionDelegate(in: core)
         let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
@@ -59,6 +63,7 @@ class DDURLSessionDelegateTests: XCTestCase {
         interceptor.onTaskMetricsCollected = { _, _ in notifyTaskMetricsCollected.fulfill() }
 
         // Given
+        let delegate = DDURLSessionDelegate(in: core)
         let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
@@ -90,6 +95,7 @@ class DDURLSessionDelegateTests: XCTestCase {
         let dateBeforeAnyRequests = Date()
 
         // Given
+        let delegate = DDURLSessionDelegate(in: core)
         let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
@@ -147,6 +153,7 @@ class DDURLSessionDelegateTests: XCTestCase {
         let dateBeforeAnyRequests = Date()
 
         // Given
+        let delegate = DDURLSessionDelegate(in: core)
         let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -35,15 +35,16 @@ class DDDatadogTests: XCTestCase {
         XCTAssertTrue(Datadog.isInitialized)
 
         let logging = defaultDatadogCore.feature(LoggingFeature.self)
+        let urlSessionInstrumentation = defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)
         XCTAssertEqual(logging?.configuration.common.applicationName, "app-name")
         XCTAssertEqual(logging?.configuration.common.environment, "tests")
-        XCTAssertNotNil(URLSessionAutoInstrumentation.instance)
+        XCTAssertNotNil(urlSessionInstrumentation)
 
-        URLSessionAutoInstrumentation.instance?.swizzler.unswizzle()
+        urlSessionInstrumentation?.swizzler.unswizzle()
         Datadog.flushAndDeinitialize()
 
         XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self))
-        XCTAssertNil(URLSessionAutoInstrumentation.instance)
+        XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
     }
 
     // MARK: - Changing Tracking Consent

--- a/Tests/DatadogTests/DatadogObjc/DDNSURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDNSURLSessionDelegateTests.swift
@@ -29,12 +29,14 @@ private class DDURLSessionDelegateMock: DDURLSessionDelegate {
 class DDNSURLSessionDelegateTests: XCTestCase {
     func testInit() {
         let delegate = DDNSURLSessionDelegate()
-        XCTAssertNil(delegate.swiftDelegate.firstPartyURLsFilter)
+        let url = URL(string: "foo.com")
+        XCTAssertFalse(delegate.swiftDelegate.firstPartyURLsFilter.isFirstParty(url: url))
     }
 
     func testInitWithAdditionalFirstPartyHosts() {
         let delegate = DDNSURLSessionDelegate(additionalFirstPartyHosts: ["foo.com"])
-        XCTAssertNotNil(delegate.swiftDelegate.firstPartyURLsFilter)
+        let url = URL(string: "http://foo.com")
+        XCTAssertTrue(delegate.swiftDelegate.firstPartyURLsFilter.isFirstParty(url: url))
     }
 
     func testItForwardsCallsToSwiftDelegate() {

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -57,7 +57,8 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
         ),
         .init(
             assert: {
-                defaultDatadogCore.feature(RUMInstrumentation.self) == nil && URLSessionAutoInstrumentation.instance == nil
+                defaultDatadogCore.feature(RUMInstrumentation.self) == nil
+                && defaultDatadogCore.feature(URLSessionAutoInstrumentation.self) == nil
             },
             problem: "All auto-instrumentation features must not be initialized.",
             solution: """


### PR DESCRIPTION
### What and why?

Register `URLSession` instrumentation v1 in `DatadogCore`.

### How?

Remove `URLSessionAutoInstrumentation.instance` singleton and other static access and expect a `DatadogCoreProtocol` complying instance when creating a `DDURLSessionDelegate`, `defaultDatadogCore` is used by default.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
