### PR TITLE
RUMM-2239 Remove use of deprecated log format APIs in E2E tests

### DIFF
--- a/Datadog/E2ETests/Helpers/LoggingE2EHelpers.swift
+++ b/Datadog/E2ETests/Helpers/LoggingE2EHelpers.swift
@@ -30,8 +30,6 @@ extension Logger {
 extension Logger.Builder.ConsoleLogFormat {
     static func random() -> Logger.Builder.ConsoleLogFormat {
         let allFormats: [Logger.Builder.ConsoleLogFormat] = [
-            .json,
-            .jsonWith(prefix: .mockRandom()),
             .short,
             .shortWith(prefix: .mockRandom())
         ]


### PR DESCRIPTION
### What and why?

⛑ Fixes the problem in nightly E2E tests, were deprecated `Logger` APIs were still used:
```
❌  /Users/vagrant/git/Datadog/E2ETests/Helpers/LoggingE2EHelpers.swift:34:14: 'jsonWith(prefix:)' is deprecated: JSON format is no longer supported for console logs and this API will be removed in future versions
            .jsonWith(prefix: .mockRandom()),
```

In #923 we deprecated two `Logger.Builder.ConsoleLogFormat` APIs: `.json` and `.jsonWith(prefix:)`, but we missed their use in E2E tests. Because CI builds are run with [_"Treat warnings as errors"_](https://github.com/DataDog/dd-sdk-ios/blob/7359006be4194184f7d506c3013dbf6da15e2981/Makefile#L32-L33), it caused a failure in recent nightly build.

### How?

Removed use of deprecated APIs from nightly tests.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
