### PR TITLE
Warn when DDNoopRUMMonitor is sent any DDRUMMonitor methods

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/DDNoopRUMMonitor.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/DDNoopRUMMonitor.swift
@@ -26,6 +26,13 @@ internal class DDNoopRUMMonitor: DDRUMMonitor {
         warn()
     }
 
+    override func stopView(
+        viewController: UIViewController,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
     override func startView(
         key: String,
         name: String? = nil,
@@ -33,4 +40,156 @@ internal class DDNoopRUMMonitor: DDRUMMonitor {
     ) {
         warn()
     }
+
+    override func stopView(
+        key: String,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func addTiming(
+        name: String
+    ) {
+        warn()
+    }
+
+    override func addError(
+        message: String,
+        type: String? = nil,
+        source: RUMErrorSource = .custom,
+        stack: String? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:],
+        file: StaticString? = #file,
+        line: UInt? = #line
+    ) {
+        warn()
+    }
+
+    override func addError(
+        error: Error,
+        source: RUMErrorSource = .custom,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func startResourceLoading(
+        resourceKey: String,
+        request: URLRequest,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func startResourceLoading(
+        resourceKey: String,
+        url: URL,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func startResourceLoading(
+        resourceKey: String,
+        httpMethod: RUMMethod,
+        urlString: String,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func addResourceMetrics(
+        resourceKey: String,
+        metrics: URLSessionTaskMetrics,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func addResourceMetrics(
+        resourceKey: String,
+        fetch: (start: Date, end: Date),
+        redirection: (start: Date, end: Date)?,
+        dns: (start: Date, end: Date)?,
+        connect: (start: Date, end: Date)?,
+        ssl: (start: Date, end: Date)?,
+        firstByte: (start: Date, end: Date)?,
+        download: (start: Date, end: Date)?,
+        responseSize: Int64?,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func stopResourceLoading(
+        resourceKey: String,
+        response: URLResponse,
+        size: Int64? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func stopResourceLoading(
+        resourceKey: String,
+        statusCode: Int?,
+        kind: RUMResourceType,
+        size: Int64? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func stopResourceLoadingWithError(
+        resourceKey: String,
+        error: Error,
+        response: URLResponse? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func stopResourceLoadingWithError(
+        resourceKey: String,
+        errorMessage: String,
+        type: String? = nil,
+        response: URLResponse? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func startUserAction(
+        type: RUMUserActionType,
+        name: String,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func stopUserAction(
+        type: RUMUserActionType,
+        name: String? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func addUserAction(
+        type: RUMUserActionType,
+        name: String,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        warn()
+    }
+
+    override func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
+        warn()
+    }
+
+    override func removeAttribute(forKey key: AttributeKey) {
+        warn()
+    }
+
 }

--- a/Sources/Datadog/RUM/RUMMonitor/DDNoopRUMMonitor.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/DDNoopRUMMonitor.swift
@@ -191,5 +191,4 @@ internal class DDNoopRUMMonitor: DDRUMMonitor {
     override func removeAttribute(forKey key: AttributeKey) {
         warn()
     }
-
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/DDNoopRUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/DDNoopRUMMonitorTests.swift
@@ -20,6 +20,23 @@ class DDNoopRUMMonitorTests: XCTestCase {
         noop.startView(key: "view-key", name: "View")
         noop.stopView(viewController: mockView)
         noop.stopView(key: "view-key")
+        noop.addTiming(name: #function)
+        noop.addError(message: #function)
+        noop.addError(error: ProgrammerError(description: #function))
+        noop.startResourceLoading(resourceKey: #function, request: .mockAny())
+        noop.startResourceLoading(resourceKey: #function, url: .mockRandom())
+        noop.startResourceLoading(resourceKey: #function, httpMethod: .mockAny(), urlString: #function)
+        noop.addResourceMetrics(resourceKey: #function, metrics: .mockAny())
+        noop.addResourceMetrics(resourceKey: #function, fetch: (start: .mockAny(), end: .mockAny()), redirection: nil, dns: nil, connect: nil, ssl: nil, firstByte: nil, download: nil, responseSize: nil)
+        noop.stopResourceLoading(resourceKey: #function, response: .mockAny())
+        noop.stopResourceLoading(resourceKey: #function, statusCode: nil, kind: .mockAny())
+        noop.stopResourceLoadingWithError(resourceKey: #function, error: ProgrammerError(description: #function))
+        noop.stopResourceLoadingWithError(resourceKey: #function, errorMessage: #function)
+        noop.startUserAction(type: .click, name: #function)
+        noop.stopUserAction(type: .click, name: #function)
+        noop.addUserAction(type: .click, name: #function)
+        noop.addAttribute(forKey: .mockAny(), value: #function)
+        noop.removeAttribute(forKey: .mockAny())
 
         // Then
         let expectedWarningMessage = """
@@ -28,7 +45,7 @@ class DDNoopRUMMonitorTests: XCTestCase {
         See https://docs.datadoghq.com/real_user_monitoring/ios
         """
 
-        XCTAssertEqual(dd.logger.criticalLogs.count, 2)
+        XCTAssertEqual(dd.logger.criticalLogs.count, 21)
         dd.logger.criticalLogs.forEach { log in
             XCTAssertEqual(log.message, expectedWarningMessage)
         }


### PR DESCRIPTION
### What and why?

This PR resolves the baseline request in #978 by calling `warn()` when any method vended by `DDRUMMonitor` is called on an instance of `DDNoopRUMMonitor`.

This change will make it more obvious when a `DDNoopRUMMonitor` has been captured and is being utilized accidentally.

### How?

I copied over all methods from `DDRUMMonitor` into `DDNoopRUMMonitor`, replaced `public` with `override`, and called `warn()` within each method body.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes – N/A

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
