### PR TITLE
RUMM-2239 Replace `Telemetry` injection with `DD.telemetry` global

### DIFF
--- a/Sources/Datadog/Core/DD/Telemetry.swift
+++ b/Sources/Datadog/Core/DD/Telemetry.swift
@@ -92,3 +92,8 @@ extension Telemetry {
         self.error(message, error: DDError(error: error), file: file, line: line)
     }
 }
+
+internal struct NoOpTelemetry: Telemetry {
+    func debug(id: String, message: String) {}
+    func error(id: String, message: String, kind: String?, stack: String?) {}
+}

--- a/Sources/Datadog/Core/DD/Telemetry.swift
+++ b/Sources/Datadog/Core/DD/Telemetry.swift
@@ -93,7 +93,7 @@ extension Telemetry {
     }
 }
 
-internal struct NoOpTelemetry: Telemetry {
+internal struct NOPTelemetry: Telemetry {
     func debug(id: String, message: String) {}
     func error(id: String, message: String, kind: String?, stack: String?) {}
 }

--- a/Sources/Datadog/Core/Feature.swift
+++ b/Sources/Datadog/Core/Feature.swift
@@ -45,20 +45,17 @@ internal struct FeatureStorage {
         queue: DispatchQueue,
         dataFormat: DataFormat,
         directories: FeatureDirectories,
-        commonDependencies: FeaturesCommonDependencies,
-        telemetry: Telemetry?
+        commonDependencies: FeaturesCommonDependencies
     ) {
         let authorizedFilesOrchestrator = FilesOrchestrator(
             directory: directories.authorized,
             performance: commonDependencies.performance,
-            dateProvider: commonDependencies.dateProvider,
-            telemetry: telemetry
+            dateProvider: commonDependencies.dateProvider
         )
         let unauthorizedFilesOrchestrator = FilesOrchestrator(
             directory: directories.unauthorized,
             performance: commonDependencies.performance,
-            dateProvider: commonDependencies.dateProvider,
-            telemetry: telemetry
+            dateProvider: commonDependencies.dateProvider
         )
 
         let dataOrchestrator = DataOrchestrator(
@@ -69,14 +66,12 @@ internal struct FeatureStorage {
 
         let unauthorizedFileWriter = FileWriter(
             orchestrator: unauthorizedFilesOrchestrator,
-            encryption: commonDependencies.encryption,
-            telemetry: telemetry
+            encryption: commonDependencies.encryption
         )
 
         let authorizedFileWriter = FileWriter(
             orchestrator: authorizedFilesOrchestrator,
-            encryption: commonDependencies.encryption,
-            telemetry: telemetry
+            encryption: commonDependencies.encryption
         )
 
         let consentAwareDataWriter = ConsentAwareDataWriter(
@@ -85,8 +80,7 @@ internal struct FeatureStorage {
             unauthorizedWriter: unauthorizedFileWriter,
             authorizedWriter: authorizedFileWriter,
             dataMigratorFactory: DataMigratorFactory(
-                directories: directories,
-                telemetry: telemetry
+                directories: directories
             )
         )
 
@@ -100,8 +94,7 @@ internal struct FeatureStorage {
             fileReader: FileReader(
                 dataFormat: dataFormat,
                 orchestrator: authorizedFilesOrchestrator,
-                encryption: commonDependencies.encryption,
-                telemetry: telemetry
+                encryption: commonDependencies.encryption
             )
         )
 
@@ -150,8 +143,7 @@ internal struct FeatureUpload {
         featureName: String,
         storage: FeatureStorage,
         requestBuilder: RequestBuilder,
-        commonDependencies: FeaturesCommonDependencies,
-        telemetry: Telemetry?
+        commonDependencies: FeaturesCommonDependencies
     ) {
         let uploadQueue = DispatchQueue(
             label: "com.datadoghq.ios-sdk-\(featureName)-upload",
@@ -175,8 +167,7 @@ internal struct FeatureUpload {
                 dataUploader: dataUploader,
                 uploadConditions: uploadConditions,
                 delay: DataUploadDelay(performance: commonDependencies.performance),
-                featureName: featureName,
-                telemetry: telemetry
+                featureName: featureName
             )
         )
     }

--- a/Sources/Datadog/Core/Persistence/FilesOrchestrator.swift
+++ b/Sources/Datadog/Core/Persistence/FilesOrchestrator.swift
@@ -19,18 +19,15 @@ internal class FilesOrchestrator {
     /// Tracks number of times the file at `lastWritableFileURL` was returned from `getWritableFile()`.
     /// This should correspond with number of objects stored in file, assuming that majority of writes succeed (the difference is negligible).
     private var lastWritableFileUsesCount: Int = 0
-    private let telemetry: Telemetry?
 
     init(
         directory: Directory,
         performance: StoragePerformancePreset,
-        dateProvider: DateProvider,
-        telemetry: Telemetry? = nil
+        dateProvider: DateProvider
     ) {
         self.directory = directory
         self.performance = performance
         self.dateProvider = dateProvider
-        self.telemetry = telemetry
     }
 
     // MARK: - `WritableFile` orchestration
@@ -79,7 +76,7 @@ internal class FilesOrchestrator {
                     return lastFile
                 }
             } catch {
-                telemetry?.error("Failed to reuse last writable file", error: error)
+                DD.telemetry.error("Failed to reuse last writable file", error: error)
             }
         }
 
@@ -113,7 +110,7 @@ internal class FilesOrchestrator {
 
             return fileIsOldEnough ? oldestFile : nil
         } catch {
-            telemetry?.error("Failed to obtain readable file", error: error)
+            DD.telemetry.error("Failed to obtain readable file", error: error)
             return nil
         }
     }
@@ -122,7 +119,7 @@ internal class FilesOrchestrator {
         do {
             try readableFile.delete()
         } catch {
-            telemetry?.error("Failed to delete file", error: error)
+            DD.telemetry.error("Failed to delete file", error: error)
         }
     }
 
@@ -130,7 +127,7 @@ internal class FilesOrchestrator {
         do {
             try directory.deleteAllFiles()
         } catch {
-            telemetry?.error("Failed to delete all readable file", error: error)
+            DD.telemetry.error("Failed to delete all readable file", error: error)
         }
     }
 

--- a/Sources/Datadog/Core/Persistence/Migrating/DataMigrator.swift
+++ b/Sources/Datadog/Core/Persistence/Migrating/DataMigrator.swift
@@ -21,17 +21,13 @@ internal struct MultiDataMigrator: DataMigrator {
 internal struct DataMigratorFactory {
     /// Data directories for the feature.
     let directories: FeatureDirectories
-    var telemetry: Telemetry? = nil
 
     /// Resolves migrator to use when the SDK is started.
     func resolveInitialMigrator() -> DataMigrator {
-        let unauthorized = DeleteAllDataMigrator(
-            directory: directories.unauthorized,
-            telemetry: telemetry
-        )
+        let unauthorized = DeleteAllDataMigrator(directory: directories.unauthorized)
 
         let deprecated = directories.deprecated.map {
-            DeleteAllDataMigrator(directory: $0, telemetry: telemetry)
+            DeleteAllDataMigrator(directory: $0)
         }
 
         return MultiDataMigrator(
@@ -43,15 +39,11 @@ internal struct DataMigratorFactory {
     func resolveMigratorForConsentChange(from previousValue: TrackingConsent, to newValue: TrackingConsent) -> DataMigrator? {
         switch (previousValue, newValue) {
         case (.pending, .notGranted):
-            return DeleteAllDataMigrator(
-                directory: directories.unauthorized,
-                telemetry: telemetry
-            )
+            return DeleteAllDataMigrator(directory: directories.unauthorized)
         case (.pending, .granted):
             return MoveDataMigrator(
                 sourceDirectory: directories.unauthorized,
-                destinationDirectory: directories.authorized,
-                telemetry: telemetry
+                destinationDirectory: directories.authorized
             )
         default:
             return nil

--- a/Sources/Datadog/Core/Persistence/Migrating/DeleteAllDataMigrator.swift
+++ b/Sources/Datadog/Core/Persistence/Migrating/DeleteAllDataMigrator.swift
@@ -9,13 +9,12 @@ import Foundation
 /// Data migrator which deletes all files in given directory.
 internal struct DeleteAllDataMigrator: DataMigrator {
     let directory: Directory
-    var telemetry: Telemetry? = nil
 
     func migrate() {
         do {
             try directory.deleteAllFiles()
         } catch {
-            telemetry?.error(
+            DD.telemetry.error(
                 "Failed to use `DeleteAllDataMigrator` in directory \(directory.url)", error: error
             )
         }

--- a/Sources/Datadog/Core/Persistence/Migrating/MoveDataMigrator.swift
+++ b/Sources/Datadog/Core/Persistence/Migrating/MoveDataMigrator.swift
@@ -11,13 +11,12 @@ import Foundation
 internal struct MoveDataMigrator: DataMigrator {
     let sourceDirectory: Directory
     let destinationDirectory: Directory
-    var telemetry: Telemetry? = nil
 
     func migrate() {
         do {
             try sourceDirectory.moveAllFiles(to: destinationDirectory)
         } catch {
-            telemetry?.error(
+            DD.telemetry.error(
                 """
                 🔥 Failed to use `MoveDataMigrator` for source directory \(sourceDirectory.url)
                 and destination directory \(destinationDirectory.url)

--- a/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
+++ b/Sources/Datadog/Core/Persistence/Reading/FileReader.swift
@@ -13,7 +13,6 @@ internal final class FileReader: Reader {
     /// Orchestrator producing reference to readable file.
     private let orchestrator: FilesOrchestrator
     private let encryption: DataEncryption?
-    private let telemetry: Telemetry?
 
     /// Files marked as read.
     private var filesRead: Set<String> = []
@@ -21,13 +20,11 @@ internal final class FileReader: Reader {
     init(
         dataFormat: DataFormat,
         orchestrator: FilesOrchestrator,
-        encryption: DataEncryption? = nil,
-        telemetry: Telemetry? = nil
+        encryption: DataEncryption? = nil
     ) {
         self.dataFormat = dataFormat
         self.orchestrator = orchestrator
         self.encryption = encryption
-        self.telemetry = telemetry
     }
 
     // MARK: - Reading batches
@@ -42,7 +39,7 @@ internal final class FileReader: Reader {
             let batchData = dataFormat.prefixData + fileData + dataFormat.suffixData
             return Batch(data: batchData, file: file)
         } catch {
-            telemetry?.error("Failed to read data from file", error: error)
+            DD.telemetry.error("Failed to read data from file", error: error)
             return nil
         }
     }

--- a/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
+++ b/Sources/Datadog/Core/Persistence/Writing/FileWriter.swift
@@ -13,17 +13,14 @@ internal final class FileWriter: Writer {
     /// JSON encoder used to encode data.
     private let jsonEncoder: JSONEncoder
     private let encryption: DataEncryption?
-    private let telemetry: Telemetry?
 
     init(
         orchestrator: FilesOrchestrator,
-        encryption: DataEncryption? = nil,
-        telemetry: Telemetry? = nil
+        encryption: DataEncryption? = nil
     ) {
         self.orchestrator = orchestrator
         self.jsonEncoder = .default()
         self.encryption = encryption
-        self.telemetry = telemetry
     }
 
     // MARK: - Writing data
@@ -36,7 +33,7 @@ internal final class FileWriter: Writer {
             try file.append(data: data)
         } catch {
             DD.logger.error("Failed to write data", error: error)
-            telemetry?.error("Failed to write data to file", error: error)
+            DD.telemetry.error("Failed to write data to file", error: error)
         }
     }
 

--- a/Sources/Datadog/Core/Upload/DataUploadWorker.swift
+++ b/Sources/Datadog/Core/Upload/DataUploadWorker.swift
@@ -23,8 +23,6 @@ internal class DataUploadWorker: DataUploadWorkerType {
     private let uploadConditions: DataUploadConditions
     /// Name of the feature this worker is performing uploads for.
     private let featureName: String
-    /// A monitor reporting errors through internal telemetry feature (if enabled).
-    private let telemetry: Telemetry?
 
     /// Delay used to schedule consecutive uploads.
     private var delay: Delay
@@ -38,8 +36,7 @@ internal class DataUploadWorker: DataUploadWorkerType {
         dataUploader: DataUploaderType,
         uploadConditions: DataUploadConditions,
         delay: Delay,
-        featureName: String,
-        telemetry: Telemetry? = nil
+        featureName: String
     ) {
         self.queue = queue
         self.fileReader = fileReader
@@ -47,7 +44,6 @@ internal class DataUploadWorker: DataUploadWorkerType {
         self.dataUploader = dataUploader
         self.delay = delay
         self.featureName = featureName
-        self.telemetry = telemetry
 
         let uploadWork = DispatchWorkItem { [weak self] in
             guard let self = self else {
@@ -79,9 +75,9 @@ internal class DataUploadWorker: DataUploadWorkerType {
                 case .unauthorized:
                     DD.logger.error("⚠️ Make sure that the provided token still exists and you're targeting the relevant Datadog site.")
                 case let .httpError(statusCode: statusCode):
-                    self.telemetry?.error("Data upload finished with status code: \(statusCode)")
+                    DD.telemetry.error("Data upload finished with status code: \(statusCode)")
                 case let .networkError(error: error):
-                    self.telemetry?.error("Data upload finished with error", error: error)
+                    DD.telemetry.error("Data upload finished with error", error: error)
                 case .none: break
                 }
             } else {

--- a/Sources/Datadog/Core/Upload/RequestBuilder.swift
+++ b/Sources/Datadog/Core/Upload/RequestBuilder.swift
@@ -100,16 +100,13 @@ internal struct RequestBuilder {
     private let precomputedHeaders: [String: String]
     /// Computed HTTP headers (their value is different in succeeding requests).
     private let computedHeaders: [String: () -> String]
-    /// A monitor reporting errors through internal telemetry feature.
-    private let telemetry: Telemetry?
 
     // MARK: - Initialization
 
     init(
         url: URL,
         queryItems: [QueryItem],
-        headers: [HTTPHeader],
-        telemetry: Telemetry? = nil
+        headers: [HTTPHeader]
     ) {
         var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
 
@@ -131,7 +128,6 @@ internal struct RequestBuilder {
         self.url = urlComponents?.url ?? url
         self.precomputedHeaders = precomputedHeaders
         self.computedHeaders = computedHeaders
-        self.telemetry = telemetry
     }
 
     /// Creates `URLRequest` for uploading given `data` to Datadog.
@@ -149,7 +145,7 @@ internal struct RequestBuilder {
             request.httpBody = body
         } else {
             request.httpBody = data
-            telemetry?.debug(
+            DD.telemetry.debug(
                 """
                 Failed to compress request payload
                 - url: \(url)

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -17,9 +17,6 @@ internal class CrashReporter {
 
     let crashContextProvider: CrashContextProviderType
 
-    /// Telemetry interface
-    let telemetry: Telemetry?
-
     // MARK: - Initialization
 
     convenience init?(
@@ -62,16 +59,14 @@ internal class CrashReporter {
                 rumSessionStateProvider: crashReportingFeature.rumSessionStateProvider,
                 appStateListener: crashReportingFeature.appStateListener
             ),
-            loggingOrRUMIntegration: availableLoggingOrRUMIntegration,
-            telemetry: crashReportingFeature.telemetry
+            loggingOrRUMIntegration: availableLoggingOrRUMIntegration
         )
     }
 
     init(
         crashReportingPlugin: DDCrashReportingPluginType,
         crashContextProvider: CrashContextProviderType,
-        loggingOrRUMIntegration: CrashReportingIntegration,
-        telemetry: Telemetry?
+        loggingOrRUMIntegration: CrashReportingIntegration
     ) {
         self.queue = DispatchQueue(
             label: "com.datadoghq.crash-reporter",
@@ -80,7 +75,6 @@ internal class CrashReporter {
         self.plugin = crashReportingPlugin
         self.loggingOrRUMIntegration = loggingOrRUMIntegration
         self.crashContextProvider = crashContextProvider
-        self.telemetry = telemetry
 
         // Inject current `CrashContext`
         self.inject(currentCrashContext: crashContextProvider.currentCrashContext)
@@ -148,7 +142,7 @@ internal class CrashReporter {
                 error: error
             )
 
-            telemetry?.error("Failed to encode crash report context", error: error)
+            DD.telemetry.error("Failed to encode crash report context", error: error)
             return nil
         }
     }
@@ -164,7 +158,7 @@ internal class CrashReporter {
                 """,
                 error: error
             )
-            telemetry?.error("Failed to decode crash report context", error: error)
+            DD.telemetry.error("Failed to decode crash report context", error: error)
             return nil
         }
     }

--- a/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
+++ b/Sources/Datadog/CrashReporting/CrashReportingFeature.swift
@@ -30,13 +30,10 @@ internal final class CrashReportingFeature {
     let rumSessionStateProvider: ValuePublisher<RUMSessionState?>
     /// Publishes changes to app "foreground" / "background" state.
     let appStateListener: AppStateListening
-    /// Telemetry interface
-    let telemetry: Telemetry?
 
     init(
         configuration: FeaturesConfiguration.CrashReporting,
-        commonDependencies: FeaturesCommonDependencies,
-        telemetry: Telemetry?
+        commonDependencies: FeaturesCommonDependencies
     ) {
         self.configuration = configuration
         self.consentProvider = commonDependencies.consentProvider
@@ -46,6 +43,5 @@ internal final class CrashReportingFeature {
         self.rumViewEventProvider = ValuePublisher(initialValue: nil) // `nil` by default, because there cannot be any RUM view at this ponit
         self.rumSessionStateProvider = ValuePublisher(initialValue: nil) // `nil` by default, because there cannot be any RUM session at this ponit
         self.appStateListener = commonDependencies.appStateListener
-        self.telemetry = telemetry
     }
 }

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -218,7 +218,7 @@ public class Datadog {
         var rumInstrumentation: RUMInstrumentation?
 
         if let rumConfiguration = configuration.rum {
-            core.telemetry = RUMTelemetry(
+            DD.telemetry = RUMTelemetry(
                 in: core,
                 sdkVersion: configuration.common.sdkVersion,
                 applicationID: rumConfiguration.applicationID,
@@ -267,8 +267,7 @@ public class Datadog {
         if let crashReportingConfiguration = configuration.crashReporting {
             crashReporting = CrashReportingFeature(
                 configuration: crashReportingConfiguration,
-                commonDependencies: commonDependencies,
-                telemetry: core.telemetry
+                commonDependencies: commonDependencies
             )
 
             core.register(feature: crashReporting)
@@ -336,6 +335,7 @@ public class Datadog {
         Global.rum = DDNoopRUMMonitor()
         Global.crashReporter?.deinitialize()
         Global.crashReporter = nil
+        DD.telemetry = NoOpTelemetry()
 
         // Deinitialize `Datadog`:
         defaultDatadogCore = NOOPDatadogCore()

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -335,7 +335,7 @@ public class Datadog {
         Global.rum = DDNoopRUMMonitor()
         Global.crashReporter?.deinitialize()
         Global.crashReporter = nil
-        DD.telemetry = NoOpTelemetry()
+        DD.telemetry = NOPTelemetry()
 
         // Deinitialize `Datadog`:
         defaultDatadogCore = NOOPDatadogCore()

--- a/Sources/Datadog/DatadogInternal/DD.swift
+++ b/Sources/Datadog/DatadogInternal/DD.swift
@@ -33,5 +33,5 @@ internal struct DD {
     ///
     /// Regardless internal optimisations, **it should be used wisely to report only useful
     /// and actionable events** that are key to SDK observability.
-    static var telemetry: Telemetry = NoOpTelemetry()
+    static var telemetry: Telemetry = NOPTelemetry()
 }

--- a/Sources/Datadog/DatadogInternal/DD.swift
+++ b/Sources/Datadog/DatadogInternal/DD.swift
@@ -24,5 +24,14 @@ internal struct DD {
         verbosityLevel: { Datadog.verbosityLevel }
     )
 
-    // TODO: RUMM-2239 Move `Telemetry` in here
+    /// The telemetry monitor providing methods to send debug information
+    /// and execution errors of the Datadog SDK. It is only available if RUM feature is used.
+    ///
+    /// All collected events are anonymous and get reported to Datadog Telemetry org.
+    /// The actual implementation of `Telemetry` provides sampling and throttling
+    /// capabilities to ensure fair usage of user quota.
+    ///
+    /// Regardless internal optimisations, **it should be used wisely to report only useful
+    /// and actionable events** that are key to SDK observability.
+    static var telemetry: Telemetry = NoOpTelemetry()
 }

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -49,7 +49,7 @@ internal struct FeatureUploadConfiguration {
 
     /// Creates the V1's `RequetsBuilder` for uploading data in this Feature.
     /// In V2 we will change it to build requests based on V2 context and batch metadata.
-    let createRequestBuilder: (DatadogV1Context, Telemetry?) -> RequestBuilder
+    let createRequestBuilder: (DatadogV1Context) -> RequestBuilder
 
     /// Data format for constructing Feature payloads in V1. It is applied by the reader when reading data from batch and
     /// before passing it to the uploader.

--- a/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
@@ -23,9 +23,6 @@ internal struct DatadogV1Context {
     private let configuration: CoreConfiguration
     private let dependencies: CoreDependencies
 
-    /// Telemetry monitor for this instance of the SDK or `nil` if not configured.
-    internal var telemetry: Telemetry?
-
     init(configuration: CoreConfiguration, dependencies: CoreDependencies) {
         self.configuration = configuration
         self.dependencies = dependencies

--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -24,7 +24,7 @@ internal func createV2LoggingStorageConfiguration() -> FeatureStorageConfigurati
 internal func createV2LoggingUploadConfiguration(v1Configuration: FeaturesConfiguration.Logging) -> FeatureUploadConfiguration {
     return FeatureUploadConfiguration(
         featureName: "logging",
-        createRequestBuilder: { v1Context, telemetry in
+        createRequestBuilder: { v1Context in
             return RequestBuilder(
                 url: v1Configuration.uploadURL,
                 queryItems: [
@@ -41,8 +41,7 @@ internal func createV2LoggingUploadConfiguration(v1Configuration: FeaturesConfig
                     .ddEVPOriginHeader(source: v1Context.ciAppOrigin ?? v1Context.source),
                     .ddEVPOriginVersionHeader(sdkVersion: v1Context.sdkVersion),
                     .ddRequestIDHeader(),
-                ],
-                telemetry: telemetry
+                ]
             )
         },
         payloadFormat: DataFormat(prefix: "[", suffix: "]", separator: ",")

--- a/Sources/Datadog/RUM/RUMEvent/RUMDeviceInfo.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMDeviceInfo.swift
@@ -8,10 +8,10 @@ import Foundation
 
 extension RUMDevice {
     init(context: DatadogV1Context) {
-        self.init(device: context.device, telemetry: context.telemetry)
+        self.init(device: context.device)
     }
 
-    init(device: DeviceInfo, telemetry: Telemetry?) {
+    init(device: DeviceInfo) {
         self.init(
             brand: device.brand,
             model: device.model,
@@ -20,7 +20,7 @@ extension RUMDevice {
                 if let type = RUMDeviceType(from: device.model) {
                     return type
                 } else {
-                    telemetry?.debug("Couldn't read `RUMDeviceType` from `device.model`: \(device.model)")
+                    DD.telemetry.debug("Couldn't read `RUMDeviceType` from `device.model`: \(device.model)")
                     return .other
                 }
             }()

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMScopeDependencies.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMScopeDependencies.swift
@@ -41,8 +41,7 @@ internal extension RUMScopeDependencies {
     init(
         rumFeature: RUMFeature,
         crashReportingFeature: CrashReportingFeature?,
-        context: DatadogV1Context,
-        telemetry: Telemetry?
+        context: DatadogV1Context
     ) {
         self.init(
             rumApplicationID: rumFeature.configuration.applicationID,
@@ -57,8 +56,7 @@ internal extension RUMScopeDependencies {
                     errorEventMapper: rumFeature.configuration.errorEventMapper,
                     resourceEventMapper: rumFeature.configuration.resourceEventMapper,
                     actionEventMapper: rumFeature.configuration.actionEventMapper,
-                    longTaskEventMapper: rumFeature.configuration.longTaskEventMapper,
-                    telemetry: telemetry
+                    longTaskEventMapper: rumFeature.configuration.longTaskEventMapper
                 )
             ),
             rumUUIDGenerator: rumFeature.configuration.uuidGenerator,
@@ -68,7 +66,7 @@ internal extension RUMScopeDependencies {
             vitalsReaders: rumFeature.configuration.vitalsFrequency.map {
                 .init(
                     frequency: $0,
-                    cpu: VitalCPUReader(telemetry: telemetry),
+                    cpu: VitalCPUReader(),
                     memory: VitalMemoryReader(),
                     refreshRate: VitalRefreshRateReader()
                 )

--- a/Sources/Datadog/RUM/RUMV2Configuration.swift
+++ b/Sources/Datadog/RUM/RUMV2Configuration.swift
@@ -24,7 +24,7 @@ internal func createV2RUMStorageConfiguration() -> FeatureStorageConfiguration {
 internal func createV2RUMUploadConfiguration(v1Configuration: FeaturesConfiguration.RUM) -> FeatureUploadConfiguration {
     return FeatureUploadConfiguration(
         featureName: "RUM",
-        createRequestBuilder: { v1Context, telemetry in
+        createRequestBuilder: { v1Context in
             return RequestBuilder(
                 url: v1Configuration.uploadURL,
                 queryItems: [
@@ -49,8 +49,7 @@ internal func createV2RUMUploadConfiguration(v1Configuration: FeaturesConfigurat
                     .ddEVPOriginHeader(source: v1Context.ciAppOrigin ?? v1Context.source),
                     .ddEVPOriginVersionHeader(sdkVersion: v1Context.sdkVersion),
                     .ddRequestIDHeader(),
-                ],
-                telemetry: telemetry
+                ]
             )
         },
         payloadFormat: DataFormat(prefix: "", suffix: "", separator: "\n")

--- a/Sources/Datadog/RUM/RUMVitals/VitalCPUReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalCPUReader.swift
@@ -14,13 +14,7 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
     private var totalInactiveTicks: natural_t = 0
     private var utilizedTicksWhenResigningActive: natural_t? = nil
 
-    let telemetry: Telemetry?
-
-    init(
-        notificationCenter: NotificationCenter = .default,
-        telemetry: Telemetry? = nil
-    ) {
-        self.telemetry = telemetry
+    init(notificationCenter: NotificationCenter = .default) {
         notificationCenter.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
@@ -71,7 +65,7 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
         if result != KERN_SUCCESS {
             // in case of error, refer to `kern_return.h` (Objc)
             // as its Swift interface doesn't have integer values
-            telemetry?.error("CPU Vital cannot be read! Error code: \(result)")
+            DD.telemetry.error("CPU Vital cannot be read! Error code: \(result)")
             return nil
         }
 

--- a/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
+++ b/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
@@ -19,7 +19,6 @@ internal struct RUMEventsMapper {
     let resourceEventMapper: RUMResourceEventMapper?
     let actionEventMapper: RUMActionEventMapper?
     let longTaskEventMapper: RUMLongTaskEventMapper?
-    var telemetry: Telemetry? = nil
 
     // MARK: - EventMapper
 
@@ -43,7 +42,7 @@ internal struct RUMEventsMapper {
         case let event as RUMLongTaskEvent:
             return map(event: event, using: longTaskEventMapper) as? T
         default:
-            telemetry?.error("No `RUMEventMapper` is registered for \(type(of: event))")
+            DD.telemetry.error("No `RUMEventMapper` is registered for \(type(of: event))")
             return event
         }
     }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -175,8 +175,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 dependencies: RUMScopeDependencies(
                     rumFeature: rumFeature,
                     crashReportingFeature: crashReporting,
-                    context: context,
-                    telemetry: context.telemetry
+                    context: context
                 ),
                 dateProvider: context.dateProvider
             )

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -156,8 +156,7 @@ internal class DDSpan: OTSpan {
                     dateCorrector: context.dateCorrector,
                     source: context.source,
                     origin: context.ciAppOrigin,
-                    eventsMapper: self.ddTracer.spanEventMapper,
-                    telemetry: context.telemetry
+                    eventsMapper: self.ddTracer.spanEventMapper
                 )
 
                 let event = builder.createSpanEvent(

--- a/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEventBuilder.swift
@@ -28,8 +28,6 @@ internal struct SpanEventBuilder {
     let origin: String?
     /// Span events mapper configured by the user, `nil` if not set.
     let eventsMapper: SpanEventMapper?
-    /// Telemetry interface
-    let telemetry: Telemetry?
 
     func createSpanEvent(
         traceID: TracingUUID,
@@ -131,7 +129,7 @@ internal struct SpanEventBuilder {
                                 codingPath: [],
                                 debugDescription: "Failed to use temporary array container when encoding span tag '\(key)' to JSON string."
                             )
-                            telemetry?.error(encodingContext.debugDescription)
+                            DD.telemetry.error(encodingContext.debugDescription)
                             throw EncodingError.invalidValue(encodable.value, encodingContext)
                         }
 
@@ -145,7 +143,7 @@ internal struct SpanEventBuilder {
                             codingPath: [],
                             debugDescription: "Failed to read utf-8 JSON data when encoding span tag '\(key)' to JSON string."
                         )
-                        telemetry?.error(encodingContext.debugDescription)
+                        DD.telemetry.error(encodingContext.debugDescription)
                         throw EncodingError.invalidValue(encodable.value, encodingContext)
                     }
                 } catch let error {

--- a/Sources/Datadog/Tracing/TracingV2Configuration.swift
+++ b/Sources/Datadog/Tracing/TracingV2Configuration.swift
@@ -24,7 +24,7 @@ internal func createV2TracingStorageConfiguration() -> FeatureStorageConfigurati
 internal func createV2TracingUploadConfiguration(v1Configuration: FeaturesConfiguration.Tracing) -> FeatureUploadConfiguration {
     return FeatureUploadConfiguration(
         featureName: "tracing",
-        createRequestBuilder: { v1Context, telemetry in
+        createRequestBuilder: { v1Context in
             return RequestBuilder(
                 url: v1Configuration.uploadURL,
                 queryItems: [],
@@ -39,8 +39,7 @@ internal func createV2TracingUploadConfiguration(v1Configuration: FeaturesConfig
                     .ddEVPOriginHeader(source: v1Context.ciAppOrigin ?? v1Context.source),
                     .ddEVPOriginVersionHeader(sdkVersion: v1Context.sdkVersion),
                     .ddRequestIDHeader(),
-                ],
-                telemetry: telemetry
+                ]
             )
         },
         payloadFormat: DataFormat(prefix: "", suffix: "", separator: "\n")

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -29,8 +29,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
                 unauthorized: directory,
                 authorized: directory
             ),
-            commonDependencies: .mockAny(),
-            telemetry: nil
+            commonDependencies: .mockAny()
         )
 
         self.writer = storage.writer

--- a/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -29,8 +29,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
                 unauthorized: directory,
                 authorized: directory
             ),
-            commonDependencies: .mockAny(),
-            telemetry: nil
+            commonDependencies: .mockAny()
         )
         self.writer = storage.writer
         self.reader = storage.reader

--- a/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -29,8 +29,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
                 unauthorized: directory,
                 authorized: directory
             ),
-            commonDependencies: .mockAny(),
-            telemetry: nil
+            commonDependencies: .mockAny()
         )
         self.writer = storage.writer
         self.reader = storage.reader

--- a/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeatureTests.swift
@@ -29,8 +29,7 @@ class FeatureStorageTests: XCTestCase {
             queue: queue,
             dataFormat: DataFormat(prefix: "", suffix: "", separator: "#"),
             directories: temporaryFeatureDirectories,
-            commonDependencies: .mockWith(consentProvider: consentProvider),
-            telemetry: nil
+            commonDependencies: .mockWith(consentProvider: consentProvider)
         )
 
         // When
@@ -70,8 +69,7 @@ class FeatureStorageTests: XCTestCase {
             queue: queue,
             dataFormat: DataFormat(prefix: "", suffix: "", separator: "#"),
             directories: temporaryFeatureDirectories,
-            commonDependencies: .mockWith(consentProvider: .init(initialConsent: .granted)),
-            telemetry: nil
+            commonDependencies: .mockWith(consentProvider: .init(initialConsent: .granted))
         )
 
         // When
@@ -102,8 +100,7 @@ class FeatureStorageTests: XCTestCase {
             queue: queue,
             dataFormat: DataFormat(prefix: "", suffix: "", separator: "#"),
             directories: temporaryFeatureDirectories,
-            commonDependencies: .mockWith(consentProvider: .init(initialConsent: .granted)),
-            telemetry: nil
+            commonDependencies: .mockWith(consentProvider: .init(initialConsent: .granted))
         )
 
         // When

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -25,8 +25,7 @@ class CrashReporterTests: XCTestCase {
         let crashReporter = CrashReporter(
             crashReportingPlugin: plugin,
             crashContextProvider: CrashContextProviderMock(),
-            loggingOrRUMIntegration: integration,
-            telemetry: nil
+            loggingOrRUMIntegration: integration
         )
 
         // Then
@@ -58,8 +57,7 @@ class CrashReporterTests: XCTestCase {
         let crashReporter = CrashReporter(
             crashReportingPlugin: plugin,
             crashContextProvider: CrashContextProviderMock(),
-            loggingOrRUMIntegration: integration,
-            telemetry: nil
+            loggingOrRUMIntegration: integration
         )
 
         // Then
@@ -86,8 +84,7 @@ class CrashReporterTests: XCTestCase {
         let crashReporter = CrashReporter(
             crashReportingPlugin: plugin,
             crashContextProvider: CrashContextProviderMock(),
-            loggingOrRUMIntegration: integration,
-            telemetry: nil
+            loggingOrRUMIntegration: integration
         )
 
         // Then
@@ -113,8 +110,7 @@ class CrashReporterTests: XCTestCase {
         let crashReporter = CrashReporter(
             crashReportingPlugin: plugin,
             crashContextProvider: CrashContextProviderMock(initialCrashContext: initialCrashContext),
-            loggingOrRUMIntegration: CrashReportingIntegrationMock(),
-            telemetry: nil
+            loggingOrRUMIntegration: CrashReportingIntegrationMock()
         )
 
         try withExtendedLifetime(crashReporter) {
@@ -137,8 +133,7 @@ class CrashReporterTests: XCTestCase {
         let crashReporter = CrashReporter(
             crashReportingPlugin: plugin,
             crashContextProvider: crashContextProvider,
-            loggingOrRUMIntegration: CrashReportingIntegrationMock(),
-            telemetry: nil
+            loggingOrRUMIntegration: CrashReportingIntegrationMock()
         )
 
         try withExtendedLifetime(crashReporter) {
@@ -179,8 +174,7 @@ class CrashReporterTests: XCTestCase {
         let crashReporter = CrashReporter(
             crashReportingPlugin: plugin,
             crashContextProvider: crashContextProvider,
-            loggingOrRUMIntegration: CrashReportingIntegrationMock(),
-            telemetry: nil
+            loggingOrRUMIntegration: CrashReportingIntegrationMock()
         )
 
         // swiftlint:disable opening_brace

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -120,7 +120,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertTrue(DD.telemetry is NoOpTelemetry, "When RUM is disabled, telemetry monitor should not be set")
+            XCTAssertTrue(DD.telemetry is NOPTelemetry, "When RUM is disabled, telemetry monitor should not be set")
         }
         verify(configuration: rumBuilder.build()) {
             // verify features:
@@ -141,7 +141,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertTrue(DD.telemetry is NoOpTelemetry)
+            XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
         verify(configuration: rumBuilder.enableLogging(false).build()) {
             // verify features:
@@ -163,7 +163,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertTrue(DD.telemetry is NoOpTelemetry)
+            XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
         verify(configuration: rumBuilder.enableTracing(false).build()) {
             // verify features:
@@ -184,7 +184,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertTrue(DD.telemetry is NoOpTelemetry)
+            XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
         verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
@@ -194,7 +194,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertTrue(DD.telemetry is NoOpTelemetry)
+            XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMViews().build()) {

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -120,7 +120,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry, "When RUM is disabled, telemetry monitor should not be set")
+            XCTAssertTrue(DD.telemetry is NoOpTelemetry, "When RUM is disabled, telemetry monitor should not be set")
         }
         verify(configuration: rumBuilder.build()) {
             // verify features:
@@ -130,7 +130,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry, "When RUM is enabled, telemetry monitor should be set")
+            XCTAssertTrue(DD.telemetry is RUMTelemetry, "When RUM is enabled, telemetry monitor should be set")
         }
 
         verify(configuration: defaultBuilder.enableLogging(false).build()) {
@@ -141,7 +141,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
+            XCTAssertTrue(DD.telemetry is NoOpTelemetry)
         }
         verify(configuration: rumBuilder.enableLogging(false).build()) {
             // verify features:
@@ -152,7 +152,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry)
+            XCTAssertTrue(DD.telemetry is RUMTelemetry)
         }
 
         verify(configuration: defaultBuilder.enableTracing(false).build()) {
@@ -163,7 +163,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
+            XCTAssertTrue(DD.telemetry is NoOpTelemetry)
         }
         verify(configuration: rumBuilder.enableTracing(false).build()) {
             // verify features:
@@ -173,7 +173,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(CrashReportingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNotNil((defaultDatadogCore as? DatadogCore)?.telemetry)
+            XCTAssertTrue(DD.telemetry is RUMTelemetry)
         }
 
         verify(configuration: defaultBuilder.enableRUM(true).build()) {
@@ -184,7 +184,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
+            XCTAssertTrue(DD.telemetry is NoOpTelemetry)
         }
         verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
@@ -194,7 +194,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
             // verify integrations:
-            XCTAssertNil((defaultDatadogCore as? DatadogCore)?.telemetry)
+            XCTAssertTrue(DD.telemetry is NoOpTelemetry)
         }
 
         verify(configuration: rumBuilder.trackUIKitRUMViews().build()) {

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -579,8 +579,7 @@ class LoggerTests: XCTestCase {
             dependencies: RUMScopeDependencies(
                 rumFeature: rum,
                 crashReportingFeature: nil,
-                context: v1Context,
-                telemetry: nil
+                context: v1Context
             ).replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
             dateProvider: v1Context.dateProvider
         )

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -1282,29 +1282,68 @@ class CoreLoggerMock: CoreLogger {
     var criticalLog: RecordedLog? { criticalLogs.last }
 }
 
+/// `Telemtry` recording received telemetry.
+class TelemetryMock: Telemetry, CustomStringConvertible {
+    private(set) var debugs: [String] = []
+    private(set) var errors: [(message: String, kind: String?, stack: String?)] = []
+    private(set) var description: String = "Telemetry logs:"
+
+    func debug(id: String, message: String) {
+        debugs.append(message)
+        description.append("\n- [debug] \(message)")
+    }
+
+    func error(id: String, message: String, kind: String?, stack: String?) {
+        errors.append((message: message, kind: kind, stack: stack))
+        description.append("\n - [error] \(message), kind: \(kind ?? "nil"), stack: \(stack ?? "nil")")
+    }
+}
+
 extension DD {
     /// Syntactic sugar for patching the `dd` bundle by replacing `logger`.
     ///
-    /// It returns the `logger` and old version of `dd`, so it can be used inline:
     /// ```
     /// let dd = DD.mockWith(logger: CoreLoggerMock())
     /// defer { dd.reset() }
     /// ```
-    static func mockWith<CL: CoreLogger>(logger: CL) -> DDMock<CL> {
+    static func mockWith<CL: CoreLogger>(logger: CL) -> DDMock<CL, TelemetryMock> {
         let mock = DDMock(
             oldLogger: DD.logger,
-            logger: logger
+            oldTelemetry: DD.telemetry,
+            logger: logger,
+            telemetry: TelemetryMock()
         )
         DD.logger = logger
         return mock
     }
+
+    /// Syntactic sugar for patching the `dd` bundle by replacing `telemetry`.
+    ///
+    /// ```
+    /// let dd = DD.mockWith(telemetry: TelemetryMock())
+    /// defer { dd.reset() }
+    /// ```
+    static func mockWith<TM: Telemetry>(telemetry: TM) -> DDMock<CoreLoggerMock, TM> {
+        let mock = DDMock(
+            oldLogger: DD.logger,
+            oldTelemetry: DD.telemetry,
+            logger: CoreLoggerMock(),
+            telemetry: telemetry
+        )
+        DD.telemetry = telemetry
+        return mock
+    }
 }
 
-struct DDMock<CL: CoreLogger> {
+struct DDMock<CL: CoreLogger, TM: Telemetry> {
     let oldLogger: CoreLogger
+    let oldTelemetry: Telemetry
+
     let logger: CL
+    let telemetry: TM
 
     func reset() {
         DD.logger = oldLogger
+        DD.telemetry = oldTelemetry
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -11,8 +11,7 @@ extension CrashReportingFeature {
     static func mockNoOp() -> CrashReportingFeature {
         return CrashReportingFeature(
             configuration: .mockWith(crashReportingPlugin: NoopCrashReportingPlugin()),
-            commonDependencies: .mockAny(),
-            telemetry: nil
+            commonDependencies: .mockAny()
         )
     }
 
@@ -22,8 +21,7 @@ extension CrashReportingFeature {
     ) -> CrashReportingFeature {
         return CrashReportingFeature(
             configuration: configuration,
-            commonDependencies: dependencies,
-            telemetry: nil
+            commonDependencies: dependencies
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
@@ -61,8 +61,7 @@ extension DatadogCoreMock: DatadogV1CoreProtocol {
 
         return DatadogCoreFeatureScope(
             context: context,
-            storage: feature.storage,
-            telemetry: nil
+            storage: feature.storage
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -305,20 +305,3 @@ class LogOutputMock: LogOutput {
             .joined(separator: "\n")
     }
 }
-
-/// `Telemtry` recording received telemetry.
-class TelemetryMock: Telemetry, CustomStringConvertible {
-    private(set) var debugs: [String] = []
-    private(set) var errors: [(message: String, kind: String?, stack: String?)] = []
-    private(set) var description: String = "Telemetry logs:"
-
-    func debug(id: String, message: String) {
-        debugs.append(message)
-        description.append("\n- [debug] \(message)")
-    }
-
-    func error(id: String, message: String, kind: String?, stack: String?) {
-        errors.append((message: message, kind: kind, stack: stack))
-        description.append("\n - [error] \(message), kind: \(kind ?? "nil"), stack: \(stack ?? "nil")")
-    }
-}

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -288,8 +288,7 @@ extension SpanEventBuilder {
         source: String = .mockAny(),
         origin: String? = nil,
         sdkVersion: String = .mockAny(),
-        eventsMapper: SpanEventMapper? = nil,
-        telemetry: Telemetry? = nil
+        eventsMapper: SpanEventMapper? = nil
     ) -> SpanEventBuilder {
         return SpanEventBuilder(
             sdkVersion: sdkVersion,
@@ -301,8 +300,7 @@ extension SpanEventBuilder {
             dateCorrector: dateCorrector,
             source: source,
             origin: origin,
-            eventsMapper: eventsMapper,
-            telemetry: telemetry
+            eventsMapper: eventsMapper
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMDeviceInfoTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMDeviceInfoTests.swift
@@ -13,8 +13,7 @@ class RUMDeviceInfoTests: XCTestCase {
         let randomName: String = .mockRandom()
 
         let info = RUMDevice(
-            device: .mockWith(name: randomName, model: randomModel),
-            telemetry: nil
+            device: .mockWith(name: randomName, model: randomModel)
         )
 
         XCTAssertEqual(info.brand, "Apple")
@@ -24,24 +23,19 @@ class RUMDeviceInfoTests: XCTestCase {
 
     func testItInfersDeviceTypeFromDeviceModel() {
         let iPhone = RUMDevice(
-            device: .mockWith(model: "iPhone" + String.mockRandom(among: .alphanumerics, length: 2)),
-            telemetry: nil
+            device: .mockWith(model: "iPhone" + String.mockRandom(among: .alphanumerics, length: 2))
         )
         let iPod = RUMDevice(
-            device: .mockWith(model: "iPod" + String.mockRandom(among: .alphanumerics, length: 2)),
-            telemetry: nil
+            device: .mockWith(model: "iPod" + String.mockRandom(among: .alphanumerics, length: 2))
         )
         let iPad = RUMDevice(
-            device: .mockWith(model: "iPad" + String.mockRandom(among: .alphanumerics, length: 2)),
-            telemetry: nil
+            device: .mockWith(model: "iPad" + String.mockRandom(among: .alphanumerics, length: 2))
         )
         let appleTV = RUMDevice(
-            device: .mockWith(model: "AppleTV" + String.mockRandom(among: .alphanumerics, length: 2)),
-            telemetry: nil
+            device: .mockWith(model: "AppleTV" + String.mockRandom(among: .alphanumerics, length: 2))
         )
         let unknownDevice = RUMDevice(
-            device: .mockWith(model: .mockRandom()),
-            telemetry: nil
+            device: .mockWith(model: .mockRandom())
         )
 
         XCTAssertEqual(iPhone.type, .mobile)

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -173,6 +173,7 @@ class RUMTelemetryTests: XCTestCase {
         telemetry.error("ns error", error: nsError)
         XCTAssertEqual(telemetry.record?.message, "ns error - error description")
     }
+
     func testSendTelemetry_discardDuplicates() throws {
         // Given
         let telemetry: RUMTelemetry = .mockAny(in: core)

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -33,8 +33,7 @@ class RUMMonitorTests: XCTestCase {
             dependencies: RUMScopeDependencies(
                 rumFeature: rumFeature,
                 crashReportingFeature: crashReportingFeature,
-                context: v1Context,
-                telemetry: v1Context.telemetry
+                context: v1Context
             ).replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
             dateProvider: v1Context.dateProvider
         )

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -153,8 +153,7 @@ class DDRUMMonitorTests: XCTestCase {
             dependencies: RUMScopeDependencies(
                 rumFeature: rumFeature,
                 crashReportingFeature: nil,
-                context: v1Context,
-                telemetry: v1Context.telemetry
+                context: v1Context
             )
             .replacing(viewUpdatesThrottlerFactory: { NoOpRUMViewUpdatesThrottler() }),
             dateProvider: v1Context.dateProvider

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -75,6 +75,18 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
             """
         ),
         .init(
+            assert: { DD.telemetry is NoOpTelemetry },
+            problem: "`DD.telemetry` must use `NoOpTelemetry` implementation.",
+            solution: """
+            Make sure the `DD` bundle is reset after test to use previous dependencies, e.g.:
+
+            ```
+            let dd = DD.mockWith(telemetry: TelemetryMock())
+            defer { dd.reset() }
+            ```
+            """
+        ),
+        .init(
             assert: { ServerMock.activeInstance == nil },
             problem: "`ServerMock` must not be active.",
             solution: """

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -75,8 +75,8 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
             """
         ),
         .init(
-            assert: { DD.telemetry is NoOpTelemetry },
-            problem: "`DD.telemetry` must use `NoOpTelemetry` implementation.",
+            assert: { DD.telemetry is NOPTelemetry },
+            problem: "`DD.telemetry` must use `NOPTelemetry` implementation.",
             solution: """
             Make sure the `DD` bundle is reset after test to use previous dependencies, e.g.:
 


### PR DESCRIPTION
### What and why?

🚚 This PR simplifies the way we expose `Telemetry` monitor to different parts of the codebase. 

Instead of passing `telemetry: Telemetry?` through initializers, we now use `DD.telemetry` as global util. It removes the need of passing the reference all around from `Datadog` facade to downstream components.

It also makes the [`Telemetry`](https://github.com/DataDog/dd-sdk-ios/blob/develop/Sources/Datadog/Core/DD/Telemetry.swift) close to available for use in cross-platform frameworks (now it only requires public API wrapper - to be added later // cc @fuzzybinary).

### How?

* Removed all `telemetry: Telemetry?` references passed through different initializers.
* Exposed `DD.telemetry` instead.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
