### PR TITLE
iOS Monitoring Doc Edit

### DIFF
--- a/docs/rum_collection/data_collected.md
+++ b/docs/rum_collection/data_collected.md
@@ -132,7 +132,6 @@ RUM action, error, resource, and long task events contain information about the 
 | Metric                | Type        | Description                                                                  |
 |-----------------------|-------------|------------------------------------------------------------------------------|
 | `view.time_spent`     | number (ns) | Time spent on this view.                                                     |
-| `view.loading_time`                             | number (ns) | Loading time for this view.                        |
 | `view.long_task.count`        | number      | Count of all long tasks collected for this view.                     |
 | `view.error.count`    | number      | Count of all errors collected for this view.                                 |
 | `view.resource.count` | number      | Count of all resources collected for this view.                              |


### PR DESCRIPTION
### What and why?

Removes the `view.loading_time` metric.

### How?

#rum-docs, #support-rum Slack

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
