### PR TITLE
Create core logic for rage tap identification

### DIFF
--- a/Sources/Datadog/RUM/FrustrationSignals/RageTapManager.swift
+++ b/Sources/Datadog/RUM/FrustrationSignals/RageTapManager.swift
@@ -1,0 +1,154 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import UIKit
+
+
+internal class RageTapManager{
+    struct Constants {
+        static let rageTapWindowTimeout : TimeInterval = 1 // 1 second
+        static let maximumTouchDistance : Double = 48*2  // ~9mm
+        static let minimumRageClicksPerSecond = 3
+    }
+    
+    class RageTapChain {
+        var lastTapPosition = CGPoint()
+        var actionCommands = [RUMAddUserActionCommand]()
+        var chainTimeout : DispatchWorkItem?
+        var workQueue : DispatchQueue?
+        
+    }
+    
+    var rageTapChainPerUIElement = [ObjectIdentifier:RageTapChain]()
+    var identifyRageTaps = true //TODO - Add API/property to change this
+    
+    
+    func canAcceptTapIntoChain(chain: RageTapChain, tapLocation: CGPoint) -> Bool{
+        if chain.actionCommands.count == 0 {
+            return true
+        }
+        
+        let sqDistanceX = (chain.lastTapPosition.x - tapLocation.x) * (chain.lastTapPosition.x - tapLocation.x)
+        let sqDistanceY = (chain.lastTapPosition.y - tapLocation.y) * (chain.lastTapPosition.y - tapLocation.y)
+
+        if (sqDistanceX + sqDistanceY) <= (RageTapManager.Constants.maximumTouchDistance * RageTapManager.Constants.maximumTouchDistance){
+            return true;
+        }
+        
+        return false
+    }
+    
+    func tryToFinalizeChain(identifier: ObjectIdentifier){
+        guard let chain = rageTapChainPerUIElement[identifier] else {
+            return
+        }
+        
+        guard let subscriber = subscriber else {
+            return
+        }
+        
+        var tapsWithinTimeout = [TimeInterval]()
+        
+        for tap in chain.actionCommands
+        {
+            tapsWithinTimeout.append(tap.time.timeIntervalSince1970)
+
+            if(tapsWithinTimeout.count == RageTapManager.Constants.minimumRageClicksPerSecond){
+                guard let firstTapTime = tapsWithinTimeout.first?.toInt64Milliseconds else {
+                    break
+                }
+                guard let lastTapTime = tapsWithinTimeout.last?.toInt64Milliseconds else {
+                    break
+                }
+                
+                let timeDiff = lastTapTime - firstTapTime
+                if (timeDiff < RageTapManager.Constants.rageTapWindowTimeout.toInt64Milliseconds)
+                {
+                    // Create rage tap at the last tap of the chain,
+                    // even though we already had matching conditions before that
+                    guard var lastCommand = chain.actionCommands.last else {
+                        break
+                    }
+                    lastCommand.isRage = true
+
+                    subscriber.process(command: lastCommand)
+                    return
+                    
+                }else{
+                    tapsWithinTimeout.remove(at: 0)
+                }
+            }
+        }
+        
+        // Failed to identify chain, send withholded events
+        for tap in chain.actionCommands
+        {
+            subscriber.process(command: tap)
+        }
+    }
+    
+    func addCommandIntoChain(command:RUMAddUserActionCommand, chain: RageTapChain, touch: UITouch){
+        chain.actionCommands.append(command)
+        chain.lastTapPosition = touch.location(in:nil)
+    }
+    
+    func startTimeoutTimerForChain(chain: RageTapChain, identifier:ObjectIdentifier){
+        let workItem = DispatchWorkItem { self.tryToFinalizeChain(identifier: identifier) }
+        chain.chainTimeout = workItem
+        DispatchQueue.global().asyncAfter(deadline: .now() + RageTapManager.Constants.rageTapWindowTimeout, execute: workItem)
+    }
+    
+    func processActionCommand(command: RUMAddUserActionCommand, event: UIEvent) -> Bool {
+        guard let targetView = command.targetView else {
+            return false
+        }
+        guard let touch = event.allTouches?.first else {
+            return false
+        }
+        
+        if !identifyRageTaps {
+            return false
+        }
+        let identifier = ObjectIdentifier(targetView)
+
+        // Check if we already have an ongoing chain for this object
+        if let rageTapChain = rageTapChainPerUIElement[identifier] {
+            rageTapChain.chainTimeout?.cancel()
+            
+            if canAcceptTapIntoChain(chain: rageTapChain, tapLocation: touch.location(in: nil)){
+                addCommandIntoChain(command: command, chain: rageTapChain, touch: touch)
+
+                startTimeoutTimerForChain(chain: rageTapChain, identifier: identifier)
+            } else{
+                // Touch was outside of acceptance distance for current object.
+                // Try to finalize the current chain and start a new one
+
+                tryToFinalizeChain(identifier: identifier)
+                
+                rageTapChain.actionCommands.removeAll()
+                addCommandIntoChain(command: command, chain: rageTapChain, touch: touch)
+                startTimeoutTimerForChain(chain: rageTapChain, identifier: identifier)
+
+            }
+        }else{
+            let newChain = RageTapChain()
+            addCommandIntoChain(command: command, chain: newChain, touch: touch)
+            rageTapChainPerUIElement[identifier] = newChain
+            
+            startTimeoutTimerForChain(chain: newChain, identifier: identifier)
+        }
+        
+        return true
+
+    }
+    
+    // TODO - Handle app closing (flush events)
+
+    weak var subscriber: RUMCommandSubscriber?
+
+    init(){}
+}

--- a/Sources/Datadog/RUM/Instrumentation/Actions/UIKit/UIKitRUMUserActionsHandler.swift
+++ b/Sources/Datadog/RUM/Instrumentation/Actions/UIKit/UIKitRUMUserActionsHandler.swift
@@ -15,6 +15,7 @@ internal protocol UIEventCommandFactory {
 }
 
 internal class UIKitRUMUserActionsHandler: UIEventHandler {
+    let rageActionManager = RageTapManager()
     let factory: UIEventCommandFactory
 
     convenience init(dateProvider: DateProvider, predicate: UITouchRUMUserActionsPredicate) {
@@ -37,6 +38,7 @@ internal class UIKitRUMUserActionsHandler: UIEventHandler {
 
     func publish(to subscriber: RUMCommandSubscriber) {
         self.subscriber = subscriber
+        rageActionManager.subscriber = subscriber
     }
 
     func notify_sendEvent(application: UIApplication, event: UIEvent) {
@@ -53,8 +55,10 @@ internal class UIKitRUMUserActionsHandler: UIEventHandler {
             )
             return
         }
-
-        subscriber.process(command: command)
+        
+        if !rageActionManager.processActionCommand(command: command, event: event){
+            subscriber.process(command: command)
+        }
     }
 }
 
@@ -112,6 +116,7 @@ internal struct UITouchCommandFactory: UIEventCommandFactory {
         return RUMAddUserActionCommand(
             time: dateProvider.now,
             attributes: action.attributes,
+            targetView: targetView,
             actionType: .tap,
             name: action.name
         )

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import UIKit
 
 /// Command processed through the tree of `RUMScopes`.
 internal protocol RUMCommand {
@@ -298,6 +299,8 @@ internal struct RUMStopUserActionCommand: RUMUserActionCommand {
 internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
+    var isRage = false
+    var targetView : UIView? = nil // Most likely target for this action
     let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
     let canStartApplicationLaunchView = true // yes, we want to track actions in "ApplicationLaunch" view (e.g. it makes sense for custom actions)
     let isUserInteraction = true // a user action definitely is a User Interacgion


### PR DESCRIPTION
### What and why?

Introduces core logic to transform taps into tap chains and from there identify rage taps according to certain constrains. 
It's intended to support chains on multiple objects at the same time, but only 1 chain per object

There's a few things that are still missing:
- Handling the current expiration restrictions around the age of events in `RumUserActionScope`
- Support for tvOS
- Unit Tests
- Code clean up
- Clarification around exposing API to disable feature or not

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
