### PR TITLE
RUMM-2662 [SR] Upload Session Replay records (batched into segments)

### DIFF
--- a/Sources/Datadog/DatadogCore/Upload/DataUploader.swift
+++ b/Sources/Datadog/DatadogCore/Upload/DataUploader.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// A type that performs data uploads.
 internal protocol DataUploaderType {
-    func upload(events: [Data], context: DatadogContext) -> DataUploadStatus
+    func upload(events: [Data], context: DatadogContext) throws -> DataUploadStatus
 }
 
 /// Synchronously uploads data to server using `HTTPClient`.
@@ -26,8 +26,8 @@ internal final class DataUploader: DataUploaderType {
 
     /// Uploads data synchronously (will block current thread) and returns the upload status.
     /// Uses timeout configured for `HTTPClient`.
-    func upload(events: [Data], context: DatadogContext) -> DataUploadStatus {
-        let request = requestBuilder.request(for: events, with: context)
+    func upload(events: [Data], context: DatadogContext) throws -> DataUploadStatus {
+        let request = try requestBuilder.request(for: events, with: context)
         let requestID = request.value(forHTTPHeaderField: URLRequestBuilder.HTTPHeader.ddRequestIDHeaderField)
 
         var uploadStatus: DataUploadStatus?

--- a/Sources/Datadog/DatadogInternal/Context/DatadogContext.swift
+++ b/Sources/Datadog/DatadogInternal/Context/DatadogContext.swift
@@ -54,7 +54,7 @@ public struct DatadogContext {
     let sdkInitDate: Date
 
     /// Current device information.
-    let device: DeviceInfo
+    public let device: DeviceInfo
 
     /// Current user information.
     var userInfo: UserInfo?

--- a/Sources/Datadog/DatadogInternal/Context/DatadogContext.swift
+++ b/Sources/Datadog/DatadogInternal/Context/DatadogContext.swift
@@ -12,10 +12,10 @@ public struct DatadogContext {
     /// [Datadog Site](https://docs.datadoghq.com/getting_started/site/) for data uploads. It can be `nil` in V1
     /// if the SDK is configured using deprecated APIs:
     /// `set(logsEndpoint:)`, `set(tracesEndpoint:)` and `set(rumEndpoint:)`.
-    let site: DatadogSite?
+    public let site: DatadogSite?
 
     /// The client token allowing for data uploads to [Datadog Site](https://docs.datadoghq.com/getting_started/site/).
-    let clientToken: String
+    public let clientToken: String
 
     /// The name of the service that data is generated from. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
     let service: String
@@ -24,14 +24,14 @@ public struct DatadogContext {
     let env: String
 
     /// The version of the application that data is generated from. Used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
-    let version: String
+    public let version: String
 
     /// Denotes the mobile application's platform, such as `"ios"` or `"flutter"` that data is generated from.
     ///  - See: Datadog [Reserved Attributes](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes).
-    let source: String
+    public let source: String
 
     /// The version of Datadog iOS SDK.
-    let sdkVersion: String
+    public let sdkVersion: String
 
     /// The name of [CI Visibility](https://docs.datadoghq.com/continuous_integration/) origin.
     /// It is only set if the SDK is running with a context passed from [Swift Tests](https://docs.datadoghq.com/continuous_integration/setup_tests/swift/?tab=swiftpackagemanager) library.
@@ -45,7 +45,7 @@ public struct DatadogContext {
     // MARK: - Application Specific
 
     /// The name of the application, read from `Info.plist` (`CFBundleExecutable`).
-    let applicationName: String
+    public let applicationName: String
 
     /// The bundle identifier, read from `Info.plist` (`CFBundleIdentifier`).
     let applicationBundleIdentifier: String

--- a/Sources/Datadog/DatadogInternal/Context/DeviceInfo.swift
+++ b/Sources/Datadog/DatadogInternal/Context/DeviceInfo.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Describes current device information.
-internal struct DeviceInfo {
+public struct DeviceInfo {
     // MARK: - Info
 
     /// Device manufacturer name.

--- a/Sources/Datadog/DatadogInternal/DatadogFeature.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogFeature.swift
@@ -27,8 +27,6 @@ public protocol DatadogFeature {
     var name: String { get }
 
     /// The URL request builder for uploading data in this Feature.
-    ///
-    /// This builder currently use the v1 context, but will be soon migrated to v2
     var requestBuilder: FeatureRequestBuilder { get }
 
     /// The message bus receiver.

--- a/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogV1Context.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// Datadog site that SDK sends data to.
 /// See: https://docs.datadoghq.com/getting_started/site/
-internal typealias DatadogSite = Datadog.Configuration.DatadogEndpoint
+public typealias DatadogSite = Datadog.Configuration.DatadogEndpoint
 
 /// The SDK context for V1, until the V2 context is created.
 ///

--- a/Sources/Datadog/DatadogInternal/Upload/FeatureRequestBuilder.swift
+++ b/Sources/Datadog/DatadogInternal/Upload/FeatureRequestBuilder.swift
@@ -9,19 +9,21 @@ import Foundation
 /// The `FeatureRequestBuilder` defines an interface for building a single `URLRequest`
 /// for a list of data events and the current core context.
 ///
-/// The core implementation can use the interface for creating requests targetting datadog intake
-/// of a given feature.
+/// A Feature should use this interface for creating requests that needs be sent to its Datadog Intake.
+/// The request will be transported by `DatadogCore`.
 public protocol FeatureRequestBuilder {
-    /// Builds a `URLRequest` for a list of events and the current core context to be uploaded
-    /// to the feature intake.
+    /// Builds an `URLRequest` for a list of events and the current core context to be uploaded
+    /// to the Feature's Intake.
     ///
-    /// The returned request must include all necessary information, including HTTP headers and
-    /// URL queries for the intake to ingest the payload. The request will be sent as is by the core
-    /// uploader.
+    /// The returned request must include all necessary information, i.e. HTTP headers and
+    /// URL queries required by the Feature's Intake. The request will be sent by the core.
+    ///
+    /// **Note:** When `Error` is thrown, underlying data will be dropped permanently and never retried. The
+    /// implementation should make a wise consideration of throwing vs recovering strategy.
     ///
     /// - Parameters:
     ///   - context: The current core context.
-    ///   - events: The events data to upload.
+    ///   - events: The events data to be uploaded.
     /// - Returns: The URL request.
-    func request(for events: [Data], with context: DatadogContext) -> URLRequest
+    func request(for events: [Data], with context: DatadogContext) throws -> URLRequest
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CoreMocks.swift
@@ -787,10 +787,10 @@ class NOPDataUploadWorker: DataUploadWorkerType {
 struct DataUploaderMock: DataUploaderType {
     let uploadStatus: DataUploadStatus
 
-    var onUpload: (() -> Void)? = nil
+    var onUpload: (() throws -> Void)? = nil
 
-    func upload(events: [Data], context: DatadogContext) -> DataUploadStatus {
-        onUpload?()
+    func upload(events: [Data], context: DatadogContext) throws -> DataUploadStatus {
+        try onUpload?()
         return uploadStatus
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/UploadMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/UploadMock.swift
@@ -26,10 +26,18 @@ internal struct FeatureRequestBuilderMock: FeatureRequestBuilder {
         self.format = format
     }
 
-    func request(for events: [Data], with context: DatadogContext) -> URLRequest {
+    func request(for events: [Data], with context: DatadogContext) throws -> URLRequest {
         let builder = URLRequestBuilder(url: url, queryItems: queryItems, headers: headers)
         let data = format.format(events)
         return builder.uploadRequest(with: data)
+    }
+}
+
+internal struct FailingRequestBuilderMock: FeatureRequestBuilder {
+    let error: Error
+
+    func request(for events: [Data], with context: DatadogContext) throws -> URLRequest {
+        throw error
     }
 }
 

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/JSON/EnrichedRecordJSON.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/JSON/EnrichedRecordJSON.swift
@@ -1,0 +1,62 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal typealias JSONObject = [String: Any]
+
+/// A mirror of `EnrichedRecord` but providing decoding capability. Unlike encodable `EnrichedRecord`
+/// it can be both encoded and decoded with `Foundation.JSONSerialization`.
+///
+/// `EnrichedRecordJSON` values are decoded from batched events (`[Data]`) upon request from `DatadogCore`.
+/// They are mapped into one or many `SegmentJSONs`. Segments are then encoded in multipart-body of `URLRequests`
+/// and sent by core on behalf of Session Replay.
+///
+/// Except containing original records created by `Processor` (in `records: [JSONObject]`), `EnrichedRecordJSON`
+/// offers a typed meta information that facilitates grouping records into segments.
+internal struct EnrichedRecordJSON {
+    /// Records enriched with further information.
+    let records: [JSONObject]
+
+    /// The RUM application ID common to all records.
+    let applicationID: String
+    /// The RUM session ID common to all records.
+    let sessionID: String
+    /// The RUM view ID common to all records.
+    let viewID: String
+    /// If there is a Full Snapshot among records.
+    let hasFullSnapshot: Bool
+    /// The timestamp of the earliest record.
+    let earliestTimestamp: Int64
+    /// The timestamp of the latest record.
+    let latestTimestamp: Int64
+
+    init(jsonObjectData: Data) throws {
+        let jsonObject: JSONObject = try decode(jsonObjectData)
+
+        self.records = try read(codingKey: .records, from: jsonObject)
+        self.applicationID = try read(codingKey: .applicationID, from: jsonObject)
+        self.sessionID = try read(codingKey: .sessionID, from: jsonObject)
+        self.viewID = try read(codingKey: .viewID, from: jsonObject)
+        self.hasFullSnapshot = try read(codingKey: .hasFullSnapshot, from: jsonObject)
+        self.earliestTimestamp = try read(codingKey: .earliestTimestamp, from: jsonObject)
+        self.latestTimestamp = try read(codingKey: .latestTimestamp, from: jsonObject)
+    }
+}
+
+private func decode<T>(_ data: Data) throws -> T {
+    guard let value = try JSONSerialization.jsonObject(with: data) as? T else {
+        throw InternalError(description: "Failed to decode \(type(of: T.self))")
+    }
+    return value
+}
+
+private func read<T>(codingKey: EnrichedRecord.CodingKeys, from object: JSONObject) throws -> T {
+    guard let value = object[codingKey.stringValue] as? T else {
+        throw InternalError(description: "Failed to read attribute at key path '\(codingKey.stringValue)'")
+    }
+    return value
+}

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSON.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSON.swift
@@ -32,7 +32,7 @@ internal struct SegmentJSON {
     /// If there is a Full Snapshot among records.
     let hasFullSnapshot: Bool
 
-    func toJSONObject() throws -> JSONObject {
+    func toJSONObject() -> JSONObject {
         return [
             segmentKey(.application): [applicationKey(.id): applicationID],
             segmentKey(.session): [sessionKey(.id): sessionID],

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSON.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSON.swift
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// A counterpart of `SRSegment`. Unlike codable `SRSegment` it can be encoded to JSON data
+/// with using anonymous `records: [JSONObject]` (the original `SRSegment` requires
+/// typed `[SRRecords]` which isn't possible to read unambiguously from event data stored in `DatadogCore`).
+///
+/// Can be considered a temporary solution until we find a way to decode `[SRRecords]` unambiguously
+/// through `Codable` interface.
+internal struct SegmentJSON {
+    /// The RUM application ID common to all records.
+    let applicationID: String
+    /// The RUM session ID common to all records.
+    let sessionID: String
+    /// The RUM view ID common to all records.
+    let viewID: String
+    /// The `source` of SDK in which the segment was recorded (e.g. `"ios"`).
+    let source: String
+    /// The timestamp of the earliest record.
+    let start: Int64
+    /// The timestamp of the latest record.
+    let end: Int64
+    /// Records to be sent in this segment.
+    let records: [JSONObject]
+    /// Number of records.
+    let recordsCount: Int64
+    /// If there is a Full Snapshot among records.
+    let hasFullSnapshot: Bool
+
+    func toJSONObject() throws -> JSONObject {
+        return [
+            segmentKey(.application): [applicationKey(.id): applicationID],
+            segmentKey(.session): [sessionKey(.id): sessionID],
+            segmentKey(.view): [viewKey(.id): viewID],
+            segmentKey(.source): source,
+            segmentKey(.start): start,
+            segmentKey(.end): end,
+            segmentKey(.hasFullSnapshot): hasFullSnapshot,
+            segmentKey(.records): records,
+            segmentKey(.recordsCount): recordsCount,
+        ]
+    }
+}
+
+private func segmentKey(_ codingKey: SRSegment.CodingKeys) -> String { codingKey.stringValue }
+private func applicationKey(_ codingKey: SRSegment.Application.CodingKeys) -> String { codingKey.stringValue }
+private func sessionKey(_ codingKey: SRSegment.Session.CodingKeys) -> String { codingKey.stringValue }
+private func viewKey(_ codingKey: SRSegment.View.CodingKeys) -> String { codingKey.stringValue }

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilder.swift
@@ -1,0 +1,108 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+internal struct SegmentJSONBuilder {
+    let source: SRSegment.Source
+
+    /// Groups records into segments.
+    ///
+    /// It scans succeeding records and groups together ones that share the same RUM context. Each group
+    /// stands for a separate segment. To ensure it produces an optimal number of segments, the `records`
+    /// array must be ordered in a way that the same RUM context appears in continuous ranges.
+    ///
+    /// - Parameter records: records to bundle within segments
+    /// - Returns: array of serializable segments
+    func createSegmentJSONs(from records: [EnrichedRecordJSON]) -> [SegmentJSON] {
+        guard !records.isEmpty else {
+            return []
+        }
+
+        var segments: [SegmentJSON?] = []
+        var current = records[0]
+
+        // Current segment state:
+        var startIndex = 0
+        var hasFullSnapshot = current.hasFullSnapshot
+        var startTime = current.earliestTimestamp
+        var endTime = current.latestTimestamp
+
+        // Loop through the array to find continuous ranges of records that have
+        // the same RUM context. For each range create a segment:
+        for index in (1..<records.count) {
+            let next = records[index]
+
+            if rumContextEquals(in: current, and: next) {
+                // Continue current segment:
+                hasFullSnapshot = hasFullSnapshot || next.hasFullSnapshot
+                startTime = min(startTime, next.earliestTimestamp)
+                endTime = max(endTime, next.latestTimestamp)
+            } else {
+                // Close current segment:
+                segments.append(
+                    createSegmentJSON(
+                        records: records[startIndex..<index],
+                        hasFullSnapshot: hasFullSnapshot,
+                        startTime: startTime,
+                        endTime: endTime
+                    )
+                )
+
+                // Start next segment:
+                startIndex = index
+                hasFullSnapshot = next.hasFullSnapshot
+                startTime = next.earliestTimestamp
+                endTime = next.latestTimestamp
+            }
+
+            current = next
+        }
+
+        // Close the last segment:
+        segments.append(
+            createSegmentJSON(
+                records: records[startIndex..<records.count],
+                hasFullSnapshot: hasFullSnapshot,
+                startTime: startTime,
+                endTime: endTime
+            )
+        )
+
+        return segments.compactMap { $0 }
+    }
+
+    private func rumContextEquals(in record1: EnrichedRecordJSON, and record2: EnrichedRecordJSON) -> Bool {
+        return record1.viewID == record2.viewID
+            && record1.sessionID == record2.sessionID
+            && record1.applicationID == record2.applicationID
+    }
+
+    private func createSegmentJSON(
+        records: ArraySlice<EnrichedRecordJSON>,
+        hasFullSnapshot: Bool,
+        startTime: Int64,
+        endTime: Int64
+    ) -> SegmentJSON? {
+        guard let anyRecord = records.first else {
+            // Unexpected, TODO: RUMM-2410 Send error telemetry
+            return nil
+        }
+        let recordsJSONArray = records.flatMap { $0.records }
+
+        return SegmentJSON(
+            applicationID: anyRecord.applicationID,
+            sessionID: anyRecord.sessionID,
+            viewID: anyRecord.viewID,
+            source: source.rawValue,
+            start: startTime,
+            end: endTime,
+            records: recordsJSONArray,
+            recordsCount: Int64(recordsJSONArray.count),
+            hasFullSnapshot: hasFullSnapshot
+        )
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/Multipart/MultipartFormData.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/Multipart/MultipartFormData.swift
@@ -1,0 +1,49 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// A helper facilitating creation of `multipart/form-data` body.
+internal struct MultipartFormData {
+    private let boundary: UUID
+    private var body = Data()
+
+    init(boundary: UUID) {
+        self.boundary = boundary
+    }
+
+    mutating func addFormField(name: String, value: String) {
+        body.append(string: "--\(boundary.uuidString)\r\n")
+        body.append(string: "Content-Disposition: form-data; name=\"\(name)\"\r\n")
+        body.append(string: "\r\n")
+        body.append(string: value)
+        body.append(string: "\r\n")
+    }
+
+    mutating func addFormData(name: String, filename: String, data: Data, mimeType: String) {
+        body.append(string: "--\(boundary.uuidString)\r\n")
+        body.append(string: "Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+        body.append(string: "Content-Type: \(mimeType)\r\n")
+        body.append(string: "\r\n")
+        body.append(data)
+        body.append(string: "\r\n")
+    }
+
+    var data: Data {
+        var data = body
+        data.append(string: "--\(boundary.uuidString)--")
+        return data
+    }
+}
+
+private extension Data {
+    mutating func append(string: String) {
+        guard let data = string.data(using: .utf8) else {
+            return
+        }
+        self.append(data)
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/Multipart/MultipartFormData.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/Multipart/MultipartFormData.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// A helper facilitating creation of `multipart/form-data` body.
 internal struct MultipartFormData {
-    private let boundary: UUID
+    let boundary: UUID
     private var body = Data()
 
     init(boundary: UUID) {

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/RequestBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/RequestBuilder.swift
@@ -1,0 +1,111 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+@testable import Datadog
+
+internal struct RequestBuilder: FeatureRequestBuilder {
+    /// An arbitrary uploader.
+    let uploader: Uploader
+
+    func request(for events: [Data], with context: DatadogContext) -> URLRequest {
+        do {
+            let source = SRSegment.Source(rawValue: context.source) ?? .ios // TODO: RUMM-2410 Send telemetry on `?? .ios`
+            let builder = SegmentJSONBuilder(source: source)
+
+            let recordJSONs = try events.map { try EnrichedRecordJSON(jsonObjectData: $0) }
+            let segmentJSONs = builder.createSegmentJSONs(from: recordJSONs)
+
+            // When SDK was configured with deprecated `set(*Endpoint:)` APIs we don't have `context.site`, so
+            // we fallback to `.us1` - TODO: RUMM-2410 Report error with `DD.logger`
+            let site = context.site ?? .us1
+            let intakeURL = intakeURL(for: site)
+
+            let requests = try segmentJSONs.map { segmentJSON in
+                var request = URLRequest(url: intakeURL)
+                try configure(&request, with: segmentJSON, context: context)
+                return request
+            }
+
+            if requests.count > 1 {
+                uploader.upload(requests: requests[1..<requests.count])
+                return requests[0]
+            } else if requests.count == 1 {
+                return requests[0]
+            } else {
+                fatalError()
+            }
+        } catch {
+            fatalError()
+        }
+    }
+
+    private func intakeURL(for site: DatadogSite) -> URL {
+        switch site {
+        case .us1:
+            return URL(string: "https://session-replay.browser-intake-datadoghq.com/api/v2/replay")!
+        case .us3:
+            return URL(string: "https://session-replay.browser-intake-us3-datadoghq.com/api/v2/replay")!
+        case .us5:
+            return URL(string: "https://session-replay.browser-intake-us5-datadoghq.com/api/v2/replay")!
+        case .eu1:
+            return URL(string: "https://session-replay.browser-intake-datadoghq.eu/api/v2/replay")!
+        case .us1_fed:
+            return URL(string: "https://session-replay.browser-intake-ddog-gov.com/api/v2/replay")!
+        }
+    }
+
+    private func configure(_ request: inout URLRequest, with segment: SegmentJSON, context: DatadogContext) throws {
+        let boundary = UUID()
+        var multipart = MultipartFormData(boundary: boundary)
+        var segmentData = try JSONSerialization.data(withJSONObject: try segment.toJSONObject())
+        segmentData.append("\n".data(using: .utf8)!)
+        let compressedSegment = try! SRCompression.compress(data: segmentData)
+
+        multipart.addFormData(
+            name: "segment",
+            filename: segment.sessionID,
+            data: compressedSegment,
+            mimeType: "application/octet-stream"
+        )
+        multipart.addFormField(name: "segment", value: segment.sessionID)
+        multipart.addFormField(name: "application.id", value: segment.applicationID)
+        multipart.addFormField(name: "session.id", value: segment.sessionID)
+        multipart.addFormField(name: "view.id", value: segment.viewID)
+        multipart.addFormField(name: "has_full_snapshot", value: segment.hasFullSnapshot ? "true" : "false")
+        multipart.addFormField(name: "records_count", value: "\(segment.recordsCount)")
+        multipart.addFormField(name: "raw_segment_size", value: "\(compressedSegment.count)")
+        multipart.addFormField(name: "start", value: "\(segment.start)")
+        multipart.addFormField(name: "end", value: "\(segment.end)")
+        multipart.addFormField(name: "source", value: "\(context.source)")
+
+        request.setValue(userAgent(from: context), forHTTPHeaderField: "User-Agent")
+        request.setValue(context.clientToken, forHTTPHeaderField: "DD-API-KEY")
+        request.setValue(context.source, forHTTPHeaderField: "DD-EVP-ORIGIN")
+        request.setValue(context.sdkVersion, forHTTPHeaderField: "DD-EVP-ORIGIN-VERSION")
+        request.setValue(UUID().uuidString, forHTTPHeaderField: "DD-REQUEST-ID")
+        request.setValue("multipart/form-data; boundary=\(boundary.uuidString)", forHTTPHeaderField: "Content-Type")
+
+        request.httpMethod = "POST"
+        request.httpBody = multipart.data
+    }
+
+    private func userAgent(from context: DatadogContext) -> String {
+        var sanitizedAppName = context.applicationName
+
+        if let regex = try? NSRegularExpression(pattern: "[^a-zA-Z0-9 -]+") {
+            sanitizedAppName = regex.stringByReplacingMatches(
+                in: context.applicationName,
+                range: NSRange(context.applicationName.startIndex..<context.applicationName.endIndex, in: context.applicationName),
+                withTemplate: ""
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        let device = context.device
+        return "\(sanitizedAppName)/\(context.version) CFNetwork (\(device.name); \(device.osName)/\(device.osVersion))"
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/RequestBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/RequestBuilder.swift
@@ -8,7 +8,7 @@ import Foundation
 import Datadog
 
 internal struct RequestBuilder: FeatureRequestBuilder {
-    private static let newlineByte = "\n".data(using: .utf8)!
+    private static let newlineByte = "\n".data(using: .utf8)! // swiftlint:disable:this force_unwrapping
 
     /// An arbitrary uploader.
     /// TODO: RUMM-2509 Remove it when passing multiple requests per batch to `DatadogCore` is possible
@@ -56,6 +56,7 @@ internal struct RequestBuilder: FeatureRequestBuilder {
     }
 
     private func intakeURL(for site: DatadogSite) -> URL {
+        // swiftlint:disable force_unwrapping
         switch site {
         case .us1:
             return URL(string: "https://session-replay.browser-intake-datadoghq.com/api/v2/replay")!
@@ -68,6 +69,7 @@ internal struct RequestBuilder: FeatureRequestBuilder {
         case .us1_fed:
             return URL(string: "https://session-replay.browser-intake-ddog-gov.com/api/v2/replay")!
         }
+        // swiftlint:enable force_unwrapping
     }
 
     private func createRequest(url: URL, segment: SegmentJSON, context: DatadogContext) throws -> URLRequest {

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/RequestBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/RequestBuilder.swift
@@ -13,6 +13,8 @@ internal struct RequestBuilder: FeatureRequestBuilder {
     /// An arbitrary uploader.
     /// TODO: RUMM-2509 Remove it when passing multiple requests per batch to `DatadogCore` is possible
     let uploader: Uploader
+    /// Custom URL for uploading data to.
+    let customUploadURL: URL?
 
     func request(for events: [Data], with context: DatadogContext) throws -> URLRequest {
         let source = SRSegment.Source(rawValue: context.source) ?? .ios // TODO: RUMM-2410 Send telemetry on `?? .ios`
@@ -25,7 +27,7 @@ internal struct RequestBuilder: FeatureRequestBuilder {
 
         // If the SDK was configured with deprecated `set(*Endpoint:)` APIs we don't have `context.site`, so
         // we fallback to `.us1` - TODO: RUMM-2410 Report error with `DD.logger` in such case
-        let url = intakeURL(for: context.site ?? .us1)
+        let url = customUploadURL ?? intakeURL(for: context.site ?? .us1)
 
         // If we fail to create request for some segments do not rethrow to caller, but instead try with
         // other segments. This is to recover from unexpected failures with maximizing the amount of data sent.

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/Uploader.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/Uploader.swift
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// A temporary uploader managing upload of multiple `URLRequests`. It will be fully replaced with `DatadogCore`.
+///
+/// TODO: RUMM-RUMM-2509 Remove this class once multiple `URLRequest` can be passed to `DatadogCore`
+internal class Uploader {
+    private let session: URLSession
+
+    init() {
+        // Counterpart of `URLSession` configuration in `DatadogCore/HTTPClient`
+        let configuration: URLSessionConfiguration = .ephemeral
+        configuration.urlCache = nil
+        self.session = URLSession(configuration: configuration)
+    }
+
+    func upload(requests: ArraySlice<URLRequest>) {
+        requests.forEach { request in
+            let task = session.dataTask(with: request) { data, response, error in
+                switch httpClientResult(for: (data, response, error)) {
+                case .failure(let error):
+                    print("🎥 error: \(error)")
+                case .success(let response):
+                    print("🎥 response.code: \(response.statusCode)")
+                }
+
+            }
+            task.resume()
+        }
+    }
+}
+
+/// An error returned if `URLSession` response state is inconsistent (like no data, no response and no error).
+/// The code execution in `URLSessionTransport` should never reach its initialization.
+internal struct URLSessionTransportInconsistencyException: Error {}
+
+/// As `URLSession` returns 3-values-tuple for request execution, this function applies consistency constraints and turns
+/// it into only two possible states of `HTTPTransportResult`.
+private func httpClientResult(for urlSessionTaskCompletion: (Data?, URLResponse?, Error?)) -> Result<HTTPURLResponse, Error> {
+    let (_, response, error) = urlSessionTaskCompletion
+
+    if let error = error {
+        return .failure(error)
+    }
+
+    if let httpResponse = response as? HTTPURLResponse {
+        return .success(httpResponse)
+    }
+
+    return .failure(URLSessionTransportInconsistencyException())
+}

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/Uploader.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RequestBuilder/Uploader.swift
@@ -24,11 +24,14 @@ internal class Uploader {
             let task = session.dataTask(with: request) { data, response, error in
                 switch httpClientResult(for: (data, response, error)) {
                 case .failure(let error):
-                    print("🎥 error: \(error)")
+                    print("[DATADOG Session Replay] 🐶🎥 →  an error occured when performing arbitrary upload: \(error)")
                 case .success(let response):
-                    print("🎥 response.code: \(response.statusCode)")
+                    if response.statusCode != 202 {
+                        print("[DATADOG Session Replay] 🐶🎥 →  arbitrary upload completed with unexpected status code: \(response.statusCode)")
+                    } else if SessionReplay.arbitraryUploadsVerbosity {
+                        print("[DATADOG Session Replay] 🐶🎥 →  arbitrary upload completed with status code: \(response.statusCode)")
+                    }
                 }
-
             }
             task.resume()
         }

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplay.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplay.swift
@@ -31,6 +31,11 @@ public struct SessionReplay {
             return NOPSessionReplayController()
         }
     }
+
+    /// Whether or not to print debug console logs on arbitrary uploads success.
+    /// TODO: RUMM-RUMM-2509 Remove this class once multiple `URLRequest` can be passed to `DatadogCore` and we no longer
+    /// need arbitrary uploader.
+    public static var arbitraryUploadsVerbosity = false
 }
 
 /// A draft interface of SR controller.

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayConfiguration.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayConfiguration.swift
@@ -10,12 +10,20 @@ import Foundation
 public struct SessionReplayConfiguration {
     /// Defines the way in which sensitive content (e.g. text or images) should be recorded.
     /// Defaults to `.maskAll`.
-    public let privacy: SessionReplayPrivacy
+    public var privacy: SessionReplayPrivacy
+
+    /// Defines a custom URL for uploading data to.
+    ///
+    /// Defaults to `nil` which makes the Session Replay upload data to Datadog Site configured in
+    /// the target instance of Datadog SDK.
+    public var customUploadURL: URL?
 
     public init(
-        privacy: SessionReplayPrivacy = .maskAll
+        privacy: SessionReplayPrivacy = .maskAll,
+        customUploadURL: URL? = nil
     ) {
         self.privacy = privacy
+        self.customUploadURL = customUploadURL
     }
 }
 

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
@@ -48,7 +48,7 @@ internal class SessionReplayFeature: DatadogFeature, SessionReplayController {
         self.processor = processor
         self.writer = writer
         self.requestBuilder = RequestBuilder(
-            uploader: Uploader()
+            uploader: Uploader() // TODO: RUMM-2509 Get rid of `Uploader` when passing multiple requests per batch to `DatadogCore` is possible
         )
     }
 

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
@@ -48,7 +48,8 @@ internal class SessionReplayFeature: DatadogFeature, SessionReplayController {
         self.processor = processor
         self.writer = writer
         self.requestBuilder = RequestBuilder(
-            uploader: Uploader() // TODO: RUMM-2509 Get rid of `Uploader` when passing multiple requests per batch to `DatadogCore` is possible
+            uploader: Uploader(), // TODO: RUMM-2509 Get rid of `Uploader` when passing multiple requests per batch to `DatadogCore` is possible
+            customUploadURL: configuration.customUploadURL
         )
     }
 

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplayFeature.swift
@@ -17,7 +17,7 @@ internal class SessionReplayFeature: DatadogFeature, SessionReplayController {
     // MARK: - DatadogFeature
 
     let name: String = "session-replay"
-    let requestBuilder: FeatureRequestBuilder = RequestBuilder()
+    let requestBuilder: FeatureRequestBuilder
     let messageReceiver: FeatureMessageReceiver
 
     // MARK: - Main Components
@@ -47,6 +47,9 @@ internal class SessionReplayFeature: DatadogFeature, SessionReplayController {
         self.recorder = recorder
         self.processor = processor
         self.writer = writer
+        self.requestBuilder = RequestBuilder(
+            uploader: Uploader()
+        )
     }
 
     func register(sessionReplayScope: FeatureScope) {
@@ -58,12 +61,4 @@ internal class SessionReplayFeature: DatadogFeature, SessionReplayController {
     func start() { recorder.start() }
     func stop() { recorder.stop() }
     func change(privacy: SessionReplayPrivacy) { recorder.change(privacy: privacy) }
-}
-
-// MARK: - WIP: RUMM-2662 Session replay data is automatically uploaded
-
-internal struct RequestBuilder: FeatureRequestBuilder {
-    func request(for events: [Data], with context: DatadogContext) -> URLRequest { // swiftlint:disable:this unavailable_function
-        fatalError("TODO: RUMM-2662 Session replay data is automatically uploaded")
-    }
 }

--- a/session-replay/Sources/DatadogSessionReplay/Writer/Models/EnrichedRecord.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Writer/Models/EnrichedRecord.swift
@@ -65,7 +65,7 @@ internal struct EnrichedRecord: Encodable {
 
 // MARK: - Convenience
 
-private extension SRRecord {
+extension SRRecord {
     var isFullSnapshot: Bool {
         switch self {
         case .fullSnapshotRecord: return true

--- a/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/EnrichedRecordJSONTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/EnrichedRecordJSONTests.swift
@@ -1,0 +1,66 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class EnrichedRecordJSONTests: XCTestCase {
+    func testWhenDecodingEnrichedRecordData_itHasTheSameInformationAvailable() throws {
+        // Given
+        let enrichedRecords = EnrichedRecord(
+            rumContext: .mockRandom(),
+            records: .mockRandom()
+        )
+        let data = try encode(enrichedRecords)
+
+        // When
+        let someRecords = try EnrichedRecordJSON(jsonObjectData: data)
+
+        // Then
+        XCTAssertEqual(someRecords.applicationID, enrichedRecords.applicationID)
+        XCTAssertEqual(someRecords.sessionID, enrichedRecords.sessionID)
+        XCTAssertEqual(someRecords.viewID, enrichedRecords.viewID)
+        XCTAssertEqual(someRecords.records.count, enrichedRecords.records.count)
+        XCTAssertEqual(someRecords.hasFullSnapshot, enrichedRecords.hasFullSnapshot)
+        XCTAssertEqual(someRecords.earliestTimestamp, enrichedRecords.earliestTimestamp)
+        XCTAssertEqual(someRecords.latestTimestamp, enrichedRecords.latestTimestamp)
+
+        let expected = try encode(enrichedRecords.records)
+        let actual = try encode(someRecords.records)
+        XCTAssertEqual(expected, actual, "Serialized records data must be equal in both `EnrichedRecord` and `EnrichedRecordJSON`")
+    }
+
+    func testWhenDecodingMalformedData_itThrows() {
+        // Given
+        let malrofmedData1 = "[]".data(using: .utf8)!
+        let malrofmedData2 = "{}".data(using: .utf8)!
+
+        // When & Then
+        XCTAssertThrowsError(try EnrichedRecordJSON(jsonObjectData: malrofmedData1)) { error in
+            let description = (error as! InternalError).description
+            XCTAssertTrue(description.hasPrefix("Failed to decode Dictionary<String, Any>.Type"))
+        }
+        XCTAssertThrowsError(try EnrichedRecordJSON(jsonObjectData: malrofmedData2)) { error in
+            let description = (error as! InternalError).description
+            XCTAssertTrue(description.hasPrefix("Failed to read attribute at key path"))
+        }
+    }
+
+    // MARK: - Encoding helpers
+
+    private func encode<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        return try encoder.encode(value)
+    }
+
+    private func encode(_ jsonArray: [JSONObject]) throws -> Data {
+        return try JSONSerialization.data(
+            withJSONObject: jsonArray,
+            options: [.sortedKeys]
+        )
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
@@ -85,7 +85,6 @@ class SegmentJSONBuilderTests: XCTestCase {
             // Decode it back to `EnrichedRecordJSON` just like it happens when preparing
             // upload requests for SR:
             .map { try EnrichedRecordJSON(jsonObjectData: $0) }
-
     }
 
     private func encode<T: Encodable>(_ value: T) throws -> Data {

--- a/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
@@ -1,0 +1,111 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class SegmentJSONBuilderTests: XCTestCase {
+    private let builder = SegmentJSONBuilder(source: .mockRandom())
+
+    func testGivenSRSegmentWithRecords_whenCreatingSegmentJSON_itEcodesToTheSameJSON() throws {
+        // Given
+        let expectedSegment = generateSegment(maxRecordsCount: 1)
+        let records = try generateEnrichedRecordJSONs(for: expectedSegment)
+
+        // When
+        let actualSegments = builder.createSegmentJSONs(from: records)
+
+        // Then
+        XCTAssertEqual(actualSegments.count, 1)
+        XCTAssertEqual(
+            try prettyJSONString(for: expectedSegment),
+            try prettyJSONString(for: actualSegments[0]),
+            "`SegmentJSON` must encode the same JSON string as `SRSegment: Codable`"
+        )
+    }
+
+    func testGivenMultipleSRSegmentsWithRecords_whenCreatingSegmentJSONs_theyEcodeToTheSameJSON() throws {
+        let expectedSegments = (0..<50).map { generateSegment(maxRecordsCount: $0 + 1) }
+
+        // Given
+        let records = try expectedSegments.flatMap { try generateEnrichedRecordJSONs(for: $0) }
+
+        // When
+        let actualSegments = builder.createSegmentJSONs(from: records)
+
+        // Then
+        XCTAssertEqual(actualSegments.count, expectedSegments.count)
+        try zip(actualSegments, expectedSegments).forEach { actual, expected in
+            XCTAssertEqual(
+                try prettyJSONString(for: expected),
+                try prettyJSONString(for: actual),
+                "`SegmentJSON` must encode the same JSON string as `SRSegment: Codable`"
+            )
+        }
+    }
+
+    // MARK: - Fuzzy Helpers
+
+    private func generateSegment(maxRecordsCount: Int64 = 100) -> SRSegment {
+        let recordsCount: Int64 = .mockRandom(min: 1, max: maxRecordsCount)
+        let records: [SRRecord] = (0..<recordsCount).map { _ in .mockRandom() }
+        let timestamps = records.map { $0.timestamp }
+
+        return SRSegment(
+            application: .init(id: .mockRandom()),
+            end: timestamps.min(by: >)!,
+            hasFullSnapshot: records.contains { $0.isFullSnapshot },
+            indexInView: nil,
+            records: records,
+            recordsCount: recordsCount,
+            session: .init(id: .mockRandom()),
+            source: builder.source,
+            start: timestamps.min(by: <)!,
+            view: .init(id: .mockRandom())
+        )
+    }
+
+    private func generateEnrichedRecordJSONs(for segment: SRSegment) throws -> [EnrichedRecordJSON] {
+        let rum = RUMContext(
+            applicationID: segment.application.id,
+            sessionID: segment.session.id,
+            viewID: segment.view.id
+        )
+        return try segment.records
+            // To make it more challenging for tested `SegmentJSONBuilder`, we chunk records in
+            // expected `segment`, so they are spread among many enriched records:
+            .chunkedRandomly(numberOfChunks: .random(in: 1...segment.records.count))
+            .map { EnrichedRecord(rumContext: rum, records: $0) }
+            // Encode `EnrichedRecords` into `Data`, just like it happens in `DatadogCore` when
+            // writting them into batches:
+            .map { try encode($0) }
+            // Decode it back to `EnrichedRecordJSON` just like it happens when preparing
+            // upload requests for SR:
+            .map { try EnrichedRecordJSON(jsonObjectData: $0) }
+
+    }
+
+    private func encode<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        return try encoder.encode(value)
+    }
+
+    private func encode(_ segment: SegmentJSON) throws -> Data {
+        return try JSONSerialization.data(
+            withJSONObject: segment.toJSONObject(),
+            options: [.sortedKeys, .prettyPrinted]
+        )
+    }
+
+    private func prettyJSONString<T: Encodable>(for value: T) throws -> String {
+        return String(data: try encode(value), encoding: .utf8) ?? ""
+    }
+
+    private func prettyJSONString(for segment: SegmentJSON) throws -> String {
+        return String(data: try encode(segment), encoding: .utf8) ?? ""
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/Multipart/MultipartFormDataTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/Multipart/MultipartFormDataTests.swift
@@ -1,0 +1,64 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class MultipartFormDataTests: XCTestCase {
+    func testBuildingFormData() throws {
+        let boundary = UUID(uuidString: "12345678-0000-0000-0000-000000000000")!
+
+        // Given
+        var multipart = MultipartFormData(boundary: boundary)
+
+        // When
+        multipart.addFormField(name: "field1", value: "value of field1")
+        multipart.addFormField(name: "field2", value: "value of field2")
+        multipart.addFormField(name: "field3", value: "value of field3")
+        multipart.addFormData(
+            name: "data1",
+            filename: "filename1",
+            data: "abcd".data(using: .utf8)!,
+            mimeType: "abc/def"
+        )
+        multipart.addFormData(
+            name: "data2",
+            filename: "filename2",
+            data: "efgh".data(using: .utf8)!,
+            mimeType: "foo/bar"
+        )
+
+        // Then
+        let actualDataString = try XCTUnwrap(String(data: multipart.data, encoding: .utf8))
+        let expectedDataString = """
+        --12345678-0000-0000-0000-000000000000
+        Content-Disposition: form-data; name="field1"
+
+        value of field1
+        --12345678-0000-0000-0000-000000000000
+        Content-Disposition: form-data; name="field2"
+
+        value of field2
+        --12345678-0000-0000-0000-000000000000
+        Content-Disposition: form-data; name="field3"
+
+        value of field3
+        --12345678-0000-0000-0000-000000000000
+        Content-Disposition: form-data; name="data1"; filename="filename1"
+        Content-Type: abc/def
+
+        abcd
+        --12345678-0000-0000-0000-000000000000
+        Content-Disposition: form-data; name="data2"; filename="filename2"
+        Content-Type: foo/bar
+
+        efgh
+        --12345678-0000-0000-0000-000000000000--
+        """.replacingOccurrences(of: "\n", with: "\r\n")
+
+        XCTAssertEqual(expectedDataString, actualDataString)
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/RequestBuilderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/RequestBuilderTests.swift
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+// swiftlint:disable empty_xctest_method
+class RequestBuilderTests: XCTestCase {
+    func testWhenBatchContainsRecordsFromOneSegment_itCreatesOneRequest() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+
+    func testWhenBatchContainsRecordsFromMultipleSegments_itCreatesMultipleRequests() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+
+    func testWhenBatchDataIsMalformed_itThrows() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+}
+// swiftlint:enable empty_xctest_method

--- a/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/RequestBuilderTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/RequestBuilderTests.swift
@@ -9,6 +9,18 @@ import XCTest
 
 // swiftlint:disable empty_xctest_method
 class RequestBuilderTests: XCTestCase {
+    func testWhenCustomUploadURLIsNotSet_itCreatesRequestsToAppropriateDatadogSite() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+
+    func testWhenCustomUploadURLIsSet_itCreatesRequestsToCustomURL() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+
     func testWhenBatchContainsRecordsFromOneSegment_itCreatesOneRequest() {
         // TODO: RUMM-2690
         // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/FoundationMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/FoundationMocks.swift
@@ -125,6 +125,23 @@ extension String: AnyMockable, RandomMockable {
     }
 }
 
+
+extension URL: AnyMockable, RandomMockable {
+    static func mockAny() -> URL {
+        return URL(string: "https://www.datadoghq.com")!
+    }
+
+    static func mockRandom() -> URL {
+        return URL(string: "https://www.foo.com/")!
+            .appendingPathComponent(
+                .mockRandom(
+                    among: .alphanumerics,
+                    length: 32
+                )
+            )
+    }
+}
+
 extension Array {
     /// Chunks the array randomly, e.g.:
     ///

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/FoundationMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/FoundationMocks.swift
@@ -124,3 +124,25 @@ extension String: AnyMockable, RandomMockable {
         }
     }
 }
+
+extension Array {
+    /// Chunks the array randomly, e.g.:
+    ///
+    ///     print([1, 2, 3, 4, 5].chunkedRandomly(numberOfChunks: 3))
+    ///     // [[1], [2, 3], [4, 5]]
+    ///
+    func chunkedRandomly(numberOfChunks: Int) -> [[Element]] {
+        assert(numberOfChunks <= count, "`numberOfChunks` must be less than or equal to \(count)")
+
+        var indexes = (1..<count).shuffled()
+        var slices: [Int] = [0, count]
+        while slices.count <= numberOfChunks {
+            slices.append(indexes.removeLast())
+        }
+        slices.sort()
+
+        return zip(slices, slices.dropFirst()).map { start, end in
+            return Array(self[start..<end])
+        }
+    }
+}

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/FoundationMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/FoundationMocks.swift
@@ -125,7 +125,6 @@ extension String: AnyMockable, RandomMockable {
     }
 }
 
-
 extension URL: AnyMockable, RandomMockable {
     static func mockAny() -> URL {
         return URL(string: "https://www.datadoghq.com")!

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/SessionReplayMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/SessionReplayMocks.swift
@@ -14,15 +14,18 @@ extension SessionReplayConfiguration: AnyMockable, RandomMockable {
 
     static func mockRandom() -> SessionReplayConfiguration {
         return SessionReplayConfiguration(
-            privacy: .mockRandom()
+            privacy: .mockRandom(),
+            customUploadURL: .mockRandom()
         )
     }
 
     static func mockWith(
-        privacy: SessionReplayPrivacy = .mockAny()
+        privacy: SessionReplayPrivacy = .mockAny(),
+        customUploadURL: URL? = .mockAny()
     ) -> SessionReplayConfiguration {
         return SessionReplayConfiguration(
-            privacy: privacy
+            privacy: privacy,
+            customUploadURL: customUploadURL
         )
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR implements Session Replay data uploads. SR records previously (#1044) written to `DatadogCore` are now read back and mapped into `URLRequests` sent to SR Intake.

### How?

#### Challenge 1
✋ Because `DatadogCore` only supports `[Data] -> URLRequest` mapping (not yet `[Data] -> [URLRequest]`), I had to implement a temporary workaround. The first request is sent through `DatadogCore` (🏅), but other are passed to arbitrary (and temporary) uploader managed by SR.

#### Challenge 2
Another problem I had to solve in this PR relates to decoding [`[SRRecord]`](https://github.com/DataDog/dd-sdk-ios/blob/253deba65b9c5da89875e2fce7a698930e5910df/session-replay/Sources/DatadogSessionReplay/Writer/SRDataModels.swift#L775) from events `[Data]` received from core. Even though our [`SRDataModels`](https://github.com/DataDog/dd-sdk-ios/blob/feature/session-replay/session-replay/Sources/DatadogSessionReplay/Writer/SRDataModels.swift) are declared `Codable`, their decoding through `Swift.Decodable` cannot be utilised for SR uploads. Our SR JSON schemas turn out to be too complex for the [naive `Decodable` conformance we generate](https://github.com/DataDog/dd-sdk-ios/blob/86a72050d02b4b3bc9e3f0ac5b3c8af1e747f25e/tools/rum-models-generator/Tests/CodeGenerationTests/Print/SwiftPrinterTests.swift#L525-L549). This leads to ambiguity when deserializing `Data` into our Swift types - a single JSON value can be decoded to more than one SR data model, which in turn makes _"records to segments"_ mapping unreliable.

By discussing this with @maxep we concluded two possible approaches:
* We could improve [rum-models-generator](https://github.com/DataDog/dd-sdk-ios/tree/86a72050d02b4b3bc9e3f0ac5b3c8af1e747f25e/tools/rum-models-generator) to generate `Decodable` conformance that relies on `type` constants declared consistently in each schema.
* Rely either on Apple's `JSONSerialization` or our [`CodableValue: Codable`](https://github.com/DataDog/dd-sdk-ios/blob/253deba65b9c5da89875e2fce7a698930e5910df/Sources/Datadog/Core/Utils/CodableValue.swift#L9-L10) ereasure to read `[SRRecord]` data back.

Discussed enhancement to `rum-models-generator` is not a simple task, so I followed the second approach instead. Because working with `CodableValue` is not very convenient (it wasn't invented for inspecting data, but only to preserve its JSON representation) and because [`JSONSerialization` is slightly faster than `Codable`](https://flight.school/articles/benchmarking-codable/) I chosed to go with this old fashioned way of coding objects in iOS.

This PR introduces 2 data models:
* `EnrichedRecordJSON` - to decode `EnrichedRecord: Encodable` and encode it back
* `SegmentJSON` - to encode [`SRSegment`](https://github.com/DataDog/dd-sdk-ios/blob/253deba65b9c5da89875e2fce7a698930e5910df/session-replay/Sources/DatadogSessionReplay/Writer/SRDataModels.swift#L12) information through `JSONSerialization`.

Even if staying away from code-generated `SRSegment`, the `SegmentJSON` uses its `CodingKeys` for type safety. I also added strong fuzzy tests to ensure that both `SRSegment` and `SegmentJSON` can be coded back and forth with the same `Data`.

---

After solving both problems, the final workflow of SR records and its integration with `DatadogCore` can be explained this:

<img width="1275" alt="Screenshot 2022-11-09 at 12 50 41" src="https://user-images.githubusercontent.com/2358722/200832275-ea2bff0e-91fd-4804-9aaf-e400abeb3e01.png">

On the `Processor` side, we write enriched (with RUM context) records to `DatadogCore`. Later, upon requesting upload records are retrieved back, grouped (by RUM context) into segments and uploaded to Session Replay Intake. 🏁 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
