### PR TITLE
RUMM-2350 Detect error tap furstration

### DIFF
--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -87,6 +87,9 @@ public struct RUMActionEvent: RUMDataModel {
 
     /// Internal properties
     public struct DD: Codable {
+        /// Action properties
+        public let action: Action?
+
         /// Browser SDK version
         public let browserSdkVersion: String?
 
@@ -97,9 +100,56 @@ public struct RUMActionEvent: RUMDataModel {
         public let session: Session?
 
         enum CodingKeys: String, CodingKey {
+            case action = "action"
             case browserSdkVersion = "browser_sdk_version"
             case formatVersion = "format_version"
             case session = "session"
+        }
+
+        /// Action properties
+        public struct Action: Codable {
+            /// Action position properties
+            public let position: Position?
+
+            /// Target properties
+            public let target: Target?
+
+            enum CodingKeys: String, CodingKey {
+                case position = "position"
+                case target = "target"
+            }
+
+            /// Action position properties
+            public struct Position: Codable {
+                /// X coordinate relative to the target element of the action (in pixels)
+                public let x: Int64
+
+                /// Y coordinate relative to the target element of the action (in pixels)
+                public let y: Int64
+
+                enum CodingKeys: String, CodingKey {
+                    case x = "x"
+                    case y = "y"
+                }
+            }
+
+            /// Target properties
+            public struct Target: Codable {
+                /// Height of the target element (in pixels)
+                public let height: Int64?
+
+                /// CSS selector path of the target element
+                public let selector: String?
+
+                /// Width of the target element (in pixels)
+                public let width: Int64?
+
+                enum CodingKeys: String, CodingKey {
+                    case height = "height"
+                    case selector = "selector"
+                    case width = "width"
+                }
+            }
         }
 
         /// Session-related internal properties
@@ -139,9 +189,6 @@ public struct RUMActionEvent: RUMDataModel {
         /// Properties of the long tasks of the action
         public let longTask: LongTask?
 
-        /// Action position properties
-        public let position: Position?
-
         /// Properties of the resources of the action
         public let resource: Resource?
 
@@ -158,7 +205,6 @@ public struct RUMActionEvent: RUMDataModel {
             case id = "id"
             case loadingTime = "loading_time"
             case longTask = "long_task"
-            case position = "position"
             case resource = "resource"
             case target = "target"
             case type = "type"
@@ -197,6 +243,8 @@ public struct RUMActionEvent: RUMDataModel {
                 case rageClick = "rage_click"
                 case deadClick = "dead_click"
                 case errorClick = "error_click"
+                case rageTap = "rage_tap"
+                case errorTap = "error_tap"
             }
         }
 
@@ -207,20 +255,6 @@ public struct RUMActionEvent: RUMDataModel {
 
             enum CodingKeys: String, CodingKey {
                 case count = "count"
-            }
-        }
-
-        /// Action position properties
-        public struct Position: Codable {
-            /// X coordinate relative to the target element of the action (in pixels)
-            public let x: Int64
-
-            /// Y coordinate relative to the target element of the action (in pixels)
-            public let y: Int64
-
-            enum CodingKeys: String, CodingKey {
-                case x = "x"
-                case y = "y"
             }
         }
 
@@ -236,23 +270,11 @@ public struct RUMActionEvent: RUMDataModel {
 
         /// Action target properties
         public struct Target: Codable {
-            /// Height of the target element (in pixels)
-            public let height: Int64?
-
             /// Target name
             public var name: String
 
-            /// CSS selector path of the target element
-            public let selector: String?
-
-            /// Width of the target element (in pixels)
-            public let width: Int64?
-
             enum CodingKeys: String, CodingKey {
-                case height = "height"
                 case name = "name"
-                case selector = "selector"
-                case width = "width"
             }
         }
 
@@ -2319,4 +2341,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/9e0f8b2ab26ce0e33b058d7d5d3663ab043847f5
+// Generated from https://github.com/DataDog/rum-events-format/tree/a2f14e5f284d21f29e4fe4e49c0ac52cfcd96d93

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -133,26 +133,26 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             attributes.merge(rumCommandAttributes: commandAttributes)
         }
 
+        var frustrations: [RUMActionEvent.Action.Frustration.FrustrationType]? = nil
+        if errorsCount > 0, actionType == .tap {
+            frustrations = [.errorTap]
+        }
+
         let actionEvent = RUMActionEvent(
             dd: .init(
+                action: nil,
                 browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
             action: .init(
                 crash: nil,
                 error: .init(count: errorsCount.toInt64),
-                frustration: nil,
+                frustration: frustrations.map { .init(type: $0) },
                 id: actionUUID.toRUMDataFormat,
                 loadingTime: completionTime.timeIntervalSince(actionStartTime).toInt64Nanoseconds,
                 longTask: .init(count: longTasksCount),
-                position: nil,
                 resource: .init(count: resourcesCount.toInt64),
-                target: .init(
-                    height: nil,
-                    name: name,
-                    selector: nil,
-                    width: nil
-                ),
+                target: .init(name: name),
                 type: actionType.toRUMDataFormat
             ),
             application: .init(id: self.context.rumApplicationID),

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -325,6 +325,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         let actionEvent = RUMActionEvent(
             dd: .init(
+                action: nil,
                 browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
@@ -335,7 +336,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 id: dependencies.rumUUIDGenerator.generateUnique().toRUMDataFormat,
                 loadingTime: loadingTime,
                 longTask: nil,
-                position: nil,
                 resource: nil,
                 target: nil,
                 type: .applicationStart

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -101,6 +101,10 @@ public class DDRUMActionEventDD: NSObject {
         self.root = root
     }
 
+    @objc public var action: DDRUMActionEventDDAction? {
+        root.swiftModel.dd.action != nil ? DDRUMActionEventDDAction(root: root) : nil
+    }
+
     @objc public var browserSdkVersion: String? {
         root.swiftModel.dd.browserSdkVersion
     }
@@ -111,6 +115,61 @@ public class DDRUMActionEventDD: NSObject {
 
     @objc public var session: DDRUMActionEventDDSession? {
         root.swiftModel.dd.session != nil ? DDRUMActionEventDDSession(root: root) : nil
+    }
+}
+
+@objc
+public class DDRUMActionEventDDAction: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var position: DDRUMActionEventDDActionPosition? {
+        root.swiftModel.dd.action!.position != nil ? DDRUMActionEventDDActionPosition(root: root) : nil
+    }
+
+    @objc public var target: DDRUMActionEventDDActionTarget? {
+        root.swiftModel.dd.action!.target != nil ? DDRUMActionEventDDActionTarget(root: root) : nil
+    }
+}
+
+@objc
+public class DDRUMActionEventDDActionPosition: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var x: NSNumber {
+        root.swiftModel.dd.action!.position!.x as NSNumber
+    }
+
+    @objc public var y: NSNumber {
+        root.swiftModel.dd.action!.position!.y as NSNumber
+    }
+}
+
+@objc
+public class DDRUMActionEventDDActionTarget: NSObject {
+    internal let root: DDRUMActionEvent
+
+    internal init(root: DDRUMActionEvent) {
+        self.root = root
+    }
+
+    @objc public var height: NSNumber? {
+        root.swiftModel.dd.action!.target!.height as NSNumber?
+    }
+
+    @objc public var selector: String? {
+        root.swiftModel.dd.action!.target!.selector
+    }
+
+    @objc public var width: NSNumber? {
+        root.swiftModel.dd.action!.target!.width as NSNumber?
     }
 }
 
@@ -179,10 +238,6 @@ public class DDRUMActionEventAction: NSObject {
         root.swiftModel.action.longTask != nil ? DDRUMActionEventActionLongTask(root: root) : nil
     }
 
-    @objc public var position: DDRUMActionEventActionPosition? {
-        root.swiftModel.action.position != nil ? DDRUMActionEventActionPosition(root: root) : nil
-    }
-
     @objc public var resource: DDRUMActionEventActionResource? {
         root.swiftModel.action.resource != nil ? DDRUMActionEventActionResource(root: root) : nil
     }
@@ -242,6 +297,8 @@ public enum DDRUMActionEventActionFrustrationFrustrationType: Int {
         case .rageClick: self = .rageClick
         case .deadClick: self = .deadClick
         case .errorClick: self = .errorClick
+        case .rageTap: self = .rageTap
+        case .errorTap: self = .errorTap
         }
     }
 
@@ -250,12 +307,16 @@ public enum DDRUMActionEventActionFrustrationFrustrationType: Int {
         case .rageClick: return .rageClick
         case .deadClick: return .deadClick
         case .errorClick: return .errorClick
+        case .rageTap: return .rageTap
+        case .errorTap: return .errorTap
         }
     }
 
     case rageClick
     case deadClick
     case errorClick
+    case rageTap
+    case errorTap
 }
 
 @objc
@@ -268,23 +329,6 @@ public class DDRUMActionEventActionLongTask: NSObject {
 
     @objc public var count: NSNumber {
         root.swiftModel.action.longTask!.count as NSNumber
-    }
-}
-
-@objc
-public class DDRUMActionEventActionPosition: NSObject {
-    internal let root: DDRUMActionEvent
-
-    internal init(root: DDRUMActionEvent) {
-        self.root = root
-    }
-
-    @objc public var x: NSNumber {
-        root.swiftModel.action.position!.x as NSNumber
-    }
-
-    @objc public var y: NSNumber {
-        root.swiftModel.action.position!.y as NSNumber
     }
 }
 
@@ -309,21 +353,9 @@ public class DDRUMActionEventActionTarget: NSObject {
         self.root = root
     }
 
-    @objc public var height: NSNumber? {
-        root.swiftModel.action.target!.height as NSNumber?
-    }
-
     @objc public var name: String {
         set { root.swiftModel.action.target!.name = newValue }
         get { root.swiftModel.action.target!.name }
-    }
-
-    @objc public var selector: String? {
-        root.swiftModel.action.target!.selector
-    }
-
-    @objc public var width: NSNumber? {
-        root.swiftModel.action.target!.width as NSNumber?
     }
 }
 
@@ -4332,4 +4364,4 @@ public class DDTelemetryDebugEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/9e0f8b2ab26ce0e33b058d7d5d3663ab043847f5
+// Generated from https://github.com/DataDog/rum-events-format/tree/a2f14e5f284d21f29e4fe4e49c0ac52cfcd96d93

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -241,6 +241,14 @@ extension RUMActionEvent: RandomMockable {
     static func mockRandom() -> RUMActionEvent {
         return RUMActionEvent(
             dd: .init(
+                action: .init(
+                    position: nil,
+                    target: .init(
+                        height: nil,
+                        selector: nil,
+                        width: .mockRandom()
+                    )
+                ),
                 browserSdkVersion: nil,
                 session: .init(plan: .plan1)
             ),
@@ -251,9 +259,8 @@ extension RUMActionEvent: RandomMockable {
                 id: .mockRandom(),
                 loadingTime: .mockRandom(),
                 longTask: .init(count: .mockRandom()),
-                position: nil,
                 resource: .init(count: .mockRandom()),
-                target: .init(height: nil, name: .mockRandom(), selector: nil, width: .mockRandom()),
+                target: .init(name: .mockRandom()),
                 type: [.tap, .swipe, .scroll].randomElement()!
             ),
             application: .init(id: .mockRandom()),

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -85,7 +85,6 @@ class RUMUserActionScopeTests: XCTestCase {
         XCTAssertEqual(recordedAction.service, "test-service")
         XCTAssertEqual(recordedAction.device?.name, "device-name")
         XCTAssertEqual(recordedAction.os?.name, "device-os")
-        XCTAssertNil(recordedAction.action.frustration)
     }
 
     func testGivenCustomSource_whenActionIsSent_itSendsCustomSource() throws {
@@ -264,7 +263,6 @@ class RUMUserActionScopeTests: XCTestCase {
         let event = try XCTUnwrap(writer.events(ofType: RUMActionEvent.self).last)
         XCTAssertEqual(event.action.resource?.count, 1, "User Action should track first successful Resource")
         XCTAssertEqual(event.action.error?.count, 1, "User Action should track second Resource failure as Error")
-        XCTAssertNil(event.action.frustration)
     }
 
     func testWhileContinuousUserActionIsActive_itCountsViewErrors() throws {
@@ -591,7 +589,7 @@ class RUMUserActionScopeTests: XCTestCase {
             isContinuous: false
         )
 
-        currentTime.addTimeInterval(0.05)
+        currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration * 0.5)
 
         XCTAssertTrue(
             scope.process(
@@ -611,5 +609,67 @@ class RUMUserActionScopeTests: XCTestCase {
 
         let event = try XCTUnwrap(writer.events(ofType: RUMActionEvent.self).first)
         XCTAssertEqual(event.action.frustration?.type.first, .errorTap)
+    }
+
+    func testGivenNotDiscreteUserActionWithError_itDoesNotWriteFrustration() throws {
+        var currentTime = Date()
+        let scope = RUMUserActionScope.mockWith(
+            parent: parent,
+            actionType: .scroll,
+            startTime: currentTime,
+            isContinuous: false
+        )
+
+        currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration * 0.5)
+
+        XCTAssertTrue(
+            scope.process(
+                command: RUMAddCurrentViewErrorCommand.mockWithErrorObject(time: currentTime),
+                context: context,
+                writer: writer
+            )
+        )
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(identity: mockView),
+                context: context,
+                writer: writer
+            )
+        )
+
+        let event = try XCTUnwrap(writer.events(ofType: RUMActionEvent.self).first)
+        XCTAssertNil(event.action.frustration)
+    }
+
+    func testGivenTimedoutTapUserActionWithError_itDoesNotWriteFrustration() throws {
+        var currentTime = Date()
+        let scope = RUMUserActionScope.mockWith(
+            parent: parent,
+            actionType: .tap,
+            startTime: currentTime,
+            isContinuous: false
+        )
+
+        currentTime.addTimeInterval(RUMUserActionScope.Constants.discreteActionTimeoutDuration * 1.5)
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMAddCurrentViewErrorCommand.mockWithErrorObject(time: currentTime),
+                context: context,
+                writer: writer
+            )
+        )
+
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopViewCommand.mockWith(identity: mockView),
+                context: context,
+                writer: writer
+            )
+        )
+
+        let event = try XCTUnwrap(writer.events(ofType: RUMActionEvent.self).first)
+        XCTAssertNil(event.action.frustration)
     }
 }


### PR DESCRIPTION
### What and why?

Add the `error_tap` frustration signal when a Tap action leads to one or more errors

### How?

Update models and add frustration type `error_tap` to action event when the action scope has one or more error.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
