### PR TITLE
RUMM-2169 Isolate Tracing feature from Core's configuration and dependencies

### DIFF
--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -32,7 +32,6 @@ internal struct FeaturesConfiguration {
     }
 
     struct Tracing {
-        let common: Common
         let uploadURL: URL
         let uuidGenerator: TracingUUIDGenerator
         let spanEventMapper: SpanEventMapper?
@@ -177,7 +176,6 @@ extension FeaturesConfiguration {
 
         if configuration.tracingEnabled {
             tracing = Tracing(
-                common: common,
                 uploadURL: try ifValid(endpointURLString: tracesEndpoint.url),
                 uuidGenerator: DefaultTracingUUIDGenerator(),
                 spanEventMapper: configuration.spanEventMapper

--- a/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
@@ -34,6 +34,9 @@ internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
 
     /// The SDK context created upon core initialization or `nil` if SDK was not yet initialized.
     var context: DatadogV1Context? { get }
+
+    /// Telemetry monitor for this instance of the SDK or `nil` if not configured.
+    var telemetry: Telemetry? { get }
 }
 
 extension NOOPDatadogCore: DatadogV1CoreProtocol {
@@ -48,6 +51,10 @@ extension NOOPDatadogCore: DatadogV1CoreProtocol {
     }
 
     var context: DatadogV1Context? {
+        return nil
+    }
+
+    var telemetry: Telemetry? {
         return nil
     }
 }

--- a/Sources/Datadog/FeaturesIntegration/TracingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/TracingWithLoggingIntegration.swift
@@ -24,21 +24,20 @@ internal struct TracingWithLoggingIntegration {
     let loggingOutput: LogOutput
 
     init(
-        tracingFeature: TracingFeature,
         tracerConfiguration: Tracer.Configuration,
         loggingFeature: LoggingFeature,
         context: DatadogV1Context
     ) {
         self.init(
             logBuilder: LogEventBuilder(
-                sdkVersion: tracingFeature.configuration.common.sdkVersion,
-                applicationVersion: tracingFeature.configuration.common.applicationVersion,
-                environment: tracingFeature.configuration.common.environment,
-                serviceName: tracerConfiguration.serviceName ?? tracingFeature.configuration.common.serviceName,
+                sdkVersion: context.sdkVersion,
+                applicationVersion: context.version,
+                environment: context.env,
+                serviceName: tracerConfiguration.serviceName ?? context.service,
                 loggerName: "trace",
-                userInfoProvider: tracingFeature.userInfoProvider,
-                networkConnectionInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.networkConnectionInfoProvider : nil,
-                carrierInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.carrierInfoProvider : nil,
+                userInfoProvider: context.userInfoProvider,
+                networkConnectionInfoProvider: tracerConfiguration.sendNetworkInfo ? context.networkConnectionInfoProvider : nil,
+                carrierInfoProvider: tracerConfiguration.sendNetworkInfo ? context.carrierInfoProvider : nil,
                 dateCorrector: context.dateCorrector,
                 logEventMapper: loggingFeature.configuration.logEventMapper
             ),

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -93,6 +93,7 @@ public class Tracer: OTTracer {
                 tracerConfiguration: configuration,
                 rumEnabled: core.v1.feature(RUMFeature.self) != nil,
                 loggingFeature: core.v1.feature(LoggingFeature.self),
+                telemetry: core.v1.telemetry,
                 context: context
             )
         } catch {
@@ -106,33 +107,33 @@ public class Tracer: OTTracer {
         tracerConfiguration: Configuration,
         rumEnabled: Bool,
         loggingFeature: LoggingFeature?,
+        telemetry: Telemetry?,
         context: DatadogV1Context
     ) {
         self.init(
             spanBuilder: SpanEventBuilder(
-                sdkVersion: tracingFeature.configuration.common.sdkVersion,
-                applicationVersion: tracingFeature.configuration.common.applicationVersion,
-                serviceName: tracerConfiguration.serviceName ?? tracingFeature.configuration.common.serviceName,
-                userInfoProvider: tracingFeature.userInfoProvider,
-                networkConnectionInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.networkConnectionInfoProvider : nil,
-                carrierInfoProvider: tracerConfiguration.sendNetworkInfo ? tracingFeature.carrierInfoProvider : nil,
-                dateCorrector: tracingFeature.dateCorrector,
-                source: tracingFeature.configuration.common.source,
-                origin: tracingFeature.configuration.common.origin ,
+                sdkVersion: context.sdkVersion,
+                applicationVersion: context.version,
+                serviceName: tracerConfiguration.serviceName ?? context.service,
+                userInfoProvider: context.userInfoProvider,
+                networkConnectionInfoProvider: tracerConfiguration.sendNetworkInfo ? context.networkConnectionInfoProvider : nil,
+                carrierInfoProvider: tracerConfiguration.sendNetworkInfo ? context.carrierInfoProvider : nil,
+                dateCorrector: context.dateCorrector,
+                source: context.source,
+                origin: context.ciAppOrigin,
                 eventsMapper: tracingFeature.configuration.spanEventMapper,
-                telemetry: tracingFeature.telemetry
+                telemetry: telemetry
             ),
             spanOutput: SpanFileOutput(
                 fileWriter: tracingFeature.storage.writer,
-                environment: tracingFeature.configuration.common.environment
+                environment: context.env
             ),
-            dateProvider: tracingFeature.dateProvider,
-            tracingUUIDGenerator: tracingFeature.tracingUUIDGenerator,
+            dateProvider: context.dateProvider,
+            tracingUUIDGenerator: tracingFeature.configuration.uuidGenerator,
             globalTags: tracerConfiguration.globalTags,
             rumContextIntegration: (rumEnabled && tracerConfiguration.bundleWithRUM) ? TracingWithRUMContextIntegration() : nil,
             loggingIntegration: loggingFeature.map {
                 TracingWithLoggingIntegration(
-                    tracingFeature: tracingFeature,
                     tracerConfiguration: tracerConfiguration,
                     loggingFeature: $0,
                     context: context

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -15,16 +15,6 @@ internal final class TracingFeature: V1FeatureInitializable {
 
     let configuration: Configuration
 
-    // MARK: - Dependencies
-
-    let dateProvider: DateProvider
-    let dateCorrector: DateCorrectorType
-    let tracingUUIDGenerator: TracingUUIDGenerator
-    let userInfoProvider: UserInfoProvider
-    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
-    let carrierInfoProvider: CarrierInfoProviderType
-    let telemetry: Telemetry?
-
     // MARK: - Components
 
     /// Span files storage.
@@ -38,20 +28,12 @@ internal final class TracingFeature: V1FeatureInitializable {
         storage: FeatureStorage,
         upload: FeatureUpload,
         configuration: FeaturesConfiguration.Tracing,
+        /// TODO: RUMM-2169 Remove `commonDependencies` from `V1FeatureInitializable` interface when all Features are migrated to use `DatadogV1Context`:
         commonDependencies: FeaturesCommonDependencies,
         telemetry: Telemetry?
     ) {
         // Configuration
         self.configuration = configuration
-
-        // Bundle dependencies
-        self.dateProvider = commonDependencies.dateProvider
-        self.dateCorrector = commonDependencies.dateCorrector
-        self.tracingUUIDGenerator = configuration.uuidGenerator
-        self.userInfoProvider = commonDependencies.userInfoProvider
-        self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
-        self.carrierInfoProvider = commonDependencies.carrierInfoProvider
-        self.telemetry = telemetry
 
         // Initialize stacks
         self.storage = storage

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -313,11 +313,9 @@ class DatadogTests: XCTestCase {
         )
 
         let core = try XCTUnwrap(defaultDatadogCore as? DatadogCore)
-        let tracing = core.v1.feature(TracingFeature.self)
         let rum = core.v1.feature(RUMFeature.self)
         XCTAssertEqual(core.configuration.performance, expectedPerformancePreset)
         XCTAssertEqual(rum?.configuration.sessionSampler.samplingRate, 100)
-        XCTAssertEqual(tracing?.configuration.common.performance, expectedPerformancePreset)
         XCTAssertEqual(Datadog.verbosityLevel, .debug)
 
         // Clear default verbosity after this test

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -237,13 +237,11 @@ extension FeaturesConfiguration.Tracing {
     static func mockAny() -> Self { mockWith() }
 
     static func mockWith(
-        common: FeaturesConfiguration.Common = .mockAny(),
         uploadURL: URL = .mockAny(),
         uuidGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator(),
         spanEventMapper: SpanEventMapper? = nil
     ) -> Self {
         return .init(
-            common: common,
             uploadURL: uploadURL,
             uuidGenerator: uuidGenerator,
             spanEventMapper: spanEventMapper

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -50,6 +50,10 @@ extension DatadogCoreMock: DatadogV1CoreProtocol {
     var context: DatadogV1Context? {
         return v1Context
     }
+
+    var telemetry: Telemetry? {
+        return nil
+    }
 }
 
 /// `Flushable` object resets its state on flush.

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -11,18 +11,19 @@ import XCTest
 // swiftlint:disable multiline_arguments_brackets
 // swiftlint:disable compiler_protocol_init
 class DDLoggerTests: XCTestCase {
+    private var core: DatadogCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
     override func setUp() {
         super.setUp()
         temporaryDirectory.create()
-        Datadog.initialize(
-            appContext: .mockAny(),
-            trackingConsent: .granted,
-            configuration: .mockWith(environment: "test")
-        )
+        core = DatadogCoreMock()
+        defaultDatadogCore = core
     }
 
     override func tearDown() {
-        Datadog.flushAndDeinitialize()
+        defaultDatadogCore = NOOPDatadogCore()
+        core.flush()
+        core = nil
         temporaryDirectory.delete()
         super.tearDown()
     }
@@ -144,6 +145,10 @@ class DDLoggerTests: XCTestCase {
     }
 
     func testSettingTagsAndAttributes() throws {
+        core.v1Context = .mockWith(
+            configuration: .mockWith(environment: "test")
+        )
+
         let feature: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         defaultDatadogCore.v1.register(feature: feature)
 

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -119,21 +119,10 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogs() throws {
-        core.v1Context = .mockWith(
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-            )
-        )
-
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
 
-        let tracing: TracingFeature = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
-            )
-        )
+        let tracing: TracingFeature = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
         core.register(feature: tracing)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
@@ -152,21 +141,10 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromArguments() throws {
-        core.v1Context = .mockWith(
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-            )
-        )
-
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
 
-        let tracing: TracingFeature = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
-            )
-        )
+        let tracing: TracingFeature = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
         core.register(feature: tracing)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())
@@ -188,21 +166,10 @@ class DDTracerTests: XCTestCase {
     }
 
     func testSendingSpanLogsWithErrorFromNSError() throws {
-        core.v1Context = .mockWith(
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .readAllFiles, uploadPerformance: .veryQuick)
-            )
-        )
-
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
         core.register(feature: logging)
 
-        let tracing: TracingFeature = .mockByRecordingSpanMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                performance: .combining(storagePerformance: .noOp, uploadPerformance: .noOp)
-            )
-        )
+        let tracing: TracingFeature = .mockByRecordingSpanMatchers(directory: temporaryDirectory)
         core.register(feature: tracing)
 
         let objcTracer = DDTracer(configuration: DDTracerConfiguration())


### PR DESCRIPTION
### What and why?

🔨🧰 A counterpart of #877 but for `TracingFeature`.

> This refactoring is required to better isolate Feature modules from Core implementation. It prepares the codebase for further introduction of SDK context in V2.

### How?

Common configuration is now removed from `FeaturesConfiguration.Tracing`:
```diff
struct Tracing {
-    let common: Common
    let uploadURL: URL
    let uuidGenerator: TracingUUIDGenerator
    let spanEventMapper: SpanEventMapper?
}
```

Common dependencies are now removed from `TracingFeature` interface:
```diff
internal final class TracingFeature: V1FeatureInitializable {
   // ...

-    // MARK: - Dependencies
-    let dateProvider: DateProvider
-    let dateCorrector: DateCorrectorType
-    let tracingUUIDGenerator: TracingUUIDGenerator
-    let userInfoProvider: UserInfoProvider
-    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
-    let carrierInfoProvider: CarrierInfoProviderType
-    let telemetry: Telemetry?

   // ...
}
```

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
