### PR TITLE
RUMM-2687 Invert frame time to get js refresh rate

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -448,7 +448,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 inForegroundPeriods: nil,
                 isActive: isActive,
                 isSlowRendered: isSlowRendered,
-                jsRefreshRate: viewPerformanceMetrics[.jsRefreshRate]?.asJsRefreshRate(),
+                jsRefreshRate: viewPerformanceMetrics[.jsFrameTimeMilliseconds]?.asJsRefreshRate(),
                 largestContentfulPaint: nil,
                 loadEvent: nil,
                 loadingTime: nil,
@@ -637,10 +637,17 @@ private extension VitalInfo {
 
     func asJsRefreshRate() -> RUMViewEvent.View.JsRefreshRate {
         return RUMViewEvent.View.JsRefreshRate(
-            average: meanValue ?? 0.0,
-            max: maxValue ?? 0.0,
+            average: invertValue(value: meanValue) * 1_000,
+            max: invertValue(value: minValue) * 1_000,
             metricMax: 60.0,
-            min: minValue ?? 0.0
+            min: invertValue(value: maxValue) * 1_000
         )
     }
+}
+
+internal func invertValue(value: Double?) -> Double {
+    if value == 0.0 || value == nil {
+        return 0.0
+    }
+    return 1 / (value ?? 1)
 }

--- a/Sources/Datadog/RUM/RUMVitals/PerformanceMetric.swift
+++ b/Sources/Datadog/RUM/RUMVitals/PerformanceMetric.swift
@@ -13,6 +13,7 @@ public enum PerformanceMetric {
     // The amount of time Flutter spent rasterizing the view.
     case flutterRasterTime
 
-    // The JavaScript refresh rate of a React Native view.
-    case jsRefreshRate
+    // The JavaScript frame time of a React Native view.
+    // We store the frame time as its average makes more sense, then invert it to get the frame rate.
+    case jsFrameTimeMilliseconds
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1396,9 +1396,12 @@ class RUMMonitorTests: XCTestCase {
         let monitor = try createTestableRUMMonitor()
 
         monitor.startView(viewController: mockView)
-        monitor.updatePerformanceMetric(metric: .jsRefreshRate, value: 40.0)
-        monitor.updatePerformanceMetric(metric: .jsRefreshRate, value: 20.0)
+        monitor.updatePerformanceMetric(metric: .jsFrameTimeMilliseconds, value: 20.0)
+        monitor.updatePerformanceMetric(metric: .jsFrameTimeMilliseconds, value: 20.0)
+        monitor.updatePerformanceMetric(metric: .jsFrameTimeMilliseconds, value: 20.0)
+        monitor.updatePerformanceMetric(metric: .jsFrameTimeMilliseconds, value: 40.0)
         monitor.updatePerformanceMetric(metric: .flutterBuildTime, value: 32.0)
+        monitor.updatePerformanceMetric(metric: .flutterBuildTime, value: 52.0)
         monitor.updatePerformanceMetric(metric: .flutterRasterTime, value: 42.0)
         monitor.stopView(viewController: mockView)
 
@@ -1406,11 +1409,13 @@ class RUMMonitorTests: XCTestCase {
 
         try rumEventMatchers.lastRUMEvent(ofType: RUMViewEvent.self)
             .model(ofType: RUMViewEvent.self) { rumModel in
-                XCTAssertEqual(rumModel.view.jsRefreshRate?.max, 40.0)
-                XCTAssertEqual(rumModel.view.jsRefreshRate?.min, 20.0)
-                XCTAssertEqual(rumModel.view.jsRefreshRate?.average, 30.0)
+                XCTAssertEqual(rumModel.view.jsRefreshRate?.max, 50.0)
+                XCTAssertEqual(rumModel.view.jsRefreshRate?.min, 25.0)
+                XCTAssertEqual(rumModel.view.jsRefreshRate?.average, 40.0)
 
-                XCTAssertEqual(rumModel.view.flutterBuildTime?.average, 32.0)
+                XCTAssertEqual(rumModel.view.flutterBuildTime?.max, 52.0)
+                XCTAssertEqual(rumModel.view.flutterBuildTime?.min, 32.0)
+                XCTAssertEqual(rumModel.view.flutterBuildTime?.average, 42.0)
                 XCTAssertEqual(rumModel.view.flutterRasterTime?.average, 42.0)
             }
     }


### PR DESCRIPTION
### What and why?

Get a more sensible for the average js refresh rate by getting the harmonic mean instead of the arithmetic mean.
See https://gamedev.net/forums/topic/628085-math-fail-adding-frames-per-second/4960225/ and https://en.wikipedia.org/wiki/Harmonic_mean#Average_speed to understand why this makes more sense.

### How?

Let the RN SDK report the frame time, then invert it when reporting to backend

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
