### PR TITLE
Allow error info to be modifiable on LogEvents

### DIFF
--- a/Sources/Datadog/Logging/Log/LogEventEncoder.swift
+++ b/Sources/Datadog/Logging/Log/LogEventEncoder.swift
@@ -37,11 +37,11 @@ public struct LogEvent: Encodable {
     }
     public struct Error {
         // The Log error kind
-        public let kind: String?
+        public var kind: String?
         // The Log error message
-        public let message: String?
+        public var message: String?
         // The Log error stack
-        public let stack: String?
+        public var stack: String?
     }
     public struct DeviceInfo: Codable {
         // The architecture of the device
@@ -67,7 +67,7 @@ public struct LogEvent: Encodable {
     /// The log message
     public var message: String
     /// The associated log error
-    public let error: Error?
+    public var error: Error?
     /// The service name configured for Logs.
     public let serviceName: String
     /// The current log environement.


### PR DESCRIPTION
### What and why?

Allow error info to be modifiable on LogEvents. This allows clients to modify that information in the LogEventMapper and scrub potentially sensitive data.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
