### PR TITLE
Fix nightly tests build

### DIFF
--- a/tools/nightly-unit-tests/bitrise-nightly-unit-tests.yml
+++ b/tools/nightly-unit-tests/bitrise-nightly-unit-tests.yml
@@ -1,5 +1,5 @@
 ---
-format_version: '8'
+format_version: 11
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: other
 
@@ -36,7 +36,7 @@ workflows:
     description: |-
         Generates best 'bitrise.yml' for running unit tests on range of runtimes.
     steps:
-    - script@1.1.6:
+    - script:
         title: Prepare host environment and generate `bitrise.yml`.
         inputs:
         - content: |-

--- a/tools/nightly-unit-tests/bitrise.yml.src
+++ b/tools/nightly-unit-tests/bitrise.yml.src
@@ -1,5 +1,5 @@
 ---
-format_version: '8'
+format_version: 11
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: other
 
@@ -21,7 +21,7 @@ workflows:
     description: |-
         Does `make dependencies` to prepare source code in repo for building and testing.
     steps:
-    - script@1.1.6:
+    - script:
         title: Do `make dependencies`.
         inputs:
         - content: |-
@@ -39,14 +39,14 @@ workflows:
 
   _run_unit_tests:
     steps:
-    - script@1.1.6:
+    - script:
         inputs:
         - content: |-
             #!/usr/bin/env bash
             echo "+------------------------------------------------------------------------------+"
             printf '| %-78s |\n' "🧪 Running unit tests for ${PROJECT_SCHEME} on ${SIMULATOR_DEVICE} (${SIMULATOR_OS_VERSION})"
             echo "+------------------------------------------------------------------------------+"
-    - xcode-test@2.4.5:
+    - xcode-test:
         title: Run unit tests for given platform
         is_always_run: true # continue next tests if some failed
         run_if: '{{(getenv "DD_SKIP_RUNNING_TESTS") | eq ""}}'

--- a/tools/nightly-unit-tests/bitrise.yml.src
+++ b/tools/nightly-unit-tests/bitrise.yml.src
@@ -56,7 +56,8 @@ workflows:
         - simulator_device: $SIMULATOR_DEVICE
         - simulator_os_version: $SIMULATOR_OS_VERSION
         - is_clean_build: 'no'
-        - ## <RETRY_ON_FAIL> ##
+        - test_repetition_mode: 'retry_on_failure'
+        - maximum_test_repetitions: 2
         - generate_code_coverage_files: 'yes'
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/Unit-tests-${PROJECT_SCHEME}-${SIMULATOR_DEVICE} (${SIMULATOR_OS_VERSION}).html"
     - deploy-to-bitrise-io: {}

--- a/tools/nightly-unit-tests/src/bitrise_yml_writter.py
+++ b/tools/nightly-unit-tests/src/bitrise_yml_writter.py
@@ -91,11 +91,6 @@ class BitriseYML:
 
         template = template.replace('## <MACOS VERSION> ##', self.host_os_version)
 
-        if self.host_os_version.startswith('11'): # macOS 11.X Big Sur
-            template = template.replace('## <RETRY_ON_FAIL> ##', "test_repetition_mode: 'retry_on_failure'")
-        else:
-            template = template.replace('## <RETRY_ON_FAIL> ##', "should_retry_test_on_fail: 'yes'")
-
         return template
 
     @staticmethod


### PR DESCRIPTION
### What and why?

💉📦 This PR fixes recent issues in nightly tests.

Nightly tests are key to our iOS version coverage - they run unit tests on all iOS Simulator versions available in macOS Monterey + Xcode 13.4.1 (dozens of iOS versions from 12.4 up). Especially critical in testing OS version-specific code (swizzlings, `@available(...)`, I/O APIs, ...).

### How?

CI job was having a problem with `xcode-test` Bitrise step:
```
ERRO[02:23:30] Step (Run unit tests for given platform) failed: Failed to prepare the step for execution through the required toolkit (go), error: Failed to install package, error: command `/usr/local/bin/go "build" "-o" "/Users/vagrant/.bitrise/toolkits/go/cache/https___github.com_bitrise-io_bitrise-steplib.git-xcode-test-2.4.5" "github.com/bitrise-steplib/steps-xcode-test"` failed: exit status 2 
```

Upgrading nightly plan to recent version of `xcode-test` solved that issue 👍.

Also, because we no longer run nightly job on macOS BigSur, I removed version-specific patch for tests repetition. Now we always use `test_repetition_mode: 'retry_on_failure'`, same way as in the root `bitrise.yml`.

I made a test with manual run and `DD_SIMULATOR_OS_VERSIONS=15.2` ENV:
<img width="927" alt="Screenshot 2022-09-13 at 09 51 47" src="https://user-images.githubusercontent.com/2358722/189845870-4921be31-2107-4df7-8b9e-d3f440272b45.png">


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
