### PR TITLE
RUMM-2169 Initialise V1 Logging with V2 configuration

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -264,6 +264,8 @@
 		616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */; };
 		616CCE13250A1868009FED46 /* RUMCommandSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CCE12250A1868009FED46 /* RUMCommandSubscriber.swift */; };
 		616CCE16250A467E009FED46 /* RUMInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CCE15250A467E009FED46 /* RUMInstrumentation.swift */; };
+		616F1FAD283D683500651A3A /* DatadogV1Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FAC283D683500651A3A /* DatadogV1Context.swift */; };
+		616F1FAE283D683500651A3A /* DatadogV1Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FAC283D683500651A3A /* DatadogV1Context.swift */; };
 		6170DC1C25C18729003AED5C /* DDCrashReportingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */; };
 		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
 		617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */; };
@@ -1452,6 +1454,7 @@
 		616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDRUMMonitorTests.swift; sourceTree = "<group>"; };
 		616CCE12250A1868009FED46 /* RUMCommandSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommandSubscriber.swift; sourceTree = "<group>"; };
 		616CCE15250A467E009FED46 /* RUMInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMInstrumentation.swift; sourceTree = "<group>"; };
+		616F1FAC283D683500651A3A /* DatadogV1Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogV1Context.swift; sourceTree = "<group>"; };
 		6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportingPlugin.swift; sourceTree = "<group>"; };
 		6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogCrashReportingTests.xcconfig; sourceTree = "<group>"; };
 		6172472625D673D7007085B3 /* CrashContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextTests.swift; sourceTree = "<group>"; };
@@ -4135,6 +4138,7 @@
 			isa = PBXGroup;
 			children = (
 				D2B3F0492829510600C2B5EE /* DatadogCoreProtocol.swift */,
+				616F1FAC283D683500651A3A /* DatadogV1Context.swift */,
 			);
 			path = DatadogInternal;
 			sourceTree = "<group>";
@@ -5050,6 +5054,7 @@
 				61B0384E2527246900518F3C /* URLSessionAutoInstrumentation.swift in Sources */,
 				61C5A88924509A0C00DA608C /* DDSpanContext.swift in Sources */,
 				6141015B251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift in Sources */,
+				616F1FAD283D683500651A3A /* DatadogV1Context.swift in Sources */,
 				616CCE16250A467E009FED46 /* RUMInstrumentation.swift in Sources */,
 				6157FA5E252767CB009A8A3B /* URLSessionRUMResourcesHandler.swift in Sources */,
 				616CCE13250A1868009FED46 /* RUMCommandSubscriber.swift in Sources */,
@@ -5642,6 +5647,7 @@
 				D2CB6E3F27C50EAE00A62B57 /* ConsentProvider.swift in Sources */,
 				D2CB6E4027C50EAE00A62B57 /* UIViewControllerSwizzler.swift in Sources */,
 				D2CB6E4127C50EAE00A62B57 /* RUMCurrentContext.swift in Sources */,
+				616F1FAE283D683500651A3A /* DatadogV1Context.swift in Sources */,
 				D2CB6E4227C50EAE00A62B57 /* RUMConnectivityInfoProvider.swift in Sources */,
 				D248ED462807193B00B315B4 /* RUMTelemetry.swift in Sources */,
 				D2CB6E4327C50EAE00A62B57 /* ObjcExceptionHandler.m in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -266,6 +266,8 @@
 		616CCE16250A467E009FED46 /* RUMInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616CCE15250A467E009FED46 /* RUMInstrumentation.swift */; };
 		616F1FAD283D683500651A3A /* DatadogV1Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FAC283D683500651A3A /* DatadogV1Context.swift */; };
 		616F1FAE283D683500651A3A /* DatadogV1Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FAC283D683500651A3A /* DatadogV1Context.swift */; };
+		616F1FB0283E227100651A3A /* LoggingV2Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FAF283E227100651A3A /* LoggingV2Configuration.swift */; };
+		616F1FB1283E227100651A3A /* LoggingV2Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FAF283E227100651A3A /* LoggingV2Configuration.swift */; };
 		6170DC1C25C18729003AED5C /* DDCrashReportingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */; };
 		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
 		617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */; };
@@ -1455,6 +1457,7 @@
 		616CCE12250A1868009FED46 /* RUMCommandSubscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCommandSubscriber.swift; sourceTree = "<group>"; };
 		616CCE15250A467E009FED46 /* RUMInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMInstrumentation.swift; sourceTree = "<group>"; };
 		616F1FAC283D683500651A3A /* DatadogV1Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogV1Context.swift; sourceTree = "<group>"; };
+		616F1FAF283E227100651A3A /* LoggingV2Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingV2Configuration.swift; sourceTree = "<group>"; };
 		6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportingPlugin.swift; sourceTree = "<group>"; };
 		6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogCrashReportingTests.xcconfig; sourceTree = "<group>"; };
 		6172472625D673D7007085B3 /* CrashContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextTests.swift; sourceTree = "<group>"; };
@@ -2186,6 +2189,7 @@
 			isa = PBXGroup;
 			children = (
 				612983CC2449E62E00D4424B /* LoggingFeature.swift */,
+				616F1FAF283E227100651A3A /* LoggingV2Configuration.swift */,
 				61133BC12423979B00786299 /* Log */,
 				61133BC52423979B00786299 /* LogOutputs */,
 				D22C1F5A2714849700922024 /* Scrubbing */,
@@ -5023,6 +5027,7 @@
 				61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */,
 				618D9DE7263AD78900A3FAD2 /* SpanEventMapper.swift in Sources */,
 				6114FE2F257687310084E372 /* ConsentProvider.swift in Sources */,
+				616F1FB0283E227100651A3A /* LoggingV2Configuration.swift in Sources */,
 				61F3CDA52511190E00C816E5 /* UIViewControllerSwizzler.swift in Sources */,
 				6156CB9024DDA8BE008CB2B2 /* RUMCurrentContext.swift in Sources */,
 				614B0A4F24EBDC6B00A2A780 /* RUMConnectivityInfoProvider.swift in Sources */,
@@ -5743,6 +5748,7 @@
 				D2CB6E9C27C50EAE00A62B57 /* NetworkConnectionInfoProvider.swift in Sources */,
 				D2CB6E9D27C50EAE00A62B57 /* RUMEventFileOutput.swift in Sources */,
 				D2CB6E9E27C50EAE00A62B57 /* RUMDebugging.swift in Sources */,
+				616F1FB1283E227100651A3A /* LoggingV2Configuration.swift in Sources */,
 				D2CB6E9F27C50EAE00A62B57 /* DataCompression.swift in Sources */,
 				D2CB6EA027C50EAE00A62B57 /* SpanOutput.swift in Sources */,
 				D2CB6EA127C50EAE00A62B57 /* LogEventEncoder.swift in Sources */,

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -19,6 +19,22 @@ internal struct FeatureDirectories {
     let authorized: Directory
 }
 
+extension FeatureDirectories {
+    /// Creates `FeatureDirectories` from V2 storage configuration.
+    /// - Parameters:
+    ///   - sdkRootDirectory: the root directory for SDK instance
+    ///   - storageConfiguration: the storage configuration of Feature
+    init(sdkRootDirectory: Directory, storageConfiguration: FeatureStorageConfiguration) throws {
+        self.init(
+            deprecated: storageConfiguration.directories.deprecated.compactMap { deprecatedPath in
+                try? sdkRootDirectory.subdirectory(path: deprecatedPath) // ignore errors - deprecated paths likely do not exist
+            },
+            unauthorized: try sdkRootDirectory.createSubdirectory(path: storageConfiguration.directories.unauthorized),
+            authorized: try sdkRootDirectory.createSubdirectory(path: storageConfiguration.directories.authorized)
+        )
+    }
+}
+
 /// Container with dependencies common to all features (Logging, Tracing and RUM).
 internal struct FeaturesCommonDependencies {
     let consentProvider: ConsentProvider

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -12,6 +12,7 @@ import Foundation
 /// unvalidated and unresolved inputs, it should never be passed to features. Instead, `FeaturesConfiguration` should be used.
 internal struct FeaturesConfiguration {
     struct Common {
+        let clientToken: String
         let applicationName: String
         let applicationVersion: String
         let applicationBundleIdentifier: String
@@ -28,14 +29,12 @@ internal struct FeaturesConfiguration {
     struct Logging {
         let common: Common
         let uploadURL: URL
-        let clientToken: String
         let logEventMapper: LogEventMapper?
     }
 
     struct Tracing {
         let common: Common
         let uploadURL: URL
-        let clientToken: String
         let spanEventMapper: SpanEventMapper?
     }
 
@@ -48,7 +47,6 @@ internal struct FeaturesConfiguration {
 
         let common: Common
         let uploadURL: URL
-        let clientToken: String
         let applicationID: String
         let sessionSampler: Sampler
         let uuidGenerator: RUMUUIDGenerator
@@ -148,6 +146,7 @@ extension FeaturesConfiguration {
         }
 
         let common = Common(
+            clientToken: try ifValid(clientToken: configuration.clientToken),
             applicationName: appContext.bundleName ?? appContext.bundleType.rawValue,
             applicationVersion: appContext.bundleVersion ?? "0.0.0",
             applicationBundleIdentifier: appContext.bundleIdentifier ?? "unknown",
@@ -169,7 +168,6 @@ extension FeaturesConfiguration {
             logging = Logging(
                 common: common,
                 uploadURL: try ifValid(endpointURLString: logsEndpoint.url),
-                clientToken: try ifValid(clientToken: configuration.clientToken),
                 logEventMapper: configuration.logEventMapper
             )
         }
@@ -178,7 +176,6 @@ extension FeaturesConfiguration {
             tracing = Tracing(
                 common: common,
                 uploadURL: try ifValid(endpointURLString: tracesEndpoint.url),
-                clientToken: try ifValid(clientToken: configuration.clientToken),
                 spanEventMapper: configuration.spanEventMapper
             )
         }
@@ -194,7 +191,6 @@ extension FeaturesConfiguration {
                 rum = RUM(
                     common: common,
                     uploadURL: try ifValid(endpointURLString: rumEndpoint.url),
-                    clientToken: try ifValid(clientToken: configuration.clientToken),
                     applicationID: rumApplicationID,
                     sessionSampler: Sampler(samplingRate: debugOverride ? 100.0 : configuration.rumSessionsSamplingRate),
                     uuidGenerator: DefaultRUMUUIDGenerator(),

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -122,17 +122,17 @@ extension FeaturesConfiguration {
         }
 
         if let customLogsEndpoint = configuration.customLogsEndpoint {
-            // If `.set(cusstomLogsEndpoint:)` API was used, it should override logs endpoint
+            // If `.set(customLogsEndpoint:)` API was used, it should override logs endpoint
             logsEndpoint = .custom(url: customLogsEndpoint.absoluteString)
         }
 
         if let customTracesEndpoint = configuration.customTracesEndpoint {
-            // If `.set(cusstomLogsEndpoint:)` API was used, it should override traces endpoint
+            // If `.set(customTracesEndpoint:)` API was used, it should override traces endpoint
             tracesEndpoint = .custom(url: customTracesEndpoint.absoluteString)
         }
 
         if let customRUMEndpoint = configuration.customRUMEndpoint {
-            // If `.set(cusstomLogsEndpoint:)` API was used, it should override RUM endpoint
+            // If `.set(customRUMEndpoint:)` API was used, it should override RUM endpoint
             rumEndpoint = .custom(url: customRUMEndpoint.absoluteString)
         }
 

--- a/Sources/Datadog/Core/Persistence/Files/Directory.swift
+++ b/Sources/Datadog/Core/Persistence/Files/Directory.swift
@@ -11,12 +11,38 @@ internal struct Directory {
     let url: URL
 
     /// Creates subdirectory with given path under system caches directory.
+    /// RUMM-2169: Use `Directory.cache().createSubdirectory(path:)` instead.
     init(withSubdirectoryPath path: String) throws {
-        self.init(url: try createCachesSubdirectoryIfNotExists(subdirectoryPath: path))
+        self.init(url: try Directory.cache().createSubdirectory(path: path).url)
     }
 
     init(url: URL) {
         self.url = url
+    }
+
+    /// Creates subdirectory with given path by creating intermediate directories if needed.
+    /// If directory already exists at given `path` it will be used, without being altered.
+    func createSubdirectory(path: String) throws -> Directory {
+        let subdirectoryURL = url.appendingPathComponent(path, isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: subdirectoryURL, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            throw InternalError(description: "Cannot create subdirectory in `/Library/Caches/` folder.")
+        }
+        return Directory(url: subdirectoryURL)
+    }
+
+    /// Returns directory at given path or throws if it doesn't exist or given `path` is not a directory.
+    func subdirectory(path: String) throws -> Directory {
+        let directoryURL = url.appendingPathComponent(path, isDirectory: true)
+        var isDirectory = ObjCBool(false)
+        let exists = FileManager.default.fileExists(atPath: directoryURL.path, isDirectory: &isDirectory)
+
+        if exists && isDirectory.boolValue {
+            return Directory(url: directoryURL)
+        } else {
+            throw InternalError(description: "Path doesn't exist or is not a directory: \(directoryURL)")
+        }
     }
 
     /// Creates file with given name.
@@ -77,18 +103,14 @@ internal struct Directory {
     }
 }
 
-/// Creates subdirectory at given path in `/Library/Caches` if it does not exist. Might throw `ProgrammerError` when it's not possible.
-/// * `/Library/Caches` is exclduded from iTunes and iCloud backups by default.
-/// * System may delete data in `/Library/Cache` to free up disk space which reduces the impact on devices working under heavy space pressure.
-private func createCachesSubdirectoryIfNotExists(subdirectoryPath: String) throws -> URL {
-    guard let cachesDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-        throw InternalError(description: "Cannot obtain `/Library/Caches/` url.")
+extension Directory {
+    /// Returns `Directory` pointing to `/Library/Caches`.
+    /// - `/Library/Caches` is exclduded from iTunes and iCloud backups by default.
+    /// - System may delete data in `/Library/Cache` to free up disk space which reduces the impact on devices working under heavy space pressure.
+    static func cache() throws -> Directory {
+        guard let cachesDirectoryURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            throw InternalError(description: "Cannot obtain `/Library/Caches/` url.")
+        }
+        return Directory(url: cachesDirectoryURL)
     }
-    let subdirectoryURL = cachesDirectoryURL.appendingPathComponent(subdirectoryPath, isDirectory: true)
-    do {
-        try FileManager.default.createDirectory(at: subdirectoryURL, withIntermediateDirectories: true, attributes: nil)
-    } catch {
-        throw InternalError(description: "Cannot create subdirectory in `/Library/Caches/` folder.")
-    }
-    return subdirectoryURL
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -238,6 +238,7 @@ public class Datadog {
                 dateProvider: dateProvider,
                 dateCorrector: dateCorrector
             )
+            core.telemetry = telemetry
 
             rum = RUMFeature(
                 directories: try obtainRUMFeatureDirectories(),

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -203,7 +203,10 @@ public class Datadog {
         )
 
         // Set default `DatadogCore`:
-        let core = DatadogCore(dependencies: commonDependencies)
+        let core = DatadogCore(
+            configuration: configuration.common,
+            dependencies: commonDependencies
+        )
 
         // First, initialize internal loggers:
         let internalLoggerConfiguration = InternalLoggerConfiguration(

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -204,6 +204,7 @@ public class Datadog {
 
         // Set default `DatadogCore`:
         let core = DatadogCore(
+            rootDirectory: try Directory.cache(),
             configuration: configuration.common,
             dependencies: commonDependencies
         )

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -261,11 +261,10 @@ public class Datadog {
         }
 
         if let loggingConfiguration = configuration.logging {
-            logging = LoggingFeature(
-                directories: try obtainLoggingFeatureDirectories(),
-                configuration: loggingConfiguration,
-                commonDependencies: commonDependencies,
-                telemetry: telemetry
+            logging = try core.create(
+                storageConfiguration: createV2LoggingStorageConfiguration(),
+                uploadConfiguration: createV2LoggingUploadConfiguration(v1Configuration: loggingConfiguration),
+                featureSpecificConfiguration: loggingConfiguration
             )
 
             core.register(feature: logging)

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -6,18 +6,23 @@
 
 import Foundation
 
-/// Feature-agnostic set of dependencies provided by core to feature modules.
+/// Feature-agnostic SDK configuration.
+internal typealias CoreConfiguration = FeaturesConfiguration.Common
+
+/// Feature-agnostic set of dependencies powering Features storage, upload and event recording.
 internal typealias CoreDependencies = FeaturesCommonDependencies
 
 /// Core implementation of Datadog SDK.
 ///
-/// The core provides a storage and upload mechanism for each registered
-/// feature based on their respective configuration.
+/// The core provides a storage and upload mechanism for each registered Feature
+/// based on their respective configuration.
 ///
 /// By complying with `DatadogCoreProtocol`, the core can
-/// provide context and writing scopes to features for event recording.
+/// provide context and writing scopes to Features for event recording.
 internal final class DatadogCore {
-    /// A set of dependencies provided by core to features.
+    /// The configuration of SDK core.
+    let configuration: CoreConfiguration
+    /// A set of dependencies used by SDK core for powering Features.
     let dependencies: CoreDependencies
 
     private var v1Features: [String: Any] = [:]
@@ -25,8 +30,13 @@ internal final class DatadogCore {
     /// Creates a core instance.
     ///
     /// - Parameters:
-    ///   - dependencies: container bundling all dependencies provided by core to features.
-    init(dependencies: CoreDependencies) {
+    ///   - configuration: the configuration of SDK core.
+    ///   - dependencies: a set of dependencies used by SDK core for powering Features.
+    init(
+        configuration: CoreConfiguration,
+        dependencies: CoreDependencies
+    ) {
+        self.configuration = configuration
         self.dependencies = dependencies
     }
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -101,23 +101,23 @@ extension DatadogCore: DatadogCoreProtocol {
         uploadConfiguration: FeatureUploadConfiguration,
         featureSpecificConfiguration: Feature.Configuration
     ) throws -> Feature {
-        let directories = FeatureDirectories(
-            deprecated: storageConfiguration.directories.deprecated.compactMap { deprecatedPath in
-                try? rootDirectory.subdirectory(path: deprecatedPath) // ignore errors - deprecated paths likely do not exist
-            },
-            unauthorized: try rootDirectory.createSubdirectory(path: storageConfiguration.directories.unauthorized),
-            authorized: try rootDirectory.createSubdirectory(path: storageConfiguration.directories.authorized)
+        let v1Directories = try FeatureDirectories(
+            sdkRootDirectory: rootDirectory,
+            storageConfiguration: storageConfiguration
         )
 
         let storage = FeatureStorage(
             featureName: storageConfiguration.featureName,
             dataFormat: uploadConfiguration.payloadFormat,
-            directories: directories,
+            directories: v1Directories,
             commonDependencies: dependencies,
             telemetry: telemetry
         )
 
-        let v1Context = DatadogV1Context(configuration: configuration, dependencies: dependencies)
+        let v1Context = DatadogV1Context(
+            configuration: configuration,
+            dependencies: dependencies
+        )
 
         let upload = FeatureUpload(
             featureName: uploadConfiguration.featureName,

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -34,12 +34,12 @@ internal protocol V1Feature {
 /// By complying with `DatadogCoreProtocol`, the core can
 /// provide context and writing scopes to Features for event recording.
 internal final class DatadogCore {
-    /// The root directory of this instance of`DatadogCore`.
-    /// It indicates the main location for managing Features data by this instance of the SDK.
+    /// The root location for storing Features data in this instance of the SDK.
+    /// Each Feature creates its own set of subdirectories in `rootDirectory` based on their storage configuration.
     let rootDirectory: Directory
     /// The configuration of SDK core.
     let configuration: CoreConfiguration
-    /// A set of dependencies used by SDK core for powering Features.
+    /// A set of dependencies used by SDK core to power Features.
     let dependencies: CoreDependencies
     /// Telemetry monitor, if configured.
     var telemetry: Telemetry?
@@ -51,7 +51,7 @@ internal final class DatadogCore {
     /// - Parameters:
     ///   - directory: the root directory for this instance of SDK.
     ///   - configuration: the configuration of SDK core.
-    ///   - dependencies: a set of dependencies used by SDK core for powering Features.
+    ///   - dependencies: a set of dependencies used by SDK core to power Features.
     init(
         rootDirectory: Directory,
         configuration: CoreConfiguration,
@@ -96,6 +96,12 @@ internal final class DatadogCore {
 extension DatadogCore: DatadogCoreProtocol {
     // MARK: - V1 interface
 
+    /// Creates V1 Feature using its V2 configuration.
+    ///
+    /// `DatadogCore` uses its core `configuration` to inject feature-agnostic parts of V1 setup.
+    /// Feature-specific part is provided explicitly with `featureSpecificConfiguration`.
+    ///
+    /// - Returns: an instance of V1 feature
     func create<Feature: V1Feature>(
         storageConfiguration: FeatureStorageConfiguration,
         uploadConfiguration: FeatureUploadConfiguration,

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -28,18 +28,18 @@ public protocol DatadogCoreProtocol {
 
 /// Provide feature specific storage configuration.
 internal struct FeatureStorageConfiguration {
-    /// A set of `/Library/Caches` subfolders for managing persisted data.
-    /// Each subfolder can be a path containing subfolders - in that case the SDK will create necessary intermediate folders.
+    /// A set of paths for managing persisted data for this Feature.
+    /// Each path is relative to the root folder of given SDK instance.
     struct Directories {
-        /// The subfolder for writing authorized data (when tracking consent is granted).
+        /// The path for writing authorized data (when tracking consent is granted).
         let authorized: String
-        /// The subfolder for writing unauthorized data (when tracking consent is pending).
+        /// The path for writing unauthorized data (when tracking consent is pending).
         let unauthorized: String
-        /// The list of deprecated folders from previous versions of this feature. It will be used by the SDK to perform cleanup.
+        /// The list of deprecated paths from previous versions of this feature. It is used to perform cleanup.
         let deprecated: [String]
     }
 
-    /// The list of directories for managing data for this feature.
+    /// Directories storing data for this Feature.
     let directories: Directories
 
     // MARK: - V1 interface
@@ -58,12 +58,11 @@ internal struct FeatureUploadConfiguration {
     let featureName: String
 
     /// Creates the V1's `RequetsBuilder` for uploading data in this Feature.
-    /// In V2 interface we will change it to build requests based on V2 context and batch metadata.
+    /// In V2 we will change it to build requests based on V2 context and batch metadata.
     let createRequestBuilder: (DatadogV1Context, Telemetry?) -> RequestBuilder
 
-    /// Data format for constructing payloads in V1. It is applied by the reader when reading data from batch and before passing
-    /// it to the uploader. It might not be necessary in V2 if we decide to us a factory method for producing payloads (based on
-    /// batched events and batch metadata)
+    /// Data format for constructing Feature payloads in V1. It is applied by the reader when reading data from batch and
+    /// before passing it to the uploader.
     let payloadFormat: DataFormat
 }
 

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -29,7 +29,7 @@ public protocol DatadogCoreProtocol {
 /// Provide feature specific storage configuration.
 internal struct FeatureStorageConfiguration {
     /// A set of `/Library/Caches` subfolders for managing persisted data.
-    /// Each subfolder can be a path containing subfolders - in that case the SDK will create necessary transitive folders.
+    /// Each subfolder can be a path containing subfolders - in that case the SDK will create necessary intermediate folders.
     struct Directories {
         /// The subfolder for writing authorized data (when tracking consent is granted).
         let authorized: String

--- a/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// The SDK context for V1, until the final V2 context is created.
+///
+/// V2-like context can be safely assembled from V1 core components. Unlike in V2, this requires more hassle and is less performant:
+/// - different values for V1 context need to be read either from common configuration or through shared dependencies (providers);
+/// - V1 context is not asynchronous, and some providers block their threads for getting their value.
+///
+/// This context should be removed after proper V2 context is implemented.
+internal struct DatadogV1Context {
+    private let configuration: CoreConfiguration
+    private let dependencies: CoreDependencies
+
+    init(configuration: CoreConfiguration, dependencies: CoreDependencies) {
+        self.configuration = configuration
+        self.dependencies = dependencies
+    }
+
+    // MARK: - Datadog Specific
+
+    /// The client token allowing for data uploads to [Datadog Site](https://docs.datadoghq.com/getting_started/site/).
+    var clientToken: String { configuration.clientToken }
+
+    /// The name of the service generating data. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    var service: String { configuration.serviceName }
+
+    /// The name of the environment in which data is generated. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    var env: String { configuration.environment }
+
+    /// The version of the application generating data. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    var version: String { configuration.applicationVersion }
+
+    /// The technology from which data originated. It is `"ios"` for native SDK or cross-platform technology name in (e.g. `"flutter"`) for dependant SDKs.
+    ///  - See: Datadog [Reserved Attributes](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes).
+    var source: String { configuration.source }
+
+    /// The version of Datadog iOS SDK.
+    var sdkVersion: String { configuration.sdkVersion }
+
+    /// The name of [CI Visibility](https://docs.datadoghq.com/continuous_integration/) origin.
+    /// Only configured if the SDK is running with a context passed from [Swift Tests](https://docs.datadoghq.com/continuous_integration/setup_tests/swift/?tab=swiftpackagemanager) library.
+    var ciAppOrigin: String? { configuration.origin }
+
+    // MARK: - Application Specific
+
+    /// The name of the application, read from `Info.plist` (`CFBundleExecutable`).
+    var applicationName: String { configuration.applicationName }
+
+    /// Current device information.
+    var mobileDevice: MobileDevice { dependencies.mobileDevice }
+}

--- a/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
@@ -6,13 +6,12 @@
 
 import Foundation
 
-/// The SDK context for V1, until the final V2 context is created.
+/// The SDK context for V1, until the V2 context is created.
 ///
 /// V2-like context can be safely assembled from V1 core components. Unlike in V2, this requires more hassle and is less performant:
 /// - different values for V1 context need to be read either from common configuration or through shared dependencies (providers);
 /// - V1 context is not asynchronous, and some providers block their threads for getting their value.
 ///
-/// This context should be removed after proper V2 context is implemented.
 internal struct DatadogV1Context {
     private let configuration: CoreConfiguration
     private let dependencies: CoreDependencies
@@ -27,16 +26,16 @@ internal struct DatadogV1Context {
     /// The client token allowing for data uploads to [Datadog Site](https://docs.datadoghq.com/getting_started/site/).
     var clientToken: String { configuration.clientToken }
 
-    /// The name of the service generating data. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    /// The name of the service that data is generated from. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
     var service: String { configuration.serviceName }
 
-    /// The name of the environment in which data is generated. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    /// The name of the environment that data is generated from. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
     var env: String { configuration.environment }
 
-    /// The version of the application generating data. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    /// The version of the application that data is generated from. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
     var version: String { configuration.applicationVersion }
 
-    /// The technology from which data originated. It is `"ios"` for native SDK or cross-platform technology name in (e.g. `"flutter"`) for dependant SDKs.
+    /// Denotes the mobile application's platform, such as `"ios"` or `"flutter"` that data is generated from.
     ///  - See: Datadog [Reserved Attributes](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes).
     var source: String { configuration.source }
 
@@ -44,7 +43,7 @@ internal struct DatadogV1Context {
     var sdkVersion: String { configuration.sdkVersion }
 
     /// The name of [CI Visibility](https://docs.datadoghq.com/continuous_integration/) origin.
-    /// Only configured if the SDK is running with a context passed from [Swift Tests](https://docs.datadoghq.com/continuous_integration/setup_tests/swift/?tab=swiftpackagemanager) library.
+    /// It is only set if the SDK is running with a context passed from [Swift Tests](https://docs.datadoghq.com/continuous_integration/setup_tests/swift/?tab=swiftpackagemanager) library.
     var ciAppOrigin: String? { configuration.origin }
 
     // MARK: - Application Specific

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -6,28 +6,14 @@
 
 import Foundation
 
-/// Obtains subdirectories in `/Library/Caches` where logging data is stored.
-internal func obtainLoggingFeatureDirectories() throws -> FeatureDirectories {
-    var version = "v1"
-    let deprecated = [
-        try Directory(withSubdirectoryPath: "com.datadoghq.logs/intermediate-\(version)"),
-        try Directory(withSubdirectoryPath: "com.datadoghq.logs/\(version)")
-    ]
-
-    version = "v2"
-    return FeatureDirectories(
-        deprecated: deprecated,
-        unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.logs/intermediate-\(version)"),
-        authorized: try Directory(withSubdirectoryPath: "com.datadoghq.logs/\(version)")
-    )
-}
-
-/// Creates and owns componetns enabling logging feature.
+/// Creates and owns components enabling logging feature.
 /// Bundles dependencies for other logging-related components created later at runtime  (i.e. `Logger`).
-internal final class LoggingFeature {
+internal final class LoggingFeature: V1Feature {
+    typealias Configuration = FeaturesConfiguration.Logging
+
     // MARK: - Configuration
 
-    let configuration: FeaturesConfiguration.Logging
+    let configuration: Configuration
 
     // MARK: - Dependencies
 
@@ -39,10 +25,6 @@ internal final class LoggingFeature {
 
     // MARK: - Components
 
-    static let featureName = "logging"
-    /// NOTE: any change to data format requires updating the directory url to be unique
-    static let dataFormat = DataFormat(prefix: "[", suffix: "]", separator: ",")
-
     /// Log files storage.
     let storage: FeatureStorage
     /// Logs upload worker.
@@ -50,82 +32,10 @@ internal final class LoggingFeature {
 
     // MARK: - Initialization
 
-    static func createStorage(
-        directories: FeatureDirectories,
-        commonDependencies: FeaturesCommonDependencies,
-        telemetry: Telemetry?
-    ) -> FeatureStorage {
-        return FeatureStorage(
-            featureName: LoggingFeature.featureName,
-            dataFormat: LoggingFeature.dataFormat,
-            directories: directories,
-            commonDependencies: commonDependencies,
-            telemetry: telemetry
-        )
-    }
-
-    static func createUpload(
-        storage: FeatureStorage,
-        configuration: FeaturesConfiguration.Logging,
-        commonDependencies: FeaturesCommonDependencies,
-        telemetry: Telemetry?
-    ) -> FeatureUpload {
-        return FeatureUpload(
-            featureName: LoggingFeature.featureName,
-            storage: storage,
-            requestBuilder: RequestBuilder(
-                url: configuration.uploadURL,
-                queryItems: [
-                    .ddsource(source: configuration.common.source)
-                ],
-                headers: [
-                    .contentTypeHeader(contentType: .applicationJSON),
-                    .userAgentHeader(
-                        appName: configuration.common.applicationName,
-                        appVersion: configuration.common.applicationVersion,
-                        device: commonDependencies.mobileDevice
-                    ),
-                    .ddAPIKeyHeader(clientToken: configuration.common.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.origin ?? configuration.common.source),
-                    .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
-                    .ddRequestIDHeader(),
-                ],
-                telemetry: telemetry
-            ),
-            commonDependencies: commonDependencies,
-            telemetry: telemetry
-        )
-    }
-
-    convenience init(
-        directories: FeatureDirectories,
-        configuration: FeaturesConfiguration.Logging,
-        commonDependencies: FeaturesCommonDependencies,
-        telemetry: Telemetry?
-    ) {
-        let storage = LoggingFeature.createStorage(
-            directories: directories,
-            commonDependencies: commonDependencies,
-            telemetry: telemetry
-        )
-        let upload = LoggingFeature.createUpload(
-            storage: storage,
-            configuration: configuration,
-            commonDependencies: commonDependencies,
-            telemetry: telemetry
-        )
-        self.init(
-            storage: storage,
-            upload: upload,
-            configuration: configuration,
-            commonDependencies: commonDependencies
-        )
-    }
-
     init(
         storage: FeatureStorage,
         upload: FeatureUpload,
-        configuration: FeaturesConfiguration.Logging,
+        configuration: Configuration,
         commonDependencies: FeaturesCommonDependencies
     ) {
         // Configuration

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -85,7 +85,7 @@ internal final class LoggingFeature {
                         appVersion: configuration.common.applicationVersion,
                         device: commonDependencies.mobileDevice
                     ),
-                    .ddAPIKeyHeader(clientToken: configuration.clientToken),
+                    .ddAPIKeyHeader(clientToken: configuration.common.clientToken),
                     .ddEVPOriginHeader(source: configuration.common.origin ?? configuration.common.source),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),

--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Creates V2 Storage configuration for V1 Logging.
+internal func createV2LoggingStorageConfiguration() -> FeatureStorageConfiguration {
+    return FeatureStorageConfiguration(
+        directories: .init(
+            authorized: "com.datadoghq.logs/v2",
+            unauthorized: "com.datadoghq.logs/intermediate-v2",
+            deprecated: [
+                "com.datadoghq.logs/v1",
+                "com.datadoghq.logs/intermediate-v1",
+            ]
+        ),
+        featureName: "logging"
+    )
+}
+
+/// Creates V2 Upload configuration for V1 Logging.
+internal func createV2LoggingUploadConfiguration(v1Configuration: FeaturesConfiguration.Logging) -> FeatureUploadConfiguration {
+    return FeatureUploadConfiguration(
+        featureName: "logging",
+        createRequestBuilder: { v1Context, telemetry in
+            return RequestBuilder(
+                url: v1Configuration.uploadURL,
+                queryItems: [
+                    .ddsource(source: v1Context.source)
+                ],
+                headers: [
+                    .contentTypeHeader(contentType: .applicationJSON),
+                    .userAgentHeader(
+                        appName: v1Context.applicationName,
+                        appVersion: v1Context.version,
+                        device: v1Context.mobileDevice
+                    ),
+                    .ddAPIKeyHeader(clientToken: v1Context.clientToken),
+                    .ddEVPOriginHeader(source: v1Context.ciAppOrigin ?? v1Context.source),
+                    .ddEVPOriginVersionHeader(sdkVersion: v1Context.sdkVersion),
+                    .ddRequestIDHeader(),
+                ],
+                telemetry: telemetry
+            )
+        },
+        payloadFormat: DataFormat(prefix: "[", suffix: "]", separator: ",")
+    )
+}

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -105,7 +105,7 @@ internal final class RUMFeature {
                         appVersion: configuration.common.applicationVersion,
                         device: commonDependencies.mobileDevice
                     ),
-                    .ddAPIKeyHeader(clientToken: configuration.clientToken),
+                    .ddAPIKeyHeader(clientToken: configuration.common.clientToken),
                     .ddEVPOriginHeader(source: configuration.common.origin ?? configuration.common.source),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -91,7 +91,7 @@ internal final class TracingFeature {
                         appVersion: configuration.common.applicationVersion,
                         device: commonDependencies.mobileDevice
                     ),
-                    .ddAPIKeyHeader(clientToken: configuration.clientToken),
+                    .ddAPIKeyHeader(clientToken: configuration.common.clientToken),
                     .ddEVPOriginHeader(source: configuration.common.origin ?? configuration.common.source),
                     .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
                     .ddRequestIDHeader(),

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -19,10 +19,12 @@ class LoggingStorageBenchmarkTests: XCTestCase {
         try super.setUpWithError()
         self.directory = try Directory(withSubdirectoryPath: "logging-benchmark")
 
-        let storage = LoggingFeature.createStorage(
-            directories: FeatureDirectories(
+        let storage = FeatureStorage(
+            featureName: "logging",
+            dataFormat: DataFormat(prefix: "[", suffix: "]", separator: ","),
+            directories: .init(
                 deprecated: [],
-                unauthorized: obtainUniqueTemporaryDirectory(),
+                unauthorized: directory,
                 authorized: directory
             ),
             commonDependencies: .mockAny(),

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -155,9 +155,7 @@ class FeaturesConfigurationTests: XCTestCase {
         let clientToken: String = .mockRandom(among: "abcdefgh")
         let configuration = try createConfiguration(clientToken: clientToken)
 
-        XCTAssertEqual(configuration.logging?.clientToken, clientToken)
-        XCTAssertEqual(configuration.tracing?.clientToken, clientToken)
-        XCTAssertEqual(configuration.rum?.clientToken, clientToken)
+        XCTAssertEqual(configuration.common.clientToken, clientToken)
     }
 
     func testEndpoint() throws {

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -123,6 +123,7 @@ class DatadogTests: XCTestCase {
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNotNil(tracing?.loggingFeatureAdapter)
+            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry, "When RUM is disabled, telemetry monitor should not be set")
         }
         verify(configuration: rumBuilder.build()) {
             // verify features:
@@ -135,6 +136,7 @@ class DatadogTests: XCTestCase {
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNotNil(tracing?.loggingFeatureAdapter)
+            XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry, "When RUM is enabled, telemetry monitor should be set")
         }
 
         verify(configuration: defaultBuilder.enableLogging(false).build()) {
@@ -148,6 +150,7 @@ class DatadogTests: XCTestCase {
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNil(tracing?.loggingFeatureAdapter)
+            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
         verify(configuration: rumBuilder.enableLogging(false).build()) {
             // verify features:
@@ -161,6 +164,7 @@ class DatadogTests: XCTestCase {
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNil(tracing?.loggingFeatureAdapter)
+            XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
 
         verify(configuration: defaultBuilder.enableTracing(false).build()) {
@@ -171,6 +175,7 @@ class DatadogTests: XCTestCase {
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
         verify(configuration: rumBuilder.enableTracing(false).build()) {
             // verify features:
@@ -180,6 +185,7 @@ class DatadogTests: XCTestCase {
             XCTAssertFalse(CrashReportingFeature.isEnabled)
             XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
             XCTAssertNil(URLSessionAutoInstrumentation.instance)
+            XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
 
         verify(configuration: defaultBuilder.enableRUM(true).build()) {
@@ -193,6 +199,7 @@ class DatadogTests: XCTestCase {
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNotNil(tracing?.loggingFeatureAdapter)
+            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
         verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
@@ -205,6 +212,7 @@ class DatadogTests: XCTestCase {
             let tracing = defaultDatadogCore.feature(TracingFeature.self)
             XCTAssertNotNil(tracing)
             XCTAssertNotNil(tracing?.loggingFeatureAdapter)
+            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMViews().build()) {

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -372,11 +372,11 @@ class DatadogTests: XCTestCase {
         )
 
         let core = defaultDatadogCore as? DatadogCore
-        XCTAssertEqual(core?.consentProvider.currentValue, initialConsent)
+        XCTAssertEqual(core?.dependencies.consentProvider.currentValue, initialConsent)
 
         Datadog.set(trackingConsent: nextConsent)
 
-        XCTAssertEqual(core?.consentProvider.currentValue, nextConsent)
+        XCTAssertEqual(core?.dependencies.consentProvider.currentValue, nextConsent)
 
         Datadog.flushAndDeinitialize()
     }
@@ -390,11 +390,11 @@ class DatadogTests: XCTestCase {
 
         let core = defaultDatadogCore as? DatadogCore
 
-        XCTAssertNotNil(core?.userInfoProvider.value)
-        XCTAssertNil(core?.userInfoProvider.value.id)
-        XCTAssertNil(core?.userInfoProvider.value.email)
-        XCTAssertNil(core?.userInfoProvider.value.name)
-        XCTAssertEqual(core?.userInfoProvider.value.extraInfo as? [String: Int], [:])
+        XCTAssertNotNil(core?.dependencies.userInfoProvider.value)
+        XCTAssertNil(core?.dependencies.userInfoProvider.value.id)
+        XCTAssertNil(core?.dependencies.userInfoProvider.value.email)
+        XCTAssertNil(core?.dependencies.userInfoProvider.value.name)
+        XCTAssertEqual(core?.dependencies.userInfoProvider.value.extraInfo as? [String: Int], [:])
 
         Datadog.setUserInfo(
             id: "foo",
@@ -403,10 +403,10 @@ class DatadogTests: XCTestCase {
             extraInfo: ["abc": 123]
         )
 
-        XCTAssertEqual(core?.userInfoProvider.value.id, "foo")
-        XCTAssertEqual(core?.userInfoProvider.value.name, "bar")
-        XCTAssertEqual(core?.userInfoProvider.value.email, "foo@bar.com")
-        XCTAssertEqual(core?.userInfoProvider.value.extraInfo as? [String: Int], ["abc": 123])
+        XCTAssertEqual(core?.dependencies.userInfoProvider.value.id, "foo")
+        XCTAssertEqual(core?.dependencies.userInfoProvider.value.name, "bar")
+        XCTAssertEqual(core?.dependencies.userInfoProvider.value.email, "foo@bar.com")
+        XCTAssertEqual(core?.dependencies.userInfoProvider.value.extraInfo as? [String: Int], ["abc": 123])
 
         Datadog.flushAndDeinitialize()
     }
@@ -428,7 +428,7 @@ class DatadogTests: XCTestCase {
         let core = defaultDatadogCore as? DatadogCore
 
         XCTAssertEqual(
-            core?.consentProvider.currentValue,
+            core?.dependencies.consentProvider.currentValue,
             .granted,
             "When using deprecated Datadog initialization API the consent should be set to `.granted`"
         )

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -455,7 +455,7 @@ class DatadogTests: XCTestCase {
                 .build()
         )
 
-        let core = defaultDatadogCore
+        let core = try XCTUnwrap(defaultDatadogCore as? DatadogCore)
         let logging = core.feature(LoggingFeature.self)
         let tracing = core.feature(TracingFeature.self)
         let rum = core.feature(RUMFeature.self)
@@ -471,7 +471,7 @@ class DatadogTests: XCTestCase {
         rumWriter.queue.sync {}
 
         let featureDirectories: [FeatureDirectories] = [
-            try obtainLoggingFeatureDirectories(),
+            try FeatureDirectories(sdkRootDirectory: core.rootDirectory, storageConfiguration: createV2LoggingStorageConfiguration()),
             try obtainTracingFeatureDirectories(),
             try obtainRUMFeatureDirectories()
         ]

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -15,10 +15,10 @@ class LoggerBuilderTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationVersion: "1.2.3",
@@ -38,7 +38,7 @@ class LoggerBuilderTests: XCTestCase {
 
     override func tearDown() {
         core.flush()
-        temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -13,12 +13,12 @@ class LoggerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
     }
 
     override func tearDown() {
         core.flush()
-        temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
@@ -26,7 +26,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingLogWithDefaultLogger() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationVersion: "1.0.0",
@@ -64,7 +64,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testSendingLogWithCustomizedLogger() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defer { feature.deinitialize() }
         core.register(feature: feature)
 
@@ -97,7 +97,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingLogsWithDifferentDates() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC(), advancingBySeconds: 1)
             )
@@ -117,7 +117,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testSendingLogsWithDifferentLevels() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defer { feature.deinitialize() }
         core.register(feature: feature)
 
@@ -141,7 +141,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Logging an error
 
     func testLoggingError() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defer { feature.deinitialize() }
         core.register(feature: feature)
 
@@ -180,7 +180,7 @@ class LoggerTests: XCTestCase {
         defer { temporaryDirectory.delete() }
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 userInfoProvider: core.dependencies.userInfoProvider
             )
@@ -234,7 +234,7 @@ class LoggerTests: XCTestCase {
     func testSendingCarrierInfoWhenEnteringAndLeavingCellularServiceRange() throws {
         let carrierInfoProvider = CarrierInfoProviderMock(carrierInfo: nil)
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 carrierInfoProvider: carrierInfoProvider
             )
@@ -276,7 +276,7 @@ class LoggerTests: XCTestCase {
     func testSendingNetworkConnectionInfoWhenReachabilityChanges() throws {
         let networkConnectionInfoProvider = NetworkConnectionInfoProviderMock.mockAny()
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 networkConnectionInfoProvider: networkConnectionInfoProvider
             )
@@ -335,7 +335,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Sending attributes
 
     func testSendingLoggerAttributesOfDifferentEncodableValues() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defer { feature.deinitialize() }
         core.register(feature: feature)
 
@@ -400,7 +400,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testSendingMessageAttributes() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defer { feature.deinitialize() }
         core.register(feature: feature)
 
@@ -431,7 +431,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingTags() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
         defer { feature.deinitialize() }
@@ -471,7 +471,7 @@ class LoggerTests: XCTestCase {
     func testGivenBadBatteryConditions_itDoesNotTryToSendLogs() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let feature: LoggingFeature = .mockWith(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 mobileDevice: .mockWith(
                     currentBatteryStatus: { () -> MobileDevice.BatteryStatus in
@@ -492,7 +492,7 @@ class LoggerTests: XCTestCase {
     func testGivenNoNetworkConnection_itDoesNotTryToSendLogs() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let feature: LoggingFeature = .mockWith(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
                     networkConnectionInfo: .mockWith(reachability: .no)
@@ -512,7 +512,7 @@ class LoggerTests: XCTestCase {
 
     func testGivenBundlingWithRUMEnabledAndRUMMonitorRegistered_whenSendingLog_itContainsCurrentRUMContext() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
         core.register(feature: logging)
@@ -552,7 +552,7 @@ class LoggerTests: XCTestCase {
 
     func testGivenBundlingWithRUMEnabledButRUMMonitorNotRegistered_whenSendingLog_itPrintsWarning() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(common: .mockWith(environment: "tests"))
         )
         core.register(feature: logging)
@@ -588,6 +588,9 @@ class LoggerTests: XCTestCase {
     }
 
     func testWhenSendingErrorOrCriticalLogs_itCreatesRUMErrorForCurrentView() throws {
+        temporaryFeatureDirectories.create()
+        defer { temporaryFeatureDirectories.delete() }
+
         let logging: LoggingFeature = .mockNoOp()
         core.register(feature: logging)
 
@@ -632,7 +635,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Integration With Active Span
 
     func testGivenBundlingWithTraceEnabledAndTracerRegistered_whenSendingLog_itContainsActiveSpanAttributes() throws {
-        let logging: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         let tracing: TracingFeature = .mockNoOp()
         core.register(feature: logging)
         core.register(feature: tracing)
@@ -663,7 +666,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testGivenBundlingWithTraceEnabledButTracerNotRegistered_whenSendingLog_itPrintsWarning() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         let tracing: TracingFeature = .mockNoOp()
         core.register(feature: feature)
         core.register(feature: tracing)
@@ -702,7 +705,7 @@ class LoggerTests: XCTestCase {
 
         // When
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(using: deviceTime),
                 dateCorrector: DateCorrectorMock(correctionOffset: serverTimeDifference)
@@ -728,7 +731,7 @@ class LoggerTests: XCTestCase {
 
         // Given
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(consentProvider: consentProvider)
         )
         defer { feature.deinitialize() }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -170,6 +170,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingUserInfo() throws {
         let core = DatadogCore(
+            configuration: .mockAny(),
             dependencies: .mockWith(
                 consentProvider: ConsentProvider(initialConsent: .granted),
                 userInfoProvider: UserInfoProvider()

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -170,14 +170,16 @@ class LoggerTests: XCTestCase {
 
     func testSendingUserInfo() throws {
         let core = DatadogCore(
-            consentProvider: ConsentProvider(initialConsent: .granted),
-            userInfoProvider: UserInfoProvider()
+            dependencies: .mockWith(
+                consentProvider: ConsentProvider(initialConsent: .granted),
+                userInfoProvider: UserInfoProvider()
+            )
         )
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
-                userInfoProvider: core.userInfoProvider
+                userInfoProvider: core.dependencies.userInfoProvider
             )
         )
         defer { feature.deinitialize() }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -170,12 +170,14 @@ class LoggerTests: XCTestCase {
 
     func testSendingUserInfo() throws {
         let core = DatadogCore(
+            rootDirectory: temporaryDirectory.create(),
             configuration: .mockAny(),
             dependencies: .mockWith(
                 consentProvider: ConsentProvider(initialConsent: .granted),
                 userInfoProvider: UserInfoProvider()
             )
         )
+        defer { temporaryDirectory.delete() }
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
             directories: temporaryFeatureDirectories,

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -45,6 +45,7 @@ class LoggingFeatureTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
+                    clientToken: randomClientToken,
                     applicationName: randomApplicationName,
                     applicationVersion: randomApplicationVersion,
                     source: randomSource,
@@ -52,8 +53,7 @@ class LoggingFeatureTests: XCTestCase {
                     sdkVersion: randomSDKVersion,
                     encryption: randomEncryption
                 ),
-                uploadURL: randomUploadURL,
-                clientToken: randomClientToken
+                uploadURL: randomUploadURL
             ),
             dependencies: .mockWith(
                 mobileDevice: .mockWith(model: randomDeviceModel, osName: randomDeviceOSName, osVersion: randomDeviceOSVersion)

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -13,13 +13,13 @@ class LoggingFeatureTests: XCTestCase {
     override func setUp() {
         super.setUp()
         XCTAssertFalse(Datadog.isInitialized)
-        temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
     }
 
     override func tearDown() {
         XCTAssertFalse(Datadog.isInitialized)
         core.flush()
-        temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
@@ -42,7 +42,7 @@ class LoggingFeatureTests: XCTestCase {
 
         // Given
         let feature: LoggingFeature = .mockWith(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 common: .mockWith(
                     clientToken: randomClientToken,
@@ -90,7 +90,7 @@ class LoggingFeatureTests: XCTestCase {
     func testItUsesExpectedPayloadFormatForUploads() throws {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
         let feature: LoggingFeature = .mockWith(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 performance: .combining(
                     storagePerformance: StoragePerformanceMock(

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -134,11 +134,7 @@ extension BundleType: CaseIterable {
     public static var allCases: [Self] { [.iOSApp, iOSAppExtension] }
 }
 
-extension Datadog.Configuration.DatadogEndpoint: AnyMockable, RandomMockable {
-    static func mockAny() -> Datadog.Configuration.DatadogEndpoint {
-        return .us1
-    }
-
+extension Datadog.Configuration.DatadogEndpoint: RandomMockable {
     static func mockRandom() -> Self {
         return [.us1, .us3, .eu1, .us1_fed].randomElement()!
     }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -134,7 +134,11 @@ extension BundleType: CaseIterable {
     public static var allCases: [Self] { [.iOSApp, iOSAppExtension] }
 }
 
-extension Datadog.Configuration.DatadogEndpoint {
+extension Datadog.Configuration.DatadogEndpoint: AnyMockable, RandomMockable {
+    static func mockAny() -> Datadog.Configuration.DatadogEndpoint {
+        return .us1
+    }
+
     static func mockRandom() -> Self {
         return [.us1, .us3, .eu1, .us1_fed].randomElement()!
     }
@@ -184,6 +188,7 @@ extension FeaturesConfiguration.Common {
     static func mockAny() -> Self { mockWith() }
 
     static func mockWith(
+        clientToken: String = .mockAny(),
         applicationName: String = .mockAny(),
         applicationVersion: String = .mockAny(),
         applicationBundleIdentifier: String = .mockAny(),
@@ -197,6 +202,7 @@ extension FeaturesConfiguration.Common {
         encryption: DataEncryption? = nil
     ) -> Self {
         return .init(
+            clientToken: clientToken,
             applicationName: applicationName,
             applicationVersion: applicationVersion,
             applicationBundleIdentifier: applicationBundleIdentifier,
@@ -218,13 +224,11 @@ extension FeaturesConfiguration.Logging {
     static func mockWith(
         common: FeaturesConfiguration.Common = .mockAny(),
         uploadURL: URL = .mockAny(),
-        clientToken: String = .mockAny(),
         logEventMapper: LogEventMapper? = nil
     ) -> Self {
         return .init(
             common: common,
             uploadURL: uploadURL,
-            clientToken: clientToken,
             logEventMapper: logEventMapper
         )
     }
@@ -236,13 +240,11 @@ extension FeaturesConfiguration.Tracing {
     static func mockWith(
         common: FeaturesConfiguration.Common = .mockAny(),
         uploadURL: URL = .mockAny(),
-        spanEventMapper: SpanEventMapper? = nil,
-        clientToken: String = .mockAny()
+        spanEventMapper: SpanEventMapper? = nil
     ) -> Self {
         return .init(
             common: common,
             uploadURL: uploadURL,
-            clientToken: clientToken,
             spanEventMapper: spanEventMapper
         )
     }
@@ -254,7 +256,6 @@ extension FeaturesConfiguration.RUM {
     static func mockWith(
         common: FeaturesConfiguration.Common = .mockAny(),
         uploadURL: URL = .mockAny(),
-        clientToken: String = .mockAny(),
         applicationID: String = .mockAny(),
         sessionSampler: Sampler = Sampler(samplingRate: 100),
         uuidGenerator: RUMUUIDGenerator = DefaultRUMUUIDGenerator(),
@@ -270,7 +271,6 @@ extension FeaturesConfiguration.RUM {
         return .init(
             common: common,
             uploadURL: uploadURL,
-            clientToken: clientToken,
             applicationID: applicationID,
             sessionSampler: sessionSampler,
             uuidGenerator: uuidGenerator,

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -27,14 +27,6 @@ internal final class DatadogCoreMock: DatadogCoreProtocol, Flushable {
         v1Features.values.compactMap { $0 as? T }
     }
 
-    /// no-op
-    func registerFeature(named featureName: String, storage: FeatureStorageConfiguration, upload: FeatureUploadConfiguration) {}
-
-    /// no-op
-    func scope(forFeature featureName: String) -> FeatureScope? {
-        return nil
-    }
-
     // MARK: V1 interface
 
     func register<T>(feature instance: T?) {

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -20,29 +20,39 @@ extension LoggingFeature {
     /// Mocks the feature instance which performs uploads to `URLSession`.
     /// Use `ServerMock` to inspect and assert recorded `URLRequests`.
     static func mockWith(
-        directories: FeatureDirectories,
+        directory: Directory,
         configuration: FeaturesConfiguration.Logging = .mockAny(),
         dependencies: FeaturesCommonDependencies = .mockAny(),
         telemetry: Telemetry? = nil
     ) -> LoggingFeature {
-        return LoggingFeature(
-            directories: directories,
-            configuration: configuration,
-            commonDependencies: dependencies,
-            telemetry: telemetry
+        // Because in V2 Feature Storage and Upload are created by `DatadogCore`, here we ask
+        // dummy V2 core instance to initialize the Feature. It is hacky, yet minimal way of
+        // providing V1 stack for partial V2 architecture in tests.
+        let v2Core = DatadogCore(
+            rootDirectory: directory,
+            configuration: configuration.common,
+            dependencies: dependencies
         )
+        v2Core.telemetry = telemetry
+
+        let feature: LoggingFeature = try! v2Core.create(
+            storageConfiguration: createV2LoggingStorageConfiguration(),
+            uploadConfiguration: createV2LoggingUploadConfiguration(v1Configuration: configuration),
+            featureSpecificConfiguration: configuration
+        )
+        return feature
     }
 
     /// Mocks the feature instance which performs uploads to mocked `DataUploadWorker`.
     /// Use `LogFeature.waitAndReturnLogMatchers()` to inspect and assert recorded `Logs`.
     static func mockByRecordingLogMatchers(
-        directories: FeatureDirectories,
+        directory: Directory,
         configuration: FeaturesConfiguration.Logging = .mockAny(),
         dependencies: FeaturesCommonDependencies = .mockAny()
     ) -> LoggingFeature {
         // Get the full feature mock:
         let fullFeature: LoggingFeature = .mockWith(
-            directories: directories,
+            directory: directory,
             configuration: configuration,
             dependencies: dependencies.replacing(
                 dateProvider: SystemDateProvider() // replace date provider in mocked `Feature.Storage`

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -44,6 +44,7 @@ class RUMFeatureTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
+                    clientToken: randomClientToken,
                     applicationName: randomApplicationName,
                     applicationVersion: randomApplicationVersion,
                     serviceName: randomServiceName,
@@ -53,8 +54,7 @@ class RUMFeatureTests: XCTestCase {
                     sdkVersion: randomSDKVersion,
                     encryption: randomEncryption
                 ),
-                uploadURL: randomUploadURL,
-                clientToken: randomClientToken
+                uploadURL: randomUploadURL
             ),
             dependencies: .mockWith(
                 mobileDevice: .mockWith(model: randomDeviceModel, osName: randomDeviceOSName, osVersion: randomDeviceOSVersion)

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -44,10 +44,12 @@ class WKUserContentController_DatadogTests: XCTestCase {
     override func setUp() {
         super.setUp()
         temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
     }
 
     override func tearDown() {
         temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
@@ -162,7 +164,7 @@ class WKUserContentController_DatadogTests: XCTestCase {
 
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationVersion: "1.0.0",

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -318,8 +318,10 @@ class TracerTests: XCTestCase {
 
     func testSendingUserInfo() throws {
         let core = DatadogCore(
-            consentProvider: ConsentProvider(initialConsent: .granted),
-            userInfoProvider: UserInfoProvider()
+            dependencies: .mockWith(
+                consentProvider: ConsentProvider(initialConsent: .granted),
+                userInfoProvider: UserInfoProvider()
+            )
         )
 
         defaultDatadogCore = core
@@ -328,7 +330,7 @@ class TracerTests: XCTestCase {
         let feature: TracingFeature = .mockByRecordingSpanMatchers(
             directories: temporaryFeatureDirectories,
             dependencies: .mockWith(
-                userInfoProvider: core.userInfoProvider
+                userInfoProvider: core.dependencies.userInfoProvider
             )
         )
         defer { feature.deinitialize() }

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -14,11 +14,13 @@ class TracerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
     }
 
     override func tearDown() {
         core.flush()
         temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
@@ -616,7 +618,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanLogs() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
@@ -661,7 +663,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
@@ -697,7 +699,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
@@ -739,7 +741,7 @@ class TracerTests: XCTestCase {
 
     func testSendingSpanLogsWithErrorFromSwiftError() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -318,12 +318,14 @@ class TracerTests: XCTestCase {
 
     func testSendingUserInfo() throws {
         let core = DatadogCore(
+            rootDirectory: temporaryDirectory.create(),
             configuration: .mockAny(),
             dependencies: .mockWith(
                 consentProvider: ConsentProvider(initialConsent: .granted),
                 userInfoProvider: UserInfoProvider()
             )
         )
+        defer { temporaryDirectory.delete() }
 
         defaultDatadogCore = core
         defer { defaultDatadogCore = NOOPDatadogCore() }

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -318,6 +318,7 @@ class TracerTests: XCTestCase {
 
     func testSendingUserInfo() throws {
         let core = DatadogCore(
+            configuration: .mockAny(),
             dependencies: .mockWith(
                 consentProvider: ConsentProvider(initialConsent: .granted),
                 userInfoProvider: UserInfoProvider()

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -45,6 +45,7 @@ class TracingFeatureTests: XCTestCase {
             directories: temporaryFeatureDirectories,
             configuration: .mockWith(
                 common: .mockWith(
+                    clientToken: randomClientToken,
                     applicationName: randomApplicationName,
                     applicationVersion: randomApplicationVersion,
                     source: randomSource,
@@ -52,8 +53,7 @@ class TracingFeatureTests: XCTestCase {
                     sdkVersion: randomSDKVersion,
                     encryption: randomEncryption
                 ),
-                uploadURL: randomUploadURL,
-                clientToken: randomClientToken
+                uploadURL: randomUploadURL
             ),
             dependencies: .mockWith(
                 mobileDevice: .mockWith(model: randomDeviceModel, osName: randomDeviceOSName, osVersion: randomDeviceOSVersion)

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -59,11 +59,11 @@ class DDDatadogTests: XCTestCase {
         )
 
         let core = defaultDatadogCore as? DatadogCore
-        XCTAssertEqual(core?.consentProvider.currentValue, initialConsent.swift)
+        XCTAssertEqual(core?.dependencies.consentProvider.currentValue, initialConsent.swift)
 
         DDDatadog.setTrackingConsent(consent: nextConsent.objc)
 
-        XCTAssertEqual(core?.consentProvider.currentValue, nextConsent.swift)
+        XCTAssertEqual(core?.dependencies.consentProvider.currentValue, nextConsent.swift)
 
         Datadog.flushAndDeinitialize()
     }
@@ -78,7 +78,7 @@ class DDDatadogTests: XCTestCase {
         )
 
         let core = defaultDatadogCore as? DatadogCore
-        let userInfo = try XCTUnwrap(core?.userInfoProvider)
+        let userInfo = try XCTUnwrap(core?.dependencies.userInfoProvider)
 
         DDDatadog.setUserInfo(
             id: "id",

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class DDLoggerTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
         Datadog.initialize(
             appContext: .mockAny(),
             trackingConsent: .granted,
@@ -23,12 +23,12 @@ class DDLoggerTests: XCTestCase {
 
     override func tearDown() {
         Datadog.flushAndDeinitialize()
-        temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
     func testSendingLogsWithDifferentLevels() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defaultDatadogCore.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
@@ -50,7 +50,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSendingNSError() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defaultDatadogCore.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
@@ -82,7 +82,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSendingMessageAttributes() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defaultDatadogCore.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
@@ -107,7 +107,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSendingLoggerAttributes() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(directories: temporaryFeatureDirectories)
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defaultDatadogCore.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
@@ -145,7 +145,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSettingTagsAndAttributes() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(common: .mockWith(environment: "test"))
         )
         defaultDatadogCore.register(feature: feature)

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -10,15 +10,18 @@ import XCTest
 
 class DDTracerTests: XCTestCase {
     let core = DatadogCoreMock()
+
     override func setUp() {
         super.setUp()
         temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
         defaultDatadogCore = core
     }
 
     override func tearDown() {
         core.flush()
         temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         defaultDatadogCore = NOOPDatadogCore()
         super.tearDown()
     }
@@ -117,7 +120,7 @@ class DDTracerTests: XCTestCase {
 
     func testSendingSpanLogs() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
@@ -151,7 +154,7 @@ class DDTracerTests: XCTestCase {
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
@@ -188,7 +191,7 @@ class DDTracerTests: XCTestCase {
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
         let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )

--- a/Tests/DatadogTests/Helpers/TestsDirectory.swift
+++ b/Tests/DatadogTests/Helpers/TestsDirectory.swift
@@ -25,7 +25,8 @@ let temporaryDirectory = obtainUniqueTemporaryDirectory()
 /// Provides handy methods to create / delete files and directories.
 extension Directory {
     /// Creates empty directory with given attributes .
-    func create(attributes: [FileAttributeKey: Any]? = nil, file: StaticString = #file, line: UInt = #line) {
+    @discardableResult
+    func create(attributes: [FileAttributeKey: Any]? = nil, file: StaticString = #file, line: UInt = #line) -> Self {
         do {
             try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: attributes)
             let initialFilesCount = try files().count
@@ -33,6 +34,7 @@ extension Directory {
         } catch {
             XCTFail("🔥 Failed to create `TestsDirectory`: \(error)", file: file, line: line)
         }
+        return self
     }
 
     /// Deletes entire directory with its content.


### PR DESCRIPTION
### What and why?

⚙️🧰 This PR makes necessary refactoring to create V1 `LoggingFeature` from V2's storage and upload configurations.

### How?

Feature initialisation is now generic and can happen in `DatadogCore` with:
```swift
func create<Feature: V1Feature>(
   storageConfiguration: FeatureStorageConfiguration,
   uploadConfiguration: FeatureUploadConfiguration,
   featureSpecificConfiguration: Feature.Configuration
) throws -> Feature 
```
The `featureSpecificConfiguration` is used to avoid impactful refactoring. It holds the feature-specific part of the config ([`FeaturesConfiguration.Logging`](https://github.com/DataDog/dd-sdk-ios/blob/b1c10dceeca16ab6e8f6a0f0314cedcf0b13dd61/Sources/Datadog/Core/FeaturesConfiguration.swift#L28-L32)). It will be removed as the last step after migrating other features to this setup.

I had to do 2 extra V2 migration steps to make this PR simpler:
- 🎁 `DatadogCore` is now configured with `rootDirectory`. This made tests refactoring way easier and it is very much aligned with what we want in V2 (each SDK instance has its own root folder).
- 💡 I had to introduce `DatadogV1Context`, a counterpart of what we need in V2. This allowed me to pass `RequestBuilder` attributes from Core to Feature.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
