### PR TITLE
Make `*.swiftinterface` validation flexible in XCFrameworks distribution

### DIFF
--- a/tools/distribution/src/release/assets/gh_asset.py
+++ b/tools/distribution/src/release/assets/gh_asset.py
@@ -36,15 +36,11 @@ class DatadogXCFrameworkValidator(XCFrameworkValidator):
             'ios-arm64',
             'ios-arm64/BCSymbolMaps/*.bcsymbolmap',
             'ios-arm64/dSYMs/*.dSYM',
-            'ios-arm64/**/arm64.swiftinterface',
-            'ios-arm64/**/arm64-apple-ios.swiftinterface',
+            'ios-arm64/**/*.swiftinterface',
 
             'ios-arm64_x86_64-simulator',
             'ios-arm64_x86_64-simulator/dSYMs/*.dSYM',
-            'ios-arm64_x86_64-simulator/**/arm64.swiftinterface',
-            'ios-arm64_x86_64-simulator/**/arm64-apple-ios-simulator.swiftinterface',
-            'ios-arm64_x86_64-simulator/**/x86_64.swiftinterface',
-            'ios-arm64_x86_64-simulator/**/x86_64-apple-ios-simulator.swiftinterface',
+            'ios-arm64_x86_64-simulator/**/*.swiftinterface',
         ])
 
         if in_version.is_older_than(min_tvos_version):
@@ -54,15 +50,11 @@ class DatadogXCFrameworkValidator(XCFrameworkValidator):
             'tvos-arm64',
             'tvos-arm64/BCSymbolMaps/*.bcsymbolmap',
             'tvos-arm64/dSYMs/*.dSYM',
-            'tvos-arm64/**/arm64.swiftinterface',
-            'tvos-arm64/**/arm64-apple-tvos.swiftinterface',
+            'tvos-arm64/**/*.swiftinterface',
 
             'tvos-arm64_x86_64-simulator',
             'tvos-arm64_x86_64-simulator/dSYMs/*.dSYM',
-            'tvos-arm64_x86_64-simulator/**/arm64.swiftinterface',
-            'tvos-arm64_x86_64-simulator/**/arm64-apple-tvos-simulator.swiftinterface',
-            'tvos-arm64_x86_64-simulator/**/x86_64.swiftinterface',
-            'tvos-arm64_x86_64-simulator/**/x86_64-apple-tvos-simulator.swiftinterface',
+            'tvos-arm64_x86_64-simulator/**/*.swiftinterface',
         ])
 
         return True
@@ -79,14 +71,10 @@ class DatadogObjcXCFrameworkValidator(XCFrameworkValidator):
             'ios-arm64',
             'ios-arm64/BCSymbolMaps/*.bcsymbolmap',
             'ios-arm64/dSYMs/*.dSYM',
-            'ios-arm64/**/arm64.swiftinterface',
-            'ios-arm64/**/arm64-apple-ios.swiftinterface',
+            'ios-arm64/**/*.swiftinterface',
 
             'ios-arm64_x86_64-simulator',
-            'ios-arm64_x86_64-simulator/**/arm64.swiftinterface',
-            'ios-arm64_x86_64-simulator/**/arm64-apple-ios-simulator.swiftinterface',
-            'ios-arm64_x86_64-simulator/**/x86_64.swiftinterface',
-            'ios-arm64_x86_64-simulator/**/x86_64-apple-ios-simulator.swiftinterface',
+            'ios-arm64_x86_64-simulator/**/*.swiftinterface',
         ])
 
         if in_version.is_older_than(min_tvos_version):
@@ -96,14 +84,10 @@ class DatadogObjcXCFrameworkValidator(XCFrameworkValidator):
             'tvos-arm64',
             'tvos-arm64/BCSymbolMaps/*.bcsymbolmap',
             'tvos-arm64/dSYMs/*.dSYM',
-            'tvos-arm64/**/arm64.swiftinterface',
-            'tvos-arm64/**/arm64-apple-tvos.swiftinterface',
+            'tvos-arm64/**/*.swiftinterface',
 
             'tvos-arm64_x86_64-simulator',
-            'tvos-arm64_x86_64-simulator/**/arm64.swiftinterface',
-            'tvos-arm64_x86_64-simulator/**/arm64-apple-tvos-simulator.swiftinterface',
-            'tvos-arm64_x86_64-simulator/**/x86_64.swiftinterface',
-            'tvos-arm64_x86_64-simulator/**/x86_64-apple-tvos-simulator.swiftinterface',
+            'tvos-arm64_x86_64-simulator/**/*.swiftinterface',
         ])
 
         return True
@@ -120,13 +104,11 @@ class DatadogCrashReportingXCFrameworkValidator(XCFrameworkValidator):
         dir.assert_it_has_files([
             'ios-arm64',
             'ios-arm64/BCSymbolMaps/*.bcsymbolmap',
-            'ios-arm64/**/arm64.swiftinterface',
-            'ios-arm64/**/arm64-apple-ios.swiftinterface',
+            'ios-arm64/**/*.swiftinterface',
 
             'ios-arm64_x86_64-simulator',
             'ios-arm64_x86_64-simulator/dSYMs/*.dSYM',
-            'ios-arm64_x86_64-simulator/**/x86_64.swiftinterface',
-            'ios-arm64_x86_64-simulator/**/x86_64-apple-ios-simulator.swiftinterface',
+            'ios-arm64_x86_64-simulator/**/*.swiftinterface',
         ])
         
         if in_version.is_older_than(min_tvos_version):
@@ -135,13 +117,11 @@ class DatadogCrashReportingXCFrameworkValidator(XCFrameworkValidator):
         dir.assert_it_has_files([
             'tvos-arm64',
             'tvos-arm64/BCSymbolMaps/*.bcsymbolmap',
-            'tvos-arm64/**/arm64.swiftinterface',
-            'tvos-arm64/**/arm64-apple-tvos.swiftinterface',
+            'tvos-arm64/**/*.swiftinterface',
 
             'tvos-arm64_x86_64-simulator',
             'tvos-arm64_x86_64-simulator/dSYMs/*.dSYM',
-            'tvos-arm64_x86_64-simulator/**/x86_64.swiftinterface',
-            'tvos-arm64_x86_64-simulator/**/x86_64-apple-tvos-simulator.swiftinterface',
+            'tvos-arm64_x86_64-simulator/**/*.swiftinterface',
         ])
 
         return True
@@ -184,18 +164,11 @@ class KronosXCFrameworkValidator(XCFrameworkValidator):
             'ios-arm64_armv7',
             'ios-arm64_armv7/BCSymbolMaps/*.bcsymbolmap',
             'ios-arm64_armv7/dSYMs/*.dSYM',
-            'ios-arm64_armv7/**/arm.swiftinterface',
-            'ios-arm64_armv7/**/arm64-apple-ios.swiftinterface',
-            'ios-arm64_armv7/**/arm64.swiftinterface',
-            'ios-arm64_armv7/**/armv7-apple-ios.swiftinterface',
-            'ios-arm64_armv7/**/armv7.swiftinterface',
+            'ios-arm64_armv7/**/*.swiftinterface',
 
             'ios-arm64_i386_x86_64-simulator',
             'ios-arm64_i386_x86_64-simulator/dSYMs/*.dSYM',
-            'ios-arm64_i386_x86_64-simulator/**/arm64-apple-ios-simulator.swiftinterface',
-            'ios-arm64_i386_x86_64-simulator/**/i386-apple-ios-simulator.swiftinterface',
-            'ios-arm64_i386_x86_64-simulator/**/x86_64-apple-ios-simulator.swiftinterface',
-            'ios-arm64_i386_x86_64-simulator/**/x86_64.swiftinterface',
+            'ios-arm64_i386_x86_64-simulator/**/*.swiftinterface',
         ])
 
         return True


### PR DESCRIPTION
### What and why?

📦 This PR fixes the `*.swiftinterface` (module stability) validation in `publish_github_asset` CI job.

Note: the SDK doesn't yet compile in module stability mode due to https://bugs.swift.org/browse/SR-14195, but we support `BUILD_LIBRARY_FOR_DISTRIBUTION=1` nevertheless.

### How?

The `gh_asset.py` script was too strict on validating the appearance of `*.swiftinterface` files. It seems that their names can differ per Xcode version, e.g.:
```
Xcode 13.1.x:
- /Datadog.xcframework/ios-arm64/Datadog.framework/Modules/Datadog.swiftmodule/arm64.swiftinterface

Xcode 13.3.x:
- /Datadog.xcframework/ios-arm64/Datadog.framework/Modules/Datadog.swiftmodule/arm64-apple-ios.swiftinterface
```
To anticipate possible name changes, I made the validation less strict and to only look if there is any `*.swiftinterface` file inside given arch slice. This should be enough to assert that `BUILD_LIBRARY_FOR_DISTRIBUTION` was configured properly for each target.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
