### PR TITLE
Improve DataBlock memory consumption and validation

### DIFF
--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -24,6 +24,7 @@ internal final class DatadogCore {
     /// The storage r/w GDC queue.
     let readWriteQueue = DispatchQueue(
         label: "com.datadoghq.ios-sdk-read-write",
+        autoreleaseFrequency: .workItem,
         target: .global(qos: .utility)
     )
 

--- a/Sources/Datadog/DatadogCore/Storage/DataBlock.swift
+++ b/Sources/Datadog/DatadogCore/Storage/DataBlock.swift
@@ -149,8 +149,8 @@ internal final class DataBlockReader {
             return Data()
         }
 
-        // Load from stream to data without unnecessary copies
-        var data = Data(repeating: 0, count: length)
+        // Load from stream directly to data without unnecessary copies
+        var data = Data(count: length)
         let count = try data.withUnsafeMutableBytes { (bytes: UnsafeMutableRawBufferPointer) in
             guard let buffer = bytes.assumingMemoryBound(to: UInt8.self).baseAddress else {
                 throw DataBlockError.dataAllocationFailure
@@ -162,7 +162,7 @@ internal final class DataBlockReader {
             throw DataBlockError.readOperationFailed(streamError: stream.streamError)
         }
 
-        if count == 0, stream.streamStatus == .atEnd {
+        if count == 0 {
             throw DataBlockError.endOfStream
         }
 

--- a/Sources/Datadog/DatadogCore/Storage/Files/File.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Files/File.swift
@@ -30,6 +30,9 @@ internal protocol ReadableFile {
     /// Reads the available data in this file.
     func read() throws -> Data
 
+    /// Creates InputStream for reading the available data from this file.
+    func readStream() throws -> InputStream
+
     /// Deletes this file.
     func delete() throws
 }
@@ -129,6 +132,13 @@ internal struct File: WritableFile, ReadableFile {
         return data
     }
 
+    func readStream() throws -> InputStream {
+        guard let stream = InputStream(url: url) else {
+            throw Errors.unableToCreateInputStream
+        }
+        return stream
+    }
+
     func size() throws -> UInt64 {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         return attributes[.size] as? UInt64 ?? 0
@@ -137,4 +147,8 @@ internal struct File: WritableFile, ReadableFile {
     func delete() throws {
         try FileManager.default.removeItem(at: url)
     }
+}
+
+private enum Errors: Error {
+    case unableToCreateInputStream
 }

--- a/Sources/Datadog/DatadogCore/Storage/Reading/FileReader.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Reading/FileReader.swift
@@ -31,7 +31,7 @@ internal final class FileReader: Reader {
         }
 
         do {
-            let events = try decode(data: file.read())
+            let events = try decode(stream: file.readStream())
             return Batch(events: events, file: file)
         } catch {
             DD.telemetry.error("Failed to read data from file", error: error)
@@ -45,10 +45,10 @@ internal final class FileReader: Reader {
     /// consumed and decrypted if encryption is available. Decrypted events are finally joined with
     /// data-format separator.
     ///
-    /// - Parameter data: The data to decode.
+    /// - Parameter stream: The InputStream that provides data to decode.
     /// - Returns: The decoded and formatted data.
-    private func decode(data: Data) throws -> [Data] {
-        let reader = DataBlockReader(data: data)
+    private func decode(stream: InputStream) throws -> [Data] {
+        let reader = DataBlockReader(input: stream)
 
         var failure: String? = nil
         defer {

--- a/Sources/Datadog/DatadogCore/Upload/FeatureUpload.swift
+++ b/Sources/Datadog/DatadogCore/Upload/FeatureUpload.swift
@@ -20,6 +20,7 @@ internal struct FeatureUpload {
     ) {
         let uploadQueue = DispatchQueue(
             label: "com.datadoghq.ios-sdk-\(featureName)-upload",
+            autoreleaseFrequency: .workItem,
             target: .global(qos: .utility)
         )
 

--- a/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
@@ -105,4 +105,18 @@ class DataBlockTests: XCTestCase {
         XCTAssertEqual(block?.data.first, 0xFF)
         XCTAssertEqual(block?.data.count, 10_000_000)
     }
+
+    func testDataBlockReader_skipsVeryLargeBytesBlock() throws {
+        let data = Data([0x00, 0x00, 0x00, 0x2D, 0x31, 0x01]) + Data.mockRepeating(byte: 0xFF, times: 20_000_000) // 20MB
+        let reader = DataBlockReader(data: data)
+
+        do {
+            _ = try reader.next()
+            XCTFail("Expected error to be thrown")
+        } catch DataBlockError.dataLengthExceedsLimit {
+            // Expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
### What and why?

Details in #1091 

This leads me to 3 possibilities:
1) Datadog is generating a huge buffer.
2) Datadog buffers are being leaked somehow (or just need more tight autorelease)
3) Something in my application is using a lot of memory and Datadog is the last straw that is being hit.

NOTE: Just realized we didn't start seeing this until after 1.12.0 upgrade.
Yeah, after digging into the 1.12.0 changes, I'm realizing that a bug causing the first possibility is the most likely. The data is already in memory at this point, and it's just being copied into a buffer. The crash is occurring during that buffer creation. It's likely that the length being provided is incorrect.

### How?

I address these:
1) Add a 10MB safety check (elsewhere it looks like file size should be limited to 4MB), currently the only check is `Int(exactly:)` which could still be huge. BlockSize is a `UInt32` which is 4GB.
2) Make the queues that are referencing these loaded buffers have a strict autorelease policy. (This wouldn't fix a leak, but I'm hoping there isn't one for now.)
3) I don't think this is likely given that I'm not seeing other low memory issues. Additionally 90PCT peak memory usage hasn't increased.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
