### PR TITLE
RUMM-2203 Use unique data directory for each instance of the SDK

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -103,7 +103,7 @@
 		61133C6D2423990D00786299 /* TestsDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C462423990D00786299 /* TestsDirectory.swift */; };
 		61133C6E2423990D00786299 /* DatadogExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C472423990D00786299 /* DatadogExtensions.swift */; };
 		61133C702423993200786299 /* Datadog.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133B82242393DE00786299 /* Datadog.framework */; };
-		6114FDEC257659E90084E372 /* FeatureDirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FDEB257659E90084E372 /* FeatureDirectoriesMock.swift */; };
+		6114FDEC257659E90084E372 /* DirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FDEB257659E90084E372 /* DirectoriesMock.swift */; };
 		6114FE0F257667D40084E372 /* ConsentAwareDataWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */; };
 		6114FE1625766B310084E372 /* TrackingConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE1525766B310084E372 /* TrackingConsent.swift */; };
 		6114FE23257671F00084E372 /* ConsentAwareDataWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */; };
@@ -429,6 +429,10 @@
 		61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980B924E28D0100E03345 /* RUMIntegrations.swift */; };
 		61D980BC24E293F600E03345 /* RUMIntegrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */; };
 		61DA20F026C40121004AFE6D /* DataUploadStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA20EF26C40121004AFE6D /* DataUploadStatusTests.swift */; };
+		61DA8CA928609C5B0074A606 /* Directories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CA828609C5B0074A606 /* Directories.swift */; };
+		61DA8CAA28609C5B0074A606 /* Directories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CA828609C5B0074A606 /* Directories.swift */; };
+		61DA8CAC2861C3720074A606 /* DirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CAB2861C3720074A606 /* DirectoriesTests.swift */; };
+		61DA8CAD2861C3720074A606 /* DirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CAB2861C3720074A606 /* DirectoriesTests.swift */; };
 		61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */; };
 		61DC6D922539E3E300FFAA22 /* LoggingCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DC6D912539E3E300FFAA22 /* LoggingCommonAsserts.swift */; };
 		61DE332625C826E4008E3EC2 /* CrashReportingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DE332525C826E4008E3EC2 /* CrashReportingFeature.swift */; };
@@ -835,7 +839,7 @@
 		D2CB6EF727C520D400A62B57 /* URLSessionAutoInstrumentationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B038B92527257B00518F3C /* URLSessionAutoInstrumentationMocks.swift */; };
 		D2CB6EF827C520D400A62B57 /* LogConsoleOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133C3E2423990D00786299 /* LogConsoleOutputTests.swift */; };
 		D2CB6EF927C520D400A62B57 /* WebRUMEventConsumerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E53889B2773C4B300A7DC42 /* WebRUMEventConsumerTests.swift */; };
-		D2CB6EFA27C520D400A62B57 /* FeatureDirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FDEB257659E90084E372 /* FeatureDirectoriesMock.swift */; };
+		D2CB6EFA27C520D400A62B57 /* DirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114FDEB257659E90084E372 /* DirectoriesMock.swift */; };
 		D2CB6EFB27C520D400A62B57 /* SpanSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61122EE725B1C92500F9C7F5 /* SpanSanitizerTests.swift */; };
 		D2CB6EFC27C520D400A62B57 /* DDGlobal+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B5E42426DFAFBC000B0A5F /* DDGlobal+apiTests.m */; };
 		D2CB6EFD27C520D400A62B57 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
@@ -1310,7 +1314,7 @@
 		61133C452423990D00786299 /* SwiftExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftExtensions.swift; sourceTree = "<group>"; };
 		61133C462423990D00786299 /* TestsDirectory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestsDirectory.swift; sourceTree = "<group>"; };
 		61133C472423990D00786299 /* DatadogExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogExtensions.swift; sourceTree = "<group>"; };
-		6114FDEB257659E90084E372 /* FeatureDirectoriesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureDirectoriesMock.swift; sourceTree = "<group>"; };
+		6114FDEB257659E90084E372 /* DirectoriesMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoriesMock.swift; sourceTree = "<group>"; };
 		6114FE0E257667D40084E372 /* ConsentAwareDataWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentAwareDataWriter.swift; sourceTree = "<group>"; };
 		6114FE1525766B310084E372 /* TrackingConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingConsent.swift; sourceTree = "<group>"; };
 		6114FE22257671F00084E372 /* ConsentAwareDataWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentAwareDataWriterTests.swift; sourceTree = "<group>"; };
@@ -1638,6 +1642,8 @@
 		61D980B924E28D0100E03345 /* RUMIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrations.swift; sourceTree = "<group>"; };
 		61D980BB24E293F600E03345 /* RUMIntegrationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMIntegrationsTests.swift; sourceTree = "<group>"; };
 		61DA20EF26C40121004AFE6D /* DataUploadStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUploadStatusTests.swift; sourceTree = "<group>"; };
+		61DA8CA828609C5B0074A606 /* Directories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Directories.swift; sourceTree = "<group>"; };
+		61DA8CAB2861C3720074A606 /* DirectoriesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoriesTests.swift; sourceTree = "<group>"; };
 		61DB33B025DEDFC200F7EA71 /* CustomObjcViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomObjcViewController.h; sourceTree = "<group>"; };
 		61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomObjcViewController.m; sourceTree = "<group>"; };
 		61DC6D912539E3E300FFAA22 /* LoggingCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingCommonAsserts.swift; sourceTree = "<group>"; };
@@ -2111,6 +2117,7 @@
 		61133B9E2423979B00786299 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				61DA8CA828609C5B0074A606 /* Directories.swift */,
 				614D812B24E3EA15004C9C5D /* Feature.swift */,
 				61BBD19424ED4E9E0023E65F /* FeaturesConfiguration.swift */,
 				614E9EB2244719FA007EE3E1 /* BundleType.swift */,
@@ -2373,7 +2380,7 @@
 				D26F59312851E30B0097C455 /* DatadogInternal */,
 				61C3646F243B5C8300C4D4E6 /* ServerMock.swift */,
 				61F1A6192498A51700075390 /* CoreMocks.swift */,
-				6114FDEB257659E90084E372 /* FeatureDirectoriesMock.swift */,
+				6114FDEB257659E90084E372 /* DirectoriesMock.swift */,
 				61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */,
 				61AD4E172451C7FF006E34EA /* TracingFeatureMocks.swift */,
 				61E5333024B75DFC003D6C4E /* RUMFeatureMocks.swift */,
@@ -2390,6 +2397,7 @@
 		61133C212423990D00786299 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				61DA8CAB2861C3720074A606 /* DirectoriesTests.swift */,
 				61EF78C0257F842000EDCCB3 /* FeatureTests.swift */,
 				61BBD19624ED50040023E65F /* FeaturesConfigurationTests.swift */,
 				61345612244756E300E7DA6B /* PerformancePresetTests.swift */,
@@ -5013,6 +5021,7 @@
 				D2EFF3D32731822A00D09F33 /* RUMViewsHandler.swift in Sources */,
 				61133BDD2423979B00786299 /* InternalLoggers.swift in Sources */,
 				6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */,
+				61DA8CA928609C5B0074A606 /* Directories.swift in Sources */,
 				D248ED4228070E2B00B315B4 /* Telemetry.swift in Sources */,
 				9EB4B864274FAB410041CD03 /* WebLogEventConsumer.swift in Sources */,
 				61EF78B1257E2E7A00EDCCB3 /* MoveDataMigrator.swift in Sources */,
@@ -5233,7 +5242,7 @@
 				61B038BA2527257B00518F3C /* URLSessionAutoInstrumentationMocks.swift in Sources */,
 				61133C672423990D00786299 /* LogConsoleOutputTests.swift in Sources */,
 				9E53889C2773C4B300A7DC42 /* WebRUMEventConsumerTests.swift in Sources */,
-				6114FDEC257659E90084E372 /* FeatureDirectoriesMock.swift in Sources */,
+				6114FDEC257659E90084E372 /* DirectoriesMock.swift in Sources */,
 				61122EE825B1C92500F9C7F5 /* SpanSanitizerTests.swift in Sources */,
 				61B5E42526DFAFBC000B0A5F /* DDGlobal+apiTests.m in Sources */,
 				61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */,
@@ -5277,6 +5286,7 @@
 				9EB4B86C27510AF90041CD03 /* WebEventBridgeTests.swift in Sources */,
 				61B0387C252724AB00518F3C /* DDURLSessionDelegateTests.swift in Sources */,
 				D26F59362851E3650097C455 /* Flushable.swift in Sources */,
+				61DA8CAC2861C3720074A606 /* DirectoriesTests.swift in Sources */,
 				61AADBDD263C7ECF008ABC6F /* EquatableInTests.swift in Sources */,
 				61133C5E2423990D00786299 /* DataUploadDelayTests.swift in Sources */,
 				61B0387A252724AB00518F3C /* FirstPartyURLsFilterTests.swift in Sources */,
@@ -5759,6 +5769,7 @@
 				D2CB6E9127C50EAE00A62B57 /* KronosTimeFreeze.swift in Sources */,
 				D2CB6E9227C50EAE00A62B57 /* DateFormatting.swift in Sources */,
 				D2CB6E9327C50EAE00A62B57 /* LogUtilityOutputs.swift in Sources */,
+				61DA8CAA28609C5B0074A606 /* Directories.swift in Sources */,
 				D2CB6E9427C50EAE00A62B57 /* RequestBuilder.swift in Sources */,
 				D2CB6E9527C50EAE00A62B57 /* RUMContext.swift in Sources */,
 				D2CB6E9627C50EAE00A62B57 /* RUMOffViewEventsHandlingRule.swift in Sources */,
@@ -5862,7 +5873,7 @@
 				D2CB6EF727C520D400A62B57 /* URLSessionAutoInstrumentationMocks.swift in Sources */,
 				D2CB6EF827C520D400A62B57 /* LogConsoleOutputTests.swift in Sources */,
 				D2CB6EF927C520D400A62B57 /* WebRUMEventConsumerTests.swift in Sources */,
-				D2CB6EFA27C520D400A62B57 /* FeatureDirectoriesMock.swift in Sources */,
+				D2CB6EFA27C520D400A62B57 /* DirectoriesMock.swift in Sources */,
 				D2CB6EFB27C520D400A62B57 /* SpanSanitizerTests.swift in Sources */,
 				D2CB6EFC27C520D400A62B57 /* DDGlobal+apiTests.m in Sources */,
 				D2CB6EFD27C520D400A62B57 /* LoggingFeatureMocks.swift in Sources */,
@@ -5905,6 +5916,7 @@
 				D2CB6F2327C520D400A62B57 /* WebEventBridgeTests.swift in Sources */,
 				D2CB6F2427C520D400A62B57 /* DDURLSessionDelegateTests.swift in Sources */,
 				D26F59372851E3650097C455 /* Flushable.swift in Sources */,
+				61DA8CAD2861C3720074A606 /* DirectoriesTests.swift in Sources */,
 				D2CB6F2527C520D400A62B57 /* EquatableInTests.swift in Sources */,
 				D2CB6F2627C520D400A62B57 /* DataUploadDelayTests.swift in Sources */,
 				D2CB6F2727C520D400A62B57 /* FirstPartyURLsFilterTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -433,6 +433,10 @@
 		61DA8CAA28609C5B0074A606 /* Directories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CA828609C5B0074A606 /* Directories.swift */; };
 		61DA8CAC2861C3720074A606 /* DirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CAB2861C3720074A606 /* DirectoriesTests.swift */; };
 		61DA8CAD2861C3720074A606 /* DirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CAB2861C3720074A606 /* DirectoriesTests.swift */; };
+		61DA8CAF28620C760074A606 /* Cryptography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CAE28620C760074A606 /* Cryptography.swift */; };
+		61DA8CB028620C760074A606 /* Cryptography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CAE28620C760074A606 /* Cryptography.swift */; };
+		61DA8CB2286215DE0074A606 /* CryptographyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CB1286215DE0074A606 /* CryptographyTests.swift */; };
+		61DA8CB3286215DE0074A606 /* CryptographyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA8CB1286215DE0074A606 /* CryptographyTests.swift */; };
 		61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */; };
 		61DC6D922539E3E300FFAA22 /* LoggingCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DC6D912539E3E300FFAA22 /* LoggingCommonAsserts.swift */; };
 		61DE332625C826E4008E3EC2 /* CrashReportingFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DE332525C826E4008E3EC2 /* CrashReportingFeature.swift */; };
@@ -1644,6 +1648,8 @@
 		61DA20EF26C40121004AFE6D /* DataUploadStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataUploadStatusTests.swift; sourceTree = "<group>"; };
 		61DA8CA828609C5B0074A606 /* Directories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Directories.swift; sourceTree = "<group>"; };
 		61DA8CAB2861C3720074A606 /* DirectoriesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoriesTests.swift; sourceTree = "<group>"; };
+		61DA8CAE28620C760074A606 /* Cryptography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cryptography.swift; sourceTree = "<group>"; };
+		61DA8CB1286215DE0074A606 /* CryptographyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptographyTests.swift; sourceTree = "<group>"; };
 		61DB33B025DEDFC200F7EA71 /* CustomObjcViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomObjcViewController.h; sourceTree = "<group>"; };
 		61DB33B125DEDFC200F7EA71 /* CustomObjcViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomObjcViewController.m; sourceTree = "<group>"; };
 		61DC6D912539E3E300FFAA22 /* LoggingCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingCommonAsserts.swift; sourceTree = "<group>"; };
@@ -2144,6 +2150,7 @@
 				611529A425E3DD51004F740E /* ValuePublisher.swift */,
 				9EAF0CF7275A2FDC0044E8CA /* HostsSanitizer.swift */,
 				613C6B8F2768FDDE00870CBF /* Sampler.swift */,
+				61DA8CAE28620C760074A606 /* Cryptography.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3262,6 +3269,7 @@
 				61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */,
 				9EA8A7F0275E1518007D6FDB /* HostsSanitizerTests.swift */,
 				613C6B912768FF3100870CBF /* SamplerTests.swift */,
+				61DA8CB1286215DE0074A606 /* CryptographyTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -5158,6 +5166,7 @@
 				D24C27EA270C8BEE005DE596 /* DataCompression.swift in Sources */,
 				61133BE42423979B00786299 /* LogEventEncoder.swift in Sources */,
 				B3FC3C0926526F0000DEED9E /* VitalInfo.swift in Sources */,
+				61DA8CAF28620C760074A606 /* Cryptography.swift in Sources */,
 				616F1FB32840125400651A3A /* RUMV2Configuration.swift in Sources */,
 				613E81F025A740140084B751 /* RUMEventsMapper.swift in Sources */,
 				61D980BA24E28D0100E03345 /* RUMIntegrations.swift in Sources */,
@@ -5252,6 +5261,7 @@
 				61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */,
 				61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */,
 				9EAF0CF6275A21100044E8CA /* WKUserContentController+DatadogTests.swift in Sources */,
+				61DA8CB2286215DE0074A606 /* CryptographyTests.swift in Sources */,
 				615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */,
 				615A4A8724A3452800233986 /* DDTracerConfigurationTests.swift in Sources */,
 				613E81F725A743600084B751 /* RUMEventsMapperTests.swift in Sources */,
@@ -5692,6 +5702,7 @@
 				D2CB6E4527C50EAE00A62B57 /* RUMResourceScope.swift in Sources */,
 				D2CB6E4627C50EAE00A62B57 /* RUMSessionScope.swift in Sources */,
 				D2B3F04B2829510600C2B5EE /* DatadogCoreProtocol.swift in Sources */,
+				61DA8CB028620C760074A606 /* Cryptography.swift in Sources */,
 				D2DC4BF727F484AA00E4FB96 /* DataEncryption.swift in Sources */,
 				D2CB6E4727C50EAE00A62B57 /* TracingUUID.swift in Sources */,
 				D2CB6E4827C50EAE00A62B57 /* ServerDateProvider.swift in Sources */,
@@ -5882,6 +5893,7 @@
 				D2CB6F0027C520D400A62B57 /* RUMSessionMatcher.swift in Sources */,
 				D2CB6F0127C520D400A62B57 /* DatadogPrivateMocks.swift in Sources */,
 				D2CB6F0227C520D400A62B57 /* TracingFeatureMocks.swift in Sources */,
+				61DA8CB3286215DE0074A606 /* CryptographyTests.swift in Sources */,
 				D2CB6F0327C520D400A62B57 /* WKUserContentController+DatadogTests.swift in Sources */,
 				D2CB6F0427C520D400A62B57 /* DDTracerTests.swift in Sources */,
 				D2CB6F0527C520D400A62B57 /* DDTracerConfigurationTests.swift in Sources */,

--- a/Sources/Datadog/Core/Directories.swift
+++ b/Sources/Datadog/Core/Directories.swift
@@ -1,0 +1,68 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Indicates the main directory for a given instance of the SDK.
+/// Each instance of `DatadogCore` creates its own `CoreDirectory` to manage data for registered Features.
+/// The core directory is created under `/Library/Caches` and uses a name that identifies the certain instance
+/// of the SDK (`<sdk-instance-uuid>`):
+///
+/// ```
+/// /Library/Cache/com.datadoghq/v2/<sdk-instance-uuid>/
+/// ```
+///
+/// Note: System may delete data in `/Library/Cache` to free up disk space which reduces the impact on devices working
+/// under heavy space pressure. This is intentional for Datadog SDK to have its data purged when system needs more memory
+/// for other apps.
+internal struct CoreDirectory {
+    /// A known OS location the core directory is created within:`/Library/Cache`.
+    let osDirectory: Directory
+    /// The core directory specific to this instance of the SDK: `/Library/Cache/com.datadoghq/v2/<sdk-instance-uuid>`.
+    let coreDirectory: Directory
+
+    /// Obtains subdirectories for managing Feature data (creates if don't exist).
+    /// - Parameter configuration: the storage configuration for given Feature
+    func getFeatureDirectories(configuration: FeatureStorageConfiguration) throws -> FeatureDirectories {
+        return FeatureDirectories(
+            deprecated: configuration.directories.deprecated.compactMap { deprecatedPath in
+                try? osDirectory.subdirectory(path: deprecatedPath) // ignore errors - deprecated paths likely do not exist
+            },
+            unauthorized: try coreDirectory.createSubdirectory(path: configuration.directories.unauthorized),
+            authorized: try coreDirectory.createSubdirectory(path: configuration.directories.authorized)
+        )
+    }
+}
+
+internal extension CoreDirectory {
+    /// Creates the core directory.
+    /// - Parameters:
+    ///   - osDirectory: the root OS directory (`/Library/Caches`) to create core directory inside.
+    ///   - configuration: the configuration of SDK instance. It is used to determine unique path of the core
+    ///   directory created for this instance of the SDK.
+    init(in osDirectory: Directory, from configuration: CoreConfiguration) throws {
+        let sdkInstanceUUID = configuration.clientToken // TODO: RUMM-2203 use hash(clientToken, DD site)
+        let path = "com.datadoghq/v2/\(sdkInstanceUUID)"
+
+        self.init(
+            osDirectory: osDirectory,
+            coreDirectory: try osDirectory.createSubdirectory(path: path)
+        )
+    }
+}
+
+/// Bundles directories for managing data in single Feature.
+internal struct FeatureDirectories {
+    /// Deprecated data directory that can be deleted safely.
+    let deprecated: [Directory]
+    /// Data directory for storing unauthorized data collected without knowing the tracking consent value.
+    /// Due to the consent change, data in this directory may be either moved to `authorized` folder or entirely deleted.
+    let unauthorized: Directory
+    /// Data directory for storing authorized data collected when tracking consent is granted.
+    /// Consent change does not impact data already stored in this folder.
+    /// Data in this folder gets uploaded to the server.
+    let authorized: Directory
+}

--- a/Sources/Datadog/Core/Directories.swift
+++ b/Sources/Datadog/Core/Directories.swift
@@ -44,7 +44,10 @@ internal extension CoreDirectory {
     ///   - configuration: the configuration of SDK instance. It is used to determine unique path of the core
     ///   directory created for this instance of the SDK.
     init(in osDirectory: Directory, from configuration: CoreConfiguration) throws {
-        let sdkInstanceUUID = configuration.clientToken // TODO: RUMM-2203 use hash(clientToken, DD site)
+        let clientToken = configuration.clientToken
+        let site = configuration.site?.rawValue ?? ""
+
+        let sdkInstanceUUID = sha256("\(clientToken)\(site)")
         let path = "com.datadoghq/v2/\(sdkInstanceUUID)"
 
         self.init(

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -6,35 +6,6 @@
 
 import Foundation
 
-/// Lists different types of data directories used by the feature.
-internal struct FeatureDirectories {
-    /// Deprecated data directory that can be deleted safely.
-    let deprecated: [Directory]
-    /// Data directory for storing unauthorized data collected without knowing the tracking consent value.
-    /// Due to the consent change, data in this directory may be either moved to `authorized` folder or entirely deleted.
-    let unauthorized: Directory
-    /// Data directory for storing authorized data collected when tracking consent is granted.
-    /// Consent change does not impact data already stored in this folder.
-    /// Data in this folder gets uploaded to the server.
-    let authorized: Directory
-}
-
-extension FeatureDirectories {
-    /// Creates `FeatureDirectories` from V2 storage configuration.
-    /// - Parameters:
-    ///   - sdkRootDirectory: the root directory for SDK instance
-    ///   - storageConfiguration: the storage configuration of Feature
-    init(sdkRootDirectory: Directory, storageConfiguration: FeatureStorageConfiguration) throws {
-        self.init(
-            deprecated: storageConfiguration.directories.deprecated.compactMap { deprecatedPath in
-                try? sdkRootDirectory.subdirectory(path: deprecatedPath) // ignore errors - deprecated paths likely do not exist
-            },
-            unauthorized: try sdkRootDirectory.createSubdirectory(path: storageConfiguration.directories.unauthorized),
-            authorized: try sdkRootDirectory.createSubdirectory(path: storageConfiguration.directories.authorized)
-        )
-    }
-}
-
 /// Container with dependencies common to all features (Logging, Tracing and RUM).
 internal struct FeaturesCommonDependencies {
     let consentProvider: ConsentProvider

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -12,6 +12,9 @@ import Foundation
 /// unvalidated and unresolved inputs, it should never be passed to features. Instead, `FeaturesConfiguration` should be used.
 internal struct FeaturesConfiguration {
     struct Common {
+        /// [Datadog Site](https://docs.datadoghq.com/getting_started/site/) for data uploads. It can be `nil` in V1
+        /// if the SDK is configured using deprecated APIs: `set(logsEndpoint:)`, `set(tracesEndpoint:)` and `set(rumEndpoint:)`.
+        let site: DatadogSite?
         let clientToken: String
         let applicationName: String
         let applicationVersion: String
@@ -149,6 +152,7 @@ extension FeaturesConfiguration {
         }
 
         let common = Common(
+            site: configuration.datadogEndpoint,
             clientToken: try ifValid(clientToken: configuration.clientToken),
             applicationName: appContext.bundleName ?? appContext.bundleType.rawValue,
             applicationVersion: appContext.bundleVersion ?? "0.0.0",

--- a/Sources/Datadog/Core/Utils/Cryptography.swift
+++ b/Sources/Datadog/Core/Utils/Cryptography.swift
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import CryptoKit
+import CommonCrypto
+
+/// Computes SHA256 for given `string`.
+///
+/// The implementation is portable between iOS versions - it uses `CryptoKit` on iOS13+ and fallbacks
+/// to `CommonCrypto` on older devices.
+internal func sha256(_ string: String) -> String {
+    guard let data = string.data(using: .utf8) else {
+        return string
+    }
+
+    if #available(iOS 13.0, tvOS 13.0, *) { // Compute SHA256 with `CryptoKit`
+        let digest = SHA256.hash(data: data)
+        return digest
+            .map({ byte in String(format: "%02x", byte) })
+            .joined(separator: "")
+    } else { // Fallback to SHA256 with `CommonCrypto`
+        var digest: [UInt8] = Array(repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        _ = data.withUnsafeBytes { CC_SHA256($0.baseAddress, UInt32(data.count), &digest) }
+        return digest
+            .map({ byte in String(format: "%02x", byte) })
+            .joined(separator: "")
+    }
+}

--- a/Sources/Datadog/Core/Utils/Cryptography.swift
+++ b/Sources/Datadog/Core/Utils/Cryptography.swift
@@ -5,28 +5,17 @@
  */
 
 import Foundation
-import CryptoKit
 import CommonCrypto
 
 /// Computes SHA256 for given `string`.
-///
-/// The implementation is portable between iOS versions - it uses `CryptoKit` on iOS13+ and fallbacks
-/// to `CommonCrypto` on older devices.
 internal func sha256(_ string: String) -> String {
     guard let data = string.data(using: .utf8) else {
         return string
     }
 
-    if #available(iOS 13.0, tvOS 13.0, *) { // Compute SHA256 with `CryptoKit`
-        let digest = SHA256.hash(data: data)
-        return digest
-            .map({ byte in String(format: "%02x", byte) })
-            .joined(separator: "")
-    } else { // Fallback to SHA256 with `CommonCrypto`
-        var digest: [UInt8] = Array(repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-        _ = data.withUnsafeBytes { CC_SHA256($0.baseAddress, UInt32(data.count), &digest) }
-        return digest
-            .map({ byte in String(format: "%02x", byte) })
-            .joined(separator: "")
-    }
+    var digest: [UInt8] = Array(repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+    _ = data.withUnsafeBytes { CC_SHA256($0.baseAddress, UInt32(data.count), &digest) }
+    return digest
+        .map({ byte in String(format: "%02x", byte) })
+        .joined(separator: "")
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -204,7 +204,7 @@ public class Datadog {
 
         // Set default `DatadogCore`:
         let core = DatadogCore(
-            rootDirectory: try Directory.cache(),
+            directory: try CoreDirectory(in: try Directory.cache(), from: configuration.common),
             configuration: configuration.common,
             dependencies: commonDependencies
         )

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -204,7 +204,7 @@ public class Datadog {
 
         // Set default `DatadogCore`:
         let core = DatadogCore(
-            directory: try CoreDirectory(in: try Directory.cache(), from: configuration.common),
+            directory: try CoreDirectory(in: Directory.cache(), from: configuration.common),
             configuration: configuration.common,
             dependencies: commonDependencies
         )

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -48,7 +48,7 @@ extension Datadog {
             case never
         }
 
-        public enum DatadogEndpoint {
+        public enum DatadogEndpoint: String {
             /// US based servers.
             /// Sends data to [app.datadoghq.com](https://app.datadoghq.com/).
             case us1

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -19,10 +19,13 @@ internal struct FeatureStorageConfiguration {
     /// Each path is relative to the root folder of given SDK instance.
     struct Directories {
         /// The path for writing authorized data (when tracking consent is granted).
+        /// This path must be relative to the core directory created for given instance of the SDK.
         let authorized: String
         /// The path for writing unauthorized data (when tracking consent is pending).
+        /// This path must be relative to the core directory created for given instance of the SDK.
         let unauthorized: String
         /// The list of deprecated paths from previous versions of this feature. It is used to perform cleanup.
+        /// These paths must be relative to the known OS location (`/Library/Caches/`) containing core directories for different instances of the SDK.
         let deprecated: [String]
     }
 

--- a/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
@@ -6,6 +6,10 @@
 
 import Foundation
 
+/// Datadog site that SDK sends data to.
+/// See: https://docs.datadoghq.com/getting_started/site/
+internal typealias DatadogSite = Datadog.Configuration.DatadogEndpoint
+
 /// The SDK context for V1, until the V2 context is created.
 ///
 /// V2-like context can be safely assembled from V1 core components. Unlike in V2, this requires more hassle and is less performant:
@@ -33,6 +37,10 @@ internal struct DatadogV1Context {
 /// This extension bundles different parts of the SDK core configuration.
 internal extension DatadogV1Context {
     // MARK: - Datadog Specific
+
+    /// [Datadog Site](https://docs.datadoghq.com/getting_started/site/) for data uploads. It can be `nil` in V1
+    /// if the SDK is configured using deprecated APIs: `set(logsEndpoint:)`, `set(tracesEndpoint:)` and `set(rumEndpoint:)`.
+    var site: DatadogSite? { configuration.site }
 
     /// The client token allowing for data uploads to [Datadog Site](https://docs.datadoghq.com/getting_started/site/).
     var clientToken: String { configuration.clientToken }

--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -10,11 +10,10 @@ import Foundation
 internal func createV2LoggingStorageConfiguration() -> FeatureStorageConfiguration {
     return FeatureStorageConfiguration(
         directories: .init(
-            authorized: "com.datadoghq.logs/v2",
-            unauthorized: "com.datadoghq.logs/intermediate-v2",
+            authorized: "logging/v2", // relative to `CoreDirectory.coreDirectory`
+            unauthorized: "logging/intermediate-v2", // relative to `CoreDirectory.coreDirectory`
             deprecated: [
-                "com.datadoghq.logs/v1",
-                "com.datadoghq.logs/intermediate-v1",
+                "com.datadoghq.logs", // relative to `CoreDirectory.osDirectory`
             ]
         ),
         featureName: "logging"

--- a/Sources/Datadog/RUM/RUMV2Configuration.swift
+++ b/Sources/Datadog/RUM/RUMV2Configuration.swift
@@ -10,11 +10,10 @@ import Foundation
 internal func createV2RUMStorageConfiguration() -> FeatureStorageConfiguration {
     return FeatureStorageConfiguration(
         directories: .init(
-            authorized: "com.datadoghq.rum/v2",
-            unauthorized: "com.datadoghq.rum/intermediate-v2",
+            authorized: "rum/v2", // relative to `CoreDirectory.coreDirectory`
+            unauthorized: "rum/intermediate-v2", // relative to `CoreDirectory.coreDirectory`
             deprecated: [
-                "com.datadoghq.rum/v1",
-                "com.datadoghq.rum/intermediate-v1",
+                "com.datadoghq.rum", // relative to `CoreDirectory.osDirectory`
             ]
         ),
         featureName: "RUM"

--- a/Sources/Datadog/Tracing/TracingV2Configuration.swift
+++ b/Sources/Datadog/Tracing/TracingV2Configuration.swift
@@ -10,11 +10,10 @@ import Foundation
 internal func createV2TracingStorageConfiguration() -> FeatureStorageConfiguration {
     return FeatureStorageConfiguration(
         directories: .init(
-            authorized: "com.datadoghq.traces/v2",
-            unauthorized: "com.datadoghq.traces/intermediate-v2",
+            authorized: "tracing/v2", // relative to `CoreDirectory.coreDirectory`
+            unauthorized: "tracing/intermediate-v2", // relative to `CoreDirectory.coreDirectory`
             deprecated: [
-                "com.datadoghq.traces/v1",
-                "com.datadoghq.traces/intermediate-v1",
+                "com.datadoghq.traces", // relative to `CoreDirectory.osDirectory`
             ]
         ),
         featureName: "tracing"

--- a/Tests/DatadogTests/Datadog/Core/DirectoriesTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/DirectoriesTests.swift
@@ -18,12 +18,53 @@ class DirectoriesTests: XCTestCase {
         super.tearDown()
     }
 
+    func testWhenCreatingCoreDirectory_thenItsNameIsUniqueForClientTokenAndSite() throws {
+        // Given
+        let fixtures: [(clientToken: String, site: DatadogSite?, expectedName: String)] = [
+            ("abcdef", .us1, "d5f91716d9c17bc76cb9931e1f9ff37724a27d4c05f1eb7081f59ea34d44c777"),
+            ("abcdef", .us3, "4a2e7e5b459af9976950e85463db2ba1e71500cdd77ead26b41559bf5a372dfb"),
+            ("abcdef", .us5, "38028ebbeab2aa980eab9e5a8ee714f93e8118621472697dabe084e6a9c55cd1"),
+            ("abcdef", .eu1, "ff203358d7d236d35dd6acbe6f74b2db17c5855c9a8c43d4f9c2d6869af413e9"),
+            ("abcdef", .us1_fed, "2a69100a36ae68ad3b081daa4c254fcade6b804ec71eda9109b7ec4b8317940b"),
+            ("abcdef", nil, "bef57ec7f53a6d40beb640a780a639c83bc29ac8a9816f1fc6c5c6dcd93c4721"),
+            ("ghijkl", .us1, "158931c9e9576ef6ed1576721227d29e641e3f0ec2083e4bff280684f6b7ca94"),
+            ("ghijkl", .us3, "e098808a9b0e3695f6b876ff677e50aaf98034606369abeabd5df45bbe8bb739"),
+            ("ghijkl", .us5, "6212ba431e02e4da2da2f36a5fe9d26b4c33641a63be75c22e81196acfde7d91"),
+            ("ghijkl", .eu1, "16fbe70ae92694f96bb36021589ae2ae5f050872548c26fe320cde96eac81957"),
+            ("ghijkl", .us1_fed, "1585291b515c607624ed20935382bde4438ffac64f190b20a064eb6c1b734c6b"),
+            ("ghijkl", nil, "54f6ee81b58accbc57adbceb0f50264897626060071dc9e92f897e7b373deb93"),
+        ]
+
+        // When
+        let coreDirectories = try fixtures.map { clientToken, site, _ in
+            try CoreDirectory(
+                in: temporaryDirectory,
+                from: .mockWith(site: site, clientToken: clientToken)
+            )
+        }
+        defer { coreDirectories.forEach { $0.delete() } }
+
+        // Then
+        zip(fixtures, coreDirectories).forEach { fixture, coreDirectory in
+            let directoryName = coreDirectory.coreDirectory.url.lastPathComponent
+            XCTAssertEqual(directoryName, fixture.expectedName)
+            XCTAssertFalse(
+                directoryName.contains(fixture.clientToken),
+                "The core directory name must not include client token"
+            )
+        }
+    }
+
     func testGivenDifferentSDKConfigurations_whenCreatingCoreDirectories_thenEachDirectoryIsUnique() throws {
         // Given
         let sdkConfigurations: [CoreConfiguration] = (0..<50).map { index in
+            let randomSite: DatadogSite = .mockRandom()
             let randomClientToken: String = .mockRandom(among: .alphanumerics, length: 31) + "\(index)"
 
-            return .mockWith(clientToken: randomClientToken)
+            return .mockWith(
+                site: randomSite,
+                clientToken: randomClientToken
+            )
         }
 
         // When

--- a/Tests/DatadogTests/Datadog/Core/DirectoriesTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/DirectoriesTests.swift
@@ -1,0 +1,112 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class DirectoriesTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        temporaryDirectory.create()
+    }
+
+    override func tearDown() {
+        temporaryDirectory.delete()
+        super.tearDown()
+    }
+
+    func testGivenDifferentSDKConfigurations_whenCreatingCoreDirectories_thenEachDirectoryIsUnique() throws {
+        // Given
+        let sdkConfigurations: [CoreConfiguration] = (0..<50).map { index in
+            let randomClientToken: String = .mockRandom(among: .alphanumerics, length: 31) + "\(index)"
+
+            return .mockWith(clientToken: randomClientToken)
+        }
+
+        // When
+        let coreDirectories = try sdkConfigurations.map { sdkConfiguration in
+            try CoreDirectory(in: temporaryDirectory, from: sdkConfiguration)
+        }
+        defer { coreDirectories.forEach { $0.delete() } }
+
+        // Then
+        let uniqueCoreDirectoryURLs = Set(coreDirectories.map({ $0.coreDirectory.url }))
+        XCTAssertEqual(
+            sdkConfigurations.count,
+            uniqueCoreDirectoryURLs.count,
+            "It must create unique core directory URL for each SDK configuration"
+        )
+    }
+
+    func testGivenCoreDirectory_whenCreatingFeatureDirectories_thenTheirPathsAreRelative() throws {
+        // Given
+        let coreDirectory = temporaryCoreDirectory.create()
+        defer { coreDirectory.delete() }
+
+        // When
+        let randomAuthorizedPath: String = .mockRandom(among: .alphanumerics)
+        let randomUnauthorizedPath: String = .mockRandom(among: .alphanumerics)
+
+        let randomFeatureConfiguration = FeatureStorageConfiguration(
+            directories: .init(
+                authorized: randomAuthorizedPath,
+                unauthorized: randomUnauthorizedPath,
+                deprecated: []
+            ),
+            featureName: .mockRandom()
+        )
+        let featureDirectories = try coreDirectory.getFeatureDirectories(configuration: randomFeatureConfiguration)
+
+        // Then
+        XCTAssertTrue(
+            featureDirectories.authorized.url.path.contains(coreDirectory.coreDirectory.url.path),
+            "Feature's authorized directory must be relative to core directory"
+        )
+        XCTAssertTrue(
+            featureDirectories.unauthorized.url.path.contains(coreDirectory.coreDirectory.url.path),
+            "Feature's unauthorized directory must be relative to core directory"
+        )
+    }
+
+    func testGivenCoreDirectory_whenCreatingFeatureDirectories_thenItObtainsOnlyDeprecatedPathsThatExist() throws {
+        // Given
+        let coreDirectory = temporaryCoreDirectory.create()
+        defer { coreDirectory.delete() }
+
+        let randomExisingDeprecatedPaths: [String] = (0..<5).map { _ in .mockRandom(among: .alphanumerics) }
+        let randomNotExistingDeprecatedPaths: [String] = (0..<5).map { _ in .mockRandom(among: .alphanumerics) }
+
+        try randomExisingDeprecatedPaths.forEach { _ = try coreDirectory.osDirectory.createSubdirectory(path: $0) }
+
+        // When
+        let randomFeatureConfiguration = FeatureStorageConfiguration(
+            directories: .init(
+                authorized: .mockRandom(among: .alphanumerics),
+                unauthorized: .mockRandom(among: .alphanumerics),
+                deprecated: (randomExisingDeprecatedPaths + randomNotExistingDeprecatedPaths).shuffled()
+            ),
+            featureName: .mockRandom()
+        )
+        let featureDirectories = try coreDirectory.getFeatureDirectories(configuration: randomFeatureConfiguration)
+
+        // Then
+        XCTAssertEqual(
+            featureDirectories.deprecated.count,
+            randomExisingDeprecatedPaths.count,
+            "It must obtain directory for each deprecated path that exists"
+        )
+        featureDirectories.deprecated.forEach { deprecatedDirectory in
+            XCTAssertTrue(
+                deprecatedDirectory.url.path.contains(coreDirectory.osDirectory.url.path),
+                "Feature's deprecated directory must be relative to OS directory"
+            )
+            XCTAssertFalse(
+                deprecatedDirectory.url.path.contains(coreDirectory.coreDirectory.url.path),
+                "Feature's deprecated directory must NOT be relative to core directory"
+            )
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -152,7 +152,7 @@ class FeaturesConfigurationTests: XCTestCase {
     }
 
     func testClientToken() throws {
-        let clientToken: String = .mockRandom(among: "abcdefgh")
+        let clientToken: String = .mockRandom(among: .alphanumerics)
         let configuration = try createConfiguration(clientToken: clientToken)
 
         XCTAssertEqual(configuration.common.clientToken, clientToken)

--- a/Tests/DatadogTests/Datadog/Core/Utils/CryptographyTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Utils/CryptographyTests.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class CryptographyTests: XCTestCase {
+    func testItComputesSHA256ForArbitraryString() {
+        (0..<20).forEach { _ in
+            // Given
+            let string: String = .mockRandom(among: .allUnicodes, length: .mockRandom(min: 1, max: 500))
+
+            // When
+            let sha = sha256(string)
+
+            // Then
+            XCTAssertEqual(sha.count, 64, "It must use 64 characters")
+            XCTAssertFalse(sha.contains(where: { !$0.isASCII }), "It must contain only ASCII characters")
+        }
+    }
+
+    func testWhenComputingSHA256_itGivesStableResults() {
+        XCTAssertEqual(sha256(""), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+        XCTAssertEqual(sha256("foo"), "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+        XCTAssertEqual(sha256("Bar Bizz"), "ad81f738a40902ef4bb3e4d5f5b83d3e2b3b7edfcd1669ddd4004d4815d03a75")
+        XCTAssertEqual(sha256(".//,"), "822236197264817e14fdd2939d9dc68c7d0151a6265798dd29511315cb428c66")
+    }
+}

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -442,9 +442,9 @@ class DatadogTests: XCTestCase {
         core.readWriteQueue.sync {}
 
         let featureDirectories: [FeatureDirectories] = [
-            try FeatureDirectories(sdkRootDirectory: core.rootDirectory, storageConfiguration: createV2LoggingStorageConfiguration()),
-            try FeatureDirectories(sdkRootDirectory: core.rootDirectory, storageConfiguration: createV2TracingStorageConfiguration()),
-            try FeatureDirectories(sdkRootDirectory: core.rootDirectory, storageConfiguration: createV2RUMStorageConfiguration())
+            try core.directory.getFeatureDirectories(configuration: createV2LoggingStorageConfiguration()),
+            try core.directory.getFeatureDirectories(configuration: createV2TracingStorageConfiguration()),
+            try core.directory.getFeatureDirectories(configuration: createV2RUMStorageConfiguration()),
         ]
 
         let allDirectories: [Directory] = featureDirectories.flatMap { [$0.authorized, $0.unauthorized] }

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -10,11 +10,11 @@ import XCTest
 class LoggingFeatureTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        temporaryDirectory.create()
+        temporaryCoreDirectory.create()
     }
 
     override func tearDown() {
-        temporaryDirectory.delete()
+        temporaryCoreDirectory.delete()
         super.tearDown()
     }
 
@@ -36,7 +36,7 @@ class LoggingFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
         let core = DatadogCore(
-            rootDirectory: temporaryDirectory,
+            directory: temporaryCoreDirectory,
             configuration: .mockWith(
                 clientToken: randomClientToken,
                 applicationName: randomApplicationName,
@@ -95,7 +95,7 @@ class LoggingFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
         let core = DatadogCore(
-            rootDirectory: temporaryDirectory,
+            directory: temporaryCoreDirectory,
             configuration: .mockAny(),
             dependencies: .mockWith(
                 performance: .combining(

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -866,7 +866,7 @@ extension RequestBuilder.HTTPHeader: RandomMockable, AnyMockable {
     static func mockRandom() -> RequestBuilder.HTTPHeader {
         let all: [RequestBuilder.HTTPHeader] = [
             .contentTypeHeader(contentType: Bool.random() ? .applicationJSON : .textPlainUTF8),
-            .userAgentHeader(appName: .mockRandom(among: .alphanumerics), appVersion: .alphanumerics, device: .mockAny()),
+            .userAgentHeader(appName: .mockRandom(among: .alphanumerics), appVersion: .mockRandom(among: .alphanumerics), device: .mockAny()),
             .ddAPIKeyHeader(clientToken: .mockRandom(among: .alphanumerics)),
             .ddEVPOriginHeader(source: .mockRandom(among: .alphanumerics)),
             .ddEVPOriginVersionHeader(sdkVersion: .mockRandom(among: .alphanumerics)),

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -141,7 +141,11 @@ extension BundleType: CaseIterable {
     public static var allCases: [Self] { [.iOSApp, iOSAppExtension] }
 }
 
-extension Datadog.Configuration.DatadogEndpoint: RandomMockable {
+extension Datadog.Configuration.DatadogEndpoint: AnyMockable, RandomMockable {
+    static func mockAny() -> Datadog.Configuration.DatadogEndpoint {
+        return .us1
+    }
+
     static func mockRandom() -> Self {
         return [.us1, .us3, .eu1, .us1_fed].randomElement()!
     }
@@ -191,6 +195,7 @@ extension FeaturesConfiguration.Common {
     static func mockAny() -> Self { mockWith() }
 
     static func mockWith(
+        site: DatadogSite? = .mockAny(),
         clientToken: String = .mockAny(),
         applicationName: String = .mockAny(),
         applicationVersion: String = .mockAny(),
@@ -205,6 +210,7 @@ extension FeaturesConfiguration.Common {
         encryption: DataEncryption? = nil
     ) -> Self {
         return .init(
+            site: site,
             clientToken: clientToken,
             applicationName: applicationName,
             applicationVersion: applicationVersion,

--- a/Tests/DatadogTests/Datadog/Mocks/DirectoriesMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DirectoriesMock.swift
@@ -6,6 +6,30 @@
 
 @testable import Datadog
 
+/// `CoreDirectory` pointing to subfolders in `/var/folders/`.
+/// This location does not exist by default and should be created and deleted by calling `.create()` and `.delete()` in each test,
+/// which guarantees clear state before and after test.
+let temporaryCoreDirectory = CoreDirectory(
+    osDirectory: obtainUniqueTemporaryDirectory(),
+    coreDirectory: obtainUniqueTemporaryDirectory()
+)
+
+extension CoreDirectory {
+    /// Creates temporary core directory.
+    @discardableResult
+    func create() -> Self {
+        osDirectory.create()
+        coreDirectory.create()
+        return self
+    }
+
+    /// Deletes temporary core directory.
+    func delete() {
+        osDirectory.delete()
+        coreDirectory.delete()
+    }
+}
+
 /// `FeatureDirectories` pointing to subfolders in `/var/folders/`.
 /// Those subfolders do not exist by default and should be created and deleted by calling `.create()` and `.delete()` in each test,
 /// which guarantees clear state before and after test.

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -10,11 +10,11 @@ import XCTest
 class RUMFeatureTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        temporaryDirectory.create()
+        temporaryCoreDirectory.create()
     }
 
     override func tearDown() {
-        temporaryDirectory.delete()
+        temporaryCoreDirectory.delete()
         super.tearDown()
     }
 
@@ -38,7 +38,7 @@ class RUMFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
         let core = DatadogCore(
-            rootDirectory: temporaryDirectory,
+            directory: temporaryCoreDirectory,
             configuration: .mockWith(
                 clientToken: randomClientToken,
                 applicationName: randomApplicationName,
@@ -104,7 +104,7 @@ class RUMFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
         let core = DatadogCore(
-            rootDirectory: temporaryDirectory,
+            directory: temporaryCoreDirectory,
             configuration: .mockAny(),
             dependencies: .mockWith(
                 performance: .combining(

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMViewIdentityTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMViewIdentityTests.swift
@@ -13,8 +13,8 @@ class RUMViewIdentityTests: XCTestCase {
 
     func testGivenTwoUIViewControllers_whenComparingTheirRUMViewIdentity_itEqualsOnlyForTheSameInstance() {
         // Given
-        let vc1 = createMockView(viewControllerClassName: .mockRandom(among: "abcdefghijklmnopqrstuvwxyz"))
-        let vc2 = createMockView(viewControllerClassName: .mockRandom(among: "abcdefghijklmnopqrstuvwxyz"))
+        let vc1 = createMockView(viewControllerClassName: .mockRandom(among: .alphanumerics))
+        let vc2 = createMockView(viewControllerClassName: .mockRandom(among: .alphanumerics))
         let vc3: UIViewController? = nil
 
         // When
@@ -53,7 +53,7 @@ class RUMViewIdentityTests: XCTestCase {
 
     func testGivenTwoRUMViewIdentitiesOfDifferentKind_whenComparing_theyDoNotEqual() {
         // Given
-        let vc = createMockView(viewControllerClassName: .mockRandom(among: "abcdefghijklmnopqrstuvwxyz"))
+        let vc = createMockView(viewControllerClassName: .mockRandom(among: .alphanumerics))
         let key: String = .mockRandom()
 
         // When

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -874,11 +874,11 @@ class TracerTests: XCTestCase {
         testThreadSafety(
             closures: [
                 // swiftlint:disable opening_brace
-                { span in span.setTag(key: .mockRandom(among: "abcde", length: 1), value: "value") },
-                { span in span.setBaggageItem(key: .mockRandom(among: "abcde", length: 1), value: "value") },
-                { span in _ = span.baggageItem(withKey: .mockRandom(among: "abcde")) },
+                { span in span.setTag(key: .mockRandom(among: .alphanumerics, length: 1), value: "value") },
+                { span in span.setBaggageItem(key: .mockRandom(among: .alphanumerics, length: 1), value: "value") },
+                { span in _ = span.baggageItem(withKey: .mockRandom(among: .alphanumerics)) },
                 { span in _ = span.context.forEachBaggageItem { _, _ in return false } },
-                { span in span.log(fields: [.mockRandom(among: "abcde", length: 1): "value"]) },
+                { span in span.log(fields: [.mockRandom(among: .alphanumerics, length: 1): "value"]) },
                 { span in span.finish() }
                 // swiftlint:enable opening_brace
             ]

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -10,11 +10,11 @@ import XCTest
 class TracingFeatureTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        temporaryDirectory.create()
+        temporaryCoreDirectory.create()
     }
 
     override func tearDown() {
-        temporaryDirectory.delete()
+        temporaryCoreDirectory.delete()
         super.tearDown()
     }
 
@@ -36,7 +36,7 @@ class TracingFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
         let core = DatadogCore(
-            rootDirectory: temporaryDirectory,
+            directory: temporaryCoreDirectory,
             configuration: .mockWith(
                 clientToken: randomClientToken,
                 applicationName: randomApplicationName,
@@ -96,7 +96,7 @@ class TracingFeatureTests: XCTestCase {
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200)))
 
         let core = DatadogCore(
-            rootDirectory: temporaryDirectory,
+            directory: temporaryCoreDirectory,
             configuration: .mockAny(),
             dependencies: .mockWith(
                 performance: .combining(

--- a/Tests/DatadogTests/Helpers/TestsDirectory.swift
+++ b/Tests/DatadogTests/Helpers/TestsDirectory.swift
@@ -10,9 +10,13 @@ import XCTest
 
 /// Creates `Directory` pointing to unique subfolder in `/var/folders/`.
 /// Does not create the subfolder - it must be later created with `.create()`.
+/// It returns different `Directory` each time it is called.
 func obtainUniqueTemporaryDirectory() -> Directory {
     let subdirectoryName = "com.datadoghq.ios-sdk-tests-\(UUID().uuidString)"
-    let osTemporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(subdirectoryName, isDirectory: true)
+    let osTemporaryDirectoryURL = URL(
+        fileURLWithPath: NSTemporaryDirectory(),
+        isDirectory: true
+    ).appendingPathComponent(subdirectoryName, isDirectory: true)
     print("💡 Obtained temporary directory URL: \(osTemporaryDirectoryURL)")
     return Directory(url: osTemporaryDirectoryURL)
 }

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -98,9 +98,19 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
             """
         ),
         .init(
+            assert: { !temporaryCoreDirectory.coreDirectory.exists()
+                && !temporaryCoreDirectory.osDirectory.exists()
+            },
+            problem: "`temporaryCoreDirectory` must not exist.",
+            solution: """
+            Make sure `temporaryCoreDirectory.delete()` is called consistently
+            with `temporaryCoreDirectory.create()`.
+            """
+        ),
+        .init(
             assert: {
-                temporaryFeatureDirectories.authorized.exists() == false
-                    && temporaryFeatureDirectories.unauthorized.exists() == false
+                !temporaryFeatureDirectories.authorized.exists()
+                    && !temporaryFeatureDirectories.unauthorized.exists()
             },
             problem: "`temporaryFeatureDirectories` must not exist.",
             solution: """


### PR DESCRIPTION
### What and why?

📦 With this PR, each instance of `DatadogCore` will use a different directory for managing its data.

This is a step forward towards V2 architecture, where we're going to support multiple SDK instances. Each instance of the SDK needs to persist data in different locations.

This is the content of `/Library/Caches/` when using two instances of `DatadogCore`:

<img width="551" alt="Screenshot 2022-06-22 at 17 13 47" src="https://user-images.githubusercontent.com/2358722/175066902-7f3514a1-f2f3-492d-ad41-b37d954d7b14.png">


### How?

Each `DatadogCore` now accepts a "core directory". I introduced a separate `CoreDirectory` type that wraps [`Directory`](https://github.com/DataDog/dd-sdk-ios/blob/ef343b1781218392790bd7085fad4b27628ea44b/Sources/Datadog/Core/Persistence/Files/Directory.swift#L10) - this is to enforce type safety at configuration level and to avoid passing wrong directory by mistake.

The `CoreDirectory` creates the folder structure for SDK and its Features. It uses a hash function (sha256) for computing the folder name that is unique for given instance of the SDK:
```swift
let directoryName = sha256("\(clientToken)\(site)")
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
