### PR TITLE
Change updatePerformanceMetrics to take a time

### DIFF
--- a/Sources/Datadog/DDRUMMonitor+Internal.swift
+++ b/Sources/Datadog/DDRUMMonitor+Internal.swift
@@ -27,18 +27,19 @@ extension DatadogExtension where ExtendedType: DDRUMMonitor {
     }
 
     public func updatePerformanceMetric(
+        at: Date,
         metric: PerformanceMetric,
         value: Double,
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {
-        guard let type = type as? RUMMonitor else {
+        guard let type = type as? RUMCommandSubscriber else {
             return
         }
 
         let performanceMetric = RUMUpdatePerformanceMetric(
             metric: metric,
             value: value,
-            time: type.dateProvider.now,
+            time: at,
             attributes: attributes
         )
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMInternalProxyTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMInternalProxyTests.swift
@@ -64,22 +64,24 @@ class RUMInternalProxyTests: XCTestCase {
         // Given
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers()
         core.register(feature: rum)
+        let date: Date = .mockRandomInThePast()
 
         let monitor = try createTestableRUMMonitor()
 
         // When
         monitor.startView(viewController: mockView)
-        monitor._internal.updatePerformanceMetric(metric: .jsFrameTimeSeconds, value: 0.02)
-        monitor._internal.updatePerformanceMetric(metric: .jsFrameTimeSeconds, value: 0.02)
-        monitor._internal.updatePerformanceMetric(metric: .jsFrameTimeSeconds, value: 0.02)
-        monitor._internal.updatePerformanceMetric(metric: .jsFrameTimeSeconds, value: 0.04)
-        monitor._internal.updatePerformanceMetric(metric: .flutterBuildTime, value: 32.0)
-        monitor._internal.updatePerformanceMetric(metric: .flutterBuildTime, value: 52.0)
-        monitor._internal.updatePerformanceMetric(metric: .flutterRasterTime, value: 42.0)
+        monitor._internal.updatePerformanceMetric(at: date, metric: .jsFrameTimeSeconds, value: 0.02)
+        monitor._internal.updatePerformanceMetric(at: date, metric: .jsFrameTimeSeconds, value: 0.02)
+        monitor._internal.updatePerformanceMetric(at: date, metric: .jsFrameTimeSeconds, value: 0.02)
+        monitor._internal.updatePerformanceMetric(at: date, metric: .jsFrameTimeSeconds, value: 0.04)
+        monitor._internal.updatePerformanceMetric(at: date, metric: .flutterBuildTime, value: 32.0)
+        monitor._internal.updatePerformanceMetric(at: date, metric: .flutterBuildTime, value: 52.0)
+        monitor._internal.updatePerformanceMetric(at: date, metric: .flutterRasterTime, value: 42.0)
         monitor.stopView(viewController: mockView)
 
         let rumEventMatchers = try rum.waitAndReturnRUMEventMatchers(count: 3)
 
+        // Then
         try rumEventMatchers.lastRUMEvent(ofType: RUMViewEvent.self)
             .model(ofType: RUMViewEvent.self) { rumModel in
                 XCTAssertEqual(rumModel.view.jsRefreshRate?.max, 50.0)


### PR DESCRIPTION
### What and why?

Change `updatePerformanceMetrics` to take a time as its first parameter, so it can cast to `RUMCommandSubscriber` instead of `RUMMonitor` (because we eliminate the dependency on dateProvider)

This is mostly to make updatePerformanceMetrics more testable in cross-platform libraries.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
