### PR TITLE
Fix Vitals Default Presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 # 1.13.0 / 07-11-2022
 
-- [IMPROVEMENT] Add a method to add properties to user info without needing to reset other user info..
+- [IMPROVEMENT] Add a method to add properties to user info without needing to reset other user info.
 - [IMPROVEMENT] Send trace sample rate (`dd.rulePsr`) for APM's traffic ingestion control page. See [#1029][]
+- [BUGFIX] Fix vitals default presets. See [#1043][]
 
 # 1.12.1 / 18-10-2022
 
@@ -402,6 +403,7 @@
 [#973]: https://github.com/DataDog/dd-sdk-ios/issues/973
 [#997]: https://github.com/DataDog/dd-sdk-ios/issues/997
 [#1029]: https://github.com/DataDog/dd-sdk-ios/issues/1029
+[#1043]: https://github.com/DataDog/dd-sdk-ios/issues/1043
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -356,7 +356,7 @@ extension Datadog {
                     rumBackgroundEventTrackingEnabled: false,
                     rumFrustrationSignalsTrackingEnabled: true,
                     rumTelemetrySamplingRate: 20,
-                    mobileVitalsFrequency: .rare,
+                    mobileVitalsFrequency: .average,
                     batchSize: .medium,
                     uploadFrequency: .average,
                     additionalConfiguration: [:],

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -8,7 +8,7 @@ import Foundation
 
 internal class RUMViewScope: RUMScope, RUMContextProvider {
     struct Constants {
-        static let frozenFrameThresholdInNs = (0.07).toInt64Nanoseconds // 70ms
+        static let frozenFrameThresholdInNs = (0.7).toInt64Nanoseconds // 700ms
         static let slowRenderingThresholdFPS = 55.0
         /// The pre-warming detection attribute key
         static let activePrewarm = "active_pre_warm"

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -59,7 +59,7 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertFalse(configuration.rumBackgroundEventTrackingEnabled)
             XCTAssertTrue(configuration.rumFrustrationSignalsTrackingEnabled)
             XCTAssertNil(configuration.rumResourceAttributesProvider)
-            XCTAssertEqual(configuration.mobileVitalsFrequency, .rare)
+            XCTAssertEqual(configuration.mobileVitalsFrequency, .average)
             XCTAssertEqual(configuration.batchSize, .medium)
             XCTAssertEqual(configuration.uploadFrequency, .average)
             XCTAssertEqual(configuration.additionalConfiguration.count, 0)

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -57,7 +57,7 @@ class DDConfigurationTests: XCTestCase {
             XCTAssertEqual(configuration.rumSessionsSamplingRate, 100.0)
             XCTAssertNil(configuration.rumUIKitViewsPredicate)
             XCTAssertNil(configuration.rumUIKitUserActionsPredicate)
-            XCTAssertEqual(configuration.mobileVitalsFrequency, .rare)
+            XCTAssertEqual(configuration.mobileVitalsFrequency, .average)
             XCTAssertEqual(configuration.batchSize, .medium)
             XCTAssertEqual(configuration.uploadFrequency, .average)
             XCTAssertNil(configuration.rumViewEventMapper)


### PR DESCRIPTION
### What and why?

Fix vitals presets and align with Android.

### Requirements

- Default Vitals Frequency: `average` (every 500ms)
- Frozen Frame Threshold: **700ms**

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
