### PR TITLE
RUMM-2725 Add --fix flag to linter script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,16 @@ The workspace for SDK development and integration (tests, benchmarks, example ap
 
 #### Lint
 
-We're using swiftlint to ensure our codebase follows Swift standard syntax. You can run the lint with our custom rules with the following command line:
+We're using `swiftlint` to ensure our codebase follows Swift standard syntax. You can run the lint with our custom rules with the following command line:
 
 ```shell
 $ ./tools/lint/run-linter.sh
+```
+
+In order to apply automatic correction of violations use `--fix` flag:
+
+```shell
+$ ./tools/lint/run-linter.sh --fix
 ```
 
 #### Dependency manager tests

--- a/tools/lint/run-linter.sh
+++ b/tools/lint/run-linter.sh
@@ -4,11 +4,21 @@ if [ ! -f "Package.swift" ]; then
 	echo "\`run-linter.sh\` must be run in repository root folder: \`./tools/lint/run-linter.sh\`"; exit 1
 fi
 
+automatic_fix=""
+while :; do
+    case $1 in
+        --fix) automatic_fix="--fix"            
+        ;;
+        *) break
+    esac
+    shift
+done
+
 if [[ -z "${XCODE_VERSION_ACTUAL}" ]]; then
 	# when run from command line
 	set -e # exit with error code if `swiftlint lint` fails
-	swiftlint lint --config ./tools/lint/sources.swiftlint.yml --reporter "emoji" --strict
-	swiftlint lint --config ./tools/lint/tests.swiftlint.yml --reporter "emoji" --strict
+	swiftlint lint --config ./tools/lint/sources.swiftlint.yml --reporter "emoji" --strict $automatic_fix
+	swiftlint lint --config ./tools/lint/tests.swiftlint.yml --reporter "emoji" --strict $automatic_fix
 else
 	# when run by Xcode in Build Phase
 	swiftlint lint --config ./tools/lint/sources.swiftlint.yml --reporter "xcode"


### PR DESCRIPTION
### What and why?

This allows running our linting script with `--fix` flag enabled. Particularly useful for people who are still aligning with the code-style.

### How?

I updated the bash script to take `--fix` into account. Also made a hint in the contribution guide.
