### PR TITLE
Removes Duplicate Front Matter

### DIFF
--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -2,14 +2,8 @@
 title: iOS Crash Reporting and Error Tracking
 kind: documentation
 beta: true
-further_reading:
-  - link: "https://datadoghq.com/blog/ios-crash-reporting-datadog/"
-    tag: "Blog"
-    text: "Introducing iOS Crash Reporting and Error Tracking"
-  - link: "/real_user_monitoring"
-    tag: "Documentation"
-    text: "Learn how to explore your RUM data"
 ---
+
 ## Overview
 
 Enable iOS Crash Reporting and Error Tracking to get comprehensive crash reports and error trends with Real User Monitoring. With this feature, you can access:

--- a/docs/rum_collection/crash_reporting.md
+++ b/docs/rum_collection/crash_reporting.md
@@ -1,9 +1,3 @@
----
-title: iOS Crash Reporting and Error Tracking
-kind: documentation
-beta: true
----
-
 ## Overview
 
 Enable iOS Crash Reporting and Error Tracking to get comprehensive crash reports and error trends with Real User Monitoring. With this feature, you can access:


### PR DESCRIPTION
### What and why?

Keeping the front matter for the Crash Reporting doc page in the `pull_config.yaml` file instead.

### How?

Will merge this PR in first, and then https://github.com/DataDog/documentation/pull/14702!

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
