### PR TITLE
RUMM-2603 Create V2 Registration Interfaces

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -592,8 +592,8 @@
 		D2135330270CA722000315AD /* DataCompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213532F270CA722000315AD /* DataCompressionTests.swift */; };
 		D21C26C528A3B49C005DD405 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C428A3B49C005DD405 /* FeatureStorage.swift */; };
 		D21C26C628A3B49C005DD405 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C428A3B49C005DD405 /* FeatureStorage.swift */; };
-		D21C26CA28A406A3005DD405 /* DatadogFeatureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C928A406A3005DD405 /* DatadogFeatureConfiguration.swift */; };
-		D21C26CB28A406A3005DD405 /* DatadogFeatureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C928A406A3005DD405 /* DatadogFeatureConfiguration.swift */; };
+		D21C26CA28A406A3005DD405 /* DatadogFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C928A406A3005DD405 /* DatadogFeature.swift */; };
+		D21C26CB28A406A3005DD405 /* DatadogFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C928A406A3005DD405 /* DatadogFeature.swift */; };
 		D21C26CE28A411FF005DD405 /* FeatureMessageReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */; };
 		D21C26CF28A411FF005DD405 /* FeatureMessageReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */; };
 		D21C26D128A64599005DD405 /* MessageBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D028A64599005DD405 /* MessageBusTests.swift */; };
@@ -1867,7 +1867,7 @@
 		D20605CC28770C3B0047275C /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		D213532F270CA722000315AD /* DataCompressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompressionTests.swift; sourceTree = "<group>"; };
 		D21C26C428A3B49C005DD405 /* FeatureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureStorage.swift; sourceTree = "<group>"; };
-		D21C26C928A406A3005DD405 /* DatadogFeatureConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogFeatureConfiguration.swift; sourceTree = "<group>"; };
+		D21C26C928A406A3005DD405 /* DatadogFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogFeature.swift; sourceTree = "<group>"; };
 		D21C26CD28A411FF005DD405 /* FeatureMessageReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureMessageReceiver.swift; sourceTree = "<group>"; };
 		D21C26D028A64599005DD405 /* MessageBusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusTests.swift; sourceTree = "<group>"; };
 		D21C26D628A647DB005DD405 /* MessageBusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusMock.swift; sourceTree = "<group>"; };
@@ -4394,7 +4394,7 @@
 			isa = PBXGroup;
 			children = (
 				D2B3F0492829510600C2B5EE /* DatadogCoreProtocol.swift */,
-				D21C26C928A406A3005DD405 /* DatadogFeatureConfiguration.swift */,
+				D21C26C928A406A3005DD405 /* DatadogFeature.swift */,
 				D2956CAA2869D1DF007D5462 /* Context */,
 				D26C49C128899B4100802B2D /* Upload */,
 				D21C26CC28A411BE005DD405 /* MessageBus */,
@@ -5343,7 +5343,7 @@
 				D2B3F04A2829510600C2B5EE /* DatadogCoreProtocol.swift in Sources */,
 				6122514827FDFF82004F5AE4 /* RUMScopeDependencies.swift in Sources */,
 				6141014F251A57AF00E3C2D9 /* UIApplicationSwizzler.swift in Sources */,
-				D21C26CA28A406A3005DD405 /* DatadogFeatureConfiguration.swift in Sources */,
+				D21C26CA28A406A3005DD405 /* DatadogFeature.swift in Sources */,
 				61494CB124C839460082C633 /* RUMResourceScope.swift in Sources */,
 				61C2C20724C098FC00C0321C /* RUMSessionScope.swift in Sources */,
 				617CEB392456BC3A00AD4669 /* TracingUUID.swift in Sources */,
@@ -6068,7 +6068,7 @@
 				492749022880489400ECD49B /* _InternalProxy.swift in Sources */,
 				D2CB6E7227C50EAE00A62B57 /* SpanEventEncoder.swift in Sources */,
 				D2CB6E7327C50EAE00A62B57 /* Tracer.swift in Sources */,
-				D21C26CB28A406A3005DD405 /* DatadogFeatureConfiguration.swift in Sources */,
+				D21C26CB28A406A3005DD405 /* DatadogFeature.swift in Sources */,
 				D2CB6E7427C50EAE00A62B57 /* OTFormat.swift in Sources */,
 				D2CB6E7527C50EAE00A62B57 /* RUMDataModels.swift in Sources */,
 				D2CB6E7627C50EAE00A62B57 /* KronosClock.swift in Sources */,

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -59,6 +59,16 @@ internal final class DatadogCore {
     /// The message bus used to dispatch messages to registered features.
     private var messageBus: [FeatureMessageReceiver] = []
 
+    /// Registery for Features.
+    private var features: [String: (
+        feature: DatadogFeature,
+        storage: FeatureStorage,
+        upload: FeatureUpload
+    )] = [:]
+
+    /// Registery for Feature Integrations.
+    private var integrations: [String: DatadogFeatureIntegration] = [:]
+
     /// Registery for v1 features.
     private var v1Features: [String: Any] = [:]
 
@@ -144,6 +154,100 @@ internal final class DatadogCore {
 }
 
 extension DatadogCore: DatadogCoreProtocol {
+    /// Registers a Feature instance.
+    ///
+    /// A Feature collect and transfer data to a Datadog Product (e.g. Logs, RUM, ...). A registered Feature can
+    /// open a `FeatureScope` to write events, the core will then be responsible for storing and uploading events
+    /// in a efficient manner. Performance presets for storage and upload are define when instanciating the core instance.
+    ///
+    /// A Feature can also communicate to other Features by sending message on the bus that is managed by the core.
+    ///
+    /// - Parameter feature: The Feature instance.
+    /* public */ func register(feature: DatadogFeature) throws {
+        let featureDirectories = try directory.getFeatureDirectories(forFeatureNamed: feature.name)
+
+        let storage = FeatureStorage(
+            featureName: feature.name,
+            queue: readWriteQueue,
+            directories: featureDirectories,
+            dateProvider: dateProvider,
+            consentProvider: consentProvider,
+            performance: performance,
+            encryption: encryption
+        )
+
+        let upload = FeatureUpload(
+            featureName: feature.name,
+            contextProvider: contextProvider,
+            fileReader: storage.reader,
+            requestBuilder: feature.requestBuilder,
+            httpClient: httpClient,
+            performance: performance
+        )
+
+        features[feature.name] = (
+            feature: feature,
+            storage: storage,
+            upload: upload
+        )
+
+        connectBus()
+    }
+
+    /// Retrieves a Feature by its name and type.
+    ///
+    /// A Feature type can be specified as parameter or inferred from the return type:
+    ///
+    ///     let feature = core.feature(named: "foo", type: Foo.self)
+    ///     let feature: Foo? = core.feature(named: "foo")
+    ///
+    /// - Parameters:
+    ///   - name: The Feature's name.
+    ///   - type: The Feature instance type.
+    /// - Returns: The Feature if any.
+    /* public */ func feature<T>(named name: String, type: T.Type = T.self) -> T? where T: DatadogFeature {
+        features[name]?.feature as? T
+    }
+
+    /// Registers a Feature Integration instance.
+    ///
+    /// A Feature Integration collect and transfer data to a local Datadog Feature. An Integration will not store nor upload,
+    /// it will collect data for other Features to consume.
+    ///
+    /// An Integration can commicate to Features via dependency or a communication channel such as the message-bus.
+    ///
+    /// - Parameter integration: The Feature Integration instance.
+    /* public */ func register(integration: DatadogFeatureIntegration) throws {
+        integrations[integration.name] = integration
+        connectBus()
+    }
+
+    /// Retrieves a Feature Integration by its name and type.
+    ///
+    /// A Feature Integration type can be specified as parameter or inferred from the return type:
+    ///
+    ///     let integration = core.integration(named: "foo", type: Foo.self)
+    ///     let integration: Foo? = core.integration(named: "foo")
+    ///
+    /// - Parameters:
+    ///   - name: The Feature Integration's name.
+    ///   - type: The Feature Integration instance type.
+    /// - Returns: The Feature Integration if any.
+    /* public */ func integration<T>(named name: String, type: T.Type = T.self) -> T? where T: DatadogFeature {
+        integrations[name] as? T
+    }
+
+    /* public */ func scope(for feature: String) -> FeatureScope? {
+        guard let storage = features[feature]?.storage else {
+            return nil
+        }
+
+        return DatadogCoreFeatureScope(
+            contextProvider: contextProvider,
+            storage: storage
+        )
+    }
+
     /* public */ func set(feature: String, attributes: @escaping () -> FeatureBaggage) {
         contextProvider.write { $0.featuresAttributes[feature] = attributes() }
     }
@@ -159,6 +263,17 @@ extension DatadogCore: DatadogCoreProtocol {
             }
         }
     }
+
+    private func connectBus() {
+        let messageBus = self.v1Features.values
+            .compactMap { $0 as? V1Feature }
+            .map(\.messageReceiver)
+            + features.values.map(\.feature.messageReceiver)
+            + integrations.values.map(\.messageReceiver)
+
+        // connect the message bus
+        messageBusQueue.async { self.messageBus = messageBus }
+    }
 }
 
 extension DatadogCore: DatadogV1CoreProtocol {
@@ -167,15 +282,7 @@ extension DatadogCore: DatadogV1CoreProtocol {
     func register<T>(feature instance: T?) {
         let key = String(describing: T.self)
         v1Features[key] = instance
-
-        let messageBus = self.v1Features.values
-            .compactMap { $0 as? V1Feature }
-            .map(\.messageReceiver)
-
-        messageBusQueue.async {
-            // add/replace v1 feature to the message bus
-            self.messageBus = messageBus
-        }
+        connectBus()
     }
 
     func feature<T>(_ type: T.Type) -> T? {
@@ -183,7 +290,7 @@ extension DatadogCore: DatadogV1CoreProtocol {
         return v1Features[key] as? T
     }
 
-    func scope<T>(for featureType: T.Type) -> FeatureV1Scope? {
+    func scope<T>(for featureType: T.Type) -> FeatureScope? {
         let key = String(describing: T.self)
 
         guard let feature = v1Features[key] as? V1Feature else {
@@ -260,7 +367,7 @@ internal protocol V1Feature {
 ///
 /// The execution block is currently running in `sync`, this will change once the
 /// context is provided on it's own queue.
-internal struct DatadogCoreFeatureScope: FeatureV1Scope {
+internal struct DatadogCoreFeatureScope: FeatureScope {
     let contextProvider: DatadogContextProvider
     let storage: FeatureStorage
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -59,17 +59,17 @@ internal final class DatadogCore {
     /// The message bus used to dispatch messages to registered features.
     private var messageBus: [FeatureMessageReceiver] = []
 
-    /// Registery for Features.
+    /// Registry for Features.
     private var features: [String: (
         feature: DatadogFeature,
         storage: FeatureStorage,
         upload: FeatureUpload
     )] = [:]
 
-    /// Registery for Feature Integrations.
+    /// Registry for Feature Integrations.
     private var integrations: [String: DatadogFeatureIntegration] = [:]
 
-    /// Registery for v1 features.
+    /// Registry for v1 features.
     private var v1Features: [String: Any] = [:]
 
     /// The SDK Context for V1.
@@ -156,7 +156,7 @@ internal final class DatadogCore {
 extension DatadogCore: DatadogCoreProtocol {
     /// Registers a Feature instance.
     ///
-    /// A Feature collect and transfer data to a Datadog Product (e.g. Logs, RUM, ...). A registered Feature can
+    /// A Feature collects and transfers data to a Datadog Product (e.g. Logs, RUM, ...). A registered Feature can
     /// open a `FeatureScope` to write events, the core will then be responsible for storing and uploading events
     /// in a efficient manner. Performance presets for storage and upload are define when instanciating the core instance.
     ///

--- a/Sources/Datadog/DatadogCore/Storage/Writing/Writer.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Writing/Writer.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// A type, writing data.
-internal protocol Writer {
+public protocol Writer {
     func write<T: Encodable>(value: T)
 }
 

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -11,6 +11,53 @@ public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOPDatadogCor
 /// A Datadog Core holds a set of features and is responsible of managing their storage
 /// and upload mechanism. It also provides a thread-safe scope for writing events.
 public protocol DatadogCoreProtocol {
+    /// Registers a Feature instance.
+    ///
+    /// A Feature collect and transfer data to a Datadog Product (e.g. Logs, RUM, ...). A registered Feature can
+    /// open a `FeatureScope` to write events, the core will then be responsible for storing and uploading events
+    /// in a efficient manner. Performance presets for storage and upload are define when instanciating the core instance.
+    ///
+    /// A Feature can also communicate to other Features by sending message on the bus that is managed by the core.
+    ///
+    /// - Parameter feature: The Feature instance.
+    func register(feature: DatadogFeature) throws
+
+    /// Retrieves a Feature by its name and type.
+    ///
+    /// A Feature type can be specified as parameter or inferred from the return type:
+    ///
+    ///     let feature = core.feature(named: "foo", type: Foo.self)
+    ///     let feature: Foo? = core.feature(named: "foo")
+    ///
+    /// - Parameters:
+    ///   - name: The Feature's name.
+    ///   - type: The Feature instance type.
+    /// - Returns: The Feature if any.
+    func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature
+
+    /// Registers a Feature Integration instance.
+    ///
+    /// A Feature Integration collect and transfer data to a local Datadog Feature. An Integration will not store nor upload,
+    /// it will collect data for other Features to consume.
+    ///
+    /// An Integration can commicate to Features via dependency or a communication channel such as the message-bus.
+    ///
+    /// - Parameter integration: The Feature Integration instance.
+    func register(integration: DatadogFeatureIntegration) throws
+
+    /// Retrieves a Feature Integration by its name and type.
+    ///
+    /// A Feature Integration type can be specified as parameter or inferred from the return type:
+    ///
+    ///     let integration = core.integration(named: "foo", type: Foo.self)
+    ///     let integration: Foo? = core.integration(named: "foo")
+    ///
+    /// - Parameters:
+    ///   - name: The Feature Integration's name.
+    ///   - type: The Feature Integration instance type.
+    /// - Returns: The Feature Integration if any.
+    func integration<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature
+
     /// Sets given attributes for a given Feature for sharing data through `DatadogContext`.
     ///
     /// This method provides a passive communication chanel between Features of the Core.
@@ -49,6 +96,34 @@ public protocol DatadogCoreProtocol {
 }
 
 extension DatadogCoreProtocol {
+    /// Retrieves a Feature by its name and type.
+    ///
+    /// A Feature type can be specified as parameter or inferred from the return type:
+    ///
+    ///     let feature = core.feature(named: "foo", type: Foo.self)
+    ///     let feature: Foo? = core.feature(named: "foo")
+    ///
+    /// - Parameters:
+    ///   - name: The Feature's name.
+    /// - Returns: The Feature if any.
+    func feature<T>(named name: String) -> T? where T: DatadogFeature {
+        feature(named: name, type: T.self)
+    }
+
+    /// Retrieves a Feature Integration by its name and type.
+    ///
+    /// A Feature Integration type can be specified as parameter or inferred from the return type:
+    ///
+    ///     let integration = core.integration(named: "foo", type: Foo.self)
+    ///     let integration: Foo? = core.integration(named: "foo")
+    ///
+    /// - Parameters:
+    ///   - name: The Feature Integration's name.
+    /// - Returns: The Feature Integration if any.
+    func integration<T>(named name: String) -> T? where T: DatadogFeature {
+        integration(named: name, type: T.self)
+    }
+
     /// Sends a message on the bus shared by features registered in this core.
     ///
     /// - Parameters:
@@ -58,13 +133,48 @@ extension DatadogCoreProtocol {
     }
 }
 
-/// A datadog feature providing thread-safe scope for writing events.
-public protocol FeatureScope {
-    // TODO: RUMM-2133
+/// Feature scope provides a context and a writer to build a record event.
+internal protocol FeatureScope {
+    /// Retrieve the event context and writer.
+    ///
+    /// The Feature scope provides the current Datadog context and event writer
+    /// for the Feature to build and record events.
+    ///
+    /// A Feature has the ability to bypass the current user consent for data collection. The `bypassConsent`
+    /// must be set to `true` only if the Feature is already aware of the user's consent for the event it is about
+    /// to write.
+    ///
+    /// - Parameters:
+    ///   - bypassConsent: `true` to bypass the current core consent and write events as authorized.
+    ///                    Default is `false`, setting `true` must still respect user's consent for
+    ///                    collecting information.
+    ///   - block: The block to execute.
+    func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) throws -> Void)
+}
+
+/// Feature scope provides a context and a writer to build a record event.
+extension FeatureScope {
+    /// Retrieve the event context and writer.
+    ///
+    /// The Feature scope provides the current Datadog context and event writer
+    /// for the Feature to build and record events.
+    ///
+    /// - Parameter block: The block to execute.
+    func eventWriteContext(_ block: @escaping (DatadogContext, Writer) throws -> Void) {
+        self.eventWriteContext(bypassConsent: false, block)
+    }
 }
 
 /// No-op implementation of `DatadogFeatureRegistry`.
 internal struct NOPDatadogCore: DatadogCoreProtocol {
+    /// no-op
+    func register(feature: DatadogFeature) throws { }
+    /// no-op
+    func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature { nil }
+    /// no-op
+    func register(integration: DatadogFeatureIntegration) throws { }
+    /// no-op
+    func integration<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature { nil }
     /// no-op
     func set(feature: String, attributes: @escaping @autoclosure () -> FeatureBaggage) { }
     /// no-op

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -13,7 +13,7 @@ public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOPDatadogCor
 public protocol DatadogCoreProtocol {
     /// Registers a Feature instance.
     ///
-    /// A Feature collect and transfer data to a Datadog Product (e.g. Logs, RUM, ...). A registered Feature can
+    /// A Feature collects and transfers data to a Datadog Product (e.g. Logs, RUM, ...). A registered Feature can
     /// open a `FeatureScope` to write events, the core will then be responsible for storing and uploading events
     /// in a efficient manner. Performance presets for storage and upload are define when instanciating the core instance.
     ///
@@ -37,7 +37,7 @@ public protocol DatadogCoreProtocol {
 
     /// Registers a Feature Integration instance.
     ///
-    /// A Feature Integration collect and transfer data to a local Datadog Feature. An Integration will not store nor upload,
+    /// A Feature Integration collects and transfers data to a local Datadog Feature. An Integration will not store nor upload,
     /// it will collect data for other Features to consume.
     ///
     /// An Integration can commicate to Features via dependency or a communication channel such as the message-bus.

--- a/Sources/Datadog/DatadogInternal/DatadogFeature.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogFeature.swift
@@ -22,21 +22,29 @@ import Foundation
     let messageReceiver: FeatureMessageReceiver
 }
 
-/* public */ internal struct DatadogFeature<Configuration> {
+public protocol DatadogFeature {
     /// The feature name.
-    let name: String
-
-    /// The feature-specific configuration.
-    let configuration: Configuration
+    var name: String { get }
 
     /// The URL request builder for uploading data in this Feature.
     ///
     /// This builder currently use the v1 context, but will be soon migrated to v2
-    let requestBuilder: FeatureRequestBuilder
+    var requestBuilder: FeatureRequestBuilder { get }
 
     /// The message bus receiver.
     ///
     /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
     /// from a bus that is shared between Features registered in a core.
-    let messageReceiver: FeatureMessageReceiver
+    var messageReceiver: FeatureMessageReceiver { get }
+}
+
+public protocol DatadogFeatureIntegration {
+    /// The feature name.
+    var name: String { get }
+
+    /// The message bus receiver.
+    ///
+    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
+    /// from a bus that is shared between Features registered in a core.
+    var messageReceiver: FeatureMessageReceiver { get }
 }

--- a/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1CoreProtocol.swift
@@ -42,39 +42,7 @@ internal protocol DatadogV1CoreProtocol: DatadogCoreProtocol {
     /// - Parameters:
     ///   - type: The feature instance type.
     /// - Returns: The feature scope if available.
-    func scope<T>(for featureType: T.Type) -> FeatureV1Scope?
-}
-
-/// Feature scope in v1 provide a context and a writer to build a record event.
-internal protocol FeatureV1Scope {
-    /// Retrieve the event context and writer.
-    ///
-    /// The Feature scope provides the current Datadog context and event writer
-    /// for the Feature to build and record events.
-    ///
-    /// A Feature has the ability to bypass the current user consent for data collection. The `bypassConsent`
-    /// must be set to `true` only if the Feature is already aware of the user's consent for the event it is about
-    /// to write.
-    ///
-    /// - Parameters:
-    ///   - bypassConsent: `true` to bypass the current core consent and write events as authorized.
-    ///                    Default is `false`, setting `true` must still respect user's consent for
-    ///                    collecting information.
-    ///   - block: The block to execute.
-    func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) throws -> Void)
-}
-
-/// Feature scope in v1 provide a context and a writer to build a record event.
-extension FeatureV1Scope {
-    /// Retrieve the event context and writer.
-    ///
-    /// The Feature scope provides the current Datadog context and event writer
-    /// for the Feature to build and record events.
-    ///
-    /// - Parameter block: The block to execute.
-    func eventWriteContext(_ block: @escaping (DatadogContext, Writer) throws -> Void) {
-        self.eventWriteContext(bypassConsent: false, block)
-    }
+    func scope<T>(for featureType: T.Type) -> FeatureScope?
 }
 
 extension NOPDatadogCore: DatadogV1CoreProtocol {
@@ -94,7 +62,7 @@ extension NOPDatadogCore: DatadogV1CoreProtocol {
     }
 
     /// no-op
-    func scope<T>(for featureType: T.Type) -> FeatureV1Scope? {
+    func scope<T>(for featureType: T.Type) -> FeatureScope? {
         return nil
     }
 }

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
@@ -12,7 +12,7 @@ import Foundation
 /// A message is composed of a key and a dictionary of attributes. A message format is a loose
 /// agreement between Features, any supported messages by a Feature should be properly
 /// documented.
-/* public */ internal protocol FeatureMessageReceiver {
+public protocol FeatureMessageReceiver {
     /// Receive a message from the message bus of a given core.
     ///
     /// The message can be used to build an event or run a process.
@@ -26,9 +26,9 @@ import Foundation
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool
 }
 
-/* public */ internal struct NOPFeatureMessageReceiver: FeatureMessageReceiver {
+public struct NOPFeatureMessageReceiver: FeatureMessageReceiver {
     /// no-op: returns `false`
-    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+    public func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
         return false
     }
 }

--- a/Sources/Datadog/DatadogInternal/Upload/FeatureRequestBuilder.swift
+++ b/Sources/Datadog/DatadogInternal/Upload/FeatureRequestBuilder.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// The core implementation can use the interface for creating requests targetting datadog intake
 /// of a given feature.
-/* public */ internal protocol FeatureRequestBuilder {
+public protocol FeatureRequestBuilder {
     /// Builds a `URLRequest` for a list of events and the current core context to be uploaded
     /// to the feature intake.
     ///

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
@@ -10,6 +10,15 @@ import XCTest
 @testable import Datadog
 
 internal final class DatadogCoreMock: Flushable {
+    /// Registery for Features.
+    private var features: [String: (
+        feature: DatadogFeature,
+        writer: Writer
+    )] = [:]
+
+    /// Registery for Feature Integrations.
+    private var integrations: [String: DatadogFeatureIntegration] = [:]
+
     private var v1Features: [String: Any] = [:]
 
     var legacyContext: DatadogV1Context? {
@@ -58,14 +67,35 @@ internal final class DatadogCoreMock: Flushable {
 extension DatadogCoreMock: DatadogCoreProtocol {
     // MARK: V2 interface
 
+    func register(feature: DatadogFeature) throws {
+        features[feature.name] = (
+            feature: feature,
+            writer: InMemoryWriter()
+        )
+    }
+
+    func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature {
+        features[name]?.feature as? T
+    }
+
+    func register(integration: DatadogFeatureIntegration) throws {
+        integrations[integration.name] = integration
+    }
+
+    func integration<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature {
+        integrations[name] as? T
+    }
+
     func set(feature: String, attributes: @escaping () -> FeatureBaggage) {
         context.featuresAttributes[feature] = attributes()
     }
 
     func send(message: FeatureMessage, else fallback: () -> Void) {
-        let receivers = v1Features.values
-            .compactMap { $0 as? V1Feature }
-            .filter { $0.messageReceiver.receive(message: message, from: self) }
+        let receivers = (
+            v1Features.values.compactMap { $0 as? V1Feature }.map(\.messageReceiver)
+            + features.values.map(\.feature.messageReceiver)
+            + integrations.values.map(\.messageReceiver)
+        ).filter { $0.receive(message: message, from: self) }
 
         if receivers.isEmpty {
             fallback()
@@ -76,7 +106,7 @@ extension DatadogCoreMock: DatadogCoreProtocol {
 extension DatadogCoreMock: DatadogV1CoreProtocol {
     // MARK: V1 interface
 
-    struct Scope: FeatureV1Scope {
+    struct Scope: FeatureScope {
         let context: DatadogContext
         let writer: Writer
 
@@ -95,7 +125,7 @@ extension DatadogCoreMock: DatadogV1CoreProtocol {
         return v1Features[key] as? T
     }
 
-    func scope<T>(for featureType: T.Type) -> FeatureV1Scope? {
+    func scope<T>(for featureType: T.Type) -> FeatureScope? {
         let key = String(describing: T.self)
 
         guard let feature = v1Features[key] as? V1Feature else {

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
@@ -10,13 +10,13 @@ import XCTest
 @testable import Datadog
 
 internal final class DatadogCoreMock: Flushable {
-    /// Registery for Features.
+    /// Registry for Features.
     private var features: [String: (
         feature: DatadogFeature,
         writer: Writer
     )] = [:]
 
-    /// Registery for Feature Integrations.
+    /// Registry for Feature Integrations.
     private var integrations: [String: DatadogFeatureIntegration] = [:]
 
     private var v1Features: [String: Any] = [:]

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -14,7 +14,7 @@ import XCTest
 /// The `DatadogCoreProtocol` implementation does not require any feature registration,
 /// it will always provide a `FeatureScope` with the current context and a `writer` that will
 /// store all events in the `events` property..
-internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureV1Scope {
+internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureScope {
     /// Current context that will be passed to feature-scopes.
     internal var legacyContext: DatadogV1Context? {
         .init(context)
@@ -71,15 +71,20 @@ internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureV1Scope 
     }
 
     /// no-op
+    func register(feature: DatadogFeature) throws { }
+    /// no-op
+    func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature { nil }
+    /// no-op
+    func register(integration: DatadogFeatureIntegration) throws { }
+    /// no-op
+    func integration<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature { nil }
+    /// no-op
     func register<T>(feature instance: T?) { }
-
     /// Returns `nil`
-    func feature<T>(_ type: T.Type) -> T? {
-        return nil
-    }
+    func feature<T>(_ type: T.Type) -> T? { nil }
 
     /// Always returns a feature-scope.
-    func scope<T>(for featureType: T.Type) -> FeatureV1Scope? {
+    func scope<T>(for featureType: T.Type) -> FeatureScope? {
         self
     }
 


### PR DESCRIPTION
### What and why?

Provide interfaces for registering v2 Features and Integrations.

### How?

A Feature or an Integration must comply to the following protocols so they can be registered in a `core` instance:
```swift
public protocol DatadogFeature {
    /// The feature name.
    var name: String { get }

    /// The URL request builder for uploading data in this Feature.
    ///
    /// This builder currently use the v1 context, but will be soon migrated to v2
    var requestBuilder: FeatureRequestBuilder { get }

    /// The message bus receiver.
    ///
    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
    /// from a bus that is shared between Features registered in a core.
    var messageReceiver: FeatureMessageReceiver { get }
}

public protocol DatadogFeatureIntegration {
    /// The feature name.
    var name: String { get }

    /// The message bus receiver.
    ///
    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
    /// from a bus that is shared between Features registered in a core.
    var messageReceiver: FeatureMessageReceiver { get }
}
```
The core will then keep strong references to each registered instances. When registering a Feature, the associated storage and upload are created.
Both Features and Integrations will be connected to the core message-bus.
 
### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
