### PR TITLE
RUMM-2662 [SR] Set `hasReplay` flag on RUM events

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -227,6 +227,10 @@
 		61570005246AADFA00E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
 		61570007246AAED100E96950 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
 		6157FA5E252767CB009A8A3B /* URLSessionRUMResourcesHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6157FA5D252767CB009A8A3B /* URLSessionRUMResourcesHandler.swift */; };
+		615950EE291C058F00470E0C /* SessionReplayDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615950ED291C058F00470E0C /* SessionReplayDependency.swift */; };
+		615950EF291C05CC00470E0C /* SessionReplayDependencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615950EA291C029700470E0C /* SessionReplayDependencyTests.swift */; };
+		615950F0291C05CD00470E0C /* SessionReplayDependencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615950EA291C029700470E0C /* SessionReplayDependencyTests.swift */; };
+		615950F1291C05D500470E0C /* SessionReplayDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615950ED291C058F00470E0C /* SessionReplayDependency.swift */; };
 		615A4A8324A3431600233986 /* Tracer+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8224A3431600233986 /* Tracer+objc.swift */; };
 		615A4A8524A3445700233986 /* TracerConfiguration+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8424A3445700233986 /* TracerConfiguration+objc.swift */; };
 		615A4A8724A3452800233986 /* DDTracerConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615A4A8624A3452800233986 /* DDTracerConfigurationTests.swift */; };
@@ -1521,6 +1525,8 @@
 		6156CB9224DDAA34008CB2B2 /* RUMCurrentContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMCurrentContextTests.swift; sourceTree = "<group>"; };
 		6156CB9B24E18224008CB2B2 /* TracingWithRUMIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingWithRUMIntegration.swift; sourceTree = "<group>"; };
 		6157FA5D252767CB009A8A3B /* URLSessionRUMResourcesHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionRUMResourcesHandler.swift; sourceTree = "<group>"; };
+		615950EA291C029700470E0C /* SessionReplayDependencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayDependencyTests.swift; sourceTree = "<group>"; };
+		615950ED291C058F00470E0C /* SessionReplayDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayDependency.swift; sourceTree = "<group>"; };
 		615A4A8224A3431600233986 /* Tracer+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tracer+objc.swift"; sourceTree = "<group>"; };
 		615A4A8424A3445700233986 /* TracerConfiguration+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TracerConfiguration+objc.swift"; sourceTree = "<group>"; };
 		615A4A8624A3452800233986 /* DDTracerConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDTracerConfigurationTests.swift; sourceTree = "<group>"; };
@@ -3132,6 +3138,22 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		615950E9291C028600470E0C /* DatadogCoreIntegration */ = {
+			isa = PBXGroup;
+			children = (
+				615950EA291C029700470E0C /* SessionReplayDependencyTests.swift */,
+			);
+			path = DatadogCoreIntegration;
+			sourceTree = "<group>";
+		};
+		615950EC291C057D00470E0C /* DatadogCoreIntegration */ = {
+			isa = PBXGroup;
+			children = (
+				615950ED291C058F00470E0C /* SessionReplayDependency.swift */,
+			);
+			path = DatadogCoreIntegration;
+			sourceTree = "<group>";
+		};
 		615AAC34251E34EF00C89EE9 /* TabBarAutoInstrumentation */ = {
 			isa = PBXGroup;
 			children = (
@@ -3768,6 +3790,7 @@
 		61E5332A24B75C3B003D6C4E /* RUM */ = {
 			isa = PBXGroup;
 			children = (
+				615950EC291C057D00470E0C /* DatadogCoreIntegration */,
 				492748FD2880484C00ECD49B /* _RUMInternalProxy.swift */,
 				61E5332B24B75C51003D6C4E /* RUMFeature.swift */,
 				616F1FB22840125300651A3A /* RUMV2Configuration.swift */,
@@ -3788,6 +3811,7 @@
 		61E5332D24B75DC7003D6C4E /* RUM */ = {
 			isa = PBXGroup;
 			children = (
+				615950E9291C028600470E0C /* DatadogCoreIntegration */,
 				49274908288048F400ECD49B /* RUMInternalProxyTests.swift */,
 				61E5332E24B75DE2003D6C4E /* RUMFeatureTests.swift */,
 				D248ED4728081B9B00B315B4 /* RUMTelemetryTests.swift */,
@@ -5342,6 +5366,7 @@
 				61494B7A27F352570082BBCC /* RUMViewUpdatesThrottler.swift in Sources */,
 				D2B3F04A2829510600C2B5EE /* DatadogCoreProtocol.swift in Sources */,
 				6122514827FDFF82004F5AE4 /* RUMScopeDependencies.swift in Sources */,
+				615950EE291C058F00470E0C /* SessionReplayDependency.swift in Sources */,
 				6141014F251A57AF00E3C2D9 /* UIApplicationSwizzler.swift in Sources */,
 				D21C26CA28A406A3005DD405 /* DatadogFeature.swift in Sources */,
 				61494CB124C839460082C633 /* RUMResourceScope.swift in Sources */,
@@ -5652,6 +5677,7 @@
 				D20605B92875729E0047275C /* ContextValuePublisherMock.swift in Sources */,
 				61C5A89E24509C1100DA608C /* WarningsTests.swift in Sources */,
 				9E36D92224373EA700BFBDB7 /* SwiftExtensionsTests.swift in Sources */,
+				615950EF291C05CC00470E0C /* SessionReplayDependencyTests.swift in Sources */,
 				61122EEE25B1D75B00F9C7F5 /* RUMEventSanitizerTests.swift in Sources */,
 				D2B3F04728292D6E00C2B5EE /* DataMigratorTests.swift in Sources */,
 				614B0A5124EBDC8000A2A780 /* RUMConnectivityInfoProviderTests.swift in Sources */,
@@ -6018,6 +6044,7 @@
 				D2CB6E4627C50EAE00A62B57 /* RUMSessionScope.swift in Sources */,
 				D2B3F04B2829510600C2B5EE /* DatadogCoreProtocol.swift in Sources */,
 				61DA8CB028620C760074A606 /* Cryptography.swift in Sources */,
+				615950F1291C05D500470E0C /* SessionReplayDependency.swift in Sources */,
 				D2DC4BF727F484AA00E4FB96 /* DataEncryption.swift in Sources */,
 				D2CB6E4727C50EAE00A62B57 /* TracingUUID.swift in Sources */,
 				D20605A7287476230047275C /* ServerOffsetPublisher.swift in Sources */,
@@ -6328,6 +6355,7 @@
 				D20605BA2875729E0047275C /* ContextValuePublisherMock.swift in Sources */,
 				D2CB6F5927C520D400A62B57 /* WarningsTests.swift in Sources */,
 				D2CB6F5A27C520D400A62B57 /* SwiftExtensionsTests.swift in Sources */,
+				615950F0291C05CD00470E0C /* SessionReplayDependencyTests.swift in Sources */,
 				D2CB6F5B27C520D400A62B57 /* RUMEventSanitizerTests.swift in Sources */,
 				D2B3F04828292D6E00C2B5EE /* DataMigratorTests.swift in Sources */,
 				D2CB6F5C27C520D400A62B57 /* RUMConnectivityInfoProviderTests.swift in Sources */,

--- a/Sources/Datadog/CrashReporting/Integrations/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/CrashReporting/Integrations/CrashReportingWithRUMIntegration.swift
@@ -186,7 +186,10 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 startDate: crashTimings.realCrashDate,
                 sessionUUID: uuidGenerator.generateUnique(), // create new RUM session
                 crashContext: crashContext,
-                hasReplay: nil // as the crash occured after initializing SDK but before starting the first view, we can't know this
+                // As the crash occured after initializing SDK but before starting the first view,
+                // we can't know if Session Replay was configured. However, lack of view implies
+                // that there must be no replay collected:
+                hasReplay: false
             )
         case .handleInBackgroundView:
             newRUMView = createNewRUMViewEvent(
@@ -195,7 +198,10 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 startDate: crashTimings.realCrashDate,
                 sessionUUID: uuidGenerator.generateUnique(), // create new RUM session
                 crashContext: crashContext,
-                hasReplay: nil // as the crash occured after initializing SDK but before starting the first view, we can't know this
+                // As the crash occured after initializing SDK but before starting the first view,
+                // we can't know if Session Replay was configured. However, lack of view implies
+                // that there must be no replay collected:
+                hasReplay: false
             )
         case .doNotHandle:
             DD.logger.debug("There was a crash in background, but it is ignored due to Background Event Tracking disabled.")

--- a/Sources/Datadog/CrashReporting/Integrations/CrashReportingWithRUMIntegration.swift
+++ b/Sources/Datadog/CrashReporting/Integrations/CrashReportingWithRUMIntegration.swift
@@ -136,7 +136,8 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 url: RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL,
                 startDate: crashTimings.realCrashDate,
                 sessionUUID: RUMUUID(rawValue: lastRUMSessionState.sessionUUID), // link it to previous RUM Session
-                crashContext: crashContext
+                crashContext: crashContext,
+                hasReplay: lastRUMSessionState.didStartWithReplay
             )
         case .handleInBackgroundView:
             // It means that the crash occured as the very first event after sending app to background in previous session.
@@ -146,7 +147,8 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 url: RUMOffViewEventsHandlingRule.Constants.backgroundViewURL,
                 startDate: crashTimings.realCrashDate,
                 sessionUUID: RUMUUID(rawValue: lastRUMSessionState.sessionUUID), // link it to previous RUM Session
-                crashContext: crashContext
+                crashContext: crashContext,
+                hasReplay: lastRUMSessionState.didStartWithReplay
             )
         case .doNotHandle:
             DD.logger.debug("There was a crash in background, but it is ignored due to Background Event Tracking disabled or sampling.")
@@ -183,7 +185,8 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 url: RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewURL,
                 startDate: crashTimings.realCrashDate,
                 sessionUUID: uuidGenerator.generateUnique(), // create new RUM session
-                crashContext: crashContext
+                crashContext: crashContext,
+                hasReplay: nil // as the crash occured after initializing SDK but before starting the first view, we can't know this
             )
         case .handleInBackgroundView:
             newRUMView = createNewRUMViewEvent(
@@ -191,7 +194,8 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
                 url: RUMOffViewEventsHandlingRule.Constants.backgroundViewURL,
                 startDate: crashTimings.realCrashDate,
                 sessionUUID: uuidGenerator.generateUnique(), // create new RUM session
-                crashContext: crashContext
+                crashContext: crashContext,
+                hasReplay: nil // as the crash occured after initializing SDK but before starting the first view, we can't know this
             )
         case .doNotHandle:
             DD.logger.debug("There was a crash in background, but it is ignored due to Background Event Tracking disabled.")
@@ -350,7 +354,8 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
         url viewURL: String,
         startDate: Date,
         sessionUUID: RUMUUID,
-        crashContext: CrashContext
+        crashContext: CrashContext,
+        hasReplay: Bool?
     ) -> RUMViewEvent {
         let viewUUID = uuidGenerator.generateUnique()
 
@@ -379,7 +384,7 @@ internal struct CrashReportingWithRUMIntegration: CrashReportingIntegration {
             os: .init(context: context),
             service: context.service,
             session: .init(
-                hasReplay: nil,
+                hasReplay: hasReplay,
                 id: sessionUUID.toRUMDataFormat,
                 type: CITestIntegration.active != nil ? .ciTest : .user
             ),

--- a/Sources/Datadog/DatadogInternal/Context/DatadogContext.swift
+++ b/Sources/Datadog/DatadogInternal/Context/DatadogContext.swift
@@ -92,5 +92,5 @@ public struct DatadogContext {
     var isLowPowerModeEnabled = false
 
     /// Feature attributes provider.
-    var featuresAttributes: [String: FeatureBaggage] = [:]
+    public internal(set) var featuresAttributes: [String: FeatureBaggage] = [:]
 }

--- a/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
+++ b/Sources/Datadog/DatadogInternal/DatadogCoreProtocol.swift
@@ -10,7 +10,10 @@ public internal(set) var defaultDatadogCore: DatadogCoreProtocol = NOPDatadogCor
 
 /// A Datadog Core holds a set of Features and is responsible for managing their storage
 /// and upload mechanism. It also provides a thread-safe scope for writing events.
-public protocol DatadogCoreProtocol {
+///
+/// Any reference to `DatadogCoreProtocol` must be captured as `weak` within a Feature. This is to avoid
+/// retain cycle of core holding the Feature and vice-versa.
+public protocol DatadogCoreProtocol: AnyObject {
     /// Registers a Feature instance.
     ///
     /// Feature collects and transfers data to a Datadog Product (e.g. Logs, RUM, ...). Upon registration, the Feature can
@@ -177,7 +180,7 @@ public extension FeatureScope {
 }
 
 /// No-op implementation of `DatadogFeatureRegistry`.
-internal struct NOPDatadogCore: DatadogCoreProtocol {
+internal class NOPDatadogCore: DatadogCoreProtocol {
     /// no-op
     func register(feature: DatadogFeature) throws { }
     /// no-op

--- a/Sources/Datadog/RUM/DatadogCoreIntegration/SessionReplayDependency.swift
+++ b/Sources/Datadog/RUM/DatadogCoreIntegration/SessionReplayDependency.swift
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// Defines dependency between RUM and Session Replay (SR) modules.
+/// It aims at centralizing documentation of contracts between both product
+internal struct SessionReplayDependency {
+    /// The key referencing SR baggage in `DatadogContext.featuresAttributes`.
+    ///
+    /// RUM expects:
+    /// - baggage with `hasReplay` key if SR Feature is configured;
+    /// - the `hasReplay` baggege key of `Bool` value indicating if the replay is being recorded.
+    static let srBaggageKey = "session-replay"
+
+    /// The key referencing a `Bool` value that indicates if replay is being recorded.
+    static let hasReplay = "has_replay"
+}
+
+// MARK: - Extracting SR context from `DatadogContext`
+
+extension DatadogContext {
+    /// The context of Session Replay Feature or `nil` if SR is not configured.
+    var srBaggage: FeatureBaggage? {
+        return featuresAttributes[SessionReplayDependency.srBaggageKey]
+    }
+}
+
+extension FeatureBaggage {
+    /// The value indicating if replay is being performed by Session Replay.
+    var isReplayBeingRecorded: Bool {
+        guard let hasReplay: Bool = self[SessionReplayDependency.hasReplay] else {
+            return false
+        }
+        return hasReplay
+    }
+}

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -65,7 +65,8 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             isInitialSession: true,
             parent: self,
             startTime: context.sdkInitDate,
-            dependencies: dependencies
+            dependencies: dependencies,
+            isReplayBeingRecorded: context.srBaggage?.isReplayBeingRecorded
         )
         sessionScope = initialSession
         sessionScopeDidUpdate(initialSession)

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -197,7 +197,7 @@ internal class RUMResourceScope: RUMScope {
             ),
             service: context.service,
             session: .init(
-                hasReplay: nil,
+                hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
@@ -257,7 +257,7 @@ internal class RUMResourceScope: RUMScope {
             os: .init(context: context),
             service: context.service,
             session: .init(
-                hasReplay: nil,
+                hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -165,7 +165,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             os: .init(context: context),
             service: context.service,
             session: .init(
-                hasReplay: nil,
+                hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -350,7 +350,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             os: .init(context: context),
             service: context.service,
             session: .init(
-                hasReplay: nil,
+                hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
@@ -404,7 +404,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             os: .init(context: context),
             service: context.service,
             session: .init(
-                hasReplay: nil,
+                hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
@@ -500,7 +500,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             os: .init(context: context),
             service: context.service,
             session: .init(
-                hasReplay: nil,
+                hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
@@ -550,7 +550,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             os: .init(context: context),
             service: context.service,
             session: .init(
-                hasReplay: nil,
+                hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMOffViewEventsHandlingRule.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMOffViewEventsHandlingRule.swift
@@ -15,6 +15,8 @@ internal struct RUMSessionState: Equatable, Codable {
     let isInitialSession: Bool
     /// If this session has ever tracked any view (used to reason about "application launch" events).
     let hasTrackedAnyView: Bool
+    /// If the there was a Session Replay recording pending at the moment of starting this session (`nil` if SR Feature was not configured).
+    let didStartWithReplay: Bool?
 }
 
 /// The rule for handling RUM events which are tracked while there is no active view.

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -941,3 +941,15 @@ class ContinuousVitalReaderMock: ContinuousVitalReader {
         }
     }
 }
+
+// MARK: - Dependency on Session Replay
+
+extension Dictionary where Key == String, Value == FeatureBaggage {
+    static func mockSessionReplayAttributes(hasReplay: Bool?) -> Self {
+        return [
+            SessionReplayDependency.srBaggageKey: [
+                SessionReplayDependency.hasReplay: hasReplay
+            ]
+        ]
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -573,15 +573,26 @@ extension RUMSessionState: AnyMockable, RandomMockable {
     }
 
     static func mockRandom() -> RUMSessionState {
-        return .init(sessionUUID: .mockRandom(), isInitialSession: .mockRandom(), hasTrackedAnyView: .mockRandom())
+        return .init(
+            sessionUUID: .mockRandom(),
+            isInitialSession: .mockRandom(),
+            hasTrackedAnyView: .mockRandom(),
+            didStartWithReplay: .mockRandom()
+        )
     }
 
     static func mockWith(
         sessionUUID: UUID = .mockAny(),
         isInitialSession: Bool = .mockAny(),
-        hasTrackedAnyView: Bool = .mockAny()
+        hasTrackedAnyView: Bool = .mockAny(),
+        didStartWithReplay: Bool? = .mockAny()
     ) -> RUMSessionState {
-        return RUMSessionState(sessionUUID: sessionUUID, isInitialSession: isInitialSession, hasTrackedAnyView: hasTrackedAnyView)
+        return RUMSessionState(
+            sessionUUID: sessionUUID,
+            isInitialSession: isInitialSession,
+            hasTrackedAnyView: hasTrackedAnyView,
+            didStartWithReplay: didStartWithReplay
+        )
     }
 }
 
@@ -676,13 +687,15 @@ extension RUMSessionScope {
         isInitialSession: Bool = .mockAny(),
         parent: RUMContextProvider = RUMContextProviderMock(),
         startTime: Date = .mockAny(),
-        dependencies: RUMScopeDependencies = .mockAny()
+        dependencies: RUMScopeDependencies = .mockAny(),
+        isReplayBeingRecorded: Bool? = .mockAny()
     ) -> RUMSessionScope {
         return RUMSessionScope(
             isInitialSession: isInitialSession,
             parent: parent,
             startTime: startTime,
-            dependencies: dependencies
+            dependencies: dependencies,
+            isReplayBeingRecorded: isReplayBeingRecorded
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/DatadogCoreIntegration/SessionReplayDependencyTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/DatadogCoreIntegration/SessionReplayDependencyTests.swift
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class SessionReplayDependencyTests: XCTestCase {
+    func testWhenSessionReplayIsConfigured_itReadsReplayBeingRecorded() {
+        let hasReplay: Bool = .random()
+
+        // When
+        let context: DatadogContext = .mockWith(
+            featuresAttributes: [
+                SessionReplayDependency.srBaggageKey: [
+                    SessionReplayDependency.hasReplay: hasReplay
+                ]
+            ]
+        )
+
+        // Then
+        XCTAssertEqual(context.srBaggage?.isReplayBeingRecorded, hasReplay)
+    }
+
+    func testWhenSessionReplayIsNotConfigured_itReadsNoSRBaggage() {
+        // When
+        let context: DatadogContext = .mockWith(featuresAttributes: [:])
+
+        // Then
+        XCTAssertNil(context.srBaggage)
+    }
+}

--- a/Tests/DatadogTests/Datadog/RUM/DatadogCoreIntegration/SessionReplayDependencyTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/DatadogCoreIntegration/SessionReplayDependencyTests.swift
@@ -13,11 +13,7 @@ class SessionReplayDependencyTests: XCTestCase {
 
         // When
         let context: DatadogContext = .mockWith(
-            featuresAttributes: [
-                SessionReplayDependency.srBaggageKey: [
-                    SessionReplayDependency.hasReplay: hasReplay
-                ]
-            ]
+            featuresAttributes: .mockSessionReplayAttributes(hasReplay: hasReplay)
         )
 
         // Then

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import Datadog
 
 class RUMResourceScopeTests: XCTestCase {
-    let datadogContext: DatadogContext = .mockWith(
+    let context: DatadogContext = .mockWith(
         service: "test-service",
         device: .mockWith(
             name: "device-name",
@@ -48,6 +48,10 @@ class RUMResourceScopeTests: XCTestCase {
     }
 
     func testGivenStartedResource_whenResourceLoadingEnds_itSendsResourceEvent() throws {
+        let hasReplay: Bool = .mockRandom()
+        var context = self.context
+        context.featuresAttributes = .mockSessionReplayAttributes(hasReplay: hasReplay)
+
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
 
         // Given
@@ -75,7 +79,7 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 200,
                     size: 1_024
                 ),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -86,6 +90,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertEqual(event.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.session.id, scope.context.sessionID.toRUMDataFormat)
         XCTAssertEqual(event.session.type, .user)
+        XCTAssertEqual(event.session.hasReplay, hasReplay)
         XCTAssertEqual(event.source, .ios)
         XCTAssertEqual(event.view.id, rumContext.activeViewID?.toRUMDataFormat)
         XCTAssertEqual(event.view.url, "FooViewController")
@@ -184,7 +189,7 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 200,
                     size: 1_024
                 ),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -250,7 +255,7 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 200,
                     size: 1_024
                 ),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -314,7 +319,7 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 500,
                     attributes: ["foo": "bar"]
                 ),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -443,7 +448,7 @@ class RUMResourceScopeTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(scope.process(command: metricsCommand, context: datadogContext, writer: writer))
+        XCTAssertTrue(scope.process(command: metricsCommand, context: context, writer: writer))
 
         currentTime.addTimeInterval(1)
 
@@ -457,7 +462,7 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 200,
                     size: 1_024
                 ),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -518,12 +523,12 @@ class RUMResourceScopeTests: XCTestCase {
         // When
         _ = scope1.process(
             command: RUMStopResourceCommand.mockWith(resourceKey: resourceKey),
-            context: datadogContext,
+            context: context,
             writer: writer
         )
         _ = scope2.process(
             command: RUMStopResourceCommand.mockWith(resourceKey: resourceKey),
-            context: datadogContext,
+            context: context,
             writer: writer
         )
 
@@ -558,7 +563,7 @@ class RUMResourceScopeTests: XCTestCase {
                     resourceKey: "/resource/1",
                     kind: kindBasedOnResponse
                 ),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -589,7 +594,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertFalse(
             scope.process(
                 command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1"),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -623,7 +628,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertFalse(
             scope.process(
                 command: RUMStopResourceCommand.mockWith(resourceKey: "/resource/1"),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -653,7 +658,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertFalse(
             scope.process(
                 command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/1"),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -687,7 +692,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertFalse(
             scope.process(
                 command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/1"),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -722,7 +727,7 @@ class RUMResourceScopeTests: XCTestCase {
                     time: currentTime,
                     attributes: [CrossPlatformAttributes.errorSourceType: "react-native"]
                 ),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -776,7 +781,7 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 200,
                     size: 1_024
                 ),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -784,7 +789,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertFalse(
             scope2.process(
                 command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/2"),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -854,7 +859,7 @@ class RUMResourceScopeTests: XCTestCase {
                     httpStatusCode: 200,
                     size: 1_024
                 ),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )
@@ -862,7 +867,7 @@ class RUMResourceScopeTests: XCTestCase {
         XCTAssertFalse(
             scope2.process(
                 command: RUMStopResourceWithErrorCommand.mockWithErrorMessage(resourceKey: "/resource/2"),
-                context: datadogContext,
+                context: context,
                 writer: writer
             )
         )

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -439,6 +439,7 @@ class RUMSessionScopeTests: XCTestCase {
     func testWhenSessionScopeIsCreated_thenItUpdatesLastRUMSessionStateInCrashContext() throws {
         let rumSessionStateProvider = ValuePublisher<RUMSessionState?>(initialValue: nil)
         let randomIsInitialSession: Bool = .mockRandom()
+        let randomIsReplayBeingRecorded: Bool? = .mockRandom()
 
         // When
         let scope: RUMSessionScope = .mockWith(
@@ -450,7 +451,8 @@ class RUMSessionScopeTests: XCTestCase {
                     rumViewEventProvider: .mockRandom(),
                     rumSessionStateProvider: rumSessionStateProvider
                 )
-            )
+            ),
+            isReplayBeingRecorded: randomIsReplayBeingRecorded
         )
 
         // Then
@@ -458,7 +460,8 @@ class RUMSessionScopeTests: XCTestCase {
         let expectedSessionState = RUMSessionState(
             sessionUUID: scope.sessionUUID.rawValue,
             isInitialSession: randomIsInitialSession,
-            hasTrackedAnyView: false
+            hasTrackedAnyView: false,
+            didStartWithReplay: randomIsReplayBeingRecorded
         )
         XCTAssertEqual(rumSessionStateInjectedToCrashContext, expectedSessionState, "It must inject expected session state to crash context")
     }
@@ -466,6 +469,7 @@ class RUMSessionScopeTests: XCTestCase {
     func testWhenSessionScopeStartsAnyView_thenItUpdatesLastRUMSessionStateInCrashContext() throws {
         let rumSessionStateProvider = ValuePublisher<RUMSessionState?>(initialValue: nil)
         let randomIsInitialSession: Bool = .mockRandom()
+        let randomIsReplayBeingRecorded: Bool? = .mockRandom()
 
         // Given
         let sessionStartTime = Date()
@@ -478,7 +482,8 @@ class RUMSessionScopeTests: XCTestCase {
                     rumViewEventProvider: .mockRandom(),
                     rumSessionStateProvider: rumSessionStateProvider
                 )
-            )
+            ),
+            isReplayBeingRecorded: randomIsReplayBeingRecorded
         )
 
         // When
@@ -491,7 +496,8 @@ class RUMSessionScopeTests: XCTestCase {
         let expectedSessionState = RUMSessionState(
             sessionUUID: scope.sessionUUID.rawValue,
             isInitialSession: randomIsInitialSession,
-            hasTrackedAnyView: true
+            hasTrackedAnyView: true,
+            didStartWithReplay: randomIsReplayBeingRecorded
         )
         XCTAssertEqual(rumSessionStateInjectedToCrashContext, expectedSessionState, "It must inject expected session state to crash context")
     }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -44,6 +44,10 @@ class RUMUserActionScopeTests: XCTestCase {
     }
 
     func testGivenActiveUserAction_whenViewIsStopped_itSendsUserActionEvent() throws {
+        let hasReplay: Bool = .mockRandom()
+        var context = self.context
+        context.featuresAttributes = .mockSessionReplayAttributes(hasReplay: hasReplay)
+
         let scope = RUMViewScope.mockWith(
             parent: parent,
             dependencies: .mockAny(),
@@ -79,6 +83,7 @@ class RUMUserActionScopeTests: XCTestCase {
         let recordedAction = try XCTUnwrap(recordedActionEvents.last)
         XCTAssertEqual(recordedAction.action.type.rawValue, String(describing: mockUserActionCmd.actionType))
         XCTAssertEqual(recordedAction.dd.session?.plan, .plan1, "All RUM events should use RUM Lite plan")
+        XCTAssertEqual(recordedAction.session.hasReplay, hasReplay)
         XCTAssertEqual(recordedAction.source, .ios)
         XCTAssertEqual(recordedAction.service, "test-service")
         XCTAssertEqual(recordedAction.device?.name, "device-name")

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -90,6 +90,9 @@ class RUMViewScopeTests: XCTestCase {
         var context = self.context
         context.launchTime = .init(launchTime: 2, isActivePrewarm: false)
 
+        let hasReplay: Bool = .mockRandom()
+        context.featuresAttributes = .mockSessionReplayAttributes(hasReplay: hasReplay)
+
         let scope = RUMViewScope(
             isInitialView: true,
             parent: parent,
@@ -116,6 +119,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.session.id, scope.context.sessionID.toRUMDataFormat)
         XCTAssertEqual(event.session.type, .user)
+        XCTAssertEqual(event.session.hasReplay, hasReplay)
         XCTAssertValidRumUUID(event.view.id)
         XCTAssertEqual(event.view.url, "UIViewController")
         XCTAssertEqual(event.view.name, "ViewName")
@@ -192,6 +196,10 @@ class RUMViewScopeTests: XCTestCase {
     }
 
     func testWhenInitialViewReceivesAnyCommand_itSendsViewUpdateEvent() throws {
+        let hasReplay: Bool = .mockRandom()
+        var context = self.context
+        context.featuresAttributes = .mockSessionReplayAttributes(hasReplay: hasReplay)
+
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
             isInitialView: true,
@@ -217,6 +225,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(event.session.id, scope.context.sessionID.toRUMDataFormat)
         XCTAssertEqual(event.session.type, .user)
+        XCTAssertEqual(event.session.hasReplay, hasReplay)
         XCTAssertValidRumUUID(event.view.id)
         XCTAssertEqual(event.view.url, "UIViewController")
         XCTAssertEqual(event.view.name, "ViewName")
@@ -919,6 +928,10 @@ class RUMViewScopeTests: XCTestCase {
     // MARK: - Error Tracking
 
     func testWhenViewErrorIsAdded_itSendsErrorEventAndViewUpdateEvent() throws {
+        let hasReplay: Bool = .mockRandom()
+        var context = self.context
+        context.featuresAttributes = .mockSessionReplayAttributes(hasReplay: hasReplay)
+
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
             isInitialView: .mockRandom(),
@@ -956,6 +969,7 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(error.application.id, scope.context.rumApplicationID)
         XCTAssertEqual(error.session.id, scope.context.sessionID.toRUMDataFormat)
         XCTAssertEqual(error.session.type, .user)
+        XCTAssertEqual(error.session.hasReplay, hasReplay)
         XCTAssertValidRumUUID(error.view.id)
         XCTAssertEqual(error.view.url, "UIViewController")
         XCTAssertEqual(error.view.name, "ViewName")
@@ -1121,6 +1135,10 @@ class RUMViewScopeTests: XCTestCase {
     // MARK: - Long tasks
 
     func testWhenLongTaskIsAdded_itSendsLongTaskEventAndViewUpdateEvent() throws {
+        let hasReplay: Bool = .mockRandom()
+        var context = self.context
+        context.featuresAttributes = .mockSessionReplayAttributes(hasReplay: hasReplay)
+
         let startViewDate: Date = .mockDecember15th2019At10AMUTC()
 
         let scope = RUMViewScope(
@@ -1161,6 +1179,8 @@ class RUMViewScopeTests: XCTestCase {
 
         XCTAssertEqual(event.action?.id.stringValue, scope.context.activeUserActionID?.toRUMDataFormat)
         XCTAssertEqual(event.application.id, scope.context.rumApplicationID)
+        XCTAssertEqual(event.session.id, scope.context.sessionID.toRUMDataFormat)
+        XCTAssertEqual(event.session.hasReplay, hasReplay)
         XCTAssertNil(event.connectivity)
         XCTAssertEqual(event.context?.contextInfo as? [String: String], ["foo": "bar"])
         XCTAssertEqual(event.date, longTaskStartingDate.timeIntervalSince1970.toInt64Milliseconds)

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMOffViewEventsHandlingRuleTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMOffViewEventsHandlingRuleTests.swift
@@ -42,7 +42,8 @@ class RUMOffViewEventsHandlingRuleTests: XCTestCase {
             sessionState: .init(
                 sessionUUID: .mockRandom(),
                 isInitialSession: true,
-                hasTrackedAnyView: false
+                hasTrackedAnyView: false,
+                didStartWithReplay: .mockAny()
             ),
             isAppInForeground: true,
             isBETEnabled: .mockRandom()
@@ -53,7 +54,8 @@ class RUMOffViewEventsHandlingRuleTests: XCTestCase {
             sessionState: .init(
                 sessionUUID: .mockRandom(),
                 isInitialSession: .mockRandom(),
-                hasTrackedAnyView: true
+                hasTrackedAnyView: true,
+                didStartWithReplay: .mockAny()
             ),
             isAppInForeground: true,
             isBETEnabled: .mockRandom()
@@ -64,7 +66,8 @@ class RUMOffViewEventsHandlingRuleTests: XCTestCase {
             sessionState: .init(
                 sessionUUID: .mockRandom(),
                 isInitialSession: false,
-                hasTrackedAnyView: .mockRandom()
+                hasTrackedAnyView: .mockRandom(),
+                didStartWithReplay: .mockAny()
             ),
             isAppInForeground: true,
             isBETEnabled: .mockRandom()
@@ -77,7 +80,8 @@ class RUMOffViewEventsHandlingRuleTests: XCTestCase {
             sessionState: .init(
                 sessionUUID: .mockRandom(),
                 isInitialSession: .mockRandom(),
-                hasTrackedAnyView: .mockRandom()
+                hasTrackedAnyView: .mockRandom(),
+                didStartWithReplay: .mockAny()
             ),
             isAppInForeground: false,
             isBETEnabled: true
@@ -88,7 +92,8 @@ class RUMOffViewEventsHandlingRuleTests: XCTestCase {
             sessionState: .init(
                 sessionUUID: .mockRandom(),
                 isInitialSession: .mockRandom(),
-                hasTrackedAnyView: .mockRandom()
+                hasTrackedAnyView: .mockRandom(),
+                didStartWithReplay: .mockAny()
             ),
             isAppInForeground: false,
             isBETEnabled: false
@@ -103,7 +108,8 @@ class RUMOffViewEventsHandlingRuleTests: XCTestCase {
             sessionState: .init(
                 sessionUUID: .nullUUID, // session is not sampled
                 isInitialSession: .mockRandom(),
-                hasTrackedAnyView: .mockRandom()
+                hasTrackedAnyView: .mockRandom(),
+                didStartWithReplay: .mockAny()
             ),
             isAppInForeground: .mockRandom(),
             isBETEnabled: .mockRandom()

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
@@ -5,7 +5,7 @@
  */
 
 import Foundation
-@testable import Datadog
+import Datadog
 
 /// The RUM context received from `DatadogCore`.
 internal struct RUMContext: Equatable {

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
@@ -9,6 +9,8 @@ import Foundation
 /// Defines dependency between Session Replay (SR) and RUM modules.
 /// It aims at centralizing documentation of contracts between both products.
 internal struct RUMDependency {
+    // MARK: Contract from RUM to SR:
+
     /// The key for referencing RUM baggage (RUM context) in `DatadogContext.featuresAttributes`.
     ///
     /// SR expects:
@@ -30,4 +32,16 @@ internal struct RUMDependency {
     ///
     /// SR expects non-optional value holding lowercased, standard UUID `String`.
     static let viewIDKey = "view.id"
+
+    // MARK: Contract from SR to RUM (mirror of `SessionReplayDependency` in RUM):
+
+    /// The key referencing SR baggage in `DatadogContext.featuresAttributes`.
+    ///
+    /// RUM expects:
+    /// - baggage with `hasReplay` key if SR Feature is configured;
+    /// - the `hasReplay` baggege key of `Bool` value indicating if the replay is being recorded.
+    static let srBaggageKey = "session-replay"
+
+    /// The key referencing a `Bool` value that indicates if replay is being recorded.
+    static let hasReplay = "has_replay"
 }

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/SRContextPublisher.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/SRContextPublisher.swift
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+import Datadog
+
+internal class SRContextPublisher {
+    private weak var core: DatadogCoreProtocol?
+
+    init(core: DatadogCoreProtocol) {
+        self.core = core
+    }
+
+    /// Notifies other Features on the state of  Session Replay recording.
+    func setRecordingIsPending(_ value: Bool) {
+        let baggage: FeatureBaggage = [
+            RUMDependency.hasReplay: value
+        ]
+
+        core?.set(feature: RUMDependency.srBaggageKey, attributes: { baggage })
+    }
+}

--- a/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/SRContextPublisher.swift
+++ b/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/SRContextPublisher.swift
@@ -7,6 +7,7 @@
 import Foundation
 import Datadog
 
+/// Publisher that sets Session Replay context for being utilized by other Features.
 internal class SRContextPublisher {
     private weak var core: DatadogCoreProtocol?
 
@@ -16,10 +17,9 @@ internal class SRContextPublisher {
 
     /// Notifies other Features on the state of  Session Replay recording.
     func setRecordingIsPending(_ value: Bool) {
-        let baggage: FeatureBaggage = [
-            RUMDependency.hasReplay: value
-        ]
-
-        core?.set(feature: RUMDependency.srBaggageKey, attributes: { baggage })
+        core?.set(
+            feature: RUMDependency.srBaggageKey,
+            attributes: { [RUMDependency.hasReplay: value] }
+        )
     }
 }

--- a/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplay.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Drafts/SessionReplay.swift
@@ -16,7 +16,10 @@ public struct SessionReplay {
         in datadogInstance: DatadogCoreProtocol = defaultDatadogCore
     ) -> SessionReplayController {
         do {
-            let feature = SessionReplayFeature(configuration: configuration)
+            let feature = SessionReplayFeature(
+                core: datadogInstance,
+                configuration: configuration
+            )
             try datadogInstance.register(feature: feature)
 
             guard let scope = datadogInstance.scope(for: feature.name) else {

--- a/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/SRContextPublisherTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/SRContextPublisherTests.swift
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+// swiftlint:disable empty_xctest_method
+class SRContextPublisherTests: XCTestCase {
+    func testItSetsHasReplayAccordingly() {
+        // TODO: RUMM-2690
+        // Implementing this test requires creating mocks for `DatadogCore` and `DatadogContext`,
+        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    }
+}
+// swiftlint:enable empty_xctest_method


### PR DESCRIPTION
### What and why?

📦 This PR delivers the last 🧩 element of Session Replay upload pipeline. It integrates SR data with RUM: If any RUM event is collected while SR module is enabled, it will have `hasReplay` flag set accordingly to the recording state (`true` | `false`).

This flag is crucial for RUM <> SR correlation, i.a.: thanks to this value we can display ▶️ button next to events that can be referenced from SR replays. Clicking on it will jump directly to this event within recording:

<img width="300" alt="Screenshot 2022-11-10 at 08 10 28" src="https://user-images.githubusercontent.com/2358722/201025396-c27b7184-a463-4e9b-9b8c-1bd90e613a7a.png">

### How?

When recorder's state changes, SR updates its `FeatureBaggage` in `DatadogContext`. This baggage is read by RUM when events are created.

For clarity, and to continue convention started with [`RUMDependency`](https://github.com/DataDog/dd-sdk-ios/blob/feature/session-replay/session-replay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift), I added `SessionReplayDependency` structure to RUM. Both structures describe the contract from one module to another.

For having max correlation between RUM evens and SR, the `hasReplay` information propagates also to crash reporting flow. This requires persisting this flag within the "last RUM session state" that gets encoded along with the crash report. Later, when creating the actual RUM error, we make our best effort to deduce if there is a replay that could correspond to this crash.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
