### PR TITLE
RUMM-2784 [SR] Migrate to `PointerInteractionData` for sending touch information

### DIFF
--- a/session-replay/Sources/DatadogSessionReplay/Processor/Processor.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/Processor.swift
@@ -87,7 +87,9 @@ internal class Processor: Processing {
 
         // Create records for denoting touch interaction:
         if let touchSnapshot = touchSnapshot {
-            records.append(recordsBuilder.createIncrementalSnapshotRecord(from: touchSnapshot))
+            records.append(
+                contentsOf: recordsBuilder.createIncrementalSnapshotRecords(from: touchSnapshot)
+            )
         }
 
         if !records.isEmpty {

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshot/TouchIdentifierGenerator.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshot/TouchIdentifierGenerator.swift
@@ -36,23 +36,23 @@ internal final class TouchIdentifierGenerator {
     /// - Parameter touch: the `UITouch` object
     /// - Returns: the `TouchIdentifier` of queried instance.
     func touchIdentifier(for touch: UITouch) -> TouchIdentifier {
-        switch touch.phase {
-        case .began, .regionEntered:
+        switch touch.phase.dd {
+        case .down:
             return persistNextID(in: touch)
-        case .moved, .regionMoved, .stationary:
+        case .move:
             guard let persistedID = touch.identifier else {
                 // It means the touch began before SR was enabled → persit next ID in this touch:
                 return persistNextID(in: touch)
             }
             return persistedID
-        case .ended, .cancelled, .regionExited:
+        case .up:
             guard let persistedID = touch.identifier else {
                 // It means the touch began before SR was enabled → only return next ID as we know the touch is ending:
                 return getNextID()
             }
             touch.identifier = nil
             return persistedID
-        @unknown default:
+        default:
             return persistNextID(in: touch)
         }
     }

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshot/TouchSnapshot.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshot/TouchSnapshot.swift
@@ -14,10 +14,18 @@ internal struct TouchSnapshot {
         /// An unique identifier of the touch. It persists throughout a multi-touch sequence (it is created on "touch down",
         /// continues thru "touch move" and ends in "touch up").
         let id: TouchIdentifier
+        /// Phase of the touch as distinguished in session replay.
+        let phase: TouchPhase
         /// A time of recording this touch
         let date: Date
         /// The position of this touch in application window.
         let position: CGPoint
+    }
+
+    enum TouchPhase {
+        case down
+        case move
+        case up
     }
 
     /// The time of the earliest touch.

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducer.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducer.swift
@@ -42,13 +42,30 @@ internal class WindowTouchSnapshotProducer: TouchSnapshotProducer, UIEventHandle
         }
 
         for touch in touches {
+            guard let phase = touch.phase.dd else {
+                continue
+            }
+
             buffer.append(
                 TouchSnapshot.Touch(
                     id: idsGenerator.touchIdentifier(for: touch),
+                    phase: phase,
                     date: Date(), // TODO: RUMM-2688 Synchronize SR snapshot timestamps with current RUM time (+ NTP offset)
                     position: touch.location(in: window)
                 )
             )
+        }
+    }
+}
+
+internal extension UITouch.Phase {
+    /// Converts `UITouch.Phase` to touch phases distinguished in session replay.
+    var dd: TouchSnapshot.TouchPhase? {
+        switch self {
+        case .began, .regionEntered: return .down
+        case .moved, .regionMoved, .stationary: return .move
+        case .ended, .cancelled, .regionExited: return .up
+        @unknown default: return nil
         }
     }
 }

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
@@ -286,6 +286,7 @@ extension TouchSnapshot.Touch: AnyMockable, RandomMockable {
     static func mockRandom() -> TouchSnapshot.Touch {
         return TouchSnapshot.Touch(
             id: .mockRandom(),
+            phase: [.down, .move, .up].randomElement()!,
             date: .mockRandom(),
             position: .mockRandom()
         )
@@ -293,11 +294,13 @@ extension TouchSnapshot.Touch: AnyMockable, RandomMockable {
 
     static func mockWith(
         id: TouchIdentifier = .mockAny(),
+        phase: TouchSnapshot.TouchPhase = .move,
         date: Date = .mockAny(),
         position: CGPoint = .mockAny()
     ) -> TouchSnapshot.Touch {
         return TouchSnapshot.Touch(
             id: id,
+            phase: phase,
             date: date,
             position: position
         )

--- a/session-replay/Tests/DatadogSessionReplayTests/Mocks/SRDataModelsMocks.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Mocks/SRDataModelsMocks.swift
@@ -1092,9 +1092,9 @@ internal extension SRRecord {
 }
 
 extension SRIncrementalSnapshotRecord {
-    var touchData: SRIncrementalSnapshotRecord.Data.TouchData? {
+    var pointerInteractionData: SRIncrementalSnapshotRecord.Data.PointerInteractionData? {
         switch data {
-        case .touchData(let value): return value
+        case .pointerInteractionData(let value): return value
         default: return nil
         }
     }


### PR DESCRIPTION
### What and why?

📦 This PR switches from using deprecated `TouchData` to a new `PointerInteractionData` for sending touches in SR.

The new `PointerInteractionData` includes information of the touch "phase" and uses "one-to-one" relationship with "incremental records" (one record = one touch position). Both make it easier for the player to seek the replay to certain position - the player doesn't need to lookup previous or next records to know if there is a touch information to render. 

Visually, new touches are rendered with a fancy animation because we know the touch phase.

### How?

This change was relatively small in current architecture. It only required recording of the touch phase and changing the events emitted to the batch.

**Before**, the `Processor` was writing one "incremental record" for a batch of touch positions.
**Now**, the `Processor` writes one "incremental record" for each touch position.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
