### PR TITLE
RUMM-2169 Isolate RUM feature from Core's configuration and dependencies

### DIFF
--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -44,7 +44,6 @@ internal struct FeaturesConfiguration {
             let longTaskThreshold: TimeInterval?
         }
 
-        let common: Common
         let uploadURL: URL
         let applicationID: String
         let sessionSampler: Sampler
@@ -199,7 +198,6 @@ extension FeaturesConfiguration {
 
             if let rumApplicationID = configuration.rumApplicationID {
                 rum = RUM(
-                    common: common,
                     uploadURL: try ifValid(endpointURLString: rumEndpoint.url),
                     applicationID: rumApplicationID,
                     sessionSampler: Sampler(samplingRate: debugOverride ? 100.0 : configuration.rumSessionsSamplingRate),

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -32,7 +32,7 @@ internal class CrashReporter {
 
         // If RUM rum is enabled prefer it for sending crash reports, otherwise use Logging feature.
         if let rumFeature = rumFeature {
-            loggingOrRUMIntegration = CrashReportingWithRUMIntegration(rumFeature: rumFeature)
+            loggingOrRUMIntegration = CrashReportingWithRUMIntegration(rumFeature: rumFeature, context: context)
         } else if let loggingFeature = loggingFeature {
             loggingOrRUMIntegration = CrashReportingWithLoggingIntegration(loggingFeature: loggingFeature, context: context)
         } else {

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -236,7 +236,7 @@ public class Datadog {
                 in: core,
                 sdkVersion: configuration.common.sdkVersion,
                 applicationID: rumConfiguration.applicationID,
-                source: rumConfiguration.common.source,
+                source: configuration.common.source,
                 dateProvider: dateProvider,
                 dateCorrector: dateCorrector,
                 sampler: rumConfiguration.telemetrySampler

--- a/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
@@ -61,6 +61,9 @@ internal extension DatadogV1Context {
 
     /// The bundle identifier, read from `Info.plist` (`CFBundleIdentifier`).
     var applicationBundleIdentifier: String { configuration.applicationBundleIdentifier }
+
+    /// Date of SDK initialization measured in device time (without NTP correction).
+    var sdkInitDate: Date { dependencies.sdkInitDate }
 }
 
 // MARK: - Providers
@@ -84,4 +87,10 @@ internal extension DatadogV1Context {
 
     /// User information provider.
     var userInfoProvider: UserInfoProvider { dependencies.userInfoProvider }
+
+    /// Provides the history of app foreground / background states and lets subscribe for their updates.
+    var appStateListener: AppStateListening { dependencies.appStateListener }
+
+    /// Provides the information about application launch time.
+    var launchTimeProvider: LaunchTimeProviderType { dependencies.launchTimeProvider }
 }

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
@@ -37,7 +37,7 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
 
     init(
         logOutput: LogOutput,
-        dateProvider: DateProvider,
+        dateProvider: DateProvider, // TODO: RUMM-2169 use context for injecting `dateProvider` and `dateCorrector`
         dateCorrector: DateCorrectorType,
         context: DatadogV1Context
     ) {

--- a/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
+++ b/Sources/Datadog/FeaturesIntegration/WebView/WKUserContentController+Datadog.swift
@@ -95,10 +95,10 @@ public extension WKUserContentController {
         if let rumFeature = rumFeature {
             rumEventConsumer = DefaultWebRUMEventConsumer(
                 dataWriter: rumFeature.storage.writer,
-                dateCorrector: rumFeature.dateCorrector,
+                dateCorrector: context.dateCorrector,
                 contextProvider: globalRUMMonitor?.contextProvider,
                 rumCommandSubscriber: globalRUMMonitor,
-                dateProvider: rumFeature.dateProvider
+                dateProvider: context.dateProvider
             )
         }
 

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -17,20 +17,9 @@ internal final class RUMFeature: V1FeatureInitializable {
 
     // MARK: - Dependencies
 
-    let sdkInitDate: Date
-    let dateProvider: DateProvider
-    let dateCorrector: DateCorrectorType
-    let appStateListener: AppStateListening
-    let userInfoProvider: UserInfoProvider
-    let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
-    let carrierInfoProvider: CarrierInfoProviderType
-    let launchTimeProvider: LaunchTimeProviderType
-
     let vitalCPUReader: SamplingBasedVitalReader
     let vitalMemoryReader: SamplingBasedVitalReader
     let vitalRefreshRateReader: ContinuousVitalReader
-
-    let onSessionStart: RUMSessionListener?
 
     // MARK: - Components
 
@@ -39,71 +28,26 @@ internal final class RUMFeature: V1FeatureInitializable {
     /// RUM upload worker.
     let upload: FeatureUpload
 
-    /// RUM events mapper.
-    let eventsMapper: RUMEventsMapper
-
     // MARK: - Initialization
 
-    convenience init(
+    init(
         storage: FeatureStorage,
         upload: FeatureUpload,
         configuration: Configuration,
+        /// TODO: RUMM-2169 Remove `commonDependencies` from `V1FeatureInitializable` interface when all Features are migrated to use `DatadogV1Context`:
         commonDependencies: FeaturesCommonDependencies,
         telemetry: Telemetry?
-    ) {
-        self.init(
-            eventsMapper: RUMEventsMapper(
-                viewEventMapper: configuration.viewEventMapper,
-                errorEventMapper: configuration.errorEventMapper,
-                resourceEventMapper: configuration.resourceEventMapper,
-                actionEventMapper: configuration.actionEventMapper,
-                longTaskEventMapper: configuration.longTaskEventMapper,
-                telemetry: telemetry
-            ),
-            storage: storage,
-            upload: upload,
-            configuration: configuration,
-            commonDependencies: commonDependencies,
-            vitalCPUReader: VitalCPUReader(telemetry: telemetry),
-            vitalMemoryReader: VitalMemoryReader(),
-            vitalRefreshRateReader: VitalRefreshRateReader(),
-            onSessionStart: configuration.onSessionStart
-        )
-    }
-
-    init(
-        eventsMapper: RUMEventsMapper,
-        storage: FeatureStorage,
-        upload: FeatureUpload,
-        configuration: FeaturesConfiguration.RUM,
-        commonDependencies: FeaturesCommonDependencies,
-        vitalCPUReader: SamplingBasedVitalReader,
-        vitalMemoryReader: SamplingBasedVitalReader,
-        vitalRefreshRateReader: ContinuousVitalReader,
-        onSessionStart: RUMSessionListener?
     ) {
         // Configuration
         self.configuration = configuration
 
-        // Bundle dependencies
-        self.sdkInitDate = commonDependencies.sdkInitDate
-        self.dateProvider = commonDependencies.dateProvider
-        self.dateCorrector = commonDependencies.dateCorrector
-        self.appStateListener = commonDependencies.appStateListener
-        self.userInfoProvider = commonDependencies.userInfoProvider
-        self.networkConnectionInfoProvider = commonDependencies.networkConnectionInfoProvider
-        self.carrierInfoProvider = commonDependencies.carrierInfoProvider
-        self.launchTimeProvider = commonDependencies.launchTimeProvider
-
         // Initialize stacks
-        self.eventsMapper = eventsMapper
         self.storage = storage
         self.upload = upload
 
-        self.vitalCPUReader = vitalCPUReader
-        self.vitalMemoryReader = vitalMemoryReader
-        self.vitalRefreshRateReader = vitalRefreshRateReader
-        self.onSessionStart = onSessionStart
+        self.vitalCPUReader = VitalCPUReader(telemetry: telemetry)
+        self.vitalMemoryReader = VitalMemoryReader()
+        self.vitalRefreshRateReader = VitalRefreshRateReader()
     }
 
     internal func deinitialize() {

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -15,12 +15,6 @@ internal final class RUMFeature: V1FeatureInitializable {
 
     let configuration: Configuration
 
-    // MARK: - Dependencies
-
-    let vitalCPUReader: SamplingBasedVitalReader
-    let vitalMemoryReader: SamplingBasedVitalReader
-    let vitalRefreshRateReader: ContinuousVitalReader
-
     // MARK: - Components
 
     /// RUM files storage.
@@ -44,10 +38,6 @@ internal final class RUMFeature: V1FeatureInitializable {
         // Initialize stacks
         self.storage = storage
         self.upload = upload
-
-        self.vitalCPUReader = VitalCPUReader(telemetry: telemetry)
-        self.vitalMemoryReader = VitalMemoryReader()
-        self.vitalRefreshRateReader = VitalRefreshRateReader()
     }
 
     internal func deinitialize() {

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegrationTests.swift
@@ -28,11 +28,15 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: currentDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: 0),
             rumConfiguration: .mockWith(
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
                 backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: currentDate),
+                    dateCorrector: DateCorrectorMock(correctionOffset: 0)
+                )
             )
         )
 
@@ -61,11 +65,14 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: currentDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: 0),
             rumConfiguration: .mockWith(
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
                 backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: currentDate)
+                )
             )
         )
 
@@ -92,11 +99,15 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: currentDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: 0),
             rumConfiguration: .mockWith(
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
                 backgroundEventTrackingEnabled: true // BET enabled
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: currentDate),
+                    dateCorrector: DateCorrectorMock(correctionOffset: 0)
+                )
             )
         )
 
@@ -124,11 +135,15 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: currentDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: 0),
             rumConfiguration: .mockWith(
                 sessionSampler: .mockKeepAll(),
                 backgroundEventTrackingEnabled: true
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: currentDate),
+                    dateCorrector: DateCorrectorMock(correctionOffset: 0)
+                )
             )
         )
 
@@ -151,11 +166,15 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
-            dateCorrector: DateCorrectorMock(),
             rumConfiguration: .mockWith(
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling
                 backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()),
+                    dateCorrector: DateCorrectorMock()
+                )
             )
         )
 
@@ -181,11 +200,14 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: currentDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: 0),
             rumConfiguration: .mockWith(
                 sessionSampler: .mockRejectAll(), // no sampling (no session should be sent)
                 backgroundEventTrackingEnabled: true
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: currentDate)
+                )
             )
         )
 
@@ -210,11 +232,15 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let dateCorrectionOffset: TimeInterval = .mockRandom()
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: crashDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
             rumConfiguration: .mockWith(
                 sessionSampler: .mockKeepAll(),
                 backgroundEventTrackingEnabled: false // BET disabled
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: crashDate),
+                    dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset)
+                )
             )
         )
 
@@ -244,11 +270,14 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
 
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: currentDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: 0),
             rumConfiguration: .mockWith(
                 sessionSampler: .mockRandom(), // no matter current session sampling
                 backgroundEventTrackingEnabled: .mockRandom()
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: currentDate)
+                )
             )
         )
 
@@ -276,11 +305,15 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let dateCorrectionOffset: TimeInterval = .mockRandom()
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(using: crashDate),
-            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
             rumConfiguration: .mockWith(
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
                 backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: crashDate),
+                    dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset)
+                )
             )
         )
         integration.send(crashReport: crashReport, with: crashContext)
@@ -364,15 +397,19 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
         let dateCorrectionOffset: TimeInterval = .mockRandom(min: 1, max: 5)
         let integration = CrashReportingWithRUMIntegration(
             rumEventOutput: rumEventOutput,
-            dateProvider: RelativeDateProvider(
-                using: crashDate.addingTimeInterval(
-                    .mockRandom(min: 10, max: 2 * CrashReportingWithRUMIntegration.Constants.viewEventAvailabilityThreshold) // simulate restarting app from 10s to 8h later
-                )
-            ),
-            dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
             rumConfiguration: .mockWith(
                 sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled)
                 backgroundEventTrackingEnabled: .mockRandom() // no matter BET
+            ),
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(
+                        using: crashDate.addingTimeInterval(
+                            .mockRandom(min: 10, max: 2 * CrashReportingWithRUMIntegration.Constants.viewEventAvailabilityThreshold) // simulate restarting app from 10s to 8h later
+                        )
+                    ),
+                    dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset)
+                )
             )
         )
         integration.send(crashReport: crashReport, with: crashContext)
@@ -455,15 +492,19 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
             let dateCorrectionOffset: TimeInterval = .mockRandom()
             let integration = CrashReportingWithRUMIntegration(
                 rumEventOutput: rumEventOutput,
-                dateProvider: RelativeDateProvider(using: crashDate),
-                dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
                 rumConfiguration: .mockWith(
-                    common: .mockWith(
-                        source: randomSource
-                    ),
                     applicationID: randomRUMAppID,
                     sessionSampler: Bool.random() ? .mockKeepAll() : .mockRejectAll(), // no matter sampling (as previous session was sampled),
                     backgroundEventTrackingEnabled: backgroundEventsTrackingEnabled
+                ),
+                context: .mockWith(
+                    configuration: .mockWith(
+                        source: randomSource
+                    ),
+                    dependencies: .mockWith(
+                        dateProvider: RelativeDateProvider(using: crashDate),
+                        dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset)
+                    )
                 )
             )
 
@@ -589,12 +630,16 @@ class CrashReportingWithRUMIntegrationTests: XCTestCase {
             let dateCorrectionOffset: TimeInterval = .mockRandom()
             let integration = CrashReportingWithRUMIntegration(
                 rumEventOutput: rumEventOutput,
-                dateProvider: RelativeDateProvider(using: crashDate),
-                dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset),
                 rumConfiguration: .mockWith(
                     applicationID: randomRUMAppID,
                     sessionSampler: .mockKeepAll(),
                     backgroundEventTrackingEnabled: backgroundEventsTrackingEnabled
+                ),
+                context: .mockWith(
+                    dependencies: .mockWith(
+                        dateProvider: RelativeDateProvider(using: crashDate),
+                        dateCorrector: DateCorrectorMock(correctionOffset: dateCorrectionOffset)
+                    )
                 )
             )
 

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -42,15 +42,11 @@ class RUMIntegrationsTests: XCTestCase {
 
     func testGivenRUMMonitorRegistered_whenSessionIsRejectedBySampler_itProvidesEmptyRUMContextAttributes() throws {
         let rum = RUMFeature(
-            eventsMapper: .mockNoOp(),
             storage: .mockNoOp(),
             upload: .mockNoOp(),
             configuration: .mockWith(sessionSampler: .mockRejectAll()),
             commonDependencies: .mockAny(),
-            vitalCPUReader: SamplingBasedVitalReaderMock(),
-            vitalMemoryReader: SamplingBasedVitalReaderMock(),
-            vitalRefreshRateReader: ContinuousVitalReaderMock(),
-            onSessionStart: nil
+            telemetry: nil
         )
         core.register(feature: rum)
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -543,7 +543,8 @@ class LoggerTests: XCTestCase {
     }
 
     func testWhenSendingErrorOrCriticalLogs_itCreatesRUMErrorForCurrentView() throws {
-        core.v1Context = .mockAny()
+        let v1Context: DatadogV1Context = .mockAny()
+        core.v1Context = v1Context
 
         let logging: LoggingFeature = .mockNoOp()
         core.register(feature: logging)
@@ -554,9 +555,13 @@ class LoggerTests: XCTestCase {
         // given
         let logger = Logger.builder.build(in: core)
         Global.rum = RUMMonitor(
-            dependencies: RUMScopeDependencies(rumFeature: rum, crashReportingFeature: nil)
-                .replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
-            dateProvider: rum.dateProvider
+            dependencies: RUMScopeDependencies(
+                rumFeature: rum,
+                crashReportingFeature: nil,
+                context: v1Context,
+                telemetry: nil
+            ).replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
+            dateProvider: v1Context.dateProvider
         )
         Global.rum.startView(viewController: mockView)
         defer { Global.rum = DDNoopRUMMonitor() }

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -98,14 +98,14 @@ class LoggingFeatureTests: XCTestCase {
                     storagePerformance: StoragePerformanceMock(
                         maxFileSize: .max,
                         maxDirectorySize: .max,
-                        maxFileAgeForWrite: .distantFuture, // write all spans to single file,
+                        maxFileAgeForWrite: .distantFuture, // write all events to single file,
                         minFileAgeForRead: StoragePerformanceMock.readAllFiles.minFileAgeForRead,
                         maxFileAgeForRead: StoragePerformanceMock.readAllFiles.maxFileAgeForRead,
                         maxObjectsInFile: 3, // write 3 spans to payload,
                         maxObjectSize: .max
                     ),
                     uploadPerformance: UploadPerformanceMock(
-                        initialUploadDelay: 0.5, // wait enough until spans are written,
+                        initialUploadDelay: 0.5, // wait enough until events are written,
                         minUploadDelay: 1,
                         maxUploadDelay: 1,
                         uploadDelayChangeRate: 0

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -253,7 +253,6 @@ extension FeaturesConfiguration.RUM {
     static func mockAny() -> Self { mockWith() }
 
     static func mockWith(
-        common: FeaturesConfiguration.Common = .mockAny(),
         uploadURL: URL = .mockAny(),
         applicationID: String = .mockAny(),
         sessionSampler: Sampler = .mockKeepAll(),
@@ -270,7 +269,6 @@ extension FeaturesConfiguration.RUM {
         firstPartyHosts: Set<String> = []
     ) -> Self {
         return .init(
-            common: common,
             uploadURL: uploadURL,
             applicationID: applicationID,
             sessionSampler: sessionSampler,

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -178,17 +178,10 @@ class WKUserContentController_DatadogTests: XCTestCase {
         )
         defer { core.flush() }
 
-        let dateProvider = RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
         let logging: LoggingFeature = .mockByRecordingLogMatchers(directory: temporaryDirectory)
-
-        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
-            directory: temporaryDirectory,
-            dependencies: .mockWith(
-                dateProvider: dateProvider
-            )
-        )
-
         core.register(feature: logging)
+
+        let rum: RUMFeature = .mockByRecordingRUMEventMatchers(directory: temporaryDirectory)
         core.register(feature: rum)
 
         Global.rum = RUMMonitor.initialize(in: core)

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -99,14 +99,14 @@ class TracingFeatureTests: XCTestCase {
                     storagePerformance: StoragePerformanceMock(
                         maxFileSize: .max,
                         maxDirectorySize: .max,
-                        maxFileAgeForWrite: .distantFuture, // write all spans to single file,
+                        maxFileAgeForWrite: .distantFuture, // write all events to single file,
                         minFileAgeForRead: StoragePerformanceMock.readAllFiles.minFileAgeForRead,
                         maxFileAgeForRead: StoragePerformanceMock.readAllFiles.maxFileAgeForRead,
                         maxObjectsInFile: 3, // write 3 spans to payload,
                         maxObjectSize: .max
                     ),
                     uploadPerformance: UploadPerformanceMock(
-                        initialUploadDelay: 0.5, // wait enough until spans are written,
+                        initialUploadDelay: 0.5, // wait enough until events are written,
                         minUploadDelay: 1,
                         maxUploadDelay: 1,
                         uploadDelayChangeRate: 0


### PR DESCRIPTION
### What and why?

🔨🧰 A counterpart of https://github.com/DataDog/dd-sdk-ios/pull/877 but for the `RUMFeature`.

> This refactoring is required to better isolate Feature modules from Core implementation. It prepares the codebase for further introduction of SDK context in V2.

### How?

Common configuration is now removed from `FeaturesConfiguration.RUM`:
```diff
struct RUM {
    // ...

-   let common: Common
    let uploadURL: URL
    let applicationID: String
    let sessionSampler: Sampler
    // ...
}
```

Common dependencies are now removed from `RUMFeature` interface:
```diff
internal final class RUMFeature: V1FeatureInitializable {
   // ...

-   // MARK: - Dependencies
-   let sdkInitDate: Date
-   let dateProvider: DateProvider
-   let dateCorrector: DateCorrectorType
-   let appStateListener: AppStateListening
-   let userInfoProvider: UserInfoProvider
-   let networkConnectionInfoProvider: NetworkConnectionInfoProviderType
-   let carrierInfoProvider: CarrierInfoProviderType
-   let launchTimeProvider: LaunchTimeProviderType

-   let vitalCPUReader: SamplingBasedVitalReader
-   let vitalMemoryReader: SamplingBasedVitalReader
-   let vitalRefreshRateReader: ContinuousVitalReader

-   let onSessionStart: RUMSessionListener?

   // ...
}
```

🚚 There will be one more PR on this subject which will consolidate all `TODOs` and cleanup this new concept. It is only possible now, after all Features are migrated to the new flow.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
