### PR TITLE
Fix E2E tests build

### DIFF
--- a/Datadog/E2ETests/NTP/KronosE2ETests.swift
+++ b/Datadog/E2ETests/NTP/KronosE2ETests.swift
@@ -83,7 +83,7 @@ class KronosE2ETests: E2ETests {
         }
 
         // Run test for each Datadog NTP pool:
-        DatadogNTPDateProvider.datadogNTPServers.forEach { ddNTPPool in
+        DatadogNTPServers.forEach { ddNTPPool in
             let result = measure(resourceName: DD.PerfSpanName.fromCurrentMethodName()) {
                 performKronosSync(using: ddNTPPool)
             }


### PR DESCRIPTION
### What and why?

🐞 This PR fixes E2E tests build. It got broken yesterday with merge to `develop` (#950) and all our monitors failed at night.

### How?

Updates the use of an API that was changed from `internal` to `public`. Lack of this caused compiler error on CI:
```
❌  /Users/vagrant/git/Datadog/E2ETests/NTP/KronosE2ETests.swift:86:32: type 'DatadogNTPDateProvider' has no member 'datadogNTPServers'
        DatadogNTPDateProvider.datadogNTPServers.forEach { ddNTPPool in
        ~~~~~~~~~~~~~~~~~~~~~~ ^~~~~~~~~~~~~~~~~
```

To avoid this situation in the future, I added `RUMM-2394 Add smoke test for E2E build on feature-branch` to our backlog.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
