### PR TITLE
RUMM-2253 Fix logging integration tests after including `version` tag

### DIFF
--- a/Tests/DatadogIntegrationTests/Scenarios/Logging/LoggingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/Logging/LoggingScenarioTests.swift
@@ -63,9 +63,9 @@ class LoggingScenarioTests: IntegrationTests, LoggingCommonAsserts {
             )
 
             #if DEBUG
-            matcher.assertTags(equal: ["env:integration", "build_configuration:debug", "tag1:tag-value", "tag2", "tag3:added"])
+            matcher.assertTags(equal: ["env:integration", "build_configuration:debug", "tag1:tag-value", "tag2", "tag3:added", "version:1.0"])
             #else
-            matcher.assertTags(equal: ["env:integration", "build_configuration:release", "tag1:tag-value", "tag2", "tag3:added"])
+            matcher.assertTags(equal: ["env:integration", "build_configuration:release", "tag1:tag-value", "tag2", "tag3:added", "version:1.0"])
             #endif
 
             matcher.assertValue(


### PR DESCRIPTION
### What and why?

📦 This PR fixes Logging integration tests. In #914 we added `version` tag to all logs, but corresponding integration test also needs update. The `develop` branch is red 🟥  currently.

### How?

Merging fix into `feature/v2` which will be merged to `develop` right after.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
