### PR TITLE
RUMM-2332 Span to Log through message bus

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -614,6 +614,12 @@
 		D21C26E828AF9388005DD405 /* FeatureMessageAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26E628AF9388005DD405 /* FeatureMessageAttributesTests.swift */; };
 		D21C26EE28AFB65B005DD405 /* RUMMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26ED28AFB65B005DD405 /* RUMMessageReceiverTests.swift */; };
 		D21C26EF28AFB65B005DD405 /* RUMMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26ED28AFB65B005DD405 /* RUMMessageReceiverTests.swift */; };
+		D21C26E028AD2E47005DD405 /* DatadogExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26DF28AD2E47005DD405 /* DatadogExtended.swift */; };
+		D21C26E128AD2E47005DD405 /* DatadogExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26DF28AD2E47005DD405 /* DatadogExtended.swift */; };
+		D21C26E428AD30E2005DD405 /* Foundation+Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26E328AD30E2005DD405 /* Foundation+Datadog.swift */; };
+		D21C26E528AD30E2005DD405 /* Foundation+Datadog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26E328AD30E2005DD405 /* Foundation+Datadog.swift */; };
+		D21C26EB28AFA11E005DD405 /* LoggingMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26EA28AFA11E005DD405 /* LoggingMessageReceiverTests.swift */; };
+		D21C26EC28AFA11E005DD405 /* LoggingMessageReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26EA28AFA11E005DD405 /* LoggingMessageReceiverTests.swift */; };
 		D22C1F5C271484B400922024 /* LogEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22C1F5B271484B400922024 /* LogEventMapper.swift */; };
 		D232CAD52832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
 		D232CAD62832D762001B262C /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D232CAD42832D762001B262C /* DatadogCoreMock.swift */; };
@@ -1881,6 +1887,9 @@
 		D21C26DC28ACD371005DD405 /* FeatureMessageAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureMessageAttributes.swift; sourceTree = "<group>"; };
 		D21C26E628AF9388005DD405 /* FeatureMessageAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureMessageAttributesTests.swift; sourceTree = "<group>"; };
 		D21C26ED28AFB65B005DD405 /* RUMMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMMessageReceiverTests.swift; sourceTree = "<group>"; };
+		D21C26DF28AD2E47005DD405 /* DatadogExtended.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogExtended.swift; sourceTree = "<group>"; };
+		D21C26E328AD30E2005DD405 /* Foundation+Datadog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+Datadog.swift"; sourceTree = "<group>"; };
+		D21C26EA28AFA11E005DD405 /* LoggingMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingMessageReceiverTests.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
 		D232CAD42832D762001B262C /* DatadogCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreMock.swift; sourceTree = "<group>"; };
 		D240684D27CE6C9E00C04F44 /* Example tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2598,6 +2607,7 @@
 			children = (
 				61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */,
 				6194D51B287ECDC00091547D /* ConsoleLoggerTests.swift */,
+				D21C26EA28AFA11E005DD405 /* LoggingMessageReceiverTests.swift */,
 				61133C3A2423990D00786299 /* Log */,
 				61133C3D2423990D00786299 /* LogOutputs */,
 			);
@@ -2710,7 +2720,6 @@
 			isa = PBXGroup;
 			children = (
 				61D980B924E28D0100E03345 /* RUMIntegrations.swift */,
-				61216275247D1CD700AC5D67 /* TracingWithLoggingIntegration.swift */,
 				6156CB9724DEFD44008CB2B2 /* LoggingWithRUMIntegration.swift */,
 				6105D19F2508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift */,
 				6156CB9B24E18224008CB2B2 /* TracingWithRUMIntegration.swift */,
@@ -3644,6 +3653,7 @@
 				61C5A8A324509FAA00DA608C /* Span */,
 				618D9DE5263AD77600A3FAD2 /* Scrubbing */,
 				61C5A88224509A0C00DA608C /* Propagation */,
+				D21C26E928AF9D22005DD405 /* Integrations */,
 				617CEB372456BC2200AD4669 /* UUIDs */,
 				613F2405252B37B0006CD2D7 /* AutoInstrumentation */,
 				61C5A87A24509A0C00DA608C /* Utils */,
@@ -4218,6 +4228,23 @@
 			path = MessageBus;
 			sourceTree = "<group>";
 		};
+		D21C26E228AD3071005DD405 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				D21C26DF28AD2E47005DD405 /* DatadogExtended.swift */,
+				D21C26E328AD30E2005DD405 /* Foundation+Datadog.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		D21C26E928AF9D22005DD405 /* Integrations */ = {
+			isa = PBXGroup;
+			children = (
+				61216275247D1CD700AC5D67 /* TracingWithLoggingIntegration.swift */,
+			);
+			path = Integrations;
+			sourceTree = "<group>";
+		};
 		D22C1F5A2714849700922024 /* Scrubbing */ = {
 			isa = PBXGroup;
 			children = (
@@ -4384,6 +4411,7 @@
 				D2956CAA2869D1DF007D5462 /* Context */,
 				D26C49C128899B4100802B2D /* Upload */,
 				D21C26CC28A411BE005DD405 /* MessageBus */,
+				D21C26E228AD3071005DD405 /* Extensions */,
 				492749002880489400ECD49B /* _InternalProxy.swift */,
 				61E945DF2869BEF500A946C4 /* DD.swift */,
 				D2D37DBE2846335F00FB4348 /* DatadogV1CoreProtocol.swift */,
@@ -5280,6 +5308,7 @@
 				6105D1A02508F1600040DD22 /* LoggingWithActiveSpanIntegration.swift in Sources */,
 				61DA8CA928609C5B0074A606 /* Directories.swift in Sources */,
 				D248ED4228070E2B00B315B4 /* Telemetry.swift in Sources */,
+				D21C26E028AD2E47005DD405 /* DatadogExtended.swift in Sources */,
 				D2EFA868286DA85700F1FAA6 /* DatadogContextProvider.swift in Sources */,
 				9EB4B864274FAB410041CD03 /* WebLogEventConsumer.swift in Sources */,
 				D26C49BF288982DA00802B2D /* FeatureUpload.swift in Sources */,
@@ -5443,6 +5472,7 @@
 				61FF281E24B8968D000B3D9B /* RUMEventBuilder.swift in Sources */,
 				E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */,
 				61133BD82423979B00786299 /* HTTPClient.swift in Sources */,
+				D21C26E428AD30E2005DD405 /* Foundation+Datadog.swift in Sources */,
 				D22C1F5C271484B400922024 /* LogEventMapper.swift in Sources */,
 				61B038542527246D00518F3C /* URLSessionSwizzler.swift in Sources */,
 				B3BBBCB2265E71C700943419 /* VitalMemoryReader.swift in Sources */,
@@ -5547,6 +5577,7 @@
 				61F1A621249A45E400075390 /* DDSpanContextTests.swift in Sources */,
 				61D03BE0273404E700367DE0 /* RUMDataModels+objcTests.swift in Sources */,
 				E143CCAF27D236F600F4018A /* CITestIntegrationTests.swift in Sources */,
+				D21C26EB28AFA11E005DD405 /* LoggingMessageReceiverTests.swift in Sources */,
 				615C3196251DD5080018781C /* UIKitRUMUserActionsHandlerTests.swift in Sources */,
 				61E917CF2464270500E6C631 /* CodableValueTests.swift in Sources */,
 				61D3E0E4277B3D92008BE766 /* KronosNTPPacketTests.swift in Sources */,
@@ -5997,6 +6028,7 @@
 				61FD9FCA2851E67100214BD9 /* Sysctl.swift in Sources */,
 				D248ED462807193B00B315B4 /* RUMTelemetry.swift in Sources */,
 				D2A1EE33287DA51900D28DFB /* UserInfoPublisher.swift in Sources */,
+				D21C26E528AD30E2005DD405 /* Foundation+Datadog.swift in Sources */,
 				D2CB6E4327C50EAE00A62B57 /* ObjcExceptionHandler.m in Sources */,
 				D2CB6E4427C50EAE00A62B57 /* UIApplicationSwizzler.swift in Sources */,
 				D2CB6E4527C50EAE00A62B57 /* RUMResourceScope.swift in Sources */,
@@ -6127,6 +6159,7 @@
 				D2CB6EAC27C50EAE00A62B57 /* DatadogConfiguration.swift in Sources */,
 				D2CB6EAE27C50EAE00A62B57 /* DataOrchestrator.swift in Sources */,
 				D2CB6EAF27C50EAE00A62B57 /* BundleType.swift in Sources */,
+				D21C26E128AD2E47005DD405 /* DatadogExtended.swift in Sources */,
 				616C0A9F28573DFF00C13264 /* RUMOperatingSystemInfo.swift in Sources */,
 				D2CB6EB027C50EAE00A62B57 /* UIKitRUMViewsPredicate.swift in Sources */,
 				D2CB6EB227C50EAE00A62B57 /* Sampler.swift in Sources */,
@@ -6223,6 +6256,7 @@
 				D2CB6F0727C520D400A62B57 /* MoveDataMigratorTests.swift in Sources */,
 				D2CB6F0827C520D400A62B57 /* DDSpanContextTests.swift in Sources */,
 				D2CB6F0927C520D400A62B57 /* RUMDataModels+objcTests.swift in Sources */,
+				D21C26EC28AFA11E005DD405 /* LoggingMessageReceiverTests.swift in Sources */,
 				D2CB6F0A27C520D400A62B57 /* UIKitRUMUserActionsHandlerTests.swift in Sources */,
 				D2CB6F0B27C520D400A62B57 /* CodableValueTests.swift in Sources */,
 				D2CB6F0C27C520D400A62B57 /* KronosNTPPacketTests.swift in Sources */,

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -250,7 +250,10 @@ public class Datadog {
 
         if let loggingConfiguration = configuration.logging {
             logging = try core.create(
-                configuration: createLoggingConfiguration(intake: loggingConfiguration.uploadURL),
+                configuration: createLoggingConfiguration(
+                    intake: loggingConfiguration.uploadURL,
+                    logEventMapper: loggingConfiguration.logEventMapper
+                ),
                 featureSpecificConfiguration: loggingConfiguration
             )
 

--- a/Sources/Datadog/DatadogInternal/Extensions/DatadogExtended.swift
+++ b/Sources/Datadog/DatadogInternal/Extensions/DatadogExtended.swift
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ *
+ * This file includes software developed by Alamofire Software Foundation (http://alamofire.org/) and altered by Datadog.
+ * Use of this source code is governed by MIT License: https://github.com/Alamofire/Alamofire/blob/master/LICENSE
+ */
+
+import Foundation
+
+/// Type that acts as a generic extension point for all `DatadogExtended` types.
+public struct DatadogExtension<ExtendedType> {
+    /// Stores the type or meta-type of any extended type.
+    public private(set) var type: ExtendedType
+
+    /// Create an instance from the provided value.
+    ///
+    /// - Parameter type: Instance being extended.
+    public init(_ type: ExtendedType) {
+        self.type = type
+    }
+}
+
+/// Protocol describing the `dd` extension points for Datadog extended types.
+public protocol DatadogExtended {
+    /// Type being extended.
+    associatedtype ExtendedType
+
+    /// Static Datadog extension point.
+    static var dd: DatadogExtension<ExtendedType>.Type { get set }
+    /// Instance Datadog extension point.
+    var dd: DatadogExtension<ExtendedType> { get set }
+}
+
+extension DatadogExtended {
+    /// Static Datadog extension point.
+    public static var dd: DatadogExtension<Self>.Type {
+        get { DatadogExtension<Self>.self }
+        set {}
+    }
+
+    /// Instance Datadog extension point.
+    public var dd: DatadogExtension<Self> {
+        get { DatadogExtension(self) }
+        set {}
+    }
+}

--- a/Sources/Datadog/DatadogInternal/Extensions/Foundation+Datadog.swift
+++ b/Sources/Datadog/DatadogInternal/Extensions/Foundation+Datadog.swift
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+extension Thread: DatadogExtended {}
+extension DatadogExtension where ExtendedType: Thread {
+    /// Returns the name of current thread if available or the nature of thread otherwise: `"main" | "background"`.
+    public var name: String {
+        if let name = Thread.current.name, !name.isEmpty {
+            return name
+        }
+
+        return Thread.isMainThread ? "main" : "background"
+    }
+}

--- a/Sources/Datadog/Logging/Log/LogEventBuilder.swift
+++ b/Sources/Datadog/Logging/Log/LogEventBuilder.swift
@@ -89,15 +89,6 @@ internal struct LogEventBuilder {
     }
 }
 
-/// Returns the name of current thread if available or the nature of thread otherwise: `"main" | "background"`.
-internal func getCurrentThreadName() -> String {
-    if let customName = Thread.current.name, !customName.isEmpty {
-        return customName
-    } else {
-        return Thread.isMainThread ? "main" : "background"
-    }
-}
-
 internal extension LogLevel {
     var asLogStatus: LogEvent.Status {
         switch self {

--- a/Sources/Datadog/Logging/RemoteLogger.swift
+++ b/Sources/Datadog/Logging/RemoteLogger.swift
@@ -106,7 +106,7 @@ internal final class RemoteLogger: LoggerProtocol {
 
         // on user thread:
         let date = dateProvider.now
-        let threadName = getCurrentThreadName()
+        let threadName = Thread.current.dd.name
 
         // SDK context must be requested on the user thread to ensure that it provides values
         // that are up-to-date for the caller.

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -55,7 +55,7 @@ public class Tracer: OTTracer {
     internal let queue: DispatchQueue
     /// Integration with RUM Context. `nil` if disabled for this Tracer or if the RUM feature is disabled.
     internal let rumContextIntegration: TracingWithRUMContextIntegration?
-    /// Integration with Logging. `nil` if the Logging feature is disabled.
+    /// Integration with Logging.
     internal let loggingIntegration: TracingWithLoggingIntegration
 
     private let tracingUUIDGenerator: TracingUUIDGenerator

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -56,7 +56,7 @@ public class Tracer: OTTracer {
     /// Integration with RUM Context. `nil` if disabled for this Tracer or if the RUM feature is disabled.
     internal let rumContextIntegration: TracingWithRUMContextIntegration?
     /// Integration with Logging. `nil` if the Logging feature is disabled.
-    internal let loggingIntegration: TracingWithLoggingIntegration?
+    internal let loggingIntegration: TracingWithLoggingIntegration
 
     private let tracingUUIDGenerator: TracingUUIDGenerator
 
@@ -91,7 +91,6 @@ public class Tracer: OTTracer {
                 tracingFeature: tracingFeature,
                 tracerConfiguration: configuration,
                 rumEnabled: core.v1.feature(RUMFeature.self) != nil,
-                loggingFeature: core.v1.feature(LoggingFeature.self),
                 context: context
             )
         } catch {
@@ -105,7 +104,6 @@ public class Tracer: OTTracer {
         tracingFeature: TracingFeature,
         tracerConfiguration: Configuration,
         rumEnabled: Bool,
-        loggingFeature: LoggingFeature?,
         context: DatadogV1Context
     ) {
         self.init(
@@ -114,14 +112,10 @@ public class Tracer: OTTracer {
             spanEventMapper: tracingFeature.configuration.spanEventMapper,
             tracingUUIDGenerator: tracingFeature.configuration.uuidGenerator,
             rumContextIntegration: (rumEnabled && tracerConfiguration.bundleWithRUM) ? TracingWithRUMContextIntegration() : nil,
-            loggingIntegration: loggingFeature.map {
-                TracingWithLoggingIntegration(
-                    core: core,
-                    context: context,
-                    tracerConfiguration: tracerConfiguration,
-                    loggingFeature: $0
-                )
-            }
+            loggingIntegration: TracingWithLoggingIntegration(
+                core: core,
+                tracerConfiguration: tracerConfiguration
+            )
         )
     }
 
@@ -131,7 +125,7 @@ public class Tracer: OTTracer {
         spanEventMapper: SpanEventMapper?,
         tracingUUIDGenerator: TracingUUIDGenerator,
         rumContextIntegration: TracingWithRUMContextIntegration?,
-        loggingIntegration: TracingWithLoggingIntegration?
+        loggingIntegration: TracingWithLoggingIntegration
     ) {
         self.core = core
         self.configuration = configuration

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -18,7 +18,7 @@ internal class DDSpan: OTSpan {
     /// Span creation date
     internal let startTime: Date
     /// Writes span logs to Logging Feature. `nil` if Logging feature is disabled.
-    private let loggingIntegration: TracingWithLoggingIntegration?
+    private let loggingIntegration: TracingWithLoggingIntegration
 
     /// Queue used for synchronizing mutable properties access.
     private let queue: DispatchQueue
@@ -178,13 +178,9 @@ internal class DDSpan: OTSpan {
     }
 
     private func sendSpanLogs(fields: [String: Encodable], date: Date) {
-        guard let loggingIntegration = loggingIntegration else {
-            queue.async {
-                DD.logger.warn("The log for span \"\(self.unsafeOperationName)\" will not be send, because the Logging feature is disabled.")
-            }
-            return
-        }
-        loggingIntegration.writeLog(withSpanContext: ddContext, fields: fields, date: date)
+        loggingIntegration.writeLog(withSpanContext: ddContext, fields: fields, date: date, else: {
+            self.queue.async { DD.logger.warn("The log for span \"\(self.unsafeOperationName)\" will not be send, because the Logging feature is disabled.") }
+        })
     }
 
     // MARK: - Private

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithLoggingIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithLoggingIntegrationTests.swift
@@ -8,13 +8,15 @@ import XCTest
 @testable import Datadog
 
 class TracingWithLoggingIntegrationTests: XCTestCase {
-    private let core = PassthroughCoreMock()
+    private let core = PassthroughCoreMock(
+        messageReceiver: LoggingMessageReceiver(logEventMapper: nil)
+    )
 
     func testSendingLogWithOTMessageField() throws {
         core.expectation = expectation(description: "Send log")
 
         // Given
-        let integration = TracingWithLoggingIntegration(core: core, logBuilder: .mockAny())
+        let integration = TracingWithLoggingIntegration(core: core, configuration: .mockAny())
 
         // When
         integration.writeLog(
@@ -23,7 +25,8 @@ class TracingWithLoggingIntegrationTests: XCTestCase {
                 OTLogFields.message: "hello",
                 "custom field": 123,
             ],
-            date: .mockDecember15th2019At10AMUTC()
+            date: .mockDecember15th2019At10AMUTC(),
+            else: {}
         )
 
         // Then
@@ -51,25 +54,28 @@ class TracingWithLoggingIntegrationTests: XCTestCase {
         core.expectation?.expectedFulfillmentCount = 3
 
         // Given
-        let integration = TracingWithLoggingIntegration(core: core, logBuilder: .mockAny())
+        let integration = TracingWithLoggingIntegration(core: core, configuration: .mockAny())
 
         // When
         integration.writeLog(
             withSpanContext: .mockAny(),
             fields: [OTLogFields.event: "error"],
-            date: .mockAny()
+            date: .mockAny(),
+            else: {}
         )
 
         integration.writeLog(
             withSpanContext: .mockAny(),
             fields: [OTLogFields.errorKind: "Swift error"],
-            date: .mockAny()
+            date: .mockAny(),
+            else: {}
         )
 
         integration.writeLog(
             withSpanContext: .mockAny(),
             fields: [OTLogFields.event: "error", OTLogFields.errorKind: "Swift error"],
-            date: .mockAny()
+            date: .mockAny(),
+            else: {}
         )
 
         // Then
@@ -87,13 +93,14 @@ class TracingWithLoggingIntegrationTests: XCTestCase {
         core.expectation = expectation(description: "Send log")
 
         // Given
-        let integration = TracingWithLoggingIntegration(core: core, logBuilder: .mockAny())
+        let integration = TracingWithLoggingIntegration(core: core, configuration: .mockAny())
 
         // When
         integration.writeLog(
             withSpanContext: .mockWith(traceID: 1, spanID: 2),
             fields: ["custom field": 123],
-            date: .mockDecember15th2019At10AMUTC()
+            date: .mockDecember15th2019At10AMUTC(),
+            else: {}
         )
 
         // Then

--- a/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingFeatureTests.swift
@@ -68,7 +68,7 @@ class LoggingFeatureTests: XCTestCase {
         // Given
         let featureConfiguration: LoggingFeature.Configuration = .mockWith(uploadURL: randomUploadURL)
         let feature: LoggingFeature = try core.create(
-            configuration: createLoggingConfiguration(intake: randomUploadURL),
+            configuration: createLoggingConfiguration(intake: randomUploadURL, logEventMapper: nil),
             featureSpecificConfiguration: featureConfiguration
         )
         defer { feature.flush() }
@@ -135,7 +135,7 @@ class LoggingFeatureTests: XCTestCase {
         // Given
         let featureConfiguration: LoggingFeature.Configuration = .mockAny()
         let feature: LoggingFeature = try core.create(
-            configuration: createLoggingConfiguration(intake: featureConfiguration.uploadURL),
+            configuration: createLoggingConfiguration(intake: featureConfiguration.uploadURL, logEventMapper: nil),
             featureSpecificConfiguration: featureConfiguration
         )
         defer { feature.flush() }

--- a/Tests/DatadogTests/Datadog/Logging/LoggingMessageReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingMessageReceiverTests.swift
@@ -1,0 +1,151 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+
+@testable import Datadog
+
+class LoggingMessageReceiverTests: XCTestCase {
+    func testReceiveIncompleteLogMessage() throws {
+        let expectation = expectation(description: "Don't send log fallback")
+
+        // Given
+        let core = PassthroughCoreMock(
+            context: .mockWith(service: "service-test"),
+            messageReceiver: LoggingMessageReceiver(logEventMapper: nil)
+        )
+
+        // When
+        core.send(
+            message: .custom(
+                key: "log",
+                attributes: [
+                    "date": Date.mockDecember15th2019At10AMUTC(),
+                    "message": "message-test",
+                ]
+            ),
+            else: { expectation.fulfill() }
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+        XCTAssertTrue(core.events.isEmpty)
+    }
+
+    func testReceivePartialLogMessage() throws {
+        // Given
+        let core = PassthroughCoreMock(
+            context: .mockWith(service: "service-test"),
+            expectation: expectation(description: "Send log"),
+            messageReceiver: LoggingMessageReceiver(logEventMapper: nil)
+        )
+
+        // Given
+        core.send(
+            message: .custom(
+                key: "log",
+                attributes: [
+                    "date": Date.mockDecember15th2019At10AMUTC(),
+                    "loggerName": "logger-test",
+                    "threadName": "thread-test",
+                    "message": "message-test",
+                    "level": LogLevel.info
+                ]
+            )
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let log: LogEvent = try XCTUnwrap(core.events().last, "It should send log")
+        XCTAssertEqual(log.date, .mockDecember15th2019At10AMUTC())
+        XCTAssertEqual(log.loggerName, "logger-test")
+        XCTAssertEqual(log.serviceName, "service-test")
+        XCTAssertEqual(log.threadName, "thread-test")
+        XCTAssertEqual(log.message, "message-test")
+        XCTAssertEqual(log.status, .info)
+        XCTAssertNil(log.error)
+        XCTAssertTrue(log.attributes.userAttributes.isEmpty)
+        XCTAssertNil(log.attributes.internalAttributes)
+        XCTAssertNil(log.networkConnectionInfo)
+    }
+
+    func testReceiveCompleteLogMessage() throws {
+        // Given
+        let core = PassthroughCoreMock(
+            context: .mockAny(),
+            expectation: expectation(description: "Send log"),
+            messageReceiver: LoggingMessageReceiver(logEventMapper: nil)
+        )
+
+        // Given
+        core.send(
+            message: .custom(
+                key: "log",
+                attributes: [
+                    "date": Date.mockDecember15th2019At10AMUTC(),
+                    "loggerName": "logger-test",
+                    "service": "service-test",
+                    "threadName": "thread-test",
+                    "message": "message-test",
+                    "level": LogLevel.info,
+                    "error": DDError.mockAny(),
+                    "userAttributes": ["user": "attribute"],
+                    "internalAttributes": ["internal": "attribute"],
+                    "sendNetworkInfo": true
+                ]
+            )
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let log: LogEvent = try XCTUnwrap(core.events().last, "It should send log")
+        XCTAssertEqual(log.date, .mockDecember15th2019At10AMUTC())
+        XCTAssertEqual(log.loggerName, "logger-test")
+        XCTAssertEqual(log.serviceName, "service-test")
+        XCTAssertEqual(log.threadName, "thread-test")
+        XCTAssertEqual(log.message, "message-test")
+        XCTAssertEqual(log.status, .info)
+        XCTAssertEqual(log.error?.message, "abc")
+        XCTAssertEqual(
+            log.attributes.userAttributes as? [String: String],
+            ["user": "attribute"]
+        )
+        XCTAssertEqual(
+            log.attributes.internalAttributes as? [String: String],
+            ["internal": "attribute"]
+        )
+        XCTAssertNotNil(log.networkConnectionInfo)
+    }
+
+    func testReceiveRejectedLogMessage() throws {
+        // Given
+        let core = PassthroughCoreMock(
+            context: .mockWith(service: "service-test"),
+            expectation: expectation(description: "Open scope but don't send log"),
+            messageReceiver: LoggingMessageReceiver(logEventMapper: { _ in nil })
+        )
+
+        // When
+        core.send(
+            message: .custom(
+                key: "log",
+                attributes: [
+                    "date": Date.mockDecember15th2019At10AMUTC(),
+                    "loggerName": "logger-test",
+                    "threadName": "thread-test",
+                    "message": "message-test",
+                    "level": LogLevel.info
+                ]
+            )
+        )
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+        XCTAssertTrue(core.events.isEmpty)
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -20,7 +20,8 @@ extension LoggingFeature {
     /// Mocks the feature instance which performs writes to `InMemoryWriter`.
     /// Use `LogFeature.waitAndReturnLogMatchers()` to inspect and assert recorded `Logs`.
     static func mockByRecordingLogMatchers(
-        featureConfiguration: FeaturesConfiguration.Logging = .mockAny()
+        featureConfiguration: FeaturesConfiguration.Logging = .mockAny(),
+        messageReceiver: FeatureMessageReceiver = LoggingMessageReceiver(logEventMapper: nil)
     ) -> LoggingFeature {
         // Mock storage with `InMemoryWriter`, used later for retrieving recorded events back:
         let interceptedStorage = FeatureStorage(
@@ -33,7 +34,7 @@ extension LoggingFeature {
             storage: interceptedStorage,
             upload: .mockNoOp(),
             configuration: featureConfiguration,
-            messageReceiver: NOPFeatureMessageReceiver()
+            messageReceiver: messageReceiver
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -261,8 +261,7 @@ extension Tracer {
         configuration: Configuration = .init(),
         spanEventMapper: SpanEventMapper? = nil,
         tracingUUIDGenerator: TracingUUIDGenerator = DefaultTracingUUIDGenerator(),
-        rumContextIntegration: TracingWithRUMContextIntegration? = nil,
-        loggingIntegration: TracingWithLoggingIntegration? = nil
+        rumContextIntegration: TracingWithRUMContextIntegration? = nil
     ) -> Tracer {
         return Tracer(
             core: core,
@@ -270,7 +269,7 @@ extension Tracer {
             spanEventMapper: spanEventMapper,
             tracingUUIDGenerator: tracingUUIDGenerator,
             rumContextIntegration: rumContextIntegration,
-            loggingIntegration: loggingIntegration
+            loggingIntegration: .init(core: core, tracerConfiguration: configuration)
         )
     }
 }
@@ -303,6 +302,16 @@ extension SpanEventBuilder {
             source: source,
             origin: origin,
             eventsMapper: eventsMapper
+        )
+    }
+}
+
+extension TracingWithLoggingIntegration.Configuration: AnyMockable {
+    static func mockAny() -> TracingWithLoggingIntegration.Configuration {
+        .init(
+            service: .mockAny(),
+            loggerName: .mockAny(),
+            sendNetworkInfo: true
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerConfigurationTests.swift
@@ -69,37 +69,4 @@ class TracerConfigurationTests: XCTestCase {
         XCTAssertTrue(tracer.configuration.sendNetworkInfo)
         XCTAssertNil(tracer.rumContextIntegration)
     }
-
-    func testWhenLoggingFeatureIsEnabled_itUsesLogsIntegration() throws {
-        // When
-        core.register(feature: LoggingFeature.mockNoOp())
-
-        // Then
-        let tracer = Tracer.initialize(
-            configuration: .init(
-                serviceName: .mockRandom(),
-                sendNetworkInfo: .mockRandom(),
-                bundleWithRUM: .mockAny(),
-                globalTags: nil
-            ),
-            in: core
-        ).dd
-        let tracingLogBuilder = try XCTUnwrap(
-            tracer.loggingIntegration?.logBuilder,
-            "When Logging feature is enabled Tracer should use `loggingIntegration`."
-        )
-        XCTAssertEqual(tracingLogBuilder.service, tracer.configuration.serviceName)
-        XCTAssertEqual(tracingLogBuilder.loggerName, "trace")
-        XCTAssertEqual(tracingLogBuilder.sendNetworkInfo, tracer.configuration.sendNetworkInfo)
-        XCTAssertNil(tracingLogBuilder.eventMapper)
-    }
-
-    func testWhenLoggingFeatureIsNotEnabled_itDoesNotUseLogsIntegration() throws {
-        // When
-        XCTAssertNil(core.v1.feature(LoggingFeature.self))
-
-        // Then
-        let tracer = Tracer.initialize(configuration: .init(), in: core).dd
-        XCTAssertNil(tracer.loggingIntegration)
-    }
 }

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -8,7 +8,10 @@ import XCTest
 @testable import Datadog
 
 class URLSessionTracingHandlerTests: XCTestCase {
-    private let core = PassthroughCoreMock()
+    private let core = PassthroughCoreMock(
+        messageReceiver: LoggingMessageReceiver(logEventMapper: nil)
+    )
+
     private let handler = URLSessionTracingHandler(
         appStateListener: AppStateListenerMock(
             history: .init(
@@ -20,18 +23,7 @@ class URLSessionTracingHandlerTests: XCTestCase {
     )
 
     override func setUp() {
-        Global.sharedTracer = Tracer.mockWith(
-            core: core,
-            loggingIntegration: .init(
-                core: core,
-                logBuilder: .init(
-                    service: .mockAny(),
-                    loggerName: .mockAny(),
-                    sendNetworkInfo: .mockAny(),
-                    eventMapper: nil
-                )
-            )
-        )
+        Global.sharedTracer = Tracer.mockWith(core: core)
         super.setUp()
     }
 

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
@@ -28,15 +28,15 @@ class DDSpanTests: XCTestCase {
     // MARK: - Sending Span Logs
 
     func testWhenLoggingSpanEvent_itWritesLogToLogOutput() throws {
-        let core = PassthroughCoreMock()
+        let core = PassthroughCoreMock(
+            messageReceiver: LoggingMessageReceiver(logEventMapper: nil)
+        )
+
         core.expectation = expectation(description: "write span event")
         core.expectation?.expectedFulfillmentCount = 2
 
         // Given
-        let tracer: Tracer = .mockWith(
-            core: core,
-            loggingIntegration: .init(core: core, logBuilder: .mockAny())
-        )
+        let tracer: Tracer = .mockWith(core: core)
         let span: DDSpan = .mockWith(tracer: tracer)
 
         // When
@@ -169,12 +169,9 @@ class DDSpanTests: XCTestCase {
         let dd = DD.mockWith(logger: CoreLoggerMock())
         defer { dd.reset() }
 
-        let core = PassthroughCoreMock()
+        let core = PassthroughCoreMock(messageReceiver: FeatureMessageReceiverMock())
         let span: DDSpan = .mockWith(
-            tracer: .mockWith(
-                core: core,
-                loggingIntegration: .init(core: core, logBuilder: .mockAny())
-            ),
+            tracer: .mockWith(core: core),
             operationName: "the span"
         )
         span.finish()


### PR DESCRIPTION
### What and why?

Send Span log to Logs through the message bus.

### How?

`TracingWithLoggingIntegration` no longer write a `LogEvent` on the Logs event write, but build and send a message instead.

### Pattern Proposal

This PR introduces `DatadogExtension` and `DatadogExtended` which is a pattern from [Alamofire](https://github.com/Alamofire/Alamofire/blob/master/Source/AlamofireExtended.swift). This pattern allows to expose external libraries extensions hided behind a `dd` property (instance or static). It can be useful when sharing type extension through `DatadogInternal`. Here, it expose the extended property `name` of type `Foundation.Thread`
```swift
Thread.current.dd.name // returns the current thread name extended by Datadog
```


### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
