### PR TITLE
RUMM-2680 [SR] Update SR data models to recent schema

### DIFF
--- a/session-replay/Sources/DatadogSessionReplay/Processor/Diffing/Diff+SRWireframes.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/Diffing/Diff+SRWireframes.swift
@@ -74,6 +74,7 @@ extension SRShapeWireframe: MutableWireframe {
         return .shapeWireframeUpdate(
             value: .init(
                 border: use(border, ifDifferentThan: other.border),
+                clip: use(clip, ifDifferentThan: other.clip),
                 height: use(height, ifDifferentThan: other.height),
                 id: id,
                 shapeStyle: use(shapeStyle, ifDifferentThan: other.shapeStyle),
@@ -97,6 +98,7 @@ extension SRTextWireframe: MutableWireframe {
         return .textWireframeUpdate(
             value: .init(
                 border: use(border, ifDifferentThan: other.border),
+                clip: use(clip, ifDifferentThan: other.clip),
                 height: use(height, ifDifferentThan: other.height),
                 id: id,
                 shapeStyle: use(shapeStyle, ifDifferentThan: other.shapeStyle),

--- a/session-replay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -41,6 +41,7 @@ internal class WireframesBuilder {
     ) -> SRWireframe {
         let wireframe = SRShapeWireframe(
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
+            clip: nil,
             height: Int64(withNoOverflow: frame.height),
             id: id,
             shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),
@@ -88,6 +89,7 @@ internal class WireframesBuilder {
 
         let wireframe = SRTextWireframe(
             border: createShapeBorder(borderColor: borderColor, borderWidth: borderWidth),
+            clip: nil,
             height: Int64(withNoOverflow: frame.height),
             id: id,
             shapeStyle: createShapeStyle(backgroundColor: backgroundColor, cornerRadius: cornerRadius, opacity: opacity),

--- a/session-replay/Sources/DatadogSessionReplay/Writer/Models/SRDataModels.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Writer/Models/SRDataModels.swift
@@ -106,6 +106,28 @@ internal struct SRShapeBorder: Codable, Hashable {
     }
 }
 
+/// Schema of clipping information for a Wireframe.
+internal struct SRContentClip: Codable, Hashable {
+    /// The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.
+    internal let bottom: Int64?
+
+    /// The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.
+    internal let left: Int64?
+
+    /// The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.
+    internal let right: Int64?
+
+    /// The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.
+    internal let top: Int64?
+
+    enum CodingKeys: String, CodingKey {
+        case bottom = "bottom"
+        case left = "left"
+        case right = "right"
+        case top = "top"
+    }
+}
+
 /// The style of this wireframe.
 internal struct SRShapeStyle: Codable, Hashable {
     /// The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.
@@ -128,6 +150,9 @@ internal struct SRShapeStyle: Codable, Hashable {
 internal struct SRShapeWireframe: Codable, Hashable {
     /// The border properties of this wireframe. The default value is null (no-border).
     internal let border: SRShapeBorder?
+
+    /// Schema of clipping information for a Wireframe.
+    internal let clip: SRContentClip?
 
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
     internal let height: Int64
@@ -152,6 +177,7 @@ internal struct SRShapeWireframe: Codable, Hashable {
 
     enum CodingKeys: String, CodingKey {
         case border = "border"
+        case clip = "clip"
         case height = "height"
         case id = "id"
         case shapeStyle = "shapeStyle"
@@ -245,6 +271,9 @@ internal struct SRTextWireframe: Codable, Hashable {
     /// The border properties of this wireframe. The default value is null (no-border).
     internal let border: SRShapeBorder?
 
+    /// Schema of clipping information for a Wireframe.
+    internal let clip: SRContentClip?
+
     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
     internal let height: Int64
 
@@ -277,6 +306,7 @@ internal struct SRTextWireframe: Codable, Hashable {
 
     enum CodingKeys: String, CodingKey {
         case border = "border"
+        case clip = "clip"
         case height = "height"
         case id = "id"
         case shapeStyle = "shapeStyle"
@@ -380,6 +410,7 @@ internal struct SRIncrementalSnapshotRecord: Codable {
         case mutationData(value: MutationData)
         case touchData(value: TouchData)
         case viewportResizeData(value: ViewportResizeData)
+        case pointerInteractionData(value: PointerInteractionData)
 
         // MARK: - Codable
 
@@ -393,6 +424,8 @@ internal struct SRIncrementalSnapshotRecord: Codable {
             case .touchData(let value):
                 try container.encode(value)
             case .viewportResizeData(let value):
+                try container.encode(value)
+            case .pointerInteractionData(let value):
                 try container.encode(value)
             }
         }
@@ -411,6 +444,10 @@ internal struct SRIncrementalSnapshotRecord: Codable {
             }
             if let value = try? container.decode(ViewportResizeData.self) {
                 self = .viewportResizeData(value: value)
+                return
+            }
+            if let value = try? container.decode(PointerInteractionData.self) {
+                self = .pointerInteractionData(value: value)
                 return
             }
             let error = DecodingError.Context(
@@ -512,6 +549,9 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                     /// The border properties of this wireframe. The default value is null (no-border).
                     internal let border: SRShapeBorder?
 
+                    /// Schema of clipping information for a Wireframe.
+                    internal let clip: SRContentClip?
+
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
                     internal let height: Int64?
 
@@ -544,6 +584,7 @@ internal struct SRIncrementalSnapshotRecord: Codable {
 
                     enum CodingKeys: String, CodingKey {
                         case border = "border"
+                        case clip = "clip"
                         case height = "height"
                         case id = "id"
                         case shapeStyle = "shapeStyle"
@@ -561,6 +602,9 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                 internal struct ShapeWireframeUpdate: Codable {
                     /// The border properties of this wireframe. The default value is null (no-border).
                     internal let border: SRShapeBorder?
+
+                    /// Schema of clipping information for a Wireframe.
+                    internal let clip: SRContentClip?
 
                     /// The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.
                     internal let height: Int64?
@@ -585,6 +629,7 @@ internal struct SRIncrementalSnapshotRecord: Codable {
 
                     enum CodingKeys: String, CodingKey {
                         case border = "border"
+                        case clip = "clip"
                         case height = "height"
                         case id = "id"
                         case shapeStyle = "shapeStyle"
@@ -647,6 +692,50 @@ internal struct SRIncrementalSnapshotRecord: Codable {
                 case height = "height"
                 case source = "source"
                 case width = "width"
+            }
+        }
+
+        /// Schema of a PointerInteractionData.
+        internal struct PointerInteractionData: Codable {
+            /// Schema of an PointerEventType
+            internal let pointerEventType: PointerEventType
+
+            /// Id of the pointer of this PointerInteraction.
+            internal let pointerId: Int64
+
+            /// Schema of an PointerType
+            internal let pointerType: PointerType
+
+            /// The source of this type of incremental data.
+            internal let source: Int64 = 9
+
+            /// X-axis coordinate for this PointerInteraction.
+            internal let x: Double
+
+            /// Y-axis coordinate for this PointerInteraction.
+            internal let y: Double
+
+            enum CodingKeys: String, CodingKey {
+                case pointerEventType = "pointerEventType"
+                case pointerId = "pointerId"
+                case pointerType = "pointerType"
+                case source = "source"
+                case x = "x"
+                case y = "y"
+            }
+
+            /// Schema of an PointerEventType
+            internal enum PointerEventType: String, Codable {
+                case down = "down"
+                case up = "up"
+                case move = "move"
+            }
+
+            /// Schema of an PointerType
+            internal enum PointerType: String, Codable {
+                case mouse = "mouse"
+                case touch = "touch"
+                case pen = "pen"
             }
         }
     }
@@ -841,4 +930,4 @@ internal enum SRRecord: Codable {
     }
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/7320f7c483c80f5fc0d868b1f40c97f22af8b0d1
+// Generated from https://github.com/DataDog/rum-events-format/tree/a11dcc7f76ebd39c1ad41ba2ad2ca575874d0ac8

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/SRDataModelsMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/SRDataModelsMocks.swift
@@ -21,6 +21,7 @@ extension SRTextWireframe: AnyMockable, RandomMockable {
     static func mockRandomWith(id: WireframeID) -> SRTextWireframe {
         return SRTextWireframe(
             border: .mockRandom(),
+            clip: .mockRandom(),
             height: .mockRandom(),
             id: id,
             shapeStyle: .mockRandom(),
@@ -35,6 +36,7 @@ extension SRTextWireframe: AnyMockable, RandomMockable {
 
     static func mockWith(
         border: SRShapeBorder? = .mockAny(),
+        clip: SRContentClip? = .mockAny(),
         height: Int64 = .mockAny(),
         id: Int64 = .mockAny(),
         shapeStyle: SRShapeStyle? = .mockAny(),
@@ -48,6 +50,7 @@ extension SRTextWireframe: AnyMockable, RandomMockable {
     ) -> SRTextWireframe {
         return SRTextWireframe(
             border: border,
+            clip: clip,
             height: height,
             id: id,
             shapeStyle: shapeStyle,
@@ -194,6 +197,7 @@ extension SRShapeWireframe: AnyMockable, RandomMockable {
     static func mockRandomWith(id: WireframeID) -> SRShapeWireframe {
         return SRShapeWireframe(
             border: .mockRandom(),
+            clip: .mockRandom(),
             height: .mockRandom(),
             id: id,
             shapeStyle: .mockRandom(),
@@ -205,6 +209,7 @@ extension SRShapeWireframe: AnyMockable, RandomMockable {
 
     static func mockWith(
         border: SRShapeBorder? = .mockAny(),
+        clip: SRContentClip? = .mockAny(),
         height: Int64 = .mockAny(),
         id: Int64 = .mockAny(),
         shapeStyle: SRShapeStyle? = .mockAny(),
@@ -214,6 +219,7 @@ extension SRShapeWireframe: AnyMockable, RandomMockable {
     ) -> SRShapeWireframe {
         return SRShapeWireframe(
             border: border,
+            clip: clip,
             height: height,
             id: id,
             shapeStyle: shapeStyle,
@@ -269,6 +275,35 @@ extension SRShapeBorder: AnyMockable, RandomMockable {
         return SRShapeBorder(
             color: color,
             width: width
+        )
+    }
+}
+
+extension SRContentClip: AnyMockable, RandomMockable {
+    static func mockAny() -> SRContentClip {
+        return .mockWith()
+    }
+
+    static func mockRandom() -> SRContentClip {
+        return SRContentClip(
+            bottom: .mockRandom(),
+            left: .mockRandom(),
+            right: .mockRandom(),
+            top: .mockRandom()
+        )
+    }
+
+    static func mockWith(
+        bottom: Int64? = .mockAny(),
+        left: Int64? = .mockAny(),
+        right: Int64? = .mockAny(),
+        top: Int64? = .mockAny()
+    ) -> SRContentClip {
+        return SRContentClip(
+            bottom: bottom,
+            left: left,
+            right: right,
+            top: top
         )
     }
 }
@@ -514,7 +549,68 @@ extension SRIncrementalSnapshotRecord.Data: AnyMockable, RandomMockable {
         return [
             .mutationData(value: .mockRandom()),
             .touchData(value: .mockRandom()),
-            .viewportResizeData(value: .mockRandom())
+            .viewportResizeData(value: .mockRandom()),
+            .pointerInteractionData(value: .mockRandom())
+        ].randomElement()!
+    }
+}
+
+extension SRIncrementalSnapshotRecord.Data.PointerInteractionData: AnyMockable, RandomMockable {
+    static func mockAny() -> SRIncrementalSnapshotRecord.Data.PointerInteractionData {
+        return .mockWith()
+    }
+
+    static func mockRandom() -> SRIncrementalSnapshotRecord.Data.PointerInteractionData {
+        return SRIncrementalSnapshotRecord.Data.PointerInteractionData(
+            pointerEventType: .mockRandom(),
+            pointerId: .mockRandom(),
+            pointerType: .mockRandom(),
+            x: .mockRandom(),
+            y: .mockRandom()
+        )
+    }
+
+    static func mockWith(
+        pointerEventType: PointerEventType = .mockAny(),
+        pointerId: Int64 = .mockAny(),
+        pointerType: PointerType = .mockAny(),
+        x: Double = .mockAny(),
+        y: Double = .mockAny()
+    ) -> SRIncrementalSnapshotRecord.Data.PointerInteractionData {
+        return SRIncrementalSnapshotRecord.Data.PointerInteractionData(
+            pointerEventType: pointerEventType,
+            pointerId: pointerId,
+            pointerType: pointerType,
+            x: x,
+            y: y
+        )
+    }
+}
+
+extension SRIncrementalSnapshotRecord.Data.PointerInteractionData.PointerType: AnyMockable, RandomMockable {
+    static func mockAny() -> SRIncrementalSnapshotRecord.Data.PointerInteractionData.PointerType {
+        return .mouse
+    }
+
+    static func mockRandom() -> SRIncrementalSnapshotRecord.Data.PointerInteractionData.PointerType {
+        return [
+            .mouse,
+            .touch,
+            .pen
+        ].randomElement()!
+    }
+}
+
+extension SRIncrementalSnapshotRecord.Data.PointerInteractionData.PointerEventType: AnyMockable, RandomMockable {
+    static func mockAny() -> SRIncrementalSnapshotRecord.Data.PointerInteractionData.PointerEventType {
+        return .down
+    }
+
+    static func mockRandom() -> SRIncrementalSnapshotRecord.Data.PointerInteractionData.PointerEventType {
+        return [
+            .down,
+            .up,
+            .move
         ].randomElement()!
     }
 }
@@ -638,6 +734,7 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUp
     static func mockRandom() -> SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUpdate {
         return SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUpdate(
             border: .mockRandom(),
+            clip: .mockRandom(),
             height: .mockRandom(),
             id: .mockRandom(),
             shapeStyle: .mockRandom(),
@@ -649,6 +746,7 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUp
 
     static func mockWith(
         border: SRShapeBorder? = .mockAny(),
+        clip: SRContentClip? = .mockAny(),
         height: Int64? = .mockAny(),
         id: Int64 = .mockAny(),
         shapeStyle: SRShapeStyle? = .mockAny(),
@@ -658,6 +756,7 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUp
     ) -> SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUpdate {
         return SRIncrementalSnapshotRecord.Data.MutationData.Updates.ShapeWireframeUpdate(
             border: border,
+            clip: clip,
             height: height,
             id: id,
             shapeStyle: shapeStyle,
@@ -676,6 +775,7 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpd
     static func mockRandom() -> SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpdate {
         return SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpdate(
             border: .mockRandom(),
+            clip: .mockRandom(),
             height: .mockRandom(),
             id: .mockRandom(),
             shapeStyle: .mockRandom(),
@@ -690,6 +790,7 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpd
 
     static func mockWith(
         border: SRShapeBorder? = .mockAny(),
+        clip: SRContentClip? = .mockAny(),
         height: Int64? = .mockAny(),
         id: Int64 = .mockAny(),
         shapeStyle: SRShapeStyle? = .mockAny(),
@@ -702,6 +803,7 @@ extension SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpd
     ) -> SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpdate {
         return SRIncrementalSnapshotRecord.Data.MutationData.Updates.TextWireframeUpdate(
             border: border,
+            clip: clip,
             height: height,
             id: id,
             shapeStyle: shapeStyle,

--- a/session-replay/Tests/DatadogSessionReplayTests/Processor/Diffing/Diff+SRWireframesTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Processor/Diffing/Diff+SRWireframesTests.swift
@@ -116,6 +116,7 @@ extension SRWireframe {
     private func merge(update: ShapeWireframeUpdate, into wireframe: SRShapeWireframe) -> SRShapeWireframe {
         return SRShapeWireframe(
             border: update.border ?? wireframe.border,
+            clip: update.clip ?? wireframe.clip,
             height: update.height ?? wireframe.height,
             id: update.id,
             shapeStyle: update.shapeStyle ?? wireframe.shapeStyle,
@@ -128,6 +129,7 @@ extension SRWireframe {
     private func merge(update: TextWireframeUpdate, into wireframe: SRTextWireframe) -> SRTextWireframe {
         return SRTextWireframe(
             border: update.border ?? wireframe.border,
+            clip: update.clip ?? wireframe.clip,
             height: update.height ?? wireframe.height,
             id: update.id,
             shapeStyle: update.shapeStyle ?? wireframe.shapeStyle,

--- a/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
+++ b/tools/rum-models-generator/Sources/CodeDecoration/SRCodeDecorator.swift
@@ -34,6 +34,7 @@ public class SRCodeDecorator: SwiftCodeDecorator {
                 "SRWireframe",
                 // For convenience, detach styles from each wireframe to shared, root-level definition:
                 "SRShapeBorder",
+                "SRContentClip",
                 "SRShapeStyle",
                 "SRTextPosition",
                 "SRTextStyle",
@@ -107,6 +108,9 @@ public class SRCodeDecorator: SwiftCodeDecorator {
         let parentWireframe = context.predecessorStruct(matching: { $0.name.lowercased().contains("wireframe") })
         if parentWireframe != nil && fixedName == "Border" {
             fixedName = "SRShapeBorder"
+        }
+        if parentWireframe != nil && fixedName == "Clip" {
+            fixedName = "SRContentClip"
         }
         if parentWireframe != nil && fixedName == "ShapeStyle" {
             fixedName = "SRShapeStyle"


### PR DESCRIPTION
### What and why?

📦 This PR upgrades SR models to their newer schema. This brings two features:
- availability of `clip` property on wireframes
- availability of `PointerInteraction` schema (that will later replace previous "touch data" models)

### How?

Nothing more than:
- upgrading Session Replay schemas to recent version
- enhancing `rum-models-generator` configuration to print prettier SR code for new models
- adding fuzzy mocks for new models

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
