### PR TITLE
RUMM-2332 Log Error to RUM through message bus

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -608,6 +608,12 @@
 		D21C26D828A647DB005DD405 /* MessageBusMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D628A647DB005DD405 /* MessageBusMock.swift */; };
 		D21C26DA28ABA073005DD405 /* FeatureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D928ABA073005DD405 /* FeatureMessage.swift */; };
 		D21C26DB28ABA073005DD405 /* FeatureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D928ABA073005DD405 /* FeatureMessage.swift */; };
+		D21C26DD28ACD371005DD405 /* FeatureMessageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26DC28ACD371005DD405 /* FeatureMessageAttributes.swift */; };
+		D21C26DE28ACD371005DD405 /* FeatureMessageAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26DC28ACD371005DD405 /* FeatureMessageAttributes.swift */; };
+		D21C26E728AF9388005DD405 /* FeatureMessageAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26E628AF9388005DD405 /* FeatureMessageAttributesTests.swift */; };
+		D21C26E828AF9388005DD405 /* FeatureMessageAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26E628AF9388005DD405 /* FeatureMessageAttributesTests.swift */; };
+		D21C26EE28AFB65B005DD405 /* RUMMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26ED28AFB65B005DD405 /* RUMMessageReceiverTests.swift */; };
+		D21C26EF28AFB65B005DD405 /* RUMMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26ED28AFB65B005DD405 /* RUMMessageReceiverTests.swift */; };
 		D22C1F5C271484B400922024 /* LogEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C1F5B271484B400922024 /* LogEventMapper.swift */; };
 		D232CAD52832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
 		D232CAD62832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
@@ -1872,6 +1878,9 @@
 		D21C26D028A64599005DD405 /* MessageBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusTests.swift; sourceTree = "<group>"; };
 		D21C26D628A647DB005DD405 /* MessageBusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusMock.swift; sourceTree = "<group>"; };
 		D21C26D928ABA073005DD405 /* FeatureMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureMessage.swift; sourceTree = "<group>"; };
+		D21C26DC28ACD371005DD405 /* FeatureMessageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureMessageAttributes.swift; sourceTree = "<group>"; };
+		D21C26E628AF9388005DD405 /* FeatureMessageAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureMessageAttributesTests.swift; sourceTree = "<group>"; };
+		D21C26ED28AFB65B005DD405 /* RUMMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMessageReceiverTests.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
 		D232CAD42832D762001B262C /* DatadogCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreMock.swift; sourceTree = "<group>"; };
 		D240684D27CE6C9E00C04F44 /* Example tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3797,6 +3806,7 @@
 				49274908288048F400ECD49B /* RUMInternalProxyTests.swift */,
 				61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */,
 				D248ED4728081B9B00B315B4 /* RUMTelemetryTests.swift */,
+				D21C26ED28AFB65B005DD405 /* RUMMessageReceiverTests.swift */,
 				9EB4B86A27510AC80041CD03 /* WebView */,
 				B3FC3C1226526F4100DEED9E /* RUMVitals */,
 				618715FA24DC5EE700FC0F69 /* DataModels */,
@@ -4202,6 +4212,7 @@
 			isa = PBXGroup;
 			children = (
 				D21C26D928ABA073005DD405 /* FeatureMessage.swift */,
+				D21C26DC28ACD371005DD405 /* FeatureMessageAttributes.swift */,
 				D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */,
 			);
 			path = MessageBus;
@@ -4322,6 +4333,7 @@
 			children = (
 				D2956CB02869D54E007D5462 /* DeviceInfoTests.swift */,
 				D26C49B12886E10E00802B2D /* AppStateHistoryTests.swift */,
+				D21C26E628AF9388005DD405 /* FeatureMessageAttributesTests.swift */,
 			);
 			path = Context;
 			sourceTree = "<group>";
@@ -5292,6 +5304,7 @@
 				61C5A8A724509FAA00DA608C /* SpanEventBuilder.swift in Sources */,
 				6179FFD3254ADB1700556A0B /* ObjcAppLaunchHandler.m in Sources */,
 				F637AED22697404200516F32 /* UIKitRUMUserActionsPredicate.swift in Sources */,
+				D21C26DD28ACD371005DD405 /* FeatureMessageAttributes.swift in Sources */,
 				D29CDD3228211A2200F7DAA5 /* DataBlock.swift in Sources */,
 				D2553829288F0B2400727FAD /* LowPowerModePublisher.swift in Sources */,
 				616C0A9E28573DFF00C13264 /* RUMOperatingSystemInfo.swift in Sources */,
@@ -5516,6 +5529,7 @@
 				9E53889C2773C4B300A7DC42 /* WebRUMEventConsumerTests.swift in Sources */,
 				6114FDEC257659E90084E372 /* DirectoriesMock.swift in Sources */,
 				61122EE825B1C92500F9C7F5 /* SpanSanitizerTests.swift in Sources */,
+				D21C26EE28AFB65B005DD405 /* RUMMessageReceiverTests.swift in Sources */,
 				61B5E42526DFAFBC000B0A5F /* DDGlobal+apiTests.m in Sources */,
 				61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */,
 				617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */,
@@ -5660,6 +5674,7 @@
 				D21C26D728A647DB005DD405 /* MessageBusMock.swift in Sources */,
 				61F2724925C943C500D54BF8 /* CrashReporterTests.swift in Sources */,
 				6172472725D673D7007085B3 /* CrashContextTests.swift in Sources */,
+				D21C26E728AF9388005DD405 /* FeatureMessageAttributesTests.swift in Sources */,
 				D2A1EE26287C35DE00D28DFB /* ContextValueReaderMock.swift in Sources */,
 				61BAD46A26415FCE001886CA /* OTSpanTests.swift in Sources */,
 				61B5E42726DFB145000B0A5F /* DDDatadog+apiTests.m in Sources */,
@@ -5931,6 +5946,7 @@
 				D2CB6E1A27C50EAE00A62B57 /* OTSpanContext.swift in Sources */,
 				D2CB6E1B27C50EAE00A62B57 /* OTTracer.swift in Sources */,
 				D2CB6E1C27C50EAE00A62B57 /* OTReference.swift in Sources */,
+				D21C26DE28ACD371005DD405 /* FeatureMessageAttributes.swift in Sources */,
 				D2CB6E1D27C50EAE00A62B57 /* ArbitraryDataWriter.swift in Sources */,
 				D2CB6E1E27C50EAE00A62B57 /* TracingWithLoggingIntegration.swift in Sources */,
 				D2CB6E1F27C50EAE00A62B57 /* WebRUMEventConsumer.swift in Sources */,
@@ -6189,6 +6205,7 @@
 				D2CB6EF727C520D400A62B57 /* URLSessionAutoInstrumentationMocks.swift in Sources */,
 				D2CB6EF927C520D400A62B57 /* WebRUMEventConsumerTests.swift in Sources */,
 				D2CB6EFA27C520D400A62B57 /* DirectoriesMock.swift in Sources */,
+				D21C26EF28AFB65B005DD405 /* RUMMessageReceiverTests.swift in Sources */,
 				D2CB6EFB27C520D400A62B57 /* SpanSanitizerTests.swift in Sources */,
 				D2CB6EFC27C520D400A62B57 /* DDGlobal+apiTests.m in Sources */,
 				D2CB6EFD27C520D400A62B57 /* LoggingFeatureMocks.swift in Sources */,
@@ -6333,6 +6350,7 @@
 				D21C26D828A647DB005DD405 /* MessageBusMock.swift in Sources */,
 				D2CB6F7C27C520D400A62B57 /* CrashReporterTests.swift in Sources */,
 				D2CB6F7D27C520D400A62B57 /* CrashContextTests.swift in Sources */,
+				D21C26E828AF9388005DD405 /* FeatureMessageAttributesTests.swift in Sources */,
 				D2A1EE27287C35DE00D28DFB /* ContextValueReaderMock.swift in Sources */,
 				D2CB6F7E27C520D400A62B57 /* OTSpanTests.swift in Sources */,
 				D2CB6F7F27C520D400A62B57 /* DDDatadog+apiTests.m in Sources */,

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -40,8 +40,6 @@ public protocol FeatureScope {
 
 /// No-op implementation of `DatadogFeatureRegistry`.
 internal struct NOPDatadogCore: DatadogCoreProtocol {
-    /// no-op: call the fallback in sync
-    func send(message: FeatureMessage, else fallback: @escaping () -> Void) {
-        fallback()
-    }
+    /// no-op
+    func send(message: FeatureMessage, else fallback: @escaping () -> Void) { }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -13,7 +13,7 @@ public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOPDatadogCor
 public protocol DatadogCoreProtocol {
     /// Sends a message on the bus shared by features registered in this core.
     ///
-    /// If the message could be be processed by any registered feature, the fallback closure
+    /// If the message could not be processed by any registered feature, the fallback closure
     /// will be invoked. Do not make any assumption on which thread the fallback is called.
     ///
     /// - Parameters:

--- a/Sources/Datadog/DatadogInternal/DatadogFeatureConfiguration.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogFeatureConfiguration.swift
@@ -21,3 +21,22 @@ import Foundation
     /// from a bus that is shared between Features registered in a core.
     let messageReceiver: FeatureMessageReceiver
 }
+
+/* public */ internal struct DatadogFeature<Configuration> {
+    /// The feature name.
+    let name: String
+
+    /// The feature-specific configuration.
+    let configuration: Configuration
+
+    /// The URL request builder for uploading data in this Feature.
+    ///
+    /// This builder currently use the v1 context, but will be soon migrated to v2
+    let requestBuilder: FeatureRequestBuilder
+
+    /// The message bus receiver.
+    ///
+    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
+    /// from a bus that is shared between Features registered in a core.
+    let messageReceiver: FeatureMessageReceiver
+}

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessage.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessage.swift
@@ -11,7 +11,7 @@ public enum FeatureMessage {
     /// An error message.
     case error(
         message: String,
-        attributes: [String: Encodable]?
+        attributes: FeatureMessageAttributes
     )
 
     /// An encodable event that will be transmitted
@@ -25,6 +25,6 @@ public enum FeatureMessage {
     /// attributes.
     case custom(
         key: String,
-        attributes: [String: Encodable]?
+        attributes: FeatureMessageAttributes
     )
 }

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageAttributes.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageAttributes.swift
@@ -1,0 +1,148 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Holds atributes for Feature message and provide convenient `subscript`
+/// access and cast attribute values.
+@dynamicMemberLookup
+public struct FeatureMessageAttributes {
+    /// The attributes dictionary.
+    private var attributes: [String: Any]
+
+    /// Accesses the value associated with the given key for reading and writing
+    /// an attribute.
+    ///
+    /// This *key-based* subscript returns the value for the given key if the key
+    /// with a value of type `T` is found in the attributes, or `nil`otherwise.
+    ///
+    /// The following example creates a new `FeatureMessageAttributes` and
+    /// prints the value of a key found in the attributes object (`"coral"`).
+    ///
+    ///     var hues: FeatureMessageAttributes = [
+    ///         "heliotrope": 296,
+    ///         "coral": 16,
+    ///         "aquamarine": 156
+    ///     ]
+    ///     print(hues["coral", type: Int.self])
+    ///     // Prints "Optional(16)"
+    ///     print(hues["coral", type: String.self])
+    ///     // Prints "null"
+    ///
+    /// When you assign a value for a key and that key already exists, the
+    /// attribute object overwrites the existing value. If the attribute object doesn't
+    /// contain the key, the key and value are added as a new key-value pair.
+    ///
+    /// Here, the value for the key `"coral"` is updated from `16` to `18` and a
+    /// new key-value pair is added for the key `"cerise"`.
+    ///
+    ///     hues["coral"] = 18
+    ///     print(hues["coral", type: Int.self])
+    ///     // Prints "Optional(18)"
+    ///
+    ///     hues["cerise"] = "ok"
+    ///     print(hues["cerise", type: String.self])
+    ///     // Prints "Optional("ok")"
+    ///
+    /// If you assign `nil` as the value for the given key, the attribute object
+    /// removes that key and its associated value.
+    ///
+    /// - Parameters:
+    ///   - key: The key to find in the dictionary.
+    ///   - type: The expected value type.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(key: String, type t: T.Type = T.self) -> T? {
+        get { attributes[key] as? T }
+        set { attributes[key] = newValue }
+    }
+
+    /// Accesses `RawRepresentable` from its `RawValue` associated with the given key
+    /// for reading an attribute.
+    ///
+    /// The attribute for the given key will be used as the `rawValue` for initializing the
+    /// `RawRepresentable` type.
+    ///
+    /// - Parameters:
+    ///   - key: The key to find in the dictionary.
+    ///   - type: The expected value type.
+    /// - Returns: The value associated with `key` if `rawValue` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(key: String, type t: T.Type = T.self) -> T? where T: RawRepresentable {
+        attributes[key]
+            .flatMap { $0 as? T.RawValue }
+            .flatMap { .init(rawValue: $0) }
+        ?? attributes[key] as? T
+    }
+
+    /// Accesses the value associated with the given key for reading and writing
+    /// a attribute type.
+    ///
+    /// This *dynamic-member-based* subscript returns the value for the given key if the key
+    /// with a value of type `T` is found in the attributes, or `nil`otherwise.
+    ///
+    /// The following example creates a new `FeatureMessageAttributes` and
+    /// prints the value of a key found in the attributes object (`"coral"`) and a key not
+    /// found in the dictionary (`"cerise"`).
+    ///
+    ///     var hues: FeatureMessageAttributes = [
+    ///         "heliotrope": 296,
+    ///         "coral": 16,
+    ///         "aquamarine": 156
+    ///     ]
+    ///     let coral: Int? = hues.coral
+    ///     print(coral as? Int)
+    ///     // Prints "16"
+    ///     let cerise: Int? = hues.cerise
+    ///     print(cerise)
+    ///     // Prints "null"
+    ///
+    /// When you assign a value for a key and that key already exists, the
+    /// attribute object overwrites the existing value. If the attribute object doesn't
+    /// contain the key, the key and value are added as a new key-value pair.
+    ///
+    /// If you assign `nil` as the value for the given key, the attribute object
+    /// removes that key and its associated value.
+    ///
+    /// In the following example, the key-value pair for the key `"aquamarine"`
+    /// is removed from the attribute object by assigning `nil` to the
+    /// dynamic-member-based subscript.
+    ///
+    ///     hues.aquamarine = nil
+    ///     print(hues)
+    ///     // Prints "["coral": 18, "heliotrope": 296, "cerise": 330]"
+    ///
+    /// - Parameter key: The key to find in the dictionary.
+    /// - Returns: The value associated with `key` if `key` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(dynamicMember key: String) -> T? {
+        get { self[key, type: T.self] }
+        set { self[key, type: T.self] = newValue }
+    }
+
+    /// Accesses `RawRepresentable` from its `RawValue` associated with the given key
+    /// for reading an attribute.
+    ///
+    /// The attribute for the given key will be used as the `rawValue` for initializing the
+    /// `RawRepresentable` type.
+    ///
+    /// - Parameter key: The key to find in the dictionary.
+    /// - Returns: The value associated with `key` if `rawValue` is in the attributes.
+    ///   `nil` otherwise.
+    public subscript<T>(dynamicMember key: String) -> T? where T: RawRepresentable {
+        get { self[key, type: T.self] }
+        set { self[key, type: T.self] = newValue }
+    }
+}
+
+extension FeatureMessageAttributes: ExpressibleByDictionaryLiteral {
+    /// Creates an instance initialized with the given key-value pairs.
+    public init(dictionaryLiteral elements: (String, Any?)...) {
+        self.attributes = elements.reduce(into: [:]) { attributes, element in
+            attributes[element.0] = element.1
+        }
+    }
+}

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageAttributes.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageAttributes.swift
@@ -17,7 +17,7 @@ public struct FeatureMessageAttributes {
     /// an attribute.
     ///
     /// This *key-based* subscript returns the value for the given key if the key
-    /// with a value of type `T` is found in the attributes, or `nil`otherwise.
+    /// with a value of type `T` is found in the attributes, or `nil` otherwise.
     ///
     /// The following example creates a new `FeatureMessageAttributes` and
     /// prints the value of a key found in the attributes object (`"coral"`).

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
@@ -21,10 +21,14 @@ import Foundation
     /// - Parameters:
     ///   - message: The Feature message
     ///   - core: The core from which the message is transmitted.
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol)
+    /// - Returns: Returns `true` if the message was processed by the receiver. `false` if it was
+    ///            ignored.
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool
 }
 
 /* public */ internal struct NOPFeatureMessageReceiver: FeatureMessageReceiver {
-    /// no-op
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) { }
+    /// no-op: returns `false`
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        return false
+    }
 }

--- a/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
+++ b/Sources/Datadog/FeaturesIntegration/LoggingWithRUMIntegration.swift
@@ -21,17 +21,3 @@ internal struct LoggingWithRUMContextIntegration {
         return attributes
     }
 }
-
-/// Sends given `Log` as RUM Errors.
-internal struct LoggingWithRUMErrorsIntegration {
-    private let rumErrorsIntegration = RUMErrorsIntegration()
-
-    func addError(for log: LogEvent) {
-        rumErrorsIntegration.addError(
-            with: log.error?.message ?? log.message,
-            type: log.error?.kind,
-            stack: log.error?.stack,
-            source: .logger
-        )
-    }
-}

--- a/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
+++ b/Sources/Datadog/FeaturesIntegration/RUMIntegrations.swift
@@ -36,11 +36,3 @@ internal struct RUMContextIntegration {
         ]
     }
 }
-
-/// Creates RUM Errors with given message.
-internal struct RUMErrorsIntegration {
-    /// Adds RUM Error with given message and stack to current RUM View.
-    func addError(with message: String, type: String?, stack: String?, source: RUMInternalErrorSource, attributes: [AttributeKey: AttributeValue] = [:]) {
-        rumMonitor?.addError(message: message, type: type, stack: stack, source: source, attributes: attributes)
-    }
-}

--- a/Sources/Datadog/Logger.swift
+++ b/Sources/Datadog/Logger.swift
@@ -376,7 +376,6 @@ public class Logger: LoggerProtocol {
                     configuration: configuration,
                     dateProvider: context.dateProvider,
                     rumContextIntegration: (rumEnabled && bundleWithRUM) ? LoggingWithRUMContextIntegration() : nil,
-                    rumErrorsIntegration: rumEnabled ? LoggingWithRUMErrorsIntegration() : nil,
                     activeSpanIntegration: (tracingEnabled && bundleWithTrace) ? LoggingWithActiveSpanIntegration() : nil
                 )
             }()

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -96,7 +96,7 @@ public enum RUMErrorSource {
     case custom
 }
 
-internal enum RUMInternalErrorSource {
+internal enum RUMInternalErrorSource: String {
     case custom
     case source
     case network

--- a/Tests/DatadogTests/Datadog/DatadogCore/MessageBusTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogCore/MessageBusTests.swift
@@ -32,7 +32,7 @@ class MessageBusTests: XCTestCase {
             switch message {
             case .custom(let key, let attributes):
                 XCTAssertEqual(key, "test")
-                XCTAssertEqual(attributes as? [String: String], ["key": "value"])
+                XCTAssertEqual(attributes["key"], "value")
             default:
                 XCTFail("wrong message case")
             }
@@ -62,6 +62,6 @@ class MessageBusTests: XCTestCase {
         // When
         core.send(message: .custom(key: "test", attributes: ["key": "value"]))
         // Then
-        waitForExpectations(timeout: 0)
+        waitForExpectations(timeout: 0.5)
     }
 }

--- a/Tests/DatadogTests/Datadog/DatadogInternal/Context/FeatureMessageAttributesTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/Context/FeatureMessageAttributesTests.swift
@@ -1,0 +1,50 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+
+@testable import Datadog
+
+class FeatureMessageAttributesTests: XCTestCase {
+    private enum EnumAttribute: String {
+        case test
+    }
+
+    let attributes: FeatureMessageAttributes = [
+        "int": 1,
+        "string": "test",
+        "double": 2.0,
+        "enum": EnumAttribute.test
+    ]
+
+    func testSubscript() {
+        var attributes = attributes
+        XCTAssertEqual(attributes["int", type: Int.self], 1)
+        XCTAssertEqual(attributes["double", type: Double.self], 2.0)
+        XCTAssertNil(attributes["string", type: Int.self])
+        XCTAssertEqual(attributes["string"], "test")
+
+        attributes["int"] = 2
+        XCTAssertEqual(attributes["int"], 2)
+    }
+
+    func testRawRepresentable() {
+        XCTAssertEqual(attributes["enum", type: EnumAttribute.self], .test)
+        XCTAssertEqual(attributes["string", type: EnumAttribute.self], .test)
+    }
+
+    func testDynamicMemberLookup() {
+        var attributes = attributes
+        XCTAssertEqual(attributes.int, 1)
+        XCTAssertEqual(attributes.double, 2.0)
+        XCTAssertEqual(attributes.string, "test")
+        XCTAssertEqual(attributes.string, EnumAttribute.test)
+        XCTAssertEqual(attributes.enum, EnumAttribute.test)
+
+        attributes.int = 2
+        XCTAssertEqual(attributes.int, 2)
+    }
+}

--- a/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerBuilderTests.swift
@@ -46,7 +46,6 @@ class LoggerBuilderTests: XCTestCase {
         XCTAssertEqual(remoteLogger.configuration.threshold, .debug)
         XCTAssertNil(remoteLogger.configuration.eventMapper)
         XCTAssertNil(remoteLogger.rumContextIntegration)
-        XCTAssertNil(remoteLogger.rumErrorsIntegration)
         XCTAssertNil(remoteLogger.activeSpanIntegration)
     }
 
@@ -95,7 +94,6 @@ class LoggerBuilderTests: XCTestCase {
         XCTAssertEqual(remoteLogger.configuration.threshold, .error)
         XCTAssertNil(remoteLogger.configuration.eventMapper)
         XCTAssertNil(remoteLogger.rumContextIntegration)
-        XCTAssertNotNil(remoteLogger.rumErrorsIntegration, "When RUM is enabled, `rumErrorsIntegration` should be available")
         XCTAssertNil(remoteLogger.activeSpanIntegration)
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
@@ -38,8 +38,14 @@ internal final class DatadogCoreMock: Flushable {
 extension DatadogCoreMock: DatadogCoreProtocol {
     // MARK: V2 interface
 
-    func send(message: FeatureMessage) {
-        // no-op
+    func send(message: FeatureMessage, else fallback: () -> Void) {
+        let receivers = v1Features.values
+            .compactMap { $0 as? V1Feature }
+            .filter { $0.messageReceiver.receive(message: message, from: self) }
+
+        if receivers.isEmpty {
+            fallback()
+        }
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/MessageBusMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/MessageBusMock.swift
@@ -30,8 +30,9 @@ internal struct FeatureMessageReceiverMock: FeatureMessageReceiver {
         self.receiver = receiver
     }
 
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) {
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
         receiver?(message)
         expectation?.fulfill()
+        return true
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -21,7 +21,8 @@ extension RUMFeature {
     /// Mocks the feature instance which performs uploads to mocked `DataUploadWorker`.
     /// Use `RUMFeature.waitAndReturnRUMEventMatchers()` to inspect and assert recorded `RUMEvents`.
     static func mockByRecordingRUMEventMatchers(
-        featureConfiguration: FeaturesConfiguration.RUM = .mockAny()
+        featureConfiguration: FeaturesConfiguration.RUM = .mockAny(),
+        messageReceiver: FeatureMessageReceiver = RUMMessageReceiver()
     ) -> RUMFeature {
         // Mock storage with `InMemoryWriter`, used later for retrieving recorded events back:
         let interceptedStorage = FeatureStorage(
@@ -34,7 +35,7 @@ extension RUMFeature {
             storage: interceptedStorage,
             upload: .mockNoOp(),
             configuration: featureConfiguration,
-            messageReceiver: NOPFeatureMessageReceiver()
+            messageReceiver: messageReceiver
         )
     }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMessageReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMessageReceiverTests.swift
@@ -1,0 +1,96 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+
+@testable import Datadog
+
+class RUMMessageReceiverTests: XCTestCase {
+    func testReceiveIncompleteLogMessage() throws {
+        let expectation = expectation(description: "Don't send error fallback")
+
+        // Given
+        let core = PassthroughCoreMock(
+            messageReceiver: RUMMessageReceiver()
+        )
+
+        Global.rum = RUMMonitor.init(core: core, dependencies: .mockAny(), dateProvider: SystemDateProvider())
+        defer { Global.rum = DDNoopRUMMonitor() }
+
+        // When
+        core.send(
+            message: .error(
+                message: "message-test",
+                attributes: [:]
+            ),
+            else: { expectation.fulfill() }
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+        XCTAssertTrue(core.events.isEmpty)
+    }
+
+    func testReceivePartialLogMessage() throws {
+        // Given
+        let core = PassthroughCoreMock(
+            expectation: expectation(description: "Send Error"),
+            messageReceiver: RUMMessageReceiver()
+        )
+
+        Global.rum = RUMMonitor.init(core: core, dependencies: .mockAny(), dateProvider: SystemDateProvider())
+        defer { Global.rum = DDNoopRUMMonitor() }
+
+        // When
+        core.send(
+            message: .error(
+                message: "message-test",
+                attributes: [
+                    "source": "custom"
+                ]
+            )
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let event: RUMErrorEvent = try XCTUnwrap(core.events().last, "It should send log")
+        XCTAssertEqual(event.error.message, "message-test")
+        XCTAssertEqual(event.error.source, .custom)
+    }
+
+    func testReceiveCompleteLogMessage() throws {
+        // Given
+        let core = PassthroughCoreMock(
+            expectation: expectation(description: "Send Error"),
+            messageReceiver: RUMMessageReceiver()
+        )
+
+        Global.rum = RUMMonitor.init(core: core, dependencies: .mockAny(), dateProvider: SystemDateProvider())
+        defer { Global.rum = DDNoopRUMMonitor() }
+
+        // When
+        core.send(
+            message: .error(
+                message: "message-test",
+                attributes: [
+                    "type": "type-test",
+                    "stack": "stack-test",
+                    "source": "logger"
+                ]
+            )
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let event: RUMErrorEvent = try XCTUnwrap(core.events().last, "It should send log")
+        XCTAssertEqual(event.error.message, "message-test")
+        XCTAssertEqual(event.error.type, "type-test")
+        XCTAssertEqual(event.error.stack, "stack-test")
+        XCTAssertEqual(event.error.source, .logger)
+    }
+}


### PR DESCRIPTION
### What and why?

Send Log error to RUM through the message bus.

### How?

- Creates a `RUMMessageReceiver` that can receive `.error` messages. 
- The `RemoteLogger` now sends error log as message through `core`. The `LoggingWithRUMErrorsIntegration` has been removed.

#### Introduce `FeatureMessageAttributes`

The `FeatureMessageAttributes` has been added as a wrapper around `[String: Any]` for message attributes. This object allow reading attributes by their keys and types which greatly facilitate reading messages on the bus. It supports 2 ways of accessing attributes: The classic `subscript` and the [`@dynamicMemberLookup`](https://github.com/apple/swift-evolution/blob/f55963fb0abd77aae643882ca3fc8939b1f969f2/proposals/0195-dynamic-member-lookup.md)

```swift
var attributes: FeatureMessageAttributes = [
  "key1": 1,
  "key2": "value 2",
  "key3": 3.0
]

let one = attributes["key1", type: Int.self]
let two: String? = attributes["key2"]
let three: Double? = attributes.key3
```


### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
