### PR TITLE
Can't compile for SwiftUI Previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [IMPROVEMENT] Add mobile vitals frequency configuration. See [#876][]
 * [IMPROVEMENT] Include the exact model information in RUM `device.model`. See [#888][]
 * [FEATURE] Allow filtering outgoing logs with a status threshold. See [#867][]
+* [BUGFIX] Fix compilation issue in SwiftUI Previews. See [#949][]
 
 # 1.11.1 / 20-06-2022
 
@@ -395,6 +396,7 @@
 [#851]: https://github.com/DataDog/dd-sdk-ios/issues/851
 [#876]: https://github.com/DataDog/dd-sdk-ios/issues/876
 [#894]: https://github.com/DataDog/dd-sdk-ios/issues/894
+[#949]: https://github.com/DataDog/dd-sdk-ios/issues/949
 [@00FA9A]: https://github.com/00FA9A
 [@Britton-Earnin]: https://github.com/Britton-Earnin
 [@Hengyu]: https://github.com/Hengyu

--- a/Package.swift
+++ b/Package.swift
@@ -11,27 +11,34 @@ let package = Package(
     products: [
         .library(
             name: "Datadog",
-            type: .dynamic,
             targets: ["Datadog"]
         ),
         .library(
             name: "DatadogObjc",
-            type: .dynamic,
             targets: ["DatadogObjc"]
         ),
         .library(
+            name: "DatadogDynamic",
+            type: .dynamic,
+            targets: ["Datadog"]
+        ),
+        .library(
+            name: "DatadogDynamicObjc",
+            type: .dynamic,
+            targets: ["DatadogObjc"]
+        ),
+        .library( // TODO: Remove in the next major version.
             name: "DatadogStatic",
             type: .static,
             targets: ["Datadog"]
         ),
-        .library(
+        .library( // TODO: Remove in the next major version.
             name: "DatadogStaticObjc",
             type: .static,
             targets: ["DatadogObjc"]
         ),
         .library(
             name: "DatadogCrashReporting",
-            type: .static,
             targets: ["DatadogCrashReporting"]
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -27,12 +27,12 @@ let package = Package(
             type: .dynamic,
             targets: ["DatadogObjc"]
         ),
-        .library( // TODO: Remove in the next major version.
+        .library( // TODO: RUMM-2387 Consider removing explicit linkage variants
             name: "DatadogStatic",
             type: .static,
             targets: ["Datadog"]
         ),
-        .library( // TODO: Remove in the next major version.
+        .library( // TODO: RUMM-2387 Consider removing explicit linkage variants
             name: "DatadogStaticObjc",
             type: .static,
             targets: ["DatadogObjc"]


### PR DESCRIPTION
### What and why?

This package is the only one that cannot be used if our own project uses SwiftUI Previews in our own packages (ie. Xcode Project links a single SPM package that links all our other dependencies, though I'd tried other arrangements unsuccessfully). This is because all library products in this package explicitly specify either `.static` or `.dynamic`, which does not play well with Xcode's build system when it needs to wiggle things around for previews.

Specifically, when importing the static variant, previews fail with:
```
HumanReadableSwiftError

SettingsError: noExecutablePath(<IDESwiftPackageStaticLibraryProductBuildable:ObjectIdentifier(0x00006000069648d0):'DatadogStatic'>)
```

and when it's dynamic:
```
PotentialCrashError: Update failed

XCPreviewAgent may have crashed. Check ~/Library/Logs/DiagnosticReports for any crash logs from your application.

==================================

|  RemoteHumanReadableError
|  
|  LoadingError: failed to load library at path "/Users/<omitted>": Optional(dlopen(/Users/<omitted>, 0x0000): Library not loaded: @rpath/Datadog.framework/Datadog
|    Referenced from: <3AFEA85D-E7EE-3D6F-9C82-72984B024CB3> /Users/<omitted>
|    Reason: tried: '/Users/<omitted>/Products/Debug-iphonesimulator/Datadog.framework/Datadog' (no such file), '/Applications/Xcode-beta-4.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/Datadog.framework/Datadog' (no such file))
|  
|  ==================================
|  
|  |  MessageSendFailure: Message send failure for <ServiceMessage 3: update>
```

This fails both in Xcode 13 and all Xcode 14 betas that I've tried.

### How?

As packaging as a dynamic library is an optimization step for when users don't want to bloat their binary (which they could better accomplish by including their own wrapper product specific to their project), this reverts the unqualified products to _not_ specify a library type which is the norm for the vast majority of projects, and introduces a new set of qualified types for the dynamic use case.

Ideally, the Static and Dynamic variants should be removed or deprecated, but I'm unaware of a method of signaling that, so I added an appropriate todo to remove at least the static variant in the next major version.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
