### PR TITLE
Fix CR integration tests flakiness 🤞

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -262,6 +262,15 @@ workflows:
         - project_path: Datadog.xcworkspace
         - xcodebuild_options: -testPlan DatadogIntegrationTests
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/DatadogIntegration-tests.html"
+    - script:
+        title: Disable Apple Crash Reporter
+        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
+        inputs:
+        - content: |-
+            #!/usr/bin/env zsh
+            # We suspect Apple Crash Reporter causing flakiness in our CR integration tests.
+            # Disabling it makes the system prompt ("Example iOS quit unexpectedly") not appear.
+            launchctl unload -w /System/Library/LaunchAgents/com.apple.ReportCrash.plist
     - xcode-test:
         title: Run integration tests for Crash Reporting (on iOS Simulator)
         run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'


### PR DESCRIPTION
### What and why?

🧪 In last 1 month, 16 out of 30 CI failures on `develop` came from Crash Reporting integration tests:

<img width="962" alt="Screenshot 2022-07-28 at 13 16 06" src="https://user-images.githubusercontent.com/2358722/181492637-8c3e8e74-cf1b-46d2-ad54-76e291bf83a7.png">

This PR is trying to address and solve this problem.

### How?

I suspect the issue comes from Apple Crash Reporter intercepting app crashes in Simulator. As a fix, I disable Apple's CR before running our CR integration tests:
```
launchctl unload -w /System/Library/LaunchAgents/com.apple.ReportCrash.plist
```

To test it, I ran CR integration tests 10x with this fix (20 tests in total), all green:

<img width="699" alt="Screenshot 2022-07-28 at 14 15 29" src="https://user-images.githubusercontent.com/2358722/181503191-e72b30e1-05cc-4a7a-930a-82d981751f29.png">


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
