### PR TITLE
Add processor architecture to RUMDeviceInfo

### DIFF
--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -2125,6 +2125,9 @@ extension RUMEventAttributes {
 
 /// Device properties
 public struct RUMDevice: Codable {
+    /// The CPU architecture of the device that is reporting the error
+    public let architecture: String?
+
     /// Device marketing brand, e.g. Apple, OPPO, Xiaomi, etc.
     public let brand: String?
 
@@ -2138,6 +2141,7 @@ public struct RUMDevice: Codable {
     public let type: RUMDeviceType
 
     enum CodingKeys: String, CodingKey {
+        case architecture = "architecture"
         case brand = "brand"
         case model = "model"
         case name = "name"
@@ -2315,4 +2319,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/39ff6329b9ab1f72da47fd9a46bfdde454e1fda9
+// Generated from https://github.com/DataDog/rum-events-format/tree/9e0f8b2ab26ce0e33b058d7d5d3663ab043847f5

--- a/Sources/Datadog/RUM/RUMEvent/RUMDeviceInfo.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMDeviceInfo.swift
@@ -13,6 +13,7 @@ extension RUMDevice {
 
     init(device: DeviceInfo) {
         self.init(
+            architecture: device.architecture,
             brand: device.brand,
             model: device.model,
             name: device.name,

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -511,6 +511,10 @@ public class DDRUMActionEventRUMDevice: NSObject {
         self.root = root
     }
 
+    @objc public var architecture: String? {
+        root.swiftModel.device!.architecture
+    }
+
     @objc public var brand: String? {
         root.swiftModel.device!.brand
     }
@@ -1091,6 +1095,10 @@ public class DDRUMErrorEventRUMDevice: NSObject {
 
     internal init(root: DDRUMErrorEvent) {
         self.root = root
+    }
+
+    @objc public var architecture: String? {
+        root.swiftModel.device!.architecture
     }
 
     @objc public var brand: String? {
@@ -1957,6 +1965,10 @@ public class DDRUMLongTaskEventRUMDevice: NSObject {
         self.root = root
     }
 
+    @objc public var architecture: String? {
+        root.swiftModel.device!.architecture
+    }
+
     @objc public var brand: String? {
         root.swiftModel.device!.brand
     }
@@ -2562,6 +2574,10 @@ public class DDRUMResourceEventRUMDevice: NSObject {
 
     internal init(root: DDRUMResourceEvent) {
         self.root = root
+    }
+
+    @objc public var architecture: String? {
+        root.swiftModel.device!.architecture
     }
 
     @objc public var brand: String? {
@@ -3430,6 +3446,10 @@ public class DDRUMViewEventRUMDevice: NSObject {
 
     internal init(root: DDRUMViewEvent) {
         self.root = root
+    }
+
+    @objc public var architecture: String? {
+        root.swiftModel.device!.architecture
     }
 
     @objc public var brand: String? {
@@ -4312,4 +4332,4 @@ public class DDTelemetryDebugEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/39ff6329b9ab1f72da47fd9a46bfdde454e1fda9
+// Generated from https://github.com/DataDog/rum-events-format/tree/9e0f8b2ab26ce0e33b058d7d5d3663ab043847f5

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -58,6 +58,15 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         let view1 = session.viewVisits[0]
         XCTAssertEqual(view1.name, "SendRUMFixture1View")
         XCTAssertEqual(view1.path, "Example.SendRUMFixture1ViewController")
+        XCTAssertNotNil(view1.viewEvents.last?.device)
+        XCTAssertNotNil(view1.viewEvents.last?.device?.architecture)
+        if let architecture = view1.viewEvents.last?.device?.architecture {
+            // i486 is the architecture of the VMs on bitrise
+            XCTAssertTrue(
+                architecture.starts(with: "x86_64") || architecture.starts(with: "arm") || architecture.starts(with: "i486"),
+                "Expected architecture to start with 'x86_64', 'i486' or 'arm'. Got \(architecture)"
+            )
+        }
         XCTAssertEqual(view1.viewEvents.last?.view.action.count, 2)
         XCTAssertEqual(view1.viewEvents.last?.view.resource.count, 1)
         XCTAssertEqual(view1.viewEvents.last?.view.error.count, 1)
@@ -92,6 +101,7 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         let view2 = session.viewVisits[1]
         XCTAssertEqual(view2.name, "SendRUMFixture2View")
         XCTAssertEqual(view2.path, "Example.SendRUMFixture2ViewController")
+        XCTAssertNotNil(view2.viewEvents.last?.device)
         XCTAssertEqual(view2.viewEvents.last?.view.action.count, 0)
         XCTAssertEqual(view2.viewEvents.last?.view.resource.count, 0)
         XCTAssertEqual(view2.viewEvents.last?.view.error.count, 1)
@@ -102,6 +112,7 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         let view3 = session.viewVisits[2]
         XCTAssertEqual(view3.name, "SendRUMFixture3View")
         XCTAssertEqual(view3.path, "fixture3-vc")
+        XCTAssertNotNil(view3.viewEvents.last?.device)
         XCTAssertEqual(view3.viewEvents.last?.view.action.count, 0)
         XCTAssertEqual(view3.viewEvents.last?.view.resource.count, 0)
         XCTAssertEqual(view3.viewEvents.last?.view.error.count, 0)

--- a/Tests/DatadogTests/Datadog/DatadogInternal/Context/DeviceInfoTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/Context/DeviceInfoTests.swift
@@ -15,6 +15,7 @@ class DeviceInfoTests: XCTestCase {
         let randomModel: String = .mockRandom()
         let randomOSName: String = .mockRandom()
         let randomOSVersion: String = .mockRandom()
+        let randomArchitecutre: String = .mockRandom()
 
         let info = DeviceInfo(
             model: randomModel,
@@ -22,7 +23,8 @@ class DeviceInfoTests: XCTestCase {
                 model: randomUIDeviceModel,
                 systemName: randomOSName,
                 systemVersion: randomOSVersion
-            )
+            ),
+            architecture: randomArchitecutre
         )
 
         XCTAssertEqual(info.brand, "Apple")
@@ -30,5 +32,6 @@ class DeviceInfoTests: XCTestCase {
         XCTAssertEqual(info.model, randomModel)
         XCTAssertEqual(info.osName, randomOSName)
         XCTAssertEqual(info.osVersion, randomOSVersion)
+        XCTAssertEqual(info.architecture, randomArchitecutre)
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -954,13 +954,15 @@ extension DeviceInfo {
         name: String = .mockAny(),
         model: String = .mockAny(),
         osName: String = .mockAny(),
-        osVersion: String = .mockAny()
+        osVersion: String = .mockAny(),
+        architecture: String = .mockAny()
     ) -> DeviceInfo {
         return .init(
             name: name,
             model: model,
             osName: osName,
-            osVersion: osVersion
+            osVersion: osVersion,
+            architecture: architecture
         )
     }
 
@@ -969,7 +971,8 @@ extension DeviceInfo {
             name: .mockRandom(),
             model: .mockRandom(),
             osName: .mockRandom(),
-            osVersion: .mockRandom()
+            osVersion: .mockRandom(),
+            architecture: .mockRandom()
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -56,6 +56,7 @@ extension RUMEventAttributes: RandomMockable {
 extension RUMDevice: RandomMockable {
     static func mockRandom() -> RUMDevice {
         return .init(
+            architecture: .mockRandom(),
             brand: .mockRandom(),
             model: .mockRandom(),
             name: .mockRandom(),

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMDeviceInfoTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMDeviceInfoTests.swift
@@ -8,17 +8,19 @@ import XCTest
 @testable import Datadog
 
 class RUMDeviceInfoTests: XCTestCase {
-    func testItSetsBrandAndModelAndName() {
+    func testItSetsProperties() {
         let randomModel: String = .mockRandom()
         let randomName: String = .mockRandom()
+        let randomArch: String = .mockRandom()
 
         let info = RUMDevice(
-            device: .mockWith(name: randomName, model: randomModel)
+            device: .mockWith(name: randomName, model: randomModel, architecture: randomArch)
         )
 
         XCTAssertEqual(info.brand, "Apple")
         XCTAssertEqual(info.name, randomName)
         XCTAssertEqual(info.model, randomModel)
+        XCTAssertEqual(info.architecture, randomArch)
     }
 
     func testItInfersDeviceTypeFromDeviceModel() {


### PR DESCRIPTION
### What and why?

Flutter / Dart needs architecture in order to select the proper symbol file to process.  Currently, only add architecture if UIKit is imported

### How?

Add architecture when creating the DeviceInfo. I've added a few checks on the Integration tests to make sure that the architecture is present and is an expected value.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [x] Run smoke tests
