### PR TITLE
RUMM-2169 Initialise V1 RUM with V2 configuration 

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -268,6 +268,8 @@
 		616F1FAE283D683500651A3A /* DatadogV1Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FAC283D683500651A3A /* DatadogV1Context.swift */; };
 		616F1FB0283E227100651A3A /* LoggingV2Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FAF283E227100651A3A /* LoggingV2Configuration.swift */; };
 		616F1FB1283E227100651A3A /* LoggingV2Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FAF283E227100651A3A /* LoggingV2Configuration.swift */; };
+		616F1FB32840125400651A3A /* RUMV2Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FB22840125300651A3A /* RUMV2Configuration.swift */; };
+		616F1FB42840125400651A3A /* RUMV2Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616F1FB22840125300651A3A /* RUMV2Configuration.swift */; };
 		6170DC1C25C18729003AED5C /* DDCrashReportingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */; };
 		6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172472625D673D7007085B3 /* CrashContextTests.swift */; };
 		617247AF25DA9BEA007085B3 /* CrashReportingObjcHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 617247AE25DA9BEA007085B3 /* CrashReportingObjcHelpers.m */; };
@@ -1460,6 +1462,7 @@
 		616CCE15250A467E009FED46 /* RUMInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMInstrumentation.swift; sourceTree = "<group>"; };
 		616F1FAC283D683500651A3A /* DatadogV1Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogV1Context.swift; sourceTree = "<group>"; };
 		616F1FAF283E227100651A3A /* LoggingV2Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingV2Configuration.swift; sourceTree = "<group>"; };
+		616F1FB22840125300651A3A /* RUMV2Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMV2Configuration.swift; sourceTree = "<group>"; };
 		6170DC1B25C18729003AED5C /* DDCrashReportingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDCrashReportingPlugin.swift; sourceTree = "<group>"; };
 		6170DC2B25C1883E003AED5C /* DatadogCrashReportingTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogCrashReportingTests.xcconfig; sourceTree = "<group>"; };
 		6172472625D673D7007085B3 /* CrashContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextTests.swift; sourceTree = "<group>"; };
@@ -3659,6 +3662,7 @@
 			isa = PBXGroup;
 			children = (
 				61E5332B24B75C51003D6C4E /* RUMFeature.swift */,
+				616F1FB22840125300651A3A /* RUMV2Configuration.swift */,
 				D248ED442807193B00B315B4 /* RUMTelemetry.swift */,
 				B3FC3C0426526EE900DEED9E /* RUMVitals */,
 				61E5333224B7A504003D6C4E /* DataModels */,
@@ -5130,6 +5134,7 @@
 				61C5A88B24509A0C00DA608C /* SpanOutput.swift in Sources */,
 				61133BE42423979B00786299 /* LogEventEncoder.swift in Sources */,
 				B3FC3C0926526F0000DEED9E /* VitalInfo.swift in Sources */,
+				616F1FB32840125400651A3A /* RUMV2Configuration.swift in Sources */,
 				613E81F025A740140084B751 /* RUMEventsMapper.swift in Sources */,
 				61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */,
 				61C5A88424509A0C00DA608C /* DDSpan.swift in Sources */,
@@ -5692,6 +5697,7 @@
 				D2CB6E6627C50EAE00A62B57 /* Reader.swift in Sources */,
 				D2CB6E6727C50EAE00A62B57 /* DDURLSessionDelegate.swift in Sources */,
 				D2CB6E6827C50EAE00A62B57 /* SwiftExtensions.swift in Sources */,
+				616F1FB42840125400651A3A /* RUMV2Configuration.swift in Sources */,
 				D2CB6E6927C50EAE00A62B57 /* KronosDNSResolver.swift in Sources */,
 				D2CB6E6A27C50EAE00A62B57 /* InternalURLsFilter.swift in Sources */,
 				D2CB6E6B27C50EAE00A62B57 /* ValuePublisher.swift in Sources */,

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -243,13 +243,11 @@ public class Datadog {
             )
             core.telemetry = telemetry
 
-            rum = RUMFeature(
-                directories: try obtainRUMFeatureDirectories(),
-                configuration: rumConfiguration,
-                commonDependencies: commonDependencies,
-                telemetry: telemetry
+            rum = try core.create(
+                storageConfiguration: createV2RUMStorageConfiguration(),
+                uploadConfiguration: createV2RUMUploadConfiguration(v1Configuration: rumConfiguration),
+                featureSpecificConfiguration: rumConfiguration
             )
-
             core.register(feature: rum)
 
             if let instrumentationConfiguration = rumConfiguration.instrumentation {
@@ -268,7 +266,6 @@ public class Datadog {
                 uploadConfiguration: createV2LoggingUploadConfiguration(v1Configuration: loggingConfiguration),
                 featureSpecificConfiguration: loggingConfiguration
             )
-
             core.register(feature: logging)
         }
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -22,7 +22,8 @@ internal protocol V1Feature {
         storage: FeatureStorage,
         upload: FeatureUpload,
         configuration: Configuration,
-        commonDependencies: FeaturesCommonDependencies
+        commonDependencies: FeaturesCommonDependencies,
+        telemetry: Telemetry?
     )
 }
 
@@ -137,7 +138,8 @@ extension DatadogCore: DatadogCoreProtocol {
             storage: storage,
             upload: upload,
             configuration: featureSpecificConfiguration,
-            commonDependencies: dependencies
+            commonDependencies: dependencies,
+            telemetry: telemetry
         )
     }
 

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -36,7 +36,8 @@ internal final class LoggingFeature: V1Feature {
         storage: FeatureStorage,
         upload: FeatureUpload,
         configuration: Configuration,
-        commonDependencies: FeaturesCommonDependencies
+        commonDependencies: FeaturesCommonDependencies,
+        telemetry: Telemetry?
     ) {
         // Configuration
         self.configuration = configuration

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -6,22 +6,6 @@
 
 import Foundation
 
-/// Obtains subdirectories in `/Library/Caches` where RUM data is stored.
-internal func obtainRUMFeatureDirectories() throws -> FeatureDirectories {
-    var version = "v1"
-    let deprecated = [
-        try Directory(withSubdirectoryPath: "com.datadoghq.rum/intermediate-\(version)"),
-        try Directory(withSubdirectoryPath: "com.datadoghq.rum/\(version)")
-    ]
-
-    version = "v2"
-    return FeatureDirectories(
-        deprecated: deprecated,
-        unauthorized: try Directory(withSubdirectoryPath: "com.datadoghq.rum/intermediate-\(version)"),
-        authorized: try Directory(withSubdirectoryPath: "com.datadoghq.rum/\(version)")
-    )
-}
-
 /// Creates and owns componetns enabling RUM feature.
 /// Bundles dependencies for other RUM-related components created later at runtime  (i.e. `RUMMonitor`).
 internal final class RUMFeature: V1Feature {

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -24,10 +24,12 @@ internal func obtainRUMFeatureDirectories() throws -> FeatureDirectories {
 
 /// Creates and owns componetns enabling RUM feature.
 /// Bundles dependencies for other RUM-related components created later at runtime  (i.e. `RUMMonitor`).
-internal final class RUMFeature {
+internal final class RUMFeature: V1Feature {
+    typealias Configuration = FeaturesConfiguration.RUM
+
     // MARK: - Configuration
 
-    let configuration: FeaturesConfiguration.RUM
+    let configuration: Configuration
 
     // MARK: - Dependencies
 
@@ -62,88 +64,22 @@ internal final class RUMFeature {
 
     // MARK: - Initialization
 
-    static func createStorage(
-        directories: FeatureDirectories,
-        commonDependencies: FeaturesCommonDependencies,
-        telemetry: Telemetry?
-    ) -> FeatureStorage {
-        return FeatureStorage(
-            featureName: RUMFeature.featureName,
-            dataFormat: RUMFeature.dataFormat,
-            directories: directories,
-            commonDependencies: commonDependencies,
-            telemetry: telemetry
-        )
-    }
-
-    static func createUpload(
-        storage: FeatureStorage,
-        configuration: FeaturesConfiguration.RUM,
-        commonDependencies: FeaturesCommonDependencies,
-        telemetry: Telemetry?
-    ) -> FeatureUpload {
-        return FeatureUpload(
-            featureName: RUMFeature.featureName,
-            storage: storage,
-            requestBuilder: RequestBuilder(
-                url: configuration.uploadURL,
-                queryItems: [
-                    .ddsource(source: configuration.common.source),
-                    .ddtags(
-                        tags: [
-                            "service:\(configuration.common.serviceName)",
-                            "version:\(configuration.common.applicationVersion)",
-                            "sdk_version:\(configuration.common.sdkVersion)",
-                            "env:\(configuration.common.environment)"
-                        ]
-                    )
-                ],
-                headers: [
-                    .contentTypeHeader(contentType: .textPlainUTF8),
-                    .userAgentHeader(
-                        appName: configuration.common.applicationName,
-                        appVersion: configuration.common.applicationVersion,
-                        device: commonDependencies.mobileDevice
-                    ),
-                    .ddAPIKeyHeader(clientToken: configuration.common.clientToken),
-                    .ddEVPOriginHeader(source: configuration.common.origin ?? configuration.common.source),
-                    .ddEVPOriginVersionHeader(sdkVersion: configuration.common.sdkVersion),
-                    .ddRequestIDHeader(),
-                ],
-                telemetry: telemetry
-            ),
-            commonDependencies: commonDependencies,
-            telemetry: telemetry
-        )
-    }
-
     convenience init(
-        directories: FeatureDirectories,
-        configuration: FeaturesConfiguration.RUM,
+        storage: FeatureStorage,
+        upload: FeatureUpload,
+        configuration: Configuration,
         commonDependencies: FeaturesCommonDependencies,
         telemetry: Telemetry?
     ) {
-        let eventsMapper = RUMEventsMapper(
-            viewEventMapper: configuration.viewEventMapper,
-            errorEventMapper: configuration.errorEventMapper,
-            resourceEventMapper: configuration.resourceEventMapper,
-            actionEventMapper: configuration.actionEventMapper,
-            longTaskEventMapper: configuration.longTaskEventMapper,
-            telemetry: telemetry
-        )
-        let storage = RUMFeature.createStorage(
-            directories: directories,
-            commonDependencies: commonDependencies,
-            telemetry: telemetry
-        )
-        let upload = RUMFeature.createUpload(
-            storage: storage,
-            configuration: configuration,
-            commonDependencies: commonDependencies,
-            telemetry: telemetry
-        )
         self.init(
-            eventsMapper: eventsMapper,
+            eventsMapper: RUMEventsMapper(
+                viewEventMapper: configuration.viewEventMapper,
+                errorEventMapper: configuration.errorEventMapper,
+                resourceEventMapper: configuration.resourceEventMapper,
+                actionEventMapper: configuration.actionEventMapper,
+                longTaskEventMapper: configuration.longTaskEventMapper,
+                telemetry: telemetry
+            ),
             storage: storage,
             upload: upload,
             configuration: configuration,

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -34,10 +34,6 @@ internal final class RUMFeature: V1Feature {
 
     // MARK: - Components
 
-    static let featureName = "rum"
-    /// NOTE: any change to data format requires updating the directory url to be unique
-    static let dataFormat = DataFormat(prefix: "", suffix: "", separator: "\n")
-
     /// RUM files storage.
     let storage: FeatureStorage
     /// RUM upload worker.

--- a/Sources/Datadog/RUM/RUMV2Configuration.swift
+++ b/Sources/Datadog/RUM/RUMV2Configuration.swift
@@ -1,0 +1,59 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Creates V2 Storage configuration for V1 RUM.
+internal func createV2RUMStorageConfiguration() -> FeatureStorageConfiguration {
+    return FeatureStorageConfiguration(
+        directories: .init(
+            authorized: "com.datadoghq.rum/v2",
+            unauthorized: "com.datadoghq.rum/intermediate-v2",
+            deprecated: [
+                "com.datadoghq.rum/v1",
+                "com.datadoghq.rum/intermediate-v1",
+            ]
+        ),
+        featureName: "RUM"
+    )
+}
+
+/// Creates V2 Upload configuration for V1 RUM.
+internal func createV2RUMUploadConfiguration(v1Configuration: FeaturesConfiguration.RUM) -> FeatureUploadConfiguration {
+    return FeatureUploadConfiguration(
+        featureName: "RUM",
+        createRequestBuilder: { v1Context, telemetry in
+            return RequestBuilder(
+                url: v1Configuration.uploadURL,
+                queryItems: [
+                    .ddsource(source: v1Context.source),
+                    .ddtags(
+                        tags: [
+                            "service:\(v1Context.service)",
+                            "version:\(v1Context.version)",
+                            "sdk_version:\(v1Context.sdkVersion)",
+                            "env:\(v1Context.env)"
+                        ]
+                    )
+                ],
+                headers: [
+                    .contentTypeHeader(contentType: .textPlainUTF8),
+                    .userAgentHeader(
+                        appName: v1Context.applicationName,
+                        appVersion: v1Context.version,
+                        device: v1Context.mobileDevice
+                    ),
+                    .ddAPIKeyHeader(clientToken: v1Context.clientToken),
+                    .ddEVPOriginHeader(source: v1Context.ciAppOrigin ?? v1Context.source),
+                    .ddEVPOriginVersionHeader(sdkVersion: v1Context.sdkVersion),
+                    .ddRequestIDHeader(),
+                ],
+                telemetry: telemetry
+            )
+        },
+        payloadFormat: DataFormat(prefix: "", suffix: "", separator: "\n")
+    )
+}

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -19,10 +19,12 @@ class RUMStorageBenchmarkTests: XCTestCase {
         try super.setUpWithError()
         self.directory = try Directory(withSubdirectoryPath: "rum-benchmark")
 
-        let storage = RUMFeature.createStorage(
-            directories: FeatureDirectories(
+        let storage = FeatureStorage(
+            featureName: "rum",
+            dataFormat: DataFormat(prefix: "", suffix: "", separator: "\n"),
+            directories: .init(
                 deprecated: [],
-                unauthorized: obtainUniqueTemporaryDirectory(),
+                unauthorized: directory,
                 authorized: directory
             ),
             commonDependencies: .mockAny(),

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -473,7 +473,7 @@ class DatadogTests: XCTestCase {
         let featureDirectories: [FeatureDirectories] = [
             try FeatureDirectories(sdkRootDirectory: core.rootDirectory, storageConfiguration: createV2LoggingStorageConfiguration()),
             try obtainTracingFeatureDirectories(),
-            try obtainRUMFeatureDirectories()
+            try FeatureDirectories(sdkRootDirectory: core.rootDirectory, storageConfiguration: createV2RUMStorageConfiguration())
         ]
 
         let allDirectories: [Directory] = featureDirectories.flatMap { [$0.authorized, $0.unauthorized] }

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -80,17 +80,17 @@ class RUMErrorsIntegrationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
     }
 
     override func tearDown() {
         core.flush()
-        temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
     func testGivenRUMMonitorRegistered_whenAddingErrorMessage_itSendsRUMErrorForCurrentView() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         // given

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -594,7 +594,7 @@ class LoggerTests: XCTestCase {
         let logging: LoggingFeature = .mockNoOp()
         core.register(feature: logging)
 
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         // given

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -13,7 +13,8 @@ extension LoggingFeature {
             storage: .mockNoOp(),
             upload: .mockNoOp(),
             configuration: .mockAny(),
-            commonDependencies: .mockAny()
+            commonDependencies: .mockAny(),
+            telemetry: nil
         )
     }
 
@@ -68,7 +69,8 @@ extension LoggingFeature {
             storage: observedStorage,
             upload: mockedUpload,
             configuration: configuration,
-            commonDependencies: dependencies
+            commonDependencies: dependencies,
+            telemetry: nil
         )
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -10,11 +10,11 @@ import XCTest
 class RUMFeatureTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
     }
 
     override func tearDown() {
-        temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
@@ -41,7 +41,7 @@ class RUMFeatureTests: XCTestCase {
 
         // Given
         let feature: RUMFeature = .mockWith(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 common: .mockWith(
                     clientToken: randomClientToken,
@@ -99,7 +99,7 @@ class RUMFeatureTests: XCTestCase {
         defer { core.flush() }
 
         let feature: RUMFeature = .mockWith(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 performance: .combining(
                     storagePerformance: StoragePerformanceMock(

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -12,9 +12,9 @@ class RUMTelemetryTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
 
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
         Global.rum = RUMMonitor.initialize(in: core)
     }
@@ -22,7 +22,7 @@ class RUMTelemetryTests: XCTestCase {
     override func tearDown() {
         core.flush()
         Global.rum = DDNoopRUMMonitor()
-        temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -43,12 +43,10 @@ final class MockScriptMessage: WKScriptMessage {
 class WKUserContentController_DatadogTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        temporaryFeatureDirectories.create()
         temporaryDirectory.create()
     }
 
     override func tearDown() {
-        temporaryFeatureDirectories.delete()
         temporaryDirectory.delete()
         super.tearDown()
     }
@@ -180,7 +178,7 @@ class WKUserContentController_DatadogTests: XCTestCase {
         )
 
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: dateProvider
             )

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -12,14 +12,14 @@ class RUMMonitorConfigurationTests: XCTestCase {
     private let carrierInfoProvider: CarrierInfoProviderMock = .mockAny()
 
     func testRUMMonitorConfiguration() throws {
-        temporaryFeatureDirectories.create()
-        defer { temporaryFeatureDirectories.delete() }
+        temporaryDirectory.create()
+        defer { temporaryDirectory.delete() }
 
         let core = DatadogCoreMock()
         defer { core.flush() }
 
         let feature: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 common: .mockWith(
                     applicationVersion: "1.2.3",

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -296,7 +296,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testLoadingResourceWithURL_thenMarksFirstPartyURLs() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 // .mockRandom always uses foo.com
                 firstPartyHosts: ["foo.com"]
@@ -322,7 +322,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testLoadingResourceWithURLString_thenMarksFirstPartyURLs() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 firstPartyHosts: ["foo.com"]
             )

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -13,12 +13,12 @@ class RUMMonitorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
     }
 
     override func tearDown() {
         core.flush()
-        temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
@@ -46,7 +46,7 @@ class RUMMonitorTests: XCTestCase {
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
         let randomServiceName: String = .mockRandom()
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 common: .mockWith(serviceName: randomServiceName)
             ),
@@ -87,7 +87,7 @@ class RUMMonitorTests: XCTestCase {
     func testStartingViewIdentifiedByStringKey() throws {
         let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: dateProvider
             )
@@ -113,7 +113,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingImageResourceWithRequest() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
@@ -147,7 +147,7 @@ class RUMMonitorTests: XCTestCase {
             return // `URLSessionTaskMetrics` mocking doesn't work prior to iOS 13.0
         }
 
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
@@ -182,7 +182,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingNativeResourceWithRequestWithExternalMetrics() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
@@ -250,7 +250,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingResourceWithURL() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
@@ -272,7 +272,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingResourceWithURLString() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
@@ -346,7 +346,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenTappingButton() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
@@ -381,7 +381,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingView_thenLoadingResources_whileScrolling() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
@@ -440,7 +440,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenIssuingErrors_whileScrolling() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 0.01)
             )
@@ -502,7 +502,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingAnotherViewBeforeFirstIsStopped_thenLoadingResourcesAfterTapingButton() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(
                     startingFrom: Date(),
@@ -559,7 +559,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testStartingLoadingResourcesFromTheFirstView_thenStartingAnotherViewWhichAlsoLoadsResources() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
@@ -624,7 +624,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenTappingButton_thenTappingAnotherButton() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
@@ -657,7 +657,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testWhenUserInfoIsProvided_itIsSendWithAllEvents() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 userInfoProvider: .mockWith(
                     userInfo: UserInfo(
@@ -716,7 +716,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testWhenNetworkAndCarrierInfoAreProvided_thenConnectivityInfoIsSendWithAllEvents() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 networkConnectionInfoProvider: NetworkConnectionInfoProviderMock(
                     networkConnectionInfo: .mockWith(reachability: .yes, availableInterfaces: [.cellular])
@@ -763,7 +763,7 @@ class RUMMonitorTests: XCTestCase {
     // MARK: - Sending Attributes
 
     func testSendingAttributes() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let view1 = createMockView(viewControllerClassName: "FirstViewController")
@@ -806,7 +806,7 @@ class RUMMonitorTests: XCTestCase {
     }
 
     func testWhenViewIsStarted_attributesCanBeAddedOrUpdatedButNotRemoved() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let monitor = try createTestableRUMMonitor()
@@ -837,7 +837,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testStartingView_thenAddingTiming() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(
                     startingFrom: Date(),
@@ -880,7 +880,7 @@ class RUMMonitorTests: XCTestCase {
         defer { core.flush() }
 
         let rum: RUMFeature = .mockWith(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 sessionSampler: keepAllSessions ? .mockKeepAll() : .mockRejectAll(),
                 onSessionStart: onSessionStart
@@ -910,7 +910,7 @@ class RUMMonitorTests: XCTestCase {
 
         // When
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: dateProvider,
                 dateCorrector: DateCorrectorMock(correctionOffset: serverTimeDifference)
@@ -966,7 +966,7 @@ class RUMMonitorTests: XCTestCase {
 
         // Given
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 consentProvider: consentProvider,
                 dateProvider: RelativeDateProvider(
@@ -1012,7 +1012,7 @@ class RUMMonitorTests: XCTestCase {
 
         // Given
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 sdkInitDate: sdkInitDate,
                 dateProvider: RelativeDateProvider(
@@ -1064,7 +1064,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testModifyingEventsBeforeTheyGetSend() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 viewEventMapper: { viewEvent in
                     var viewEvent = viewEvent
@@ -1135,7 +1135,7 @@ class RUMMonitorTests: XCTestCase {
 
     func testDroppingEventsBeforeTheyGetSent() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             configuration: .mockWith(
                 resourceEventMapper: { _ in nil },
                 actionEventMapper: { event in
@@ -1182,7 +1182,7 @@ class RUMMonitorTests: XCTestCase {
         let randomViewEventAttributes = mockRandomAttributes()
 
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 userInfoProvider: .mockWith(
                     userInfo: .init(

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -134,12 +134,12 @@ class DDRUMMonitorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        temporaryFeatureDirectories.create()
+        temporaryDirectory.create()
     }
 
     override func tearDown() {
         core.flush()
-        temporaryFeatureDirectories.delete()
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
@@ -156,7 +156,7 @@ class DDRUMMonitorTests: XCTestCase {
     }
 
     func testSendingViewEvents() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
@@ -191,7 +191,7 @@ class DDRUMMonitorTests: XCTestCase {
     }
 
     func testSendingViewEventsWithTiming() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
@@ -220,7 +220,7 @@ class DDRUMMonitorTests: XCTestCase {
             return // `URLSessionTaskMetrics` mocking doesn't work prior to iOS 13.0
         }
 
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
@@ -273,7 +273,7 @@ class DDRUMMonitorTests: XCTestCase {
     }
 
     func testSendingErrorEvents() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()
@@ -337,7 +337,7 @@ class DDRUMMonitorTests: XCTestCase {
 
     func testSendingActionEvents() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directories: temporaryFeatureDirectories,
+            directory: temporaryDirectory,
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
@@ -375,7 +375,7 @@ class DDRUMMonitorTests: XCTestCase {
     }
 
     func testSendingGlobalAttributes() throws {
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directories: temporaryFeatureDirectories)
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         let objcRUMMonitor = try createTestableDDRUMMonitor()


### PR DESCRIPTION
### What and why?

⚙️🧰 This PR makes necessary refactoring to create V1 `RUMFeature` from V2's storage and upload configurations.

### How?

Based on the refactoring done in #866 for `LoggingFeature`, this PR applies similar configuration to RUM.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
