### PR TITLE
RUMM-2171 Use core feature scope in Logger

### DIFF
--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -209,19 +209,7 @@ public class Datadog {
             dependencies: commonDependencies
         )
 
-        // First, initialize internal loggers:
-        let internalLoggerConfiguration = InternalLoggerConfiguration(
-            sdkVersion: configuration.common.sdkVersion,
-            applicationVersion: configuration.common.applicationVersion,
-            environment: configuration.common.environment,
-            userInfoProvider: userInfoProvider,
-            networkConnectionInfoProvider: networkConnectionInfoProvider,
-            carrierInfoProvider: carrierInfoProvider
-        )
-
-        userLogger = createSDKUserLogger(configuration: internalLoggerConfiguration)
-
-        // Then, initialize features:
+        // First, initialize features:
         var telemetry: Telemetry?
         var logging: LoggingFeature?
         var tracing: TracingFeature?
@@ -299,6 +287,9 @@ public class Datadog {
 
         core.v1.feature(RUMInstrumentation.self)?.enable()
         core.v1.feature(URLSessionAutoInstrumentation.self)?.enable()
+
+        // Then, initialize internal loggers:
+        userLogger = createSDKUserLogger(in: core)
 
         defaultDatadogCore = core
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -193,7 +193,7 @@ internal struct DatadogCoreFeatureScope: V1FeatureScope {
     let storage: FeatureStorage
     let telemetry: Telemetry?
 
-    func execute(_ block: (DatadogV1Context, Writer) throws -> Void) {
+    func eventWriteContext(_ block: (DatadogV1Context, Writer) throws -> Void) {
         do {
             try block(context, storage.writer)
         } catch {

--- a/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
@@ -20,6 +20,12 @@ extension DatadogCoreProtocol {
 internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
     // MARK: - V1 interface
 
+    /// The SDK context created upon core initialization or `nil` if SDK was not yet initialized.
+    var context: DatadogV1Context? { get }
+
+    /// Telemetry monitor for this instance of the SDK or `nil` if not configured.
+    var telemetry: Telemetry? { get }
+
     /// Registers a feature instance by its type description.
     ///
     /// - Parameter instance: The feaure instance to register
@@ -32,15 +38,38 @@ internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
     /// - Returns: The feature if any.
     func feature<T>(_ type: T.Type) -> T?
 
-    /// The SDK context created upon core initialization or `nil` if SDK was not yet initialized.
-    var context: DatadogV1Context? { get }
+    /// Returns a Feature scope for a given feature type.
+    ///
+    /// A feature instance of the given type must be registered, otherwise return `nil`.
+    ///
+    /// - Parameters:
+    ///   - type: The feature instance type.
+    /// - Returns: The feature scope if available.
+    func scope<T>(for featureType: T.Type) -> V1FeatureScope?
+}
 
-    /// Telemetry monitor for this instance of the SDK or `nil` if not configured.
-    var telemetry: Telemetry? { get }
+/// Feature scope in v1 provide a context and a writer to build a record event.
+internal protocol V1FeatureScope {
+    /// Execute the given block in the feature scope.
+    ///
+    /// The feature scope provide the current Datadog context and event writer
+    /// for the feature to build and record events.
+    ///
+    /// - Parameter block: The block to execute.
+    func execute(_ block: (DatadogV1Context, Writer) throws -> Void)
 }
 
 extension NOOPDatadogCore: DatadogV1CoreProtocol {
     // MARK: - V1 interface
+
+    /// Returns `nil`.
+    var context: DatadogV1Context? {
+        return nil
+    }
+
+    var telemetry: Telemetry? {
+        return nil
+    }
 
     /// no-op
     func register<T>(feature instance: T?) {}
@@ -50,11 +79,8 @@ extension NOOPDatadogCore: DatadogV1CoreProtocol {
         return nil
     }
 
-    var context: DatadogV1Context? {
-        return nil
-    }
-
-    var telemetry: Telemetry? {
+    /// no-op
+    func scope<T>(for featureType: T.Type) -> V1FeatureScope? {
         return nil
     }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
@@ -50,13 +50,13 @@ internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
 
 /// Feature scope in v1 provide a context and a writer to build a record event.
 internal protocol V1FeatureScope {
-    /// Execute the given block in the feature scope.
+    /// Retrieve the event context and writer.
     ///
     /// The Feature scope provides the current Datadog context and event writer
     /// for the Feature to build and record events.
     ///
     /// - Parameter block: The block to execute.
-    func execute(_ block: (DatadogV1Context, Writer) throws -> Void)
+    func eventWriteContext(_ block: (DatadogV1Context, Writer) throws -> Void)
 }
 
 extension NOOPDatadogCore: DatadogV1CoreProtocol {

--- a/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
@@ -40,7 +40,7 @@ internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
 
     /// Returns a Feature scope for a given feature type.
     ///
-    /// A feature instance of the given type must be registered, otherwise return `nil`.
+    /// A Feature instance of the given type must be registered, otherwise return `nil`.
     ///
     /// - Parameters:
     ///   - type: The feature instance type.
@@ -52,8 +52,8 @@ internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
 internal protocol V1FeatureScope {
     /// Execute the given block in the feature scope.
     ///
-    /// The feature scope provide the current Datadog context and event writer
-    /// for the feature to build and record events.
+    /// The Feature scope provides the current Datadog context and event writer
+    /// for the Feature to build and record events.
     ///
     /// - Parameter block: The block to execute.
     func execute(_ block: (DatadogV1Context, Writer) throws -> Void)

--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegration.swift
@@ -24,10 +24,7 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
     init(loggingFeature: LoggingFeature, context: DatadogV1Context) {
         self.init(
             logOutput: LogFileOutput(
-                fileWriter: loggingFeature.storage.arbitraryAuthorizedWriter,
-                // The RUM Errors integration is not set for this instance of the `LogFileOutput` we don't want to
-                // issue additional RUM Errors for crash reports. Those are send through `CrashReportingWithRUMIntegration`.
-                rumErrorsIntegration: nil
+                fileWriter: loggingFeature.storage.arbitraryAuthorizedWriter
             ),
             dateProvider: context.dateProvider,
             dateCorrector: context.dateCorrector,

--- a/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
@@ -35,3 +35,12 @@ internal struct LoggingWithRUMErrorsIntegration {
         )
     }
 }
+
+extension LoggingWithRUMErrorsIntegration: LogOutput {
+    /// Writes `critical` and `error` logs to RUM.
+    func write(log: LogEvent) {
+        if log.status == .error || log.status == .critical {
+            addError(for: log)
+        }
+    }
+}

--- a/Sources/Datadog/FeaturesIntegration/TracingWithLoggingIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/TracingWithLoggingIntegration.swift
@@ -42,12 +42,7 @@ internal struct TracingWithLoggingIntegration {
                 logEventMapper: loggingFeature.configuration.logEventMapper
             ),
             loggingOutput: LogFileOutput(
-                fileWriter: loggingFeature.storage.writer,
-
-                // The RUM Errors integration is not set for this instance of the `LogFileOutput`, as RUM Errors for
-                // spans are managed through more comprehensive `TracingWithRUMErrorsIntegration`.
-                // Having additional integration here would produce duplicated RUM Errors for span errors set through `span.log()` API.
-                rumErrorsIntegration: nil
+                fileWriter: loggingFeature.storage.writer
             )
         )
     }

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -58,38 +58,54 @@ public enum LogLevel: Int, Codable {
 public typealias DDLogger = Logger
 
 public class Logger {
-    /// Builds the `Log` from user input; `nil` for no-op logger.
-    internal let logBuilder: LogEventBuilder?
-    /// Writes the `Log` to file; `nil` for no-op logger.
-    internal let logOutput: LogOutput?
-    /// Provides date for log creation.
-    private let dateProvider: DateProvider
+    internal typealias LogEventValidation = (LogEvent) -> Bool
+
+    internal let core: DatadogCoreProtocol
     /// Attributes associated with every log.
     private var loggerAttributes: [String: Encodable] = [:]
     /// Taggs associated with every log.
     private var loggerTags: Set<String> = []
     /// Queue ensuring thread-safety of the `Logger`. It synchronizes tags and attributes mutation.
     private let queue: DispatchQueue
+
+    internal let serviceName: String?
+    internal let loggerName: String?
+    internal let sendNetworkInfo: Bool
+    internal let useCoreOutput: Bool
+    internal let validate: LogEventValidation
+    internal let additionalOutput: LogOutput?
+    /// Log events mapper configured by the user, `nil` if not set.
+    internal let logEventMapper: LogEventMapper?
     /// Integration with RUM Context. `nil` if disabled for this Logger or if the RUM feature disabled.
     internal let rumContextIntegration: LoggingWithRUMContextIntegration?
     /// Integration with Tracing. `nil` if disabled for this Logger or if the Tracing feature disabled.
     internal let activeSpanIntegration: LoggingWithActiveSpanIntegration?
 
     init(
-        logBuilder: LogEventBuilder?,
-        logOutput: LogOutput?,
-        dateProvider: DateProvider,
+        core: DatadogCoreProtocol,
         identifier: String,
+        serviceName: String?,
+        loggerName: String?,
+        sendNetworkInfo: Bool,
+        useCoreOutput: Bool,
+        validation: LogEventValidation?,
         rumContextIntegration: LoggingWithRUMContextIntegration?,
-        activeSpanIntegration: LoggingWithActiveSpanIntegration?
+        activeSpanIntegration: LoggingWithActiveSpanIntegration?,
+        additionalOutput: LogOutput?,
+        logEventMapper: LogEventMapper?
     ) {
-        self.logBuilder = logBuilder
-        self.logOutput = logOutput
-        self.dateProvider = dateProvider
+        self.core = core
         self.queue = DispatchQueue(
             label: "com.datadoghq.logger-\(identifier)",
             target: .global(qos: .userInteractive)
         )
+        self.serviceName = serviceName
+        self.loggerName = loggerName
+        self.sendNetworkInfo = sendNetworkInfo
+        self.useCoreOutput = useCoreOutput
+        self.validate = validation ?? { _ in true }
+        self.additionalOutput = additionalOutput
+        self.logEventMapper = logEventMapper
         self.rumContextIntegration = rumContextIntegration
         self.activeSpanIntegration = activeSpanIntegration
     }
@@ -244,10 +260,6 @@ public class Logger {
     // MARK: - Private
 
     private func log(level: LogLevel, message: String, error: Error?, messageAttributes: [String: Encodable]?) {
-        guard let logBuilder = logBuilder, let logOutput = logOutput else {
-            return // ignore, as the `Logger` is no-op
-        }
-
         var combinedUserAttributes = messageAttributes ?? [:]
         combinedUserAttributes = queue.sync {
             return self.loggerAttributes.merging(combinedUserAttributes) { _, userAttributeValue in
@@ -267,20 +279,41 @@ public class Logger {
             return self.loggerTags
         }
 
-        let log = logBuilder.createLogWith(
-            level: level,
-            message: message,
-            error: error.flatMap { DDError(error: $0) },
-            date: dateProvider.currentDate(),
-            attributes: LogEvent.Attributes(
-                userAttributes: combinedUserAttributes,
-                internalAttributes: combinedInternalAttributes
-            ),
-            tags: tags
-        )
+        core.v1.scope(for: LoggingFeature.self)?.execute { context, writer in
+            let builder = LogEventBuilder(
+                sdkVersion: context.sdkVersion,
+                applicationVersion: context.version,
+                environment: context.env,
+                serviceName: self.serviceName ?? context.service,
+                loggerName: self.loggerName ?? context.applicationBundleIdentifier,
+                userInfoProvider: context.userInfoProvider,
+                networkConnectionInfoProvider: self.sendNetworkInfo ? context.networkConnectionInfoProvider : nil,
+                carrierInfoProvider: self.sendNetworkInfo ? context.carrierInfoProvider : nil,
+                dateCorrector: context.dateCorrector,
+                logEventMapper: self.logEventMapper
+            )
 
-        if let event = log {
-            logOutput.write(log: event)
+            let event = builder.createLogWith(
+                level: level,
+                message: message,
+                error: error.map { DDError(error: $0) },
+                date: context.dateProvider.currentDate(),
+                attributes: .init(
+                    userAttributes: combinedUserAttributes,
+                    internalAttributes: combinedInternalAttributes
+                ),
+                tags: tags
+            )
+
+            guard let log = event, self.validate(log) else {
+                return
+            }
+
+            self.additionalOutput?.write(log: log)
+
+            if self.useCoreOutput {
+                writer.write(value: log)
+            }
         }
     }
 
@@ -305,8 +338,8 @@ public class Logger {
         internal var sendNetworkInfo = false
         internal var bundleWithRUM = true
         internal var bundleWithTrace = true
-        internal var useFileOutput = true
-        internal var useConsoleLogFormat: ConsoleLogFormat?
+        internal var useCoreOutput = true
+        internal var consoleLogFormat: ConsoleLogFormat?
 
         /// Sets the service name that will appear in logs.
         /// - Parameter serviceName: the service name  (default value is set to application bundle identifier)
@@ -354,7 +387,7 @@ public class Logger {
         /// See also: `printLogsToConsole(_:)`.
         /// - Parameter enabled: `true` by default
         public func sendLogsToDatadog(_ enabled: Bool) -> Builder {
-            self.useFileOutput = enabled
+            self.useCoreOutput = enabled
             return self
         }
 
@@ -377,7 +410,7 @@ public class Logger {
         ///   - enabled: `false` by default
         ///   - format: format to use when printing logs to console - either `.short` or `.json` (`.short` is default)
         public func printLogsToConsole(_ enabled: Bool, usingFormat format: ConsoleLogFormat = .short) -> Builder {
-            useConsoleLogFormat = enabled ? format : nil
+            consoleLogFormat = enabled ? format : nil
             return self
         }
 
@@ -388,12 +421,17 @@ public class Logger {
             } catch {
                 consolePrint("\(error)")
                 return Logger(
-                    logBuilder: nil,
-                    logOutput: nil,
-                    dateProvider: SystemDateProvider(),
+                    core: NOOPDatadogCore(),
                     identifier: "no-op",
+                    serviceName: nil,
+                    loggerName: nil,
+                    sendNetworkInfo: false,
+                    useCoreOutput: false,
+                    validation: nil,
                     rumContextIntegration: nil,
-                    activeSpanIntegration: nil
+                    activeSpanIntegration: nil,
+                    additionalOutput: nil,
+                    logEventMapper: nil
                 )
             }
         }
@@ -411,71 +449,42 @@ public class Logger {
                 )
             }
 
-            let (logBuilder, logOutput) = resolveLogBuilderAndOutput(for: loggingFeature, context: context) ?? (nil, nil)
-
             // RUMM-2133 Note: strong feature coupling while migrating to v2.
             // In v2 active span will be provided in context from feature scope.
             let rumEnabled = core.v1.feature(RUMFeature.self) != nil
             let tracingEnabled = core.v1.feature(TracingFeature.self) != nil
 
             return Logger(
-                logBuilder: logBuilder,
-                logOutput: logOutput,
-                dateProvider: context.dateProvider,
-                identifier: resolveLoggerName(with: context),
+                core: core,
+                identifier: loggerName ?? context.applicationBundleIdentifier,
+                serviceName: serviceName,
+                loggerName: loggerName,
+                sendNetworkInfo: sendNetworkInfo,
+                useCoreOutput: useCoreOutput,
+                validation: nil,
                 rumContextIntegration: (rumEnabled && bundleWithRUM) ? LoggingWithRUMContextIntegration() : nil,
-                activeSpanIntegration: (tracingEnabled && bundleWithTrace) ? LoggingWithActiveSpanIntegration() : nil
+                activeSpanIntegration: (tracingEnabled && bundleWithTrace) ? LoggingWithActiveSpanIntegration() : nil,
+                additionalOutput: resolveOuput(),
+                logEventMapper: loggingFeature.configuration.logEventMapper
             )
         }
 
-        private func resolveLogBuilderAndOutput(for loggingFeature: LoggingFeature, context: DatadogV1Context) -> (LogEventBuilder, LogOutput)? {
-            let logBuilder = LogEventBuilder(
-                sdkVersion: context.sdkVersion,
-                applicationVersion: context.version,
-                environment: context.env,
-                serviceName: serviceName ?? context.service,
-                loggerName: resolveLoggerName(with: context),
-                userInfoProvider: context.userInfoProvider,
-                networkConnectionInfoProvider: sendNetworkInfo ? context.networkConnectionInfoProvider : nil,
-                carrierInfoProvider: sendNetworkInfo ? context.carrierInfoProvider : nil,
-                dateCorrector: context.dateCorrector,
-                logEventMapper: loggingFeature.configuration.logEventMapper
-            )
-
-            switch (useFileOutput, useConsoleLogFormat) {
-            case (true, let format?):
-                let logOutput = CombinedLogOutput(
+        private func resolveOuput() -> LogOutput? {
+            switch (useCoreOutput, consoleLogFormat) {
+            case let (true, format?):
+                return CombinedLogOutput(
                     combine: [
-                        LogFileOutput(
-                            fileWriter: loggingFeature.storage.writer,
-                            rumErrorsIntegration: LoggingWithRUMErrorsIntegration()
-                        ),
-                        LogConsoleOutput(
-                            format: format,
-                            timeZone: .current
-                        )
+                        LogConsoleOutput(format: format, timeZone: .current),
+                        LoggingWithRUMErrorsIntegration()
                     ]
                 )
-                return (logBuilder, logOutput)
             case (true, nil):
-                let logOutput = LogFileOutput(
-                    fileWriter: loggingFeature.storage.writer,
-                    rumErrorsIntegration: LoggingWithRUMErrorsIntegration()
-                )
-                return (logBuilder, logOutput)
-            case (false, let format?):
-                let logOutput = LogConsoleOutput(
-                    format: format,
-                    timeZone: .current
-                )
-                return (logBuilder, logOutput)
+                return LoggingWithRUMErrorsIntegration()
+            case let (false, format?):
+                return LogConsoleOutput(format: format, timeZone: .current)
             case (false, nil):
                 return nil
             }
-        }
-
-        private func resolveLoggerName(with context: DatadogV1Context) -> String {
-            return loggerName ?? context.applicationBundleIdentifier
         }
     }
 }

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -279,7 +279,7 @@ public class Logger {
             return self.loggerTags
         }
 
-        core.v1.scope(for: LoggingFeature.self)?.execute { context, writer in
+        core.v1.scope(for: LoggingFeature.self)?.eventWriteContext { context, writer in
             let builder = LogEventBuilder(
                 sdkVersion: context.sdkVersion,
                 applicationVersion: context.version,

--- a/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
@@ -14,12 +14,3 @@ internal struct LogFileOutput: LogOutput {
         fileWriter.write(value: log)
     }
 }
-
-extension LoggingWithRUMErrorsIntegration: LogOutput {
-    /// Writes `critical` and `error` logs to RUM.
-    func write(log: LogEvent) {
-        if log.status == .error || log.status == .critical {
-            addError(for: log)
-        }
-    }
-}

--- a/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
+++ b/Sources/Datadog/Logging/LogOutputs/LogFileOutput.swift
@@ -9,14 +9,17 @@ import Foundation
 /// `LogOutput` writing logs to file.
 internal struct LogFileOutput: LogOutput {
     let fileWriter: Writer
-    /// Integration with RUM Errors.
-    let rumErrorsIntegration: LoggingWithRUMErrorsIntegration?
 
     func write(log: LogEvent) {
         fileWriter.write(value: log)
+    }
+}
 
+extension LoggingWithRUMErrorsIntegration: LogOutput {
+    /// Writes `critical` and `error` logs to RUM.
+    func write(log: LogEvent) {
         if log.status == .error || log.status == .critical {
-            rumErrorsIntegration?.addError(for: log)
+            addError(for: log)
         }
     }
 }

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// Creates and owns components enabling logging feature.
 /// Bundles dependencies for other logging-related components created later at runtime  (i.e. `Logger`).
-internal final class LoggingFeature: V1FeatureInitializable {
+internal final class LoggingFeature: V1FeatureInitializable, V1Feature {
     typealias Configuration = FeaturesConfiguration.Logging
 
     // MARK: - Configuration

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -51,7 +51,7 @@ class FileWriterTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         let writer = FileWriter(
             orchestrator: FilesOrchestrator(
@@ -91,7 +91,7 @@ class FileWriterTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         let writer = FileWriter(
             orchestrator: FilesOrchestrator(
@@ -112,7 +112,7 @@ class FileWriterTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         let writer = FileWriter(
             orchestrator: FilesOrchestrator(

--- a/Tests/DatadogTests/Datadog/Core/System/Time/DateCorrectionTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/System/Time/DateCorrectionTests.swift
@@ -29,7 +29,7 @@ class DateCorrectorTests: XCTestCase {
         super.setUp()
         self.previousUserLogger = userLogger
         self.userLogOutput = LogOutputMock()
-        userLogger = .mockWith(logOutput: userLogOutput)
+        userLogger = .mockConsoleLogger(output: userLogOutput)
     }
 
     override func tearDown() {

--- a/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Upload/DataUploadWorkerTests.swift
@@ -231,7 +231,7 @@ class DataUploadWorkerTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let mockUserLoggerOutput = LogOutputMock()
-        userLogger = .mockWith(logOutput: mockUserLoggerOutput)
+        userLogger = .mockConsoleLogger(output: mockUserLoggerOutput)
 
         // Given
         writer.write(value: ["key": "value"])
@@ -278,7 +278,7 @@ class DataUploadWorkerTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let mockUserLoggerOutput = LogOutputMock()
-        userLogger = .mockWith(logOutput: mockUserLoggerOutput)
+        userLogger = .mockConsoleLogger(output: mockUserLoggerOutput)
 
         // Given
         writer.write(value: ["key": "value"])

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -203,7 +203,7 @@ class CrashReporterTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         let plugin = CrashReportingPluginMock()
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -519,7 +519,7 @@ class LoggerTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockWith(core: core, additionalOutput: output)
 
         // given
         let logger = Logger.builder.build(in: core)
@@ -635,7 +635,7 @@ class LoggerTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockWith(core: core, additionalOutput: output)
 
         // given
         let logger = Logger.builder.build(in: core)
@@ -692,12 +692,17 @@ class LoggerTests: XCTestCase {
         }
 
         let logger = Logger(
-            logBuilder: .mockAny(),
-            logOutput: NoOpLogOutput(),
-            dateProvider: SystemDateProvider(),
+            core: core,
             identifier: .mockAny(),
+            serviceName: nil,
+            loggerName: nil,
+            sendNetworkInfo: false,
+            useCoreOutput: true,
+            validation: nil,
             rumContextIntegration: nil,
-            activeSpanIntegration: nil
+            activeSpanIntegration: nil,
+            additionalOutput: nil,
+            logEventMapper: nil
         )
 
         DispatchQueue.concurrentPerform(iterations: 900) { iteration in
@@ -737,8 +742,7 @@ class LoggerTests: XCTestCase {
             printFunction.printedMessage,
             "🔥 Datadog SDK usage error: `Datadog.initialize()` must be called prior to `Logger.builder.build()`."
         )
-        XCTAssertNil(logger.logBuilder)
-        XCTAssertNil(logger.logOutput)
+        XCTAssertTrue(logger.core is NOOPDatadogCore)
     }
 
     func testGivenLoggingFeatureDisabled_whenInitializingLogger_itPrintsError() {
@@ -758,8 +762,7 @@ class LoggerTests: XCTestCase {
             printFunction.printedMessage,
             "🔥 Datadog SDK usage error: `Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."
         )
-        XCTAssertNil(logger.logBuilder)
-        XCTAssertNil(logger.logOutput)
+        XCTAssertTrue(logger.core is NOOPDatadogCore)
     }
 
     func testDDLoggerIsLoggerTypealias() {

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
@@ -30,8 +30,7 @@ class LogFileOutputTests: XCTestCase {
                     ),
                     dateProvider: fileCreationDateProvider
                 )
-            ),
-            rumErrorsIntegration: nil
+            )
         )
 
         let log1: LogEvent = .mockWith(status: .info, message: "log message 1")

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogCoreMock.swift
@@ -47,6 +47,24 @@ extension DatadogCoreMock: DatadogV1CoreProtocol {
         return v1Features[key] as? T
     }
 
+    func scope<T>(for featureType: T.Type) -> V1FeatureScope? {
+        guard let context = v1Context else {
+            return nil
+        }
+
+        let key = String(describing: T.self)
+
+        guard let feature = v1Features[key] as? V1Feature else {
+            return nil
+        }
+
+        return DatadogCoreFeatureScope(
+            context: context,
+            storage: feature.storage,
+            telemetry: nil
+        )
+    }
+
     var context: DatadogV1Context? {
         return v1Context
     }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -174,20 +174,52 @@ extension LogEvent.Error: RandomMockable {
 
 extension Logger {
     static func mockWith(
-        logBuilder: LogEventBuilder = .mockAny(),
-        logOutput: LogOutput = LogOutputMock(),
-        dateProvider: DateProvider = SystemDateProvider(),
+        core: DatadogCoreProtocol,
         identifier: String = .mockAny(),
+        serviceName: String? = nil,
+        loggerName: String? = nil,
+        sendNetworkInfo: Bool = false,
+        useCoreOutput: Bool = true,
+        validation: LogEventValidation? = nil,
         rumContextIntegration: LoggingWithRUMContextIntegration? = nil,
-        activeSpanIntegration: LoggingWithActiveSpanIntegration? = nil
+        activeSpanIntegration: LoggingWithActiveSpanIntegration? = nil,
+        additionalOutput: LogOutput = LogOutputMock(),
+        logEventMapper: LogEventMapper? = nil
     ) -> Logger {
         return Logger(
-            logBuilder: logBuilder,
-            logOutput: logOutput,
-            dateProvider: dateProvider,
+            core: core,
             identifier: identifier,
+            serviceName: serviceName,
+            loggerName: loggerName,
+            sendNetworkInfo: sendNetworkInfo,
+            useCoreOutput: useCoreOutput,
+            validation: validation,
             rumContextIntegration: rumContextIntegration,
-            activeSpanIntegration: activeSpanIntegration
+            activeSpanIntegration: activeSpanIntegration,
+            additionalOutput: additionalOutput,
+            logEventMapper: logEventMapper
+        )
+    }
+
+    static func mockConsoleLogger(
+        output: LogOutput,
+        context: DatadogV1Context = .mockAny()
+    ) -> Logger {
+        let core = DatadogCoreMock(v1Context: context)
+        core.register(feature: LoggingFeature.mockNoOp())
+
+        return Logger(
+            core: core,
+            identifier: "user-logger-mock",
+            serviceName: nil,
+            loggerName: nil,
+            sendNetworkInfo: false,
+            useCoreOutput: false,
+            validation: nil,
+            rumContextIntegration: nil,
+            activeSpanIntegration: nil,
+            additionalOutput: output,
+            logEventMapper: nil
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/DDNoopRUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/DDNoopRUMMonitorTests.swift
@@ -13,7 +13,7 @@ class DDNoopRUMMonitorTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         // Given
         let noop = DDNoopRUMMonitor()

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -468,7 +468,7 @@ class RUMSessionScopeTests: XCTestCase {
             defer { userLogger = previousUserLogger }
 
             let logOutput = LogOutputMock()
-            userLogger = .mockWith(logOutput: logOutput)
+            userLogger = .mockConsoleLogger(output: logOutput)
 
             // When
             _ = scope.process(command: command)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -543,7 +543,7 @@ class RUMViewScopeTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let logOutput = LogOutputMock()
-        userLogger = .mockWith(logOutput: logOutput)
+        userLogger = .mockConsoleLogger(output: logOutput)
 
         XCTAssertTrue(
             scope.process(command: RUMStartViewCommand.mockWith(identity: mockView))
@@ -604,7 +604,7 @@ class RUMViewScopeTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let logOutput = LogOutputMock()
-        userLogger = .mockWith(logOutput: logOutput)
+        userLogger = .mockConsoleLogger(output: logOutput)
 
         XCTAssertTrue(
             scope.process(command: RUMStartViewCommand.mockWith(time: currentTime, identity: mockView))
@@ -1098,7 +1098,7 @@ class RUMViewScopeTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let logOutput = LogOutputMock()
-        userLogger = .mockWith(logOutput: logOutput)
+        userLogger = .mockConsoleLogger(output: logOutput)
 
         // When
         currentTime.addTimeInterval(0.5)

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -79,7 +79,7 @@ class WKUserContentController_DatadogTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         let mockSanitizer = MockHostsSanitizer()
         let controller = DDUserContentController()
@@ -140,7 +140,7 @@ class WKUserContentController_DatadogTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         let controller = DDUserContentController()
         controller.addDatadogMessageHandler(

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1369,7 +1369,7 @@ class RUMMonitorTests: XCTestCase {
         defer { Datadog.flushAndDeinitialize() }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockWith(core: defaultDatadogCore, additionalOutput: output)
 
         // Given
         let urlInstrumentation = try XCTUnwrap(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -720,7 +720,7 @@ class TracerTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         // given
         let tracer = Tracer.initialize(configuration: .init(), in: core).dd
@@ -947,7 +947,7 @@ class TracerTests: XCTestCase {
         )
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         // when
         let tracer = Tracer.initialize(configuration: .init())
@@ -1002,7 +1002,7 @@ class TracerTests: XCTestCase {
         defer { Datadog.flushAndDeinitialize() }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         // Given
         let instrumentation = defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self)

--- a/Tests/DatadogTests/Datadog/Tracing/DDNoopTracerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDNoopTracerTests.swift
@@ -13,7 +13,7 @@ class DDNoopTracerTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         // Given
         let noop = DDNoopTracer()

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
@@ -165,7 +165,7 @@ class DDSpanTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         let span: DDSpan = .mockWith(
             tracer: .mockWith(loggingIntegration: .init(logBuilder: .mockAny(), loggingOutput: LogOutputMock())),

--- a/Tests/DatadogTests/Datadog/Tracing/Span/SpanEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Span/SpanEventBuilderTests.swift
@@ -369,7 +369,7 @@ class SpanEventBuilderTests: XCTestCase {
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output)
+        userLogger = .mockConsoleLogger(output: output)
 
         let builder: SpanEventBuilder = .mockAny()
 

--- a/Tests/DatadogTests/Datadog/Tracing/Utils/WarningsTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Utils/WarningsTests.swift
@@ -9,11 +9,22 @@ import XCTest
 
 class WarningsTests: XCTestCase {
     func testPrintingWarningsOnDifferentConditions() {
+        let core = DatadogCoreMock()
+        core.register(feature: LoggingFeature.mockNoOp())
+        defer { core.flush() }
+
         let previousUserLogger = userLogger
         defer { userLogger = previousUserLogger }
 
         let output = LogOutputMock()
-        userLogger = .mockWith(logOutput: output, dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC()))
+        userLogger = .mockConsoleLogger(
+            output: output,
+            context: .mockWith(
+                dependencies: .mockWith(
+                    dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+                )
+            )
+        )
 
         XCTAssertTrue(warn(if: true, message: "message"))
         XCTAssertEqual(output.recordedLog?.status, .warn)

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerBuilderTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerBuilderTests.swift
@@ -21,7 +21,7 @@ class DDLoggerBuilderTests: XCTestCase {
         XCTAssertEqual(swiftBuilder.loggerName, "logger-name")
         XCTAssertEqual(swiftBuilder.serviceName, "service-name")
         XCTAssertTrue(swiftBuilder.sendNetworkInfo)
-        XCTAssertFalse(swiftBuilder.useFileOutput)
-        XCTAssertNotNil(swiftBuilder.useConsoleLogFormat)
+        XCTAssertFalse(swiftBuilder.useCoreOutput)
+        XCTAssertNotNil(swiftBuilder.consoleLogFormat)
     }
 }

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -77,7 +77,7 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
             """
         ),
         .init(
-            assert: { userLogger.logBuilder == nil && userLogger.logOutput == nil },
+            assert: { userLogger.core is NOOPDatadogCore },
             problem: "`userLogger` must use no-op implementation.",
             solution: """
             Make sure the `userLogger` is captured before test and reset to the previous implementation after, e.g.:


### PR DESCRIPTION
### What and why?

`Logger` instances now build and record events using `V1FeatureScope` provided by `DatadogV1CoreProtocol`.

### How?

The `Logger` now keeps a reference to the provided `core` to retrieve the scope when a log event needs to be recorded. The `LogEventBuilder` is created using the context provided with the scope, the event is then written to the `writer` provided by core, and an additional log output if available. The additional output allow to write the event to the console and/or to RUM Error Integration.

The `userLogger` static instance is now instantiated using the `core` created at `Datadog.initialize()`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
