### PR TITLE
Add architecture to logs

### DIFF
--- a/Sources/Datadog/CrashReporting/Integrations/CrashReportingWithLoggingIntegration.swift
+++ b/Sources/Datadog/CrashReporting/Integrations/CrashReportingWithLoggingIntegration.swift
@@ -65,6 +65,7 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
         errorAttributes[DDError.wasTruncated] = crashReport.wasTruncated
 
         let user = crashContext.lastUserInfo
+        let deviceInfo = context.device
 
         return LogEvent(
             date: crashDate,
@@ -81,6 +82,9 @@ internal struct CrashReportingWithLoggingIntegration: CrashReportingIntegration 
             loggerVersion: context.sdkVersion,
             threadName: nil,
             applicationVersion: context.version,
+            dd: LogEvent.Dd(
+                device: LogEvent.DeviceInfo(architecture: deviceInfo.architecture)
+            ),
             userInfo: .init(
                 id: user?.id,
                 name: user?.name,

--- a/Sources/Datadog/Logging/Log/LogEventBuilder.swift
+++ b/Sources/Datadog/Logging/Log/LogEventBuilder.swift
@@ -69,6 +69,9 @@ internal struct LogEventBuilder {
             loggerVersion: context.sdkVersion,
             threadName: threadName,
             applicationVersion: context.version,
+            dd: LogEvent.Dd(
+                device: LogEvent.DeviceInfo(architecture: context.device.architecture)
+            ),
             userInfo: .init(
                 id: userInfo.id,
                 name: userInfo.name,

--- a/Sources/Datadog/Logging/Log/LogEventEncoder.swift
+++ b/Sources/Datadog/Logging/Log/LogEventEncoder.swift
@@ -43,6 +43,22 @@ public struct LogEvent: Encodable {
         // The Log error stack
         public let stack: String?
     }
+    public struct DeviceInfo: Codable {
+        // The architecture of the device
+        public let architecture: String
+
+        enum CodingKeys: String, CodingKey {
+            case architecture = "architecture"
+        }
+    }
+    public struct Dd: Codable {
+        // Device informatino
+        public let device: DeviceInfo
+
+        enum CodingKeys: String, CodingKey {
+            case device = "device"
+        }
+    }
 
     /// The log's timestamp
     public let date: Date
@@ -64,6 +80,8 @@ public struct LogEvent: Encodable {
     public let threadName: String?
     /// The current application version.
     public let applicationVersion: String
+    /// Datadog specific attributes
+    public let dd: Dd
     /// Custom user information configured globally for the SDK.
     public var userInfo: UserInfo
     /// The network connection information from the moment the log was sent.
@@ -101,6 +119,9 @@ internal struct LogEventEncoder {
         // MARK: - Application info
 
         case applicationVersion = "version"
+
+        // MARK: - Dd info
+        case dd = "_dd"
 
         // MARK: - Logger info
 
@@ -161,6 +182,8 @@ internal struct LogEventEncoder {
 
         // Encode application info
         try container.encode(log.applicationVersion, forKey: .applicationVersion)
+
+        try container.encode(log.dd, forKey: .dd)
 
         // Encode user info
         try log.userInfo.id.ifNotNil { try container.encode($0, forKey: .userId) }

--- a/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/Tests/DatadogBenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -97,6 +97,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
             loggerVersion: "0.0.0",
             threadName: "main",
             applicationVersion: "0.0.0",
+            dd: .init(device: .init(architecture: "testArch")),
             userInfo: .init(id: "abc-123", name: "foo", email: "foo@bar.com", extraInfo: ["str": "value", "int": 11_235, "bool": true]),
             networkConnectionInfo: .init(
                 reachability: .yes,

--- a/Tests/DatadogIntegrationTests/Scenarios/Logging/LoggingScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/Logging/LoggingScenarioTests.swift
@@ -61,6 +61,7 @@ class LoggingScenarioTests: IntegrationTests, LoggingCommonAsserts {
                     "some-url": "redacted",
                 ]
             )
+            matcher.assertHasArchitecture()
 
             #if DEBUG
             matcher.assertTags(equal: ["env:integration", "build_configuration:debug", "tag1:tag-value", "tag2", "tag3:added", "version:1.0"])

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/CrashReporting/CrashReportingWithLoggingIntegrationTests.swift
@@ -81,6 +81,7 @@ class CrashReportingWithLoggingIntegrationTests: XCTestCase {
         )
 
         // When
+        let mockArchitecture = String.mockRandom()
         let integration = CrashReportingWithLoggingIntegration(
             core: core,
             context: .mockWith(
@@ -88,6 +89,9 @@ class CrashReportingWithLoggingIntegrationTests: XCTestCase {
                 env: configuration.environment,
                 version: configuration.applicationVersion,
                 sdkVersion: configuration.sdkVersion,
+                device: .mockWith(
+                    architecture: mockArchitecture
+                ),
                 dateCorrector: DateCorrectorMock(offset: dateCorrectionOffset)
             ),
             dateProvider: RelativeDateProvider(using: .mockRandomInThePast())
@@ -113,6 +117,7 @@ class CrashReportingWithLoggingIntegrationTests: XCTestCase {
             loggerVersion: configuration.sdkVersion,
             threadName: nil,
             applicationVersion: configuration.applicationVersion,
+            dd: .init(device: .init(architecture: mockArchitecture)),
             userInfo: .init(
                 id: user.id,
                 name: user.name,

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -29,7 +29,8 @@ class LoggerTests: XCTestCase {
             service: "default-service-name",
             env: "tests",
             version: "1.0.0",
-            sdkVersion: "1.2.3"
+            sdkVersion: "1.2.3",
+            device: .mockWith(architecture: "testArch")
         )
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers(
@@ -53,7 +54,12 @@ class LoggerTests: XCTestCase {
           "logger.thread_name" : "main",
           "date" : "2019-12-15T10:00:00.000Z",
           "version": "1.0.0",
-          "ddtags": "env:tests,version:1.0.0"
+          "ddtags": "env:tests,version:1.0.0",
+          "_dd": {
+            "device": {
+              "architecture": "testArch"
+            }
+          }
         }
         """)
     }

--- a/Tests/DatadogTests/Datadog/Logging/Log/LogEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/Log/LogEventBuilderTests.swift
@@ -18,6 +18,7 @@ class LogEventBuilderTests: XCTestCase {
         let randomService: String = .mockRandom()
         let randomLoggerName: String = .mockRandom()
         let randomThreadName: String = .mockRandom()
+        let randomArchitecture: String = .mockRandom()
 
         // Given
         let builder = LogEventBuilder(
@@ -35,7 +36,12 @@ class LogEventBuilderTests: XCTestCase {
             error: randomError,
             attributes: randomAttributes,
             tags: randomTags,
-            context: .mockWith(serverTimeOffset: 0),
+            context: .mockWith(
+                serverTimeOffset: 0,
+                device: .mockWith(
+                    architecture: randomArchitecture
+                )
+            ),
             threadName: randomThreadName
         )
         let log = try XCTUnwrap(event)
@@ -52,6 +58,7 @@ class LogEventBuilderTests: XCTestCase {
         XCTAssertEqual(log.serviceName, randomService)
         XCTAssertEqual(log.loggerName, randomLoggerName)
         XCTAssertEqual(log.threadName, randomThreadName)
+        XCTAssertEqual(log.dd.device.architecture, randomArchitecture)
     }
 
     func testItBuildsLogEventWithSDKContextInformation() throws {

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -95,6 +95,7 @@ extension LogEvent: AnyMockable, RandomMockable {
         loggerVersion: String = .mockAny(),
         threadName: String = .mockAny(),
         applicationVersion: String = .mockAny(),
+        dd: LogEvent.Dd = .mockAny(),
         userInfo: UserInfo = .mockAny(),
         networkConnectionInfo: NetworkConnectionInfo = .mockAny(),
         mobileCarrierInfo: CarrierInfo? = .mockAny(),
@@ -112,6 +113,7 @@ extension LogEvent: AnyMockable, RandomMockable {
             loggerVersion: loggerVersion,
             threadName: threadName,
             applicationVersion: applicationVersion,
+            dd: dd,
             userInfo: userInfo,
             networkConnectionInfo: networkConnectionInfo,
             mobileCarrierInfo: mobileCarrierInfo,
@@ -132,6 +134,7 @@ extension LogEvent: AnyMockable, RandomMockable {
             loggerVersion: .mockRandom(),
             threadName: .mockRandom(),
             applicationVersion: .mockRandom(),
+            dd: .mockRandom(),
             userInfo: .mockRandom(),
             networkConnectionInfo: .mockRandom(),
             mobileCarrierInfo: .mockRandom(),
@@ -175,6 +178,34 @@ extension LogEvent.UserInfo: AnyMockable, RandomMockable {
     }
 }
 
+extension LogEvent.Dd: AnyMockable, RandomMockable {
+    static func mockAny() -> LogEvent.Dd {
+        return LogEvent.Dd(
+            device: .mockAny()
+        )
+    }
+
+    static func mockRandom() -> LogEvent.Dd {
+        return LogEvent.Dd(
+            device: .mockRandom()
+        )
+    }
+}
+
+extension LogEvent.DeviceInfo: AnyMockable, RandomMockable {
+    static func mockAny() -> LogEvent.DeviceInfo {
+        return LogEvent.DeviceInfo(
+            architecture: .mockAny()
+        )
+    }
+
+    static func mockRandom() -> LogEvent.DeviceInfo {
+        return LogEvent.DeviceInfo(
+            architecture: .mockRandom()
+        )
+    }
+}
+
 extension LogEvent.Error: RandomMockable {
     static func mockRandom() -> Self {
         return .init(
@@ -196,7 +227,8 @@ extension LogEventBuilder: AnyMockable {
         service: String = .mockAny(),
         loggerName: String = .mockAny(),
         sendNetworkInfo: Bool = .mockAny(),
-        eventMapper: LogEventMapper? = nil
+        eventMapper: LogEventMapper? = nil,
+        deviceInfo: DeviceInfo = .mockAny()
     ) -> LogEventBuilder {
         return LogEventBuilder(
             service: service,

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -54,6 +54,11 @@ internal class LogMatcher: JSONDataMatcher {
         static let errorKind = "error.kind"
         static let errorMessage = "error.message"
         static let errorStack = "error.stack"
+
+        // MARK: - Dd info
+        static let dd = "_dd"
+        static let ddDevice = "device"
+        static let ddDeviceArchitecture = "architecture"
     }
 
     /// Allowed values for `network.client.available_interfaces` attribute.
@@ -163,6 +168,16 @@ internal class LogMatcher: JSONDataMatcher {
         let logTags = Set(tagsString.split(separator: ",").map { String($0) })
 
         XCTAssertEqual(matcherTags, logTags, file: file, line: line)
+    }
+
+    func assertHasArchitecture() {
+        var architecture: String?
+        if let dd = json[JSONKey.dd] as? [String: Any],
+           let device = dd[JSONKey.ddDevice] as? [String: Any] {
+            architecture = device[JSONKey.ddDeviceArchitecture] as? String
+        }
+
+        XCTAssertNotNil(architecture)
     }
 }
 


### PR DESCRIPTION
### What and why?

Add an `architecture` attribute to logs, under a new `_dd` structure for reserved attributes.

### How?

The method for encoding this is a bit different than the rest of the logs, and closer to what Android is doing. Instead of encoding nested properties with `.` keys, it encodes with the full JSON object.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
