### PR TITLE
RUMM-2661 [SR] Inject RUM context to Session Replay

### DIFF
--- a/Datadog.xcworkspace/contents.xcworkspacedata
+++ b/Datadog.xcworkspace/contents.xcworkspacedata
@@ -7,7 +7,4 @@
    <FileRef
       location = "group:instrumented-tests/http-server-mock">
    </FileRef>
-   <FileRef
-      location = "group:session-replay">
-   </FileRef>
 </Workspace>

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -242,7 +242,6 @@
 		615CC4102694A64D0005F08C /* SwiftExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615CC40F2694A64D0005F08C /* SwiftExtensionTests.swift */; };
 		615CC4132695957C0005F08C /* CrashReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615CC4122695957C0005F08C /* CrashReportTests.swift */; };
 		615F197C25B5A64B00BE14B5 /* UIKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615F197B25B5A64B00BE14B5 /* UIKitExtensions.swift */; };
-		6160D3B32892F508000768DD /* DatadogSessionReplay in Frameworks */ = {isa = PBXBuildFile; productRef = 6160D3B22892F508000768DD /* DatadogSessionReplay */; };
 		6161247925CA9CA6009901BE /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6161247825CA9CA6009901BE /* CrashReporter.swift */; };
 		6161249E25CAB340009901BE /* CrashContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6161249D25CAB340009901BE /* CrashContext.swift */; };
 		616124A725CAC268009901BE /* CrashContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616124A625CAC268009901BE /* CrashContextProvider.swift */; };
@@ -488,7 +487,6 @@
 		61F3CDA52511190E00C816E5 /* UIViewControllerSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA42511190E00C816E5 /* UIViewControllerSwizzler.swift */; };
 		61F3CDA72512144600C816E5 /* UIKitRUMViewsPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDA62512144600C816E5 /* UIKitRUMViewsPredicate.swift */; };
 		61F3CDAB25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F3CDAA25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift */; };
-		61F4A01D289D5C00001B1BB6 /* DatadogSessionReplay in Frameworks */ = {isa = PBXBuildFile; productRef = 61F4A01C289D5C00001B1BB6 /* DatadogSessionReplay */; };
 		61F74AF426F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F74AF326F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift */; };
 		61F7F1DD266F9CB000F9F53B /* CodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61133BA02423979B00786299 /* CodableValue.swift */; };
 		61F8CC092469295500FE2908 /* DatadogConfigurationBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F8CC082469295500FE2908 /* DatadogConfigurationBuilderTests.swift */; };
@@ -1981,7 +1979,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9E5BD8042819742200CB568E /* SwiftUI.framework in Frameworks */,
-				6160D3B32892F508000768DD /* DatadogSessionReplay in Frameworks */,
 				D240687827CF982B00C04F44 /* CrashReporter.xcframework in Frameworks */,
 				D240687B27CF982C00C04F44 /* Datadog.framework in Frameworks */,
 				D240687D27CF982D00C04F44 /* DatadogCrashReporting.framework in Frameworks */,
@@ -2061,7 +2058,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9E5BD8062819742C00CB568E /* SwiftUI.framework in Frameworks */,
-				61F4A01D289D5C00001B1BB6 /* DatadogSessionReplay in Frameworks */,
 				D240687027CF971C00C04F44 /* CrashReporter.xcframework in Frameworks */,
 				D240687127CF971C00C04F44 /* Datadog.framework in Frameworks */,
 				D240687227CF971C00C04F44 /* DatadogCrashReporting.framework in Frameworks */,
@@ -4575,7 +4571,6 @@
 			);
 			name = "Example iOS";
 			packageProductDependencies = (
-				6160D3B22892F508000768DD /* DatadogSessionReplay */,
 			);
 			productName = Example;
 			productReference = 61441C0224616DE9003D8BB8 /* Example iOS.app */;
@@ -4739,7 +4734,6 @@
 			);
 			name = "Example tvOS";
 			packageProductDependencies = (
-				61F4A01C289D5C00001B1BB6 /* DatadogSessionReplay */,
 			);
 			productName = Example;
 			productReference = D240684D27CE6C9E00C04F44 /* Example tvOS.app */;
@@ -8156,14 +8150,6 @@
 		6152C83D24BE1C91006A1679 /* HTTPServerMock */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = HTTPServerMock;
-		};
-		6160D3B22892F508000768DD /* DatadogSessionReplay */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = DatadogSessionReplay;
-		};
-		61F4A01C289D5C00001B1BB6 /* DatadogSessionReplay */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = DatadogSessionReplay;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Datadog/Example/ExampleAppDelegate.swift
+++ b/Datadog/Example/ExampleAppDelegate.swift
@@ -6,7 +6,6 @@
 
 import UIKit
 import Datadog
-import DatadogSessionReplay
 
 var logger: Logger!
 var tracer: OTTracer { Global.sharedTracer }
@@ -25,10 +24,6 @@ class ExampleAppDelegate: UIResponder, UIApplicationDelegate {
             appConfiguration = UITestsAppConfiguration()
         } else {
             appConfiguration = ExampleAppConfiguration()
-
-            // Draft integration with SR feature:
-            SessionReplayFeature.instance = SessionReplayFeature()
-            SessionReplayFeature.instance?.start()
         }
 
         // Initialize Datadog SDK

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -14,17 +14,17 @@ public protocol DatadogCoreProtocol {
     /// Registers a Feature instance.
     ///
     /// Feature collects and transfers data to a Datadog Product (e.g. Logs, RUM, ...). Upon registration, the Feature can
-    /// retrieve a `FeatureScope` interface for writing events. The core will store and upload events in an efficient way
-    /// with performance presets defined on initialization.
+    /// retrieve a `FeatureScope` interface for writing events to the core. The core will store and upload events efficiently
+    /// according to the performance presets defined on initialization.
     ///
-    /// The Feature can also communicate to other Features by sending messages on the message bus managed by core.
+    /// A Feature can also communicate to other Features by sending messages on the message bus managed by core.
     ///
     /// - Parameter feature: The Feature instance - it will be retained and held by core.
     func register(feature: DatadogFeature) throws
 
     /// Retrieves previously registered Feature by its name and type.
     ///
-    /// Feature's type can be specified as parameter or inferred from the return type:
+    /// A Feature type can be specified as parameter or inferred from the return type:
     ///
     ///     let feature = core.feature(named: "foo", type: Foo.self)
     ///     let feature: Foo? = core.feature(named: "foo")

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -8,23 +8,23 @@ import Foundation
 
 public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOPDatadogCore()
 
-/// A Datadog Core holds a set of features and is responsible of managing their storage
+/// A Datadog Core holds a set of Features and is responsible for managing their storage
 /// and upload mechanism. It also provides a thread-safe scope for writing events.
 public protocol DatadogCoreProtocol {
     /// Registers a Feature instance.
     ///
-    /// A Feature collects and transfers data to a Datadog Product (e.g. Logs, RUM, ...). A registered Feature can
-    /// open a `FeatureScope` to write events, the core will then be responsible for storing and uploading events
-    /// in a efficient manner. Performance presets for storage and upload are define when instanciating the core instance.
+    /// Feature collects and transfers data to a Datadog Product (e.g. Logs, RUM, ...). Upon registration, the Feature can
+    /// retrieve a `FeatureScope` interface for writing events. The core will store and upload events in an efficient way
+    /// with performance presets defined on initialization.
     ///
-    /// A Feature can also communicate to other Features by sending message on the bus that is managed by the core.
+    /// The Feature can also communicate to other Features by sending messages on the message bus managed by core.
     ///
-    /// - Parameter feature: The Feature instance.
+    /// - Parameter feature: The Feature instance - it will be retained and held by core.
     func register(feature: DatadogFeature) throws
 
-    /// Retrieves a Feature by its name and type.
+    /// Retrieves previously registered Feature by its name and type.
     ///
-    /// A Feature type can be specified as parameter or inferred from the return type:
+    /// Feature's type can be specified as parameter or inferred from the return type:
     ///
     ///     let feature = core.feature(named: "foo", type: Foo.self)
     ///     let feature: Foo? = core.feature(named: "foo")

--- a/Sources/Datadog/DatadogInternal/DatadogFeature.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogFeature.swift
@@ -34,7 +34,7 @@ public protocol DatadogFeature {
     /// The message bus receiver.
     ///
     /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
-    /// from a bus that is shared between Features registered in a core.
+    /// from a bus that is shared between all Features registered in the core.
     var messageReceiver: FeatureMessageReceiver { get }
 }
 

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureMessageReceiver.swift
@@ -6,23 +6,25 @@
 
 import Foundation
 
-/// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
-/// from a bus that is shared between Features registered in a core.
+/// The `FeatureMessageReceiver` defines an interface for a Feature to receive messages
+/// from a bus that is shared between Features registered to same instance of the core.
 ///
-/// A message is composed of a key and a dictionary of attributes. A message format is a loose
-/// agreement between Features, any supported messages by a Feature should be properly
-/// documented.
+/// The message is composed of a key and a dictionary of attributes. The message format is a loose
+/// agreement between Features - all messages supported by a Feature should be properly documented.
 public protocol FeatureMessageReceiver {
-    /// Receive a message from the message bus of a given core.
+    /// Receives messages from the message bus.
     ///
-    /// The message can be used to build an event or run a process.
-    /// Be mindful of not blocking the caller thread.
+    /// The message can be used to build an event or execute custom routine in the Feature.
+    ///
+    /// This method is always called on the same thread managed by core. If the implementation
+    /// of `FeatureMessageReceiver` needs to manage a state it can consider its mutations started
+    /// from `receive(message:from:)` to be thread-safe. The implementation should be mindful of
+    /// not blocking the caller thread to not delay processing of other messages in the system.
     ///
     /// - Parameters:
-    ///   - message: The Feature message
-    ///   - core: The core from which the message is transmitted.
-    /// - Returns: Returns `true` if the message was processed by the receiver. `false` if it was
-    ///            ignored.
+    ///   - message: The message
+    ///   - core: An instance of the core from which the message is transmitted.
+    /// - Returns: `true` if the message was processed by the receiver;`false` if it was ignored.
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool
 }
 

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -148,9 +148,14 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
 
     /// RUM Attributes shared with other Feature registered in core.
     internal struct Attributes {
+        /// The ID of RUM application (`String`).
         internal static let applicationID = "application_id"
+        /// The ID of current RUM session (standard UUID `String`, lowercased).
+        /// In case the session is rejected (not sampled), RUM context is set to empty (`[:]`) in core.
         internal static let sessionID = "session_id"
+        /// The ID of current RUM view (standard UUID `String`, lowercased).
         internal static let viewID = "view.id"
+        /// The ID of current RUM action (standard UUID `String`, lowercased).
         internal static let userActionID = "user_action.id"
     }
 

--- a/session-replay/Package.swift
+++ b/session-replay/Package.swift
@@ -15,11 +15,12 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(name: "Datadog", path: ".."),
     ],
     targets: [
         .target(
             name: "DatadogSessionReplay",
-            dependencies: []
+            dependencies: ["Datadog"]
         ),
         .testTarget(
             name: "DatadogSessionReplayTests",

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
@@ -1,0 +1,96 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+@testable import Datadog
+
+/// The RUM context received from `DatadogCore`.
+internal struct RUMContext: Equatable {
+    /// Current RUM application ID - standard UUID string, lowecased.
+    let applicationID: String
+    /// Current RUM session ID - standard UUID string, lowecased.
+    let sessionID: String
+    /// Current RUM view ID - standard UUID string, lowecased.
+    let viewID: String
+}
+
+/// An observer notifying on`RUMContext` changes.
+internal protocol RUMContextObserver {
+    /// Starts notifying on distinct changes to `RUMContext`.
+    ///
+    /// - Parameters:
+    ///   - queue: a queue to call `notify` block on
+    ///   - notify: a closure receiving new `RUMContext` or `nil` if current RUM session is not sampled
+    func observe(on queue: Queue, notify: @escaping (RUMContext?) -> Void)
+}
+
+/// Receives RUM context from `DatadogCore` and notifies it through `RUMContextObserver` interface.
+internal class RUMContextReceiver: FeatureMessageReceiver, RUMContextObserver {
+    /// Notifies new `RUMContext` or `nil` if current RUM session is not sampled.
+    private var onNew: ((RUMContext?) -> Void)?
+    private var previous: RUMContext?
+
+    // MARK: - FeatureMessageReceiver
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard let rumBaggage = message.contextMessage?.rumBaggage else {
+            // No RUM baggage in the message
+            return false
+        }
+
+        // Extract the `RUMContext` or `nil` if RUM session is not sampled:
+        let new = rumBaggage.rumContext
+
+        // Notify only if it has changed:
+        if new != previous {
+            onNew?(new)
+            previous = new
+        }
+
+        return true
+    }
+
+    // MARK: - RUMContextObserver
+
+    func observe(on queue: Queue, notify: @escaping (RUMContext?) -> Void) {
+        onNew = { new in
+            queue.run {
+                notify(new)
+            }
+        }
+    }
+}
+
+// MARK: - Extracting RUM context from `DatadogCore` message
+
+private extension FeatureMessage {
+    var contextMessage: DatadogContext? {
+        guard case let .context(datadogContext) = self else {
+            return nil
+        }
+        return datadogContext
+    }
+}
+
+private extension DatadogContext {
+    var rumBaggage: FeatureBaggage? {
+        return featuresAttributes[RUMDependency.rumBaggageKey]
+    }
+}
+
+private extension FeatureBaggage {
+    var rumContext: RUMContext? {
+        guard let applicationID: String = self[RUMDependency.applicationIDKey],
+              let sessionID: String = self[RUMDependency.sessionIDKey],
+              let viewID: String = self[RUMDependency.viewIDKey]
+        else {
+            // Current RUM session is not sampled
+            return nil
+        }
+
+        return RUMContext(applicationID: applicationID, sessionID: sessionID, viewID: viewID)
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Defines dependency between Session Replay and RUM modules.
+/// It aims at centralizing documentation of contracts between both products.
+internal struct RUMDependency {
+    /// The key for referencing RUM baggage (RUM context) in `DatadogContext.featuresAttributes`.
+    ///
+    /// SR expects:
+    /// - empty baggage (`[:]`) if current RUM session is not sampled,
+    /// - baggage with `applicationIDKey`, `sessionIDKey` and `viewIDKey` keys if RUM session is sampled.
+    static let rumBaggageKey = "rum"
+
+    /// The key for referencing RUM application ID inside RUM baggage.
+    ///
+    /// SR expects non-optional value holding lowercased, standard UUID `String`.
+    static let applicationIDKey = "application_id"
+
+    /// The key for referencing RUM session ID inside RUM baggage.
+    ///
+    /// SR expects non-optional value holding lowercased, standard UUID `String`.
+    static let sessionIDKey = "session_id"
+
+    /// The key for referencing RUM view ID inside RUM baggage.
+    ///
+    /// SR expects non-optional value holding lowercased, standard UUID `String`.
+    static let viewIDKey = "view.id"
+}

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// Defines dependency between Session Replay and RUM modules.
+/// Defines dependency between Session Replay (SR) and RUM modules.
 /// It aims at centralizing documentation of contracts between both products.
 internal struct RUMDependency {
     /// The key for referencing RUM baggage (RUM context) in `DatadogContext.featuresAttributes`.

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplay.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplay.swift
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import Datadog
+
+/// A draft interface for SR Feature initialization.
+/// TODO: RUMM-2268 Design convenient public API
+public struct SessionReplay {
+    @discardableResult
+    public static func initialize(
+        with configuration: SessionReplayConfiguration,
+        in datadogInstance: DatadogCoreProtocol = defaultDatadogCore
+    ) throws -> SessionReplayController {
+        let sessionReplay = SessionReplayFeature(configuration: configuration)
+        try datadogInstance.register(feature: sessionReplay)
+
+        return sessionReplay
+    }
+}
+
+/// A draft interface of SR controller.
+/// TODO: RUMM-2268 Design convenient public API
+public protocol SessionReplayController {
+    /// Start recording.
+    func start()
+
+    /// Stop recording.
+    func stop()
+
+    /// Changes the content recording policy.
+    func change(privacy: SessionReplayPrivacy)
+}

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayConfiguration.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayConfiguration.swift
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// A draft interface of SR configuration.
+public struct SessionReplayConfiguration {
+    /// Defines the way in which sensitive content (e.g. text or images) should be recorded.
+    /// Defaults to `.maskAll`.
+    public let privacy: SessionReplayPrivacy
+
+    public init(
+        privacy: SessionReplayPrivacy = .maskAll
+    ) {
+        self.privacy = privacy
+    }
+}
+
+/// Session Replay content recording policy.
+/// It describes the way in which sensitive content (e.g. text or images) should be captured.
+public enum SessionReplayPrivacy {
+    /// Record all content as it is.
+    /// When using this option: all text, images and other information will be recorded and presented in the player.
+    case allowAll
+
+    /// Mask all content.
+    /// When using this option: all characters in texts will be replaced with "x", images will be
+    /// replaced with placeholders and other content will be masked accordingly, so the original
+    /// information will not be presented in the player.
+    ///
+    /// This is the default content policy.
+    case maskAll
+}

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorder.swift
@@ -24,7 +24,7 @@ internal struct UILabelRecorder: NodeRecorder {
             text: label.text ?? "",
             textColor: label.textColor?.cgColor,
             font: label.font,
-            textObfuscator: context.options.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator
+            textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator
         )
         return SpecificElement(wireframesBuilder: builder)
     }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorder.swift
@@ -49,7 +49,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
             textColor: textField.textColor?.cgColor,
             font: textField.font,
             editor: editorProperties,
-            textObfuscator: context.options.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator
+            textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator
         )
         return SpecificElement(wireframesBuilder: builder)
     }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshot.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshot.swift
@@ -18,7 +18,8 @@ import UIKit
 internal struct ViewTreeSnapshot {
     /// The time of taking this snapshot.
     let date: Date
-
+    /// The RUM context from the moment of taking this snapshot.
+    let rumContext: RUMContext
     /// The node indicating the root view of this snapshot.
     let root: Node
 }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilder.swift
@@ -13,10 +13,10 @@ import UIKit
 internal struct ViewTreeSnapshotBuilder {
     /// The context of building current snapshot.
     struct Context {
+        /// The context of the Recorder.
+        let recorder: Recorder.Context
         /// The coordinate space to convert node positions to.
         let coordinateSpace: UICoordinateSpace
-        /// Options of creating the snapshot.
-        let options: ViewTreeSnapshotOptions
         /// Generates stable IDs for traversed views.
         let ids: NodeIDGenerator
         /// Masks text in recorded nodes.
@@ -36,20 +36,21 @@ internal struct ViewTreeSnapshotBuilder {
     /// Builds the `ViewTreeSnapshot` for given root view.
     ///
     /// - Parameter rootView: the root view
-    /// - Parameter options: options of the snapshot
+    /// - Parameter recorderContext: the context of the Recorder from the moment of requesting this snapshot
     /// - Returns: snapshot describing the view tree starting in `rootView`. All properties in snapshot nodes
     /// are computed relatively to the `rootView` (e.g. the `x` and `y` position of all descendant nodes  is given
     /// as its position in the root, no matter of nesting level).
-    func createSnapshot(of rootView: UIView, with options: ViewTreeSnapshotOptions) -> ViewTreeSnapshot {
-        let context = Context(
+    func createSnapshot(of rootView: UIView, with recorderContext: Recorder.Context) -> ViewTreeSnapshot {
+        let builderContext = Context(
+            recorder: recorderContext,
             coordinateSpace: rootView,
-            options: options,
             ids: idsGenerator,
             textObfuscator: textObfuscator
         )
         let viewTreeSnapshot = ViewTreeSnapshot(
-            date: Date(),
-            root: createNode(for: rootView, in: context)
+            date: recorderContext.date,
+            rumContext: recorderContext.rumContext,
+            root: createNode(for: rootView, in: builderContext)
         )
         return viewTreeSnapshot
     }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/ViewTreeSnapshotProducer.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/ViewTreeSnapshotProducer.swift
@@ -6,16 +6,11 @@
 
 import Foundation
 
-internal struct ViewTreeSnapshotOptions: Equatable {
-    /// The content recording policy for creating current snapshot.
-    let privacy: SessionReplayPrivacy
-}
-
 /// Produces `ViewTreeSnapshot` describing the user interface in current app.
 internal protocol ViewTreeSnapshotProducer {
     /// Produces the snapshot of a view tree.
-    /// - Parameter options: options of the snapshot
+    /// - Parameter context: the context of Recorder from the moment of requesting snapshot
     /// - Returns: the snapshot or `nil` if it cannot be taken.
     /// - Throws: can throw an `InternalError` if any problem occurs.
-    func takeSnapshot(with options: ViewTreeSnapshotOptions) throws -> ViewTreeSnapshot?
+    func takeSnapshot(with context: Recorder.Context) throws -> ViewTreeSnapshot?
 }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/WindowSnapshotProducer.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/SnapshotProducer/WindowSnapshotProducer.swift
@@ -14,10 +14,10 @@ internal struct WindowSnapshotProducer: ViewTreeSnapshotProducer {
     /// Builds snapshot from the app window.
     let snapshotBuilder: ViewTreeSnapshotBuilder
 
-    func takeSnapshot(with options: ViewTreeSnapshotOptions) throws -> ViewTreeSnapshot? {
+    func takeSnapshot(with context: Recorder.Context) throws -> ViewTreeSnapshot? {
         guard let window = windowObserver.relevantWindow else {
             return nil
         }
-        return snapshotBuilder.createSnapshot(of: window, with: options)
+        return snapshotBuilder.createSnapshot(of: window, with: context)
     }
 }

--- a/session-replay/Sources/DatadogSessionReplay/Utilities/Queue.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Utilities/Queue.swift
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal protocol Queue {
+    func run(_ block: @escaping () -> Void)
+}
+
+internal struct MainAsyncQueue: Queue {
+    private let queue: DispatchQueue = .main
+
+    func run(_ block: @escaping () -> Void) {
+        queue.async { block() }
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/Utilities/Schedulers/MainThreadScheduler.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Utilities/Schedulers/MainThreadScheduler.swift
@@ -20,15 +20,15 @@ internal class MainThreadScheduler: Scheduler {
         static let timerTolerance: Double = 0.1
     }
 
-    /// The queue for ensuring thread safety of this scheduler.
-    private let mainQueue = DispatchQueue.main
     /// The time interval between repeating operations.
     private let interval: TimeInterval
-
     /// The timer driving this scheduler.
     private var timer: Timer? = nil
     /// An array of scheduled operations.
     private var operations: [() -> Void] = []
+
+    /// The queue that operations are executed on.
+    let queue: Queue = MainAsyncQueue()
 
     /// Initializer.
     /// - Parameter interval: the interval between repeating operations
@@ -37,13 +37,13 @@ internal class MainThreadScheduler: Scheduler {
     }
 
     func schedule(operation: @escaping () -> Void) {
-        mainQueue.async {
+        queue.run {
             self.operations.append(operation)
         }
     }
 
     func start() {
-        mainQueue.async {
+        queue.run {
             guard self.timer == nil else {
                 return // is running
             }
@@ -59,7 +59,7 @@ internal class MainThreadScheduler: Scheduler {
     }
 
     func stop() {
-        mainQueue.async {
+        queue.run {
             guard self.timer != nil else {
                 return // is not running
             }

--- a/session-replay/Sources/DatadogSessionReplay/Utilities/Schedulers/Scheduler.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Utilities/Schedulers/Scheduler.swift
@@ -6,15 +6,18 @@
 
 import Foundation
 
-/// Schedules operations and fires them in a recurring way.
+/// Schedules operations for later execution.
 internal protocol Scheduler {
+    /// The queue that operations are executed on.
+    var queue: Queue { get }
+
     /// Adds operation to the scheduler.
-    /// Operations can be added no matter if this scheduler is running or not.
+    /// Operations can be added no matter if the scheduler is running.
     func schedule(operation: @escaping () -> Void)
 
-    /// Starts repeating scheduled operations.
+    /// Starts executing scheduled operations.
     func start()
 
-    /// Stops repeating scheduled operations.
+    /// Stops executing scheduled operations.
     func stop()
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+// swiftlint:disable empty_xctest_method
+class RUMContextReceiverTests: XCTestCase {
+    private let receiver = RUMContextReceiver()
+
+    func testWhenMessageContainsNonEmptyRUMBaggage_itNotifiesRUMContext() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating partial mocks for `FeatureMessage` and `DatadogContext`,
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+
+    func testWhenMessageContainsEmptyRUMBaggage_itNotifiesNoRUMContext() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating partial mocks for `FeatureMessage` and `DatadogContext`,
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+
+    func testWhenSucceedingMessagesContainDifferentRUMBaggages_itNotifiesRUMContextChange() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating partial mocks for `FeatureMessage` and `DatadogContext`,
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+
+    func testWhenSucceedingMessagesContainEqualRUMBaggages_itDoesNotNotifyRUMContextChange() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating partial mocks for `FeatureMessage` and `DatadogContext`,
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+}
+// swiftlint:enable empty_xctest_method

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/QueueMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/QueueMocks.swift
@@ -4,11 +4,12 @@
  * Copyright 2019-2020 Datadog, Inc.
  */
 
-import XCTest
+import Foundation
 @testable import DatadogSessionReplay
 
-final class SessionReplayFeatureTests: XCTestCase {
-    func testExample() throws {
-        XCTAssertNil(SessionReplayFeature.instance)
+/// A queue that executes synchronously on the caller thread.
+internal struct NoQueue: Queue {
+    func run(_ block: @escaping () -> Void) {
+        block()
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
@@ -22,16 +22,19 @@ extension ViewTreeSnapshot: AnyMockable, RandomMockable {
     static func mockRandom() -> ViewTreeSnapshot {
         return ViewTreeSnapshot(
             date: .mockRandom(),
+            rumContext: .mockRandom(),
             root: .mockRandom()
         )
     }
 
     static func mockWith(
         date: Date = .mockAny(),
+        rumContext: RUMContext = .mockRandom(),
         root: Node = .mockAny()
     ) -> ViewTreeSnapshot {
         return ViewTreeSnapshot(
             date: date,
+            rumContext: rumContext,
             root: root
         )
     }
@@ -194,58 +197,77 @@ extension ViewTreeSnapshotBuilder.Context: AnyMockable, RandomMockable {
 
     static func mockRandom() -> ViewTreeSnapshotBuilder.Context {
         return .init(
+            recorder: .mockRandom(),
             coordinateSpace: UIView.mockRandom(),
-            options: .mockRandom(),
             ids: NodeIDGenerator(),
             textObfuscator: TextObfuscator()
         )
     }
 
     static func mockWith(
+        recorder: Recorder.Context = .mockAny(),
         coordinateSpace: UICoordinateSpace = UIView.mockAny(),
-        options: ViewTreeSnapshotOptions = .mockAny(),
         ids: NodeIDGenerator = NodeIDGenerator(),
         textObfuscator: TextObfuscator = TextObfuscator()
     ) -> ViewTreeSnapshotBuilder.Context {
         return .init(
+            recorder: recorder,
             coordinateSpace: coordinateSpace,
-            options: options,
             ids: ids,
             textObfuscator: textObfuscator
         )
     }
 }
 
-extension ViewTreeSnapshotOptions: AnyMockable, RandomMockable {
-    static func mockAny() -> ViewTreeSnapshotOptions {
+extension RUMContext: AnyMockable, RandomMockable {
+    static func mockAny() -> RUMContext {
         return .mockWith()
     }
 
-    static func mockRandom() -> ViewTreeSnapshotOptions {
-        return ViewTreeSnapshotOptions(
-            privacy: .mockRandom()
+    static func mockRandom() -> RUMContext {
+        return RUMContext(
+            applicationID: .mockRandom(),
+            sessionID: .mockRandom(),
+            viewID: .mockRandom()
         )
     }
 
     static func mockWith(
-        privacy: SessionReplayPrivacy = .mockAny()
-    ) -> ViewTreeSnapshotOptions {
-        return ViewTreeSnapshotOptions(
-            privacy: privacy
+        applicationID: String = .mockAny(),
+        sessionID: String = .mockAny(),
+        viewID: String = .mockAny()
+    ) -> RUMContext {
+        return RUMContext(
+            applicationID: applicationID,
+            sessionID: sessionID,
+            viewID: viewID
         )
     }
 }
 
-extension SessionReplayPrivacy: AnyMockable, RandomMockable {
-    static func mockAny() -> SessionReplayPrivacy {
-        return .allowAll
+extension Recorder.Context: AnyMockable, RandomMockable {
+    static func mockAny() -> Recorder.Context {
+        return .mockWith()
     }
 
-    static func mockRandom() -> SessionReplayPrivacy {
-        return [
-            .allowAll,
-            .maskAll
-        ].randomElement()!
+    static func mockRandom() -> Recorder.Context {
+        return Recorder.Context(
+            date: .mockRandom(),
+            privacy: .mockRandom(),
+            rumContext: .mockRandom()
+        )
+    }
+
+    static func mockWith(
+        date: Date = .mockAny(),
+        privacy: SessionReplayPrivacy = .mockAny(),
+        rumContext: RUMContext = .mockAny()
+    ) -> Recorder.Context {
+        return Recorder.Context(
+            date: date,
+            privacy: privacy,
+            rumContext: rumContext
+        )
     }
 }
 

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/SessionReplayMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/SessionReplayMocks.swift
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+@testable import DatadogSessionReplay
+
+extension SessionReplayConfiguration: AnyMockable, RandomMockable {
+    static func mockAny() -> SessionReplayConfiguration {
+        return .mockWith()
+    }
+
+    static func mockRandom() -> SessionReplayConfiguration {
+        return SessionReplayConfiguration(
+            privacy: .mockRandom()
+        )
+    }
+
+    static func mockWith(
+        privacy: SessionReplayPrivacy = .mockAny()
+    ) -> SessionReplayConfiguration {
+        return SessionReplayConfiguration(
+            privacy: privacy
+        )
+    }
+}
+
+extension SessionReplayPrivacy: AnyMockable, RandomMockable {
+    static func mockAny() -> SessionReplayPrivacy {
+        return .allowAll
+    }
+
+    static func mockRandom() -> SessionReplayPrivacy {
+        return [
+            .allowAll,
+            .maskAll
+        ].randomElement()!
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/SnapshotProducerMock.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/SnapshotProducerMock.swift
@@ -15,17 +15,17 @@ internal class SnapshotProducerMock: ViewTreeSnapshotProducer {
         self.succeedingSnapshots = succeedingSnapshots
     }
 
-    func takeSnapshot(with options: ViewTreeSnapshotOptions) throws -> ViewTreeSnapshot? {
+    func takeSnapshot(with context: Recorder.Context) throws -> ViewTreeSnapshot? {
         return succeedingSnapshots.isEmpty ? nil : succeedingSnapshots.removeFirst()
     }
 }
 
 internal class SnapshotProducerSpy: ViewTreeSnapshotProducer {
-    /// Succeeding `options` passed to `takeSnapshot(with:)`.
-    var succeedingOptions: [ViewTreeSnapshotOptions] = []
+    /// Succeeding `context` values passed to `takeSnapshot(with:)`.
+    var succeedingContexts: [Recorder.Context] = []
 
-    func takeSnapshot(with options: ViewTreeSnapshotOptions) throws -> ViewTreeSnapshot? {
-        succeedingOptions.append(options)
+    func takeSnapshot(with context: Recorder.Context) throws -> ViewTreeSnapshot? {
+        succeedingContexts.append(context)
         return nil
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/RecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/RecorderTests.swift
@@ -7,18 +7,36 @@
 import XCTest
 @testable import DatadogSessionReplay
 
+private class RUMContextObserverMock: RUMContextObserver {
+    private var queue: Queue?
+    private var onNew: ((RUMContext?) -> Void)?
+
+    func observe(on queue: Queue, notify: @escaping (RUMContext?) -> Void) {
+        self.queue = queue
+        self.onNew = notify
+    }
+
+    func notify(rumContext: RUMContext?) {
+        queue?.run { self.onNew?(rumContext) }
+    }
+}
+
 class RecorderTests: XCTestCase {
-    func testWhenStarted_itCapturesSnapshotsAndPassesThemToProcessor() {
+    func testGivenRUMContextAvailable_whenStarted_itCapturesSnapshotsAndPassesThemToProcessor() {
         let numberOfSnapshots = 10
         let mockSnapshots: [ViewTreeSnapshot] = .mockRandom(count: numberOfSnapshots)
+        let rumContextObserver = RUMContextObserverMock()
+        let processor = ProcessorSpy()
 
         // Given
-        let processor = ProcessorSpy()
         let recorder = Recorder(
+            configuration: .mockAny(),
+            rumContextObserver: rumContextObserver,
             scheduler: TestScheduler(numberOfRepeats: numberOfSnapshots),
             snapshotProducer: SnapshotProducerMock(succeedingSnapshots: mockSnapshots),
             snapshotProcessor: processor
         )
+        rumContextObserver.notify(rumContext: .mockAny())
 
         // When
         recorder.start()
@@ -28,23 +46,78 @@ class RecorderTests: XCTestCase {
         XCTAssertEqual(processor.processedSnapshots, mockSnapshots)
     }
 
-    func testWhenCapturingSnapshot_itUsesPrivacyOption() {
-        let randomPrivacy: SessionReplayPrivacy = .mockRandom()
+    func testGivenNoRUMContextAvailable_whenStarted_itDoesNotCaptureAnySnapshots() {
+        let rumContextObserver = RUMContextObserverMock()
+        let processor = ProcessorSpy()
 
         // Given
-        let snapshotProducer = SnapshotProducerSpy()
         let recorder = Recorder(
+            configuration: .mockAny(),
+            rumContextObserver: rumContextObserver,
+            scheduler: TestScheduler(numberOfRepeats: 1),
+            snapshotProducer: SnapshotProducerMock(succeedingSnapshots: .mockAny(count: 1)),
+            snapshotProcessor: processor
+        )
+        rumContextObserver.notify(rumContext: nil)
+
+        // When
+        recorder.start()
+
+        // Then
+        XCTAssertTrue(processor.processedSnapshots.isEmpty)
+    }
+
+    func testGivenRUMContextAvailable_whenCapturingSnapshot_itUsesDefaultRecorderContext() {
+        let randomPrivacy: SessionReplayPrivacy = .mockRandom()
+        let randomRUMContext: RUMContext = .mockRandom()
+        let rumContextObserver = RUMContextObserverMock()
+        let snapshotProducer = SnapshotProducerSpy()
+
+        // Given
+        let recorder = Recorder(
+            configuration: SessionReplayConfiguration(privacy: randomPrivacy),
+            rumContextObserver: rumContextObserver,
             scheduler: TestScheduler(numberOfRepeats: 1),
             snapshotProducer: snapshotProducer,
             snapshotProcessor: ProcessorSpy()
         )
+        rumContextObserver.notify(rumContext: randomRUMContext)
 
         // When
-        recorder.privacy = randomPrivacy
         recorder.start()
 
         // Then
-        XCTAssertEqual(snapshotProducer.succeedingOptions.count, 1)
-        XCTAssertEqual(snapshotProducer.succeedingOptions[0].privacy, randomPrivacy)
+        XCTAssertEqual(snapshotProducer.succeedingContexts.count, 1)
+        XCTAssertEqual(snapshotProducer.succeedingContexts[0].privacy, randomPrivacy)
+        XCTAssertEqual(snapshotProducer.succeedingContexts[0].rumContext, randomRUMContext)
+    }
+
+    func testGivenRUMContextAvailable_whenCapturingSnapshot_itUsesCurrentRecorderContext() {
+        let rumContextObserver = RUMContextObserverMock()
+        let snapshotProducer = SnapshotProducerSpy()
+
+        // Given
+        let recorder = Recorder(
+            configuration: SessionReplayConfiguration(privacy: .mockRandom()),
+            rumContextObserver: rumContextObserver,
+            scheduler: TestScheduler(numberOfRepeats: 1),
+            snapshotProducer: snapshotProducer,
+            snapshotProcessor: ProcessorSpy()
+        )
+        rumContextObserver.notify(rumContext: .mockRandom())
+
+        // When
+        let currentPrivacy: SessionReplayPrivacy = .mockRandom()
+        recorder.change(privacy: currentPrivacy)
+
+        let currentRUMContext: RUMContext = .mockRandom()
+        rumContextObserver.notify(rumContext: currentRUMContext)
+
+        recorder.start()
+
+        // Then
+        XCTAssertEqual(snapshotProducer.succeedingContexts.count, 1)
+        XCTAssertEqual(snapshotProducer.succeedingContexts[0].privacy, currentPrivacy)
+        XCTAssertEqual(snapshotProducer.succeedingContexts[0].rumContext, currentRUMContext)
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UILabelRecorderTests.swift
@@ -62,8 +62,8 @@ class UILabelRecorderTests: XCTestCase {
         label.text = .mockRandom()
 
         // When
-        let semantics1 = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockWith(options: .mockWith(privacy: .maskAll))))
-        let semantics2 = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockWith(options: .mockWith(privacy: .allowAll))))
+        let semantics1 = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .maskAll))))
+        let semantics2 = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .allowAll))))
 
         // Then
         let builder1 = try XCTUnwrap(semantics1.wireframesBuilder as? UILabelWireframesBuilder)

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/NodeRecorders/UITextFieldRecorderTests.swift
@@ -65,8 +65,8 @@ class UITextFieldRecorderTests: XCTestCase {
         textField.text = .mockRandom()
 
         // When
-        let semantics1 = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockWith(options: .mockWith(privacy: .maskAll))))
-        let semantics2 = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockWith(options: .mockWith(privacy: .allowAll))))
+        let semantics1 = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .maskAll))))
+        let semantics2 = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .allowAll))))
 
         // Then
         let builder1 = try XCTUnwrap(semantics1.wireframesBuilder as? UITextFieldWireframesBuilder)

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/SnapshotBuilder/ViewTreeSnapshotBuilderTests.swift
@@ -80,17 +80,20 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         // Given
         let view = UIView(frame: .mockRandom())
 
-        let randomSnapshotOptions: ViewTreeSnapshotOptions = .mockRandom()
+        let randomRecorderContext: Recorder.Context = .mockRandom()
         let recorder = NodeRecorderMock(resultForView: { _ in nil })
         let builder = ViewTreeSnapshotBuilder(nodeRecorders: [recorder])
 
         // When
-        _ = builder.createSnapshot(of: view, with: randomSnapshotOptions)
+        let snapshot = builder.createSnapshot(of: view, with: randomRecorderContext)
 
         // Then
+        XCTAssertEqual(snapshot.date, randomRecorderContext.date)
+        XCTAssertEqual(snapshot.rumContext, randomRecorderContext.rumContext)
+
         let queryContext = try XCTUnwrap(recorder.queryContexts.first)
         XCTAssertTrue(queryContext.coordinateSpace === view)
-        XCTAssertEqual(queryContext.options, randomSnapshotOptions)
+        XCTAssertEqual(queryContext.recorder, randomRecorderContext)
     }
 
     // MARK: - Recording Nodes Recursively


### PR DESCRIPTION
### What and why?

🚚 This PR injects RUM context to Session Replay. From now on, the SR module receives up-to-date information on RUM _app ID_, _session ID_ and _view ID_ (or lack of them if RUM session is not sampled).

This is a necessary step to establish the link between SR and RUM.

### How?

`Datadog` module (exposing V2 APIs) is declared as dependency in SR's `Package.swift`.

At the entry level, SR module defines conformances to V2 Feature interfaces:
* `SessionReplayFeature: DatadogFeature` - to register V2 Feature,
* `RUMContextReceiver: FeatureMessageReceiver` - to receive `DatadogContext` updates through V2 message bus.

Once received, the `RUMContext` is passed to `Recorder`. It is then bundled in recorded `ViewTreeSnapshot` sent to `Processor`. In RUMM-2679 the context will be also used to pause and resume `Recorder` accordingly to RUM session sampling (to avoid consuming device resources when RUM session is rejected).

Based on the `snapshot.rumContext` value, `Processor` will take decision on creating appropriate SR records. This work will be implemented in _RUMM-2662: Session replay data is automatically uploaded_.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
