### PR TITLE
RUMM-2429 [SR] Add TextField, ImageView and UISwitch semantics

### DIFF
--- a/session-replay/Sources/DatadogSessionReplay/Processor/Flattening/NodesFlattener.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/Flattening/NodesFlattener.swift
@@ -18,8 +18,8 @@ internal struct NodesFlattener {
         var flattened: [Node] = []
 
         dfsVisit(startingFrom: snapshot.root) { nextNode in
-            // Skip nodes with no semantics:
-            if nextNode.semantics.importance > InvisibleElement.importance {
+            // Skip invisible nodes:
+            if !(nextNode.semantics is InvisibleElement) {
                 // When accepting nodes, remove ones that are covered by another opaque node:
                 flattened = flattened.compactMap { previousNode in
                     let isPreviousNodeCovered = nextNode.viewAttributes.frame.contains(previousNode.viewAttributes.frame)

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UIImageViewRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UIImageViewRecorder.swift
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal struct UIImageViewRecorder: NodeRecorder {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        guard let imageView = view as? UIImageView else {
+            return nil
+        }
+
+        let hasImage = imageView.image != nil
+
+        guard hasImage || attributes.hasAnyAppearance else {
+            return InvisibleElement.constant
+        }
+
+        // TODO: RUMM-2455
+        // Enhance image placeholders rendering by considering `.contentMode` and resizing
+        // the wireframe to fit the actual image, not surrounding `UIImageView`.
+        let imageFrame = attributes.frame
+
+        let builder = UIImageViewWireframesBuilder(
+            attributes: attributes,
+            imageFrame: imageFrame
+        )
+        return SpecificElement(wireframesBuilder: builder)
+    }
+}
+
+internal struct UIImageViewWireframesBuilder: NodeWireframesBuilder {
+    struct Defaults {
+        /// Until we suppport images in SR V.x., this color is used as placeholder in SR V.0.:
+        static let placeholderColor: CGColor = UIColor.systemGray.cgColor
+    }
+
+    /// Attributes of the base `UIView`.
+    let attributes: ViewAttributes
+    /// The actual frame of the image, in screen coordinates.
+    let imageFrame: CGRect
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        return [
+            builder.createShapeWireframe(
+                frame: imageFrame,
+                borderColor: attributes.layerBorderColor,
+                borderWidth: attributes.layerBorderWidth,
+                backgroundColor: attributes.backgroundColor ?? Defaults.placeholderColor,
+                cornerRadius: attributes.layerCornerRadius,
+                opacity: attributes.alpha
+            )
+        ]
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UISwitchRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UISwitchRecorder.swift
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal struct UISwitchRecorder: NodeRecorder {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        guard let `switch` = view as? UISwitch else {
+            return nil
+        }
+
+        guard attributes.isVisible else {
+            return InvisibleElement.constant
+        }
+
+        let builder = UISwitchWireframesBuilder(
+            attributes: attributes,
+            isOn: `switch`.isOn,
+            thumbTintColor: `switch`.thumbTintColor?.cgColor,
+            onTintColor: `switch`.onTintColor?.cgColor,
+            offTintColor: `switch`.tintColor?.cgColor
+        )
+        return SpecificElement(wireframesBuilder: builder)
+    }
+}
+
+internal struct UISwitchWireframesBuilder: NodeWireframesBuilder {
+    struct SystemDefaults {
+        /// Default color of the thumb.
+        static let thumbTintColor: CGColor = UIColor.white.cgColor
+        /// Default color of the background in "on" state.
+        static let onTintColor: CGColor = UIColor.systemGreen.cgColor
+        /// Default color of the background in "off" state.
+        static let offTintColor: CGColor = UIColor.lightGray.cgColor
+    }
+
+    /// Attributes of the base `UIView`.
+    let attributes: ViewAttributes
+    /// If the switch is "on" or "off".
+    let isOn: Bool
+    /// The custom color of the thumb.
+    let thumbTintColor: CGColor?
+    /// The custom color of the background in "on" state.
+    let onTintColor: CGColor?
+    /// The custom color of the background in "off" state.
+    let offTintColor: CGColor?
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        let radius = attributes.frame.height * 0.5
+        let backgroundColor = isOn ? (onTintColor ?? SystemDefaults.onTintColor) : (offTintColor ?? SystemDefaults.offTintColor)
+
+        let background = builder.createShapeWireframe(
+            frame: attributes.frame,
+            borderColor: nil,
+            borderWidth: nil,
+            backgroundColor: backgroundColor,
+            cornerRadius: radius,
+            opacity: attributes.alpha
+        )
+
+        let thumbFrame = CGRect(
+            x: attributes.frame.minX + (isOn ? radius : 0.0),
+            y: attributes.frame.minY,
+            width: radius * 2,
+            height: attributes.frame.height
+        )
+
+        let thumb = builder.createShapeWireframe(
+            frame: thumbFrame,
+            borderColor: nil,
+            borderWidth: nil,
+            backgroundColor: thumbTintColor ?? SystemDefaults.thumbTintColor,
+            cornerRadius: radius,
+            opacity: attributes.alpha
+        )
+
+        return [background, thumb]
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorder.swift
@@ -1,0 +1,106 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import UIKit
+
+internal struct UITextFieldRecorder: NodeRecorder {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        guard let textField = view as? UITextField else {
+            return nil
+        }
+
+        guard attributes.isVisible else {
+            return InvisibleElement.constant
+        }
+
+        // TODO: RUMM-2459
+        // Explore other (better) ways of infering text field appearance:
+
+        var editorProperties: UITextFieldWireframesBuilder.EditorFieldProperties? = nil
+        // Lookup the actual editor field's view in `textField` hierarchy to infer its appearance.
+        // Perhaps this can be do better by infering it from `UITextField` object in RUMM-2459:
+        dfsVisitSubviews(of: textField) { subview in
+            if subview.bounds == textField.bounds {
+                editorProperties = .init(
+                    backgroundColor: subview.backgroundColor?.cgColor,
+                    layerBorderColor: subview.layer.borderColor,
+                    layerBorderWidth: subview.layer.borderWidth,
+                    layerCornerRadius: subview.layer.cornerRadius
+                )
+            }
+        }
+
+        let text: String = {
+            guard let textFieldText = textField.text, !textFieldText.isEmpty else {
+                return textField.placeholder ?? ""
+            }
+            return textFieldText
+        }()
+
+        let builder = UITextFieldWireframesBuilder(
+            attributes: attributes,
+            text: text,
+            // TODO: RUMM-2459
+            // Is it correct to assume `textField.textColor` for placeholder text?
+            textColor: textField.textColor?.cgColor,
+            font: textField.font,
+            editor: editorProperties
+        )
+        return SpecificElement(wireframesBuilder: builder)
+    }
+}
+
+internal struct UITextFieldWireframesBuilder: NodeWireframesBuilder {
+    /// Attributes of the base `UIView`.
+    let attributes: ViewAttributes
+    /// The text inside text field.
+    let text: String
+    /// The color of the text.
+    let textColor: CGColor?
+    /// The font used by the text field.
+    let font: UIFont?
+    /// Properties of the editor field (which is a nested subview in `UITextField`).
+    let editor: EditorFieldProperties?
+
+    struct EditorFieldProperties {
+        /// Editor view's `.backgorundColor`.
+        var backgroundColor: CGColor? = nil
+        /// Editor view's `layer.backgorundColor`.
+        var layerBorderColor: CGColor? = nil
+        /// Editor view's `layer.backgorundColor`.
+        var layerBorderWidth: CGFloat = 0
+        /// Editor view's `layer.cornerRadius`.
+        var layerCornerRadius: CGFloat = 0
+    }
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        // TODO: RUMM-2459
+        // Enhance text fields rendering by calculating the actual frame of the text:
+        let textFrame = attributes.frame
+
+        return [
+            builder.createTextWireframe(
+                frame: attributes.frame,
+                text: text,
+                textFrame: textFrame,
+                textColor: textColor,
+                font: font,
+                borderColor: editor?.layerBorderColor ?? attributes.layerBorderColor,
+                borderWidth: editor?.layerBorderWidth ?? attributes.layerBorderWidth,
+                backgroundColor: editor?.backgroundColor ?? attributes.backgroundColor,
+                cornerRadius: editor?.layerCornerRadius ?? attributes.layerCornerRadius,
+                opacity: attributes.alpha
+            )
+        ]
+    }
+}
+
+private func dfsVisitSubviews(of view: UIView, visit: (UIView) -> Void) {
+    view.subviews.forEach { subview in
+        visit(subview)
+        dfsVisitSubviews(of: subview, visit: visit)
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshot.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshot.swift
@@ -176,7 +176,7 @@ internal struct InvisibleElement: NodeSemantics {
 /// A semantics of an UI element that is of `UIView` type. This semantics mean that the element has visual appearance in SR, but
 /// it will only utilize its base `UIView` attributes. The full identity of the node will remain ambiguous if not overwritten with `SpecificElement`.
 internal struct AmbiguousElement: NodeSemantics {
-    static let importance: Int = 1
+    static let importance: Int = 0
     let wireframesBuilder: NodeWireframesBuilder?
 }
 

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
@@ -84,6 +84,11 @@ extension ViewTreeSnapshotBuilder {
             nodeRecorders: [
                 UIViewRecorder(),
                 UILabelRecorder(),
+                UIViewRecorder(),
+                UILabelRecorder(),
+                UIImageViewRecorder(),
+                UITextFieldRecorder(),
+                UISwitchRecorder(),
             ]
         )
     }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
@@ -52,7 +52,7 @@ internal struct ViewTreeSnapshotBuilder {
                 continue
             }
 
-            if nextSemantics.importance > semantics.importance {
+            if nextSemantics.importance >= semantics.importance {
                 semantics = nextSemantics
 
                 if nextSemantics.importance == .max {

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/UIKitMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/UIKitMocks.swift
@@ -40,15 +40,4 @@ extension UIView: AnyMockable, RandomMockable {
         view.isHidden = .random()
         return view as! Self
     }
-
-    func replacing(
-        frame: CGRect? = nil,
-        alpha: CGFloat? = nil,
-        isHidden: Bool? = nil
-    ) -> Self {
-        self.frame = frame ?? self.frame
-        self.alpha = alpha ?? self.alpha
-        self.isHidden = isHidden ?? self.isHidden
-        return self
-    }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UIImageViewRecorderTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 @testable import DatadogSessionReplay
 
+// swiftlint:disable opening_brace
 class UIImageViewRecorderTests: XCTestCase {
     private let recorder = UIImageViewRecorder()
     /// The view under test.
@@ -59,3 +60,4 @@ class UIImageViewRecorderTests: XCTestCase {
         XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
     }
 }
+// swiftlint:enable opening_brace

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UIImageViewRecorderTests.swift
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class UIImageViewRecorderTests: XCTestCase {
+    private let recorder = UIImageViewRecorder()
+    /// The view under test.
+    private let imageView = UIImageView()
+    /// `ViewAttributes` simulating common attributes of image view's `UIView`.
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenImageViewHasNoImageAndNoAppearance() throws {
+        // When
+        imageView.image = nil
+        viewAttributes = .mockWith(hasAnyAppearance: false)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+    }
+
+    func testWhenImageViewHasImageOrAppearance() throws {
+        // When
+        oneOf([
+            {
+                self.imageView.image = UIImage()
+                self.viewAttributes = .mockWith(hasAnyAppearance: true)
+            },
+            {
+                self.imageView.image = nil
+                self.viewAttributes = .mockWith(hasAnyAppearance: true)
+            },
+            {
+                self.imageView.image = UIImage()
+                self.viewAttributes = .mockWith(hasAnyAppearance: false)
+            },
+        ])
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+
+        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UIImageViewWireframesBuilder)
+        XCTAssertEqual(builder.attributes, viewAttributes)
+        XCTAssertEqual(builder.imageFrame, viewAttributes.frame)
+    }
+
+    func testWhenViewIsNotOfExpectedType() {
+        // When
+        let view = UITextField()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UISwitchRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UISwitchRecorderTests.swift
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class UISwitchRecorderTests: XCTestCase {
+    private let recorder = UISwitchRecorder()
+    /// The label under test.
+    private let `switch` = UISwitch()
+    /// `ViewAttributes` simulating common attributes of switch's `UIView`.
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenSwitchIsNotVisible() throws {
+        // When
+        viewAttributes = .mockWith(isVisible: false)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: `switch`, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+    }
+
+    func testWhenSwitchIsVisible() throws {
+        // Given
+        `switch`.isOn = .mockRandom()
+        `switch`.thumbTintColor = .mockRandom()
+        `switch`.onTintColor = .mockRandom()
+        `switch`.tintColor = .mockRandom()
+
+        // When
+        viewAttributes = .mockWith(isVisible: true)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: `switch`, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+
+        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UISwitchWireframesBuilder)
+        XCTAssertEqual(builder.attributes, viewAttributes)
+        XCTAssertEqual(builder.isOn, `switch`.isOn)
+        XCTAssertEqual(builder.thumbTintColor, `switch`.thumbTintColor?.cgColor)
+        XCTAssertEqual(builder.onTintColor, `switch`.onTintColor?.cgColor)
+        XCTAssertEqual(builder.offTintColor, `switch`.tintColor?.cgColor)
+    }
+
+    func testWhenViewIsNotOfExpectedType() {
+        // When
+        let view = UITextField()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 @testable import DatadogSessionReplay
 
+// swiftlint:disable opening_brace
 class UITextFieldRecorderTests: XCTestCase {
     private let recorder = UITextFieldRecorder()
     /// The label under test.
@@ -67,3 +68,4 @@ class UITextFieldRecorderTests: XCTestCase {
         XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
     }
 }
+// swiftlint:enable opening_brace

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
@@ -1,0 +1,69 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class UITextFieldRecorderTests: XCTestCase {
+    private let recorder = UITextFieldRecorder()
+    /// The label under test.
+    private let textField = UITextField(frame: .mockAny())
+    /// `ViewAttributes` simulating common attributes of text field's `UIView`.
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenTextFieldIsNotVisible() throws {
+        // When
+        viewAttributes = .mockWith(isVisible: false)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+    }
+
+    func testWhenTextFieldHasText() throws {
+        // Given
+        let randomText: String = .mockRandom()
+        textField.textColor = .mockRandom()
+        textField.font = .systemFont(ofSize: .mockRandom())
+
+        // When
+        oneOf([
+            {
+                self.textField.text = randomText
+                self.textField.placeholder = nil
+            },
+            {
+                self.textField.text = nil
+                self.textField.placeholder = randomText
+            },
+            {
+                self.textField.text = randomText
+                self.textField.placeholder = .mockRandom()
+            },
+        ])
+        viewAttributes = .mockWith(isVisible: true)
+        textField.layoutSubviews() // force layout (so TF creates its sub-tree)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+
+        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UITextFieldWireframesBuilder)
+        XCTAssertEqual(builder.text, randomText)
+        XCTAssertEqual(builder.textColor, textField.textColor?.cgColor)
+        XCTAssertEqual(builder.font, textField.font)
+        XCTAssertNotNil(builder.editor)
+    }
+
+    func testWhenViewIsNotOfExpectedType() {
+        // When
+        let view = UILabel()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotTests.swift
@@ -111,9 +111,23 @@ class NodeSemanticsTests: XCTestCase {
         let ambiguousElement = AmbiguousElement(wireframesBuilder: nil)
         let specificElement = SpecificElement(wireframesBuilder: nil)
 
-        XCTAssertGreaterThan(specificElement.importance, ambiguousElement.importance)
-        XCTAssertGreaterThan(ambiguousElement.importance, invisibleElement.importance)
-        XCTAssertGreaterThan(invisibleElement.importance, unknownElement.importance)
+        XCTAssertGreaterThan(
+            specificElement.importance,
+            ambiguousElement.importance,
+            "`SpecificElement` should override `AmbiguousElement` semantics"
+        )
+        XCTAssertGreaterThanOrEqual(
+            invisibleElement.importance,
+            ambiguousElement.importance,
+            """
+            `InvisibleElement` should override `AmbiguousElement` semantics - as invisibility
+            can be noticed in specialised recorers by determining empty state for certain
+            `UIView` subclass (e.g. no text in `UILabel` which has no other appearance but is visible)
+            """
+        )
+        XCTAssertGreaterThan(invisibleElement.importance, unknownElement.importance, "All semantics should override `UnknownElement`")
+        XCTAssertGreaterThan(ambiguousElement.importance, unknownElement.importance, "All semantics should override `UnknownElement`")
+        XCTAssertGreaterThan(specificElement.importance, unknownElement.importance, "All semantics should override `UnknownElement`")
         XCTAssertEqual(specificElement.importance, .max)
     }
 }


### PR DESCRIPTION
### What and why?

📦 Supplementing #985, this PR adds 3 more semantics to session replay:
* `UITextField`
* `UIImageView`
* `UISwitch`

### How?

I leverated the `NodeRecorder` + `NodeSemantics` framework introduced in #985 by adding 3 specialised node recorders: `UITextFieldRecorder`, `UIImageViewRecorder` and `UISwitchRecorder`.

It required some adjustments to `NodeSemantics.importance` to ensure that new node semantics are resolved consistently by `ViewTreeSnapshotBuilder`. More explanation in inline comment.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
