### PR TITLE
RUMM-2381 Add internal proxy API for customising app `version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Changes
 
+* [IMPROVEMENT] Enable cross-platform SDKs to change app `version`. See [#973][]
+
 # 1.12.0-beta2 / 10-08-2022
 
 ### Changes
@@ -412,6 +414,7 @@
 [#949]: https://github.com/DataDog/dd-sdk-ios/issues/949
 [#950]: https://github.com/DataDog/dd-sdk-ios/issues/950
 [#964]: https://github.com/DataDog/dd-sdk-ios/issues/964
+[#973]: https://github.com/DataDog/dd-sdk-ios/issues/973
 [@00FA9A]: https://github.com/00FA9A
 [@Britton-Earnin]: https://github.com/Britton-Earnin
 [@Hengyu]: https://github.com/Hengyu

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -176,6 +176,8 @@
 		613F592A28ABD8CF0099E182 /* AppVersionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F592828ABD8CF0099E182 /* AppVersionProvider.swift */; };
 		613F592C28AD314E0099E182 /* AppVersionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F592B28AD314E0099E182 /* AppVersionProviderTests.swift */; };
 		613F592D28AD314E0099E182 /* AppVersionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F592B28AD314E0099E182 /* AppVersionProviderTests.swift */; };
+		613F592F28AD341B0099E182 /* _InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F592E28AD341B0099E182 /* _InternalProxyTests.swift */; };
+		613F593028AD341B0099E182 /* _InternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F592E28AD341B0099E182 /* _InternalProxyTests.swift */; };
 		61410141251A454500E3C2D9 /* TracingCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61410140251A454500E3C2D9 /* TracingCommonAsserts.swift */; };
 		6141014F251A57AF00E3C2D9 /* UIApplicationSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */; };
 		6141015B251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */; };
@@ -1399,6 +1401,7 @@
 		613F23FC252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionAutoInstrumentationTests.swift; sourceTree = "<group>"; };
 		613F592828ABD8CF0099E182 /* AppVersionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionProvider.swift; sourceTree = "<group>"; };
 		613F592B28AD314E0099E182 /* AppVersionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionProviderTests.swift; sourceTree = "<group>"; };
+		613F592E28AD341B0099E182 /* _InternalProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _InternalProxyTests.swift; sourceTree = "<group>"; };
 		61410140251A454500E3C2D9 /* TracingCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingCommonAsserts.swift; sourceTree = "<group>"; };
 		6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationSwizzler.swift; sourceTree = "<group>"; };
 		6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandler.swift; sourceTree = "<group>"; };
@@ -4180,6 +4183,7 @@
 			isa = PBXGroup;
 			children = (
 				D2956CAF2869D520007D5462 /* Context */,
+				613F592E28AD341B0099E182 /* _InternalProxyTests.swift */,
 			);
 			path = DatadogInternal;
 			sourceTree = "<group>";
@@ -5406,6 +5410,7 @@
 				61E45BD22450F65B00F2C652 /* SpanEventBuilderTests.swift in Sources */,
 				61F2723F25C86DA400D54BF8 /* CrashReportingFeatureMocks.swift in Sources */,
 				61FF416225EE5FF400CE35EC /* CrashReportingWithLoggingIntegrationTests.swift in Sources */,
+				613F592F28AD341B0099E182 /* _InternalProxyTests.swift in Sources */,
 				61A9238E256FCAA2009B9667 /* DateCorrectionTests.swift in Sources */,
 				61EF7890257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift in Sources */,
 				61E45BCF2450A6EC00F2C652 /* TracingUUIDTests.swift in Sources */,
@@ -6047,6 +6052,7 @@
 				D2CB6F4727C520D400A62B57 /* SpanEventBuilderTests.swift in Sources */,
 				D2CB6F4827C520D400A62B57 /* CrashReportingFeatureMocks.swift in Sources */,
 				D2CB6F4927C520D400A62B57 /* CrashReportingWithLoggingIntegrationTests.swift in Sources */,
+				613F593028AD341B0099E182 /* _InternalProxyTests.swift in Sources */,
 				D2CB6F4A27C520D400A62B57 /* DateCorrectionTests.swift in Sources */,
 				D2CB6F4B27C520D400A62B57 /* DeleteAllDataMigratorTests.swift in Sources */,
 				D2CB6F4C27C520D400A62B57 /* TracingUUIDTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -172,6 +172,10 @@
 		613F23E4252B062F006CD2D7 /* TaskInterceptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23E3252B062F006CD2D7 /* TaskInterceptionTests.swift */; };
 		613F23F1252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23F0252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift */; };
 		613F23FD252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F23FC252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift */; };
+		613F592928ABD8CF0099E182 /* AppVersionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F592828ABD8CF0099E182 /* AppVersionProvider.swift */; };
+		613F592A28ABD8CF0099E182 /* AppVersionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F592828ABD8CF0099E182 /* AppVersionProvider.swift */; };
+		613F592C28AD314E0099E182 /* AppVersionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F592B28AD314E0099E182 /* AppVersionProviderTests.swift */; };
+		613F592D28AD314E0099E182 /* AppVersionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613F592B28AD314E0099E182 /* AppVersionProviderTests.swift */; };
 		61410141251A454500E3C2D9 /* TracingCommonAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61410140251A454500E3C2D9 /* TracingCommonAsserts.swift */; };
 		6141014F251A57AF00E3C2D9 /* UIApplicationSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */; };
 		6141015B251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */; };
@@ -1393,6 +1397,8 @@
 		613F23E3252B062F006CD2D7 /* TaskInterceptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInterceptionTests.swift; sourceTree = "<group>"; };
 		613F23F0252B129E006CD2D7 /* URLSessionRUMResourcesHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionRUMResourcesHandlerTests.swift; sourceTree = "<group>"; };
 		613F23FC252B3755006CD2D7 /* URLSessionAutoInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionAutoInstrumentationTests.swift; sourceTree = "<group>"; };
+		613F592828ABD8CF0099E182 /* AppVersionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionProvider.swift; sourceTree = "<group>"; };
+		613F592B28AD314E0099E182 /* AppVersionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionProviderTests.swift; sourceTree = "<group>"; };
 		61410140251A454500E3C2D9 /* TracingCommonAsserts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingCommonAsserts.swift; sourceTree = "<group>"; };
 		6141014E251A57AF00E3C2D9 /* UIApplicationSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationSwizzler.swift; sourceTree = "<group>"; };
 		6141015A251A601D00E3C2D9 /* UIKitRUMUserActionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitRUMUserActionsHandler.swift; sourceTree = "<group>"; };
@@ -2181,6 +2187,7 @@
 				61133BA22423979B00786299 /* CarrierInfoProvider.swift */,
 				61133BA42423979B00786299 /* NetworkConnectionInfoProvider.swift */,
 				9ED6A6B325F2901800CB2E29 /* AppStateListener.swift */,
+				613F592828ABD8CF0099E182 /* AppVersionProvider.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -2442,6 +2449,7 @@
 				614AD085254C3027004999A3 /* LaunchTimeProviderTests.swift */,
 				61133C242423990D00786299 /* NetworkConnectionInfoProviderTests.swift */,
 				61133C262423990D00786299 /* CarrierInfoProviderTests.swift */,
+				613F592B28AD314E0099E182 /* AppVersionProviderTests.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -5136,6 +5144,7 @@
 				618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				E1D202EA24C065CF00D1AF3A /* ActiveSpansPool.swift in Sources */,
+				613F592928ABD8CF0099E182 /* AppVersionProvider.swift in Sources */,
 				9ED6A6B425F2901800CB2E29 /* AppStateListener.swift in Sources */,
 				61F3CDA3251118FB00C816E5 /* UIViewControllerHandler.swift in Sources */,
 				61C5A88824509A0C00DA608C /* Warnings.swift in Sources */,
@@ -5322,6 +5331,7 @@
 				61F9CABA2513A7F5000A5E61 /* RUMSessionMatcher.swift in Sources */,
 				61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */,
 				61AD4E182451C7FF006E34EA /* TracingFeatureMocks.swift in Sources */,
+				613F592C28AD314E0099E182 /* AppVersionProviderTests.swift in Sources */,
 				9EAF0CF6275A21100044E8CA /* WKUserContentController+DatadogTests.swift in Sources */,
 				61DA8CB2286215DE0074A606 /* CryptographyTests.swift in Sources */,
 				615A4A8924A34FD700233986 /* DDTracerTests.swift in Sources */,
@@ -5809,6 +5819,7 @@
 				D2CB6E6B27C50EAE00A62B57 /* ValuePublisher.swift in Sources */,
 				D2CB6E6D27C50EAE00A62B57 /* RUMUUID.swift in Sources */,
 				D2CB6E6E27C50EAE00A62B57 /* URLSessionInterceptor.swift in Sources */,
+				613F592A28ABD8CF0099E182 /* AppVersionProvider.swift in Sources */,
 				D2CB6E6F27C50EAE00A62B57 /* TracingHTTPHeaders.swift in Sources */,
 				D2CB6E7027C50EAE00A62B57 /* MethodSwizzler.swift in Sources */,
 				492749022880489400ECD49B /* _InternalProxy.swift in Sources */,
@@ -5961,6 +5972,7 @@
 				D2CB6EFF27C520D400A62B57 /* AttributesMocks.swift in Sources */,
 				D2CB6F0027C520D400A62B57 /* RUMSessionMatcher.swift in Sources */,
 				D2CB6F0127C520D400A62B57 /* DatadogPrivateMocks.swift in Sources */,
+				613F592D28AD314E0099E182 /* AppVersionProviderTests.swift in Sources */,
 				D2CB6F0227C520D400A62B57 /* TracingFeatureMocks.swift in Sources */,
 				61DA8CB3286215DE0074A606 /* CryptographyTests.swift in Sources */,
 				D2CB6F0327C520D400A62B57 /* WKUserContentController+DatadogTests.swift in Sources */,

--- a/Sources/Datadog/Core/Attributes/Attributes.swift
+++ b/Sources/Datadog/Core/Attributes/Attributes.swift
@@ -67,38 +67,43 @@ public typealias AttributeValue = Encodable
 /// Internal attributes, passed from cross-platform bridge.
 /// Used to configure or override SDK internal features and attributes for the need of cross-platform SDKs (e.g. React Native SDK).
 internal struct CrossPlatformAttributes {
-    /// Custom SDK version passed from bridge SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
+    /// Custom app version passed from CP SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
+    /// It should replace the default native `version` read from `Info.plist`.
+    /// Expects `String` value (semantic version).
+    static let version: String = "_dd.version"
+
+    /// Custom SDK version passed from CP SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
     /// It should replace the default native `sdkVersion`.
     /// Expects `String` value (semantic version).
     static let sdkVersion: String = "_dd.sdk_version"
 
-    /// Custom SDK `source` passed from bridge SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
+    /// Custom SDK `source` passed from CP SDK. Used for all events issued by the SDK (both coming from cross-platform SDK and produced internally, like RUM long tasks).
     /// It should replace the default native `ddsource` value (`"ios"`).
     /// Expects `String` value.
     static let ddsource: String = "_dd.source"
 
-    /// Event timestamp passed from bridge SDK. Used for all RUM events issued by cross platform SDK.
+    /// Event timestamp passed from CP SDK. Used for all RUM events issued by cross platform SDK.
     /// It should replace event time obtained from `DateProvider` to ensure that events are not skewed due to time difference in native and cross-platform SDKs.
     /// Expects `Int64` value (milliseconds).
     static let timestampInMilliseconds = "_dd.timestamp"
 
-    /// Custom "source type" of the error passed from bridge SDK. Used in RUM errors reported by cross platform SDK.
+    /// Custom "source type" of the error passed from CP SDK. Used in RUM errors reported by cross platform SDK.
     /// It names the language or platform of the RUM error stack trace, so the SCI backend knows how to symbolicate it.
     /// Expects `String` value.
     static let errorSourceType = "_dd.error.source_type"
 
-    /// Custom attribute of the error passed from bridge SDK. Used in RUM errors reported by cross platform SDK.
+    /// Custom attribute of the error passed from CP SDK. Used in RUM errors reported by cross platform SDK.
     /// It flags the error has being fatal for the host application.
     /// Expects `Bool` value.
     static let errorIsCrash = "_dd.error.is_crash"
 
-    /// Trace ID passed from bridge SDK. Used in RUM resources created by cross platform SDK.
+    /// Trace ID passed from CP SDK. Used in RUM resources created by cross platform SDK.
     /// When cross-platform SDK injects tracing headers to intercepted resource, we pass tracing information through this attribute
     /// and send it within the RUM resource, so the RUM backend can issue corresponding APM span on behalf of the mobile app.
     /// Expects `String` value.
     static let traceID = "_dd.trace_id"
 
-    /// Span ID passed from bridge SDK. Used in RUM resources created by cross platform SDK.
+    /// Span ID passed from CP SDK. Used in RUM resources created by cross platform SDK.
     /// When cross-platform SDK injects tracing headers to intercepted resource, we pass tracing information through this attribute
     /// and send it within the RUM resource, so the RUM backend can issue corresponding APM span on behalf of the mobile app.
     /// Expects `String` value.

--- a/Sources/Datadog/Core/FeaturesConfiguration.swift
+++ b/Sources/Datadog/Core/FeaturesConfiguration.swift
@@ -145,6 +145,7 @@ extension FeaturesConfiguration {
 
         let source = (configuration.additionalConfiguration[CrossPlatformAttributes.ddsource] as? String) ?? Datadog.Constants.ddsource
         let sdkVersion = (configuration.additionalConfiguration[CrossPlatformAttributes.sdkVersion] as? String) ?? __sdkVersion
+        let appVersion = (configuration.additionalConfiguration[CrossPlatformAttributes.version] as? String) ?? appContext.bundleVersion ?? "0.0.0"
 
         let debugOverride = appContext.processInfo.arguments.contains(Datadog.LaunchArguments.Debug)
         if debugOverride {
@@ -156,7 +157,7 @@ extension FeaturesConfiguration {
             site: configuration.datadogEndpoint,
             clientToken: try ifValid(clientToken: configuration.clientToken),
             applicationName: appContext.bundleName ?? appContext.bundleType.rawValue,
-            applicationVersion: appContext.bundleVersion ?? "0.0.0",
+            applicationVersion: appVersion,
             applicationBundleIdentifier: appContext.bundleIdentifier ?? "unknown",
             serviceName: configuration.serviceName ?? appContext.bundleIdentifier ?? "ios",
             environment: try ifValid(environment: configuration.environment),

--- a/Sources/Datadog/Core/System/AppVersionProvider.swift
+++ b/Sources/Datadog/Core/System/AppVersionProvider.swift
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Provides the app version.
+internal final class AppVersionProvider {
+    private let publisher: ValuePublisher<String>
+
+    init(configuration: CoreConfiguration) {
+        self.publisher = ValuePublisher(initialValue: configuration.applicationVersion)
+    }
+
+    var value: String {
+        set { publisher.publishSync(newValue) }
+        get { publisher.currentValue }
+    }
+}

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -182,6 +182,7 @@ public class Datadog {
         let networkConnectionInfoProvider = NetworkConnectionInfoProvider()
         let carrierInfoProvider = CarrierInfoProvider()
         let launchTimeProvider = LaunchTimeProvider()
+        let appVersionProvider = AppVersionProvider(configuration: configuration.common)
 
         // Bundle all core dependencies provided by `DatadogCore` to features:
         let commonDependencies = CoreDependencies(
@@ -205,7 +206,8 @@ public class Datadog {
         let core = DatadogCore(
             directory: try CoreDirectory(in: Directory.cache(), from: configuration.common),
             configuration: configuration.common,
-            dependencies: commonDependencies
+            dependencies: commonDependencies,
+            appVersionProvider: appVersionProvider
         )
 
         // First, initialize features:

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -57,15 +57,17 @@ internal final class DatadogCore {
     ///   - directory: the core directory for this instance of the SDK.
     ///   - configuration: the configuration of the SDK core.
     ///   - dependencies: a set of dependencies used by the SDK core to power Features.
+    ///   - appVersionProvider: The app version provider.
     init(
         directory: CoreDirectory,
         configuration: CoreConfiguration,
-        dependencies: CoreDependencies
+        dependencies: CoreDependencies,
+        appVersionProvider: AppVersionProvider
     ) {
         self.directory = directory
         self.configuration = configuration
         self.dependencies = dependencies
-        self.v1Context = DatadogV1Context(configuration: configuration, dependencies: dependencies)
+        self.v1Context = DatadogV1Context(configuration: configuration, dependencies: dependencies, appVersionProvider: appVersionProvider)
     }
 
     /// Sets current user information.

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -46,6 +46,9 @@ internal final class DatadogCore {
         target: .global(qos: .utility)
     )
 
+    /// The app version provider.
+    let appVersionProvider: AppVersionProvider
+
     private var v1Features: [String: Any] = [:]
 
     /// The SDK Context for V1.
@@ -67,6 +70,7 @@ internal final class DatadogCore {
         self.directory = directory
         self.configuration = configuration
         self.dependencies = dependencies
+        self.appVersionProvider = appVersionProvider
         self.v1Context = DatadogV1Context(configuration: configuration, dependencies: dependencies, appVersionProvider: appVersionProvider)
     }
 

--- a/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
@@ -22,10 +22,12 @@ internal typealias DatadogSite = Datadog.Configuration.DatadogEndpoint
 internal struct DatadogV1Context {
     private let configuration: CoreConfiguration
     private let dependencies: CoreDependencies
+    private let appVersionProvider: AppVersionProvider
 
-    init(configuration: CoreConfiguration, dependencies: CoreDependencies) {
+    init(configuration: CoreConfiguration, dependencies: CoreDependencies, appVersionProvider: AppVersionProvider) {
         self.configuration = configuration
         self.dependencies = dependencies
+        self.appVersionProvider = appVersionProvider
     }
 }
 
@@ -49,7 +51,7 @@ internal extension DatadogV1Context {
     var env: String { configuration.environment }
 
     /// The version of the application that data is generated from. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
-    var version: String { configuration.applicationVersion }
+    var version: String { appVersionProvider.value }
 
     /// Denotes the mobile application's platform, such as `"ios"` or `"flutter"` that data is generated from.
     ///  - See: Datadog [Reserved Attributes](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes).

--- a/Sources/Datadog/DatadogInternal/_InternalProxy.swift
+++ b/Sources/Datadog/DatadogInternal/_InternalProxy.swift
@@ -15,6 +15,7 @@ import Foundation
 /// Methods, members, and functionality of this class  are subject to change without notice, as they
 /// are not considered part of the public interface of the Datadog SDK.
 public class _InternalProxy {
+    public let _configuration = _ConfigurationProxy()
     public let _telemtry = _TelemetryProxy()
 }
 
@@ -27,5 +28,16 @@ public class _TelemetryProxy {
     /// See Telementry.error
     public func error(id: String, message: String, kind: String?, stack: String?) {
         DD.telemetry.error(id: id, message: message, kind: kind, stack: stack)
+    }
+}
+
+public class _ConfigurationProxy {
+    /// Changes the `version` used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+    public func set(customVersion: String) {
+        guard let core = defaultDatadogCore as? DatadogCore else {
+            return
+        }
+
+        core.appVersionProvider.value = customVersion
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/FeaturesConfigurationTests.swift
@@ -38,6 +38,13 @@ class FeaturesConfigurationTests: XCTestCase {
             appContext: .mockWith(bundleVersion: nil)
         )
         XCTAssertEqual(configuration.common.applicationVersion, "0.0.0", "should fallback to '0.0.0'")
+
+        let randomVersion: String = .mockRandom()
+        configuration = try FeaturesConfiguration(
+            configuration: .mockWith(additionalConfiguration: [CrossPlatformAttributes.version: randomVersion]),
+            appContext: .mockAny()
+        )
+        XCTAssertEqual(configuration.common.applicationVersion, randomVersion, "Version can be customized through additional configuration")
     }
 
     func testApplicationBundleIdentifier() throws {

--- a/Tests/DatadogTests/Datadog/Core/System/AppVersionProviderTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/System/AppVersionProviderTests.swift
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class AppVersionProviderTests: XCTestCase {
+    func testItReadsInitialValueFromConfiguration() {
+        // Given
+        let randomVersion: String = .mockRandom()
+        let configuration: CoreConfiguration = .mockWith(applicationVersion: randomVersion)
+
+        // When
+        let provider = AppVersionProvider(configuration: configuration)
+
+        // Then
+        XCTAssertEqual(provider.value, randomVersion)
+    }
+
+    func testWhenValueChanges_itProvidesNewValue() {
+        // Given
+        let provider = AppVersionProvider(configuration: .mockWith(applicationVersion: .mockRandom()))
+
+        // When
+        let randomVersion: String = .mockRandom()
+        provider.value = randomVersion
+
+        // Then
+        XCTAssertEqual(provider.value, randomVersion)
+    }
+}

--- a/Tests/DatadogTests/Datadog/DatadogInternal/_InternalProxyTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/_InternalProxyTests.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class _InternalProxyTests: XCTestCase {
+    func testWhenTelemetryIsSentThroughProxy_thenItForwardsToDDTelemetry() throws {
+        // Given
+        let dd = DD.mockWith(telemetry: TelemetryMock())
+        defer { dd.reset() }
+
+        let proxy = _InternalProxy()
+
+        // When
+        let randomDebugMessage: String = .mockRandom()
+        let randomErrorMessage: String = .mockRandom()
+        proxy._telemtry.debug(id: .mockAny(), message: randomDebugMessage)
+        proxy._telemtry.error(id: .mockAny(), message: randomErrorMessage, kind: .mockAny(), stack: .mockAny())
+
+        // Then
+        XCTAssertEqual(dd.telemetry.debugs.first, randomDebugMessage)
+        XCTAssertEqual(dd.telemetry.errors.first?.message, randomErrorMessage)
+    }
+
+    func testWhenNewVersionIsSetInConfigurationProxy_thenItChangesAppVersionInCore() throws {
+        // Given
+        Datadog.initialize(appContext: .mockAny(), trackingConsent: .mockRandom(), configuration: .mockAny())
+        defer { Datadog.flushAndDeinitialize() }
+
+        // When
+        let randomVersion: String = .mockRandom()
+        Datadog._internal._configuration.set(customVersion: randomVersion)
+
+        // Then
+        let core = try XCTUnwrap(defaultDatadogCore as? DatadogCore)
+        XCTAssertEqual(core.appVersionProvider.value, randomVersion)
+    }
+}

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
@@ -88,7 +88,8 @@ class CrashReportingWithLoggingIntegrationTests: XCTestCase {
                 dependencies: .mockWith(
                     dateProvider: RelativeDateProvider(using: .mockRandomInThePast()),
                     dateCorrector: DateCorrectorMock(offset: dateCorrectionOffset)
-                )
+                ),
+                appVersionProvider: .mockWith(version: configuration.applicationVersion)
             )
         )
         integration.send(crashReport: crashReport, with: crashContext)

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -27,7 +27,6 @@ class LoggerTests: XCTestCase {
     func testSendingLogWithDefaultLogger() throws {
         core.context = .mockWith(
             configuration: .mockWith(
-                applicationVersion: "1.0.0",
                 applicationBundleIdentifier: "com.datadoghq.ios-sdk",
                 serviceName: "default-service-name",
                 environment: "tests",
@@ -35,7 +34,8 @@ class LoggerTests: XCTestCase {
             ),
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
-            )
+            ),
+            appVersionProvider: .mockWith(version: "1.0.0")
         )
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers()
@@ -452,9 +452,9 @@ class LoggerTests: XCTestCase {
     func testSendingTags() throws {
         core.context = .mockWith(
             configuration: .mockWith(
-                applicationVersion: "1.2.3",
                 environment: "tests"
-            )
+            ),
+            appVersionProvider: .mockWith(version: "1.2.3")
         )
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers()

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -40,7 +40,6 @@ class LoggingFeatureTests: XCTestCase {
             configuration: .mockWith(
                 clientToken: randomClientToken,
                 applicationName: randomApplicationName,
-                applicationVersion: randomApplicationVersion,
                 source: randomSource,
                 origin: randomOrigin,
                 sdkVersion: randomSDKVersion,
@@ -52,7 +51,8 @@ class LoggingFeatureTests: XCTestCase {
                     osName: randomDeviceOSName,
                     osVersion: randomDeviceOSVersion
                 )
-            )
+            ),
+            appVersionProvider: .mockWith(version: randomApplicationVersion)
         )
 
         // Given
@@ -115,7 +115,8 @@ class LoggingFeatureTests: XCTestCase {
                         uploadDelayChangeRate: 0
                     )
                 )
-            )
+            ),
+            appVersionProvider: .mockAny()
         )
 
         // Given

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -1181,6 +1181,16 @@ class CarrierInfoProviderMock: CarrierInfoProviderType {
     }
 }
 
+extension AppVersionProvider: AnyMockable {
+    static func mockAny() -> AppVersionProvider {
+        return AppVersionProvider(configuration: .mockAny())
+    }
+
+    static func mockWith(version: String) -> AppVersionProvider {
+        return AppVersionProvider(configuration: .mockWith(applicationVersion: version))
+    }
+}
+
 extension CodableValue {
     static func mockAny() -> CodableValue {
         return CodableValue(String.mockAny())

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
@@ -73,11 +73,13 @@ extension DatadogV1Context: AnyMockable {
 
     static func mockWith(
         configuration: CoreConfiguration = .mockAny(),
-        dependencies: CoreDependencies = .mockAny()
+        dependencies: CoreDependencies = .mockAny(),
+        appVersionProvider: AppVersionProvider = .mockAny()
     ) -> DatadogV1Context {
         return DatadogV1Context(
             configuration: configuration,
-            dependencies: dependencies
+            dependencies: dependencies,
+            appVersionProvider: appVersionProvider
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMFeatureTests.swift
@@ -42,7 +42,6 @@ class RUMFeatureTests: XCTestCase {
             configuration: .mockWith(
                 clientToken: randomClientToken,
                 applicationName: randomApplicationName,
-                applicationVersion: randomApplicationVersion,
                 serviceName: randomServiceName,
                 environment: randomEnvironmentName,
                 source: randomSource,
@@ -56,7 +55,8 @@ class RUMFeatureTests: XCTestCase {
                     osName: randomDeviceOSName,
                     osVersion: randomDeviceOSVersion
                 )
-            )
+            ),
+            appVersionProvider: .mockWith(version: randomApplicationVersion)
         )
 
         // Given
@@ -124,7 +124,8 @@ class RUMFeatureTests: XCTestCase {
                         uploadDelayChangeRate: 0
                     )
                 )
-            )
+            ),
+            appVersionProvider: .mockAny()
         )
 
         // Given

--- a/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/WebView/WKUserContentController+DatadogTests.swift
@@ -150,7 +150,6 @@ class WKUserContentController_DatadogTests: XCTestCase {
         let core = DatadogCoreMock(
             context: .mockWith(
                 configuration: .mockWith(
-                    applicationVersion: "1.0.0",
                     applicationBundleIdentifier: "com.datadoghq.ios-sdk",
                     serviceName: "default-service-name",
                     environment: "tests",
@@ -158,7 +157,8 @@ class WKUserContentController_DatadogTests: XCTestCase {
                 ),
                 dependencies: .mockWith(
                     dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
-                )
+                ),
+                appVersionProvider: .mockWith(version: "1.0.0")
             )
         )
         defer { core.flush() }

--- a/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorConfigurationTests.swift
@@ -18,7 +18,6 @@ class RUMMonitorConfigurationTests: XCTestCase {
         let core = DatadogCoreMock(
             context: .mockWith(
                 configuration: .mockWith(
-                    applicationVersion: "1.2.3",
                     serviceName: "service-name",
                     environment: "tests",
                     sdkVersion: "3.4.5"
@@ -27,7 +26,8 @@ class RUMMonitorConfigurationTests: XCTestCase {
                     userInfoProvider: userInfoProvider,
                     networkConnectionInfoProvider: networkConnectionInfoProvider,
                     carrierInfoProvider: carrierInfoProvider
-                )
+                ),
+                appVersionProvider: .mockWith(version: "1.2.3")
             )
         )
         defer { core.flush() }

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -27,7 +27,6 @@ class TracerTests: XCTestCase {
     func testSendingSpanWithDefaultTracer() throws {
         core.context = .mockWith(
             configuration: .mockWith(
-                applicationVersion: "1.0.0",
                 applicationBundleIdentifier: "com.datadoghq.ios-sdk",
                 serviceName: "default-service-name",
                 environment: "custom",
@@ -36,7 +35,8 @@ class TracerTests: XCTestCase {
             ),
             dependencies: .mockWith(
                 dateProvider: RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
-            )
+            ),
+            appVersionProvider: .mockWith(version: "1.0.0")
         )
 
         let feature: TracingFeature = .mockByRecordingSpanMatchers(

--- a/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingFeatureTests.swift
@@ -40,7 +40,6 @@ class TracingFeatureTests: XCTestCase {
             configuration: .mockWith(
                 clientToken: randomClientToken,
                 applicationName: randomApplicationName,
-                applicationVersion: randomApplicationVersion,
                 source: randomSource,
                 origin: randomOrigin,
                 sdkVersion: randomSDKVersion,
@@ -52,7 +51,8 @@ class TracingFeatureTests: XCTestCase {
                     osName: randomDeviceOSName,
                     osVersion: randomDeviceOSVersion
                 )
-            )
+            ),
+            appVersionProvider: .mockWith(version: randomApplicationVersion)
         )
 
         // Given
@@ -116,7 +116,8 @@ class TracingFeatureTests: XCTestCase {
                         uploadDelayChangeRate: 0
                     )
                 )
-            )
+            ),
+            appVersionProvider: .mockAny()
         )
 
         let featureConfiguration: TracingFeature.Configuration = .mockAny()

--- a/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDLoggerTests.swift
@@ -145,9 +145,9 @@ class DDLoggerTests: XCTestCase {
     func testSettingTagsAndAttributes() throws {
         core.context = .mockWith(
             configuration: .mockWith(
-                applicationVersion: "1.2.3",
                 environment: "test"
-            )
+            ),
+            appVersionProvider: .mockWith(version: "1.2.3")
         )
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers()


### PR DESCRIPTION
### What and why?

📦 This PR adds `set(customVersion:)` API to internal proxy available in cross-platform SDKs. This is to unlock OTA use cases in RN, where `version` can change without restarting the app.

### How?

I added `AppVersionProvider`, which reads initial `version` from configuration (supporting `_dd.version ` override) and accepts its updates through `_InternalProxy.configuration` proxy.

Cross-platform SDKs can now customize `version` in 2 ways:
* on SDK init, by passing `"_dd.version"` in `additionalConfiguration`;
* later at runtime by using `Datadog._internal._configuration.set(customVersion:)`.

Aware of architectural changes made in https://github.com/DataDog/dd-sdk-ios/pull/947, notably the removal of `FeatureCommonDependencies` container, this new provider is added directly to `DatadogCore` - in the same way as done on V2 branch.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
