### PR TITLE
RUMM-2503 [SR] Add "mask all" privacy rule

### DIFF
--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
@@ -18,4 +18,28 @@ public class SessionReplayFeature {
 
     public func start() { recorder.start() }
     public func stop() { recorder.stop() }
+
+    /// The content recording policy for Session Replay. It describes the way in which sensitive content (e.g. text or images) should be recorded.
+    /// Uses `.maskAll` by default.
+    ///
+    /// **Note**: It must be changed from the main thread.
+    public var privacy: SessionReplayPrivacy {
+        set { recorder.privacy = newValue }
+        get { recorder.privacy }
+    }
+}
+
+/// Session Replay content policy. It describes the way in which sensitive content (e.g. text or images) should be recorded.
+public enum SessionReplayPrivacy {
+    /// Record all content as it is.
+    /// When using this option: all text, images and other information will be recorded and presented in the player.
+    case allowAll
+
+    /// Mask all content.
+    /// When using this option: all characters in texts will be replaced with "x", images will be
+    /// replaced with placeholders and other content will be masked accordingly, so the original
+    /// information will not be presented in the player.
+    ///
+    /// This is the default content policy.
+    case maskAll
 }

--- a/session-replay/Sources/DatadogSessionReplay/Processor/Privacy/TextObfuscator.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/Privacy/TextObfuscator.swift
@@ -6,7 +6,15 @@
 
 import Foundation
 
-internal struct TextObfuscator {
+internal protocol TextObfuscating {
+    /// Obfuscates given `text`.
+    /// - Parameter text: the text to be obfuscated
+    /// - Returns: obfuscated text
+    func mask(text: String) -> String
+}
+
+/// Text obfuscator which replaces all readable characters with `"x"`.
+internal struct TextObfuscator: TextObfuscating {
     /// The character to mask text with.
     let maskCharacter: UnicodeScalar = "x"
 
@@ -30,3 +38,13 @@ internal struct TextObfuscator {
         return masked
     }
 }
+
+/// Text obfuscator which only returns the original text.
+internal struct NOPTextObfuscator: TextObfuscating {
+    func mask(text: String) -> String {
+        return text
+    }
+}
+
+/// Text obfuscator which only returns the original text.
+internal let nopTextObfuscator: TextObfuscating = NOPTextObfuscator()

--- a/session-replay/Sources/DatadogSessionReplay/Processor/Privacy/TextObfuscator.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/Privacy/TextObfuscator.swift
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct TextObfuscator {
+    /// The character to mask text with.
+    let maskCharacter: UnicodeScalar = "x"
+
+    /// Masks given `text` by replacing all not whitespace characters with `"x"`.
+    /// - Parameter text: the text to be masked
+    /// - Returns: masked text
+    func mask(text: String) -> String {
+        var masked = ""
+
+        var iterator = text.unicodeScalars.makeIterator()
+
+        while let nextScalar = iterator.next() {
+            switch nextScalar {
+            case " ", "\n", "\r", "\t":
+                masked.unicodeScalars.append(nextScalar)
+            default:
+                masked.unicodeScalars.append(maskCharacter)
+            }
+        }
+
+        return masked
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/Recorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/Recorder.swift
@@ -19,6 +19,9 @@ internal class Recorder {
     /// Turns view tree snapshots into data models that will be uploaded to SR BE.
     let snapshotProcessor: ViewTreeSnapshotProcessor
 
+    /// The content recording policy for creating snapshots.
+    var privacy: SessionReplayPrivacy = .maskAll
+
     convenience init() {
         self.init(
             scheduler: MainThreadScheduler(interval: 0.25),
@@ -56,7 +59,9 @@ internal class Recorder {
     /// **Note**: This is called on the main thread.
     private func captureNextRecord() {
         do {
-            guard let snapshot = try snapshotProducer.takeSnapshot() else {
+            let currentOptions = ViewTreeSnapshotOptions(privacy: privacy)
+
+            guard let snapshot = try snapshotProducer.takeSnapshot(with: currentOptions) else {
                 return // there is nothing visible yet (i.e. the key window is not yet ready)
             }
 

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
@@ -23,7 +23,8 @@ internal struct UILabelRecorder: NodeRecorder {
             attributes: attributes,
             text: label.text ?? "",
             textColor: label.textColor?.cgColor,
-            font: label.font
+            font: label.font,
+            textObfuscator: context.options.privacy == .maskAll ? context.textObfuscator : nil
         )
         return SpecificElement(wireframesBuilder: builder)
     }
@@ -39,6 +40,8 @@ internal struct UILabelWireframesBuilder: NodeWireframesBuilder {
     let textColor: CGColor?
     /// The font used by the label.
     let font: UIFont?
+    /// Text obfuscator for masking text (`nil` if text should not be obfuscated for this element).
+    let textObfuscator: TextObfuscator?
 
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
         // The actual frame of the text, which is smaller than the frame of the label:
@@ -53,7 +56,7 @@ internal struct UILabelWireframesBuilder: NodeWireframesBuilder {
             builder.createTextWireframe(
                 id: wireframeID,
                 frame: attributes.frame,
-                text: text,
+                text: textObfuscator.map { $0.mask(text: text) } ?? text,
                 textFrame: textFrame,
                 textColor: textColor,
                 font: font,

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
@@ -24,7 +24,7 @@ internal struct UILabelRecorder: NodeRecorder {
             text: label.text ?? "",
             textColor: label.textColor?.cgColor,
             font: label.font,
-            textObfuscator: context.options.privacy == .maskAll ? context.textObfuscator : nil
+            textObfuscator: context.options.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator
         )
         return SpecificElement(wireframesBuilder: builder)
     }
@@ -40,8 +40,8 @@ internal struct UILabelWireframesBuilder: NodeWireframesBuilder {
     let textColor: CGColor?
     /// The font used by the label.
     let font: UIFont?
-    /// Text obfuscator for masking text (`nil` if text should not be obfuscated for this element).
-    let textObfuscator: TextObfuscator?
+    /// Text obfuscator for masking text.
+    let textObfuscator: TextObfuscating
 
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
         // The actual frame of the text, which is smaller than the frame of the label:
@@ -56,7 +56,7 @@ internal struct UILabelWireframesBuilder: NodeWireframesBuilder {
             builder.createTextWireframe(
                 id: wireframeID,
                 frame: attributes.frame,
-                text: textObfuscator.map { $0.mask(text: text) } ?? text,
+                text: textObfuscator.mask(text: text),
                 textFrame: textFrame,
                 textColor: textColor,
                 font: font,

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorder.swift
@@ -48,7 +48,8 @@ internal struct UITextFieldRecorder: NodeRecorder {
             // Is it correct to assume `textField.textColor` for placeholder text?
             textColor: textField.textColor?.cgColor,
             font: textField.font,
-            editor: editorProperties
+            editor: editorProperties,
+            textObfuscator: context.options.privacy == .maskAll ? context.textObfuscator : nil
         )
         return SpecificElement(wireframesBuilder: builder)
     }
@@ -66,6 +67,8 @@ internal struct UITextFieldWireframesBuilder: NodeWireframesBuilder {
     let font: UIFont?
     /// Properties of the editor field (which is a nested subview in `UITextField`).
     let editor: EditorFieldProperties?
+    /// Text obfuscator for masking text (`nil` if text should not be obfuscated for this element).
+    let textObfuscator: TextObfuscator?
 
     struct EditorFieldProperties {
         /// Editor view's `.backgorundColor`.
@@ -87,7 +90,7 @@ internal struct UITextFieldWireframesBuilder: NodeWireframesBuilder {
             builder.createTextWireframe(
                 id: wireframeID,
                 frame: attributes.frame,
-                text: text,
+                text: textObfuscator.map { $0.mask(text: text) } ?? text,
                 textFrame: textFrame,
                 textColor: textColor,
                 font: font,

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorder.swift
@@ -49,7 +49,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
             textColor: textField.textColor?.cgColor,
             font: textField.font,
             editor: editorProperties,
-            textObfuscator: context.options.privacy == .maskAll ? context.textObfuscator : nil
+            textObfuscator: context.options.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator
         )
         return SpecificElement(wireframesBuilder: builder)
     }
@@ -67,8 +67,8 @@ internal struct UITextFieldWireframesBuilder: NodeWireframesBuilder {
     let font: UIFont?
     /// Properties of the editor field (which is a nested subview in `UITextField`).
     let editor: EditorFieldProperties?
-    /// Text obfuscator for masking text (`nil` if text should not be obfuscated for this element).
-    let textObfuscator: TextObfuscator?
+    /// Text obfuscator for masking text.
+    let textObfuscator: TextObfuscating
 
     struct EditorFieldProperties {
         /// Editor view's `.backgorundColor`.
@@ -90,7 +90,7 @@ internal struct UITextFieldWireframesBuilder: NodeWireframesBuilder {
             builder.createTextWireframe(
                 id: wireframeID,
                 frame: attributes.frame,
-                text: textObfuscator.map { $0.mask(text: text) } ?? text,
+                text: textObfuscator.mask(text: text),
                 textFrame: textFrame,
                 textColor: textColor,
                 font: font,

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
@@ -15,7 +15,9 @@ internal struct ViewTreeSnapshotBuilder {
     struct Context {
         /// The coordinate space to convert node positions to.
         let coordinateSpace: UICoordinateSpace
-
+        /// Options of creating the snapshot.
+        let options: ViewTreeSnapshotOptions
+        /// Generates stable IDs for traversed views.
         let ids: NodeIDGenerator
     }
 
@@ -24,18 +26,20 @@ internal struct ViewTreeSnapshotBuilder {
     /// The order in this this array  should be managed consciously. For each node, the implementation loops
     /// through `nodeRecorders` and stops on the one that recorded node semantics with highes importance.
     let nodeRecorders: [NodeRecorder]
-
+    /// Generates stable IDs for traversed views.
     let idsGenerator = NodeIDGenerator()
 
     /// Builds the `ViewTreeSnapshot` for given root view.
     ///
     /// - Parameter rootView: the root view
+    /// - Parameter options: options of the snapshot
     /// - Returns: snapshot describing the view tree starting in `rootView`. All properties in snapshot nodes
     /// are computed relatively to the `rootView` (e.g. the `x` and `y` position of all descendant nodes  is given
     /// as its position in the root, no matter of nesting level).
-    func createSnapshot(of rootView: UIView) -> ViewTreeSnapshot {
+    func createSnapshot(of rootView: UIView, with options: ViewTreeSnapshotOptions) -> ViewTreeSnapshot {
         let context = Context(
             coordinateSpace: rootView,
+            options: options,
             ids: idsGenerator
         )
         let viewTreeSnapshot = ViewTreeSnapshot(

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
@@ -19,6 +19,8 @@ internal struct ViewTreeSnapshotBuilder {
         let options: ViewTreeSnapshotOptions
         /// Generates stable IDs for traversed views.
         let ids: NodeIDGenerator
+        /// Masks text in recorded nodes.
+        let textObfuscator: TextObfuscator
     }
 
     /// An array of enabled node recorders.
@@ -28,6 +30,8 @@ internal struct ViewTreeSnapshotBuilder {
     let nodeRecorders: [NodeRecorder]
     /// Generates stable IDs for traversed views.
     let idsGenerator = NodeIDGenerator()
+    /// Masks text in recorded nodes.
+    let textObfuscator = TextObfuscator()
 
     /// Builds the `ViewTreeSnapshot` for given root view.
     ///
@@ -40,7 +44,8 @@ internal struct ViewTreeSnapshotBuilder {
         let context = Context(
             coordinateSpace: rootView,
             options: options,
-            ids: idsGenerator
+            ids: idsGenerator,
+            textObfuscator: textObfuscator
         )
         let viewTreeSnapshot = ViewTreeSnapshot(
             date: Date(),

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/ViewTreeSnapshotProducer.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/ViewTreeSnapshotProducer.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-internal struct ViewTreeSnapshotOptions {
+internal struct ViewTreeSnapshotOptions: Equatable {
     /// The content recording policy for creating current snapshot.
     let privacy: SessionReplayPrivacy
 }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/ViewTreeSnapshotProducer.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/ViewTreeSnapshotProducer.swift
@@ -6,10 +6,16 @@
 
 import Foundation
 
+internal struct ViewTreeSnapshotOptions {
+    /// The content recording policy for creating current snapshot.
+    let privacy: SessionReplayPrivacy
+}
+
 /// Produces `ViewTreeSnapshot` describing the user interface in current app.
 internal protocol ViewTreeSnapshotProducer {
     /// Produces the snapshot of a view tree.
+    /// - Parameter options: options of the snapshot
     /// - Returns: the snapshot or `nil` if it cannot be taken.
     /// - Throws: can throw an `InternalError` if any problem occurs.
-    func takeSnapshot() throws -> ViewTreeSnapshot?
+    func takeSnapshot(with options: ViewTreeSnapshotOptions) throws -> ViewTreeSnapshot?
 }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/WindowSnapshotProducer.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/WindowSnapshotProducer.swift
@@ -14,10 +14,10 @@ internal struct WindowSnapshotProducer: ViewTreeSnapshotProducer {
     /// Builds snapshot from the app window.
     let snapshotBuilder: ViewTreeSnapshotBuilder
 
-    func takeSnapshot() throws -> ViewTreeSnapshot? {
+    func takeSnapshot(with options: ViewTreeSnapshotOptions) throws -> ViewTreeSnapshot? {
         guard let window = windowObserver.relevantWindow else {
             return nil
         }
-        return snapshotBuilder.createSnapshot(of: window)
+        return snapshotBuilder.createSnapshot(of: window, with: options)
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
@@ -196,19 +196,22 @@ extension ViewTreeSnapshotBuilder.Context: AnyMockable, RandomMockable {
         return .init(
             coordinateSpace: UIView.mockRandom(),
             options: .mockRandom(),
-            ids: NodeIDGenerator()
+            ids: NodeIDGenerator(),
+            textObfuscator: TextObfuscator()
         )
     }
 
     static func mockWith(
         coordinateSpace: UICoordinateSpace = UIView.mockAny(),
         options: ViewTreeSnapshotOptions = .mockAny(),
-        ids: NodeIDGenerator = NodeIDGenerator()
+        ids: NodeIDGenerator = NodeIDGenerator(),
+        textObfuscator: TextObfuscator = TextObfuscator()
     ) -> ViewTreeSnapshotBuilder.Context {
         return .init(
             coordinateSpace: coordinateSpace,
             options: options,
-            ids: ids
+            ids: ids,
+            textObfuscator: textObfuscator
         )
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
@@ -195,18 +195,54 @@ extension ViewTreeSnapshotBuilder.Context: AnyMockable, RandomMockable {
     static func mockRandom() -> ViewTreeSnapshotBuilder.Context {
         return .init(
             coordinateSpace: UIView.mockRandom(),
+            options: .mockRandom(),
             ids: NodeIDGenerator()
         )
     }
 
     static func mockWith(
         coordinateSpace: UICoordinateSpace = UIView.mockAny(),
+        options: ViewTreeSnapshotOptions = .mockAny(),
         ids: NodeIDGenerator = NodeIDGenerator()
     ) -> ViewTreeSnapshotBuilder.Context {
         return .init(
             coordinateSpace: coordinateSpace,
+            options: options,
             ids: ids
         )
+    }
+}
+
+extension ViewTreeSnapshotOptions: AnyMockable, RandomMockable {
+    static func mockAny() -> ViewTreeSnapshotOptions {
+        return .mockWith()
+    }
+
+    static func mockRandom() -> ViewTreeSnapshotOptions {
+        return ViewTreeSnapshotOptions(
+            privacy: .mockRandom()
+        )
+    }
+
+    static func mockWith(
+        privacy: SessionReplayPrivacy = .mockAny()
+    ) -> ViewTreeSnapshotOptions {
+        return ViewTreeSnapshotOptions(
+            privacy: privacy
+        )
+    }
+}
+
+extension SessionReplayPrivacy: AnyMockable, RandomMockable {
+    static func mockAny() -> SessionReplayPrivacy {
+        return .allowAll
+    }
+
+    static func mockRandom() -> SessionReplayPrivacy {
+        return [
+            .allowAll,
+            .maskAll
+        ].randomElement()!
     }
 }
 

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/SnapshotProducerMock.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/SnapshotProducerMock.swift
@@ -15,7 +15,7 @@ internal class SnapshotProducerMock: ViewTreeSnapshotProducer {
         self.succeedingSnapshots = succeedingSnapshots
     }
 
-    func takeSnapshot() -> ViewTreeSnapshot? {
+    func takeSnapshot(with options: ViewTreeSnapshotOptions) throws -> ViewTreeSnapshot? {
         return succeedingSnapshots.isEmpty ? nil : succeedingSnapshots.removeFirst()
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/SnapshotProducerMock.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/SnapshotProducerMock.swift
@@ -19,3 +19,13 @@ internal class SnapshotProducerMock: ViewTreeSnapshotProducer {
         return succeedingSnapshots.isEmpty ? nil : succeedingSnapshots.removeFirst()
     }
 }
+
+internal class SnapshotProducerSpy: ViewTreeSnapshotProducer {
+    /// Succeeding `options` passed to `takeSnapshot(with:)`.
+    var succeedingOptions: [ViewTreeSnapshotOptions] = []
+
+    func takeSnapshot(with options: ViewTreeSnapshotOptions) throws -> ViewTreeSnapshot? {
+        succeedingOptions.append(options)
+        return nil
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Processor/Privacy/TextObfuscatorTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Processor/Privacy/TextObfuscatorTests.swift
@@ -1,0 +1,50 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class TestObfuscatorTests: XCTestCase {
+    let obfuscator = TextObfuscator()
+
+    func testWhenMaskingEmptyText() {
+        XCTAssertEqual(obfuscator.mask(text: ""), "")
+    }
+
+    func testWhenObfuscatingTextWithWhitespacesAndNewlines() {
+        func test(separator: String) {
+            // Given
+            let text: String = (0..<5)
+                .map { _ in String.mockRandom(among: .alphanumerics, length: 10) }
+                .joined(separator: separator)
+
+            // When
+            let actual = obfuscator.mask(text: text)
+
+            // Then
+            let expectedText: String = text
+                .map { ch in String(ch) == separator ? String(ch) : "x" }
+                .joined()
+
+            XCTAssertEqual(expectedText, actual)
+        }
+
+        test(separator: " ")
+        test(separator: "\n")
+        test(separator: "\r")
+        test(separator: "\t")
+    }
+
+    func testWhenObfuscatingTextWithCustomUnicodeCodePoints() {
+        XCTAssertEqual(obfuscator.mask(text: "◌̀"), "xx")
+        XCTAssertEqual(obfuscator.mask(text: "🍕"), "x")
+        XCTAssertEqual(obfuscator.mask(text: "🍕🇮🇹"), "xxx")
+        XCTAssertEqual(obfuscator.mask(text: "🇮🇹"), "xx")
+        XCTAssertEqual(obfuscator.mask(text: "foo ◌̀ bar"), "xxx xx xxx")
+        XCTAssertEqual(obfuscator.mask(text: "foo 🍕 bar"), "xxx x xxx")
+        XCTAssertEqual(obfuscator.mask(text: "foo 🇮🇹 bar"), "xxx xx xxx")
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/RecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/RecorderTests.swift
@@ -27,4 +27,24 @@ class RecorderTests: XCTestCase {
         XCTAssertEqual(processor.processedSnapshots.count, numberOfSnapshots, "Processor should receive \(numberOfSnapshots) snapshots")
         XCTAssertEqual(processor.processedSnapshots, mockSnapshots)
     }
+
+    func testWhenCapturingSnapshot_itUsesPrivacyOption() {
+        let randomPrivacy: SessionReplayPrivacy = .mockRandom()
+
+        // Given
+        let snapshotProducer = SnapshotProducerSpy()
+        let recorder = Recorder(
+            scheduler: TestScheduler(numberOfRepeats: 1),
+            snapshotProducer: snapshotProducer,
+            snapshotProcessor: ProcessorSpy()
+        )
+
+        // When
+        recorder.privacy = randomPrivacy
+        recorder.start()
+
+        // Then
+        XCTAssertEqual(snapshotProducer.succeedingOptions.count, 1)
+        XCTAssertEqual(snapshotProducer.succeedingOptions[0].privacy, randomPrivacy)
+    }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
@@ -68,8 +68,8 @@ class UILabelRecorderTests: XCTestCase {
         // Then
         let builder1 = try XCTUnwrap(semantics1.wireframesBuilder as? UILabelWireframesBuilder)
         let builder2 = try XCTUnwrap(semantics2.wireframesBuilder as? UILabelWireframesBuilder)
-        XCTAssertNotNil(builder1.textObfuscator, "With `.maskAll` privacy the text obfuscator should be used")
-        XCTAssertNil(builder2.textObfuscator, "With `.allowAll` privacy the text obfuscator should not be used")
+        XCTAssertTrue(builder1.textObfuscator is TextObfuscator, "With `.maskAll` privacy the text obfuscator should be used")
+        XCTAssertTrue(builder2.textObfuscator is NOPTextObfuscator, "With `.allowAll` privacy the text obfuscator should not be used")
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
@@ -57,6 +57,21 @@ class UILabelRecorderTests: XCTestCase {
         XCTAssertEqual(builder.font, label.font)
     }
 
+    func testWhenRecordingInDifferentPrivacyModes() throws {
+        // Given
+        label.text = .mockRandom()
+
+        // When
+        let semantics1 = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockWith(options: .mockWith(privacy: .maskAll))))
+        let semantics2 = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockWith(options: .mockWith(privacy: .allowAll))))
+
+        // Then
+        let builder1 = try XCTUnwrap(semantics1.wireframesBuilder as? UILabelWireframesBuilder)
+        let builder2 = try XCTUnwrap(semantics2.wireframesBuilder as? UILabelWireframesBuilder)
+        XCTAssertNotNil(builder1.textObfuscator, "With `.maskAll` privacy the text obfuscator should be used")
+        XCTAssertNil(builder2.textObfuscator, "With `.allowAll` privacy the text obfuscator should not be used")
+    }
+
     func testWhenViewIsNotOfExpectedType() {
         // When
         let view = UITextField()

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
@@ -60,6 +60,21 @@ class UITextFieldRecorderTests: XCTestCase {
         XCTAssertNotNil(builder.editor)
     }
 
+    func testWhenRecordingInDifferentPrivacyModes() throws {
+        // Given
+        textField.text = .mockRandom()
+
+        // When
+        let semantics1 = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockWith(options: .mockWith(privacy: .maskAll))))
+        let semantics2 = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockWith(options: .mockWith(privacy: .allowAll))))
+
+        // Then
+        let builder1 = try XCTUnwrap(semantics1.wireframesBuilder as? UITextFieldWireframesBuilder)
+        let builder2 = try XCTUnwrap(semantics2.wireframesBuilder as? UITextFieldWireframesBuilder)
+        XCTAssertNotNil(builder1.textObfuscator, "With `.maskAll` privacy the text obfuscator should be used")
+        XCTAssertNil(builder2.textObfuscator, "With `.allowAll` privacy the text obfuscator should not be used")
+    }
+
     func testWhenViewIsNotOfExpectedType() {
         // When
         let view = UILabel()

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
@@ -71,8 +71,8 @@ class UITextFieldRecorderTests: XCTestCase {
         // Then
         let builder1 = try XCTUnwrap(semantics1.wireframesBuilder as? UITextFieldWireframesBuilder)
         let builder2 = try XCTUnwrap(semantics2.wireframesBuilder as? UITextFieldWireframesBuilder)
-        XCTAssertNotNil(builder1.textObfuscator, "With `.maskAll` privacy the text obfuscator should be used")
-        XCTAssertNil(builder2.textObfuscator, "With `.allowAll` privacy the text obfuscator should not be used")
+        XCTAssertTrue(builder1.textObfuscator is TextObfuscator, "With `.maskAll` privacy the text obfuscator should be used")
+        XCTAssertTrue(builder2.textObfuscator is NOPTextObfuscator, "With `.allowAll` privacy the text obfuscator should not be used")
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilderTests.swift
@@ -39,7 +39,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             NodeRecorderMock(resultForView: { _ in nil }),
         ]
         let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders)
-        _ = builder.createSnapshot(of: rootView)
+        _ = builder.createSnapshot(of: rootView, with: .mockRandom())
 
         // Then
         XCTAssertEqual(recorders[0].queriedViews, [rootView, childView, grandchildView])
@@ -64,7 +64,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             NodeRecorderMock(resultForView: { _ in specificElement }), // ... so this one should not be queried
         ]
         let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders)
-        _ = builder.createSnapshot(of: view)
+        _ = builder.createSnapshot(of: view, with: .mockRandom())
 
         // Then
         XCTAssertEqual(recorders[0].queriedViews, [view], "It should be queried as semantics is not known")
@@ -103,7 +103,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         // When
         let nodeRecorder = NodeRecorderMock(resultForView: { view in semanticsByView[view] })
         let builder = ViewTreeSnapshotBuilder(nodeRecorders: [nodeRecorder])
-        let snapshot = builder.createSnapshot(of: rootView)
+        let snapshot = builder.createSnapshot(of: rootView, with: .mockRandom())
 
         // Then
         XCTAssertTrue(snapshot.root.semantics is AmbiguousElement)
@@ -140,7 +140,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         ]
 
         // When
-        let snapshots = views.map { builder.createSnapshot(of: $0) }
+        let snapshots = views.map { builder.createSnapshot(of: $0, with: .mockRandom()) }
 
         // Then
         zip(snapshots, views).forEach { snapshot, view in
@@ -165,7 +165,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         let `switch` = try UISwitch.mock(withFixture: .visibleWithNoAppearance)
 
         // When
-        let viewSnapshot = builder.createSnapshot(of: view)
+        let viewSnapshot = builder.createSnapshot(of: view, with: .mockRandom())
         XCTAssertTrue(
             viewSnapshot.root.semantics is AmbiguousElement,
             """
@@ -175,7 +175,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             """
         )
 
-        let labelSnapshot = builder.createSnapshot(of: label)
+        let labelSnapshot = builder.createSnapshot(of: label, with: .mockRandom())
         XCTAssertTrue(
             labelSnapshot.root.semantics is InvisibleElement,
             """
@@ -184,7 +184,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             """
         )
 
-        let imageViewSnapshot = builder.createSnapshot(of: imageView)
+        let imageViewSnapshot = builder.createSnapshot(of: imageView, with: .mockRandom())
         XCTAssertTrue(
             imageViewSnapshot.root.semantics is InvisibleElement,
             """
@@ -193,7 +193,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             """
         )
 
-        let textFieldSnapshot = builder.createSnapshot(of: textField)
+        let textFieldSnapshot = builder.createSnapshot(of: textField, with: .mockRandom())
         XCTAssertTrue(
             textFieldSnapshot.root.semantics is SpecificElement,
             """
@@ -202,7 +202,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             """
         )
 
-        let switchSnapshot = builder.createSnapshot(of: `switch`)
+        let switchSnapshot = builder.createSnapshot(of: `switch`, with: .mockRandom())
         XCTAssertTrue(
             switchSnapshot.root.semantics is SpecificElement,
             """
@@ -218,7 +218,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         let view = try UIView.mock(withFixture: .visibleWithSomeAppearance)
 
         // When
-        let snapshot = builder.createSnapshot(of: view)
+        let snapshot = builder.createSnapshot(of: view, with: .mockRandom())
 
         // Then
         XCTAssertTrue(
@@ -242,7 +242,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         ]
 
         // When
-        let snapshots = views.map { builder.createSnapshot(of: $0) }
+        let snapshots = views.map { builder.createSnapshot(of: $0, with: .mockRandom()) }
 
         // Then
         zip(snapshots, views).forEach { snapshot, view in


### PR DESCRIPTION
### What and why?

🚚🔒 This PR adds "mask all" and "allow all" privacy rules to Session Replay.

With "mask all" (default setting), no text will be recorded in traversed `UILabels` and `UITextFields`. Instead, visible characters will be replaced by `"x"` (except whitespaces and newlines).

### How?

The public API added in this PR is still a draft (we will work on the actual one when integrating with V2 SDK).

The actual masking is done by basic iteration over `String` with replacing certain characters. To make it performant:
* It uses [`String.UnicodeScalarView.Iterator`](https://developer.apple.com/documentation/swift/string/unicodescalarview/iterator) which gives good performance and encapsulates Unicode complexity. I measured this to be 10x faster than RegExp (with 40K characters-long string and 1K repeats, it was `20ms` vs `2ms`). More on this approach and benchmarks can be also read [here](https://medium.com/@tonyallevato/strings-characters-and-performance-in-swift-a-deep-dive-b7b5bde58d53).
* The `String` is captured on the main queue, but masking is performed on the background thread.

In proposed implementation I'm trying to foresee next rules that we will introduce for parity with web SR [privacy options](https://docs.datadoghq.com/real_user_monitoring/session_replay/privacy_options):
* The "mask user input" option will likely target interactive elements (`UITextFields`). To anticipate this need, I have decentralised the logic of text obfuscation, so each node recorder (`UILabelRecorder` and `UITextFieldRecorder`) decides on its own if masking should be applied.
* Very likely we will also add ways to override this setting for certain instances of `UIView` (perhaps in similar fashion as our RUM views predicate works). To make sure the solution scales to this use case, each node recorder resolves `privacy` information on the main thread (even though the actual masking is performed on background queue). This way we will be able to inspect the element or even pass it to sort of predicate in public API.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
