### PR TITLE
RUMM-2266 Enable Session Replay models generation

### DIFF
--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
@@ -86,7 +86,6 @@ internal class JSONSchema: Decodable {
             if self.type == nil && self.properties != nil {
                 self.type = .object
             }
-
         } catch let keyedContainerError as DecodingError {
             // If data in this `decoder` cannot be represented as keyed container, perhaps it encodes
             // a single value. Check known schema values:

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/JSON/JSONSchema.swift
@@ -79,6 +79,14 @@ internal class JSONSchema: Decodable {
             self.ref = try keyedContainer.decodeIfPresent(String.self, forKey: .ref)
             self.allOf = try keyedContainer.decodeIfPresent([JSONSchema].self, forKey: .allOf)
             self.oneOf = try keyedContainer.decodeIfPresent([JSONSchema].self, forKey: .oneOf)
+
+            // RUMM-2266 Patch:
+            // If schema doesn't define `type`, but defines `properties`, it is safe to assume
+            // that its `.object` schema:
+            if self.type == nil && self.properties != nil {
+                self.type = .object
+            }
+
         } catch let keyedContainerError as DecodingError {
             // If data in this `decoder` cannot be represented as keyed container, perhaps it encodes
             // a single value. Check known schema values:

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -39,21 +39,15 @@ internal class JSONToSwiftTypeTransformer {
         let jsonObjects = rootJSONOneOfs.types.compactMap { $0.type as? JSONObject }
         let jsonOneOfs = rootJSONOneOfs.types.compactMap { $0.type as? JSONOneOfs }
 
-        let onlyJSONObjects = jsonObjects.count == numberOfTypes
-        let onlyJSONOneOfs = jsonOneOfs.count == numberOfTypes
-
-        guard onlyJSONObjects || onlyJSONOneOfs else {
+        guard (jsonObjects.count + jsonOneOfs.count) == numberOfTypes else {
             let mixedTypes = rootJSONOneOfs.types.map { "\(type(of: $0))" }
-            throw Exception.unimplemented("Transforming root `JSONOneOfs` with mixed `oneOf` types is not supported (mixed types: [\(mixedTypes)]).")
+            throw Exception.unimplemented("Transforming root `JSONOneOfs` with mixed `oneOf` types is not supported (mixed types: \(mixedTypes)).", in: debuggingStack)
         }
 
-        if onlyJSONOneOfs {
-            return try jsonOneOfs.flatMap { jsonOneOf in try transform(rootJSONOneOfs: jsonOneOf) }
-        } else if onlyJSONObjects {
-            return try jsonObjects.map { jsonObject in try transform(rootJSONObject: jsonObject) }
-        } else {
-            throw Exception.inconsistency("Expected all `oneOfs` to be `JSONObject` or `JSONOneOfs`")
-        }
+        let transformedJSONOneOfs = try jsonOneOfs.flatMap { jsonOneOf in try transform(rootJSONOneOfs: jsonOneOf) }
+        let transformedJSONObjects = try jsonObjects.map { jsonObject in try transform(rootJSONObject: jsonObject) }
+
+        return transformedJSONOneOfs + transformedJSONObjects
     }
 
     // MARK: - Transforming ambiguous types

--- a/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
+++ b/tools/rum-models-generator/Sources/RUMModelsGeneratorCore/Input/Swift/JSONToSwiftTypeTransformer.swift
@@ -41,7 +41,7 @@ internal class JSONToSwiftTypeTransformer {
 
         guard (jsonObjects.count + jsonOneOfs.count) == numberOfTypes else {
             let mixedTypes = rootJSONOneOfs.types.map { "\(type(of: $0))" }
-            throw Exception.unimplemented("Transforming root `JSONOneOfs` with mixed `oneOf` types is not supported (mixed types: \(mixedTypes)).", in: debuggingStack)
+            throw Exception.unimplemented("Transforming root `JSONOneOfs` with mixed `oneOf` types is not supported (mixed types: \(mixedTypes)).")
         }
 
         let transformedJSONOneOfs = try jsonOneOfs.flatMap { jsonOneOf in try transform(rootJSONOneOfs: jsonOneOf) }

--- a/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
+++ b/tools/rum-models-generator/Tests/rum-models-generator-coreTests/Input/JSONToSwiftTypeTransformerTests.swift
@@ -713,4 +713,55 @@ final class JSONToSwiftTypeTransformerTests: XCTestCase {
         let actual = try JSONToSwiftTypeTransformer().transform(jsonType: rootOneOfs)
         XCTAssertEqual(expected, actual)
     }
+
+    func testTransformingRootJSONOneOfsWithMixedOneOfTypes() throws {
+        let rootOneOfs = JSONOneOfs(
+            name: "Root oneOf",
+            comment: "Root oneOf comment",
+            types: [
+                JSONOneOfs.OneOf(
+                    name: "Root 1",
+                    type: JSONOneOfs(
+                        name: "Nested oneOf",
+                        comment: "Nested oneOf comment",
+                        types: [
+                            JSONOneOfs.OneOf(
+                                name: "Nested oneOf A",
+                                type: JSONObject(
+                                    name: "JSONObject 1A",
+                                    comment: nil,
+                                    properties: []
+                                )
+                            ),
+                            JSONOneOfs.OneOf(
+                                name: "Nested oneOf B",
+                                type: JSONObject(
+                                    name: "JSONObject 1B",
+                                    comment: nil,
+                                    properties: []
+                                )
+                            ),
+                        ]
+                    )
+                ),
+                JSONOneOfs.OneOf(
+                    name: "Root 2",
+                    type: JSONObject(
+                        name: "JSONObject 2",
+                        comment: nil,
+                        properties: []
+                    )
+                )
+            ]
+        )
+
+        let expected: [SwiftStruct] = [
+            SwiftStruct(name: "JSONObject 1A", comment: nil, properties: [], conformance: []),
+            SwiftStruct(name: "JSONObject 1B", comment: nil, properties: [], conformance: []),
+            SwiftStruct(name: "JSONObject 2", comment: nil, properties: [], conformance: []),
+        ]
+
+        let actual = try JSONToSwiftTypeTransformer().transform(jsonType: rootOneOfs)
+        XCTAssertEqual(expected, actual)
+    }
 }


### PR DESCRIPTION
### What and why?

📦 This PR fixes 2 problems discovered when running models generation for Session Replay schemas. With this fix, the generator makes successful run on [session-replay-mobile-events-format.json](https://github.com/DataDog/rum-events-format/blob/master/session-replay-mobile-events-format.json) and prints Swift code.

This PR **doesn't yet**:
* Decorate SR models code appropriately. Similar to RUM, there are several things we may want to adjust in produced code (e.g. naming, or reusing common types) to make it more convenient to work with.
* Restructure `rum-models-generator` package to include separate generation tracks for RUM and SR.

Both elements will be delivered in next PRs.

### How?

First, I enhanced JSON schema reader with inferring `type` if it is not explicitly defined. This is the case of [`mutation-data-schema.json`](https://github.com/DataDog/rum-events-format/blob/1a3eef2e1422106dc4dc1ad72dcca50cdefd3284/schemas/session-replay/mobile/mutation-data-schema.json#L16-L35) which defines following array items without declaring `type: object`:
```json
"items": {
   "required": [
       "wireframe"
   ],
   "properties": {
       "previousId": {
           "type": "integer",
           "description": "The previous wireframe id next or after which this new wireframe is drawn or attached to, respectively.",
           "readOnly": true
       },
       "wireframe": {
           "$ref": "wireframe-schema.json",
           "description": "The new wireframe that needs to be added to the screen.",
           "readOnly": true
       }
   }
}
```
In such case ☝️, we can infer that item is of `type: object`, because it defines `properties`. 

Alternatively, we could consider updating `mutation-data-schema.json` with `type` information. I don't do it for two reasons:
* couldn't find anywhere in JSON schema doc if `type` is a mandatory field (seems not);
* other generators (Kotlin + TS) seem to handle this case, so it sounds reasonable to include it in ours.

Second, there was one generation branch in `oneOf` resolution marked as _"not yet supported"_. In this PR I'm adding support to mixing `JSONObject` and `JSONOneOf` definitions in a single `oneOf`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
