### PR TITLE
RUMM-2299 Core Context User Info Publisher

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -646,12 +646,18 @@
 		D29D5A4D273BF8B400A687C1 /* SwiftUIActionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */; };
 		D2A1EE26287C35DE00D28DFB /* ContextValueReaderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE25287C35DE00D28DFB /* ContextValueReaderMock.swift */; };
 		D2A1EE27287C35DE00D28DFB /* ContextValueReaderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE25287C35DE00D28DFB /* ContextValueReaderMock.swift */; };
+		D2A1EE2F287DA4F200D28DFB /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE2E287DA4F200D28DFB /* UserInfo.swift */; };
+		D2A1EE30287DA4F200D28DFB /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE2E287DA4F200D28DFB /* UserInfo.swift */; };
+		D2A1EE32287DA51900D28DFB /* UserInfoPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE31287DA51900D28DFB /* UserInfoPublisher.swift */; };
+		D2A1EE33287DA51900D28DFB /* UserInfoPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE31287DA51900D28DFB /* UserInfoPublisher.swift */; };
 		D2A1EE35287EB8DB00D28DFB /* KronosClockPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE34287EB8DB00D28DFB /* KronosClockPublisherTests.swift */; };
 		D2A1EE36287EB8DB00D28DFB /* KronosClockPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE34287EB8DB00D28DFB /* KronosClockPublisherTests.swift */; };
 		D2A1EE38287EEB7400D28DFB /* NetworkConnectionInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE37287EBE4200D28DFB /* NetworkConnectionInfoPublisherTests.swift */; };
 		D2A1EE39287EEB7600D28DFB /* NetworkConnectionInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE37287EBE4200D28DFB /* NetworkConnectionInfoPublisherTests.swift */; };
 		D2A1EE3B287EECC000D28DFB /* CarrierInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE3A287EECA800D28DFB /* CarrierInfoPublisherTests.swift */; };
 		D2A1EE3C287EECC200D28DFB /* CarrierInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE3A287EECA800D28DFB /* CarrierInfoPublisherTests.swift */; };
+		D2A1EE442886B8B400D28DFB /* UserInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE432886B8B400D28DFB /* UserInfoPublisherTests.swift */; };
+		D2A1EE452886B8B400D28DFB /* UserInfoPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE432886B8B400D28DFB /* UserInfoPublisherTests.swift */; };
 		D2B3F0442823EE8400C2B5EE /* DataBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */; };
 		D2B3F0452823EE8400C2B5EE /* DataBlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */; };
 		D2B3F04728292D6E00C2B5EE /* DataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3F04628292D6E00C2B5EE /* DataMigratorTests.swift */; };
@@ -1844,9 +1850,12 @@
 		D29CDD3128211A2200F7DAA5 /* DataBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlock.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
 		D2A1EE25287C35DE00D28DFB /* ContextValueReaderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextValueReaderMock.swift; sourceTree = "<group>"; };
+		D2A1EE2E287DA4F200D28DFB /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
+		D2A1EE31287DA51900D28DFB /* UserInfoPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoPublisher.swift; sourceTree = "<group>"; };
 		D2A1EE34287EB8DB00D28DFB /* KronosClockPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KronosClockPublisherTests.swift; sourceTree = "<group>"; };
 		D2A1EE37287EBE4200D28DFB /* NetworkConnectionInfoPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectionInfoPublisherTests.swift; sourceTree = "<group>"; };
 		D2A1EE3A287EECA800D28DFB /* CarrierInfoPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarrierInfoPublisherTests.swift; sourceTree = "<group>"; };
+		D2A1EE432886B8B400D28DFB /* UserInfoPublisherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfoPublisherTests.swift; sourceTree = "<group>"; };
 		D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlockTests.swift; sourceTree = "<group>"; };
 		D2B3F04628292D6E00C2B5EE /* DataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorTests.swift; sourceTree = "<group>"; };
 		D2B3F0492829510600C2B5EE /* DatadogCoreProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreProtocol.swift; sourceTree = "<group>"; };
@@ -4216,6 +4225,7 @@
 				D2EFA86A286DCDBB00F1FAA6 /* DateCorrector.swift */,
 				D20605AB2874C2040047275C /* NetworkConnectionInfo.swift */,
 				D20605AE2874DAD70047275C /* CarrierInfo.swift */,
+				D2A1EE2E287DA4F200D28DFB /* UserInfo.swift */,
 			);
 			path = Context;
 			sourceTree = "<group>";
@@ -4294,6 +4304,7 @@
 				D20605A5287476230047275C /* KronosClockPublisher.swift */,
 				D20605A82874C1CD0047275C /* NetworkConnectionInfoPublisher.swift */,
 				D20605B12874E1660047275C /* CarrierInfoPublisher.swift */,
+				D2A1EE31287DA51900D28DFB /* UserInfoPublisher.swift */,
 			);
 			path = Context;
 			sourceTree = "<group>";
@@ -4305,6 +4316,7 @@
 				D2A1EE34287EB8DB00D28DFB /* KronosClockPublisherTests.swift */,
 				D2A1EE3A287EECA800D28DFB /* CarrierInfoPublisherTests.swift */,
 				D2A1EE37287EBE4200D28DFB /* NetworkConnectionInfoPublisherTests.swift */,
+				D2A1EE432886B8B400D28DFB /* UserInfoPublisherTests.swift */,
 			);
 			path = DatadogCore;
 			sourceTree = "<group>";
@@ -5291,6 +5303,7 @@
 				61D447E224917F8F00649287 /* DateFormatting.swift in Sources */,
 				61133BE72423979B00786299 /* LogUtilityOutputs.swift in Sources */,
 				61133BDA2423979B00786299 /* RequestBuilder.swift in Sources */,
+				D2A1EE2F287DA4F200D28DFB /* UserInfo.swift in Sources */,
 				61C3E63924BF19B4008053F2 /* RUMContext.swift in Sources */,
 				61A614E8276B2BD000A06CE7 /* RUMOffViewEventsHandlingRule.swift in Sources */,
 				61ED39D426C2A36B002C0F26 /* DataUploadStatus.swift in Sources */,
@@ -5331,6 +5344,7 @@
 				61B038602527247200518F3C /* URLSessionTracingHandler.swift in Sources */,
 				61122ED425B1B84D00F9C7F5 /* RUMEventSanitizer.swift in Sources */,
 				61363D9D24D999F70084CD6F /* DDError.swift in Sources */,
+				D2A1EE32287DA51900D28DFB /* UserInfoPublisher.swift in Sources */,
 				61133BD52423979B00786299 /* DataUploadConditions.swift in Sources */,
 				612983CD2449E62E00D4424B /* LoggingFeature.swift in Sources */,
 				61C3E63B24BF1A4B008053F2 /* RUMCommand.swift in Sources */,
@@ -5469,6 +5483,7 @@
 				9E2EF44F2694FA14008A7DAE /* VitalInfoSamplerTests.swift in Sources */,
 				61C1510D25AC8C1B00362D4B /* RUMViewIdentityTests.swift in Sources */,
 				6137C574271DBF4800EFC4A1 /* DataOrchestratorTests.swift in Sources */,
+				D2A1EE442886B8B400D28DFB /* UserInfoPublisherTests.swift in Sources */,
 				613E820525A879AF0084B751 /* RUMDataModelMocks.swift in Sources */,
 				61133C492423990D00786299 /* DDLoggerBuilderTests.swift in Sources */,
 				B3FC3C3C2653A97700DEED9E /* VitalInfoTests.swift in Sources */,
@@ -5852,6 +5867,7 @@
 				D2CB6E4227C50EAE00A62B57 /* RUMConnectivityInfoProvider.swift in Sources */,
 				61FD9FCA2851E67100214BD9 /* Sysctl.swift in Sources */,
 				D248ED462807193B00B315B4 /* RUMTelemetry.swift in Sources */,
+				D2A1EE33287DA51900D28DFB /* UserInfoPublisher.swift in Sources */,
 				D2CB6E4327C50EAE00A62B57 /* ObjcExceptionHandler.m in Sources */,
 				D2CB6E4427C50EAE00A62B57 /* UIApplicationSwizzler.swift in Sources */,
 				D2CB6E4527C50EAE00A62B57 /* RUMResourceScope.swift in Sources */,
@@ -5879,6 +5895,7 @@
 				D2CB6E5827C50EAE00A62B57 /* SpanSanitizer.swift in Sources */,
 				D2CB6E5927C50EAE00A62B57 /* Writer.swift in Sources */,
 				D2CB6E5A27C50EAE00A62B57 /* URLSessionAutoInstrumentation.swift in Sources */,
+				D2A1EE30287DA4F200D28DFB /* UserInfo.swift in Sources */,
 				D2CB6E5B27C50EAE00A62B57 /* DDSpanContext.swift in Sources */,
 				D2CB6E5C27C50EAE00A62B57 /* UIKitRUMUserActionsHandler.swift in Sources */,
 				D2CB6E5D27C50EAE00A62B57 /* RUMInstrumentation.swift in Sources */,
@@ -6121,6 +6138,7 @@
 				D2CB6F3C27C520D400A62B57 /* VitalInfoSamplerTests.swift in Sources */,
 				D2CB6F3D27C520D400A62B57 /* RUMViewIdentityTests.swift in Sources */,
 				D2CB6F3E27C520D400A62B57 /* DataOrchestratorTests.swift in Sources */,
+				D2A1EE452886B8B400D28DFB /* UserInfoPublisherTests.swift in Sources */,
 				D2CB6F3F27C520D400A62B57 /* RUMDataModelMocks.swift in Sources */,
 				D2CB6F4027C520D400A62B57 /* DDLoggerBuilderTests.swift in Sources */,
 				D2CB6F4127C520D400A62B57 /* VitalInfoTests.swift in Sources */,

--- a/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
+++ b/Sources/Datadog/Core/Attributes/UserInfoProvider.swift
@@ -34,25 +34,3 @@ internal class UserInfoProvider {
         publisher.subscribe(subscriber)
     }
 }
-
-internal struct UserInfo {
-    /// User ID, if any.
-    internal let id: String?
-    /// Name representing the user, if any.
-    internal let name: String?
-    /// User email, if any.
-    internal let email: String?
-    /// User custom attributes, if any.
-    internal var extraInfo: [AttributeKey: AttributeValue]
-}
-
-extension UserInfo {
-    internal static var empty: Self {
-        .init(
-            id: nil,
-            name: nil,
-            email: nil,
-            extraInfo: [:]
-        )
-    }
-}

--- a/Sources/Datadog/DatadogCore/Context/UserInfoPublisher.swift
+++ b/Sources/Datadog/DatadogCore/Context/UserInfoPublisher.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Publishes the current `UserInfo` value to receiver.
+internal final class UserInfoPublisher: ContextValuePublisher {
+    let initialValue: UserInfo = .empty
+
+    private var receiver: ContextValueReceiver<UserInfo>?
+
+    var current: UserInfo = .empty {
+        didSet { receiver?(current) }
+    }
+
+    func publish(to receiver: @escaping ContextValueReceiver<UserInfo>) {
+        self.receiver = receiver
+    }
+
+    func cancel() {
+        receiver = nil
+    }
+}

--- a/Sources/Datadog/DatadogInternal/Context/DatadogContext.swift
+++ b/Sources/Datadog/DatadogInternal/Context/DatadogContext.swift
@@ -56,6 +56,9 @@ internal struct DatadogContext {
     /// Current device information.
     let device: DeviceInfo
 
+    /// Current user information.
+    var userInfo: UserInfo
+
     // MARK: - Device Specific
 
     /// Network information.

--- a/Sources/Datadog/DatadogInternal/Context/UserInfo.swift
+++ b/Sources/Datadog/DatadogInternal/Context/UserInfo.swift
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct UserInfo {
+    /// User ID, if any.
+    internal let id: String?
+    /// Name representing the user, if any.
+    internal let name: String?
+    /// User email, if any.
+    internal let email: String?
+    /// User custom attributes, if any.
+    internal var extraInfo: [AttributeKey: AttributeValue]
+}
+
+extension UserInfo {
+    internal static var empty: Self {
+        .init(
+            id: nil,
+            name: nil,
+            email: nil,
+            extraInfo: [:]
+        )
+    }
+}

--- a/Tests/DatadogTests/Datadog/DatadogCore/UserInfoPublisherTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogCore/UserInfoPublisherTests.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class UserInfoPublisherTests: XCTestCase {
+    func testEmptyInitialValue() throws {
+        let publisher = UserInfoPublisher()
+        XCTAssertEqual(publisher.initialValue, .empty)
+    }
+
+    func testPublishUserInfo() throws {
+        let expectation = expectation(description: "user info publisher publishes data")
+
+        // Given
+        let publisher = UserInfoPublisher()
+        let userInfo: UserInfo = .mockRandom()
+
+        // When
+        publisher.publish {
+            // Then
+            XCTAssertEqual($0, userInfo)
+            expectation.fulfill()
+        }
+
+        publisher.current = userInfo
+
+        // UserInfoPublisher publishes in sync
+        waitForExpectations(timeout: 0)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogContextMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogContextMock.swift
@@ -25,6 +25,7 @@ extension DatadogContext: AnyMockable {
         applicationBundleIdentifier: String = .mockAny(),
         sdkInitDate: Date = .mockRandomInThePast(),
         device: DeviceInfo = .mockAny(),
+        userInfo: UserInfo = .mockAny(),
         networkConnectionInfo: NetworkConnectionInfo = .mockAny(),
         carrierInfo: CarrierInfo? = .mockAny()
     ) -> DatadogContext {
@@ -42,6 +43,7 @@ extension DatadogContext: AnyMockable {
             applicationBundleIdentifier: applicationBundleIdentifier,
             sdkInitDate: sdkInitDate,
             device: device,
+            userInfo: userInfo,
             networkConnectionInfo: networkConnectionInfo,
             carrierInfo: carrierInfo
         )


### PR DESCRIPTION
### What and why?

Publish user info to Datadog Context.

### How?

Implement a `UserInfoPublisher` that complies to `ContextValuePublisher` and provide `UserInfo` to the context. Setting the `current` user info property of the publisher will publish the value to the subscriber.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
