### PR TITLE
RUMM-2169 Isolate Logging feature from Core's configuration and dependencies

### DIFF
--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -27,7 +27,6 @@ internal struct FeaturesConfiguration {
     }
 
     struct Logging {
-        let common: Common
         let uploadURL: URL
         let logEventMapper: LogEventMapper?
     }
@@ -171,7 +170,6 @@ extension FeaturesConfiguration {
 
         if configuration.loggingEnabled {
             logging = Logging(
-                common: common,
                 uploadURL: try ifValid(endpointURLString: logsEndpoint.url),
                 logEventMapper: configuration.logEventMapper
             )

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -25,7 +25,8 @@ internal class CrashReporter {
     convenience init?(
         crashReportingFeature: CrashReportingFeature,
         loggingFeature: LoggingFeature?,
-        rumFeature: RUMFeature?
+        rumFeature: RUMFeature?,
+        context: DatadogV1Context
     ) {
         let loggingOrRUMIntegration: CrashReportingIntegration?
 
@@ -33,7 +34,7 @@ internal class CrashReporter {
         if let rumFeature = rumFeature {
             loggingOrRUMIntegration = CrashReportingWithRUMIntegration(rumFeature: rumFeature)
         } else if let loggingFeature = loggingFeature {
-            loggingOrRUMIntegration = CrashReportingWithLoggingIntegration(loggingFeature: loggingFeature)
+            loggingOrRUMIntegration = CrashReportingWithLoggingIntegration(loggingFeature: loggingFeature, context: context)
         } else {
             loggingOrRUMIntegration = nil
         }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -308,7 +308,8 @@ public class Datadog {
             Global.crashReporter = CrashReporter(
                 crashReportingFeature: crashReportingFeature,
                 loggingFeature: logging,
-                rumFeature: rum
+                rumFeature: rum,
+                context: core.v1Context
             )
 
             Global.crashReporter?.sendCrashReportIfFound()

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -52,6 +52,9 @@ internal final class DatadogCore {
 
     private var v1Features: [String: Any] = [:]
 
+    /// The SDK Context for V1.
+    internal let v1Context: DatadogV1Context
+
     /// Creates a core instance.
     ///
     /// - Parameters:
@@ -66,6 +69,7 @@ internal final class DatadogCore {
         self.rootDirectory = rootDirectory
         self.configuration = configuration
         self.dependencies = dependencies
+        self.v1Context = DatadogV1Context(configuration: configuration, dependencies: dependencies)
     }
 
     /// Sets current user information.
@@ -127,11 +131,6 @@ extension DatadogCore: DatadogV1CoreProtocol {
             telemetry: telemetry
         )
 
-        let v1Context = DatadogV1Context(
-            configuration: configuration,
-            dependencies: dependencies
-        )
-
         let upload = FeatureUpload(
             featureName: uploadConfiguration.featureName,
             storage: storage,
@@ -157,6 +156,10 @@ extension DatadogCore: DatadogV1CoreProtocol {
     func feature<T>(_ type: T.Type) -> T? {
         let key = String(describing: T.self)
         return v1Features[key] as? T
+    }
+
+    var context: DatadogV1Context? {
+        return v1Context
     }
 }
 

--- a/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
@@ -12,6 +12,9 @@ import Foundation
 /// - different values for V1 context need to be read either from common configuration or through shared dependencies (providers);
 /// - V1 context is not asynchronous, and some providers block their threads for getting their value.
 ///
+/// `DatadogV1Context` can be safely captured during component initialization. It will never change during component's lifespan, meaning that:
+/// - exposed static configuration won't change;
+/// - bundled provider references won't change (although the value they provide will be different over time).
 internal struct DatadogV1Context {
     private let configuration: CoreConfiguration
     private let dependencies: CoreDependencies
@@ -20,7 +23,12 @@ internal struct DatadogV1Context {
         self.configuration = configuration
         self.dependencies = dependencies
     }
+}
 
+// MARK: - Configuration
+
+/// This extension bundles different parts of the SDK core configuration.
+internal extension DatadogV1Context {
     // MARK: - Datadog Specific
 
     /// The client token allowing for data uploads to [Datadog Site](https://docs.datadoghq.com/getting_started/site/).
@@ -51,6 +59,29 @@ internal struct DatadogV1Context {
     /// The name of the application, read from `Info.plist` (`CFBundleExecutable`).
     var applicationName: String { configuration.applicationName }
 
+    /// The bundle identifier, read from `Info.plist` (`CFBundleIdentifier`).
+    var applicationBundleIdentifier: String { configuration.applicationBundleIdentifier }
+}
+
+// MARK: - Providers
+
+/// This extension bundles different providers managed by the SDK core.
+internal extension DatadogV1Context {
     /// Current device information.
     var mobileDevice: MobileDevice { dependencies.mobileDevice }
+
+    /// Time provider.
+    var dateProvider: DateProvider { dependencies.dateProvider }
+
+    /// NTP time correction provider.
+    var dateCorrector: DateCorrectorType { dependencies.dateCorrector }
+
+    /// Network information provider.
+    var networkConnectionInfoProvider: NetworkConnectionInfoProviderType { dependencies.networkConnectionInfoProvider }
+
+    /// Carrier information provider.
+    var carrierInfoProvider: CarrierInfoProviderType { dependencies.carrierInfoProvider }
+
+    /// User information provider.
+    var userInfoProvider: UserInfoProvider { dependencies.userInfoProvider }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
@@ -31,6 +31,9 @@ internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
     ///   - type: The feature instance type.
     /// - Returns: The feature if any.
     func feature<T>(_ type: T.Type) -> T?
+
+    /// The SDK context created upon core initialization or `nil` if SDK was not yet initialized.
+    var context: DatadogV1Context? { get }
 }
 
 extension NOOPDatadogCore: DatadogV1CoreProtocol {
@@ -41,6 +44,10 @@ extension NOOPDatadogCore: DatadogV1CoreProtocol {
 
     /// no-op
     func feature<T>(_ type: T.Type) -> T? {
+        return nil
+    }
+
+    var context: DatadogV1Context? {
         return nil
     }
 }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
@@ -19,10 +19,9 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
     private let dateProvider: DateProvider
     private let dateCorrector: DateCorrectorType
 
-    /// Global configuration set for the SDK (service name, environment, application version, ...)
-    private let configuration: FeaturesConfiguration.Common
+    private let context: DatadogV1Context
 
-    init(loggingFeature: LoggingFeature) {
+    init(loggingFeature: LoggingFeature, context: DatadogV1Context) {
         self.init(
             logOutput: LogFileOutput(
                 fileWriter: loggingFeature.storage.arbitraryAuthorizedWriter,
@@ -30,9 +29,9 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
                 // issue additional RUM Errors for crash reports. Those are send through `CrashReportingWithRUMIntegration`.
                 rumErrorsIntegration: nil
             ),
-            dateProvider: loggingFeature.dateProvider,
-            dateCorrector: loggingFeature.dateCorrector,
-            configuration: loggingFeature.configuration.common
+            dateProvider: context.dateProvider,
+            dateCorrector: context.dateCorrector,
+            context: context
         )
     }
 
@@ -40,12 +39,12 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
         logOutput: LogOutput,
         dateProvider: DateProvider,
         dateCorrector: DateCorrectorType,
-        configuration: FeaturesConfiguration.Common
+        context: DatadogV1Context
     ) {
         self.logOutput = logOutput
         self.dateProvider = dateProvider
         self.dateCorrector = dateCorrector
-        self.configuration = configuration
+        self.context = context
     }
 
     func send(crashReport: DDCrashReport, with crashContext: CrashContext) {
@@ -85,12 +84,12 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
                 message: crashReport.message,
                 stack: crashReport.stack
             ),
-            serviceName: configuration.serviceName,
-            environment: configuration.environment,
+            serviceName: context.service,
+            environment: context.env,
             loggerName: Constants.loggerName,
-            loggerVersion: configuration.sdkVersion,
+            loggerVersion: context.sdkVersion,
             threadName: nil,
-            applicationVersion: configuration.applicationVersion,
+            applicationVersion: context.version,
             userInfo: .init(
                 id: user?.id,
                 name: user?.name,

--- a/Sources/Datadog/FeaturesIntegration/TracingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/TracingWithLoggingIntegration.swift
@@ -23,7 +23,12 @@ internal struct TracingWithLoggingIntegration {
     /// Actual `LogOutput` bridged to `LoggingFeature`.
     let loggingOutput: LogOutput
 
-    init(tracingFeature: TracingFeature, tracerConfiguration: Tracer.Configuration, loggingFeature: LoggingFeature) {
+    init(
+        tracingFeature: TracingFeature,
+        tracerConfiguration: Tracer.Configuration,
+        loggingFeature: LoggingFeature,
+        context: DatadogV1Context
+    ) {
         self.init(
             logBuilder: LogEventBuilder(
                 sdkVersion: tracingFeature.configuration.common.sdkVersion,
@@ -34,7 +39,7 @@ internal struct TracingWithLoggingIntegration {
                 userInfoProvider: tracingFeature.userInfoProvider,
                 networkConnectionInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.networkConnectionInfoProvider : nil,
                 carrierInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.carrierInfoProvider : nil,
-                dateCorrector: loggingFeature.dateCorrector,
+                dateCorrector: context.dateCorrector,
                 logEventMapper: loggingFeature.configuration.logEventMapper
             ),
             loggingOutput: LogFileOutput(

--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -25,11 +25,26 @@ public extension WKUserContentController {
     ///
     /// - Parameter hosts: a list of hosts instrumented with Browser SDK to capture Datadog events from
     func trackDatadogEvents(in hosts: Set<String>, sdk core: DatadogCoreProtocol = defaultDatadogCore) {
+        do {
+            try trackDatadogEventsOrThrow(in: hosts, sdk: core)
+        } catch {
+            consolePrint("\(error)")
+        }
+    }
+
+    private func trackDatadogEventsOrThrow(in hosts: Set<String>, sdk core: DatadogCoreProtocol) throws {
+        guard let context = core.v1.context else {
+            throw ProgrammerError(
+                description: "`Datadog.initialize()` must be called prior to `trackDatadogEvents(in:)`."
+            )
+        }
+
         addDatadogMessageHandler(
             allowedWebViewHosts: hosts,
             hostsSanitizer: HostsSanitizer(),
             loggingFeature: core.v1.feature(LoggingFeature.self),
-            rumFeature: core.v1.feature(RUMFeature.self)
+            rumFeature: core.v1.feature(RUMFeature.self),
+            context: context
         )
     }
 
@@ -53,7 +68,8 @@ public extension WKUserContentController {
         allowedWebViewHosts: Set<String>,
         hostsSanitizer: HostsSanitizing,
         loggingFeature: LoggingFeature?,
-        rumFeature: RUMFeature?
+        rumFeature: RUMFeature?,
+        context: DatadogV1Context
     ) {
         guard !isTracking else {
               userLogger.warn("`trackDatadogEvents(in:)` was called more than once for the same WebView. Second call will be ignored. Make sure you call it only once.")
@@ -68,10 +84,10 @@ public extension WKUserContentController {
         if let loggingFeature = loggingFeature {
             logEventConsumer = DefaultWebLogEventConsumer(
                 userLogsWriter: loggingFeature.storage.writer,
-                dateCorrector: loggingFeature.dateCorrector,
+                dateCorrector: context.dateCorrector,
                 rumContextProvider: globalRUMMonitor?.contextProvider,
-                applicationVersion: loggingFeature.configuration.common.applicationVersion,
-                environment: loggingFeature.configuration.common.environment
+                applicationVersion: context.version,
+                environment: context.env
             )
         }
 

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -399,15 +399,19 @@ public class Logger {
         }
 
         private func buildOrThrow(in core: DatadogCoreProtocol) throws -> Logger {
-            guard let loggingFeature = core.v1.feature(LoggingFeature.self) else {
+            guard let context = core.v1.context else {
                 throw ProgrammerError(
-                    description: Datadog.isInitialized
-                        ? "`Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."
-                        : "`Datadog.initialize()` must be called prior to `Logger.builder.build()`."
+                    description: "`Datadog.initialize()` must be called prior to `Logger.builder.build()`."
                 )
             }
 
-            let (logBuilder, logOutput) = resolveLogBuilderAndOutput(for: loggingFeature) ?? (nil, nil)
+            guard let loggingFeature = core.v1.feature(LoggingFeature.self) else {
+                throw ProgrammerError(
+                    description: "`Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."
+                )
+            }
+
+            let (logBuilder, logOutput) = resolveLogBuilderAndOutput(for: loggingFeature, context: context) ?? (nil, nil)
 
             // RUMM-2133 Note: strong feature coupling while migrating to v2.
             // In v2 active span will be provided in context from feature scope.
@@ -417,24 +421,24 @@ public class Logger {
             return Logger(
                 logBuilder: logBuilder,
                 logOutput: logOutput,
-                dateProvider: loggingFeature.dateProvider,
-                identifier: resolveLoggerName(for: loggingFeature),
+                dateProvider: context.dateProvider,
+                identifier: resolveLoggerName(with: context),
                 rumContextIntegration: (rumEnabled && bundleWithRUM) ? LoggingWithRUMContextIntegration() : nil,
                 activeSpanIntegration: (tracingEnabled && bundleWithTrace) ? LoggingWithActiveSpanIntegration() : nil
             )
         }
 
-        private func resolveLogBuilderAndOutput(for loggingFeature: LoggingFeature) -> (LogEventBuilder, LogOutput)? {
+        private func resolveLogBuilderAndOutput(for loggingFeature: LoggingFeature, context: DatadogV1Context) -> (LogEventBuilder, LogOutput)? {
             let logBuilder = LogEventBuilder(
-                sdkVersion: loggingFeature.configuration.common.sdkVersion,
-                applicationVersion: loggingFeature.configuration.common.applicationVersion,
-                environment: loggingFeature.configuration.common.environment,
-                serviceName: serviceName ?? loggingFeature.configuration.common.serviceName,
-                loggerName: resolveLoggerName(for: loggingFeature),
-                userInfoProvider: loggingFeature.userInfoProvider,
-                networkConnectionInfoProvider: sendNetworkInfo ? loggingFeature.networkConnectionInfoProvider : nil,
-                carrierInfoProvider: sendNetworkInfo ? loggingFeature.carrierInfoProvider : nil,
-                dateCorrector: loggingFeature.dateCorrector,
+                sdkVersion: context.sdkVersion,
+                applicationVersion: context.version,
+                environment: context.env,
+                serviceName: serviceName ?? context.service,
+                loggerName: resolveLoggerName(with: context),
+                userInfoProvider: context.userInfoProvider,
+                networkConnectionInfoProvider: sendNetworkInfo ? context.networkConnectionInfoProvider : nil,
+                carrierInfoProvider: sendNetworkInfo ? context.carrierInfoProvider : nil,
+                dateCorrector: context.dateCorrector,
                 logEventMapper: loggingFeature.configuration.logEventMapper
             )
 
@@ -470,8 +474,8 @@ public class Logger {
             }
         }
 
-        private func resolveLoggerName(for loggingFeature: LoggingFeature) -> String {
-            return loggerName ?? loggingFeature.configuration.common.applicationBundleIdentifier
+        private func resolveLoggerName(with context: DatadogV1Context) -> String {
+            return loggerName ?? context.applicationBundleIdentifier
         }
     }
 }

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -15,14 +15,6 @@ internal final class LoggingFeature: V1FeatureInitializable {
 
     let configuration: Configuration
 
-    // MARK: - Dependencies
-
-    let dateProvider: DateProvider
-    let dateCorrector: DateCorrectorType
-    let userInfoProvider: UserInfoProvider
-    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
-    let carrierInfoProvider: CarrierInfoProviderType
-
     // MARK: - Components
 
     /// Log files storage.
@@ -36,18 +28,12 @@ internal final class LoggingFeature: V1FeatureInitializable {
         storage: FeatureStorage,
         upload: FeatureUpload,
         configuration: Configuration,
+        /// TODO: RUMM-2169 Remove `commonDependencies` from `V1FeatureInitializable` interface when all Features are migrated to use `DatadogV1Context`:
         commonDependencies: FeaturesCommonDependencies,
         telemetry: Telemetry?
     ) {
         // Configuration
         self.configuration = configuration
-
-        // Bundle dependencies
-        self.dateProvider = commonDependencies.dateProvider
-        self.dateCorrector = commonDependencies.dateCorrector
-        self.userInfoProvider = commonDependencies.userInfoProvider
-        self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
-        self.carrierInfoProvider = commonDependencies.carrierInfoProvider
 
         // Initialize stacks
         self.storage = storage

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -71,6 +71,11 @@ public class Tracer: OTTracer {
     ///   - configuration: the tracer configuration obtained using `Tracer.Configuration()`.
     public static func initialize(configuration: Configuration, in core: DatadogCoreProtocol = defaultDatadogCore) -> OTTracer {
         do {
+            guard let context = core.v1.context else {
+                throw ProgrammerError(
+                    description: "`Datadog.initialize()` must be called prior to `Tracer.initialize()`."
+                )
+            }
             if Global.sharedTracer is Tracer {
                 throw ProgrammerError(
                     description: """
@@ -80,16 +85,15 @@ public class Tracer: OTTracer {
             }
             guard let tracingFeature = core.v1.feature(TracingFeature.self) else {
                 throw ProgrammerError(
-                    description: Datadog.isInitialized
-                        ? "`Tracer.initialize(configuration:)` produces a non-functional tracer, as the tracing feature is disabled."
-                        : "`Datadog.initialize()` must be called prior to `Tracer.initialize()`."
+                    description: "`Tracer.initialize(configuration:)` produces a non-functional tracer, as the tracing feature is disabled."
                 )
             }
             return DDTracer(
                 tracingFeature: tracingFeature,
                 tracerConfiguration: configuration,
                 rumEnabled: core.v1.feature(RUMFeature.self) != nil,
-                loggingFeature: core.v1.feature(LoggingFeature.self)
+                loggingFeature: core.v1.feature(LoggingFeature.self),
+                context: context
             )
         } catch {
             consolePrint("\(error)")
@@ -101,7 +105,8 @@ public class Tracer: OTTracer {
         tracingFeature: TracingFeature,
         tracerConfiguration: Configuration,
         rumEnabled: Bool,
-        loggingFeature: LoggingFeature?
+        loggingFeature: LoggingFeature?,
+        context: DatadogV1Context
     ) {
         self.init(
             spanBuilder: SpanEventBuilder(
@@ -125,7 +130,14 @@ public class Tracer: OTTracer {
             tracingUUIDGenerator: tracingFeature.tracingUUIDGenerator,
             globalTags: tracerConfiguration.globalTags,
             rumContextIntegration: (rumEnabled && tracerConfiguration.bundleWithRUM) ? TracingWithRUMContextIntegration() : nil,
-            loggingIntegration: loggingFeature.map { TracingWithLoggingIntegration(tracingFeature: tracingFeature, tracerConfiguration: tracerConfiguration, loggingFeature: $0) }
+            loggingIntegration: loggingFeature.map {
+                TracingWithLoggingIntegration(
+                    tracingFeature: tracingFeature,
+                    tracerConfiguration: tracerConfiguration,
+                    loggingFeature: $0,
+                    context: context
+                )
+            }
         )
     }
 

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -214,7 +214,8 @@ class CrashReporterTests: XCTestCase {
         let crashReporter = CrashReporter(
             crashReportingFeature: .mockNoOp(),
             loggingFeature: nil,
-            rumFeature: nil
+            rumFeature: nil,
+            context: .mockAny()
         )
 
         // Then

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -287,7 +287,7 @@ class DatadogTests: XCTestCase {
         }
     }
 
-    func testSupplyingDebugLaunchArgument_itOverridesUserSettings() {
+    func testSupplyingDebugLaunchArgument_itOverridesUserSettings() throws {
         let mockProcessInfo = ProcessInfoMock(
             arguments: [Datadog.LaunchArguments.Debug]
         )
@@ -312,11 +312,10 @@ class DatadogTests: XCTestCase {
             bundleType: .iOSApp
         )
 
-        let core = defaultDatadogCore
-        let logging = core.v1.feature(LoggingFeature.self)
+        let core = try XCTUnwrap(defaultDatadogCore as? DatadogCore)
         let tracing = core.v1.feature(TracingFeature.self)
         let rum = core.v1.feature(RUMFeature.self)
-        XCTAssertEqual(logging?.configuration.common.performance, expectedPerformancePreset)
+        XCTAssertEqual(core.configuration.performance, expectedPerformancePreset)
         XCTAssertEqual(rum?.configuration.sessionSampler.samplingRate, 100)
         XCTAssertEqual(tracing?.configuration.common.performance, expectedPerformancePreset)
         XCTAssertEqual(Datadog.verbosityLevel, .debug)

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
@@ -24,7 +24,7 @@ class CrashReportingWithLoggingIntegrationTests: XCTestCase {
             logOutput: logOutput,
             dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
             dateCorrector: DateCorrectorMock(),
-            configuration: .mockAny()
+            context: .mockAny()
         )
         integration.send(crashReport: crashReport, with: crashContext)
 
@@ -82,7 +82,7 @@ class CrashReportingWithLoggingIntegrationTests: XCTestCase {
             logOutput: logOutput,
             dateProvider: RelativeDateProvider(using: .mockRandomInThePast()),
             dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
-            configuration: configuration
+            context: .mockWith(configuration: configuration)
         )
         integration.send(crashReport: crashReport, with: crashContext)
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -482,53 +482,6 @@ class LoggerTests: XCTestCase {
         logMatchers[1].assertTags(equal: ["tag1", "tag2:abcd", "env:tests"])
         logMatchers[2].assertTags(equal: ["env:tests"])
     }
-//
-//    // MARK: - Sending logs with different network and battery conditions
-//
-//    func testGivenBadBatteryConditions_itDoesNotTryToSendLogs() throws {
-//        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-//
-//        let core = DatadogCoreMock(
-//            v1Context: .mockWith(
-//                dependencies: .mockWith(
-//                    mobileDevice: .mockWith(
-//                        currentBatteryStatus: { () -> MobileDevice.BatteryStatus in
-//                            .mockWith(state: .charging, level: 0.05, isLowPowerModeEnabled: true)
-//                        }
-//                    )
-//                )
-//            )
-//        )
-//        defer { core.flush() }
-//
-//        let feature: LoggingFeature = .mockWith(directory: temporaryDirectory)
-//        defer { feature.deinitialize() }
-//        core.register(feature: feature)
-//
-//        let logger = Logger.builder.build(in: core)
-//        logger.debug("message")
-//
-//        server.waitAndAssertNoRequestsSent()
-//    }
-
-//    func testGivenNoNetworkConnection_itDoesNotTryToSendLogs() throws {
-//        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
-//        let feature: LoggingFeature = .mockWith(
-//            directory: temporaryDirectory,
-//            dependencies: .mockWith(
-//                networkConnectionInfoProvider: NetworkConnectionInfoProviderMock.mockWith(
-//                    networkConnectionInfo: .mockWith(reachability: .no)
-//                )
-//            )
-//        )
-//        defer { feature.deinitialize() }
-//        core.register(feature: feature)
-//
-//        let logger = Logger.builder.build(in: core)
-//        logger.debug("message")
-//
-//        server.waitAndAssertNoRequestsSent()
-//    }
 
     // MARK: - Integration With RUM Feature
 
@@ -755,42 +708,6 @@ class LoggerTests: XCTestCase {
             logDate == deviceTime.addingTimeInterval(serverTimeDifference)
         }
     }
-//
-//    // MARK: - Tracking Consent
-//
-//    func testWhenChangingConsentValues_itUploadsOnlyAuthorizedLogs() throws {
-//        let consentProvider = ConsentProvider(initialConsent: .pending)
-//
-//        // Given
-//        let core = DatadogCoreMock(
-//            v1Context: .mockWith(
-//                dependencies: .mockWith(
-//                    consentProvider: consentProvider
-//                )
-//            )
-//        )
-//        defer { core.flush() }
-//
-//        let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
-//        core.register(feature: logging)
-//
-//        let logger = Logger.builder.build(in: core)
-//
-//        // When
-//        logger.info("message in `.pending` consent changed to `.granted`")
-//        consentProvider.changeConsent(to: .granted)
-//        logger.info("message in `.granted` consent")
-//        consentProvider.changeConsent(to: .notGranted)
-//        logger.info("message in `.notGranted` consent")
-//        consentProvider.changeConsent(to: .granted)
-//        logger.info("another message in `.granted` consent")
-//
-//        // Then
-//        let logMatchers = try logging.waitAndReturnLogMatchers(count: 3)
-//        logMatchers[0].assertMessage(equals: "message in `.pending` consent changed to `.granted`")
-//        logMatchers[1].assertMessage(equals: "message in `.granted` consent")
-//        logMatchers[2].assertMessage(equals: "another message in `.granted` consent")
-//    }
 
     // MARK: - Thread safety
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -9,12 +9,17 @@ import XCTest
 
 // swiftlint:disable multiline_arguments_brackets
 class LoggerTests: XCTestCase {
+    private var core: DatadogCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
     override func setUp() {
         super.setUp()
         temporaryDirectory.create()
+        core = DatadogCoreMock()
     }
 
     override func tearDown() {
+        core.flush()
+        core = nil
         temporaryDirectory.delete()
         super.tearDown()
     }
@@ -22,21 +27,18 @@ class LoggerTests: XCTestCase {
     // MARK: - Customizing Logger
 
     func testSendingLogWithDefaultLogger() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                configuration: .mockWith(
-                    applicationVersion: "1.0.0",
-                    applicationBundleIdentifier: "com.datadoghq.ios-sdk",
-                    serviceName: "default-service-name",
-                    environment: "tests",
-                    sdkVersion: "1.2.3"
-                ),
-                dependencies: .mockWith(
-                    dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
-                )
+        core.v1Context = .mockWith(
+            configuration: .mockWith(
+                applicationVersion: "1.0.0",
+                applicationBundleIdentifier: "com.datadoghq.ios-sdk",
+                serviceName: "default-service-name",
+                environment: "tests",
+                sdkVersion: "1.2.3"
+            ),
+            dependencies: .mockWith(
+                dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
             )
         )
-        defer { core.flush() }
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -61,8 +63,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testSendingLogWithCustomizedLogger() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -95,14 +96,11 @@ class LoggerTests: XCTestCase {
     // MARK: - Sending Customized Logs
 
     func testSendingLogsWithDifferentDates() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    dateProvider: RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC(), advancingBySeconds: 1)
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                dateProvider: RelativeDateProvider(startingFrom: .mockDecember15th2019At10AMUTC(), advancingBySeconds: 1)
             )
         )
-        defer { core.flush() }
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -119,8 +117,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testSendingLogsWithDifferentLevels() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -145,8 +142,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Logging an error
 
     func testLoggingError() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -177,14 +173,11 @@ class LoggerTests: XCTestCase {
     func testSendingUserInfo() throws {
         let userInfoProvider = UserInfoProvider()
 
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    userInfoProvider: userInfoProvider
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                userInfoProvider: userInfoProvider
             )
         )
-        defer { core.flush() }
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -236,14 +229,11 @@ class LoggerTests: XCTestCase {
     func testSendingCarrierInfoWhenEnteringAndLeavingCellularServiceRange() throws {
         let carrierInfoProvider = CarrierInfoProviderMock(carrierInfo: nil)
 
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    carrierInfoProvider: carrierInfoProvider
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                carrierInfoProvider: carrierInfoProvider
             )
         )
-        defer { core.flush() }
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -282,14 +272,11 @@ class LoggerTests: XCTestCase {
     func testSendingNetworkConnectionInfoWhenReachabilityChanges() throws {
         let networkConnectionInfoProvider = NetworkConnectionInfoProviderMock.mockAny()
 
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    networkConnectionInfoProvider: networkConnectionInfoProvider
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                networkConnectionInfoProvider: networkConnectionInfoProvider
             )
         )
-        defer { core.flush() }
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -345,8 +332,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Sending attributes
 
     func testSendingLoggerAttributesOfDifferentEncodableValues() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -412,8 +398,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testSendingMessageAttributes() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -444,12 +429,9 @@ class LoggerTests: XCTestCase {
     // MARK: - Sending tags
 
     func testSendingTags() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                configuration: .mockWith(environment: "tests")
-            )
+        core.v1Context = .mockWith(
+            configuration: .mockWith(environment: "tests")
         )
-        defer { core.flush() }
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: feature)
@@ -486,8 +468,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Integration With RUM Feature
 
     func testGivenBundlingWithRUMEnabledAndRUMMonitorRegistered_whenSendingLog_itContainsCurrentRUMContext() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -526,8 +507,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testGivenBundlingWithRUMEnabledButRUMMonitorNotRegistered_whenSendingLog_itPrintsWarning() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -563,8 +543,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testWhenSendingErrorOrCriticalLogs_itCreatesRUMErrorForCurrentView() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let logging: LoggingFeature = .mockNoOp()
         core.register(feature: logging)
@@ -610,8 +589,7 @@ class LoggerTests: XCTestCase {
     // MARK: - Integration With Active Span
 
     func testGivenBundlingWithTraceEnabledAndTracerRegistered_whenSendingLog_itContainsActiveSpanAttributes() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -645,8 +623,7 @@ class LoggerTests: XCTestCase {
     }
 
     func testGivenBundlingWithTraceEnabledButTracerNotRegistered_whenSendingLog_itPrintsWarning() throws {
-        let core = DatadogCoreMock(v1Context: .mockAny())
-        defer { core.flush() }
+        core.v1Context = .mockAny()
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -685,15 +662,13 @@ class LoggerTests: XCTestCase {
         // Given
         let deviceTime: Date = .mockDecember15th2019At10AMUTC()
         let serverTimeDifference = TimeInterval.random(in: -5..<5).rounded() // few seconds difference
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    dateProvider: RelativeDateProvider(using: deviceTime),
-                    dateCorrector: DateCorrectorMock(correctionOffset: serverTimeDifference)
-                )
+
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                dateProvider: RelativeDateProvider(using: deviceTime),
+                dateCorrector: DateCorrectorMock(correctionOffset: serverTimeDifference)
             )
         )
-        defer { core.flush() }
 
         // When
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
@@ -752,7 +727,7 @@ class LoggerTests: XCTestCase {
         defer { consolePrint = { print($0) } }
 
         // given
-        let core = DatadogCoreMock(v1Context: nil)
+        core.v1Context = nil
 
         // when
         let logger = Logger.builder.build(in: core)
@@ -772,7 +747,7 @@ class LoggerTests: XCTestCase {
         defer { consolePrint = { print($0) } }
 
         // given
-        let core = DatadogCoreMock(v1Context: .mockAny())
+        core.v1Context = .mockAny()
         XCTAssertNil(core.feature(LoggingFeature.self))
 
         // when

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -222,12 +222,10 @@ extension FeaturesConfiguration.Logging {
     static func mockAny() -> Self { mockWith() }
 
     static func mockWith(
-        common: FeaturesConfiguration.Common = .mockAny(),
         uploadURL: URL = .mockAny(),
         logEventMapper: LogEventMapper? = nil
     ) -> Self {
         return .init(
-            common: common,
             uploadURL: uploadURL,
             logEventMapper: logEventMapper
         )

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -9,6 +9,11 @@ import Foundation
 
 internal final class DatadogCoreMock: Flushable {
     private var v1Features: [String: Any] = [:]
+    private var v1Context: DatadogV1Context
+
+    init(v1Context: DatadogV1Context = .mockAny()) {
+        self.v1Context = v1Context
+    }
 
     /// Flush resgistered features.
     ///
@@ -39,6 +44,10 @@ extension DatadogCoreMock: DatadogV1CoreProtocol {
     func feature<T>(_ type: T.Type) -> T? {
         let key = String(describing: T.self)
         return v1Features[key] as? T
+    }
+
+    var context: Any {
+        return v1Context
     }
 }
 
@@ -78,5 +87,21 @@ extension RUMInstrumentation: Flushable {
 extension URLSessionAutoInstrumentation: Flushable {
     func flush() {
         deinitialize()
+    }
+}
+
+extension DatadogV1Context: AnyMockable {
+    static func mockAny() -> DatadogV1Context {
+        return mockWith()
+    }
+
+    static func mockWith(
+        configuration: CoreConfiguration = .mockAny(),
+        dependencies: CoreDependencies = .mockAny()
+    ) -> DatadogV1Context {
+        return DatadogV1Context(
+            configuration: configuration,
+            dependencies: dependencies
+        )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -9,9 +9,9 @@ import Foundation
 
 internal final class DatadogCoreMock: Flushable {
     private var v1Features: [String: Any] = [:]
-    private var v1Context: DatadogV1Context
+    private var v1Context: DatadogV1Context?
 
-    init(v1Context: DatadogV1Context = .mockAny()) {
+    init(v1Context: DatadogV1Context? = .mockAny()) {
         self.v1Context = v1Context
     }
 
@@ -46,7 +46,7 @@ extension DatadogCoreMock: DatadogV1CoreProtocol {
         return v1Features[key] as? T
     }
 
-    var context: Any {
+    var context: DatadogV1Context? {
         return v1Context
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -9,7 +9,8 @@ import Foundation
 
 internal final class DatadogCoreMock: Flushable {
     private var v1Features: [String: Any] = [:]
-    private var v1Context: DatadogV1Context?
+
+    var v1Context: DatadogV1Context?
 
     init(v1Context: DatadogV1Context? = .mockAny()) {
         self.v1Context = v1Context

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1203,7 +1203,8 @@ class RUMMonitorTests: XCTestCase {
         Global.crashReporter = CrashReporter(
             crashReportingFeature: crashReporting,
             loggingFeature: nil,
-            rumFeature: rum
+            rumFeature: rum,
+            context: .mockAny()
         )
         defer { Global.crashReporter = nil }
 

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -9,15 +9,17 @@ import XCTest
 
 // swiftlint:disable multiline_arguments_brackets
 class TracerTests: XCTestCase {
-    let core = DatadogCoreMock()
+    private var core: DatadogCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUp() {
         super.setUp()
         temporaryDirectory.create()
+        core = DatadogCoreMock()
     }
 
     override func tearDown() {
         core.flush()
+        core = nil
         temporaryDirectory.delete()
         super.tearDown()
     }
@@ -615,14 +617,11 @@ class TracerTests: XCTestCase {
     // MARK: - Integration With Logging Feature
 
     func testSendingSpanLogs() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { core.flush() }
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -662,14 +661,11 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { core.flush() }
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -701,14 +697,11 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { core.flush() }
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -746,14 +739,11 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromSwiftError() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defer { core.flush() }
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -1034,7 +1024,7 @@ class TracerTests: XCTestCase {
         defer { consolePrint = { print($0) } }
 
         // given
-        let core = DatadogCoreMock(v1Context: nil)
+        core.v1Context = nil
 
         // when
         let tracer = Tracer.initialize(configuration: .init(), in: core)

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -615,13 +615,16 @@ class TracerTests: XCTestCase {
     // MARK: - Integration With Logging Feature
 
     func testSendingSpanLogs() throws {
-        let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+        let core = DatadogCoreMock(
+            v1Context: .mockWith(
+                dependencies: .mockWith(
+                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+                )
             )
         )
+        defer { core.flush() }
 
+        let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
@@ -659,12 +662,16 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
-        let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+        let core = DatadogCoreMock(
+            v1Context: .mockWith(
+                dependencies: .mockWith(
+                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+                )
             )
         )
+        defer { core.flush() }
+
+        let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
@@ -694,12 +701,16 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
-        let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+        let core = DatadogCoreMock(
+            v1Context: .mockWith(
+                dependencies: .mockWith(
+                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+                )
             )
         )
+        defer { core.flush() }
+
+        let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
@@ -735,12 +746,16 @@ class TracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromSwiftError() throws {
-        let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+        let core = DatadogCoreMock(
+            v1Context: .mockWith(
+                dependencies: .mockWith(
+                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+                )
             )
         )
+        defer { core.flush() }
+
+        let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
@@ -1019,7 +1034,7 @@ class TracerTests: XCTestCase {
         defer { consolePrint = { print($0) } }
 
         // given
-        XCTAssertFalse(Datadog.isInitialized)
+        let core = DatadogCoreMock(v1Context: nil)
 
         // when
         let tracer = Tracer.initialize(configuration: .init(), in: core)

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -34,10 +34,9 @@ class DDDatadogTests: XCTestCase {
 
         XCTAssertTrue(Datadog.isInitialized)
 
-        let logging = defaultDatadogCore.v1.feature(LoggingFeature.self)
         let urlSessionInstrumentation = defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self)
-        XCTAssertEqual(logging?.configuration.common.applicationName, "app-name")
-        XCTAssertEqual(logging?.configuration.common.environment, "tests")
+        XCTAssertEqual(defaultDatadogCore.v1.context?.applicationName, "app-name")
+        XCTAssertEqual(defaultDatadogCore.v1.context?.env, "tests")
         XCTAssertNotNil(urlSessionInstrumentation)
 
         urlSessionInstrumentation?.swizzler.unswizzle()

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -17,7 +17,7 @@ class DDLoggerTests: XCTestCase {
         Datadog.initialize(
             appContext: .mockAny(),
             trackingConsent: .granted,
-            configuration: .mockAny()
+            configuration: .mockWith(environment: "test")
         )
     }
 
@@ -144,10 +144,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSettingTagsAndAttributes() throws {
-        let feature: LoggingFeature = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
-            configuration: .mockWith(common: .mockWith(environment: "test"))
-        )
+        let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defaultDatadogCore.v1.register(feature: feature)
 
         let objcLogger = DDLogger.builder().build()

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -9,18 +9,20 @@ import XCTest
 @testable import DatadogObjc
 
 class DDTracerTests: XCTestCase {
-    let core = DatadogCoreMock()
+    private var core: DatadogCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUp() {
         super.setUp()
         temporaryDirectory.create()
+        core = DatadogCoreMock()
         defaultDatadogCore = core
     }
 
     override func tearDown() {
-        core.flush()
-        temporaryDirectory.delete()
         defaultDatadogCore = NOOPDatadogCore()
+        core.flush()
+        core = nil
+        temporaryDirectory.delete()
         super.tearDown()
     }
 
@@ -117,18 +119,11 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogs() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defaultDatadogCore = core
-        defer {
-            core.flush()
-            defaultDatadogCore = NOOPDatadogCore()
-        }
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -157,18 +152,11 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defaultDatadogCore = core
-        defer {
-            core.flush()
-            defaultDatadogCore = NOOPDatadogCore()
-        }
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
@@ -200,18 +188,11 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
-        let core = DatadogCoreMock(
-            v1Context: .mockWith(
-                dependencies: .mockWith(
-                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-                )
+        core.v1Context = .mockWith(
+            dependencies: .mockWith(
+                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
             )
         )
-        defaultDatadogCore = core
-        defer {
-            core.flush()
-            defaultDatadogCore = NOOPDatadogCore()
-        }
 
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -117,12 +117,21 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogs() throws {
-        let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+        let core = DatadogCoreMock(
+            v1Context: .mockWith(
+                dependencies: .mockWith(
+                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+                )
             )
         )
+        defaultDatadogCore = core
+        defer {
+            core.flush()
+            defaultDatadogCore = NOOPDatadogCore()
+        }
+
+        let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
@@ -130,8 +139,6 @@ class DDTracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             )
         )
-
-        core.register(feature: logging)
         core.register(feature: tracing)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
@@ -150,12 +157,21 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
-        let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+        let core = DatadogCoreMock(
+            v1Context: .mockWith(
+                dependencies: .mockWith(
+                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+                )
             )
         )
+        defaultDatadogCore = core
+        defer {
+            core.flush()
+            defaultDatadogCore = NOOPDatadogCore()
+        }
+
+        let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
@@ -163,8 +179,6 @@ class DDTracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             )
         )
-
-        core.register(feature: logging)
         core.register(feature: tracing)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
@@ -186,12 +200,21 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
-        let logging: LoggingFeature = .mockByRecordingLogMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+        let core = DatadogCoreMock(
+            v1Context: .mockWith(
+                dependencies: .mockWith(
+                    performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
+                )
             )
         )
+        defaultDatadogCore = core
+        defer {
+            core.flush()
+            defaultDatadogCore = NOOPDatadogCore()
+        }
+
+        let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
+        core.register(feature: logging)
 
         let tracing: TracingFeature = .mockByRecordingSpanMatchers(
             directory: temporaryDirectory,
@@ -199,8 +222,6 @@ class DDTracerTests: XCTestCase {
                 performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
             )
         )
-
-        core.register(feature: logging)
         core.register(feature: tracing)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())


### PR DESCRIPTION
### What and why?

🔨🧰 This PR makes `LoggingFeature` no longer depend on `CoreConfiguration` and `CoreDependencies`.

This refactoring is required to better isolate Feature modules from Core implementation. It prepares the codebase for further introduction of SDK context in V2.

### How?

There are two main changes and everything else is mainly their consequence:
* Common configuration is now removed from `FeaturesConfiguration.Logging`
```diff
struct Logging {
-   let common: Common
   let uploadURL: URL
   let logEventMapper: LogEventMapper?
}
```
* Common dependencies are now removed from `LoggingFeature` interface
```diff
internal final class LoggingFeature: V1FeatureInitializable {
   // ...

-   // MARK: - Dependencies
- 
-   let dateProvider: DateProvider
-   let dateCorrector: DateCorrectorType
-   let userInfoProvider: UserInfoProvider
-   let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
-   let carrierInfoProvider: CarrierInfoProviderType

   // ...
}
```

In V2 both, "common configuration" and "common dependencies" will belong to the Core module and their values will be passed through SDK context.

🎁 I made a bonus change, which should help us in transitioning to V2-like Features testing. The way we now create `LoggingFeature` in tests does no longer depend on dummy `DatadogCore` instance. Instead, the feature is instantiated with mocked `FeatureStorage` and `FeatureUpload`:
* `FeatureUpload` is now 100% no-op as we won't need any uploads in V2 Features tests;
* `FeatureStorage` uses new `InMemoryWriter`, which records events in-memory and returns them back for assertions.

This bonus change is only scoped to configuration update in `LoggingFeatureMocks` and addition of `InMemoryWriter`. It's transparent for everything else.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
