### PR TITLE
RUMM-2197 Update RUM Models to use `device` and `os` info

### DIFF
--- a/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithRUMIntegration.swift
@@ -235,6 +235,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             connectivity: lastRUMView.connectivity,
             context: nil,
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds,
+            device: nil, // TODO: RUMM-2197 add device and OS info
             error: .init(
                 handling: nil,
                 handlingStack: nil,
@@ -247,6 +248,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 stack: errorStackTrace,
                 type: errorType
             ),
+            os: nil, // TODO: RUMM-2197 add device and OS info
             service: lastRUMView.service,
             session: .init(
                 hasReplay: lastRUMView.session.hasReplay,
@@ -284,6 +286,8 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             connectivity: original.connectivity,
             context: original.context,
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds - 1, // -1ms to put the crash after view in RUM session
+            device: nil, // TODO: RUMM-2197 add device and OS info
+            os: nil, // TODO: RUMM-2197 add device and OS info
             service: original.service,
             session: original.session,
             source: original.source ?? .ios,
@@ -305,6 +309,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 firstInputDelay: original.view.firstInputDelay,
                 firstInputTime: original.view.firstInputTime,
                 frozenFrame: nil,
+                frustration: nil,
                 id: original.view.id,
                 inForegroundPeriods: original.view.inForegroundPeriods,
                 isActive: false,
@@ -353,6 +358,8 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             ),
             context: nil,
             date: startDate.timeIntervalSince1970.toInt64Milliseconds,
+            device: nil, // TODO: RUMM-2197 add device and OS info
+            os: nil, // TODO: RUMM-2197 add device and OS info
             service: rumConfiguration.common.serviceName,
             session: .init(
                 hasReplay: nil,
@@ -378,6 +385,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 firstInputDelay: nil,
                 firstInputTime: nil,
                 frozenFrame: nil,
+                frustration: nil,
                 id: viewUUID.toRUMDataFormat,
                 inForegroundPeriods: nil,
                 isActive: false, // we know it won't receive updates

--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -31,6 +31,12 @@ public struct RUMActionEvent: RUMDataModel {
     /// Start of the event in ms from epoch
     public let date: Int64
 
+    /// Device properties
+    public let device: RUMDevice?
+
+    /// Operating system properties
+    public let os: RUMOS?
+
     /// The service name for this application
     public let service: String?
 
@@ -63,6 +69,8 @@ public struct RUMActionEvent: RUMDataModel {
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
+        case device = "device"
+        case os = "os"
         case service = "service"
         case session = "session"
         case source = "source"
@@ -115,8 +123,8 @@ public struct RUMActionEvent: RUMDataModel {
         /// Properties of the errors of the action
         public let error: Error?
 
-        /// Action frustration types
-        public let frustrationType: [FrustrationType]?
+        /// Action frustration properties
+        public let frustration: Frustration?
 
         /// UUID of the action
         public let id: String?
@@ -126,6 +134,9 @@ public struct RUMActionEvent: RUMDataModel {
 
         /// Properties of the long tasks of the action
         public let longTask: LongTask?
+
+        /// Action position properties
+        public let position: Position?
 
         /// Properties of the resources of the action
         public let resource: Resource?
@@ -139,10 +150,11 @@ public struct RUMActionEvent: RUMDataModel {
         enum CodingKeys: String, CodingKey {
             case crash = "crash"
             case error = "error"
-            case frustrationType = "frustration_type"
+            case frustration = "frustration"
             case id = "id"
             case loadingTime = "loading_time"
             case longTask = "long_task"
+            case position = "position"
             case resource = "resource"
             case target = "target"
             case type = "type"
@@ -168,10 +180,20 @@ public struct RUMActionEvent: RUMDataModel {
             }
         }
 
-        public enum FrustrationType: String, Codable {
-            case rage = "rage"
-            case dead = "dead"
-            case error = "error"
+        /// Action frustration properties
+        public struct Frustration: Codable {
+            /// Action frustration types
+            public let type: [FrustrationType]
+
+            enum CodingKeys: String, CodingKey {
+                case type = "type"
+            }
+
+            public enum FrustrationType: String, Codable {
+                case rageClick = "rage_click"
+                case deadClick = "dead_click"
+                case errorClick = "error_click"
+            }
         }
 
         /// Properties of the long tasks of the action
@@ -181,6 +203,20 @@ public struct RUMActionEvent: RUMDataModel {
 
             enum CodingKeys: String, CodingKey {
                 case count = "count"
+            }
+        }
+
+        /// Action position properties
+        public struct Position: Codable {
+            /// X coordinate of the action (in pixels)
+            public let x: Int64
+
+            /// Y coordinate of the action (in pixels)
+            public let y: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case x = "x"
+                case y = "y"
             }
         }
 
@@ -196,11 +232,23 @@ public struct RUMActionEvent: RUMDataModel {
 
         /// Action target properties
         public struct Target: Codable {
+            /// Height of the target element (in pixels)
+            public let height: Int64?
+
             /// Target name
             public var name: String
 
+            /// CSS selector path of the target element
+            public let selector: String?
+
+            /// Width of the target element (in pixels)
+            public let width: Int64?
+
             enum CodingKeys: String, CodingKey {
+                case height = "height"
                 case name = "name"
+                case selector = "selector"
+                case width = "width"
             }
         }
 
@@ -328,8 +376,14 @@ public struct RUMErrorEvent: RUMDataModel {
     /// Start of the event in ms from epoch
     public let date: Int64
 
+    /// Device properties
+    public let device: RUMDevice?
+
     /// Error properties
     public var error: Error
+
+    /// Operating system properties
+    public let os: RUMOS?
 
     /// The service name for this application
     public let service: String?
@@ -363,7 +417,9 @@ public struct RUMErrorEvent: RUMDataModel {
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
+        case device = "device"
         case error = "error"
+        case os = "os"
         case service = "service"
         case session = "session"
         case source = "source"
@@ -661,8 +717,14 @@ public struct RUMLongTaskEvent: RUMDataModel {
     /// Start of the event in ms from epoch
     public let date: Int64
 
+    /// Device properties
+    public let device: RUMDevice?
+
     /// Long Task properties
     public let longTask: LongTask
+
+    /// Operating system properties
+    public let os: RUMOS?
 
     /// The service name for this application
     public let service: String?
@@ -696,7 +758,9 @@ public struct RUMLongTaskEvent: RUMDataModel {
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
+        case device = "device"
         case longTask = "long_task"
+        case os = "os"
         case service = "service"
         case session = "session"
         case source = "source"
@@ -877,6 +941,12 @@ public struct RUMResourceEvent: RUMDataModel {
     /// Start of the event in ms from epoch
     public let date: Int64
 
+    /// Device properties
+    public let device: RUMDevice?
+
+    /// Operating system properties
+    public let os: RUMOS?
+
     /// Resource properties
     public var resource: Resource
 
@@ -912,6 +982,8 @@ public struct RUMResourceEvent: RUMDataModel {
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
+        case device = "device"
+        case os = "os"
         case resource = "resource"
         case service = "service"
         case session = "session"
@@ -1277,6 +1349,12 @@ public struct RUMViewEvent: RUMDataModel {
     /// Start of the event in ms from epoch
     public let date: Int64
 
+    /// Device properties
+    public let device: RUMDevice?
+
+    /// Operating system properties
+    public let os: RUMOS?
+
     /// The service name for this application
     public let service: String?
 
@@ -1308,6 +1386,8 @@ public struct RUMViewEvent: RUMDataModel {
         case connectivity = "connectivity"
         case context = "context"
         case date = "date"
+        case device = "device"
+        case os = "os"
         case service = "service"
         case session = "session"
         case source = "source"
@@ -1462,6 +1542,9 @@ public struct RUMViewEvent: RUMDataModel {
         /// Properties of the frozen frames of the view
         public let frozenFrame: FrozenFrame?
 
+        /// Properties of the frustrations of the view
+        public let frustration: Frustration?
+
         /// UUID of the view
         public let id: String
 
@@ -1531,6 +1614,7 @@ public struct RUMViewEvent: RUMDataModel {
             case firstInputDelay = "first_input_delay"
             case firstInputTime = "first_input_time"
             case frozenFrame = "frozen_frame"
+            case frustration = "frustration"
             case id = "id"
             case inForegroundPeriods = "in_foreground_periods"
             case isActive = "is_active"
@@ -1584,6 +1668,16 @@ public struct RUMViewEvent: RUMDataModel {
         /// Properties of the frozen frames of the view
         public struct FrozenFrame: Codable {
             /// Number of frozen frames that occurred on the view
+            public let count: Int64
+
+            enum CodingKeys: String, CodingKey {
+                case count = "count"
+            }
+        }
+
+        /// Properties of the frustrations of the view
+        public struct Frustration: Codable {
+            /// Number of frustrations that occurred on the view
             public let count: Int64
 
             enum CodingKeys: String, CodingKey {
@@ -2001,6 +2095,57 @@ extension RUMEventAttributes {
     }
 }
 
+/// Device properties
+public struct RUMDevice: Codable {
+    /// Device marketing brand, e.g. Apple, OPPO, Xiaomi, etc.
+    public let brand: String?
+
+    /// Device SKU model, e.g. Samsung SM-988GN, etc. Quite often name and model can be the same.
+    public let model: String?
+
+    /// Device marketing name, e.g. Xiaomi Redmi Note 8 Pro, Pixel 5, etc.
+    public let name: String?
+
+    /// Device type info
+    public let type: RUMDeviceType
+
+    enum CodingKeys: String, CodingKey {
+        case brand = "brand"
+        case model = "model"
+        case name = "name"
+        case type = "type"
+    }
+
+    /// Device type info
+    public enum RUMDeviceType: String, Codable {
+        case mobile = "mobile"
+        case desktop = "desktop"
+        case tablet = "tablet"
+        case tv = "tv"
+        case gamingConsole = "gaming_console"
+        case bot = "bot"
+        case other = "other"
+    }
+}
+
+/// Operating system properties
+public struct RUMOS: Codable {
+    /// Operating system name, e.g. Android, iOS
+    public let name: String
+
+    /// Full operating system version, e.g. 8.1.1
+    public let version: String
+
+    /// Major operating system version, e.g. 8
+    public let versionMajor: String
+
+    enum CodingKeys: String, CodingKey {
+        case name = "name"
+        case version = "version"
+        case versionMajor = "version_major"
+    }
+}
+
 /// User properties
 public struct RUMUser: Codable {
     /// Email of the user
@@ -2076,4 +2221,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/568fc1bcfb0d2775a11c07914120b70a3d5780fe
+// Generated from https://github.com/DataDog/rum-events-format/tree/d5a943ad55117da57d0b87f9af417ccbcbd49daf

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -142,6 +142,8 @@ internal class RUMResourceScope: RUMScope {
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: resourceStartTime).timeIntervalSince1970.toInt64Milliseconds,
+            device: nil, // TODO: RUMM-2197 add device and OS info
+            os: nil, // TODO: RUMM-2197 add device and OS info
             resource: .init(
                 connect: resourceMetrics?.connect.flatMap { metric in
                     .init(
@@ -229,6 +231,7 @@ internal class RUMResourceScope: RUMScope {
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
+            device: nil,
             error: .init(
                 handling: nil,
                 handlingStack: nil,
@@ -246,6 +249,7 @@ internal class RUMResourceScope: RUMScope {
                 stack: command.stack,
                 type: command.errorType
             ),
+            os: nil, // TODO: RUMM-2197 add device and OS info
             service: dependencies.serviceName,
             session: .init(
                 hasReplay: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -140,12 +140,18 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             action: .init(
                 crash: nil,
                 error: .init(count: errorsCount.toInt64),
-                frustrationType: nil,
+                frustration: nil,
                 id: actionUUID.toRUMDataFormat,
                 loadingTime: completionTime.timeIntervalSince(actionStartTime).toInt64Nanoseconds,
                 longTask: .init(count: longTasksCount),
+                position: nil,
                 resource: .init(count: resourcesCount.toInt64),
-                target: .init(name: name),
+                target: .init(
+                    height: nil,
+                    name: name,
+                    selector: nil,
+                    width: nil
+                ),
                 type: actionType.toRUMDataFormat
             ),
             application: .init(id: context.rumApplicationID),
@@ -153,6 +159,8 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: actionStartTime).timeIntervalSince1970.toInt64Milliseconds,
+            device: nil, // TODO: RUMM-2197 add device and OS info
+            os: nil, // TODO: RUMM-2197 add device and OS info
             service: dependencies.serviceName,
             session: .init(
                 hasReplay: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -330,10 +330,11 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             action: .init(
                 crash: nil,
                 error: nil,
-                frustrationType: nil,
+                frustration: nil,
                 id: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
                 loadingTime: loadingTime,
                 longTask: nil,
+                position: nil,
                 resource: nil,
                 target: nil,
                 type: .applicationStart
@@ -343,6 +344,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
+            device: nil, // TODO: RUMM-2197 add device and OS info
+            os: nil, // TODO: RUMM-2197 add device and OS info
             service: dependencies.serviceName,
             session: .init(
                 hasReplay: nil,
@@ -393,6 +396,8 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: viewStartTime).timeIntervalSince1970.toInt64Milliseconds,
+            device: nil, // TODO: RUMM-2197 add device and OS info
+            os: nil, // TODO: RUMM-2197 add device and OS info
             service: dependencies.serviceName,
             session: .init(
                 hasReplay: nil,
@@ -420,6 +425,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 firstInputDelay: nil,
                 firstInputTime: nil,
                 frozenFrame: .init(count: frozenFramesCount),
+                frustration: nil,
                 id: viewUUID.toRUMDataFormat,
                 inForegroundPeriods: nil,
                 isActive: isActive,
@@ -472,6 +478,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time).timeIntervalSince1970.toInt64Milliseconds,
+            device: nil, // TODO: RUMM-2197 add device and OS info
             error: .init(
                 handling: nil,
                 handlingStack: nil,
@@ -484,6 +491,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 stack: command.stack,
                 type: command.type
             ),
+            os: nil, // TODO: RUMM-2197 add device and OS info
             service: dependencies.serviceName,
             session: .init(
                 hasReplay: nil,
@@ -526,7 +534,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             connectivity: dependencies.connectivityInfoProvider.current,
             context: .init(contextInfo: attributes),
             date: dateCorrection.applying(to: command.time - command.duration).timeIntervalSince1970.toInt64Milliseconds,
+            device: nil, // TODO: RUMM-2197 add device and OS info
             longTask: .init(duration: taskDurationInNs, id: nil, isFrozenFrame: isFrozenFrame),
+            os: nil, // TODO: RUMM-2197 add device and OS info
             service: dependencies.serviceName,
             session: .init(
                 hasReplay: nil,

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -48,6 +48,14 @@ public class DDRUMActionEvent: NSObject {
         root.swiftModel.date as NSNumber
     }
 
+    @objc public var device: DDRUMActionEventRUMDevice? {
+        root.swiftModel.device != nil ? DDRUMActionEventRUMDevice(root: root) : nil
+    }
+
+    @objc public var os: DDRUMActionEventRUMOS? {
+        root.swiftModel.os != nil ? DDRUMActionEventRUMOS(root: root) : nil
+    }
+
     @objc public var service: String? {
         root.swiftModel.service
     }
@@ -151,8 +159,8 @@ public class DDRUMActionEventAction: NSObject {
         root.swiftModel.action.error != nil ? DDRUMActionEventActionError(root: root) : nil
     }
 
-    @objc public var frustrationType: [Int]? {
-        root.swiftModel.action.frustrationType?.map { DDRUMActionEventActionFrustrationType(swift: $0).rawValue }
+    @objc public var frustration: DDRUMActionEventActionFrustration? {
+        root.swiftModel.action.frustration != nil ? DDRUMActionEventActionFrustration(root: root) : nil
     }
 
     @objc public var id: String? {
@@ -165,6 +173,10 @@ public class DDRUMActionEventAction: NSObject {
 
     @objc public var longTask: DDRUMActionEventActionLongTask? {
         root.swiftModel.action.longTask != nil ? DDRUMActionEventActionLongTask(root: root) : nil
+    }
+
+    @objc public var position: DDRUMActionEventActionPosition? {
+        root.swiftModel.action.position != nil ? DDRUMActionEventActionPosition(root: root) : nil
     }
 
     @objc public var resource: DDRUMActionEventActionResource? {
@@ -207,29 +219,39 @@ public class DDRUMActionEventActionError: NSObject {
 }
 
 @objc
-public enum DDRUMActionEventActionFrustrationType: Int {
-    internal init(swift: RUMActionEvent.Action.FrustrationType?) {
+public class DDRUMActionEventActionFrustration: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var type: [Int] {
+        root.swiftModel.action.frustration!.type.map { DDRUMActionEventActionFrustrationFrustrationType(swift: $0).rawValue }
+    }
+}
+
+@objc
+public enum DDRUMActionEventActionFrustrationFrustrationType: Int {
+    internal init(swift: RUMActionEvent.Action.Frustration.FrustrationType) {
         switch swift {
-        case nil: self = .none
-        case .rage?: self = .rage
-        case .dead?: self = .dead
-        case .error?: self = .error
+        case .rageClick: self = .rageClick
+        case .deadClick: self = .deadClick
+        case .errorClick: self = .errorClick
         }
     }
 
-    internal var toSwift: RUMActionEvent.Action.FrustrationType? {
+    internal var toSwift: RUMActionEvent.Action.Frustration.FrustrationType {
         switch self {
-        case .none: return nil
-        case .rage: return .rage
-        case .dead: return .dead
-        case .error: return .error
+        case .rageClick: return .rageClick
+        case .deadClick: return .deadClick
+        case .errorClick: return .errorClick
         }
     }
 
-    case none
-    case rage
-    case dead
-    case error
+    case rageClick
+    case deadClick
+    case errorClick
 }
 
 @objc
@@ -242,6 +264,23 @@ public class DDRUMActionEventActionLongTask: NSObject {
 
     @objc public var count: NSNumber {
         root.swiftModel.action.longTask!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMActionEventActionPosition: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var x: NSNumber {
+        root.swiftModel.action.position!.x as NSNumber
+    }
+
+    @objc public var y: NSNumber {
+        root.swiftModel.action.position!.y as NSNumber
     }
 }
 
@@ -266,9 +305,21 @@ public class DDRUMActionEventActionTarget: NSObject {
         self.root = root
     }
 
+    @objc public var height: NSNumber? {
+        root.swiftModel.action.target!.height as NSNumber?
+    }
+
     @objc public var name: String {
         set { root.swiftModel.action.target!.name = newValue }
         get { root.swiftModel.action.target!.name }
+    }
+
+    @objc public var selector: String? {
+        root.swiftModel.action.target!.selector
+    }
+
+    @objc public var width: NSNumber? {
+        root.swiftModel.action.target!.width as NSNumber?
     }
 }
 
@@ -445,6 +496,87 @@ public class DDRUMActionEventRUMEventAttributes: NSObject {
 
     @objc public var contextInfo: [String: Any] {
         root.swiftModel.context!.contextInfo.castToObjectiveC()
+    }
+}
+
+@objc
+public class DDRUMActionEventRUMDevice: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var brand: String? {
+        root.swiftModel.device!.brand
+    }
+
+    @objc public var model: String? {
+        root.swiftModel.device!.model
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.device!.name
+    }
+
+    @objc public var type: DDRUMActionEventRUMDeviceRUMDeviceType {
+        .init(swift: root.swiftModel.device!.type)
+    }
+}
+
+@objc
+public enum DDRUMActionEventRUMDeviceRUMDeviceType: Int {
+    internal init(swift: RUMDevice.RUMDeviceType) {
+        switch swift {
+        case .mobile: self = .mobile
+        case .desktop: self = .desktop
+        case .tablet: self = .tablet
+        case .tv: self = .tv
+        case .gamingConsole: self = .gamingConsole
+        case .bot: self = .bot
+        case .other: self = .other
+        }
+    }
+
+    internal var toSwift: RUMDevice.RUMDeviceType {
+        switch self {
+        case .mobile: return .mobile
+        case .desktop: return .desktop
+        case .tablet: return .tablet
+        case .tv: return .tv
+        case .gamingConsole: return .gamingConsole
+        case .bot: return .bot
+        case .other: return .other
+        }
+    }
+
+    case mobile
+    case desktop
+    case tablet
+    case tv
+    case gamingConsole
+    case bot
+    case other
+}
+
+@objc
+public class DDRUMActionEventRUMOS: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var name: String {
+        root.swiftModel.os!.name
+    }
+
+    @objc public var version: String {
+        root.swiftModel.os!.version
+    }
+
+    @objc public var versionMajor: String {
+        root.swiftModel.os!.versionMajor
     }
 }
 
@@ -639,8 +771,16 @@ public class DDRUMErrorEvent: NSObject {
         root.swiftModel.date as NSNumber
     }
 
+    @objc public var device: DDRUMErrorEventRUMDevice? {
+        root.swiftModel.device != nil ? DDRUMErrorEventRUMDevice(root: root) : nil
+    }
+
     @objc public var error: DDRUMErrorEventError {
         DDRUMErrorEventError(root: root)
+    }
+
+    @objc public var os: DDRUMErrorEventRUMOS? {
+        root.swiftModel.os != nil ? DDRUMErrorEventRUMOS(root: root) : nil
     }
 
     @objc public var service: String? {
@@ -882,6 +1022,66 @@ public class DDRUMErrorEventRUMEventAttributes: NSObject {
     @objc public var contextInfo: [String: Any] {
         root.swiftModel.context!.contextInfo.castToObjectiveC()
     }
+}
+
+@objc
+public class DDRUMErrorEventRUMDevice: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var brand: String? {
+        root.swiftModel.device!.brand
+    }
+
+    @objc public var model: String? {
+        root.swiftModel.device!.model
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.device!.name
+    }
+
+    @objc public var type: DDRUMErrorEventRUMDeviceRUMDeviceType {
+        .init(swift: root.swiftModel.device!.type)
+    }
+}
+
+@objc
+public enum DDRUMErrorEventRUMDeviceRUMDeviceType: Int {
+    internal init(swift: RUMDevice.RUMDeviceType) {
+        switch swift {
+        case .mobile: self = .mobile
+        case .desktop: self = .desktop
+        case .tablet: self = .tablet
+        case .tv: self = .tv
+        case .gamingConsole: self = .gamingConsole
+        case .bot: self = .bot
+        case .other: self = .other
+        }
+    }
+
+    internal var toSwift: RUMDevice.RUMDeviceType {
+        switch self {
+        case .mobile: return .mobile
+        case .desktop: return .desktop
+        case .tablet: return .tablet
+        case .tv: return .tv
+        case .gamingConsole: return .gamingConsole
+        case .bot: return .bot
+        case .other: return .other
+        }
+    }
+
+    case mobile
+    case desktop
+    case tablet
+    case tv
+    case gamingConsole
+    case bot
+    case other
 }
 
 @objc
@@ -1167,6 +1367,27 @@ public enum DDRUMErrorEventErrorSourceType: Int {
 }
 
 @objc
+public class DDRUMErrorEventRUMOS: NSObject {
+    internal let root: DDRUMErrorEvent
+
+    internal init(root: DDRUMErrorEvent) {
+        self.root = root
+    }
+
+    @objc public var name: String {
+        root.swiftModel.os!.name
+    }
+
+    @objc public var version: String {
+        root.swiftModel.os!.version
+    }
+
+    @objc public var versionMajor: String {
+        root.swiftModel.os!.versionMajor
+    }
+}
+
+@objc
 public class DDRUMErrorEventSession: NSObject {
     internal let root: DDRUMErrorEvent
 
@@ -1357,8 +1578,16 @@ public class DDRUMLongTaskEvent: NSObject {
         root.swiftModel.date as NSNumber
     }
 
+    @objc public var device: DDRUMLongTaskEventRUMDevice? {
+        root.swiftModel.device != nil ? DDRUMLongTaskEventRUMDevice(root: root) : nil
+    }
+
     @objc public var longTask: DDRUMLongTaskEventLongTask {
         DDRUMLongTaskEventLongTask(root: root)
+    }
+
+    @objc public var os: DDRUMLongTaskEventRUMOS? {
+        root.swiftModel.os != nil ? DDRUMLongTaskEventRUMOS(root: root) : nil
     }
 
     @objc public var service: String? {
@@ -1603,6 +1832,66 @@ public class DDRUMLongTaskEventRUMEventAttributes: NSObject {
 }
 
 @objc
+public class DDRUMLongTaskEventRUMDevice: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var brand: String? {
+        root.swiftModel.device!.brand
+    }
+
+    @objc public var model: String? {
+        root.swiftModel.device!.model
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.device!.name
+    }
+
+    @objc public var type: DDRUMLongTaskEventRUMDeviceRUMDeviceType {
+        .init(swift: root.swiftModel.device!.type)
+    }
+}
+
+@objc
+public enum DDRUMLongTaskEventRUMDeviceRUMDeviceType: Int {
+    internal init(swift: RUMDevice.RUMDeviceType) {
+        switch swift {
+        case .mobile: self = .mobile
+        case .desktop: self = .desktop
+        case .tablet: self = .tablet
+        case .tv: self = .tv
+        case .gamingConsole: self = .gamingConsole
+        case .bot: self = .bot
+        case .other: self = .other
+        }
+    }
+
+    internal var toSwift: RUMDevice.RUMDeviceType {
+        switch self {
+        case .mobile: return .mobile
+        case .desktop: return .desktop
+        case .tablet: return .tablet
+        case .tv: return .tv
+        case .gamingConsole: return .gamingConsole
+        case .bot: return .bot
+        case .other: return .other
+        }
+    }
+
+    case mobile
+    case desktop
+    case tablet
+    case tv
+    case gamingConsole
+    case bot
+    case other
+}
+
+@objc
 public class DDRUMLongTaskEventLongTask: NSObject {
     internal let root: DDRUMLongTaskEvent
 
@@ -1620,6 +1909,27 @@ public class DDRUMLongTaskEventLongTask: NSObject {
 
     @objc public var isFrozenFrame: NSNumber? {
         root.swiftModel.longTask.isFrozenFrame as NSNumber?
+    }
+}
+
+@objc
+public class DDRUMLongTaskEventRUMOS: NSObject {
+    internal let root: DDRUMLongTaskEvent
+
+    internal init(root: DDRUMLongTaskEvent) {
+        self.root = root
+    }
+
+    @objc public var name: String {
+        root.swiftModel.os!.name
+    }
+
+    @objc public var version: String {
+        root.swiftModel.os!.version
+    }
+
+    @objc public var versionMajor: String {
+        root.swiftModel.os!.versionMajor
     }
 }
 
@@ -1808,6 +2118,14 @@ public class DDRUMResourceEvent: NSObject {
 
     @objc public var date: NSNumber {
         root.swiftModel.date as NSNumber
+    }
+
+    @objc public var device: DDRUMResourceEventRUMDevice? {
+        root.swiftModel.device != nil ? DDRUMResourceEventRUMDevice(root: root) : nil
+    }
+
+    @objc public var os: DDRUMResourceEventRUMOS? {
+        root.swiftModel.os != nil ? DDRUMResourceEventRUMOS(root: root) : nil
     }
 
     @objc public var resource: DDRUMResourceEventResource {
@@ -2060,6 +2378,87 @@ public class DDRUMResourceEventRUMEventAttributes: NSObject {
 
     @objc public var contextInfo: [String: Any] {
         root.swiftModel.context!.contextInfo.castToObjectiveC()
+    }
+}
+
+@objc
+public class DDRUMResourceEventRUMDevice: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var brand: String? {
+        root.swiftModel.device!.brand
+    }
+
+    @objc public var model: String? {
+        root.swiftModel.device!.model
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.device!.name
+    }
+
+    @objc public var type: DDRUMResourceEventRUMDeviceRUMDeviceType {
+        .init(swift: root.swiftModel.device!.type)
+    }
+}
+
+@objc
+public enum DDRUMResourceEventRUMDeviceRUMDeviceType: Int {
+    internal init(swift: RUMDevice.RUMDeviceType) {
+        switch swift {
+        case .mobile: self = .mobile
+        case .desktop: self = .desktop
+        case .tablet: self = .tablet
+        case .tv: self = .tv
+        case .gamingConsole: self = .gamingConsole
+        case .bot: self = .bot
+        case .other: self = .other
+        }
+    }
+
+    internal var toSwift: RUMDevice.RUMDeviceType {
+        switch self {
+        case .mobile: return .mobile
+        case .desktop: return .desktop
+        case .tablet: return .tablet
+        case .tv: return .tv
+        case .gamingConsole: return .gamingConsole
+        case .bot: return .bot
+        case .other: return .other
+        }
+    }
+
+    case mobile
+    case desktop
+    case tablet
+    case tv
+    case gamingConsole
+    case bot
+    case other
+}
+
+@objc
+public class DDRUMResourceEventRUMOS: NSObject {
+    internal let root: DDRUMResourceEvent
+
+    internal init(root: DDRUMResourceEvent) {
+        self.root = root
+    }
+
+    @objc public var name: String {
+        root.swiftModel.os!.name
+    }
+
+    @objc public var version: String {
+        root.swiftModel.os!.version
+    }
+
+    @objc public var versionMajor: String {
+        root.swiftModel.os!.versionMajor
     }
 }
 
@@ -2576,6 +2975,14 @@ public class DDRUMViewEvent: NSObject {
         root.swiftModel.date as NSNumber
     }
 
+    @objc public var device: DDRUMViewEventRUMDevice? {
+        root.swiftModel.device != nil ? DDRUMViewEventRUMDevice(root: root) : nil
+    }
+
+    @objc public var os: DDRUMViewEventRUMOS? {
+        root.swiftModel.os != nil ? DDRUMViewEventRUMOS(root: root) : nil
+    }
+
     @objc public var service: String? {
         root.swiftModel.service
     }
@@ -2809,6 +3216,87 @@ public class DDRUMViewEventRUMEventAttributes: NSObject {
 }
 
 @objc
+public class DDRUMViewEventRUMDevice: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var brand: String? {
+        root.swiftModel.device!.brand
+    }
+
+    @objc public var model: String? {
+        root.swiftModel.device!.model
+    }
+
+    @objc public var name: String? {
+        root.swiftModel.device!.name
+    }
+
+    @objc public var type: DDRUMViewEventRUMDeviceRUMDeviceType {
+        .init(swift: root.swiftModel.device!.type)
+    }
+}
+
+@objc
+public enum DDRUMViewEventRUMDeviceRUMDeviceType: Int {
+    internal init(swift: RUMDevice.RUMDeviceType) {
+        switch swift {
+        case .mobile: self = .mobile
+        case .desktop: self = .desktop
+        case .tablet: self = .tablet
+        case .tv: self = .tv
+        case .gamingConsole: self = .gamingConsole
+        case .bot: self = .bot
+        case .other: self = .other
+        }
+    }
+
+    internal var toSwift: RUMDevice.RUMDeviceType {
+        switch self {
+        case .mobile: return .mobile
+        case .desktop: return .desktop
+        case .tablet: return .tablet
+        case .tv: return .tv
+        case .gamingConsole: return .gamingConsole
+        case .bot: return .bot
+        case .other: return .other
+        }
+    }
+
+    case mobile
+    case desktop
+    case tablet
+    case tv
+    case gamingConsole
+    case bot
+    case other
+}
+
+@objc
+public class DDRUMViewEventRUMOS: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var name: String {
+        root.swiftModel.os!.name
+    }
+
+    @objc public var version: String {
+        root.swiftModel.os!.version
+    }
+
+    @objc public var versionMajor: String {
+        root.swiftModel.os!.versionMajor
+    }
+}
+
+@objc
 public class DDRUMViewEventSession: NSObject {
     internal let root: DDRUMViewEvent
 
@@ -2994,6 +3482,10 @@ public class DDRUMViewEventView: NSObject {
         root.swiftModel.view.frozenFrame != nil ? DDRUMViewEventViewFrozenFrame(root: root) : nil
     }
 
+    @objc public var frustration: DDRUMViewEventViewFrustration? {
+        root.swiftModel.view.frustration != nil ? DDRUMViewEventViewFrustration(root: root) : nil
+    }
+
     @objc public var id: String {
         root.swiftModel.view.id
     }
@@ -3119,6 +3611,19 @@ public class DDRUMViewEventViewFrozenFrame: NSObject {
 
     @objc public var count: NSNumber {
         root.swiftModel.view.frozenFrame!.count as NSNumber
+    }
+}
+
+@objc
+public class DDRUMViewEventViewFrustration: NSObject {
+    internal let root: DDRUMViewEvent
+
+    internal init(root: DDRUMViewEvent) {
+        self.root = root
+    }
+
+    @objc public var count: NSNumber {
+        root.swiftModel.view.frustration!.count as NSNumber
     }
 }
 
@@ -3560,4 +4065,4 @@ public class DDTelemetryDebugEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/568fc1bcfb0d2775a11c07914120b70a3d5780fe
+// Generated from https://github.com/DataDog/rum-events-format/tree/d5a943ad55117da57d0b87f9af417ccbcbd49daf

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -14,6 +14,8 @@ extension RUMActionEvent: EquatableInTests {}
 extension RUMErrorEvent: EquatableInTests {}
 extension RUMLongTaskEvent: EquatableInTests {}
 extension RUMCrashEvent: EquatableInTests {}
+extension RUMDevice: EquatableInTests {}
+extension RUMOS: EquatableInTests {}
 
 extension RUMUser {
     static func mockRandom() -> RUMUser {
@@ -51,6 +53,33 @@ extension RUMEventAttributes: RandomMockable {
     }
 }
 
+extension RUMDevice: RandomMockable {
+    static func mockRandom() -> RUMDevice {
+        return .init(
+            brand: .mockRandom(),
+            model: .mockRandom(),
+            name: .mockRandom(),
+            type: .mockRandom()
+        )
+    }
+}
+
+extension RUMDevice.RUMDeviceType: RandomMockable {
+    static func mockRandom() -> RUMDevice.RUMDeviceType {
+        return [.mobile, .desktop, .tablet, .tv, .gamingConsole, .bot, .other].randomElement()!
+    }
+}
+
+extension RUMOS: RandomMockable {
+    static func mockRandom() -> RUMOS {
+        return .init(
+            name: .mockRandom(length: 5),
+            version: .mockRandom(among: .decimalDigits, length: 2),
+            versionMajor: .mockRandom(among: .decimalDigits, length: 1)
+        )
+    }
+}
+
 extension RUMViewEvent: RandomMockable {
     static func mockRandom() -> RUMViewEvent {
         return mockRandomWith()
@@ -72,6 +101,8 @@ extension RUMViewEvent: RandomMockable {
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
+            device: .mockRandom(),
+            os: .mockRandom(),
             service: .mockRandom(),
             session: .init(
                 hasReplay: nil,
@@ -97,6 +128,7 @@ extension RUMViewEvent: RandomMockable {
                 firstInputDelay: .mockRandom(),
                 firstInputTime: .mockRandom(),
                 frozenFrame: .init(count: .mockRandom()),
+                frustration: nil,
                 id: .mockRandom(),
                 inForegroundPeriods: [
                     .init(
@@ -140,6 +172,8 @@ extension RUMResourceEvent: RandomMockable {
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
+            device: .mockRandom(),
+            os: .mockRandom(),
             resource: .init(
                 connect: .init(duration: .mockRandom(), start: .mockRandom()),
                 dns: .init(duration: .mockRandom(), start: .mockRandom()),
@@ -189,12 +223,13 @@ extension RUMActionEvent: RandomMockable {
             action: .init(
                 crash: .init(count: .mockRandom()),
                 error: .init(count: .mockRandom()),
-                frustrationType: nil,
+                frustration: nil,
                 id: .mockRandom(),
                 loadingTime: .mockRandom(),
                 longTask: .init(count: .mockRandom()),
+                position: nil,
                 resource: .init(count: .mockRandom()),
-                target: .init(name: .mockRandom()),
+                target: .init(height: nil, name: .mockRandom(), selector: nil, width: .mockRandom()),
                 type: [.tap, .swipe, .scroll].randomElement()!
             ),
             application: .init(id: .mockRandom()),
@@ -202,6 +237,8 @@ extension RUMActionEvent: RandomMockable {
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
+            device: .mockRandom(),
+            os: .mockRandom(),
             service: .mockRandom(),
             session: .init(
                 hasReplay: nil,
@@ -241,6 +278,7 @@ extension RUMErrorEvent: RandomMockable {
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
+            device: .mockRandom(),
             error: .init(
                 handling: nil,
                 handlingStack: nil,
@@ -262,6 +300,7 @@ extension RUMErrorEvent: RandomMockable {
                 stack: .mockRandom(),
                 type: .mockRandom()
             ),
+            os: .mockRandom(),
             service: .mockRandom(),
             session: .init(
                 hasReplay: nil,
@@ -308,7 +347,9 @@ extension RUMLongTaskEvent: RandomMockable {
             connectivity: .mockRandom(),
             context: .mockRandom(),
             date: .mockRandom(),
+            device: .mockRandom(),
             longTask: .init(duration: .mockRandom(), id: .mockRandom(), isFrozenFrame: .mockRandom()),
+            os: .mockRandom(),
             service: .mockRandom(),
             session: .init(hasReplay: false, id: .mockRandom(), type: .user),
             source: .ios,

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Preparing/TypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Output/Preparing/TypeTransformer.swift
@@ -20,6 +20,10 @@ internal class TransformationContext<T> {
 
     var current: T? { stack.last }
     var parent: T? { stack.dropLast().last }
+
+    func predecessor(matching predicate: (T) -> Bool) -> T? {
+        return stack.reversed().first { predicate($0) }
+    }
 }
 
 /// Transforms given type `T`.

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/RUM/RUMSwiftTypeTransformer.swift
@@ -10,7 +10,16 @@ import Foundation
 internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
     /// Types which will shared between all input `types`. Sharing means detaching those types from nested declaration
     /// and putting them at the root level of the resultant `types` array, so the type can be printed without being nested.
-    private let sharedTypeNames = ["RUMConnectivity", "RUMUser", "RUMMethod", "RUMEventAttributes", "RUMCITest"]
+    private let sharedTypeNames = [
+        "RUMConnectivity",
+        "RUMUser",
+        "RUMMethod",
+        "RUMEventAttributes",
+        "RUMCITest",
+        "RUMDevice",
+        "RUMOS",
+    ]
+
     /// `RUMDataModel` protocol, implemented by all RUM models.
     private let rumDataModelProtocol = SwiftProtocol(name: "RUMDataModel", conformance: [codableProtocol])
 
@@ -152,7 +161,8 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
 
         // If the type name collides with Swift `Type` keyword, prefix it with parent type name.
         if fixedName == "Type" {
-            let parentTypeName = (context.parent as? SwiftStruct)?.name ?? ""
+            let parentStruct = context.predecessor(matching: { $0 is SwiftStruct }) as? SwiftStruct
+            let parentTypeName = parentStruct?.name ?? ""
             fixedName = format(structName: parentTypeName) + fixedName
         }
 
@@ -174,6 +184,14 @@ internal class RUMSwiftTypeTransformer: TypeTransformer<SwiftType> {
 
         if fixedName == "CiTest" {
             fixedName = "RUMCITest"
+        }
+
+        if fixedName == "Device" {
+            fixedName = "RUMDevice"
+        }
+
+        if fixedName == "OS" {
+            fixedName = "RUMOS"
         }
 
         return fixedName

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUMModelsGeneratorTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/RUMModelsGeneratorTests.swift
@@ -9,24 +9,21 @@ import XCTest
 
 final class RUMModelsGeneratorTests: XCTestCase {
     /// Test made for debugging purpose.
-    /// Uncomment it to run code generation for `../../../rum-events-format/schemas`.
+    /// Uncomment it to run code generation for `../../../rum-events-format/rum-events-format.json`.
 //    func testPrintDebugSchemas() throws {
-//        let rumEventsFormatSchemasFolder = URL(fileURLWithPath: #file)
+//        let schema = URL(fileURLWithPath: #file)
 //            .deletingLastPathComponent()
 //            .deletingLastPathComponent()
 //            .deletingLastPathComponent()
-//            .appendingPathComponent("rum-events-format/schemas", isDirectory: true)
+//            .appendingPathComponent("rum-events-format/rum-events-format.json")
 //
-//        let schemasFolderURL = URL(fileURLWithPath: rumEventsFormatSchemasFolder.absoluteString)
-//
-//        let schemas = try RUMJSONSchemaFiles(folder: schemasFolderURL)
 //        let generator = RUMModelsGenerator()
-
+//
 //        print(">>>>>>>>>>>>>>>>>> Swift >>>>>>>>>>>>>>>>>>>>>>")
-//        print(try generator.printRUMModels(for: schemas, using: .swift))
+//        print(try generator.printRUMModels(path: schema, using: .swift))
 //        print("<<<<<<<<<<<<<<<<<< Swift <<<<<<<<<<<<<<<<<<<<<<")
 //        print(">>>>>>>>>>>>>>>>>> ObjcInterop >>>>>>>>>>>>>>>>>>>>>>")
-//        print(try generator.printRUMModels(for: schemas, using: .objcInterop))
+//        print(try generator.printRUMModels(path: schema, using: .objcInterop))
 //        print(">>>>>>>>>>>>>>>>>> ObjcInterop >>>>>>>>>>>>>>>>>>>>>>")
 //    }
 }


### PR DESCRIPTION
### What and why?

📦 This PR updates RUM models to https://github.com/DataDog/rum-events-format/commit/d5a943ad55117da57d0b87f9af417ccbcbd49daf so we can set `device` and `os` information.

This PR only introduces new fields that will be set in the next PR.

### How?

* Upgraded RUM models to https://github.com/DataDog/rum-events-format/commit/d5a943ad55117da57d0b87f9af417ccbcbd49daf.
* I enhanced the patch from https://github.com/DataDog/dd-sdk-ios/pull/801 to be more strict and only applied for `action.id`.
* I did smaller adjustments to the RUM models generator to make model definitions looks good in public APIs.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
