### PR TITLE
RUMM-2429 [SR] Capture `UIViews` and `UILabels` semantics

### DIFF
--- a/session-replay/Sources/DatadogSessionReplay/Processor/Flattening/NodesFlattener.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/Flattening/NodesFlattener.swift
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import CoreGraphics
+
+/// Flattens VTS received from `Recorder` by transforming its tree-structure of nodes into array of nodes.
+///
+/// Flattening includes removal of nodes that are invisible because of being covered by other nodes displayed
+/// closer to the screen surface.
+internal struct NodesFlattener {
+    /// This current implementation is greedy and works in `O(n*log(n))`, wheares `O(n)` is possible.
+    /// TODO: RUMM-2461 Improve flattening performance.
+    func flattenNodes(in snapshot: ViewTreeSnapshot) -> [Node] {
+        var flattened: [Node] = []
+
+        dfsVisit(startingFrom: snapshot.root) { nextNode in
+            // Skip nodes with no semantics:
+            if nextNode.semantics.importance > InvisibleElement.importance {
+                // When accepting nodes, remove ones that are covered by another opaque node:
+                flattened = flattened.compactMap { previousNode in
+                    let isPreviousNodeCovered = nextNode.viewAttributes.frame.contains(previousNode.viewAttributes.frame)
+                    let isNextNodeOpaque = nextNode.viewAttributes.alpha == 1
+                    return (isPreviousNodeCovered && isNextNodeOpaque) ? nil : previousNode
+                }
+
+                flattened.append(nextNode)
+            }
+        }
+
+        return flattened
+    }
+
+    private func dfsVisit(startingFrom node: Node, visit: (Node) -> Void) {
+        visit(node)
+        node.children.forEach { child in
+            dfsVisit(startingFrom: child, visit: visit)
+        }
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/RecordsBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/RecordsBuilder.swift
@@ -20,9 +20,9 @@ internal class RecordsBuilder {
     func createMetaRecord(from snapshot: ViewTreeSnapshot) -> SRRecord {
         let record = SRMetaRecord(
             data: .init(
-                height: snapshot.root.frame.height,
+                height: Int64(withNoOverflow: snapshot.root.viewAttributes.frame.height),
                 href: nil,
-                width: snapshot.root.frame.width
+                width: Int64(withNoOverflow: snapshot.root.viewAttributes.frame.width)
             ),
             timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
         )

--- a/session-replay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -5,6 +5,8 @@
  */
 
 import Foundation
+import CoreGraphics
+import UIKit
 
 /// TODO: RUMM-2440 - configure models generator to emit root-level `SRWireframe` instead of this
 internal typealias SRWireframe = SRMobileFullSnapshotRecord.Data.Wireframes
@@ -16,25 +18,134 @@ internal typealias SRWireframe = SRMobileFullSnapshotRecord.Data.Wireframes
 ///
 /// Note: `WireframesBuilder` is used by `Processor` on a single background thread.
 internal class WireframesBuilder {
+    /// A set of fallback values to use if the actual value cannot be read or converted.
+    ///
+    /// The idea is to always provide value, which would make certain element visible in the player.
+    /// This should create faster feedback loop than if skipping inconsistent wireframes.
+    struct Fallback {
+        /// The color (solid red) to use when the actual color conversion goes wrong.
+        static let color = "#FF0000FF"
+        /// The font family to use when the actual one cannot be read.
+        static let fontFamily = "-apple-system, Roboto, Helvetica, Arial"
+        /// The font size to use when the actual one cannot be read.
+        static let fontSize: CGFloat = 10
+    }
+
     /// TODO: RUMM-2272 Add a stable way of managing wireframe IDs (so they can be reduced in incremental SR records)
     var dummyIDsGenerator: Int64 = 0
 
-    func createShapeWireframe(from node: Node) -> SRWireframe {
+    func createShapeWireframe(
+        frame: CGRect,
+        borderColor: CGColor? = nil,
+        borderWidth: CGFloat? = nil,
+        backgroundColor: CGColor? = nil,
+        cornerRadius: CGFloat? = nil,
+        opacity: CGFloat? = nil
+    ) -> SRWireframe {
         dummyIDsGenerator += 1
 
-        // TODO: RUMM-2429 Record real appearance information in `Node`
-        let shape = SRShapeWireframe(
-            border: .init(color: "#4900FF", width: 1),
-            height: node.frame.height,
+        var border: SRShapeWireframe.Border? = nil
+
+        if let borderColor = borderColor, let borderWidth = borderWidth, borderWidth > 0.0 {
+            border = .init(
+                color: hexString(from: borderColor) ?? Fallback.color,
+                width: Int64(withNoOverflow: borderWidth.rounded(.up))
+            )
+        }
+
+        var style: SRShapeWireframe.ShapeStyle? = nil
+
+        if let backgroundColor = backgroundColor {
+            style = .init(
+                backgroundColor: hexString(from: backgroundColor) ?? Fallback.color,
+                cornerRadius: cornerRadius.map { Double($0) },
+                opacity: opacity.map { Double($0) }
+            )
+        }
+
+        let wireframe = SRShapeWireframe(
+            border: border,
+            height: Int64(withNoOverflow: frame.height),
             id: dummyIDsGenerator,
-            shapeStyle: nil,
-            width: node.frame.width,
-            x: node.frame.x,
-            y: node.frame.y
+            shapeStyle: style,
+            width: Int64(withNoOverflow: frame.width),
+            x: Int64(withNoOverflow: frame.minX),
+            y: Int64(withNoOverflow: frame.minY)
         )
 
-        return .shapeWireframe(value: shape)
+        return .shapeWireframe(value: wireframe)
     }
 
-    // TODO: RUMM-2429 Create specialised wireframes for different UI elements
+    func createTextWireframe(
+        frame: CGRect,
+        text: String,
+        textFrame: CGRect? = nil,
+        textColor: CGColor? = nil,
+        font: UIFont? = nil,
+        borderColor: CGColor? = nil,
+        borderWidth: CGFloat? = nil,
+        backgroundColor: CGColor? = nil,
+        cornerRadius: CGFloat? = nil,
+        opacity: CGFloat? = nil
+    ) -> SRWireframe {
+        dummyIDsGenerator += 1
+
+        // TODO: RUMM-2440 Share `.border` type between wireframes:
+        var border: SRTextWireframe.Border? = nil
+
+        if let borderColor = borderColor, let borderWidth = borderWidth, borderWidth > 0.0 {
+            border = .init(
+                color: hexString(from: borderColor) ?? Fallback.color,
+                width: Int64(withNoOverflow: borderWidth.rounded(.up))
+            )
+        }
+
+        // TODO: RUMM-2440 Share `.style` type between wireframes:
+        var style: SRTextWireframe.ShapeStyle? = nil
+
+        if let backgroundColor = backgroundColor {
+            style = .init(
+                backgroundColor: hexString(from: backgroundColor) ?? Fallback.color,
+                cornerRadius: cornerRadius.map { Double($0) },
+                opacity: opacity.map { Double($0) }
+            )
+        }
+
+        var textPosition: SRTextWireframe.TextPosition? = nil
+
+        if let textFrame = textFrame {
+            textPosition = .init(
+                alignment: nil, // TODO: RUMM-2452 Improve text rendering
+                padding: .init(
+                    bottom: Int64(withNoOverflow: frame.maxY - textFrame.maxY),
+                    left: Int64(withNoOverflow: textFrame.minX - frame.minX),
+                    right: Int64(withNoOverflow: frame.maxX - textFrame.maxX),
+                    top: Int64(withNoOverflow: textFrame.minY - frame.minY)
+                )
+            )
+        }
+
+        // TODO: RUMM-2452 Better recognize the font:
+        let textStyle = SRTextWireframe.TextStyle(
+            color: textColor.flatMap { hexString(from: $0) } ?? Fallback.color,
+            family: Fallback.fontFamily,
+            size: Int64(withNoOverflow: font?.pointSize ?? Fallback.fontSize),
+            type: .sansSerif
+        )
+
+        let wireframe = SRTextWireframe(
+            border: border,
+            height: Int64(withNoOverflow: frame.height),
+            id: dummyIDsGenerator,
+            shapeStyle: style,
+            text: text,
+            textPosition: textPosition,
+            textStyle: textStyle,
+            width: Int64(withNoOverflow: frame.width),
+            x: Int64(withNoOverflow: frame.minX),
+            y: Int64(withNoOverflow: frame.minY)
+        )
+
+        return .textWireframe(value: wireframe)
+    }
 }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/NodeRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/NodeRecorder.swift
@@ -1,0 +1,62 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+/// A type recording semantics of a given `UIView` or its subclasses. Different implementations of `NodeRecorder` should
+/// recognise specialised subclasses of `UIView` and record their semantics accordingly.
+///
+/// **Note:** The `NodeRecorder` is used on the main thread by `Recorder`.
+internal protocol NodeRecorder {
+    /// The `UIView` subclass this recorder is specialised for.
+    associatedtype View: UIView
+
+    /// Finds the semantic of given`view`.
+    /// - Parameters:
+    ///   - view: the view to determine semantics for
+    ///   - attributes: attributes of this view inferred from its base `UIView` interface
+    ///   - context: the context of building current `ViewTreeSnapshot`
+    /// - Returns: the value of `NodeSemantics` or `nil` if the view is a member of view subclass other than the one this recorder is specialised for.
+    func semantics(of view: View, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics?
+}
+
+/// A type producing SR wireframes.
+///
+/// Each type of UI element (e.g.: label, text field, toggle, button) should provide their own implementaion of `NodeWireframesBuilder`.
+///
+/// **Note:** The `NodeWireframesBuilder` is used on background thread by `Processor`.
+internal protocol NodeWireframesBuilder {
+    /// Creates wireframes that are later uploaded to SR backend.
+    /// - Parameter builder: the generic builder for constructing SR data models.
+    /// - Returns: one or more wireframes that describe a node in SR.
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe]
+}
+
+// MARK: - Type Erasure
+
+/// Type erasure for `NodeRecorder`.
+internal struct AnyNodeRecorder<View> {
+    private let erasedMethod: (View, ViewAttributes, ViewTreeSnapshotBuilder.Context) -> NodeSemantics?
+
+    init<NR: NodeRecorder>(_ concreteRecorder: NR) {
+        self.erasedMethod = { view, node, context in
+            guard let concreteView = view as? NR.View else {
+                // Means that the `UIView` instance passed to erased `NodeRecorder` was not of the type
+                // that this recorder supports. In that case, semantics cannot be determined.
+                return nil
+            }
+            return concreteRecorder.semantics(of: concreteView, with: node, in: context)
+        }
+    }
+
+    func semantics(of view: View, with node: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        return erasedMethod(view, node, context)
+    }
+}
+
+extension NodeRecorder {
+    var eraseToAnyNodeRecorder: AnyNodeRecorder<UIView> { AnyNodeRecorder(self) }
+}

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
@@ -7,7 +7,11 @@
 import UIKit
 
 internal struct UILabelRecorder: NodeRecorder {
-    func semantics(of label: UILabel, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        guard let label = view as? UILabel else {
+            return nil
+        }
+
         let hasVisibleText = !(label.text?.isEmpty ?? true)
 
         guard hasVisibleText || attributes.hasAnyAppearance else {

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal struct UILabelRecorder: NodeRecorder {
+    func semantics(of label: UILabel, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        let hasVisibleText = !(label.text?.isEmpty ?? true)
+
+        guard hasVisibleText || attributes.hasAnyAppearance else {
+            return InvisibleElement.constant
+        }
+
+        let builder = UILabelWireframesBuilder(
+            attributes: attributes,
+            text: label.text ?? "",
+            textColor: label.textColor?.cgColor,
+            font: label.font
+        )
+        return SpecificElement(wireframesBuilder: builder)
+    }
+}
+
+internal struct UILabelWireframesBuilder: NodeWireframesBuilder {
+    /// Attributes of the base `UIView`.
+    let attributes: ViewAttributes
+    /// The text inside label.
+    let text: String
+    /// The color of the text.
+    let textColor: CGColor?
+    /// The font used by the label.
+    let font: UIFont?
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        // The actual frame of the text, which is smaller than the frame of the label:
+        let textFrame = CGRect(
+            x: attributes.frame.minX,
+            y: attributes.frame.minY + (attributes.frame.height - attributes.intrinsicContentSize.height) * 0.5,
+            width: attributes.intrinsicContentSize.width,
+            height: attributes.intrinsicContentSize.height
+        )
+
+        return [
+            builder.createTextWireframe(
+                frame: attributes.frame,
+                text: text,
+                textFrame: textFrame,
+                textColor: textColor,
+                font: font,
+                borderColor: attributes.layerBorderColor,
+                borderWidth: attributes.layerBorderWidth,
+                backgroundColor: attributes.backgroundColor,
+                cornerRadius: attributes.layerCornerRadius,
+                opacity: attributes.alpha
+            )
+        ]
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UIViewRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UIViewRecorder.swift
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal struct UIViewRecorder: NodeRecorder {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        guard attributes.isVisible else {
+            return InvisibleElement.constant
+        }
+
+        let builder = UIViewWireframesBuilder(attributes: attributes)
+        return AmbiguousElement(wireframesBuilder: builder)
+    }
+}
+
+internal struct UIViewWireframesBuilder: NodeWireframesBuilder {
+    /// Attributes of the `UIView`.
+    let attributes: ViewAttributes
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        return [
+            builder.createShapeWireframe(
+                frame: attributes.frame,
+                borderColor: attributes.layerBorderColor,
+                borderWidth: attributes.layerBorderWidth,
+                backgroundColor: attributes.backgroundColor,
+                cornerRadius: attributes.layerCornerRadius,
+                opacity: attributes.alpha
+            )
+        ]
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshot.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshot.swift
@@ -5,6 +5,8 @@
  */
 
 import Foundation
+import CoreGraphics
+import UIKit
 
 /// The `ViewTreeSnapshot` is an intermediate representation of the app UI in Session Replay
 /// recording: [views hierarchy] → [`ViewTreeSnapshot`] → [wireframes].
@@ -13,36 +15,175 @@ import Foundation
 /// it doesn't translate 1:1 into wireframes that get uploaded to the SR BE. Instead, it provides its
 /// own description of the view hierarchy, which can be optimised for efficiency in SR recorder (e.g. unlike
 /// the real views hierarchy, `ViewTreeSnapshot` is meant to be safe when accesed on a background thread).
-internal struct ViewTreeSnapshot: Equatable {
+internal struct ViewTreeSnapshot {
     /// The time of taking this snapshot.
     let date: Date
 
-    /// The snapshot of a root view.
+    /// The node indicating the root view of this snapshot.
     let root: Node
+}
 
-    /// An individual node in the`ViewTreeSnapshot` tree structure. It denotes a snapshot of an individual view
-    /// or views hierarchy.
+/// An individual node in `ViewTreeSnapshot`. It abstracts an individual view or part of views hierarchy.
+///
+/// The `Node` can describe a view by nesting nodes for each of its subviews OR it can abstract the view along with its childs
+/// by merging their information into single node. This stands for the key difference between the hierarchy of native views and
+/// hierarchy of nodes - typically there is significantly less nodes than number of native views they describe.
+///
+/// **Note:** The purpose of this structure is to be lightweight and create minimal overhead when the view-tree
+/// is captured on the main thread (the `Recorder` constantly creates `Nodes` for views residing in the hierarchy).
+internal struct Node {
+    /// Attributes of the `UIView` that this node was created for.
+    let viewAttributes: ViewAttributes
+
+    /// The semantics of this node.
+    let semantics: NodeSemantics
+
+    /// Nodes created for subviews of this node's `UIView`.
+    let children: [Node]
+}
+
+/// Attributes of the `UIView` that the node was created for.
+///
+/// It is used by the `Recorder` to capture view attributes on the main thread.
+/// It enforces immutability for later (thread safe) access from background queue in `Processor`.
+internal struct ViewAttributes: Equatable {
+    /// The view's `frame`, in VTS's root view's coordinate space (usually, the screen coordinate space).
+    let frame: CGRect
+
+    /// Original view's `.backgorundColor`.
+    let backgroundColor: CGColor?
+
+    /// Original view's `layer.backgorundColor`.
+    let layerBorderColor: CGColor?
+
+    /// Original view's `layer.backgorundColor`.
+    let layerBorderWidth: CGFloat
+
+    /// Original view's `layer.cornerRadius`.
+    let layerCornerRadius: CGFloat
+
+    /// Original view's `.alpha` (between `0.0` and `1.0`).
+    let alpha: CGFloat
+
+    /// Original view's `.intrinsicContentSize`.
+    let intrinsicContentSize: CGSize
+
+    /// If the view is visible (considering: alpha + hidden state + non-zero frame).
     ///
-    /// The `Node` can describe a view by nesting nodes for each of its child views OR it can abstract
-    /// the view along with its childs by merging their information into single node. This stands for the key difference
-    /// between the hierarchy of native views and hierarchy of nodes - typically there is significantly less nodes
-    /// than number of native views they describe.
-    internal struct Node: Equatable {
-        internal struct Frame: Equatable {
-            /// The x position of this node, in VTS's root view coordinate space.
-            let x: Int64
-            /// The y position of this node, in VTS's root view coordinate space.
-            let y: Int64
-            /// The width of this node.
-            let width: Int64
-            /// The height of this node.
-            let height: Int64
-        }
+    /// Example: A can be not visible if it has `.zero` size or it is fully transparent.
+    let isVisible: Bool
 
-        /// Nodes (snapshots) denoting subviews of this node's view.
-        let children: [Node]
+    /// If the view has any visible appearance (considering: background color + border style)
+    ///
+    /// Example: A view might have no appearance if it has `0` border width and transparent fill color.
+    let hasAnyAppearance: Bool
+}
 
-        /// The frame of this node, in VTS's root view's coordinate space.
-        let frame: Frame
+extension ViewAttributes {
+    init(frameInRootView: CGRect, view: UIView) {
+        self.frame = frameInRootView
+        self.backgroundColor = view.backgroundColor?.cgColor
+        self.layerBorderColor = view.layer.borderColor
+        self.layerBorderWidth = view.layer.borderWidth
+        self.layerCornerRadius = view.layer.cornerRadius
+        self.intrinsicContentSize = view.intrinsicContentSize
+        self.alpha = view.alpha
+
+        let hasBorderAppearance: Bool = {
+            guard view.layer.borderWidth > 0, let borderAlpha = view.layer.borderColor?.alpha else {
+                return false
+            }
+            return borderAlpha > 0
+        }()
+
+        let hasFillAppearance: Bool = {
+            guard let fillAlpha = view.backgroundColor?.cgColor.alpha else {
+                return false
+            }
+            return fillAlpha > 0
+        }()
+
+        self.isVisible = !view.isHidden && view.alpha > 0 && frame != .zero
+        self.hasAnyAppearance = self.isVisible && (hasBorderAppearance || hasFillAppearance)
     }
+}
+
+/// A type denoting semantics of given UI element in Session Replay.
+///
+/// The `NodeSemantics` is attached to each node produced by `Recorder`. During tree traversal,
+/// views are queried in available node recorders. Each `NodeRecorder` inspects the view object and
+/// tries to infer its identity (a `NodeSemantics`).
+///
+/// There are two `NodeSemantics` that describe the identity of UI element:
+/// - `AmbiguousElement` - element is of `UIView` class and we only know its base attributes (the real identity could be ambiguous);
+/// - `SpecificElement` - element is one of `UIView` subclasses and we know its specific identity along with set of subclass-specific
+/// attributes (e.g. text in `UILabel` or the "on" / "off" state of `UISwitch` control).
+///
+/// Additionally, there are two utility semantics that control the processing of nodes in SR:
+/// - `InvisibleElement` - element is either `UIView` or one of its known subclasses, but it has no visual appearance in SR, so it can
+/// be safely ignored in `Recorder` or `Processor` (e.g. a `UILabel` with no text, no border and fully transparent color).
+/// - `UnknownElement` - the element is of unknown kind, which could indicate an error during view tree traversal (e.g. working on
+/// assumption that is not met).
+///
+/// Both `AmbiguousElement` and `SpecificElement` provide an implementation of `NodeWireframesBuilder` which describes
+/// how to construct SR wireframes for UI elements they refer to. No builder is provided for `InvisibleElement` and `UnknownElement`.
+internal protocol NodeSemantics {
+    /// The severity of this semantic.
+    ///
+    /// While querying certain `view` with an array of supported `NodeRecorders` each recorder can spot different semantics of
+    /// the same view. In that case, the semantics with higher `importance` takes precedence.
+    static var importance: Int { get }
+
+    /// A type defining how to build SR wireframes for the UI element this semantic was recorded for.
+    var wireframesBuilder: NodeWireframesBuilder? { get }
+}
+
+extension NodeSemantics {
+    /// The severity of this semantic.
+    ///
+    /// While querying certain `view` with an array of supported `NodeRecorders` each recorder can spot different semantics of
+    /// the same view. In that case, the semantics with higher `importance` takes precedence.
+    var importance: Int { Self.importance }
+}
+
+/// Semantics of an UI element that is of unknown kind. Receiving this semantics in `Processor` could indicate an error
+/// in view-tree traversal performed in `Recorder` (e.g. working on assumption that is not met).
+internal struct UnknownElement: NodeSemantics {
+    static let importance: Int = .min
+    let wireframesBuilder: NodeWireframesBuilder? = nil
+
+    /// Use `UnknownElement.constant` instead.
+    fileprivate init () {}
+
+    /// A constant value of `UnknownElement` semantics.
+    static let constant = UnknownElement()
+}
+
+/// A semantics of an UI element that is either `UIView` or one of its known subclasses. This semantics mean that the element
+/// has no visual appearance that can be presented in SR (e.g. a `UILabel` with no text, no border and fully transparent color).
+/// Nodes with this semantics can be safely ignored in `Recorder` or in `Processor`.
+internal struct InvisibleElement: NodeSemantics {
+    static let importance: Int = 0
+    let wireframesBuilder: NodeWireframesBuilder? = nil
+
+    /// Use `InvisibleElement.constant` instead.
+    fileprivate init () {}
+
+    /// A constant value of `InvisibleElement` semantics.
+    static let constant = InvisibleElement()
+}
+
+/// A semantics of an UI element that is of `UIView` type. This semantics mean that the element has visual appearance in SR, but
+/// it will only utilize its base `UIView` attributes. The full identity of the node will remain ambiguous if not overwritten with `SpecificElement`.
+internal struct AmbiguousElement: NodeSemantics {
+    static let importance: Int = 1
+    let wireframesBuilder: NodeWireframesBuilder?
+}
+
+/// A semantics of an UI element that is one of `UIView` subclasses. This semantics mean that we know its full identity along with set of
+/// subclass-specific attributes that will be used to render it in SR (e.g. all base `UIView` attributes plus the text in `UILabel` or the
+/// "on" / "off" state of `UISwitch` control).
+internal struct SpecificElement: NodeSemantics {
+    static let importance: Int = .max
+    let wireframesBuilder: NodeWireframesBuilder?
 }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshot.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshot.swift
@@ -153,7 +153,7 @@ internal struct UnknownElement: NodeSemantics {
     let wireframesBuilder: NodeWireframesBuilder? = nil
 
     /// Use `UnknownElement.constant` instead.
-    fileprivate init () {}
+    private init () {}
 
     /// A constant value of `UnknownElement` semantics.
     static let constant = UnknownElement()
@@ -167,7 +167,7 @@ internal struct InvisibleElement: NodeSemantics {
     let wireframesBuilder: NodeWireframesBuilder? = nil
 
     /// Use `InvisibleElement.constant` instead.
-    fileprivate init () {}
+    private init () {}
 
     /// A constant value of `InvisibleElement` semantics.
     static let constant = InvisibleElement()

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
@@ -7,16 +7,21 @@
 import Foundation
 import UIKit
 
-internal typealias Node = ViewTreeSnapshot.Node
-
 /// Builds `ViewTreeSnapshot` for given root view.
 ///
 /// Note: This builder is used by `Recorder` on the main thread.
 internal struct ViewTreeSnapshotBuilder {
     /// The context of building current snapshot.
-    private struct Context {
-        let rootView: UIView
+    struct Context {
+        /// The coordinate space to convert node positions to.
+        let coordinateSpace: UICoordinateSpace
     }
+
+    /// An array of enabled node recorders.
+    ///
+    /// The order in this this array  should be managed consciously. For each node, the implementation loops
+    /// through `nodeRecorders` and stops on the one that recorded node semantics with highes importance.
+    let nodeRecorders: [AnyNodeRecorder<UIView>]
 
     /// Builds the `ViewTreeSnapshot` for given root view.
     ///
@@ -24,8 +29,8 @@ internal struct ViewTreeSnapshotBuilder {
     /// - Returns: snapshot describing the view tree starting in `rootView`. All properties in snapshot nodes
     /// are computed relatively to the `rootView` (e.g. the `x` and `y` position of all descendant nodes  is given
     /// as its position in the root, no matter of nesting level).
-    func createSnapshot(of rootView: UIView) throws -> ViewTreeSnapshot {
-        let context = Context(rootView: rootView)
+    func createSnapshot(of rootView: UIView) -> ViewTreeSnapshot {
+        let context = Context(coordinateSpace: rootView)
         let viewTreeSnapshot = ViewTreeSnapshot(
             date: Date(),
             root: createNode(for: rootView, in: context)
@@ -33,27 +38,53 @@ internal struct ViewTreeSnapshotBuilder {
         return viewTreeSnapshot
     }
 
+    /// Takes the native view and creates its `Node` recursively.
     private func createNode(for anyView: UIView, in context: Context) -> Node {
-        let frameInRoot = anyView.convert(anyView.bounds, to: context.rootView)
-        let node = Node(
-            children: anyView.subviews.map { createNode(for: $0, in: context) },
-            frame: Node.Frame(cgRect: frameInRoot)
+        let viewAttributes = ViewAttributes(
+            frameInRootView: anyView.convert(anyView.bounds, to: context.coordinateSpace),
+            view: anyView
         )
-        return node
-    }
 
-    // TODO: RUMM-2429 Collect semantic information on various UI elements (UIButton, UILabel, UITabBar, ...)
+        var semantics: NodeSemantics = UnknownElement.constant
+
+        for nodeRecorder in nodeRecorders {
+            guard let nextSemantics = nodeRecorder.semantics(of: anyView, with: viewAttributes, in: context) else {
+                continue
+            }
+
+            if nextSemantics.importance > semantics.importance {
+                semantics = nextSemantics
+
+                if nextSemantics.importance >= SpecificElement.importance {
+                    // We know the current semantics is best we can get, so skip querying other `nodeRecorders`:
+                    break
+                }
+            }
+        }
+
+        return Node(
+            viewAttributes: viewAttributes,
+            semantics: semantics,
+            children: {
+                if semantics.importance < SpecificElement.importance {
+                    // Only resolve child nodes if the semantics of parent node is low (so if the
+                    // sub-tree remains ambiguous):
+                    return anyView.subviews.map { createNode(for: $0, in: context) }
+                } else {
+                    return []
+                }
+            }()
+        )
+    }
 }
 
-// MARK: - Convenience
-
-extension Node.Frame {
-    init(cgRect: CGRect) {
+extension ViewTreeSnapshotBuilder {
+    init() {
         self.init(
-            x: Int64(withNoOverflow: cgRect.origin.x),
-            y: Int64(withNoOverflow: cgRect.origin.y),
-            width: Int64(withNoOverflow: cgRect.size.width),
-            height: Int64(withNoOverflow: cgRect.size.height)
+            nodeRecorders: [
+                UIViewRecorder().eraseToAnyNodeRecorder,
+                UILabelRecorder().eraseToAnyNodeRecorder,
+            ]
         )
     }
 }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
@@ -21,7 +21,7 @@ internal struct ViewTreeSnapshotBuilder {
     ///
     /// The order in this this array  should be managed consciously. For each node, the implementation loops
     /// through `nodeRecorders` and stops on the one that recorded node semantics with highes importance.
-    let nodeRecorders: [AnyNodeRecorder<UIView>]
+    let nodeRecorders: [NodeRecorder]
 
     /// Builds the `ViewTreeSnapshot` for given root view.
     ///
@@ -55,7 +55,7 @@ internal struct ViewTreeSnapshotBuilder {
             if nextSemantics.importance > semantics.importance {
                 semantics = nextSemantics
 
-                if nextSemantics.importance >= SpecificElement.importance {
+                if nextSemantics.importance == .max {
                     // We know the current semantics is best we can get, so skip querying other `nodeRecorders`:
                     break
                 }
@@ -66,7 +66,7 @@ internal struct ViewTreeSnapshotBuilder {
             viewAttributes: viewAttributes,
             semantics: semantics,
             children: {
-                if semantics.importance < SpecificElement.importance {
+                if semantics.importance != .max {
                     // Only resolve child nodes if the semantics of parent node is low (so if the
                     // sub-tree remains ambiguous):
                     return anyView.subviews.map { createNode(for: $0, in: context) }
@@ -82,8 +82,8 @@ extension ViewTreeSnapshotBuilder {
     init() {
         self.init(
             nodeRecorders: [
-                UIViewRecorder().eraseToAnyNodeRecorder,
-                UILabelRecorder().eraseToAnyNodeRecorder,
+                UIViewRecorder(),
+                UILabelRecorder(),
             ]
         )
     }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/WindowSnapshotProducer.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/WindowSnapshotProducer.swift
@@ -18,6 +18,6 @@ internal struct WindowSnapshotProducer: ViewTreeSnapshotProducer {
         guard let window = windowObserver.relevantWindow else {
             return nil
         }
-        return try snapshotBuilder.createSnapshot(of: window)
+        return snapshotBuilder.createSnapshot(of: window)
     }
 }

--- a/session-replay/Sources/DatadogSessionReplay/Utilities/Colors.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Utilities/Colors.swift
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import CoreGraphics
+import UIKit
+
+/// Computes `#RRGGBBAA` string for given `color`.
+/// The implementation is pretty manual for better performance (using String format would be cleaner, but more heavy).
+/// - Parameters:
+///   - color: the color
+/// - Returns: `#RRGGBBAA` string or `nil` if it cannot be constructed for given `color`.
+internal func hexString(from color: CGColor) -> String? {
+    let uiColor = UIColor(cgColor: color) // TODO: RUMM-2250 Check if there's a way without converting to `UIColor`
+
+    var r: CGFloat = 0
+    var g: CGFloat = 0
+    var b: CGFloat = 0
+    var a: CGFloat = 1
+
+    guard uiColor.getRed(&r, green: &g, blue: &b, alpha: &a) else {
+        return nil
+    }
+
+    let ri = Int16(withNoOverflow: round(r * 255))
+    let gi = Int16(withNoOverflow: round(g * 255))
+    let bi = Int16(withNoOverflow: round(b * 255))
+    let ai = Int16(withNoOverflow: round(a * 255))
+
+    var rstr = String(ri, radix: 16, uppercase: true)
+    var gstr = String(gi, radix: 16, uppercase: true)
+    var bstr = String(bi, radix: 16, uppercase: true)
+    var astr = String(ai, radix: 16, uppercase: true)
+
+    rstr = ri < 16 ? "0\(rstr)" : rstr
+    gstr = gi < 16 ? "0\(gstr)" : gstr
+    bstr = bi < 16 ? "0\(bstr)" : bstr
+    astr = ai < 16 ? "0\(astr)" : astr
+
+    return "#\(rstr)\(gstr)\(bstr)\(astr)"
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/CoreGraphicsMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/CoreGraphicsMocks.swift
@@ -5,6 +5,7 @@
  */
 
 import CoreGraphics
+import UIKit
 
 extension CGFloat: AnyMockable, RandomMockable {
     static func mockAny() -> CGFloat {
@@ -26,11 +27,53 @@ extension CGRect: AnyMockable, RandomMockable {
     }
 
     static func mockRandom() -> CGRect {
+        return mockRandom(minWidth: 0, minHeight: 0)
+    }
+
+    static func mockRandom(minWidth: CGFloat = 0, minHeight: CGFloat = 0) -> CGRect {
+        return .init(
+            origin: .mockRandom(),
+            size: .mockRandom(minWidth: minWidth, minHeight: minHeight)
+        )
+    }
+}
+
+extension CGPoint: AnyMockable, RandomMockable {
+    static func mockAny() -> CGPoint {
+        return .init(x: 0, y: 0)
+    }
+
+    static func mockRandom() -> CGPoint {
         return .init(
             x: .mockRandom(min: -1_000, max: 1_000),
-            y: .mockRandom(min: -1_000, max: 1_000),
-            width: .mockRandom(min: 0, max: 1_000),
-            height: .mockRandom(min: 0, max: 1_000)
+            y: .mockRandom(min: -1_000, max: 1_000)
         )
+    }
+}
+
+extension CGSize: AnyMockable, RandomMockable {
+    static func mockAny() -> CGSize {
+        return .init(width: 400, height: 200)
+    }
+
+    static func mockRandom() -> CGSize {
+        return .mockRandom(minWidth: 0, minHeight: 0)
+    }
+
+    static func mockRandom(minWidth: CGFloat = 0, minHeight: CGFloat = 0) -> CGSize {
+        return .init(
+            width: .mockRandom(min: minWidth, max: minWidth + 1_000),
+            height: .mockRandom(min: minHeight, max: minHeight + 1_000)
+        )
+    }
+}
+
+extension CGColor: AnyMockable, RandomMockable {
+    static func mockAny() -> Self {
+        return UIColor.mockAny().cgColor as! Self
+    }
+
+    static func mockRandom() -> Self {
+        return UIColor.mockRandom().cgColor as! Self
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/FoundationMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/FoundationMocks.swift
@@ -6,6 +6,11 @@
 
 import Foundation
 
+extension Bool: AnyMockable, RandomMockable {
+    static func mockAny() -> Bool { true }
+    static func mockRandom() -> Bool { .random() }
+}
+
 extension Date: AnyMockable, RandomMockable {
     static func mockAny() -> Date {
         return .mockDecember15th2019At10AMUTC()
@@ -56,3 +61,56 @@ extension FixedWidthInteger where Self: AnyMockable {
 
 extension Int: AnyMockable, RandomMockable {}
 extension Int64: AnyMockable, RandomMockable {}
+
+extension String: AnyMockable, RandomMockable {
+    static func mockAny() -> String {
+        return "abc"
+    }
+
+    static func mockRandom() -> String {
+        return mockRandom(length: 10)
+    }
+
+    static func mockRandom(length: Int) -> String {
+        return mockRandom(among: .alphanumericsAndWhitespace, length: length)
+    }
+
+    static func mockRandom(among characters: RandomStringCharacterSet, length: Int = 10) -> String {
+        return characters.random(ofLength: length)
+    }
+
+    static func mockRepeating(character: Character, times: Int) -> String {
+        let characters = (0..<times).map { _ in character }
+        return String(characters)
+    }
+
+    enum RandomStringCharacterSet {
+        private static let alphanumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        private static let decimalDigitCharacters = "0123456789"
+
+        /// Only letters and numbers (lower and upper cased).
+        case alphanumerics
+        /// Letters, numbers and whitespace (lower and upper cased).
+        case alphanumericsAndWhitespace
+        /// Only numbers.
+        case decimalDigits
+        /// Custom characters.
+        case custom(characters: String)
+
+        func random(ofLength length: Int) -> String {
+            var characters: String
+            switch self {
+            case .alphanumerics:
+                characters = RandomStringCharacterSet.alphanumericCharacters
+            case .alphanumericsAndWhitespace:
+                characters = RandomStringCharacterSet.alphanumericCharacters + " "
+            case .decimalDigits:
+                characters = RandomStringCharacterSet.decimalDigitCharacters
+            case .custom(let customCharacters):
+                characters = customCharacters
+            }
+
+            return String((0..<length).map { _ in characters.randomElement()! })
+        }
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/UIKitMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/UIKitMocks.swift
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+extension UIColor: AnyMockable, RandomMockable {
+    static func mockAny() -> Self {
+        return UIColor.green as! Self
+    }
+
+    static func mockRandom() -> Self {
+        return mockRandomWith(alpha: .mockRandom(min: 0, max: 1))
+    }
+
+    static func mockRandomWith(alpha: CGFloat) -> Self {
+        return UIColor(
+            red: .mockRandom(min: 0, max: 1),
+            green: .mockRandom(min: 0, max: 1),
+            blue: .mockRandom(min: 0, max: 1),
+            alpha: alpha
+        ) as! Self
+    }
+}
+
+extension UIView: AnyMockable, RandomMockable {
+    static func mockAny() -> Self {
+        return UIView(frame: .init(x: 0, y: 0, width: 200, height: 400)) as! Self
+    }
+
+    static func mockRandom() -> Self {
+        let view = UIView(frame: .mockRandom())
+        view.backgroundColor = .mockRandom()
+        view.layer.borderColor = .mockRandom()
+        view.layer.backgroundColor = .mockRandom()
+        view.layer.cornerRadius = .mockRandom(min: 0, max: 5)
+        view.alpha = .mockRandom(min: 0, max: 1)
+        view.isHidden = .random()
+        return view as! Self
+    }
+
+    func replacing(
+        frame: CGRect? = nil,
+        alpha: CGFloat? = nil,
+        isHidden: Bool? = nil
+    ) -> Self {
+        self.frame = frame ?? self.frame
+        self.alpha = alpha ?? self.alpha
+        self.isHidden = isHidden ?? self.isHidden
+        return self
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/Utilities/XCTestCase+Extensions.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/Utilities/XCTestCase+Extensions.swift
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+
+extension XCTestCase {
+    /// Randomly picks and executes one of provided effects.
+    func oneOf(_ effects: [() -> Void]) {
+        guard let randomEffect = effects.randomElement() else {
+            return
+        }
+        randomEffect()
+    }
+
+    /// Randomly picks and executes one or more of provided effects.
+    func oneOrMoreOf(_ effects: [() -> Void]) {
+        guard effects.count > 1 else {
+            effects.first?()
+            return
+        }
+
+        let randomNumberOfEffects: Int = .random(in: (1..<effects.count))
+        let randomEffects = effects.shuffled()[0..<randomNumberOfEffects]
+        randomEffects.forEach { randomEffect in
+            randomEffect()
+        }
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+// swiftlint:disable opening_brace
+class UILabelRecorderTests: XCTestCase {
+    private let recorder = UILabelRecorder()
+    /// The label under test.
+    private let label = UILabel()
+    /// `ViewAttributes` simulating common attributes of label's `UIView`.
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenLabelHasNoTextAndNoAppearance() throws {
+        // When
+        oneOf([
+            { self.label.text = nil },
+            { self.label.text = "" },
+        ])
+        viewAttributes = .mockWith(hasAnyAppearance: false)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+    }
+
+    func testWhenLabelHasTextOrAppearance() throws {
+        // When
+        oneOf([
+            {
+                self.label.text = .mockRandom()
+                self.viewAttributes = .mockWith(hasAnyAppearance: true)
+            },
+            {
+                self.label.text = nil
+                self.viewAttributes = .mockWith(hasAnyAppearance: true)
+            },
+            {
+                self.label.text = .mockRandom()
+                self.viewAttributes = .mockWith(hasAnyAppearance: false)
+            },
+        ])
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+
+        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UILabelWireframesBuilder)
+        XCTAssertEqual(builder.attributes, viewAttributes)
+        XCTAssertEqual(builder.text, label.text ?? "")
+        XCTAssertEqual(builder.textColor, label.textColor?.cgColor)
+        XCTAssertEqual(builder.font, label.font)
+    }
+}
+// swiftlint:enable opening_brace

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
@@ -56,5 +56,13 @@ class UILabelRecorderTests: XCTestCase {
         XCTAssertEqual(builder.textColor, label.textColor?.cgColor)
         XCTAssertEqual(builder.font, label.font)
     }
+
+    func testWhenViewIsNotOfExpectedType() {
+        // When
+        let view = UITextField()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+    }
 }
 // swiftlint:enable opening_brace

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UIViewRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UIViewRecorderTests.swift
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class UIViewRecorderTests: XCTestCase {
+    private let recorder = UIViewRecorder()
+    /// The view under test.
+    private let view = UIView()
+    /// `ViewAttributes` simulating common attributes of the view.
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenViewIsNotVisible() throws {
+        // When
+        viewAttributes = .mockWith(isVisible: false)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+    }
+
+    func testWhenViewIsVisible() throws {
+        // When
+        viewAttributes = .mockWith(isVisible: true)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is AmbiguousElement)
+
+        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UIViewWireframesBuilder)
+        XCTAssertEqual(builder.attributes, viewAttributes)
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilderTests.swift
@@ -38,7 +38,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             NodeRecorderMock(resultForView: { _ in nil }),
             NodeRecorderMock(resultForView: { _ in nil }),
         ]
-        let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders.map { $0.eraseToAnyNodeRecorder })
+        let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders)
         _ = builder.createSnapshot(of: rootView)
 
         // Then
@@ -63,7 +63,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             NodeRecorderMock(resultForView: { _ in specificElement }), // here we find best semantics...
             NodeRecorderMock(resultForView: { _ in specificElement }), // ... so this one should not be queried
         ]
-        let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders.map { $0.eraseToAnyNodeRecorder })
+        let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders)
         _ = builder.createSnapshot(of: view)
 
         // Then
@@ -102,7 +102,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
 
         // When
         let nodeRecorder = NodeRecorderMock(resultForView: { view in semanticsByView[view] })
-        let builder = ViewTreeSnapshotBuilder(nodeRecorders: [nodeRecorder.eraseToAnyNodeRecorder])
+        let builder = ViewTreeSnapshotBuilder(nodeRecorders: [nodeRecorder])
         let snapshot = builder.createSnapshot(of: rootView)
 
         // Then

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilderTests.swift
@@ -7,31 +7,24 @@
 import XCTest
 @testable import DatadogSessionReplay
 
-private typealias Frame = ViewTreeSnapshot.Node.Frame
+private class NodeRecorderMock: NodeRecorder {
+    var queriedViews: Set<UIView> = []
+    var resultForView: (UIView) -> NodeSemantics?
 
-class ViewTreeSnapshotBuilderTests: XCTestCase {
-    private let builder = ViewTreeSnapshotBuilder()
-
-    // MARK: - Computing Frames
-
-    func testComputingFrameWhenRootViewHasNoSubviews() throws {
-        // Given
-        let rootView = UIView(frame: .mockRandom())
-        XCTAssertEqual(rootView.subviews.count, 0)
-
-        // When
-        let snapshot = try builder.createSnapshot(of: rootView)
-
-        // Then
-        XCTAssertTrue(snapshot.root.children.isEmpty, "It should have no children")
-
-        XCTAssertEqual(snapshot.root.frame.x, 0, "The root view should always start at (0, 0)")
-        XCTAssertEqual(snapshot.root.frame.y, 0, "The root view should always start at (0, 0)")
-        XCTAssertEqual(snapshot.root.frame.width, Int64(withNoOverflow: rootView.frame.width))
-        XCTAssertEqual(snapshot.root.frame.height, Int64(withNoOverflow: rootView.frame.height))
+    init(resultForView: @escaping (UIView) -> NodeSemantics?) {
+        self.resultForView = resultForView
     }
 
-    func testComputingFramesWhenRootViewHasNestedSubviews() throws {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        queriedViews.insert(view)
+        return resultForView(view)
+    }
+}
+
+class ViewTreeSnapshotBuilderTests: XCTestCase {
+    // MARK: - Querying Node Recorders
+
+    func testItQueriesAllNodeRecorders() {
         // Given
         let rootView = UIView(frame: .mockRandom())
         let childView = UIView(frame: .mockRandom())
@@ -40,41 +33,96 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         rootView.addSubview(childView)
 
         // When
-        let snapshot = try builder.createSnapshot(of: rootView)
+        let recorders: [NodeRecorderMock] = [
+            NodeRecorderMock(resultForView: { _ in nil }),
+            NodeRecorderMock(resultForView: { _ in nil }),
+            NodeRecorderMock(resultForView: { _ in nil }),
+        ]
+        let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders.map { $0.eraseToAnyNodeRecorder })
+        _ = builder.createSnapshot(of: rootView)
 
         // Then
-        XCTAssertEqual(snapshot.root.children.count, 1)
-        XCTAssertEqual(snapshot.root.children[0].children.count, 1)
-        XCTAssertEqual(snapshot.root.children[0].children[0].children.count, 0)
+        XCTAssertEqual(recorders[0].queriedViews, [rootView, childView, grandchildView])
+        XCTAssertEqual(recorders[1].queriedViews, [rootView, childView, grandchildView])
+        XCTAssertEqual(recorders[2].queriedViews, [rootView, childView, grandchildView])
+    }
 
-        XCTAssertEqual(
-            snapshot.root.frame,
-            Frame(
-                x: 0,
-                y: 0,
-                width: Int64(withNoOverflow: rootView.frame.width),
-                height: Int64(withNoOverflow: rootView.frame.height)
-            )
+    func testItQueriesNodeRecordersInOrderUntilOneFindsBestSemantics() {
+        // Given
+        let view = UIView(frame: .mockRandom())
+
+        let unknownElement = UnknownElement.constant
+        let ambiguousElement = AmbiguousElement(wireframesBuilder: NOPWireframesBuilderMock())
+        let specificElement = SpecificElement(wireframesBuilder: NOPWireframesBuilderMock())
+
+        // When
+        let recorders: [NodeRecorderMock] = [
+            NodeRecorderMock(resultForView: { _ in unknownElement }),
+            NodeRecorderMock(resultForView: { _ in ambiguousElement }),
+            NodeRecorderMock(resultForView: { _ in ambiguousElement }),
+            NodeRecorderMock(resultForView: { _ in specificElement }), // here we find best semantics...
+            NodeRecorderMock(resultForView: { _ in specificElement }), // ... so this one should not be queried
+        ]
+        let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders.map { $0.eraseToAnyNodeRecorder })
+        _ = builder.createSnapshot(of: view)
+
+        // Then
+        XCTAssertEqual(recorders[0].queriedViews, [view], "It should be queried as semantics is not known")
+        XCTAssertEqual(recorders[1].queriedViews, [view], "It should be queried as semantics is not known")
+        XCTAssertEqual(recorders[2].queriedViews, [view], "It should be queried as only 'ambiguous' semantics is known")
+        XCTAssertEqual(recorders[3].queriedViews, [view], "It should be queried as only 'ambiguous' semantics is known")
+        XCTAssertEqual(recorders[4].queriedViews, [], "It should NOT be queried as 'specific' semantics is known")
+    }
+
+    // MARK: - Recording Nodes Recursively
+
+    func testItQueriesViewTreeRecursively() {
+        // Given
+        let rootView = UIView(frame: .mockRandom(minWidth: 1, minHeight: 1))
+        let ambiguousChild = UIView(frame: .mockRandom(minWidth: 1, minHeight: 1))
+        let specificChild = UILabel(frame: .mockRandom(minWidth: 1, minHeight: 1))
+        let childOfAmbiguousElement = UIView(frame: .mockAny())
+        let childOfSpecificElement = UIView(frame: .mockAny())
+
+        ambiguousChild.addSubview(childOfAmbiguousElement)
+        specificChild.addSubview(childOfSpecificElement)
+        rootView.addSubview(ambiguousChild)
+        rootView.addSubview(specificChild)
+
+        let ambiguousElement = AmbiguousElement(wireframesBuilder: NOPWireframesBuilderMock())
+        let specificElement = SpecificElement(wireframesBuilder: NOPWireframesBuilderMock())
+
+        let semanticsByView: [UIView: NodeSemantics] = [
+            rootView: ambiguousElement,
+            ambiguousChild: ambiguousElement,
+            specificChild: specificElement,
+            childOfAmbiguousElement: ambiguousElement,
+            childOfSpecificElement: specificElement,
+        ]
+
+        // When
+        let nodeRecorder = NodeRecorderMock(resultForView: { view in semanticsByView[view] })
+        let builder = ViewTreeSnapshotBuilder(nodeRecorders: [nodeRecorder.eraseToAnyNodeRecorder])
+        let snapshot = builder.createSnapshot(of: rootView)
+
+        // Then
+        XCTAssertTrue(snapshot.root.semantics is AmbiguousElement)
+        XCTAssertEqual(snapshot.root.children.count, 2)
+        XCTAssertTrue(snapshot.root.children[0].semantics is AmbiguousElement)
+        XCTAssertTrue(snapshot.root.children[1].semantics is SpecificElement)
+        XCTAssertEqual(snapshot.root.children[0].children.count, 1, "It should resolve this sub-tree as parent node doesn't have 'specific' semantics")
+        XCTAssertEqual(snapshot.root.children[1].children.count, 0, "It should NOT resolve this sub-tree as parent has 'specific' semantics")
+
+        XCTAssertTrue(nodeRecorder.queriedViews.contains(rootView))
+        XCTAssertTrue(nodeRecorder.queriedViews.contains(ambiguousChild))
+        XCTAssertTrue(nodeRecorder.queriedViews.contains(specificChild))
+        XCTAssertTrue(
+            nodeRecorder.queriedViews.contains(childOfAmbiguousElement),
+            "It should query `childViewOfBasicSemantis`, because the parent does not have 'specific' semantics"
         )
-        XCTAssertEqual(
-            snapshot.root.children[0].frame,
-            Frame(
-                x: Int64(withNoOverflow: childView.frame.origin.x),
-                y: Int64(withNoOverflow: childView.frame.origin.y),
-                width: Int64(withNoOverflow: childView.frame.width),
-                height: Int64(withNoOverflow: childView.frame.height)
-            ),
-            "The position of nested snapshots should be given in root's coordinate space"
-        )
-        XCTAssertEqual(
-            snapshot.root.children[0].children[0].frame,
-            Frame(
-                x: Int64(withNoOverflow: childView.frame.origin.x + grandchildView.frame.origin.x),
-                y: Int64(withNoOverflow: childView.frame.origin.y + grandchildView.frame.origin.y),
-                width: Int64(withNoOverflow: grandchildView.frame.width),
-                height: Int64(withNoOverflow: grandchildView.frame.height)
-            ),
-            "The position of nested snapshots should be given in root's coordinate space"
+        XCTAssertFalse(
+            nodeRecorder.queriedViews.contains(childOfSpecificElement),
+            "It should NOT query `childViewOfMeaningfulSemantis`, because the parent has 'specific' semantics"
         )
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotTests.swift
@@ -114,5 +114,6 @@ class NodeSemanticsTests: XCTestCase {
         XCTAssertGreaterThan(specificElement.importance, ambiguousElement.importance)
         XCTAssertGreaterThan(ambiguousElement.importance, invisibleElement.importance)
         XCTAssertGreaterThan(invisibleElement.importance, unknownElement.importance)
+        XCTAssertEqual(specificElement.importance, .max)
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotTests.swift
@@ -1,0 +1,118 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+// swiftlint:disable opening_brace
+class ViewAttributesTests: XCTestCase {
+    func testItCapturesViewAttributes() {
+        // Given
+        let view: UIView = .mockRandom()
+
+        // When
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+
+        // Then
+        XCTAssertEqual(attributes.frame, view.frame)
+        XCTAssertEqual(attributes.backgroundColor, view.backgroundColor?.cgColor)
+        XCTAssertEqual(attributes.layerBorderColor, view.layer.borderColor)
+        XCTAssertEqual(attributes.layerBorderWidth, view.layer.borderWidth)
+        XCTAssertEqual(attributes.layerCornerRadius, view.layer.cornerRadius)
+        XCTAssertEqual(attributes.intrinsicContentSize, view.intrinsicContentSize)
+        XCTAssertEqual(attributes.alpha, view.alpha)
+    }
+
+    func testWhenViewIsVisible() {
+        // Given
+        let view: UIView = .mockRandom()
+
+        // When
+        view.isHidden = false
+        view.alpha = .mockRandom(min: 0.01, max: 1.0)
+        view.frame = .mockRandom(minWidth: 0.01, minHeight: 0.01)
+
+        // Then
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        XCTAssertTrue(attributes.isVisible)
+    }
+
+    func testWhenViewIsNotVisible() {
+        // Given
+        let view: UIView = .mockRandom()
+
+        // When
+        oneOrMoreOf([
+            { view.isHidden = true },
+            { view.alpha = 0 },
+            { view.frame = .zero },
+        ])
+
+        // Then
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        XCTAssertFalse(attributes.isVisible)
+    }
+
+    func testWhenViewHasSomeAppearance() {
+        // Given
+        let view: UIView = .mockRandom()
+
+        // When
+        view.isHidden = false
+        view.alpha = .mockRandom(min: 0.01, max: 1.0)
+        view.frame = .mockRandom(minWidth: 0.01, minHeight: 0.01)
+        oneOf([
+            {
+                view.layer.borderWidth = .mockRandom(min: 0.01, max: 10)
+                view.layer.borderColor = UIColor.mockRandomWith(alpha: .mockRandom(min: 0.01, max: 1)).cgColor
+            },
+            {
+                view.backgroundColor = .mockRandomWith(alpha: .mockRandom(min: 0.01, max: 1))
+            }
+        ])
+
+        // Then
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        XCTAssertTrue(attributes.hasAnyAppearance)
+    }
+
+    func testWhenViewHasNoAppearance() {
+        // Given
+        let view: UIView = .mockRandom()
+
+        // When
+        oneOf([
+            {
+                view.isHidden = false
+                view.alpha = 0
+                view.frame = .zero
+            },
+            {
+                view.layer.borderWidth = 0
+                view.layer.borderColor = UIColor.mockRandomWith(alpha: 0).cgColor
+                view.backgroundColor = .mockRandomWith(alpha: 0)
+            }
+        ])
+
+        // Then
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+        XCTAssertFalse(attributes.hasAnyAppearance)
+    }
+}
+// swiftlint:enable opening_brace
+
+class NodeSemanticsTests: XCTestCase {
+    func testSemanticsImportance() {
+        let unknownElement = UnknownElement.constant
+        let invisibleElement = InvisibleElement.constant
+        let ambiguousElement = AmbiguousElement(wireframesBuilder: nil)
+        let specificElement = SpecificElement(wireframesBuilder: nil)
+
+        XCTAssertGreaterThan(specificElement.importance, ambiguousElement.importance)
+        XCTAssertGreaterThan(ambiguousElement.importance, invisibleElement.importance)
+        XCTAssertGreaterThan(invisibleElement.importance, unknownElement.importance)
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Utilities/ColorsTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Utilities/ColorsTests.swift
@@ -1,0 +1,74 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class ColorsTests: XCTestCase {
+    func testWhenConvertingKnownOpaqueColorsToHexString() {
+        let red = UIColor(red: 1, green: 0, blue: 0, alpha: 1).cgColor
+        XCTAssertEqual(hexString(from: red), "#FF0000FF")
+
+        let green = UIColor(red: 0, green: 1, blue: 0, alpha: 1).cgColor
+        XCTAssertEqual(hexString(from: green), "#00FF00FF")
+
+        let blue = UIColor(red: 0, green: 0, blue: 1, alpha: 1).cgColor
+        XCTAssertEqual(hexString(from: blue), "#0000FFFF")
+
+        let black = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+        XCTAssertEqual(hexString(from: black), "#000000FF")
+
+        let white = UIColor(red: 1, green: 1, blue: 1, alpha: 1).cgColor
+        XCTAssertEqual(hexString(from: white), "#FFFFFFFF")
+    }
+
+    func testWhenConvertingKnownSemiTransparentColorsToHexString() {
+        let red = UIColor(red: 1, green: 0, blue: 0, alpha: 0.5).cgColor
+        XCTAssertEqual(hexString(from: red), "#FF000080")
+
+        let green = UIColor(red: 0, green: 1, blue: 0, alpha: 0.5).cgColor
+        XCTAssertEqual(hexString(from: green), "#00FF0080")
+
+        let blue = UIColor(red: 0, green: 0, blue: 1, alpha: 0.5).cgColor
+        XCTAssertEqual(hexString(from: blue), "#0000FF80")
+
+        let black = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5).cgColor
+        XCTAssertEqual(hexString(from: black), "#00000080")
+
+        let white = UIColor(red: 1, green: 1, blue: 1, alpha: 0.5).cgColor
+        XCTAssertEqual(hexString(from: white), "#FFFFFF80")
+    }
+
+    func testWhenConvertingAnyColorToHexString() throws {
+        /// Returns `CGColor` constructed from provided `#RRGGBBAA` string.
+        func cgColor(from rrggbbaaHex: String) -> CGColor {
+            let hex8 = UInt64(rrggbbaaHex.dropFirst(), radix: 16)!
+            return UIColor(
+                red: CGFloat((hex8 & 0xFF000000) >> 24) / CGFloat(255),
+                green: CGFloat((hex8 & 0x00FF0000) >> 16) / CGFloat(255),
+                blue: CGFloat((hex8 & 0x0000FF00) >> 8) / CGFloat(255),
+                alpha: CGFloat(hex8 & 0x000000FF) / CGFloat(255)
+            ).cgColor
+        }
+
+        /// Returns random hexadecimal character (0-F).
+        func randomHexCharacter() -> String {
+            return String(Int.mockRandom(min: 0, max: 15), radix: 16, uppercase: true)
+        }
+
+        try (0..<100).forEach { _ in
+            // Given
+            let expectedHex = "#" + (0..<8).map({ _ in randomHexCharacter() }).joined(separator: "")
+            let actualColor = cgColor(from: expectedHex)
+
+            // When
+            let actualHex = try XCTUnwrap(hexString(from: actualColor))
+
+            // Then
+            XCTAssertEqual(expectedHex, actualHex)
+        }
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR enhances Session Replay with recognising certain node semantics for `UIViews` and `UILabels`. For both, the recorder now captures more information on the native view and puts it into the JSON prepared for SR player. 

The `Recorder` now captures:
* appearance information on each `UIView`:
   * background color
   * border style (color + width)
   * corner radius
   * alpha
* text information on each `UILabel`:
   * the text displayed
   * the actual frame of the test (including paddings)
   * text color
   * font

### How?

Proposed implementation introduces a small framework prepared for capturing semantics of other nodes in extensible way promoting OCP (`UITextField`, `UIImageView`, `UISwitch` will come in next PR).

Each view traversed by `ViewTreeSnapshotBuilder` gets queried by a sequence of `NodeRecorders`:
```swift
nodeRecorders: [
    UIViewRecorder().eraseToAnyNodeRecorder,
    UILabelRecorder().eraseToAnyNodeRecorder,
    UIImageViewRecorder().eraseToAnyNodeRecorder, // coming in next PR
    UITextFieldRecorder().eraseToAnyNodeRecorder, // coming in next PR
    UISwitchRecorder().eraseToAnyNodeRecorder,    // coming in next PR
]
```
Each recorder gets asked for a semantics of given `view`:
```swift
internal protocol NodeRecorder {
    associatedtype View: UIView

    func semantics(of view: View, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics?
}
```
To avoid querying all recorders for each `view`, the iteration stops as soon as _best_ semantics is found. Pessimistically, this gives `O(N * M)` time complexity on the main thread, where `N` is number of views and `M` is number of node recorders. Given that `M` is constant and some recorders (e.g. `UISwitchRecorder`) will not require inspecting sub-tree, the effective estimate will be `O(N)`.

To enable different optimisations and stay open for future extensibility of `Recorder` (to support more types in ambiguous view trees), the `NodeSemantics` is defined as a broad interface:
```swift
internal protocol NodeSemantics {
    /// The severity of this semantic.
    ///
    /// While querying certain `view` with an array of supported `NodeRecorders` each recorder can spot different semantics of
    /// the same view. In that case, the semantics with higher `importance` takes precedence.
    static var importance: Int { get }

    /// A type defining how to build SR wireframes for the UI element this semantic was recorded for.
    var wireframesBuilder: NodeWireframesBuilder? { get }
}
```

with 4 semantics introduced in this PR:
```swift
/// Semantics of an UI element that is of unknown kind. Receiving this semantics in `Processor` could indicate an error
/// in view-tree traversal performed in `Recorder` (e.g. working on assumption that is not met).
internal struct UnknownElement: NodeSemantics { /**/ }

/// A semantics of an UI element that is either `UIView` or one of its known subclasses. This semantics mean that the element
/// has no visual appearance that can be presented in SR (e.g. a `UILabel` with no text, no border and fully transparent color).
/// Nodes with this semantics can be safely ignored in `Recorder` or in `Processor`.
internal struct InvisibleElement: NodeSemantics { /**/ }

/// A semantics of an UI element that is of `UIView` type. This semantics mean that the element has visual appearance in SR, but
/// it will only utilize its base `UIView` attributes. The full identity of the node will remain ambiguous if not overwritten with `SpecificElement`.
internal struct AmbiguousElement: NodeSemantics { /**/ }

/// A semantics of an UI element that is one of `UIView` subclasses. This semantics mean that we know its full identity along with set of
/// subclass-specific attributes that will be used to render it in SR (e.g. all base `UIView` attributes plus the text in `UILabel` or the
/// "on" / "off" state of `UISwitch` control).
internal struct SpecificElement: NodeSemantics { /**/ }
```

These 4 semantics are enough to handle basics, incl.: `UIViewRecorder`, `UILabelRecorder`, `UIImageViewRecorder`, `UITextFieldRecorder` and `UISwitchRecorder`. We may want to introduce more semantics when dealing with elements that require very much different rendering (like alerts or popovers displayed on top of other views). I haven't yet looked into this.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
