### PR TITLE
Fix "`xcodebuild` exit code: 65" on CI

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -5214,7 +5214,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CARTHAGE\" == \"YES\" ]; then\n  echo \"Skipping linting for carthage build...\"\nelif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif [ \"$CARTHAGE\" == \"YES\" ]; then\n  echo \"Skipping linting for carthage build...\"\nelif which swiftlint > /dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		6170DC2325C18762003AED5C /* ⚙️ Run linter */ = {
@@ -5234,7 +5234,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CARTHAGE\" == \"YES\" ]; then\n  echo \"Skipping linting for carthage build...\"\nelif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif [ \"$CARTHAGE\" == \"YES\" ]; then\n  echo \"Skipping linting for carthage build...\"\nelif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		6170DC2425C18784003AED5C /* ⚙️ Run linter */ = {
@@ -5254,7 +5254,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		61993671265BBF8E009D7EA8 /* ⚙️ Run linter */ = {
@@ -5274,7 +5274,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		61BACC00267279CB00AB58DC /* ShellScript */ = {
@@ -5313,7 +5313,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		D2CB6ECB27C50EAE00A62B57 /* ⚙️ Run linter */ = {
@@ -5333,7 +5333,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CARTHAGE\" == \"YES\" ]; then\n  echo \"Skipping linting for carthage build...\"\nelif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif [ \"$CARTHAGE\" == \"YES\" ]; then\n  echo \"Skipping linting for carthage build...\"\nelif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		D2CB6F8A27C520D400A62B57 /* ⚙️ Run linter */ = {
@@ -5353,7 +5353,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		D2CB6FC927C5348200A62B57 /* ⚙️ Run linter */ = {
@@ -5373,7 +5373,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CARTHAGE\" == \"YES\" ]; then\n  echo \"Skipping linting for carthage build...\"\nelif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif [ \"$CARTHAGE\" == \"YES\" ]; then\n  echo \"Skipping linting for carthage build...\"\nelif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		D2CB6FE727C5352300A62B57 /* ⚙️ Run linter */ = {
@@ -5393,7 +5393,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/..\n  ./tools/lint/run-linter.sh\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -5199,6 +5199,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		61133C772423A4C300786299 /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5218,6 +5219,7 @@
 		};
 		6170DC2325C18762003AED5C /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5237,6 +5239,7 @@
 		};
 		6170DC2425C18784003AED5C /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5256,6 +5259,7 @@
 		};
 		61993671265BBF8E009D7EA8 /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5294,6 +5298,7 @@
 		};
 		9EA6A53C24489AB100621535 /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5313,6 +5318,7 @@
 		};
 		D2CB6ECB27C50EAE00A62B57 /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5332,6 +5338,7 @@
 		};
 		D2CB6F8A27C520D400A62B57 /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5351,6 +5358,7 @@
 		};
 		D2CB6FC927C5348200A62B57 /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -5370,6 +5378,7 @@
 		};
 		D2CB6FE727C5352300A62B57 /* ⚙️ Run linter */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -4966,7 +4966,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1310;
+				LastUpgradeCheck = 1410;
 				ORGANIZATIONNAME = Datadog;
 				TargetAttributes = {
 					61133B81242393DE00786299 = {

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogBenchmarkTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogCrashReporting tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogIntegrationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogObjc tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2E.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2EInstrumentationTests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2EInstrumentationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2ETests.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/E2ETests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1410"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DD_SDK_SWIFT_TESTING_VERSION = 2.2.0-rc.4
 define DD_SDK_TESTING_XCCONFIG_CI
 FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
 LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
-FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]==$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
+FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
 LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
 OTHER_LDFLAGS=$$(inherited) -framework DatadogSDKTesting\n
 DD_TEST_RUNNER=1\n

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instru
 LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/ios-arm64_x86_64-simulator/\n
 FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
 LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*]=$$(inherited) $$(SRCROOT)/../instrumented-tests/DatadogSDKTesting.xcframework/tvos-arm64_x86_64-simulator/\n
-OTHER_LDFLAGS=$$(inherited) -framework DatadogSDKTesting\n
+OTHER_LDFLAGS[sdk=iphonesimulator*]=$$(inherited) -framework DatadogSDKTesting\n
+// Temporarily disabled - causes "Touching Example\ tvOS.app" exit code: 65 on CI
+// OTHER_LDFLAGS[sdk=appletvsimulator*]=$$(inherited) -framework DatadogSDKTesting\n
 DD_TEST_RUNNER=1\n
 DD_SDK_SWIFT_TESTING_SERVICE=dd-sdk-ios\n
 DD_SDK_SWIFT_TESTING_APIKEY=${DD_SDK_SWIFT_TESTING_APIKEY}\n

--- a/Sources/Datadog/DatadogCore/Storage/Files/Directory.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Files/Directory.swift
@@ -95,7 +95,7 @@ internal struct Directory {
         try retry(times: 3, delay: 0.001) {
             try files().forEach { file in
                 let destinationFileURL = destinationDirectory.url.appendingPathComponent(file.name)
-                try? retry(times: 3, delay: 0.000_1) {
+                try? retry(times: 3, delay: 0.0001) {
                     try FileManager.default.moveItem(at: file.url, to: destinationFileURL)
                 }
             }

--- a/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTSpan+objc.swift
@@ -7,7 +7,8 @@
 import Foundation
 
 /// Corresponds to: https://github.com/opentracing/opentracing-objc/blob/master/Pod/Classes/OTSpan.h
-@objc public protocol OTSpan {
+@objc
+public protocol OTSpan {
     var context: OTSpanContext { get }
     var tracer: OTTracer { get }
 

--- a/Sources/DatadogObjc/OpenTracing/OTSpanContext+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTSpanContext+objc.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 /// Corresponds to: https://github.com/opentracing/opentracing-objc/blob/master/Pod/Classes/OTSpanContext.h
-@objc public protocol OTSpanContext {
+@objc
+public protocol OTSpanContext {
     func forEachBaggageItem(_ callback: (_ key: String, _ value: String) -> Bool)
 }

--- a/Sources/DatadogObjc/OpenTracing/OTTracer+objc.swift
+++ b/Sources/DatadogObjc/OpenTracing/OTTracer+objc.swift
@@ -12,7 +12,8 @@ public class OT: NSObject {
 }
 
 /// Corresponds to: https://github.com/opentracing/opentracing-objc/blob/master/Pod/Classes/OTTracer.h
-@objc public protocol OTTracer {
+@objc
+public protocol OTTracer {
     func startSpan(_ operationName: String) -> OTSpan
     func startSpan(_ operationName: String, tags: NSDictionary?) -> OTSpan
     func startSpan(_ operationName: String, childOf parent: OTSpanContext?) -> OTSpan

--- a/Tests/DatadogTests/Datadog/Kronos/KronosNTPPacketTests.swift
+++ b/Tests/DatadogTests/Datadog/Kronos/KronosNTPPacketTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class KronosNTPPacketTests: XCTestCase {
     func testToData() {
         var packet = KronosNTPPacket()
-        let data = packet.prepareToSend(transmitTime: 1_463_303_662.776_552)
+        let data = packet.prepareToSend(transmitTime: 1_463_303_662.776552)
         XCTAssertEqual(data, Data(hex: "1b0004fa0001000000010000000000000000000000000000" +
                                        "00000000000000000000000000000000dae2bc6ec6cc1c00")!)
     }
@@ -40,11 +40,11 @@ final class KronosNTPPacketTests: XCTestCase {
         let network = Data(hex: "1c0203e90000065700000a68ada2c09cdae2d084a5a76d5fdae2d3354a529000dae2d32b" +
                                 "b38bab46dae2d32bb38d9e00")!
         let PDU = try? KronosNTPPacket(data: network, destinationTime: 0)
-        XCTAssertEqual(PDU?.rootDelay, 0.024_765_014_648_437_5)
-        XCTAssertEqual(PDU?.rootDispersion, 0.040_649_414_062_5)
+        XCTAssertEqual(PDU?.rootDelay, 0.0247650146484375)
+        XCTAssertEqual(PDU?.rootDispersion, 0.0406494140625)
         XCTAssertEqual(PDU?.clockSource.ID, 2_913_124_508)
-        XCTAssertEqual(PDU?.referenceTime, 1_463_308_804.647_085_905_1)
-        XCTAssertEqual(PDU?.originTime, 1_463_309_493.290_322_303_8)
-        XCTAssertEqual(PDU?.receiveTime, 1_463_309_483.701_349_973_7)
+        XCTAssertEqual(PDU?.referenceTime, 1_463_308_804.6470859051)
+        XCTAssertEqual(PDU?.originTime, 1_463_309_493.2903223038)
+        XCTAssertEqual(PDU?.receiveTime, 1_463_309_483.7013499737)
     }
 }

--- a/Tests/DatadogTests/Datadog/Kronos/KronosTimeStorageTests.swift
+++ b/Tests/DatadogTests/Datadog/Kronos/KronosTimeStorageTests.swift
@@ -33,7 +33,7 @@ class KronosTimeStoragePolicyTests: XCTestCase {
 class KronosTimeStorageTests: XCTestCase {
     func testStoringAndRetrievingTimeFreeze() {
         var storage = KronosTimeStorage(storagePolicy: .standard)
-        let sampleFreeze = KronosTimeFreeze(offset: 5_000.324_23)
+        let sampleFreeze = KronosTimeFreeze(offset: 5_000.32423)
         storage.stableTime = sampleFreeze
 
         let fromDefaults = storage.stableTime
@@ -42,7 +42,7 @@ class KronosTimeStorageTests: XCTestCase {
     }
 
     func testRetrievingTimeFreezeAfterReboot() {
-        let sampleFreeze = KronosTimeFreeze(offset: 5_000.324_23)
+        let sampleFreeze = KronosTimeFreeze(offset: 5_000.32423)
         var storedData = sampleFreeze.toDictionary()
         storedData["Uptime"] = storedData["Uptime"]! + 10
 

--- a/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
@@ -38,11 +38,11 @@ class TimeIntervalExtensionTests: XCTestCase {
         XCTAssertEqual(date15Dec2019.timeIntervalSince1970.toNanoseconds, 1_576_404_000_000_000_000)
 
         // As `TimeInterval` yields sub-millisecond precision this rounds up to the nearest millisecond:
-        let dateAdvanced = date15Dec2019 + 9.999_999_999
+        let dateAdvanced = date15Dec2019 + 9.999999999
         XCTAssertEqual(dateAdvanced.timeIntervalSince1970.toNanoseconds, 1_576_404_010_000_000_000)
 
         // As `TimeInterval` yields sub-millisecond precision this rounds up to the nearest millisecond:
-        let dateAgo = date15Dec2019 - 0.000_000_001
+        let dateAgo = date15Dec2019 - 0.000000001
         XCTAssertEqual(dateAgo.timeIntervalSince1970.toNanoseconds, 1_576_404_000_000_000_000)
 
         let overflownDate = Date(timeIntervalSinceReferenceDate: .greatestFiniteMagnitude)
@@ -62,14 +62,14 @@ class UUIDExtensionTests: XCTestCase {
 
 class IntegerOverflowExtensionTests: XCTestCase {
     func testHappyPath() {
-        let reasonableDouble = Double(1_000.123_456)
+        let reasonableDouble = Double(1_000.123456)
 
         XCTAssertNoThrow(try UInt64(withReportingOverflow: reasonableDouble))
         XCTAssertEqual(try UInt64(withReportingOverflow: reasonableDouble), 1_000)
     }
 
     func testNegative() {
-        let negativeDouble = Double(-1_000.123_456)
+        let negativeDouble = Double(-1_000.123456)
 
         XCTAssertThrowsError(try UInt64(withReportingOverflow: negativeDouble)) { error in
             XCTAssertTrue(error is FixedWidthIntegerError<Double>)
@@ -80,7 +80,7 @@ class IntegerOverflowExtensionTests: XCTestCase {
     }
 
     func testFloat() {
-        let simpleFloat = Float(222.123_456)
+        let simpleFloat = Float(222.123456)
 
         XCTAssertNoThrow(try UInt8(withReportingOverflow: simpleFloat))
         XCTAssertEqual(try UInt8(withReportingOverflow: simpleFloat), 222)

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -257,6 +257,14 @@ workflows:
         Runs integration tests from Datadog.xcworkspace.
         Only ran if 'DD_RUN_INTEGRATION_TESTS' is '1'.
     steps:
+    - script:
+        title: Generate mock server address
+        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
+        inputs:
+        - content: |-
+            #!/usr/bin/env zsh
+            set -e
+            ./tools/config/generate-http-server-mock-config.sh
     - xcode-test:
         title: Run benchmarks - DatadogBenchmarkTests on iOS Simulator
         run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'


### PR DESCRIPTION
### What and why?

🧑‍🚒 This PR aims at fixing recent CI issue:
```
▸ Touching Example\ tvOS.app (in target 'Example tvOS' from project 'Datadog')
Exit code:  65
```
and bringing seamless build experience on Xcode 14.x stack (changed recently).

### How?

### Fixing `exit code: 65` issue

It seems that the problem is caused by CI app instrumentation - perhaps changes introduced in https://github.com/DataDog/dd-sdk-ios/pull/1072. To unlock us from struggling CI hangs, this PR **temporarily disables CI app instrumentation for tvOS targets**.

While considering disabling CI app for tvOS as a last resort solution, I made sure nothing else helps:
* fixed typo in CI app's `FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]`
* fixed linter build phase warnings
* fixed "upgrade to recommended settings" Xcode warning.

Also, I stepped across [this post](https://circleci.com/blog/xcodebuild-exit-code-65-what-it-is-and-how-to-solve-for-ios-and-macos-builds/) on `xcodebuild - exit code 65`, which recommends pre-warming tvOS simulator before starting tests. Leaving it as a note for now - I'd prefer to first have @nachoBonafonte investigate potential problem in `dd-swift-testing`.

#### Fixing build on Xcode 14.x stack

Because we upgraded to Xcode 14 stack on Bitrise, which pre-installs `swiftlint` 0.50.1, I ran through the code and fixed all new issues. Ideally, we could lock a certain version of `swiftlint`, but this work is beyond the scope of this PR.

Stepping across linter, I noticed that `swiftlint` stopped working as usual on our M1 machines. To fix it, this patch is added to all build phases:
```diff
+ export PATH="$PATH:/opt/homebrew/bin"
+ 
if [ "$CARTHAGE" == "YES" ]; then
  echo "Skipping linting for carthage build..."
elif which swiftlint >/dev/null; then
  cd ${SOURCE_ROOT}/..
  ./tools/lint/run-linter.sh
fi
```

Last, Xcode 14 upgrade seems to bring another issue, related to integration tests with mock server:
```
Testing failed:
	could not find included file '../xcconfigs/MockServerAddress.local.xcconfig' in search paths
	Testing cancelled because the build failed.
```
It appears that Xcode 14 finds it hard to both generate this file from "Build -> Pre-actions" (in scheme) and read it into `Info.plist` within the same build. The only sustainable workaround I found is to run this as separate "script" phase on CI.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
