### PR TITLE
RUMM-2256 Fix Mac Catalyst compatibility in `1.11.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Changes
 
+* [BUGFIX] Fix Mac Catalyst builds compatibility. See [#894][]
+
 # 1.11.0 / 13-06-2022
 
 ### Changes
@@ -385,6 +387,7 @@
 [#837]: https://github.com/DataDog/dd-sdk-ios/issues/837
 [#832]: https://github.com/DataDog/dd-sdk-ios/issues/832
 [#851]: https://github.com/DataDog/dd-sdk-ios/issues/851
+[#894]: https://github.com/DataDog/dd-sdk-ios/issues/894
 [@00FA9A]: https://github.com/00FA9A
 [@Britton-Earnin]: https://github.com/Britton-Earnin
 [@Hengyu]: https://github.com/Hengyu

--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -50,7 +50,7 @@ internal protocol CarrierInfoProviderType {
 extension CarrierInfo.RadioAccessTechnology {
     init(ctRadioAccessTechnologyConstant: String) {
         switch ctRadioAccessTechnologyConstant {
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         case CTRadioAccessTechnologyGPRS: self = .GPRS
         case CTRadioAccessTechnologyEdge: self = .Edge
         case CTRadioAccessTechnologyWCDMA: self = .WCDMA
@@ -74,7 +74,7 @@ internal class CarrierInfoProvider: CarrierInfoProviderType {
     private let wrappedProvider: CarrierInfoProviderType
 
     convenience init() {
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(macCatalyst)
         if #available(iOS 12.0, *) {
             self.init(wrappedProvider: iOS12CarrierInfoProvider(networkInfo: CTTelephonyNetworkInfo()))
         } else {
@@ -106,7 +106,7 @@ internal struct NOPCarrierInfoProvider: CarrierInfoProviderType {
     func subscribe<Observer>(_ subscriber: Observer) where Observer: ValueObserver, Observer.ObservedValue == CarrierInfo? {}
 }
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 /// Carrier info provider for iOS 12 and above.
 /// It reads `CarrierInfo?` from `CTTelephonyNetworkInfo` only when `CTCarrier` has changed (e.g. when the SIM card was swapped).
 @available(iOS 12, *)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -289,14 +289,18 @@ workflows:
             #!/usr/bin/env bash
             set -e
             make test-spm ci=${CI}
-    - xcodebuild:
+    - script:
         title: Check Mac Catalyst compatibility (build SPMProject for Catalyst)
         run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
         inputs:
-        - scheme: App iOS
-        - destination: platform=macOS,variant=Mac Catalyst
-        - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/spm/SPMProject.xcodeproj"
-        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/SPMProject-catalyst-sanity-check.html"
+        - content: |-
+            #!/usr/bin/env bash
+            set -euxo pipefail
+
+            xcodebuild build -scheme "App iOS" \
+                -project "$BITRISE_SOURCE_DIR/dependency-manager-tests/spm/SPMProject.xcodeproj" \
+                -destination "platform=macOS,variant=Mac Catalyst" \
+                | xcpretty
     - xcode-test:
         title: Run SPMProject iOS tests
         run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'


### PR DESCRIPTION
### What and why?

🐞 Solves #892 revealing Mac Catalyst compatibility broken in `1.11.0`.

It was broken incidentally  in https://github.com/DataDog/dd-sdk-ios/pull/764 and because we lost observability on it in smoke tests, the problem was not alerted.

### How?

First, I fixed the Mac Catalyst compatibility **smoke test** in `bitrise.yml`. This test started failing silently (we don't know when). Because it was based on 3rd-party [`cbf1/bitrise-step-xcodebuild`](https://github.com/cbf1/bitrise-step-xcodebuild) instead of tracing the problem, I replace it with plain 1st-party [`script`](https://github.com/bitrise-steplib/steps-script). We now run `xcodebuild` directly with `-euxo pipefail` flags to fail the job on any issues.

Second, I fixed the actual **implementation** by bringing back `#if targetEnvironment(macCatalyst)` checks incidentally removed in https://github.com/DataDog/dd-sdk-ios/pull/764.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [x] Run smoke tests
