### PR TITLE
RUMM-2508 Fix manual User Action dropped if a new view start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [BUGFIX] Fix manual User Action dropped if new a view start. See [#997][]
+- [BUGFIX] Fix manual User Action dropped if a new view start. See [#997][]
 
 # 1.12.0-beta3 / 30-08-2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [BUGFIX] Fix manual User Action dropped if new a view start. See [#997][]
+
 # 1.12.0-beta3 / 30-08-2022
 
 ### Changes
@@ -417,6 +419,7 @@
 [#950]: https://github.com/DataDog/dd-sdk-ios/issues/950
 [#964]: https://github.com/DataDog/dd-sdk-ios/issues/964
 [#973]: https://github.com/DataDog/dd-sdk-ios/issues/973
+[#997]: https://github.com/DataDog/dd-sdk-ios/issues/997
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -100,7 +100,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
 
         lastActivityTime = command.time
         switch command {
-        case is RUMStopViewCommand:
+        case is RUMStartViewCommand, is RUMStopViewCommand:
             sendActionEvent(completionTime: command.time, on: command, context: context, writer: writer)
             return false
         case let command as RUMStopUserActionCommand:


### PR DESCRIPTION
### What and why?

A user action should be sent if a new view start shortly after.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
