### PR TITLE
plousada/RUMM-2425/increase-event-size-limit

### DIFF
--- a/Sources/Datadog/Core/PerformancePreset.swift
+++ b/Sources/Datadog/Core/PerformancePreset.swift
@@ -133,7 +133,7 @@ internal extension PerformancePreset {
         self.minFileAgeForRead = meanFileAge * 1.05 //  5% above the mean age
         self.maxFileAgeForRead = 18 * 60 * 60 // 18h
         self.maxObjectsInFile = 500
-        self.maxObjectSize = 256 * 1_024 // 256KB
+        self.maxObjectSize = 512 * 1_024 // 512KB
         self.initialUploadDelay = minUploadDelay * uploadDelayFactors.initial
         self.minUploadDelay = minUploadDelay * uploadDelayFactors.min
         self.maxUploadDelay = minUploadDelay * uploadDelayFactors.max

--- a/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
@@ -89,7 +89,7 @@ class PerformancePresetTests: XCTestCase {
         XCTAssertEqual(preset.maxDirectorySize, 512 * 1_024 * 1_024) // 512 MB
         XCTAssertEqual(preset.maxFileAgeForRead, 18 * 60 * 60) // 18h
         XCTAssertEqual(preset.maxObjectsInFile, 500)
-        XCTAssertEqual(preset.maxObjectSize, 256 * 1_024) // 256KB
+        XCTAssertEqual(preset.maxObjectSize, 512 * 1_024) // 512KB
     }
 
     func testPresetsConsistency() {


### PR DESCRIPTION
### What and why?

Increasing the sing event size limit to 512KB in order to match Android and decrease amount of dropped events. 

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
