### PR TITLE
RUMM-2264 Set up Session Replay module

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,7 +11,8 @@ workflows:
         This workflow is triggered on starting new PR or pushing new changes to existing PRs.
         By default, it doesn't run any test phases, but this behaviour is overwritten in `choose_workflows.py` when:
         - one or more `DD_OVERWRITE_RUN_(phase)_TESTS` ENVs are passed to the current CI job:
-            - DD_OVERRIDE_RUN_UNIT_TESTS='1' to run unit tests phase
+            - DD_OVERRIDE_RUN_UNIT_TESTS='1' to run unit tests phase for the main SDK
+            - DD_OVERRIDE_RUN_SR_UNIT_TESTS='1' to run unit tests phase for Session Replay product
             - DD_OVERRIDE_RUN_INTEGRATION_TESTS='1' to run integration tests phase
             - DD_OVERRIDE_RUN_SMOKE_TESTS='1' to run smoke tests phase
             - DD_OVERRIDE_TOOLS_TESTS='1' to run tools tests phase
@@ -19,6 +20,7 @@ workflows:
         - the PR changes a file which matches phase filter (e.g. changing a file in `Sources/*` will trigger unit tests phase)
     envs:
       - DD_RUN_UNIT_TESTS: '0'
+      - DD_RUN_SR_UNIT_TESTS: '0'
       - DD_RUN_INTEGRATION_TESTS: '0'
       - DD_RUN_SMOKE_TESTS: '0'
       - DD_RUN_TOOLS_TESTS: '0'
@@ -32,6 +34,7 @@ workflows:
         This workflow is triggered for each new commit pushed to `develop` or `master` branch.
     envs:
       - DD_RUN_UNIT_TESTS: '1'
+      - DD_RUN_SR_UNIT_TESTS: '1'
       - DD_RUN_INTEGRATION_TESTS: '1'
       - DD_RUN_SMOKE_TESTS: '0'
       - DD_RUN_TOOLS_TESTS: '0'
@@ -46,6 +49,7 @@ workflows:
         This workflow is triggered every night.
     envs:
       - DD_RUN_UNIT_TESTS: '0'
+      - DD_RUN_SR_UNIT_TESTS: '0'
       - DD_RUN_INTEGRATION_TESTS: '0'
       - DD_RUN_SMOKE_TESTS: '1'
       - DD_RUN_TOOLS_TESTS: '1'
@@ -71,6 +75,7 @@ workflows:
         This workflow is triggered on pushing a new release tag.
     envs:
       - DD_RUN_UNIT_TESTS: '1'
+      - DD_RUN_SR_UNIT_TESTS: '1'
       - DD_RUN_INTEGRATION_TESTS: '1'
       - DD_RUN_SMOKE_TESTS: '1'
       - DD_RUN_TOOLS_TESTS: '0'
@@ -180,7 +185,9 @@ workflows:
     description: |-
         Runs unit tests for SDK on iOS Simulator.
         Runs unit tests for SDK on tvOS Simulator.
-        Only ran if 'DD_RUN_UNIT_TESTS' is '1'.
+        Selectively runs:
+        - main SDK tests when 'DD_RUN_UNIT_TESTS' is '1'
+        - or Session Replay tests when when 'DD_RUN_SR_UNIT_TESTS' is '1'
     steps:
     - script:
         title: Verify RUM data models
@@ -232,6 +239,17 @@ workflows:
         - generate_code_coverage_files: 'yes'
         - project_path: Datadog.xcworkspace
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogCrashReporting-tvos-unit-tests.html"
+    - xcode-test:
+        title: Run unit tests for Session Replay - iOS Simulator
+        run_if: '{{enveq "DD_RUN_SR_UNIT_TESTS" "1"}}'
+        inputs:
+        - scheme: DatadogSessionReplay
+        - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
+        - should_build_before_test: 'no'
+        - is_clean_build: 'no'
+        - generate_code_coverage_files: 'yes'
+        - project_path: session-replay/Package.swift
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogSessionReplay-tests.html"
 
   run_integration_tests:
     description: |-

--- a/session-replay/.gitignore
+++ b/session-replay/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/session-replay/Package.swift
+++ b/session-replay/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 
 import PackageDescription
 

--- a/session-replay/Package.swift
+++ b/session-replay/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.6
+
+import PackageDescription
+
+let package = Package(
+    name: "DatadogSessionReplay",
+    platforms: [
+        .iOS(.v15),
+    ],
+    products: [
+        .library(
+            name: "DatadogSessionReplay",
+            targets: ["DatadogSessionReplay"]
+        ),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "DatadogSessionReplay",
+            dependencies: []
+        ),
+        .testTarget(
+            name: "DatadogSessionReplayTests",
+            dependencies: ["DatadogSessionReplay"]
+        ),
+    ]
+)

--- a/session-replay/README.md
+++ b/session-replay/README.md
@@ -1,0 +1,3 @@
+# Session Replay
+
+🚧 The Session Replay feature is under construction.

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
@@ -8,4 +8,5 @@ import Foundation
 
 /// A draft interface of SR feature.
 public class SessionReplayFeature {
+    public static let testBool = true
 }

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// A draft interface of SR feature.
+public class SessionReplayFeature {
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/SessionReplayFeatureTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/SessionReplayFeatureTests.swift
@@ -9,7 +9,6 @@ import XCTest
 
 final class SessionReplayFeatureTests: XCTestCase {
     func testExample() throws {
-        let bool = true
-        XCTAssertTrue(bool)
+        XCTAssertTrue(SessionReplayFeature.testBool)
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/SessionReplayFeatureTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/SessionReplayFeatureTests.swift
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+final class SessionReplayFeatureTests: XCTestCase {
+    func testExample() throws {
+        let bool = true
+        XCTAssertTrue(bool)
+    }
+}

--- a/tools/ci/choose_workflows.py
+++ b/tools/ci/choose_workflows.py
@@ -32,6 +32,20 @@ def should_run_unit_tests(ctx: CIContext) -> bool:
     )
 
 
+def should_run_sr_unit_tests(ctx: CIContext) -> bool:
+    print('⚙️ Resolving `unit tests` phase for Session Replay:')
+    return should_run_phase(
+        ctx=ctx,
+        trigger_env=context.trigger_env.DD_RUN_SR_UNIT_TESTS,
+        build_env=context.build_env.DD_OVERRIDE_RUN_SR_UNIT_TESTS,
+        pr_keyword='[x] Run unit tests for Session Replay',
+        pr_path_prefixes=[
+            'session-replay/',
+        ],
+        pr_file_extensions=[]
+    )
+
+
 def should_run_integration_tests(ctx: CIContext) -> bool:
     print('⚙️ Resolving `integration tests` phase:')
     return should_run_phase(
@@ -147,6 +161,9 @@ if __name__ == "__main__":
 
         if should_run_unit_tests(context):
             export_env('DD_RUN_UNIT_TESTS', '1', dry_run=dry_run)
+
+        if should_run_sr_unit_tests(context):
+            export_env('DD_RUN_SR_UNIT_TESTS', '1', dry_run=dry_run)
 
         if should_run_integration_tests(context):
             export_env('DD_RUN_INTEGRATION_TESTS', '1', dry_run=dry_run)

--- a/tools/ci/src/ci_context.py
+++ b/tools/ci/src/ci_context.py
@@ -24,6 +24,7 @@ class TriggerENVs:
     ENVs defined for a trigger in `bitrise.yml`.
     """
     DD_RUN_UNIT_TESTS: str
+    DD_RUN_SR_UNIT_TESTS: str
     DD_RUN_INTEGRATION_TESTS: str
     DD_RUN_SMOKE_TESTS: str
     DD_RUN_TOOLS_TESTS: str
@@ -35,6 +36,7 @@ class BuildENVs:
     Optional ENVs passed from outside (when starting build manually).
     """
     DD_OVERRIDE_RUN_UNIT_TESTS: Optional[str]
+    DD_OVERRIDE_RUN_SR_UNIT_TESTS: Optional[str]
     DD_OVERRIDE_RUN_INTEGRATION_TESTS: Optional[str]
     DD_OVERRIDE_RUN_SMOKE_TESTS: Optional[str]
     DD_OVERRIDE_RUN_TOOLS_TESTS: Optional[str]
@@ -85,6 +87,7 @@ class PullRequestFiles:
 def get_ci_context() -> CIContext:
     trigger_env = TriggerENVs(
         DD_RUN_UNIT_TESTS=os.environ.get('DD_RUN_UNIT_TESTS') or "0",
+        DD_RUN_SR_UNIT_TESTS=os.environ.get('DD_RUN_SR_UNIT_TESTS') or "0",
         DD_RUN_INTEGRATION_TESTS=os.environ.get('DD_RUN_INTEGRATION_TESTS') or "0",
         DD_RUN_SMOKE_TESTS=os.environ.get('DD_RUN_SMOKE_TESTS') or "0",
         DD_RUN_TOOLS_TESTS=os.environ.get('DD_RUN_TOOLS_TESTS') or "0"
@@ -92,6 +95,7 @@ def get_ci_context() -> CIContext:
 
     build_env = BuildENVs(
         DD_OVERRIDE_RUN_UNIT_TESTS=os.environ.get('DD_OVERRIDE_RUN_UNIT_TESTS'),
+        DD_OVERRIDE_RUN_SR_UNIT_TESTS=os.environ.get('DD_OVERRIDE_RUN_SR_UNIT_TESTS'),
         DD_OVERRIDE_RUN_INTEGRATION_TESTS=os.environ.get('DD_OVERRIDE_RUN_INTEGRATION_TESTS'),
         DD_OVERRIDE_RUN_SMOKE_TESTS=os.environ.get('DD_OVERRIDE_RUN_SMOKE_TESTS'),
         DD_OVERRIDE_RUN_TOOLS_TESTS=os.environ.get('DD_OVERRIDE_RUN_TOOLS_TESTS')

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -90,6 +90,7 @@ custom_rules:
 
 included:
   - ../../Sources
+  - ../../session-replay/Sources
   - ../../Datadog/E2E
   - ../../instrumented-tests/http-server-mock/Sources
   - ../../tools/api-surface/Sources

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -83,6 +83,7 @@ custom_rules:
 
 included:
   - ../../Tests
+  - ../../session-replay/Tests
   - ../../Datadog/E2ETests
   - ../../Datadog/E2EInstrumentationTests
   - ../../instrumented-tests/http-server-mock/Tests

--- a/tools/xcode-templates/Datadog/Swift File.xctemplate/TemplateInfo.plist
+++ b/tools/xcode-templates/Datadog/Swift File.xctemplate/TemplateInfo.plist
@@ -18,5 +18,7 @@
 	<string>File</string>
 	<key>MainTemplateFile</key>
 	<string>___FILEBASENAME___.swift</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 </dict>
 </plist>

--- a/tools/xcode-templates/Datadog/Unit Test Case Class.xctemplate/TemplateInfo.plist
+++ b/tools/xcode-templates/Datadog/Unit Test Case Class.xctemplate/TemplateInfo.plist
@@ -18,5 +18,7 @@
 	<string>File</string>
 	<key>MainTemplateFile</key>
 	<string>___FILEBASENAME___.swift</string>
+	<key>SupportsSwiftPackage</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
### What and why?

📦 This PR starts the Session Replay module 🥳. It will be an ongoing work, so it targets `feature/session-replay` branch. 

Initially, Session Replay module won't require any code from the main SDK, so it is created as a stand-alone and self-contained SPM package (under `session-replay/` folder). This will guarantee no conflicts with `develop` code and still enable code reuse through `.xcworkspace` if necessary.

Very likely, we will change the structure of `DatadogSessionReplay` package when extracting V2 modules.

### How?

* Created `DatadogSessionReplay` module with tests target;
* Updated linter to include `session-replay/` path;
* Updated CI to run unit tests for Session Replay conditionally (using existing `choose_workflows.py`, it will skip tests for other code if only `session-replay/*` paths were altered, resulting with ~2min CI time)

```
+---+---------------------------------------------------------------+----------+
| ✓ | Run unit tests for Session Replay - iOS Simulator             | 1.7 min  |
+---+---------------------------------------------------------------+----------+
```

* 🎁 Extended Datadog Xcode templates to work with Swift Package projects.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
