### PR TITLE
RUMM-2171 V1 Interface Segregation

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -597,8 +597,6 @@
 		D29CDD3228211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
 		D29CDD3328211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
 		D29D5A4D273BF8B400A687C1 /* SwiftUIActionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */; };
-		D2B3F052282E827700C2B5EE /* DDHTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F051282E826A00C2B5EE /* DDHTTPHeadersWriter+apiTests.m */; };
-		D2B3F053282E827B00C2B5EE /* DDHTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F051282E826A00C2B5EE /* DDHTTPHeadersWriter+apiTests.m */; };
 		D2B3F0442823EE8400C2B5EE /* DataBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */; };
 		D2B3F0452823EE8400C2B5EE /* DataBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */; };
 		D2B3F04728292D6E00C2B5EE /* DataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F04628292D6E00C2B5EE /* DataMigratorTests.swift */; };
@@ -607,6 +605,8 @@
 		D2B3F04B2829510600C2B5EE /* DatadogCoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F0492829510600C2B5EE /* DatadogCoreProtocol.swift */; };
 		D2B3F04D282A85FD00C2B5EE /* DatadogCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F04C282A85FD00C2B5EE /* DatadogCore.swift */; };
 		D2B3F04E282A85FD00C2B5EE /* DatadogCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F04C282A85FD00C2B5EE /* DatadogCore.swift */; };
+		D2B3F052282E827700C2B5EE /* DDHTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F051282E826A00C2B5EE /* DDHTTPHeadersWriter+apiTests.m */; };
+		D2B3F053282E827B00C2B5EE /* DDHTTPHeadersWriter+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F051282E826A00C2B5EE /* DDHTTPHeadersWriter+apiTests.m */; };
 		D2CB6E0C27C50EAE00A62B57 /* Datadog.h in Headers */ = {isa = PBXBuildFile; fileRef = 61133B85242393DE00786299 /* Datadog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2CB6E0D27C50EAE00A62B57 /* ObjcAppLaunchHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6179FFD1254ADB1100556A0B /* ObjcAppLaunchHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D2CB6E0E27C50EAE00A62B57 /* ObjcExceptionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E68FB54244707FD0013A8AA /* ObjcExceptionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1008,6 +1008,8 @@
 		D2CB6FE527C5352300A62B57 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 614ED36B260352DC00C8C519 /* CrashReporter.xcframework */; };
 		D2CB6FEE27C5365A00A62B57 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2CB6ED127C50EAE00A62B57 /* Datadog.framework */; };
 		D2CB6FF327C5369600A62B57 /* DatadogCrashReporting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */; };
+		D2D37DBF2846335F00FB4348 /* DatadogV1CoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D37DBE2846335F00FB4348 /* DatadogV1CoreProtocol.swift */; };
+		D2D37DC02846335F00FB4348 /* DatadogV1CoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D37DBE2846335F00FB4348 /* DatadogV1CoreProtocol.swift */; };
 		D2DC4BBC27F234D600E4FB96 /* CITestIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11625D727B681D200E428C6 /* CITestIntegration.swift */; };
 		D2DC4BBD27F234E000E4FB96 /* CITestIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */; };
 		D2DC4BF627F484AA00E4FB96 /* DataEncryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */; };
@@ -1771,16 +1773,17 @@
 		D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandlerTests.swift; sourceTree = "<group>"; };
 		D29CDD3128211A2200F7DAA5 /* DataBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlock.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
-		D2B3F051282E826A00C2B5EE /* DDHTTPHeadersWriter+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDHTTPHeadersWriter+apiTests.m"; sourceTree = "<group>"; };
 		D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlockTests.swift; sourceTree = "<group>"; };
 		D2B3F04628292D6E00C2B5EE /* DataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorTests.swift; sourceTree = "<group>"; };
 		D2B3F0492829510600C2B5EE /* DatadogCoreProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreProtocol.swift; sourceTree = "<group>"; };
 		D2B3F04C282A85FD00C2B5EE /* DatadogCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCore.swift; sourceTree = "<group>"; };
+		D2B3F051282E826A00C2B5EE /* DDHTTPHeadersWriter+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDHTTPHeadersWriter+apiTests.m"; sourceTree = "<group>"; };
 		D2CB6ED127C50EAE00A62B57 /* Datadog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Datadog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6F8F27C520D400A62B57 /* DatadogTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FB027C5217A00A62B57 /* DatadogObjc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogObjc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FD127C5348200A62B57 /* DatadogCrashReporting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DatadogCrashReporting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2CB6FEC27C5352300A62B57 /* DatadogCrashReportingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DatadogCrashReportingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2D37DBE2846335F00FB4348 /* DatadogV1CoreProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogV1CoreProtocol.swift; sourceTree = "<group>"; };
 		D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataEncryption.swift; sourceTree = "<group>"; };
 		D2EFF3D22731822A00D09F33 /* RUMViewsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandler.swift; sourceTree = "<group>"; };
 		D2F1B81026D795F3009F3293 /* DDNoopRUMMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDNoopRUMMonitor.swift; sourceTree = "<group>"; };
@@ -4148,6 +4151,7 @@
 			isa = PBXGroup;
 			children = (
 				D2B3F0492829510600C2B5EE /* DatadogCoreProtocol.swift */,
+				D2D37DBE2846335F00FB4348 /* DatadogV1CoreProtocol.swift */,
 				616F1FAC283D683500651A3A /* DatadogV1Context.swift */,
 			);
 			path = DatadogInternal;
@@ -4993,6 +4997,7 @@
 				61E909ED24A24DD3005EA2DE /* OTSpan.swift in Sources */,
 				61FF9A4525AC5DEA001058CC /* RUMViewIdentity.swift in Sources */,
 				616124A725CAC268009901BE /* CrashContextProvider.swift in Sources */,
+				D2D37DBF2846335F00FB4348 /* DatadogV1CoreProtocol.swift in Sources */,
 				61E909F324A24DD3005EA2DE /* OTSpanContext.swift in Sources */,
 				61E909F024A24DD3005EA2DE /* OTTracer.swift in Sources */,
 				61E909F124A24DD3005EA2DE /* OTReference.swift in Sources */,
@@ -5643,6 +5648,7 @@
 				61494B7B27F352570082BBCC /* RUMViewUpdatesThrottler.swift in Sources */,
 				D2CB6E2F27C50EAE00A62B57 /* SpanTagsReducer.swift in Sources */,
 				D2CB6E3027C50EAE00A62B57 /* RUMApplicationScope.swift in Sources */,
+				D2D37DC02846335F00FB4348 /* DatadogV1CoreProtocol.swift in Sources */,
 				D2CB6E3127C50EAE00A62B57 /* FileWriter.swift in Sources */,
 				D2CB6E3227C50EAE00A62B57 /* SwiftUIActionModifier.swift in Sources */,
 				D2CB6E3327C50EAE00A62B57 /* OTConstants.swift in Sources */,

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -151,9 +151,9 @@ public class Datadog {
 
     /// Clears all data that has not already been sent to Datadog servers.
     public static func clearAllData() {
-        let logging = defaultDatadogCore.feature(LoggingFeature.self)
-        let tracing = defaultDatadogCore.feature(TracingFeature.self)
-        let rum = defaultDatadogCore.feature(RUMFeature.self)
+        let logging = defaultDatadogCore.v1.feature(LoggingFeature.self)
+        let tracing = defaultDatadogCore.v1.feature(TracingFeature.self)
+        let rum = defaultDatadogCore.v1.feature(RUMFeature.self)
         logging?.storage.clearAllData()
         tracing?.storage.clearAllData()
         rum?.storage.clearAllData()
@@ -297,14 +297,14 @@ public class Datadog {
             core.register(feature: urlSessionAutoInstrumentation)
         }
 
-        core.feature(RUMInstrumentation.self)?.enable()
-        core.feature(URLSessionAutoInstrumentation.self)?.enable()
+        core.v1.feature(RUMInstrumentation.self)?.enable()
+        core.v1.feature(URLSessionAutoInstrumentation.self)?.enable()
 
         defaultDatadogCore = core
 
         // After everything is set up, if the Crash Reporting feature was enabled,
         // register crash reporter and send crash report if available:
-        if let crashReportingFeature = core.feature(CrashReportingFeature.self) {
+        if let crashReportingFeature = core.v1.feature(CrashReportingFeature.self) {
             Global.crashReporter = CrashReporter(
                 crashReportingFeature: crashReportingFeature,
                 loggingFeature: logging,
@@ -333,11 +333,11 @@ public class Datadog {
         assert(Datadog.isInitialized, "SDK must be first initialized.")
 
         // Tear down and deinitialize all features:
-        let logging = defaultDatadogCore.feature(LoggingFeature.self)
-        let tracing = defaultDatadogCore.feature(TracingFeature.self)
-        let rum = defaultDatadogCore.feature(RUMFeature.self)
-        let rumInstrumentation = defaultDatadogCore.feature(RUMInstrumentation.self)
-        let urlSessionInstrumentation = defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)
+        let logging = defaultDatadogCore.v1.feature(LoggingFeature.self)
+        let tracing = defaultDatadogCore.v1.feature(TracingFeature.self)
+        let rum = defaultDatadogCore.v1.feature(RUMFeature.self)
+        let rumInstrumentation = defaultDatadogCore.v1.feature(RUMInstrumentation.self)
+        let urlSessionInstrumentation = defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self)
         logging?.deinitialize()
         tracing?.deinitialize()
         rum?.deinitialize()

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -99,7 +99,7 @@ internal final class DatadogCore {
     }
 }
 
-extension DatadogCore: DatadogCoreProtocol {
+extension DatadogCore: DatadogV1CoreProtocol {
     // MARK: - V1 interface
 
     /// Creates V1 Feature using its V2 configuration.
@@ -158,4 +158,8 @@ extension DatadogCore: DatadogCoreProtocol {
         let key = String(describing: T.self)
         return v1Features[key] as? T
     }
+}
+
+internal protocol V1Feature {
+    var storage: FeatureStorage { get }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -11,19 +11,6 @@ public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOOPDatadogCo
 /// A Datadog Core holds a set of features and is responsible of managing their storage
 /// and upload mechanism. It also provides a thread-safe scope for writing events.
 public protocol DatadogCoreProtocol {
-    // MARK: - V1 interface
-
-    /// Registers a feature instance by its type description.
-    ///
-    /// - Parameter instance: The feaure instance to register
-    func register<T>(feature instance: T?)
-
-    /// Returns a Feature instance by its type.
-    ///
-    /// - Parameters:
-    ///   - type: The feature instance type.
-    /// - Returns: The feature if any.
-    func feature<T>(_ type: T.Type) -> T?
 }
 
 /// Provide feature specific storage configuration.
@@ -73,13 +60,4 @@ public protocol FeatureScope {
 
 /// No-op implementation of `DatadogFeatureRegistry`.
 internal struct NOOPDatadogCore: DatadogCoreProtocol {
-    // MARK: - V1 interface
-
-    /// no-op
-    func register<T>(feature instance: T?) {}
-
-    /// no-op
-    func feature<T>(_ type: T.Type) -> T? {
-        return nil
-    }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
@@ -1,0 +1,46 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+extension DatadogCoreProtocol {
+    // Upcast `DatadogCoreProtocol` instance to `DatadogV1CoreProtocol`
+    // to access v1 related implementation.
+    // If upcasting fails, a `NOOPDatadogCore` instance is returned.
+    var v1: DatadogV1CoreProtocol {
+        self as? DatadogV1CoreProtocol ?? NOOPDatadogCore()
+    }
+}
+
+/// A Datadog Core holds a set of features and is responsible of managing their storage
+/// and upload mechanism. It also provides a thread-safe scope for writing events.
+internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
+    // MARK: - V1 interface
+
+    /// Registers a feature instance by its type description.
+    ///
+    /// - Parameter instance: The feaure instance to register
+    func register<T>(feature instance: T?)
+
+    /// Returns a Feature instance by its type.
+    ///
+    /// - Parameters:
+    ///   - type: The feature instance type.
+    /// - Returns: The feature if any.
+    func feature<T>(_ type: T.Type) -> T?
+}
+
+extension NOOPDatadogCore: DatadogV1CoreProtocol {
+    // MARK: - V1 interface
+
+    /// no-op
+    func register<T>(feature instance: T?) {}
+
+    /// no-op
+    func feature<T>(_ type: T.Type) -> T? {
+        return nil
+    }
+}

--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -28,8 +28,8 @@ public extension WKUserContentController {
         addDatadogMessageHandler(
             allowedWebViewHosts: hosts,
             hostsSanitizer: HostsSanitizer(),
-            loggingFeature: core.feature(LoggingFeature.self),
-            rumFeature: core.feature(RUMFeature.self)
+            loggingFeature: core.v1.feature(LoggingFeature.self),
+            rumFeature: core.v1.feature(RUMFeature.self)
         )
     }
 

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -399,7 +399,7 @@ public class Logger {
         }
 
         private func buildOrThrow(in core: DatadogCoreProtocol) throws -> Logger {
-            guard let loggingFeature = core.feature(LoggingFeature.self) else {
+            guard let loggingFeature = core.v1.feature(LoggingFeature.self) else {
                 throw ProgrammerError(
                     description: Datadog.isInitialized
                         ? "`Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."
@@ -411,8 +411,8 @@ public class Logger {
 
             // RUMM-2133 Note: strong feature coupling while migrating to v2.
             // In v2 active span will be provided in context from feature scope.
-            let rumEnabled = core.feature(RUMFeature.self) != nil
-            let tracingEnabled = core.feature(TracingFeature.self) != nil
+            let rumEnabled = core.v1.feature(RUMFeature.self) != nil
+            let tracingEnabled = core.v1.feature(TracingFeature.self) != nil
 
             return Logger(
                 logBuilder: logBuilder,

--- a/Sources/Datadog/RUM/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
+++ b/Sources/Datadog/RUM/Instrumentation/Views/SwiftUI/SwiftUIViewModifier.swift
@@ -59,7 +59,7 @@ public extension SwiftUI.View {
         in core: DatadogCoreProtocol = defaultDatadogCore
     ) -> some View {
         let path = "\(name)/\(typeDescription.hashValue)"
-        let instrumentation = core.feature(RUMInstrumentation.self)
+        let instrumentation = core.v1.feature(RUMInstrumentation.self)
         return modifier(
             RUMViewModifier(
                 instrumentation: instrumentation,

--- a/Sources/Datadog/RUM/RUMTelemetry.swift
+++ b/Sources/Datadog/RUM/RUMTelemetry.swift
@@ -129,7 +129,7 @@ internal final class RUMTelemetry: Telemetry {
     }
 
     private func record(event id: String, operation: @escaping (RUMContext, Writer) -> Void) {
-        let rum = core.feature(RUMFeature.self)
+        let rum = core.v1.feature(RUMFeature.self)
 
         guard
             sampler.sample(),

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -157,7 +157,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     """
                 )
             }
-            guard let rumFeature = core.feature(RUMFeature.self) else {
+            guard let rumFeature = core.v1.feature(RUMFeature.self) else {
                 throw ProgrammerError(
                     description: Datadog.isInitialized
                         ? "`RUMMonitor.initialize()` produces a non-functional monitor, as the RUM feature is disabled."
@@ -165,14 +165,14 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 )
             }
 
-            let crashReporting = core.feature(CrashReportingFeature.self)
+            let crashReporting = core.v1.feature(CrashReportingFeature.self)
             let monitor = RUMMonitor(
                 dependencies: RUMScopeDependencies(rumFeature: rumFeature, crashReportingFeature: crashReporting),
                 dateProvider: rumFeature.dateProvider
             )
 
-            core.feature(RUMInstrumentation.self)?.publish(to: monitor)
-            core.feature(URLSessionAutoInstrumentation.self)?.publish(to: monitor)
+            core.v1.feature(RUMInstrumentation.self)?.publish(to: monitor)
+            core.v1.feature(URLSessionAutoInstrumentation.self)?.publish(to: monitor)
 
             return monitor
         } catch {

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -78,7 +78,7 @@ public class Tracer: OTTracer {
                     """
                 )
             }
-            guard let tracingFeature = core.feature(TracingFeature.self) else {
+            guard let tracingFeature = core.v1.feature(TracingFeature.self) else {
                 throw ProgrammerError(
                     description: Datadog.isInitialized
                         ? "`Tracer.initialize(configuration:)` produces a non-functional tracer, as the tracing feature is disabled."
@@ -88,8 +88,8 @@ public class Tracer: OTTracer {
             return DDTracer(
                 tracingFeature: tracingFeature,
                 tracerConfiguration: configuration,
-                rumEnabled: core.feature(RUMFeature.self) != nil,
-                loggingFeature: core.feature(LoggingFeature.self)
+                rumEnabled: core.v1.feature(RUMFeature.self) != nil,
+                loggingFeature: core.v1.feature(LoggingFeature.self)
             )
         } catch {
             consolePrint("\(error)")

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -29,7 +29,7 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
     }
 
     var instrumentation: URLSessionAutoInstrumentation? {
-        core().feature(URLSessionAutoInstrumentation.self)
+        core().v1.feature(URLSessionAutoInstrumentation.self)
     }
 
     let firstPartyURLsFilter: FirstPartyURLsFilter

--- a/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/Interception/URLSessionInterceptor.swift
@@ -28,7 +28,7 @@ internal protocol URLSessionInterceptorType: AnyObject {
 /// An object performing interception of requests sent with `URLSession`.
 public class URLSessionInterceptor: URLSessionInterceptorType {
     public static var shared: URLSessionInterceptor? {
-        let instrumentation = defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)
+        let instrumentation = defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self)
         return instrumentation?.interceptor as? URLSessionInterceptor
     }
 

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -102,132 +102,132 @@ class DatadogTests: XCTestCase {
             )
             verificationBlock()
 
-            defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler?.unswizzle()
-            defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)?.swizzler.unswizzle()
+            defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.viewControllerSwizzler?.unswizzle()
+            defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self)?.swizzler.unswizzle()
             Datadog.flushAndDeinitialize()
         }
 
         defer {
-            defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler?.unswizzle()
-            defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)?.swizzler.unswizzle()
+            defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.viewControllerSwizzler?.unswizzle()
+            defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self)?.swizzler.unswizzle()
         }
 
         verify(configuration: defaultBuilder.build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
-            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry, "When RUM is disabled, telemetry monitor should not be set")
         }
         verify(configuration: rumBuilder.build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
-            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(LoggingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry, "When RUM is enabled, telemetry monitor should be set")
         }
 
         verify(configuration: defaultBuilder.enableLogging(false).build()) {
             // verify features:
-            XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
-            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
         verify(configuration: rumBuilder.enableLogging(false).build()) {
             // verify features:
-            XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self))
-            XCTAssertNotNil(defaultDatadogCore.feature(TracingFeature.self))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
-            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(LoggingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(TracingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
 
         verify(configuration: defaultBuilder.enableTracing(false).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
-            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(TracingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
+            XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
         verify(configuration: rumBuilder.enableTracing(false).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(TracingFeature.self))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
-            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(TracingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
+            XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
 
         verify(configuration: defaultBuilder.enableRUM(true).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature cannot be enabled")
-            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature cannot be enabled")
+            XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
         verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(LoggingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(LoggingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
             XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMViews().build()) {
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self))
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
         verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitRUMViews().build()
         ) {
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMActions().build()) {
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
-            XCTAssertNotNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
         verify(
             configuration: rumBuilder.enableRUM(false).trackUIKitRUMActions().build()
         ) {
-            XCTAssertNil(defaultDatadogCore.feature(RUMFeature.self))
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
-            XCTAssertNil(defaultDatadogCore.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.viewControllerSwizzler)
+            XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self)?.userActionsAutoInstrumentation)
         }
 
         verify(configuration: defaultBuilder.trackURLSession(firstPartyHosts: ["example.com"]).build()) {
-            XCTAssertNotNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
         }
         verify(configuration: defaultBuilder.trackURLSession().build()) {
-            XCTAssertNotNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
         }
 
         verify(
@@ -237,7 +237,7 @@ class DatadogTests: XCTestCase {
                 .enableCrashReporting(using: CrashReportingPluginMock())
                 .build()
         ) {
-            XCTAssertNotNil(defaultDatadogCore.feature(CrashReportingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
             XCTAssertTrue(
                 Global.crashReporter?.loggingOrRUMIntegration is CrashReportingWithLoggingIntegration,
                 "When only Logging feature is enabled, the Crash Reporter should send crash reports as Logs"
@@ -251,7 +251,7 @@ class DatadogTests: XCTestCase {
                 .enableCrashReporting(using: CrashReportingPluginMock())
                 .build()
         ) {
-            XCTAssertNotNil(defaultDatadogCore.feature(CrashReportingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
             XCTAssertTrue(
                 Global.crashReporter?.loggingOrRUMIntegration is CrashReportingWithRUMIntegration,
                 "When only RUM feature is enabled, the Crash Reporter should send crash reports as RUM Events"
@@ -265,7 +265,7 @@ class DatadogTests: XCTestCase {
                 .enableCrashReporting(using: CrashReportingPluginMock())
                 .build()
         ) {
-            XCTAssertNotNil(defaultDatadogCore.feature(CrashReportingFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
             XCTAssertTrue(
                 Global.crashReporter?.loggingOrRUMIntegration is CrashReportingWithRUMIntegration,
                 "When both Logging and RUM features are enabled, the Crash Reporter should send crash reports as RUM Events"
@@ -279,7 +279,7 @@ class DatadogTests: XCTestCase {
                 .enableCrashReporting(using: CrashReportingPluginMock())
                 .build()
         ) {
-            XCTAssertNil(defaultDatadogCore.feature(CrashReportingFeature.self))
+            XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
             XCTAssertNil(
                 Global.crashReporter,
                 "When both Logging and RUM are disabled, Crash Reporter should not be registered"
@@ -313,9 +313,9 @@ class DatadogTests: XCTestCase {
         )
 
         let core = defaultDatadogCore
-        let logging = core.feature(LoggingFeature.self)
-        let tracing = core.feature(TracingFeature.self)
-        let rum = core.feature(RUMFeature.self)
+        let logging = core.v1.feature(LoggingFeature.self)
+        let tracing = core.v1.feature(TracingFeature.self)
+        let rum = core.v1.feature(RUMFeature.self)
         XCTAssertEqual(logging?.configuration.common.performance, expectedPerformancePreset)
         XCTAssertEqual(rum?.configuration.sessionSampler.samplingRate, 100)
         XCTAssertEqual(tracing?.configuration.common.performance, expectedPerformancePreset)

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -48,7 +48,7 @@ class LoggerBuilderTests: XCTestCase {
         XCTAssertNil(logger.rumContextIntegration)
         XCTAssertNil(logger.activeSpanIntegration)
 
-        let feature = try XCTUnwrap(core.feature(LoggingFeature.self))
+        let feature = try XCTUnwrap(core.v1.feature(LoggingFeature.self))
         XCTAssertTrue(
             logger.logOutput is LogFileOutput,
             "When Logging feature is enabled the Logger should use `LogFileOutput`."
@@ -107,7 +107,7 @@ class LoggerBuilderTests: XCTestCase {
         XCTAssertNil(logger.rumContextIntegration)
         XCTAssertNil(logger.activeSpanIntegration)
 
-        let feature = try XCTUnwrap(core.feature(LoggingFeature.self))
+        let feature = try XCTUnwrap(core.v1.feature(LoggingFeature.self))
         XCTAssertTrue(
             logger.logOutput is LogFileOutput,
             "When Logging feature is enabled the Logger should use `LogFileOutput`."

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -7,7 +7,7 @@
 import Foundation
 @testable import Datadog
 
-internal final class DatadogCoreMock: DatadogCoreProtocol, Flushable {
+internal final class DatadogCoreMock: Flushable {
     private var v1Features: [String: Any] = [:]
 
     /// Flush resgistered features.
@@ -26,7 +26,9 @@ internal final class DatadogCoreMock: DatadogCoreProtocol, Flushable {
     func all<T>(_ type: T.Type) -> [T] {
         v1Features.values.compactMap { $0 as? T }
     }
+}
 
+extension DatadogCoreMock: DatadogV1CoreProtocol {
     // MARK: V1 interface
 
     func register<T>(feature instance: T?) {

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -86,7 +86,7 @@ extension LoggingFeature {
 
     // swiftlint:disable:next function_default_parameter_at_end
     static func waitAndReturnLogMatchers(in core: DatadogCoreProtocol = defaultDatadogCore, count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
-        guard let logging = core.feature(LoggingFeature.self) else {
+        guard let logging = core.v1.feature(LoggingFeature.self) else {
             preconditionFailure("LoggingFeature is not registered in core")
         }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -95,7 +95,7 @@ extension RUMFeature {
 
     // swiftlint:disable:next function_default_parameter_at_end
     static func waitAndReturnRUMEventMatchers(in core: DatadogCoreProtocol = defaultDatadogCore, count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [RUMEventMatcher] {
-        guard let rum = core.feature(RUMFeature.self) else {
+        guard let rum = core.v1.feature(RUMFeature.self) else {
             preconditionFailure("RUMFeature is not registered in core")
         }
         return try rum.waitAndReturnRUMEventMatchers(count: count, file: file, line: line)

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -87,7 +87,7 @@ extension TracingFeature {
 
     // swiftlint:disable:next function_default_parameter_at_end
     static func waitAndReturnSpanMatchers(in core: DatadogCoreProtocol = defaultDatadogCore, count: UInt, file: StaticString = #file, line: UInt = #line) throws -> [SpanMatcher] {
-        guard let tracing = core.feature(TracingFeature.self) else {
+        guard let tracing = core.v1.feature(TracingFeature.self) else {
             preconditionFailure("TracingFeature is not registered in core")
         }
 

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -31,8 +31,8 @@ class RUMMonitorTests: XCTestCase {
     /// Creates `RUMMonitor` instance for tests.
     /// The only difference vs. `RUMMonitor.initialize()` is that we disable RUM view updates sampling to get deterministic behaviour.
     private func createTestableRUMMonitor(in core: DatadogCoreProtocol) throws -> DDRUMMonitor {
-        let rumFeature: RUMFeature = try XCTUnwrap(core.feature(RUMFeature.self), "RUM feature must be initialized before creating `RUMMonitor`")
-        let crashReportingFeature = core.feature(CrashReportingFeature.self)
+        let rumFeature: RUMFeature = try XCTUnwrap(core.v1.feature(RUMFeature.self), "RUM feature must be initialized before creating `RUMMonitor`")
+        let crashReportingFeature = core.v1.feature(CrashReportingFeature.self)
         return RUMMonitor(
             dependencies: RUMScopeDependencies(rumFeature: rumFeature, crashReportingFeature: crashReportingFeature)
                 .replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
@@ -1371,9 +1371,9 @@ class RUMMonitorTests: XCTestCase {
         userLogger = .mockWith(logOutput: output)
 
         // Given
-        let urlInstrumentation = try XCTUnwrap(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+        let urlInstrumentation = try XCTUnwrap(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
         let resourcesHandler = urlInstrumentation.interceptor.handler
-        let rumInstrumentation = try XCTUnwrap(defaultDatadogCore.feature(RUMInstrumentation.self))
+        let rumInstrumentation = try XCTUnwrap(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
         let viewsHandler = rumInstrumentation.viewsHandler
         let userActionsHandler = try XCTUnwrap(rumInstrumentation.userActionsAutoInstrumentation?.handler)
 

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -46,7 +46,7 @@ class TracerConfigurationTests: XCTestCase {
 
         XCTAssertNil(tracer.rumContextIntegration)
 
-        let feature = try XCTUnwrap(core.feature(TracingFeature.self))
+        let feature = try XCTUnwrap(core.v1.feature(TracingFeature.self))
         XCTAssertEqual((tracer.spanOutput as? SpanFileOutput)?.environment, "tests")
         XCTAssertEqual(tracer.spanBuilder.applicationVersion, "1.2.3")
         XCTAssertEqual(tracer.spanBuilder.serviceName, "service-name")
@@ -78,7 +78,7 @@ class TracerConfigurationTests: XCTestCase {
 
         XCTAssertNil(tracer.rumContextIntegration)
 
-        let feature = try XCTUnwrap(core.feature(TracingFeature.self))
+        let feature = try XCTUnwrap(core.v1.feature(TracingFeature.self))
         XCTAssertEqual((tracer.spanOutput as? SpanFileOutput)?.environment, "tests")
         XCTAssertEqual(tracer.spanBuilder.applicationVersion, "1.2.3")
         XCTAssertEqual(tracer.spanBuilder.serviceName, "custom-service-name")
@@ -105,13 +105,13 @@ class TracerConfigurationTests: XCTestCase {
         XCTAssertNil(tracingLogBuilder.networkConnectionInfoProvider)
         XCTAssertNil(tracingLogBuilder.carrierInfoProvider)
 
-        let feature = try XCTUnwrap(core.feature(TracingFeature.self))
+        let feature = try XCTUnwrap(core.v1.feature(TracingFeature.self))
         XCTAssertTrue(tracer.loggingIntegration?.logBuilder.userInfoProvider === feature.userInfoProvider)
     }
 
     func testWhenLoggingFeatureIsNotEnabled_itDoesNotUseLogsIntegration() throws {
         // When
-        XCTAssertNil(core.feature(LoggingFeature.self))
+        XCTAssertNil(core.v1.feature(LoggingFeature.self))
 
         // Then
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -1128,7 +1128,7 @@ class TracerTests: XCTestCase {
         userLogger = .mockWith(logOutput: output)
 
         // Given
-        let instrumentation = defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)
+        let instrumentation = defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self)
         let tracingHandler = try XCTUnwrap(instrumentation?.interceptor.handler)
 
         // When

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -34,8 +34,8 @@ class DDDatadogTests: XCTestCase {
 
         XCTAssertTrue(Datadog.isInitialized)
 
-        let logging = defaultDatadogCore.feature(LoggingFeature.self)
-        let urlSessionInstrumentation = defaultDatadogCore.feature(URLSessionAutoInstrumentation.self)
+        let logging = defaultDatadogCore.v1.feature(LoggingFeature.self)
+        let urlSessionInstrumentation = defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self)
         XCTAssertEqual(logging?.configuration.common.applicationName, "app-name")
         XCTAssertEqual(logging?.configuration.common.environment, "tests")
         XCTAssertNotNil(urlSessionInstrumentation)
@@ -43,8 +43,8 @@ class DDDatadogTests: XCTestCase {
         urlSessionInstrumentation?.swizzler.unswizzle()
         Datadog.flushAndDeinitialize()
 
-        XCTAssertNil(defaultDatadogCore.feature(LoggingFeature.self))
-        XCTAssertNil(defaultDatadogCore.feature(URLSessionAutoInstrumentation.self))
+        XCTAssertNil(defaultDatadogCore.v1.feature(LoggingFeature.self))
+        XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
     }
 
     // MARK: - Changing Tracking Consent

--- a/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
@@ -30,7 +30,7 @@ class DDGlobalTests: XCTestCase {
 
     func testWhenTracerIsSet_itSetsSwiftImplementation() {
         let tracing: TracingFeature = .mockNoOp()
-        defaultDatadogCore.register(feature: tracing)
+        defaultDatadogCore.v1.register(feature: tracing)
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.sharedTracer,
@@ -57,7 +57,7 @@ class DDGlobalTests: XCTestCase {
 
     func testWhenRUMMonitorIsSet_itSetsSwiftImplementation() {
         let rum: RUMFeature = .mockNoOp()
-        defaultDatadogCore.register(feature: rum)
+        defaultDatadogCore.v1.register(feature: rum)
 
         let previousGlobal = (
             objc: DatadogObjc.DDGlobal.rum,

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -29,7 +29,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingLogsWithDifferentLevels() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
-        defaultDatadogCore.register(feature: feature)
+        defaultDatadogCore.v1.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 
@@ -51,7 +51,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingNSError() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
-        defaultDatadogCore.register(feature: feature)
+        defaultDatadogCore.v1.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 
@@ -83,7 +83,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingMessageAttributes() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
-        defaultDatadogCore.register(feature: feature)
+        defaultDatadogCore.v1.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 
@@ -108,7 +108,7 @@ class DDLoggerTests: XCTestCase {
 
     func testSendingLoggerAttributes() throws {
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
-        defaultDatadogCore.register(feature: feature)
+        defaultDatadogCore.v1.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 
@@ -148,7 +148,7 @@ class DDLoggerTests: XCTestCase {
             directory: temporaryDirectory,
             configuration: .mockWith(common: .mockWith(environment: "test"))
         )
-        defaultDatadogCore.register(feature: feature)
+        defaultDatadogCore.v1.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()
 

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -146,7 +146,7 @@ class DDRUMMonitorTests: XCTestCase {
     /// Creates `DDRUMMonitor` instance for tests.
     /// The only difference vs. `DDRUMMonitor.initialize()` is that we disable RUM view updates sampling to get deterministic behaviour.
     private func createTestableDDRUMMonitor() throws -> DatadogObjc.DDRUMMonitor {
-        let rumFeature: RUMFeature = try XCTUnwrap(core.feature(RUMFeature.self), "RUM feature must be initialized before creating `RUMMonitor`")
+        let rumFeature: RUMFeature = try XCTUnwrap(core.v1.feature(RUMFeature.self), "RUM feature must be initialized before creating `RUMMonitor`")
         let swiftMonitor = RUMMonitor(
             dependencies: RUMScopeDependencies(rumFeature: rumFeature, crashReportingFeature: nil)
                 .replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -45,10 +45,10 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
         ),
         .init(
             assert: {
-                defaultDatadogCore.feature(LoggingFeature.self) == nil
-                    && defaultDatadogCore.feature(TracingFeature.self) == nil
-                    && defaultDatadogCore.feature(RUMFeature.self) == nil
-                    && defaultDatadogCore.feature(CrashReportingFeature.self) == nil
+                defaultDatadogCore.v1.feature(LoggingFeature.self) == nil
+                    && defaultDatadogCore.v1.feature(TracingFeature.self) == nil
+                    && defaultDatadogCore.v1.feature(RUMFeature.self) == nil
+                    && defaultDatadogCore.v1.feature(CrashReportingFeature.self) == nil
             },
             problem: "All features must not be initialized.",
             solution: """
@@ -57,8 +57,8 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
         ),
         .init(
             assert: {
-                defaultDatadogCore.feature(RUMInstrumentation.self) == nil
-                && defaultDatadogCore.feature(URLSessionAutoInstrumentation.self) == nil
+                defaultDatadogCore.v1.feature(RUMInstrumentation.self) == nil
+                && defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self) == nil
             },
             problem: "All auto-instrumentation features must not be initialized.",
             solution: """


### PR DESCRIPTION
### What and why?

SDK V1 implementation defines multiple `internal` objects that need to stay hidden from the public interface while we migrate to v2 core module and configuration. The PR is a proposal to segregate v1 from v2 interfaces to be able to keep all v1 apis `internal`.

### How?

The `DatadogCoreProtocol` will internally expose a `v1` extension to access all v1 apis needed to register and retrieve features.

``` swift
extension DatadogCoreProtocol {
    // Upcast `DatadogCoreProtocol` instance to `DatadogV1CoreProtocol`
    // to access v1 related implementation.
    // If upcasting fails, a `NOOPDatadogCore` instance is returned.
    var v1: DatadogV1CoreProtocol {
        self as? DatadogV1CoreProtocol ?? NOOPDatadogCore()
    }
}
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
