### PR TITLE
RUMM-2077 Vitals Frequency Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ### Changes
+* [IMPROVEMENT] Add mobile vitals frequency configuration. See [#876][]
 
 # 1.11.0-rc1 / 18-05-2022
 
@@ -367,6 +368,7 @@
 [#837]: https://github.com/DataDog/dd-sdk-ios/issues/837
 [#832]: https://github.com/DataDog/dd-sdk-ios/issues/832
 [#851]: https://github.com/DataDog/dd-sdk-ios/issues/851
+[#876]: https://github.com/DataDog/dd-sdk-ios/issues/876
 [@00FA9A]: https://github.com/00FA9A
 [@Britton-Earnin]: https://github.com/Britton-Earnin
 [@Hengyu]: https://github.com/Hengyu

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -63,6 +63,7 @@ internal struct FeaturesConfiguration {
         let backgroundEventTrackingEnabled: Bool
         let onSessionStart: RUMSessionListener?
         let firstPartyHosts: Set<String>
+        let vitalsFrequency: TimeInterval?
     }
 
     struct URLSessionAutoInstrumentation {
@@ -219,7 +220,8 @@ extension FeaturesConfiguration {
                     instrumentation: instrumentation,
                     backgroundEventTrackingEnabled: configuration.rumBackgroundEventTrackingEnabled,
                     onSessionStart: configuration.rumSessionsListener,
-                    firstPartyHosts: sanitizedHosts
+                    firstPartyHosts: sanitizedHosts,
+                    vitalsFrequency: configuration.mobileVitalsFrequency.timeInterval
                 )
             } else {
                 let error = ProgrammerError(
@@ -285,6 +287,17 @@ extension FeaturesConfiguration {
         self.rum = rum
         self.urlSessionAutoInstrumentation = urlSessionAutoInstrumentation
         self.crashReporting = crashReporting
+    }
+}
+
+extension Datadog.Configuration.VitalsFrequency {
+    var timeInterval: TimeInterval? {
+        switch self {
+        case .frequent: return 0.1
+        case .average: return 0.5
+        case .rare: return 1
+        case .never: return nil
+        }
     }
 }
 

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -35,6 +35,19 @@ extension Datadog {
             case rare
         }
 
+        /// Defines the frequency at which Datadog SDK will collect mobile vitals, such as CPU
+        /// and memory usage.
+        public enum VitalsFrequency {
+            /// Collect mobile vitals every 100ms.
+            case frequent
+            /// Collect mobile vitals every 500ms.
+            case average
+            /// Collect mobile vitals every 1000ms.
+            case rare
+            /// Don't provide mobile vitals.
+            case never
+        }
+
         public enum DatadogEndpoint {
             /// US based servers.
             /// Sends data to [app.datadoghq.com](https://app.datadoghq.com/).
@@ -265,6 +278,7 @@ extension Datadog {
         private(set) var rumResourceAttributesProvider: URLSessionRUMAttributesProvider?
         private(set) var rumBackgroundEventTrackingEnabled: Bool
         private(set) var rumTelemetrySamplingRate: Float
+        private(set) var mobileVitalsFrequency: VitalsFrequency
         private(set) var batchSize: BatchSize
         private(set) var uploadFrequency: UploadFrequency
         private(set) var additionalConfiguration: [String: Any]
@@ -339,6 +353,7 @@ extension Datadog {
                     rumResourceAttributesProvider: nil,
                     rumBackgroundEventTrackingEnabled: false,
                     rumTelemetrySamplingRate: 20,
+                    mobileVitalsFrequency: .rare,
                     batchSize: .medium,
                     uploadFrequency: .average,
                     additionalConfiguration: [:],
@@ -705,6 +720,13 @@ extension Datadog {
             ///                   means no telemetry will be sent, 100 means all telemetry will be kept.
             public func set(sampleTelemetry rate: Float) -> Builder {
                 configuration.rumTelemetrySamplingRate = rate
+                return self
+            }
+
+            /// Sets the preferred frequency for collecting mobile vitals.
+            /// - Parameter mobileVitalsFrequency: `.average` by default.
+            public func set(mobileVitalsFrequency: VitalsFrequency) -> Builder {
+                configuration.mobileVitalsFrequency = mobileVitalsFrequency
                 return self
             }
 

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -38,12 +38,8 @@ internal final class RUMFeature {
     let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
     let carrierInfoProvider: CarrierInfoProviderType
     let launchTimeProvider: LaunchTimeProviderType
-
-    let vitalCPUReader: SamplingBasedVitalReader
-    let vitalMemoryReader: SamplingBasedVitalReader
-    let vitalRefreshRateReader: ContinuousVitalReader
-
     let onSessionStart: RUMSessionListener?
+    let telemetry: Telemetry?
 
     // MARK: - Components
 
@@ -147,10 +143,8 @@ internal final class RUMFeature {
             upload: upload,
             configuration: configuration,
             commonDependencies: commonDependencies,
-            vitalCPUReader: VitalCPUReader(telemetry: telemetry),
-            vitalMemoryReader: VitalMemoryReader(),
-            vitalRefreshRateReader: VitalRefreshRateReader(),
-            onSessionStart: configuration.onSessionStart
+            onSessionStart: configuration.onSessionStart,
+            telemetry: telemetry
         )
     }
 
@@ -160,10 +154,8 @@ internal final class RUMFeature {
         upload: FeatureUpload,
         configuration: FeaturesConfiguration.RUM,
         commonDependencies: FeaturesCommonDependencies,
-        vitalCPUReader: SamplingBasedVitalReader,
-        vitalMemoryReader: SamplingBasedVitalReader,
-        vitalRefreshRateReader: ContinuousVitalReader,
-        onSessionStart: RUMSessionListener?
+        onSessionStart: RUMSessionListener?,
+        telemetry: Telemetry?
     ) {
         // Configuration
         self.configuration = configuration
@@ -183,10 +175,8 @@ internal final class RUMFeature {
         self.storage = storage
         self.upload = upload
 
-        self.vitalCPUReader = vitalCPUReader
-        self.vitalMemoryReader = vitalMemoryReader
-        self.vitalRefreshRateReader = vitalRefreshRateReader
         self.onSessionStart = onSessionStart
+        self.telemetry = telemetry
     }
 
     internal func deinitialize() {

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -37,6 +37,7 @@ internal struct RUMScopeDependencies {
     /// Produces `RUMViewUpdatesThrottlerType` for each started RUM view scope.
     let viewUpdatesThrottlerFactory: () -> RUMViewUpdatesThrottlerType
 
+    let vitalFrequency: TimeInterval?
     let vitalCPUReader: SamplingBasedVitalReader
     let vitalMemoryReader: SamplingBasedVitalReader
     let vitalRefreshRateReader: ContinuousVitalReader
@@ -74,6 +75,7 @@ internal extension RUMScopeDependencies {
             crashContextIntegration: RUMWithCrashContextIntegration(),
             ciTest: CITestIntegration.active?.rumCITest,
             viewUpdatesThrottlerFactory: { RUMViewUpdatesThrottler() },
+            vitalFrequency: rumFeature.configuration.vitalsFrequency,
             vitalCPUReader: rumFeature.vitalCPUReader,
             vitalMemoryReader: rumFeature.vitalMemoryReader,
             vitalRefreshRateReader: rumFeature.vitalRefreshRateReader,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -102,7 +102,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         self.vitalInfoSampler = VitalInfoSampler(
             cpuReader: dependencies.vitalCPUReader,
             memoryReader: dependencies.vitalMemoryReader,
-            refreshRateReader: dependencies.vitalRefreshRateReader
+            refreshRateReader: dependencies.vitalRefreshRateReader,
+            frequency: dependencies.vitalFrequency
         )
         self.viewUpdatesThrottler = dependencies.viewUpdatesThrottlerFactory()
     }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -71,7 +71,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     /// It can be toggled from inside `RUMResourceScope`/`RUMUserActionScope` callbacks, as they are called from processing `RUMCommand`s inside `process()`.
     private var needsViewUpdate = false
 
-    private let vitalInfoSampler: VitalInfoSampler
+    private let vitalInfoSampler: VitalInfoSampler?
 
     /// Samples view update events, so we can minimize the number of events in payload.
     private let viewUpdatesThrottler: RUMViewUpdatesThrottlerType
@@ -98,13 +98,14 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         self.viewName = name
         self.viewStartTime = startTime
         self.dateCorrection = dependencies.dateCorrector.currentCorrection
-
-        self.vitalInfoSampler = VitalInfoSampler(
-            cpuReader: dependencies.vitalCPUReader,
-            memoryReader: dependencies.vitalMemoryReader,
-            refreshRateReader: dependencies.vitalRefreshRateReader,
-            frequency: dependencies.vitalFrequency
-        )
+        self.vitalInfoSampler = dependencies.vitalsReaders.map {
+            .init(
+                cpuReader: $0.cpu,
+                memoryReader: $0.memory,
+                refreshRateReader: $0.refreshRate,
+                frequency: $0.frequency
+            )
+        }
         self.viewUpdatesThrottler = dependencies.viewUpdatesThrottlerFactory()
     }
 
@@ -376,10 +377,10 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let isActive = isActiveView || !resourceScopes.isEmpty
         // RUMM-2079 `time_spent` can't be lower than 1ns
         let timeSpent = max(1e-9, command.time.timeIntervalSince(viewStartTime))
-        let cpuInfo = vitalInfoSampler.cpu
-        let memoryInfo = vitalInfoSampler.memory
-        let refreshRateInfo = vitalInfoSampler.refreshRate
-        let isSlowRendered = refreshRateInfo.meanValue.flatMap { $0 < Constants.slowRenderingThresholdFPS }
+        let cpuInfo = vitalInfoSampler?.cpu
+        let memoryInfo = vitalInfoSampler?.memory
+        let refreshRateInfo = vitalInfoSampler?.refreshRate
+        let isSlowRendered = refreshRateInfo?.meanValue.flatMap { $0 < Constants.slowRenderingThresholdFPS }
 
         let eventData = RUMViewEvent(
             dd: .init(
@@ -404,8 +405,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             version: dependencies.applicationVersion,
             view: .init(
                 action: .init(count: actionsCount.toInt64),
-                cpuTicksCount: cpuInfo.greatestDiff,
-                cpuTicksPerSecond: cpuInfo.greatestDiff?.divideIfNotZero(by: Double(timeSpent)),
+                cpuTicksCount: cpuInfo?.greatestDiff,
+                cpuTicksPerSecond: cpuInfo?.greatestDiff?.divideIfNotZero(by: Double(timeSpent)),
                 crash: nil,
                 cumulativeLayoutShift: nil,
                 customTimings: customTimings.reduce(into: [:]) { acc, element in
@@ -428,12 +429,12 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 loadingTime: nil,
                 loadingType: nil,
                 longTask: .init(count: longTasksCount),
-                memoryAverage: memoryInfo.meanValue,
-                memoryMax: memoryInfo.maxValue,
+                memoryAverage: memoryInfo?.meanValue,
+                memoryMax: memoryInfo?.maxValue,
                 name: viewName,
                 referrer: nil,
-                refreshRateAverage: refreshRateInfo.meanValue,
-                refreshRateMin: refreshRateInfo.minValue,
+                refreshRateAverage: refreshRateInfo?.meanValue,
+                refreshRateMin: refreshRateInfo?.minValue,
                 resource: .init(count: resourcesCount.toInt64),
                 timeSpent: timeSpent.toInt64Nanoseconds,
                 url: viewPath

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -23,8 +23,6 @@ internal final class VitalInfoSampler {
         static let normalizedRefreshRate = 60.0
     }
 
-    private static let frequency: TimeInterval = 1.0
-
     let cpuReader: SamplingBasedVitalReader
     private let cpuPublisher = VitalPublisher(initialValue: VitalInfo())
 
@@ -54,7 +52,7 @@ internal final class VitalInfoSampler {
         cpuReader: SamplingBasedVitalReader,
         memoryReader: SamplingBasedVitalReader,
         refreshRateReader: ContinuousVitalReader,
-        frequency: TimeInterval = VitalInfoSampler.frequency,
+        frequency: TimeInterval?,
         maximumRefreshRate: Double = Double(UIScreen.main.maximumFramesPerSecond)
     ) {
         self.cpuReader = cpuReader
@@ -64,6 +62,10 @@ internal final class VitalInfoSampler {
         self.refreshRateReader = refreshRateReader
         self.refreshRateReader.register(self.refreshRatePublisher)
         self.maximumRefreshRate = maximumRefreshRate
+
+        guard let frequency = frequency else {
+            return
+        }
 
         takeSample()
         let timer = Timer(

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -52,7 +52,7 @@ internal final class VitalInfoSampler {
         cpuReader: SamplingBasedVitalReader,
         memoryReader: SamplingBasedVitalReader,
         refreshRateReader: ContinuousVitalReader,
-        frequency: TimeInterval?,
+        frequency: TimeInterval,
         maximumRefreshRate: Double = Double(UIScreen.main.maximumFramesPerSecond)
     ) {
         self.cpuReader = cpuReader
@@ -62,10 +62,6 @@ internal final class VitalInfoSampler {
         self.refreshRateReader = refreshRateReader
         self.refreshRateReader.register(self.refreshRatePublisher)
         self.maximumRefreshRate = maximumRefreshRate
-
-        guard let frequency = frequency else {
-            return
-        }
 
         takeSample()
         let timer = Timer(

--- a/Sources/DatadogObjc/DatadogConfiguration+objc.swift
+++ b/Sources/DatadogObjc/DatadogConfiguration+objc.swift
@@ -143,6 +143,23 @@ public enum DDUploadFrequency: Int {
 }
 
 @objc
+public enum DDVitalsFrequency: Int {
+    case frequent
+    case average
+    case rare
+    case never
+
+    internal var swiftType: Datadog.Configuration.VitalsFrequency {
+        switch self {
+        case .frequent: return .frequent
+        case .average: return .average
+        case .rare: return .rare
+        case .never: return .never
+        }
+    }
+}
+
+@objc
 public protocol DDDataEncryption: AnyObject {
     /// Encrypts given `Data` with user-chosen encryption.
     ///
@@ -377,6 +394,11 @@ public class DDConfigurationBuilder: NSObject {
             let objcEvent = DDRUMLongTaskEvent(swiftModel: swiftEvent)
             return mapper(objcEvent)?.swiftModel
         }
+    }
+
+    @objc
+    public func set(mobileVitalsFrequency: DDVitalsFrequency) {
+        _ = sdkBuilder.set(mobileVitalsFrequency: mobileVitalsFrequency.swiftType)
     }
 
     @objc

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -440,6 +440,44 @@ class FeaturesConfigurationTests: XCTestCase {
         XCTAssertNil(longTaskConfigured.rum!.instrumentation!.uiKitRUMUserActionsPredicate)
     }
 
+    func testMobileVitalsFrequency() throws {
+        var custom = try FeaturesConfiguration(
+            configuration: .mockWith(
+                rumEnabled: true,
+                mobileVitalsFrequency: .average
+            ),
+            appContext: .mockAny()
+        )
+        XCTAssertEqual(custom.rum?.vitalsFrequency, 0.5)
+
+        custom = try FeaturesConfiguration(
+            configuration: .mockWith(
+                rumEnabled: true,
+                mobileVitalsFrequency: .frequent
+            ),
+            appContext: .mockAny()
+        )
+        XCTAssertEqual(custom.rum?.vitalsFrequency, 0.1)
+
+        custom = try FeaturesConfiguration(
+            configuration: .mockWith(
+                rumEnabled: true,
+                mobileVitalsFrequency: .rare
+            ),
+            appContext: .mockAny()
+        )
+        XCTAssertEqual(custom.rum?.vitalsFrequency, 1)
+
+        custom = try FeaturesConfiguration(
+            configuration: .mockWith(
+                rumEnabled: true,
+                mobileVitalsFrequency: .never
+            ),
+            appContext: .mockAny()
+        )
+        XCTAssertNil(custom.rum?.vitalsFrequency)
+    }
+
     // MARK: - Crash Reporting Configuration Tests
 
     func testWhenCrashReportingIsDisabled() throws {

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -57,6 +57,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertNil(configuration.rumErrorEventMapper)
             XCTAssertNil(configuration.rumLongTaskEventMapper)
             XCTAssertNil(configuration.rumResourceAttributesProvider)
+            XCTAssertEqual(configuration.mobileVitalsFrequency, .rare)
             XCTAssertEqual(configuration.batchSize, .medium)
             XCTAssertEqual(configuration.uploadFrequency, .average)
             XCTAssertEqual(configuration.additionalConfiguration.count, 0)
@@ -101,6 +102,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
                 .setRUMActionEventMapper { _ in mockRUMActionEvent }
                 .setRUMLongTaskEventMapper { _ in mockRUMLongTaskEvent }
                 .setRUMResourceAttributesProvider { _, _, _, _ in ["foo": "bar"] }
+                .set(mobileVitalsFrequency: .frequent)
                 .set(batchSize: .small)
                 .set(uploadFrequency: .frequent)
                 .set(additionalConfiguration: ["foo": 42, "bar": "something"])
@@ -162,6 +164,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertEqual(configuration.rumLongTaskEventMapper?(.mockRandom()), mockRUMLongTaskEvent)
             XCTAssertEqual(configuration.rumResourceAttributesProvider?(.mockAny(), nil, nil, nil) as? [String: String], ["foo": "bar"])
             XCTAssertFalse(configuration.rumBackgroundEventTrackingEnabled)
+            XCTAssertEqual(configuration.mobileVitalsFrequency, .frequent)
             XCTAssertEqual(configuration.batchSize, .small)
             XCTAssertEqual(configuration.uploadFrequency, .frequent)
             XCTAssertEqual(configuration.additionalConfiguration["foo"] as? Int, 42)

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -40,10 +40,8 @@ class RUMIntegrationsTests: XCTestCase {
             upload: .mockNoOp(),
             configuration: .mockWith(sessionSampler: .mockRejectAll()),
             commonDependencies: .mockAny(),
-            vitalCPUReader: SamplingBasedVitalReaderMock(),
-            vitalMemoryReader: SamplingBasedVitalReaderMock(),
-            vitalRefreshRateReader: ContinuousVitalReaderMock(),
-            onSessionStart: nil
+            onSessionStart: nil,
+            telemetry: nil
         )
         defer { RUMFeature.instance?.deinitialize() }
 

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -57,6 +57,7 @@ extension Datadog.Configuration {
         rumResourceAttributesProvider: URLSessionRUMAttributesProvider? = nil,
         rumBackgroundEventTrackingEnabled: Bool = false,
         rumTelemetrySamplingRate: Float = 100.0,
+        mobileVitalsFrequency: VitalsFrequency = .average,
         batchSize: BatchSize = .medium,
         uploadFrequency: UploadFrequency = .average,
         additionalConfiguration: [String: Any] = [:],
@@ -88,6 +89,7 @@ extension Datadog.Configuration {
             rumResourceAttributesProvider: rumResourceAttributesProvider,
             rumBackgroundEventTrackingEnabled: rumBackgroundEventTrackingEnabled,
             rumTelemetrySamplingRate: rumTelemetrySamplingRate,
+            mobileVitalsFrequency: mobileVitalsFrequency,
             batchSize: batchSize,
             uploadFrequency: uploadFrequency,
             additionalConfiguration: additionalConfiguration,
@@ -271,7 +273,8 @@ extension FeaturesConfiguration.RUM {
         instrumentation: FeaturesConfiguration.RUM.Instrumentation? = nil,
         backgroundEventTrackingEnabled: Bool = false,
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListener(),
-        firstPartyHosts: Set<String> = []
+        firstPartyHosts: Set<String> = [],
+        vitalsFrequency: TimeInterval? = 0.5
     ) -> Self {
         return .init(
             common: common,
@@ -289,7 +292,8 @@ extension FeaturesConfiguration.RUM {
             instrumentation: instrumentation,
             backgroundEventTrackingEnabled: backgroundEventTrackingEnabled,
             onSessionStart: onSessionStart,
-            firstPartyHosts: firstPartyHosts
+            firstPartyHosts: firstPartyHosts,
+            vitalsFrequency: vitalsFrequency
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -671,6 +671,7 @@ extension RUMScopeDependencies {
         crashContextIntegration: RUMWithCrashContextIntegration? = nil,
         ciTest: RUMCITest? = nil,
         viewUpdatesThrottlerFactory: @escaping () -> RUMViewUpdatesThrottlerType = { NoOpRUMViewUpdatesThrottler() },
+        vitalFrequency: TimeInterval? = nil,
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListener()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -694,6 +695,7 @@ extension RUMScopeDependencies {
             crashContextIntegration: crashContextIntegration,
             ciTest: ciTest,
             viewUpdatesThrottlerFactory: viewUpdatesThrottlerFactory,
+            vitalFrequency: vitalFrequency,
             vitalCPUReader: SamplingBasedVitalReaderMock(),
             vitalMemoryReader: SamplingBasedVitalReaderMock(),
             vitalRefreshRateReader: ContinuousVitalReaderMock(),
@@ -723,6 +725,7 @@ extension RUMScopeDependencies {
         crashContextIntegration: RUMWithCrashContextIntegration? = nil,
         ciTest: RUMCITest? = nil,
         viewUpdatesThrottlerFactory: (() -> RUMViewUpdatesThrottlerType)? = nil,
+        vitalFrequency: TimeInterval? = nil,
         onSessionStart: RUMSessionListener? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -746,6 +749,7 @@ extension RUMScopeDependencies {
             crashContextIntegration: crashContextIntegration ?? self.crashContextIntegration,
             ciTest: ciTest ?? self.ciTest,
             viewUpdatesThrottlerFactory: viewUpdatesThrottlerFactory ?? self.viewUpdatesThrottlerFactory,
+            vitalFrequency: vitalFrequency ?? self.vitalFrequency,
             vitalCPUReader: SamplingBasedVitalReaderMock(),
             vitalMemoryReader: SamplingBasedVitalReaderMock(),
             vitalRefreshRateReader: ContinuousVitalReaderMock(),

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -16,10 +16,8 @@ extension RUMFeature {
             upload: .mockNoOp(),
             configuration: .mockAny(),
             commonDependencies: .mockAny(),
-            vitalCPUReader: SamplingBasedVitalReaderMock(),
-            vitalMemoryReader: SamplingBasedVitalReaderMock(),
-            vitalRefreshRateReader: ContinuousVitalReaderMock(),
-            onSessionStart: nil
+            onSessionStart: nil,
+            telemetry: nil
         )
     }
 
@@ -66,10 +64,8 @@ extension RUMFeature {
             upload: mockedUpload,
             configuration: configuration,
             commonDependencies: dependencies,
-            vitalCPUReader: SamplingBasedVitalReaderMock(),
-            vitalMemoryReader: SamplingBasedVitalReaderMock(),
-            vitalRefreshRateReader: ContinuousVitalReaderMock(),
-            onSessionStart: configuration.onSessionStart
+            onSessionStart: configuration.onSessionStart,
+            telemetry: nil
         )
     }
 
@@ -671,7 +667,7 @@ extension RUMScopeDependencies {
         crashContextIntegration: RUMWithCrashContextIntegration? = nil,
         ciTest: RUMCITest? = nil,
         viewUpdatesThrottlerFactory: @escaping () -> RUMViewUpdatesThrottlerType = { NoOpRUMViewUpdatesThrottler() },
-        vitalFrequency: TimeInterval? = nil,
+        vitalsReaders: VitalsReaders? = nil,
         onSessionStart: @escaping RUMSessionListener = mockNoOpSessionListener()
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -695,10 +691,7 @@ extension RUMScopeDependencies {
             crashContextIntegration: crashContextIntegration,
             ciTest: ciTest,
             viewUpdatesThrottlerFactory: viewUpdatesThrottlerFactory,
-            vitalFrequency: vitalFrequency,
-            vitalCPUReader: SamplingBasedVitalReaderMock(),
-            vitalMemoryReader: SamplingBasedVitalReaderMock(),
-            vitalRefreshRateReader: ContinuousVitalReaderMock(),
+            vitalsReaders: vitalsReaders,
             onSessionStart: onSessionStart
         )
     }
@@ -725,7 +718,7 @@ extension RUMScopeDependencies {
         crashContextIntegration: RUMWithCrashContextIntegration? = nil,
         ciTest: RUMCITest? = nil,
         viewUpdatesThrottlerFactory: (() -> RUMViewUpdatesThrottlerType)? = nil,
-        vitalFrequency: TimeInterval? = nil,
+        vitalsReaders: VitalsReaders? = nil,
         onSessionStart: RUMSessionListener? = nil
     ) -> RUMScopeDependencies {
         return RUMScopeDependencies(
@@ -749,10 +742,7 @@ extension RUMScopeDependencies {
             crashContextIntegration: crashContextIntegration ?? self.crashContextIntegration,
             ciTest: ciTest ?? self.ciTest,
             viewUpdatesThrottlerFactory: viewUpdatesThrottlerFactory ?? self.viewUpdatesThrottlerFactory,
-            vitalFrequency: vitalFrequency ?? self.vitalFrequency,
-            vitalCPUReader: SamplingBasedVitalReaderMock(),
-            vitalMemoryReader: SamplingBasedVitalReaderMock(),
-            vitalRefreshRateReader: ContinuousVitalReaderMock(),
+            vitalsReaders: vitalsReaders ?? self.vitalsReaders,
             onSessionStart: onSessionStart ?? self.onSessionStart
         )
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalInfoSamplerTests.swift
@@ -67,31 +67,6 @@ class VitalInfoSamplerTests: XCTestCase {
         }
     }
 
-    func testItDoesNotSamplePeriodically() {
-        let mockCPUReader = SamplingBasedVitalReaderMock()
-        let mockMemoryReader = SamplingBasedVitalReaderMock()
-
-        let sampler = VitalInfoSampler(
-            cpuReader: mockCPUReader,
-            memoryReader: mockMemoryReader,
-            refreshRateReader: ContinuousVitalReaderMock(),
-            frequency: nil
-        )
-
-        mockCPUReader.vitalData = 123.0
-        mockMemoryReader.vitalData = 321.0
-
-        let samplingExpectation = expectation(description: "sampling expectation")
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
-            samplingExpectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 1.0) { _ in
-            XCTAssertEqual(sampler.cpu.sampleCount, 0)
-            XCTAssertEqual(sampler.memory.sampleCount, 0)
-        }
-    }
-
     func testItSamplesDataFromBackgroundThreads() {
         // swiftlint:disable implicitly_unwrapped_optional
         var sampler: VitalInfoSampler!

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -57,6 +57,7 @@ class DDConfigurationTests: XCTestCase {
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 100.0)
             XCTAssertNil(configuration.rumUIKitViewsPredicate)
             XCTAssertNil(configuration.rumUIKitUserActionsPredicate)
+            XCTAssertEqual(configuration.mobileVitalsFrequency, .rare)
             XCTAssertEqual(configuration.batchSize, .medium)
             XCTAssertEqual(configuration.uploadFrequency, .average)
             XCTAssertNil(configuration.rumViewEventMapper)
@@ -181,6 +182,9 @@ class DDConfigurationTests: XCTestCase {
 
         objcBuilder.set(batchSize: .small)
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.batchSize, .small)
+
+        objcBuilder.set(mobileVitalsFrequency: .frequent)
+        XCTAssertEqual(objcBuilder.build().sdkConfiguration.mobileVitalsFrequency, .frequent)
 
         objcBuilder.set(batchSize: .large)
         XCTAssertEqual(objcBuilder.build().sdkConfiguration.batchSize, .large)

--- a/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
+++ b/Tests/DatadogTests/DatadogObjc/ObjcAPITests/DDConfiguration+apiTests.m
@@ -127,6 +127,7 @@
     [builder setRUMLongTaskEventMapper:^DDRUMLongTaskEvent * _Nullable(DDRUMLongTaskEvent * _Nonnull longTaskEvent) {
         return nil;
     }];
+    [builder setWithMobileVitalsFrequency:DDVitalsFrequencyFrequent];
     [builder setWithBatchSize:DDBatchSizeMedium];
     [builder setWithUploadFrequency:DDUploadFrequencyAverage];
     [builder setWithAdditionalConfiguration:@{}];

--- a/docs/rum_collection/advanced_configuration.md
+++ b/docs/rum_collection/advanced_configuration.md
@@ -251,6 +251,9 @@ You can use the following methods in `Datadog.Configuration.Builder` when creati
 `set(uploadFrequency: UploadFrequency)`
 : Sets the preferred frequency of uploading data to Datadog. Available values include: `.frequent`, `.average`, and `.rare`.
 
+`set(mobileVitalsFrequency: VitalsFrequency)`
+: Sets the preferred frequency of collecting mobile vitals. Available values include: `.frequent` (every 100ms), `.average` (every 500ms), `.rare` (every 1s), and `.never` (disable vitals monitoring).
+
 ### RUM configuration
 
 `enableRUM(_ enabled: Bool)`


### PR DESCRIPTION
### What and why?

Customers can set the desired delay between Mobile Vitals update (CPU/RAM) as follows:

- FREQUENT - every 100ms 
- AVERAGE - 500 ms 
- RARE - 1000ms
- NEVER - don’t provide vitals data

### How?

`VitalInfoSampler` will start the sample timer only if `frequency` parameter is available.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
