### PR TITLE
Add public visibility to Internal Proxy methods.

### DIFF
--- a/Sources/Datadog/DatadogInternal/_InternalProxy.swift
+++ b/Sources/Datadog/DatadogInternal/_InternalProxy.swift
@@ -15,17 +15,17 @@ import Foundation
 /// Methods, members, and functionality of this class  are subject to change without notice, as they
 /// are not considered part of the public interface of the Datadog SDK.
 public class _InternalProxy {
-    let _telemtry = _TelemetryProxy()
+    public let _telemtry = _TelemetryProxy()
 }
 
 public class _TelemetryProxy {
     /// See Telementry.debug
-    func debug(id: String, message: String) {
+    public func debug(id: String, message: String) {
         DD.telemetry.debug(id: id, message: message)
     }
 
     /// See Telementry.error
-    func error(id: String, message: String, kind: String?, stack: String?) {
+    public func error(id: String, message: String, kind: String?, stack: String?) {
         DD.telemetry.error(id: id, message: message, kind: kind, stack: stack)
     }
 }

--- a/Sources/Datadog/RUM/_RUMInternalProxy.swift
+++ b/Sources/Datadog/RUM/_RUMInternalProxy.swift
@@ -21,7 +21,7 @@ public class _RUMInternalProxy {
         self.subscriber = subscriber
     }
 
-    func addLongTask(at: Date, duration: TimeInterval, attributes: [AttributeKey: AttributeValue] = [:]) {
+    public func addLongTask(at: Date, duration: TimeInterval, attributes: [AttributeKey: AttributeValue] = [:]) {
         let longTaskCommand = RUMAddLongTaskCommand(time: at, attributes: attributes, duration: duration)
 
         subscriber?.process(command: longTaskCommand)


### PR DESCRIPTION
### What and why?

Add `public` to all the Internal Proxy methods as they need to be public to be useful.

### How?

Just add `public` in front.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
