### PR TITLE
Update to version 2.2.0-beta.8 of testing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: dependencies xcodeproj-httpservermock templates
 
 # The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
-DD_SDK_SWIFT_TESTING_VERSION = 2.2.0-beta.6
+DD_SDK_SWIFT_TESTING_VERSION = 2.2.0-beta.8
 
 define DD_SDK_TESTING_XCCONFIG_CI
 FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n


### PR DESCRIPTION
### What and why?

Update to new version of the tracer, it includes support for the Intelligent Test runner configuration through:
CI -> Settings->Test Service Settings
But as it needs admin rights for configuring I have kept the environment variables with the configuration (that overrides those of the settings)
### How?

Uopdated the version of the Makefile

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
