### PR TITLE
Vend DatadogAlamofireExtension from Package.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [IMPROVEMENT] Add a method for sending error attributes on logs as strings.
 - [IMPROVEMENT] Add manual Open Telemetry b3 headers injection. See [#1057][]
+- [IMPROVEMENT] Vend `DatadogAlamofireExtension` from Package.swift. See [#1069][]
 
 # 1.13.0 / 08-11-2022
 

--- a/Package.swift
+++ b/Package.swift
@@ -41,9 +41,14 @@ let package = Package(
             name: "DatadogCrashReporting",
             targets: ["DatadogCrashReporting"]
         ),
+        .library(
+            name: "DatadogAlamofireExtension",
+            targets: ["DatadogAlamofireExtension"]
+        )
     ],
     dependencies: [
         .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.0"),
+        .package(name: "Alamofire", url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0")
     ],
     targets: [
         .target(
@@ -68,6 +73,14 @@ let package = Package(
                 "Datadog",
                 .product(name: "CrashReporter", package: "PLCrashReporter"),
             ]
-        )
+        ),
+        .target(
+            name: "DatadogAlamofireExtension",
+            dependencies: [
+                "Datadog",
+                "Alamofire"
+            ],
+            path: "Sources/DatadogExtensions/Alamofire/"
+        ),
     ]
 )

--- a/Sources/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
+++ b/Sources/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
@@ -6,6 +6,7 @@
 
 import class Datadog.URLSessionInterceptor
 import Alamofire
+import Foundation
 
 /// An `Alamofire.EventMonitor` which instruments `Alamofire.Session` with Datadog RUM and Tracing.
 public class DDEventMonitor: EventMonitor {

--- a/Sources/DatadogExtensions/Alamofire/README.md
+++ b/Sources/DatadogExtensions/Alamofire/README.md
@@ -14,13 +14,32 @@ pod 'DatadogSDKAlamofireExtension'
 ```
 `DatadogSDKAlamofireExtension` requires Datadog SDK `1.5.0` or higher and `Alamofire 5.0` or higher.
 
-### Carthage and SPM
+### SPM
 
-The Datadog [Alamofire][1] integration doesn't support [Carthage][2] or [SPM][3], however, the code needed for set up is very low. You may want to include the source files from this folder directly in your project.
+To include the Datadog integration for [Alamofire][1] in your project, add the
+following to your `Package.swift` file:
+```swift
+    dependencies: [
+        .package(url: "https://github.com/DataDog/dd-sdk-ios", branch: "develop"),
+    ],
+    targets: [
+        .target(
+            name: "YourTargetHere",
+            dependencies: [
+                .product(name: "DatadogAlamofireExtension", package: "dd-sdk-ios"),
+            ])
+    ],
+]
+```
+`DatadogSDKAlamofireExtension` requires Datadog SDK `1.5.0` or higher and `Alamofire 5.0` or higher.
+
+### Carthage
+
+The Datadog [Alamofire][1] integration doesn't support [Carthage][2], however, the code needed for set up is very low. You may want to include the source files from this folder directly in your project.
 
 ### Initial setup
 
-Follow the regular steps for initializing Datadog SDK for [Tracing][4] or [RUM][5].
+Follow the regular steps for initializing Datadog SDK for [Tracing][3] or [RUM][4].
 
 Instead of using `DDURLSessionDelegate` for `URLSession`, use `DDEventMonitor` and `DDRequestInterceptor` for `Alamofire.Session`:
 
@@ -46,6 +65,5 @@ Pull requests are welcome. First, open an issue to discuss what you would like t
 
 [1]: https://github.com/Alamofire/Alamofire
 [2]: https://github.com/Carthage/Carthage
-[3]: https://swift.org/package-manager/
-[4]: https://docs.datadoghq.com/tracing/setup_overview/setup/ios/
-[5]: https://docs.datadoghq.com/real_user_monitoring/ios
+[3]: https://docs.datadoghq.com/tracing/setup_overview/setup/ios/
+[4]: https://docs.datadoghq.com/real_user_monitoring/ios

--- a/Sources/DatadogExtensions/Alamofire/README.md
+++ b/Sources/DatadogExtensions/Alamofire/README.md
@@ -31,7 +31,7 @@ following to your `Package.swift` file:
     ],
 ]
 ```
-`DatadogSDKAlamofireExtension` requires Datadog SDK `1.5.0` or higher and `Alamofire 5.0` or higher.
+`DatadogSDKAlamofireExtension` requires Datadog SDK `1.5.0` or later and `Alamofire 5.0` or later.
 
 ### Carthage
 

--- a/Sources/DatadogExtensions/Alamofire/README.md
+++ b/Sources/DatadogExtensions/Alamofire/README.md
@@ -35,7 +35,7 @@ following to your `Package.swift` file:
 
 ### Carthage
 
-The Datadog [Alamofire][1] integration doesn't support [Carthage][2], however, the code needed for set up is very low. You may want to include the source files from this folder directly in your project.
+The Datadog [Alamofire][1] integration doesn't support [Carthage][2]; however, the code needed for set up is minimal. You may want to include the source files from this folder directly in your project.
 
 ### Initial setup
 


### PR DESCRIPTION
### What and why?

This PR addresses #1069 by allowing the `DatadogAlamofireExtension` package to be vended from Swift Package Manager.

Note that I called the library `DatadogAlamofireExtension` rather than `DatadogSDKAlamofireExtension` to match the naming pattern of the existing packages. I'm happy to change the name of the library and target if desired.

### How?

I added a `target` and `library` to the `Package.swift` file.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
