### PR TITLE
RUMM-2332 Introduce Message Bus Design

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -606,6 +606,8 @@
 		D21C26D228A64599005DD405 /* MessageBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D028A64599005DD405 /* MessageBusTests.swift */; };
 		D21C26D728A647DB005DD405 /* MessageBusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D628A647DB005DD405 /* MessageBusMock.swift */; };
 		D21C26D828A647DB005DD405 /* MessageBusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D628A647DB005DD405 /* MessageBusMock.swift */; };
+		D21C26DA28ABA073005DD405 /* FeatureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D928ABA073005DD405 /* FeatureMessage.swift */; };
+		D21C26DB28ABA073005DD405 /* FeatureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D928ABA073005DD405 /* FeatureMessage.swift */; };
 		D22C1F5C271484B400922024 /* LogEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C1F5B271484B400922024 /* LogEventMapper.swift */; };
 		D232CAD52832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
 		D232CAD62832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
@@ -1869,6 +1871,7 @@
 		D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureMessageReceiver.swift; sourceTree = "<group>"; };
 		D21C26D028A64599005DD405 /* MessageBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusTests.swift; sourceTree = "<group>"; };
 		D21C26D628A647DB005DD405 /* MessageBusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusMock.swift; sourceTree = "<group>"; };
+		D21C26D928ABA073005DD405 /* FeatureMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureMessage.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
 		D232CAD42832D762001B262C /* DatadogCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreMock.swift; sourceTree = "<group>"; };
 		D240684D27CE6C9E00C04F44 /* Example tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4198,6 +4201,7 @@
 		D21C26CC28A411BE005DD405 /* MessageBus */ = {
 			isa = PBXGroup;
 			children = (
+				D21C26D928ABA073005DD405 /* FeatureMessage.swift */,
 				D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */,
 			);
 			path = MessageBus;
@@ -5278,6 +5282,7 @@
 				61C2C21224C5951400C0321C /* RUMViewScope.swift in Sources */,
 				61D3E0D5277B23F1008BE766 /* KronosNTPPacket.swift in Sources */,
 				61DE332625C826E4008E3EC2 /* CrashReportingFeature.swift in Sources */,
+				D21C26DA28ABA073005DD405 /* FeatureMessage.swift in Sources */,
 				61E36A11254B2280001AD6F2 /* LaunchTimeProvider.swift in Sources */,
 				614872772485067300E3EBDB /* SpanTagsReducer.swift in Sources */,
 				61C3E63E24BF1B91008053F2 /* RUMApplicationScope.swift in Sources */,
@@ -6102,6 +6107,7 @@
 				D2CB6EAA27C50EAE00A62B57 /* URLSessionSwizzler.swift in Sources */,
 				D2CB6EAB27C50EAE00A62B57 /* VitalMemoryReader.swift in Sources */,
 				D26C49B72889416300802B2D /* UploadPerformancePreset.swift in Sources */,
+				D21C26DB28ABA073005DD405 /* FeatureMessage.swift in Sources */,
 				D2CB6EAC27C50EAE00A62B57 /* DatadogConfiguration.swift in Sources */,
 				D2CB6EAE27C50EAE00A62B57 /* DataOrchestrator.swift in Sources */,
 				D2CB6EAF27C50EAE00A62B57 /* BundleType.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -598,6 +598,14 @@
 		D2135330270CA722000315AD /* DataCompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213532F270CA722000315AD /* DataCompressionTests.swift */; };
 		D21C26C528A3B49C005DD405 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C428A3B49C005DD405 /* FeatureStorage.swift */; };
 		D21C26C628A3B49C005DD405 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C428A3B49C005DD405 /* FeatureStorage.swift */; };
+		D21C26CA28A406A3005DD405 /* DatadogFeatureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C928A406A3005DD405 /* DatadogFeatureConfiguration.swift */; };
+		D21C26CB28A406A3005DD405 /* DatadogFeatureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C928A406A3005DD405 /* DatadogFeatureConfiguration.swift */; };
+		D21C26CE28A411FF005DD405 /* FeatureMessageReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */; };
+		D21C26CF28A411FF005DD405 /* FeatureMessageReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */; };
+		D21C26D128A64599005DD405 /* MessageBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D028A64599005DD405 /* MessageBusTests.swift */; };
+		D21C26D228A64599005DD405 /* MessageBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D028A64599005DD405 /* MessageBusTests.swift */; };
+		D21C26D728A647DB005DD405 /* MessageBusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D628A647DB005DD405 /* MessageBusMock.swift */; };
+		D21C26D828A647DB005DD405 /* MessageBusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D628A647DB005DD405 /* MessageBusMock.swift */; };
 		D22C1F5C271484B400922024 /* LogEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C1F5B271484B400922024 /* LogEventMapper.swift */; };
 		D232CAD52832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
 		D232CAD62832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
@@ -1857,6 +1865,10 @@
 		D20605CC28770C3B0047275C /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		D213532F270CA722000315AD /* DataCompressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompressionTests.swift; sourceTree = "<group>"; };
 		D21C26C428A3B49C005DD405 /* FeatureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureStorage.swift; sourceTree = "<group>"; };
+		D21C26C928A406A3005DD405 /* DatadogFeatureConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogFeatureConfiguration.swift; sourceTree = "<group>"; };
+		D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureMessageReceiver.swift; sourceTree = "<group>"; };
+		D21C26D028A64599005DD405 /* MessageBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusTests.swift; sourceTree = "<group>"; };
+		D21C26D628A647DB005DD405 /* MessageBusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusMock.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
 		D232CAD42832D762001B262C /* DatadogCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreMock.swift; sourceTree = "<group>"; };
 		D240684D27CE6C9E00C04F44 /* Example tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4183,6 +4195,14 @@
 			path = DatadogCore;
 			sourceTree = "<group>";
 		};
+		D21C26CC28A411BE005DD405 /* MessageBus */ = {
+			isa = PBXGroup;
+			children = (
+				D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */,
+			);
+			path = MessageBus;
+			sourceTree = "<group>";
+		};
 		D22C1F5A2714849700922024 /* Scrubbing */ = {
 			isa = PBXGroup;
 			children = (
@@ -4249,10 +4269,11 @@
 			isa = PBXGroup;
 			children = (
 				D232CAD42832D762001B262C /* DatadogCoreMock.swift */,
+				D26F59352851E3650097C455 /* Flushable.swift */,
 				D26F59322851E3440097C455 /* PassthroughCoreMock.swift */,
 				D2EFA870286DFF7900F1FAA6 /* DatadogContextMock.swift */,
 				D2553806288AA84F00727FAD /* UploadMock.swift */,
-				D26F59352851E3650097C455 /* Flushable.swift */,
+				D21C26D628A647DB005DD405 /* MessageBusMock.swift */,
 			);
 			path = DatadogInternal;
 			sourceTree = "<group>";
@@ -4343,8 +4364,10 @@
 			isa = PBXGroup;
 			children = (
 				D2B3F0492829510600C2B5EE /* DatadogCoreProtocol.swift */,
+				D21C26C928A406A3005DD405 /* DatadogFeatureConfiguration.swift */,
 				D2956CAA2869D1DF007D5462 /* Context */,
 				D26C49C128899B4100802B2D /* Upload */,
+				D21C26CC28A411BE005DD405 /* MessageBus */,
 				492749002880489400ECD49B /* _InternalProxy.swift */,
 				61E945DF2869BEF500A946C4 /* DD.swift */,
 				D2D37DBE2846335F00FB4348 /* DatadogV1CoreProtocol.swift */,
@@ -4381,6 +4404,7 @@
 				D2A1EE432886B8B400D28DFB /* UserInfoPublisherTests.swift */,
 				D2A1EE3D2885D7EC00D28DFB /* LaunchTimeReaderTests.swift */,
 				D26C49AE2886DC7B00802B2D /* ApplicationStatePublisherTests.swift */,
+				D21C26D028A64599005DD405 /* MessageBusTests.swift */,
 			);
 			path = DatadogCore;
 			sourceTree = "<group>";
@@ -5286,6 +5310,7 @@
 				D2B3F04A2829510600C2B5EE /* DatadogCoreProtocol.swift in Sources */,
 				6122514827FDFF82004F5AE4 /* RUMScopeDependencies.swift in Sources */,
 				6141014F251A57AF00E3C2D9 /* UIApplicationSwizzler.swift in Sources */,
+				D21C26CA28A406A3005DD405 /* DatadogFeatureConfiguration.swift in Sources */,
 				61494CB124C839460082C633 /* RUMResourceScope.swift in Sources */,
 				61C2C20724C098FC00C0321C /* RUMSessionScope.swift in Sources */,
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
@@ -5337,6 +5362,7 @@
 				61C5A88E24509A1F00DA608C /* Tracer.swift in Sources */,
 				61DA8CB528643B220074A606 /* InternalLogger.swift in Sources */,
 				D20605CD28770C3B0047275C /* AppState.swift in Sources */,
+				D21C26CE28A411FF005DD405 /* FeatureMessageReceiver.swift in Sources */,
 				61E909EE24A24DD3005EA2DE /* OTFormat.swift in Sources */,
 				9E26E6B924C87693000B3270 /* RUMDataModels.swift in Sources */,
 				61D3E0D6277B23F1008BE766 /* KronosClock.swift in Sources */,
@@ -5626,6 +5652,7 @@
 				9E989A4225F640D100235FC3 /* AppStateListenerTests.swift in Sources */,
 				D2EFA871286DFF7900F1FAA6 /* DatadogContextMock.swift in Sources */,
 				617B954024BF4DB300E6F443 /* RUMApplicationScopeTests.swift in Sources */,
+				D21C26D728A647DB005DD405 /* MessageBusMock.swift in Sources */,
 				61F2724925C943C500D54BF8 /* CrashReporterTests.swift in Sources */,
 				6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */,
 				D2A1EE26287C35DE00D28DFB /* ContextValueReaderMock.swift in Sources */,
@@ -5640,6 +5667,7 @@
 				6184751826EFD03400C7C9C5 /* DatadogTestsObserverLoader.m in Sources */,
 				61345613244756E300E7DA6B /* PerformancePresetTests.swift in Sources */,
 				D2553807288AA84F00727FAD /* UploadMock.swift in Sources */,
+				D21C26D128A64599005DD405 /* MessageBusTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6004,6 +6032,7 @@
 				492749022880489400ECD49B /* _InternalProxy.swift in Sources */,
 				D2CB6E7227C50EAE00A62B57 /* SpanEventEncoder.swift in Sources */,
 				D2CB6E7327C50EAE00A62B57 /* Tracer.swift in Sources */,
+				D21C26CB28A406A3005DD405 /* DatadogFeatureConfiguration.swift in Sources */,
 				D2CB6E7427C50EAE00A62B57 /* OTFormat.swift in Sources */,
 				D2CB6E7527C50EAE00A62B57 /* RUMDataModels.swift in Sources */,
 				D2CB6E7627C50EAE00A62B57 /* KronosClock.swift in Sources */,
@@ -6102,6 +6131,7 @@
 				D2CB6EC627C50EAE00A62B57 /* HTTPHeadersWriter.swift in Sources */,
 				D2CB6EC727C50EAE00A62B57 /* PerformancePreset.swift in Sources */,
 				D2CB6EC827C50EAE00A62B57 /* RUMUserInfoProvider.swift in Sources */,
+				D21C26CF28A411FF005DD405 /* FeatureMessageReceiver.swift in Sources */,
 				D2CB6EC927C50EAE00A62B57 /* Directory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -6294,6 +6324,7 @@
 				D2CB6F7A27C520D400A62B57 /* AppStateListenerTests.swift in Sources */,
 				D2EFA872286DFF7900F1FAA6 /* DatadogContextMock.swift in Sources */,
 				D2CB6F7B27C520D400A62B57 /* RUMApplicationScopeTests.swift in Sources */,
+				D21C26D828A647DB005DD405 /* MessageBusMock.swift in Sources */,
 				D2CB6F7C27C520D400A62B57 /* CrashReporterTests.swift in Sources */,
 				D2CB6F7D27C520D400A62B57 /* CrashContextTests.swift in Sources */,
 				D2A1EE27287C35DE00D28DFB /* ContextValueReaderMock.swift in Sources */,
@@ -6308,6 +6339,7 @@
 				D2CB6F8427C520D400A62B57 /* DatadogTestsObserverLoader.m in Sources */,
 				D2CB6F8527C520D400A62B57 /* PerformancePresetTests.swift in Sources */,
 				D2553808288AA84F00727FAD /* UploadMock.swift in Sources */,
+				D21C26D228A64599005DD405 /* MessageBusTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -358,7 +358,7 @@ public class Datadog {
         DD.telemetry = NOPTelemetry()
 
         // Deinitialize `Datadog`:
-        defaultDatadogCore = NOOPDatadogCore()
+        defaultDatadogCore = NOPDatadogCore()
     }
 
     // MARK: - Internal Proxy - exposure of internal classes (Mostly used for cross platform libraries)

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -232,8 +232,7 @@ public class Datadog {
             )
 
             rum = try core.create(
-                storageConfiguration: createV2RUMStorageConfiguration(),
-                uploadConfiguration: createV2RUMUploadConfiguration(v1Configuration: rumConfiguration),
+                configuration: createRUMConfiguration(intake: rumConfiguration.uploadURL),
                 featureSpecificConfiguration: rumConfiguration
             )
 
@@ -251,19 +250,19 @@ public class Datadog {
 
         if let loggingConfiguration = configuration.logging {
             logging = try core.create(
-                storageConfiguration: createV2LoggingStorageConfiguration(),
-                uploadConfiguration: createV2LoggingUploadConfiguration(v1Configuration: loggingConfiguration),
+                configuration: createLoggingConfiguration(intake: loggingConfiguration.uploadURL),
                 featureSpecificConfiguration: loggingConfiguration
             )
+
             core.register(feature: logging)
         }
 
         if let tracingConfiguration = configuration.tracing {
             tracing = try core.create(
-                storageConfiguration: createV2TracingStorageConfiguration(),
-                uploadConfiguration: createV2TracingUploadConfiguration(v1Configuration: tracingConfiguration),
+                configuration: createTracingConfiguration(intake: tracingConfiguration.uploadURL),
                 featureSpecificConfiguration: tracingConfiguration
             )
+
             core.register(feature: tracing)
         }
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -222,10 +222,10 @@ internal protocol V1Feature {
     /// The feature's storage.
     var storage: FeatureStorage { get }
 
-    /// The message bus receiver.
+    /// The message receiver.
     ///
-    /// The `FeatureMessageReceiver` defines an interface for feature to receive any message
-    /// from a bus that is shared between feature registered in a core.
+    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
+    /// from a bus that is shared between Features registered in a core.
     var messageReceiver: FeatureMessageReceiver { get }
 }
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -134,8 +134,8 @@ internal final class DatadogCore {
 extension DatadogCore: DatadogCoreProtocol {
     // MARK: - V2 interface
 
-    func send(message: String, attributes: [String: Any]? = nil) {
-        messageBus.forEach { $0.receive(message: message, attributes: attributes) }
+    /* public */ func send(message: FeatureMessage) {
+        messageBus.forEach { $0.receive(message: message, from: self) }
     }
 }
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -50,6 +50,9 @@ internal final class DatadogCore {
     /// `contextProvider`
     let userInfoPublisher = UserInfoPublisher()
 
+    /// The message bus used to dispatch messages to registered features.
+    private var messageBus: [FeatureMessageReceiver] = []
+
     /// Registery for v1 features.
     private var v1Features: [String: Any] = [:]
 
@@ -128,51 +131,25 @@ internal final class DatadogCore {
     }
 }
 
+extension DatadogCore: DatadogCoreProtocol {
+    // MARK: - V2 interface
+
+    func send(message: String, attributes: [String: Any]? = nil) {
+        messageBus.forEach { $0.receive(message: message, attributes: attributes) }
+    }
+}
+
 extension DatadogCore: DatadogV1CoreProtocol {
     // MARK: - V1 interface
-
-    /// Creates V1 Feature using its V2 configuration.
-    ///
-    /// `DatadogCore` uses its core `configuration` to inject feature-agnostic parts of V1 setup.
-    /// Feature-specific part is provided explicitly with `featureSpecificConfiguration`.
-    ///
-    /// - Returns: an instance of V1 feature
-    func create<Feature: V1FeatureInitializable>(
-        storageConfiguration: FeatureStorageConfiguration,
-        uploadConfiguration: FeatureV1UploadConfiguration,
-        featureSpecificConfiguration: Feature.Configuration
-    ) throws -> Feature {
-        let featureDirectories = try directory.getFeatureDirectories(configuration: storageConfiguration)
-
-        let storage = FeatureStorage(
-            featureName: storageConfiguration.featureName,
-            queue: readWriteQueue,
-            directories: featureDirectories,
-            dateProvider: dateProvider,
-            consentProvider: consentProvider,
-            performance: performance,
-            encryption: encryption
-        )
-
-        let upload = FeatureUpload(
-            featureName: uploadConfiguration.featureName,
-            contextProvider: contextProvider,
-            fileReader: storage.reader,
-            requestBuilder: uploadConfiguration.requestBuilder,
-            httpClient: httpClient,
-            performance: performance
-        )
-
-        return Feature(
-            storage: storage,
-            upload: upload,
-            configuration: featureSpecificConfiguration
-        )
-    }
 
     func register<T>(feature instance: T?) {
         let key = String(describing: T.self)
         v1Features[key] = instance
+
+        // add/replace v1 feature to the message bus
+        messageBus = v1Features.values
+            .compactMap { $0 as? V1Feature }
+            .map(\.messageReceiver)
     }
 
     func feature<T>(_ type: T.Type) -> T? {
@@ -196,12 +173,60 @@ extension DatadogCore: DatadogV1CoreProtocol {
     var context: DatadogV1Context? {
         return v1Context
     }
+
+    /// Creates V1 Feature using its V2 configuration.
+    ///
+    /// `DatadogCore` uses its core `configuration` to inject feature-agnostic parts of V1 setup.
+    /// Feature-specific part is provided explicitly with `featureSpecificConfiguration`.
+    ///
+    /// - Parameters:
+    ///   - configuration: The generic feature configuration.
+    ///   - featureSpecificConfiguration: The feature-specific configuration.
+    /// - Returns: an instance of V1 feature
+    func create<Feature: V1FeatureInitializable>(
+        configuration: DatadogFeatureConfiguration,
+        featureSpecificConfiguration: Feature.Configuration
+    ) throws -> Feature {
+        let featureDirectories = try directory.getFeatureDirectories(forFeatureNamed: configuration.name)
+
+        let storage = FeatureStorage(
+            featureName: configuration.name,
+            queue: readWriteQueue,
+            directories: featureDirectories,
+            dateProvider: dateProvider,
+            consentProvider: consentProvider,
+            performance: performance,
+            encryption: encryption
+        )
+
+        let upload = FeatureUpload(
+            featureName: configuration.name,
+            contextProvider: contextProvider,
+            fileReader: storage.reader,
+            requestBuilder: configuration.requestBuilder,
+            httpClient: httpClient,
+            performance: performance
+        )
+
+        return Feature(
+            storage: storage,
+            upload: upload,
+            configuration: featureSpecificConfiguration,
+            messageReceiver: configuration.messageReceiver
+        )
+    }
 }
 
 /// A v1 Feature with an associated stroage.
 internal protocol V1Feature {
     /// The feature's storage.
     var storage: FeatureStorage { get }
+
+    /// The message bus receiver.
+    ///
+    /// The `FeatureMessageReceiver` defines an interface for feature to receive any message
+    /// from a bus that is shared between feature registered in a core.
+    var messageReceiver: FeatureMessageReceiver { get }
 }
 
 /// This Scope complies with `V1FeatureScope` to provide context and writer to
@@ -343,6 +368,7 @@ internal protocol V1FeatureInitializable {
     init(
         storage: FeatureStorage,
         upload: FeatureUpload,
-        configuration: Configuration
+        configuration: Configuration,
+        messageReceiver: FeatureMessageReceiver
     )
 }

--- a/Sources/Datadog/DatadogCore/Storage/Directories.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Directories.swift
@@ -25,11 +25,13 @@ internal struct CoreDirectory {
     let coreDirectory: Directory
 
     /// Obtains subdirectories for managing Feature data (creates if don't exist).
-    /// - Parameter configuration: the storage configuration for given Feature
-    func getFeatureDirectories(configuration: FeatureStorageConfiguration) throws -> FeatureDirectories {
+    ///
+    /// - Parameter name: The given Feature name.
+    /// - Returns: The Feature's directories
+    func getFeatureDirectories(forFeatureNamed name: String) throws -> FeatureDirectories {
         return FeatureDirectories(
-            unauthorized: try coreDirectory.createSubdirectory(path: configuration.directories.unauthorized),
-            authorized: try coreDirectory.createSubdirectory(path: configuration.directories.authorized)
+            unauthorized: try coreDirectory.createSubdirectory(path: "\(name)/intermediate-v2"),
+            authorized: try coreDirectory.createSubdirectory(path: "\(name)/v2")
         )
     }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -11,29 +11,15 @@ public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOOPDatadogCo
 /// A Datadog Core holds a set of features and is responsible of managing their storage
 /// and upload mechanism. It also provides a thread-safe scope for writing events.
 public protocol DatadogCoreProtocol {
-}
-
-/// Provide feature specific storage configuration.
-internal struct FeatureStorageConfiguration {
-    /// A set of paths for managing persisted data for this Feature.
-    /// Each path is relative to the root folder of given SDK instance.
-    struct Directories {
-        /// The path for writing authorized data (when tracking consent is granted).
-        /// This path must be relative to the core directory created for given instance of the SDK.
-        let authorized: String
-        /// The path for writing unauthorized data (when tracking consent is pending).
-        /// This path must be relative to the core directory created for given instance of the SDK.
-        let unauthorized: String
-    }
-
-    /// Directories storing data for this Feature.
-    let directories: Directories
-
-    // MARK: - V1 interface
-
-    /// A human-readable name of this Feature used for naming internal queues specific to this Feature and annotating
-    /// origin of telemetry and verbosity logs produced by the SDK.
-    let featureName: String
+    /// Sends a message on the bus shared by features registered in this core.
+    ///
+    /// The message is composed of a key and attributes that the feature can use to build an
+    /// event or run a process. Be mindful of not blocking the caller thread.
+    ///
+    /// - Parameters:
+    ///   - message: The message key.
+    ///   - attributes: The message attributes.
+    func send(message: String, attributes: [String: Any]?)
 }
 
 /// A datadog feature providing thread-safe scope for writing events.
@@ -43,4 +29,6 @@ public protocol FeatureScope {
 
 /// No-op implementation of `DatadogFeatureRegistry`.
 internal struct NOOPDatadogCore: DatadogCoreProtocol {
+    /// no-op
+    func send(message: String, attributes: [String: Any]?) { }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -17,9 +17,8 @@ public protocol DatadogCoreProtocol {
     /// event or run a process. Be mindful of not blocking the caller thread.
     ///
     /// - Parameters:
-    ///   - message: The message key.
-    ///   - attributes: The message attributes.
-    func send(message: String, attributes: [String: Any]?)
+    ///   - message: The message.
+    func send(message: FeatureMessage)
 }
 
 /// A datadog feature providing thread-safe scope for writing events.
@@ -30,5 +29,5 @@ public protocol FeatureScope {
 /// No-op implementation of `DatadogFeatureRegistry`.
 internal struct NOOPDatadogCore: DatadogCoreProtocol {
     /// no-op
-    func send(message: String, attributes: [String: Any]?) { }
+    func send(message: FeatureMessage) { }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOOPDatadogCore()
+public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOPDatadogCore()
 
 /// A Datadog Core holds a set of features and is responsible of managing their storage
 /// and upload mechanism. It also provides a thread-safe scope for writing events.
@@ -27,7 +27,7 @@ public protocol FeatureScope {
 }
 
 /// No-op implementation of `DatadogFeatureRegistry`.
-internal struct NOOPDatadogCore: DatadogCoreProtocol {
+internal struct NOPDatadogCore: DatadogCoreProtocol {
     /// no-op
     func send(message: FeatureMessage) { }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogFeatureConfiguration.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogFeatureConfiguration.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /* public */ internal struct DatadogFeatureConfiguration {
-    /// The feature name.
+    /// The Feature name.
     let name: String
 
     /// The URL request builder for uploading data in this Feature.
@@ -17,7 +17,7 @@ import Foundation
 
     /// The message bus receiver.
     ///
-    /// The `FeatureMessageReceiver` defines an interface for feature to receive any message
-    /// from a bus that is shared between feature registered in a core.
+    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
+    /// from a bus that is shared between Features registered in a core.
     let messageReceiver: FeatureMessageReceiver
 }

--- a/Sources/Datadog/DatadogInternal/DatadogFeatureConfiguration.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogFeatureConfiguration.swift
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/* public */ internal struct DatadogFeatureConfiguration {
+    /// The feature name.
+    let name: String
+
+    /// The URL request builder for uploading data in this Feature.
+    ///
+    /// This builder currently use the v1 context, but will be soon migrated to v2
+    let requestBuilder: FeatureRequestBuilder
+
+    /// The message bus receiver.
+    ///
+    /// The `FeatureMessageReceiver` defines an interface for feature to receive any message
+    /// from a bus that is shared between feature registered in a core.
+    let messageReceiver: FeatureMessageReceiver
+}

--- a/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
@@ -45,20 +45,6 @@ internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
     func scope<T>(for featureType: T.Type) -> FeatureV1Scope?
 }
 
-/// Provide feature specific upload configuration.
-internal struct FeatureV1UploadConfiguration {
-    // MARK: - V1 interface
-
-    /// A human-readable name of this Feature used for naming internal queues specific to this Feature and annotating
-    /// origin of telemetry and verbosity logs produced by the SDK.
-    let featureName: String
-
-    /// The URL request builder for uploading data in this Feature.
-    ///
-    /// This builder currently use the v1 context, but will be soon migrated to v2
-    let requestBuilder: FeatureRequestBuilder
-}
-
 /// Feature scope in v1 provide a context and a writer to build a record event.
 internal protocol FeatureV1Scope {
     /// Retrieve the event context and writer.

--- a/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
@@ -11,7 +11,7 @@ extension DatadogCoreProtocol {
     // to access v1 related implementation.
     // If upcasting fails, a `NOOPDatadogCore` instance is returned.
     var v1: DatadogV1CoreProtocol {
-        self as? DatadogV1CoreProtocol ?? NOOPDatadogCore()
+        self as? DatadogV1CoreProtocol ?? NOPDatadogCore()
     }
 }
 
@@ -56,7 +56,7 @@ internal protocol FeatureV1Scope {
     func eventWriteContext(_ block: (DatadogV1Context, Writer) throws -> Void)
 }
 
-extension NOOPDatadogCore: DatadogV1CoreProtocol {
+extension NOPDatadogCore: DatadogV1CoreProtocol {
     // MARK: - V1 interface
 
     /// Returns `nil`.

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessage.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessage.swift
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// The set of messages that can be transimtted on the Features message bus.
+public enum FeatureMessage {
+    /// An error message.
+    case error(
+        message: String,
+        attributes: [String: Encodable]?
+    )
+
+    /// An encodable event that will be transmitted
+    /// as-is through a Feature.
+    case event(
+        type: String,
+        encodable: Encodable
+    )
+
+    /// A custom message with generic encodable
+    /// attributes.
+    case custom(
+        key: String,
+        attributes: [String: Encodable]?
+    )
+}

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// The `FeatureMessageReceiver` defines an interface for feature to receive any message
+/// from a bus that is shared between feature registered in a core.
+///
+/// A message is composed of a key and a dictionary of attributes. A message format is a loose
+/// agreement between features, any supported messages by a feature should be properly
+/// documented.
+/* public */ internal protocol FeatureMessageReceiver {
+    /// Receive a message from the bus.
+    ///
+    /// The message is composed of a key and attributes that the feature can use to build an
+    /// event or run a process. Be mindful of not blocking the caller thread.
+    ///
+    /// - Parameters:
+    ///   - message: The message key.
+    ///   - attributes: The message attributes.
+    func receive(message: String, attributes: [String: Any]?)
+}
+
+/* public */ internal struct NOOPFeatureMessageReceiver: FeatureMessageReceiver {
+    /// no-op
+    func receive(message: String, attributes: [String: Any]?) { }
+}

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
@@ -24,7 +24,7 @@ import Foundation
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol)
 }
 
-/* public */ internal struct NOOPFeatureMessageReceiver: FeatureMessageReceiver {
+/* public */ internal struct NOPFeatureMessageReceiver: FeatureMessageReceiver {
     /// no-op
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) { }
 }

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
@@ -6,11 +6,11 @@
 
 import Foundation
 
-/// The `FeatureMessageReceiver` defines an interface for feature to receive any message
-/// from a bus that is shared between feature registered in a core.
+/// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
+/// from a bus that is shared between Features registered in a core.
 ///
 /// A message is composed of a key and a dictionary of attributes. A message format is a loose
-/// agreement between features, any supported messages by a feature should be properly
+/// agreement between Features, any supported messages by a Feature should be properly
 /// documented.
 /* public */ internal protocol FeatureMessageReceiver {
     /// Receive a message from the message bus of a given core.

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
@@ -13,18 +13,18 @@ import Foundation
 /// agreement between features, any supported messages by a feature should be properly
 /// documented.
 /* public */ internal protocol FeatureMessageReceiver {
-    /// Receive a message from the bus.
+    /// Receive a message from the message bus of a given core.
     ///
-    /// The message is composed of a key and attributes that the feature can use to build an
-    /// event or run a process. Be mindful of not blocking the caller thread.
+    /// The message can be used to build an event or run a process.
+    /// Be mindful of not blocking the caller thread.
     ///
     /// - Parameters:
-    ///   - message: The message key.
-    ///   - attributes: The message attributes.
-    func receive(message: String, attributes: [String: Any]?)
+    ///   - message: The Feature message
+    ///   - core: The core from which the message is transmitted.
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol)
 }
 
 /* public */ internal struct NOOPFeatureMessageReceiver: FeatureMessageReceiver {
     /// no-op
-    func receive(message: String, attributes: [String: Any]?) { }
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) { }
 }

--- a/Sources/Datadog/Logging/LoggingFeature.swift
+++ b/Sources/Datadog/Logging/LoggingFeature.swift
@@ -22,12 +22,15 @@ internal final class LoggingFeature: V1FeatureInitializable, V1Feature {
     /// Logs upload worker.
     let upload: FeatureUpload
 
+    let messageReceiver: FeatureMessageReceiver
+
     // MARK: - Initialization
 
     init(
         storage: FeatureStorage,
         upload: FeatureUpload,
-        configuration: Configuration
+        configuration: Configuration,
+        messageReceiver: FeatureMessageReceiver
     ) {
         // Configuration
         self.configuration = configuration
@@ -35,6 +38,7 @@ internal final class LoggingFeature: V1FeatureInitializable, V1Feature {
         // Initialize stacks
         self.storage = storage
         self.upload = upload
+        self.messageReceiver = messageReceiver
     }
 
     internal func deinitialize() {

--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -14,7 +14,7 @@ internal func createLoggingConfiguration(intake: URL) -> DatadogFeatureConfigura
     return DatadogFeatureConfiguration(
         name: "logging",
         requestBuilder: LoggingRequestBuilder(intake: intake),
-        messageReceiver: NOOPFeatureMessageReceiver()
+        messageReceiver: NOPFeatureMessageReceiver()
     )
 }
 

--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -6,22 +6,15 @@
 
 import Foundation
 
-/// Creates V2 Storage configuration for V1 Logging.
-internal func createV2LoggingStorageConfiguration() -> FeatureStorageConfiguration {
-    return FeatureStorageConfiguration(
-        directories: .init(
-            authorized: "logging/v2", // relative to `CoreDirectory.coreDirectory`
-            unauthorized: "logging/intermediate-v2" // relative to `CoreDirectory.coreDirectory`
-        ),
-        featureName: "logging"
-    )
-}
-
-/// Creates V2 Upload configuration for V1 Logging.
-internal func createV2LoggingUploadConfiguration(v1Configuration: FeaturesConfiguration.Logging) -> FeatureV1UploadConfiguration {
-    return FeatureV1UploadConfiguration(
-        featureName: "logging",
-        requestBuilder: LoggingRequestBuilder(intake: v1Configuration.uploadURL)
+/// Creates Logging Feature Configuration.
+///
+/// - Parameter intake: The Logging intake URL.
+/// - Returns: The Logging feature configuration.
+internal func createLoggingConfiguration(intake: URL) -> DatadogFeatureConfiguration {
+    return DatadogFeatureConfiguration(
+        name: "logging",
+        requestBuilder: LoggingRequestBuilder(intake: intake),
+        messageReceiver: NOOPFeatureMessageReceiver()
     )
 }
 

--- a/Sources/Datadog/RUM/RUMFeature.swift
+++ b/Sources/Datadog/RUM/RUMFeature.swift
@@ -22,12 +22,15 @@ internal final class RUMFeature: V1FeatureInitializable, V1Feature {
     /// RUM upload worker.
     let upload: FeatureUpload
 
+    let messageReceiver: FeatureMessageReceiver
+
     // MARK: - Initialization
 
     init(
         storage: FeatureStorage,
         upload: FeatureUpload,
-        configuration: Configuration
+        configuration: Configuration,
+        messageReceiver: FeatureMessageReceiver
     ) {
         // Configuration
         self.configuration = configuration
@@ -35,6 +38,7 @@ internal final class RUMFeature: V1FeatureInitializable, V1Feature {
         // Initialize stacks
         self.storage = storage
         self.upload = upload
+        self.messageReceiver = messageReceiver
     }
 
     internal func deinitialize() {

--- a/Sources/Datadog/RUM/RUMV2Configuration.swift
+++ b/Sources/Datadog/RUM/RUMV2Configuration.swift
@@ -14,7 +14,7 @@ internal func createRUMConfiguration(intake: URL) -> DatadogFeatureConfiguration
     return DatadogFeatureConfiguration(
         name: "rum",
         requestBuilder: RUMRequestBuilder(intake: intake),
-        messageReceiver: NOOPFeatureMessageReceiver()
+        messageReceiver: NOPFeatureMessageReceiver()
     )
 }
 

--- a/Sources/Datadog/RUM/RUMV2Configuration.swift
+++ b/Sources/Datadog/RUM/RUMV2Configuration.swift
@@ -6,22 +6,15 @@
 
 import Foundation
 
-/// Creates V2 Storage configuration for V1 RUM.
-internal func createV2RUMStorageConfiguration() -> FeatureStorageConfiguration {
-    return FeatureStorageConfiguration(
-        directories: .init(
-            authorized: "rum/v2", // relative to `CoreDirectory.coreDirectory`
-            unauthorized: "rum/intermediate-v2" // relative to `CoreDirectory.coreDirectory`
-        ),
-        featureName: "RUM"
-    )
-}
-
-/// Creates V2 Upload configuration for V1 RUM.
-internal func createV2RUMUploadConfiguration(v1Configuration: FeaturesConfiguration.RUM) -> FeatureV1UploadConfiguration {
-    return FeatureV1UploadConfiguration(
-        featureName: "RUM",
-        requestBuilder: RUMRequestBuilder(intake: v1Configuration.uploadURL)
+/// Creates RUM Feature Configuration.
+///
+/// - Parameter intake: The RUM intake URL.
+/// - Returns: The RUM feature configuration.
+internal func createRUMConfiguration(intake: URL) -> DatadogFeatureConfiguration {
+    return DatadogFeatureConfiguration(
+        name: "rum",
+        requestBuilder: RUMRequestBuilder(intake: intake),
+        messageReceiver: NOOPFeatureMessageReceiver()
     )
 }
 

--- a/Sources/Datadog/Tracing/TracingFeature.swift
+++ b/Sources/Datadog/Tracing/TracingFeature.swift
@@ -22,12 +22,15 @@ internal final class TracingFeature: V1FeatureInitializable, V1Feature {
     /// Spans upload worker.
     let upload: FeatureUpload
 
+    let messageReceiver: FeatureMessageReceiver
+
     // MARK: - Initialization
 
     init(
         storage: FeatureStorage,
         upload: FeatureUpload,
-        configuration: FeaturesConfiguration.Tracing
+        configuration: Configuration,
+        messageReceiver: FeatureMessageReceiver
     ) {
         // Configuration
         self.configuration = configuration
@@ -35,6 +38,7 @@ internal final class TracingFeature: V1FeatureInitializable, V1Feature {
         // Initialize stacks
         self.storage = storage
         self.upload = upload
+        self.messageReceiver = messageReceiver
     }
 
     internal func deinitialize() {

--- a/Sources/Datadog/Tracing/TracingV2Configuration.swift
+++ b/Sources/Datadog/Tracing/TracingV2Configuration.swift
@@ -14,7 +14,7 @@ internal func createTracingConfiguration(intake: URL) -> DatadogFeatureConfigura
     return DatadogFeatureConfiguration(
         name: "tracing",
         requestBuilder: TracingRequestBuilder(intake: intake),
-        messageReceiver: NOOPFeatureMessageReceiver()
+        messageReceiver: NOPFeatureMessageReceiver()
     )
 }
 

--- a/Sources/Datadog/Tracing/TracingV2Configuration.swift
+++ b/Sources/Datadog/Tracing/TracingV2Configuration.swift
@@ -6,22 +6,15 @@
 
 import Foundation
 
-/// Creates V2 Storage configuration for V1 Tracing.
-internal func createV2TracingStorageConfiguration() -> FeatureStorageConfiguration {
-    return FeatureStorageConfiguration(
-        directories: .init(
-            authorized: "tracing/v2", // relative to `CoreDirectory.coreDirectory`
-            unauthorized: "tracing/intermediate-v2" // relative to `CoreDirectory.coreDirectory`
-        ),
-        featureName: "tracing"
-    )
-}
-
-/// Creates V2 Upload configuration for V1 Tracing.
-internal func createV2TracingUploadConfiguration(v1Configuration: FeaturesConfiguration.Tracing) -> FeatureV1UploadConfiguration {
-    return FeatureV1UploadConfiguration(
-        featureName: "tracing",
-        requestBuilder: TracingRequestBuilder(intake: v1Configuration.uploadURL)
+/// Creates Tracing Feature Configuration.
+///
+/// - Parameter intake: The Tracing intake URL.
+/// - Returns: The Tracing feature configuration.
+internal func createTracingConfiguration(intake: URL) -> DatadogFeatureConfiguration {
+    return DatadogFeatureConfiguration(
+        name: "tracing",
+        requestBuilder: TracingRequestBuilder(intake: intake),
+        messageReceiver: NOOPFeatureMessageReceiver()
     )
 }
 

--- a/Tests/DatadogTests/Datadog/Core/DirectoriesTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/DirectoriesTests.swift
@@ -88,17 +88,7 @@ class DirectoriesTests: XCTestCase {
         defer { coreDirectory.delete() }
 
         // When
-        let randomAuthorizedPath: String = .mockRandom(among: .alphanumerics)
-        let randomUnauthorizedPath: String = .mockRandom(among: .alphanumerics)
-
-        let randomFeatureConfiguration = FeatureStorageConfiguration(
-            directories: .init(
-                authorized: randomAuthorizedPath,
-                unauthorized: randomUnauthorizedPath
-            ),
-            featureName: .mockRandom()
-        )
-        let featureDirectories = try coreDirectory.getFeatureDirectories(configuration: randomFeatureConfiguration)
+        let featureDirectories = try coreDirectory.getFeatureDirectories(forFeatureNamed: .mockRandom())
 
         // Then
         XCTAssertTrue(

--- a/Tests/DatadogTests/Datadog/DatadogCore/MessageBusTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogCore/MessageBusTests.swift
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class MessageBusTests: XCTestCase {
+    func testV1MessageBus() throws {
+        let expectation = expectation(description: "message received from the bus")
+        expectation.expectedFulfillmentCount = 2
+
+        // Given
+        let core = DatadogCore(
+            directory: temporaryCoreDirectory,
+            dateProvider: SystemDateProvider(),
+            consentProvider: .mockAny(),
+            userInfoProvider: .mockAny(),
+            performance: .mockAny(),
+            httpClient: .mockAny(),
+            encryption: nil,
+            v1Context: .mockAny(),
+            contextProvider: .mockAny()
+        )
+
+        defer { temporaryCoreDirectory.delete() }
+
+        let receiver = FeatureMessageReceiverMock(expectation: expectation) { message, attributes in
+            // Then
+            XCTAssertEqual(message, "test")
+            XCTAssertEqual(attributes as? [String: String], ["key": "value"])
+        }
+
+        let logging: LoggingFeature = try core.create(
+            configuration: .init(
+                name: "logs",
+                requestBuilder: FeatureRequestBuilderMock(),
+                messageReceiver: receiver
+            ),
+            featureSpecificConfiguration: .mockAny()
+        )
+
+        let rum: RUMFeature = try core.create(
+            configuration: .init(
+                name: "rum",
+                requestBuilder: FeatureRequestBuilderMock(),
+                messageReceiver: receiver
+            ),
+            featureSpecificConfiguration: .mockAny()
+        )
+
+        core.register(feature: logging)
+        core.register(feature: rum)
+
+        // When
+        core.send(message: "test", attributes: ["key": "value"])
+
+        // Then
+        waitForExpectations(timeout: 0)
+    }
+}

--- a/Tests/DatadogTests/Datadog/DatadogCore/MessageBusTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogCore/MessageBusTests.swift
@@ -27,10 +27,15 @@ class MessageBusTests: XCTestCase {
 
         defer { temporaryCoreDirectory.delete() }
 
-        let receiver = FeatureMessageReceiverMock(expectation: expectation) { message, attributes in
+        let receiver = FeatureMessageReceiverMock(expectation: expectation) { message in
             // Then
-            XCTAssertEqual(message, "test")
-            XCTAssertEqual(attributes as? [String: String], ["key": "value"])
+            switch message {
+            case .custom(let key, let attributes):
+                XCTAssertEqual(key, "test")
+                XCTAssertEqual(attributes as? [String: String], ["key": "value"])
+            default:
+                XCTFail("wrong message case")
+            }
         }
 
         let logging: LoggingFeature = try core.create(
@@ -55,8 +60,7 @@ class MessageBusTests: XCTestCase {
         core.register(feature: rum)
 
         // When
-        core.send(message: "test", attributes: ["key": "value"])
-
+        core.send(message: .custom(key: "test", attributes: ["key": "value"]))
         // Then
         waitForExpectations(timeout: 0)
     }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -452,9 +452,9 @@ class DatadogTests: XCTestCase {
         core.readWriteQueue.sync {}
 
         let featureDirectories: [FeatureDirectories] = [
-            try core.directory.getFeatureDirectories(configuration: createV2LoggingStorageConfiguration()),
-            try core.directory.getFeatureDirectories(configuration: createV2TracingStorageConfiguration()),
-            try core.directory.getFeatureDirectories(configuration: createV2RUMStorageConfiguration()),
+            try core.directory.getFeatureDirectories(forFeatureNamed: "logging"),
+            try core.directory.getFeatureDirectories(forFeatureNamed: "tracing"),
+            try core.directory.getFeatureDirectories(forFeatureNamed: "rum"),
         ]
 
         let allDirectories: [Directory] = featureDirectories.flatMap { [$0.authorized, $0.unauthorized] }

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -45,7 +45,7 @@ class RUMIntegrationsTests: XCTestCase {
             storage: .mockNoOp(),
             upload: .mockNoOp(),
             configuration: .mockWith(sessionSampler: .mockRejectAll()),
-            messageReceiver: NOOPFeatureMessageReceiver()
+            messageReceiver: NOPFeatureMessageReceiver()
         )
         core.register(feature: rum)
 

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/RUMIntegrationsTests.swift
@@ -44,7 +44,8 @@ class RUMIntegrationsTests: XCTestCase {
         let rum = RUMFeature(
             storage: .mockNoOp(),
             upload: .mockNoOp(),
-            configuration: .mockWith(sessionSampler: .mockRejectAll())
+            configuration: .mockWith(sessionSampler: .mockRejectAll()),
+            messageReceiver: NOOPFeatureMessageReceiver()
         )
         core.register(feature: rum)
 

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -68,8 +68,7 @@ class LoggingFeatureTests: XCTestCase {
         // Given
         let featureConfiguration: LoggingFeature.Configuration = .mockWith(uploadURL: randomUploadURL)
         let feature: LoggingFeature = try core.create(
-            storageConfiguration: createV2LoggingStorageConfiguration(),
-            uploadConfiguration: createV2LoggingUploadConfiguration(v1Configuration: featureConfiguration),
+            configuration: createLoggingConfiguration(intake: randomUploadURL),
             featureSpecificConfiguration: featureConfiguration
         )
         defer { feature.flush() }
@@ -136,8 +135,7 @@ class LoggingFeatureTests: XCTestCase {
         // Given
         let featureConfiguration: LoggingFeature.Configuration = .mockAny()
         let feature: LoggingFeature = try core.create(
-            storageConfiguration: createV2LoggingStorageConfiguration(),
-            uploadConfiguration: createV2LoggingUploadConfiguration(v1Configuration: featureConfiguration),
+            configuration: createLoggingConfiguration(intake: featureConfiguration.uploadURL),
             featureSpecificConfiguration: featureConfiguration
         )
         defer { feature.flush() }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
@@ -35,6 +35,14 @@ internal final class DatadogCoreMock: Flushable {
     }
 }
 
+extension DatadogCoreMock: DatadogCoreProtocol {
+    // MARK: V2 interface
+
+    func send(message: String, attributes: [String: Any]?) {
+        // no-op
+    }
+}
+
 extension DatadogCoreMock: DatadogV1CoreProtocol {
     // MARK: V1 interface
 

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
@@ -38,7 +38,7 @@ internal final class DatadogCoreMock: Flushable {
 extension DatadogCoreMock: DatadogCoreProtocol {
     // MARK: V2 interface
 
-    func send(message: String, attributes: [String: Any]?) {
+    func send(message: FeatureMessage) {
         // no-op
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/MessageBusMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/MessageBusMock.swift
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import XCTest
+
+@testable import Datadog
+
+internal struct FeatureMessageReceiverMock: FeatureMessageReceiver {
+    typealias ReceiverClosure = (String, [String: Any]?) -> Void
+
+    /// Test expectation that will be fullfilled when a message is received.
+    internal var expectation: XCTestExpectation?
+
+    internal var receiver: ReceiverClosure?
+
+    /// Creates a Feature Message Receiever  mock.
+    /// - Parameters:
+    ///   - expectation: Test expectation that will be fullfilled when a message is
+    ///                  received.
+    ///   - receiver: The receiver closure called when receiving a message.
+    init(
+        expectation: XCTestExpectation? = nil,
+        receiver: ReceiverClosure? = nil
+    ) {
+        self.expectation = expectation
+        self.receiver = receiver
+    }
+
+    func receive(message: String, attributes: [String: Any]?) {
+        receiver?(message, attributes)
+        expectation?.fulfill()
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/MessageBusMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/MessageBusMock.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import Datadog
 
 internal struct FeatureMessageReceiverMock: FeatureMessageReceiver {
-    typealias ReceiverClosure = (String, [String: Any]?) -> Void
+    typealias ReceiverClosure = (FeatureMessage) -> Void
 
     /// Test expectation that will be fullfilled when a message is received.
     internal var expectation: XCTestExpectation?
@@ -30,8 +30,8 @@ internal struct FeatureMessageReceiverMock: FeatureMessageReceiver {
         self.receiver = receiver
     }
 
-    func receive(message: String, attributes: [String: Any]?) {
-        receiver?(message, attributes)
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) {
+        receiver?(message)
         expectation?.fulfill()
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -51,6 +51,10 @@ internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureV1Scope 
         self
     }
 
+    func send(message: String, attributes: [String: Any]?) {
+        // no-op
+    }
+
     /// Execute `block` with the current context and a `writer` to record events.
     ///
     /// - Parameter block: The block to execute.

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -51,8 +51,9 @@ internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureV1Scope 
         self
     }
 
-    func send(message: String, attributes: [String: Any]?) {
+    func send(message: FeatureMessage) {
         // no-op
+
     }
 
     /// Execute `block` with the current context and a `writer` to record events.

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -12,7 +12,8 @@ extension LoggingFeature {
         return LoggingFeature(
             storage: .mockNoOp(),
             upload: .mockNoOp(),
-            configuration: .mockAny()
+            configuration: .mockAny(),
+            messageReceiver: NOOPFeatureMessageReceiver()
         )
     }
 
@@ -31,7 +32,8 @@ extension LoggingFeature {
         return LoggingFeature(
             storage: interceptedStorage,
             upload: .mockNoOp(),
-            configuration: featureConfiguration
+            configuration: featureConfiguration,
+            messageReceiver: NOOPFeatureMessageReceiver()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -13,7 +13,7 @@ extension LoggingFeature {
             storage: .mockNoOp(),
             upload: .mockNoOp(),
             configuration: .mockAny(),
-            messageReceiver: NOOPFeatureMessageReceiver()
+            messageReceiver: NOPFeatureMessageReceiver()
         )
     }
 
@@ -33,7 +33,7 @@ extension LoggingFeature {
             storage: interceptedStorage,
             upload: .mockNoOp(),
             configuration: featureConfiguration,
-            messageReceiver: NOOPFeatureMessageReceiver()
+            messageReceiver: NOPFeatureMessageReceiver()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -14,7 +14,7 @@ extension RUMFeature {
             storage: .mockNoOp(),
             upload: .mockNoOp(),
             configuration: .mockAny(),
-            messageReceiver: NOOPFeatureMessageReceiver()
+            messageReceiver: NOPFeatureMessageReceiver()
         )
     }
 
@@ -34,7 +34,7 @@ extension RUMFeature {
             storage: interceptedStorage,
             upload: .mockNoOp(),
             configuration: featureConfiguration,
-            messageReceiver: NOOPFeatureMessageReceiver()
+            messageReceiver: NOPFeatureMessageReceiver()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -13,7 +13,8 @@ extension RUMFeature {
         return RUMFeature(
             storage: .mockNoOp(),
             upload: .mockNoOp(),
-            configuration: .mockAny()
+            configuration: .mockAny(),
+            messageReceiver: NOOPFeatureMessageReceiver()
         )
     }
 
@@ -32,7 +33,8 @@ extension RUMFeature {
         return RUMFeature(
             storage: interceptedStorage,
             upload: .mockNoOp(),
-            configuration: featureConfiguration
+            configuration: featureConfiguration,
+            messageReceiver: NOOPFeatureMessageReceiver()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -12,7 +12,8 @@ extension TracingFeature {
         return TracingFeature(
             storage: .mockNoOp(),
             upload: .mockNoOp(),
-            configuration: .mockAny()
+            configuration: .mockAny(),
+            messageReceiver: NOOPFeatureMessageReceiver()
         )
     }
 
@@ -31,7 +32,8 @@ extension TracingFeature {
         return TracingFeature(
             storage: interceptedStorage,
             upload: .mockNoOp(),
-            configuration: featureConfiguration
+            configuration: featureConfiguration,
+            messageReceiver: NOOPFeatureMessageReceiver()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -13,7 +13,7 @@ extension TracingFeature {
             storage: .mockNoOp(),
             upload: .mockNoOp(),
             configuration: .mockAny(),
-            messageReceiver: NOOPFeatureMessageReceiver()
+            messageReceiver: NOPFeatureMessageReceiver()
         )
     }
 
@@ -33,7 +33,7 @@ extension TracingFeature {
             storage: interceptedStorage,
             upload: .mockNoOp(),
             configuration: featureConfiguration,
-            messageReceiver: NOOPFeatureMessageReceiver()
+            messageReceiver: NOPFeatureMessageReceiver()
         )
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -72,8 +72,7 @@ class RUMFeatureTests: XCTestCase {
         // Given
         let featureConfiguration: RUMFeature.Configuration = .mockWith(uploadURL: randomUploadURL)
         let feature: RUMFeature = try core.create(
-            storageConfiguration: createV2RUMStorageConfiguration(),
-            uploadConfiguration: createV2RUMUploadConfiguration(v1Configuration: featureConfiguration),
+            configuration: createRUMConfiguration(intake: randomUploadURL),
             featureSpecificConfiguration: featureConfiguration
         )
         defer { feature.flush() }
@@ -145,8 +144,7 @@ class RUMFeatureTests: XCTestCase {
         // Given
         let featureConfiguration: RUMFeature.Configuration = .mockAny()
         let feature: RUMFeature = try core.create(
-            storageConfiguration: createV2RUMStorageConfiguration(),
-            uploadConfiguration: createV2RUMUploadConfiguration(v1Configuration: featureConfiguration),
+            configuration: createRUMConfiguration(intake: featureConfiguration.uploadURL),
             featureSpecificConfiguration: featureConfiguration
         )
         defer { feature.flush() }

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -67,9 +67,9 @@ class TracingFeatureTests: XCTestCase {
 
         // Given
         let featureConfiguration: TracingFeature.Configuration = .mockWith(uploadURL: randomUploadURL)
+
         let feature: TracingFeature = try core.create(
-            storageConfiguration: createV2TracingStorageConfiguration(),
-            uploadConfiguration: createV2TracingUploadConfiguration(v1Configuration: featureConfiguration),
+            configuration: createTracingConfiguration(intake: featureConfiguration.uploadURL),
             featureSpecificConfiguration: featureConfiguration
         )
         defer { feature.flush() }
@@ -136,8 +136,7 @@ class TracingFeatureTests: XCTestCase {
 
         let featureConfiguration: TracingFeature.Configuration = .mockAny()
         let feature: TracingFeature = try core.create(
-            storageConfiguration: createV2TracingStorageConfiguration(),
-            uploadConfiguration: createV2TracingUploadConfiguration(v1Configuration: featureConfiguration),
+            configuration: createTracingConfiguration(intake: featureConfiguration.uploadURL),
             featureSpecificConfiguration: featureConfiguration
         )
         defer { feature.flush() }

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionAutoInstrumentationTests.swift
@@ -17,7 +17,7 @@ class URLSessionAutoInstrumentationTests: XCTestCase {
 
     func testWhenURLSessionAutoInstrumentationIsEnabled_thenSharedInterceptorIsAvailable() {
         defaultDatadogCore = core
-        defer { defaultDatadogCore = NOOPDatadogCore() }
+        defer { defaultDatadogCore = NOPDatadogCore() }
 
         XCTAssertNil(URLSessionInterceptor.shared)
 

--- a/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDGlobalTests.swift
@@ -18,7 +18,7 @@ class DDGlobalTests: XCTestCase {
 
     override func tearDown() {
         core.flush()
-        defaultDatadogCore = NOOPDatadogCore()
+        defaultDatadogCore = NOPDatadogCore()
         super.tearDown()
     }
     // MARK: - Test Global Tracer

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -20,7 +20,7 @@ class DDLoggerTests: XCTestCase {
     }
 
     override func tearDown() {
-        defaultDatadogCore = NOOPDatadogCore()
+        defaultDatadogCore = NOPDatadogCore()
         core.flush()
         core = nil
         super.tearDown()

--- a/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDTracerTests.swift
@@ -18,7 +18,7 @@ class DDTracerTests: XCTestCase {
     }
 
     override func tearDown() {
-        defaultDatadogCore = NOOPDatadogCore()
+        defaultDatadogCore = NOPDatadogCore()
         core.flush()
         core = nil
         super.tearDown()

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -45,7 +45,7 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
         ),
         .init(
             assert: {
-                defaultDatadogCore is NOOPDatadogCore
+                defaultDatadogCore is NOPDatadogCore
             },
             problem: "`defaultDatadogCore` must be reset after each test.",
             solution: """


### PR DESCRIPTION
### What and why?

Introduce interface for feature to communicate through core.

### How?

A Feature can now provide a `FeatureMessageReceiver` implementation to process any messages sent from other features registered to the core. The receiver is provided at registration through the `DatadogFeatureConfiguration` which combined the previous storage and upload configuration.

In the process of updating the feature config, I've remove the storage directories. The consent logic is now solely managed by the core.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
