### PR TITLE
RUMM-2795 Fix Logs Tags & Attributes Consistency

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -607,6 +607,8 @@
 		D20605CB2875A83F0047275C /* ContextValueReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605C62875A77D0047275C /* ContextValueReader.swift */; };
 		D20605CD28770C3B0047275C /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605CC28770C3B0047275C /* AppState.swift */; };
 		D20605CE28770C3B0047275C /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20605CC28770C3B0047275C /* AppState.swift */; };
+		D2079DC8294C91DE00C4D25E /* ConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2079DC7294C91DE00C4D25E /* ConcurrencyTests.swift */; };
+		D2079DC9294C91DE00C4D25E /* ConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2079DC7294C91DE00C4D25E /* ConcurrencyTests.swift */; };
 		D2135330270CA722000315AD /* DataCompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213532F270CA722000315AD /* DataCompressionTests.swift */; };
 		D21C26C528A3B49C005DD405 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C428A3B49C005DD405 /* FeatureStorage.swift */; };
 		D21C26C628A3B49C005DD405 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C428A3B49C005DD405 /* FeatureStorage.swift */; };
@@ -715,6 +717,8 @@
 		D29889C9273413ED00A4D1A9 /* RUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */; };
 		D29CDD3228211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
 		D29CDD3328211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
+		D29CF4BE294C7C98008CD037 /* Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CF4BD294C7C98008CD037 /* Concurrency.swift */; };
+		D29CF4BF294C7C98008CD037 /* Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CF4BD294C7C98008CD037 /* Concurrency.swift */; };
 		D29D5A4D273BF8B400A687C1 /* SwiftUIActionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */; };
 		D2A1EE23287740B500D28DFB /* ApplicationStatePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */; };
 		D2A1EE24287740B500D28DFB /* ApplicationStatePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */; };
@@ -1904,6 +1908,7 @@
 		D20605BB28757BFB0047275C /* KronosClockMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KronosClockMock.swift; sourceTree = "<group>"; };
 		D20605C62875A77D0047275C /* ContextValueReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextValueReader.swift; sourceTree = "<group>"; };
 		D20605CC28770C3B0047275C /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		D2079DC7294C91DE00C4D25E /* ConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcurrencyTests.swift; sourceTree = "<group>"; };
 		D213532F270CA722000315AD /* DataCompressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataCompressionTests.swift; sourceTree = "<group>"; };
 		D21C26C428A3B49C005DD405 /* FeatureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureStorage.swift; sourceTree = "<group>"; };
 		D21C26C928A406A3005DD405 /* DatadogFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogFeature.swift; sourceTree = "<group>"; };
@@ -1951,6 +1956,7 @@
 		D2956CB02869D54E007D5462 /* DeviceInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfoTests.swift; sourceTree = "<group>"; };
 		D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandlerTests.swift; sourceTree = "<group>"; };
 		D29CDD3128211A2200F7DAA5 /* DataBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlock.swift; sourceTree = "<group>"; };
+		D29CF4BD294C7C98008CD037 /* Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Concurrency.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
 		D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStatePublisher.swift; sourceTree = "<group>"; };
 		D2A1EE25287C35DE00D28DFB /* ContextValueReaderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextValueReaderMock.swift; sourceTree = "<group>"; };
@@ -4436,6 +4442,7 @@
 				D2CBC25C294215BE00134409 /* Codable */,
 				D2956CAF2869D520007D5462 /* Context */,
 				D29294E5291D65EA00F8EFF9 /* _InternalProxyTests.swift */,
+				D2079DC7294C91DE00C4D25E /* ConcurrencyTests.swift */,
 			);
 			path = DatadogInternal;
 			sourceTree = "<group>";
@@ -4448,6 +4455,14 @@
 				D21C26E628AF9388005DD405 /* FeatureMessageAttributesTests.swift */,
 			);
 			path = Context;
+			sourceTree = "<group>";
+		};
+		D29CF4C0294C7CA6008CD037 /* Concurrency */ = {
+			isa = PBXGroup;
+			children = (
+				D29CF4BD294C7C98008CD037 /* Concurrency.swift */,
+			);
+			path = Concurrency;
 			sourceTree = "<group>";
 		};
 		D29D5A48273BF7E100A687C1 /* UIKit */ = {
@@ -4496,6 +4511,7 @@
 				D2956CAA2869D1DF007D5462 /* Context */,
 				D26C49C128899B4100802B2D /* Upload */,
 				D21C26CC28A411BE005DD405 /* MessageBus */,
+				D29CF4C0294C7CA6008CD037 /* Concurrency */,
 				D21C26E228AD3071005DD405 /* Extensions */,
 				D2CBC2522942003B00134409 /* Codable */,
 				61E945DF2869BEF500A946C4 /* DD.swift */,
@@ -5462,6 +5478,7 @@
 				6139CD712589FAFD007E8BB7 /* Retrying.swift in Sources */,
 				D2CBC2542942007800134409 /* AnyEncodable.swift in Sources */,
 				61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */,
+				D29CF4BE294C7C98008CD037 /* Concurrency.swift in Sources */,
 				618D9DE7263AD78900A3FAD2 /* SpanEventMapper.swift in Sources */,
 				D2A1EE29287D914900D28DFB /* LaunchTime.swift in Sources */,
 				6114FE2F257687310084E372 /* ConsentProvider.swift in Sources */,
@@ -5668,6 +5685,7 @@
 				61133C5A2423990D00786299 /* FileTests.swift in Sources */,
 				61AD4E3A24534075006E34EA /* TracingFeatureTests.swift in Sources */,
 				613C6B922768FF3100870CBF /* SamplerTests.swift in Sources */,
+				D2079DC8294C91DE00C4D25E /* ConcurrencyTests.swift in Sources */,
 				61133C6B2423990D00786299 /* LogMatcher.swift in Sources */,
 				D2135330270CA722000315AD /* DataCompressionTests.swift in Sources */,
 				61DB33B225DEDFC200F7EA71 /* CustomObjcViewController.m in Sources */,
@@ -6159,6 +6177,7 @@
 				D20605B32874E1660047275C /* CarrierInfoPublisher.swift in Sources */,
 				D2CB6E4027C50EAE00A62B57 /* UIViewControllerSwizzler.swift in Sources */,
 				D2CB6E4127C50EAE00A62B57 /* RUMCurrentContext.swift in Sources */,
+				D29CF4BF294C7C98008CD037 /* Concurrency.swift in Sources */,
 				D2CB6E4227C50EAE00A62B57 /* RUMConnectivityInfoProvider.swift in Sources */,
 				61FD9FCA2851E67100214BD9 /* Sysctl.swift in Sources */,
 				D248ED462807193B00B315B4 /* RUMTelemetry.swift in Sources */,
@@ -6412,6 +6431,7 @@
 				D2CB6F1027C520D400A62B57 /* DDNSURLSessionDelegateTests.swift in Sources */,
 				D2CB6F1127C520D400A62B57 /* CrashReportingWithRUMIntegrationTests.swift in Sources */,
 				D2CB6F1227C520D400A62B57 /* LoggerBuilderTests.swift in Sources */,
+				D2079DC9294C91DE00C4D25E /* ConcurrencyTests.swift in Sources */,
 				D2CB6F1327C520D400A62B57 /* DDConfigurationTests.swift in Sources */,
 				D2CB6F1427C520D400A62B57 /* UUID.swift in Sources */,
 				D2CB6F1527C520D400A62B57 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -717,8 +717,8 @@
 		D29889C9273413ED00A4D1A9 /* RUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */; };
 		D29CDD3228211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
 		D29CDD3328211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
-		D29CF4BE294C7C98008CD037 /* Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CF4BD294C7C98008CD037 /* Concurrency.swift */; };
-		D29CF4BF294C7C98008CD037 /* Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CF4BD294C7C98008CD037 /* Concurrency.swift */; };
+		D29CF4BE294C7C98008CD037 /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CF4BD294C7C98008CD037 /* ReadWriteLock.swift */; };
+		D29CF4BF294C7C98008CD037 /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CF4BD294C7C98008CD037 /* ReadWriteLock.swift */; };
 		D29D5A4D273BF8B400A687C1 /* SwiftUIActionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */; };
 		D2A1EE23287740B500D28DFB /* ApplicationStatePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */; };
 		D2A1EE24287740B500D28DFB /* ApplicationStatePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */; };
@@ -1956,7 +1956,7 @@
 		D2956CB02869D54E007D5462 /* DeviceInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfoTests.swift; sourceTree = "<group>"; };
 		D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandlerTests.swift; sourceTree = "<group>"; };
 		D29CDD3128211A2200F7DAA5 /* DataBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlock.swift; sourceTree = "<group>"; };
-		D29CF4BD294C7C98008CD037 /* Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Concurrency.swift; sourceTree = "<group>"; };
+		D29CF4BD294C7C98008CD037 /* ReadWriteLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
 		D2A1EE22287740B500D28DFB /* ApplicationStatePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStatePublisher.swift; sourceTree = "<group>"; };
 		D2A1EE25287C35DE00D28DFB /* ContextValueReaderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextValueReaderMock.swift; sourceTree = "<group>"; };
@@ -4460,7 +4460,7 @@
 		D29CF4C0294C7CA6008CD037 /* Concurrency */ = {
 			isa = PBXGroup;
 			children = (
-				D29CF4BD294C7C98008CD037 /* Concurrency.swift */,
+				D29CF4BD294C7C98008CD037 /* ReadWriteLock.swift */,
 			);
 			path = Concurrency;
 			sourceTree = "<group>";
@@ -5478,7 +5478,7 @@
 				6139CD712589FAFD007E8BB7 /* Retrying.swift in Sources */,
 				D2CBC2542942007800134409 /* AnyEncodable.swift in Sources */,
 				61BBD19524ED4E9E0023E65F /* FeaturesConfiguration.swift in Sources */,
-				D29CF4BE294C7C98008CD037 /* Concurrency.swift in Sources */,
+				D29CF4BE294C7C98008CD037 /* ReadWriteLock.swift in Sources */,
 				618D9DE7263AD78900A3FAD2 /* SpanEventMapper.swift in Sources */,
 				D2A1EE29287D914900D28DFB /* LaunchTime.swift in Sources */,
 				6114FE2F257687310084E372 /* ConsentProvider.swift in Sources */,
@@ -6177,7 +6177,7 @@
 				D20605B32874E1660047275C /* CarrierInfoPublisher.swift in Sources */,
 				D2CB6E4027C50EAE00A62B57 /* UIViewControllerSwizzler.swift in Sources */,
 				D2CB6E4127C50EAE00A62B57 /* RUMCurrentContext.swift in Sources */,
-				D29CF4BF294C7C98008CD037 /* Concurrency.swift in Sources */,
+				D29CF4BF294C7C98008CD037 /* ReadWriteLock.swift in Sources */,
 				D2CB6E4227C50EAE00A62B57 /* RUMConnectivityInfoProvider.swift in Sources */,
 				61FD9FCA2851E67100214BD9 /* Sysctl.swift in Sources */,
 				D248ED462807193B00B315B4 /* RUMTelemetry.swift in Sources */,

--- a/Sources/Datadog/DatadogInternal/Concurrency/Concurrency.swift
+++ b/Sources/Datadog/DatadogInternal/Concurrency/Concurrency.swift
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// A property wrapper using a fair, POSIX conforming reader-writer lock for atomic
+/// access to the value.
+///
+/// The wrapper is a class to prevent copying the lock, it creates and initilaizes a `pthread_rwlock_t`.
+/// An additional method `mutate` allow to safely mutate the value within a closure.
+@propertyWrapper
+public final class _pthread_rwlock<Value> {
+    /// The wrapped value.
+    private var value: Value
+
+    /// The lock object.
+    private var rwlock = pthread_rwlock_t()
+
+    public init(wrappedValue value: Value) {
+        pthread_rwlock_init(&rwlock, nil)
+        self.value = value
+    }
+
+    deinit {
+        pthread_rwlock_destroy(&rwlock)
+    }
+
+    /// The wrapped value.
+    ///
+    /// The `get` will acquire the lock for reading while the `set` will acquire for
+    /// writing.
+    public var wrappedValue: Value {
+        get {
+            pthread_rwlock_rdlock(&rwlock)
+            defer { pthread_rwlock_unlock(&rwlock) }
+            return value
+        }
+        set {
+            pthread_rwlock_wrlock(&rwlock)
+            value = newValue
+            pthread_rwlock_unlock(&rwlock)
+        }
+    }
+
+    /// Provides a closure for mutation that will be called synchronously.
+    ///
+    /// - Parameter closure: The closure with the mutable value.
+    public func mutate(_ closure: (inout Value) -> Void) {
+        pthread_rwlock_wrlock(&rwlock)
+        closure(&value)
+        pthread_rwlock_unlock(&rwlock)
+    }
+}

--- a/Sources/Datadog/DatadogInternal/Concurrency/ReadWriteLock.swift
+++ b/Sources/Datadog/DatadogInternal/Concurrency/ReadWriteLock.swift
@@ -13,7 +13,7 @@ import Foundation
 /// An additional method `mutate` allow to safely mutate the value in-place (to read it
 /// and write it while obtaining the lock only once).
 @propertyWrapper
-/* public */ internal final class _pthread_rwlock<Value> {
+/* public */ internal final class ReadWriteLock<Value> {
     /// The wrapped value.
     private var value: Value
 

--- a/Sources/Datadog/Logging/RemoteLogger.swift
+++ b/Sources/Datadog/Logging/RemoteLogger.swift
@@ -37,10 +37,10 @@ internal final class RemoteLogger: LoggerProtocol {
     /// Can be `false` if the integration is disabled for this logger.
     internal let activeSpanIntegration: Bool
     /// Logger-specific attributes.
-    @_pthread_rwlock
+    @ReadWriteLock
     private var attributes: [String: Encodable] = [:]
     /// Logger-specific tags.
-    @_pthread_rwlock
+    @ReadWriteLock
     private var tags: Set<String> = []
 
     init(

--- a/Sources/Datadog/Logging/RemoteLogger.swift
+++ b/Sources/Datadog/Logging/RemoteLogger.swift
@@ -28,14 +28,6 @@ internal final class RemoteLogger: LoggerProtocol {
     internal let core: DatadogCoreProtocol
     /// Configuration specific to this logger.
     internal let configuration: Configuration
-
-    /// Logger-specific attributes (must be accesset through `queue`).
-    private var unsafeAttributes: [String: Encodable] = [:]
-    /// Logger-specific tags (must be accesset through `queue`).
-    private var unsafeTags: Set<String> = []
-    /// Queue for ensuring thread-safety of tags and attributes mutation.
-    private let queue: DispatchQueue
-
     /// Date provider for logs.
     private let dateProvider: DateProvider
     /// Integration with RUM. It is used to correlate Logs with RUM events by injecting RUM context to `LogEvent`.
@@ -44,6 +36,12 @@ internal final class RemoteLogger: LoggerProtocol {
     /// Integration with Tracing. It is used to correlate Logs with Spans by injecting `Span` context to `LogEvent`.
     /// Can be `false` if the integration is disabled for this logger.
     internal let activeSpanIntegration: Bool
+    /// Logger-specific attributes.
+    @_pthread_rwlock
+    private var attributes: [String: Encodable] = [:]
+    /// Logger-specific tags.
+    @_pthread_rwlock
+    private var tags: Set<String> = []
 
     init(
         core: DatadogCoreProtocol,
@@ -55,11 +53,6 @@ internal final class RemoteLogger: LoggerProtocol {
         self.core = core
         self.configuration = configuration
         self.dateProvider = dateProvider
-        self.queue = DispatchQueue(
-            label: "com.datadoghq.logger-\(configuration.loggerName)",
-            target: .global(qos: .userInteractive)
-        )
-
         self.rumContextIntegration = rumContextIntegration
         self.activeSpanIntegration = activeSpanIntegration
     }
@@ -67,29 +60,29 @@ internal final class RemoteLogger: LoggerProtocol {
     // MARK: - Attributes
 
     func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
-        queue.async { self.unsafeAttributes[key] = value }
+        _attributes.mutate { $0[key] = value }
     }
 
     func removeAttribute(forKey key: AttributeKey) {
-        queue.async { self.unsafeAttributes.removeValue(forKey: key) }
+        _attributes.mutate { $0.removeValue(forKey: key) }
     }
 
     // MARK: - Tags
 
     func addTag(withKey key: String, value: String) {
-        queue.async { self.unsafeTags.insert("\(key):\(value)") }
+        _tags.mutate { $0.insert("\(key):\(value)") }
     }
 
     func removeTag(withKey key: String) {
-        queue.async { self.unsafeTags = self.unsafeTags.filter { !$0.hasPrefix("\(key):") } }
+        _tags.mutate { $0 = $0.filter { !$0.hasPrefix("\(key):") } }
     }
 
     func add(tag: String) {
-        queue.async { self.unsafeTags.insert(tag) }
+        _tags.mutate { $0.insert(tag) }
     }
 
     func remove(tag: String) {
-        queue.async { self.unsafeTags.remove(tag) }
+        _tags.mutate { $0.remove(tag) }
     }
 
     // MARK: - Logging
@@ -121,61 +114,61 @@ internal final class RemoteLogger: LoggerProtocol {
         let date = dateProvider.now
         let threadName = Thread.current.dd.name
 
+        // capture current tags and attributes before opening the write event context
+        let tags = self.tags
+        let userAttributes = self.attributes
+            .merging(attributes ?? [:]) { $1 } // prefer message attributes
+
         // SDK context must be requested on the user thread to ensure that it provides values
         // that are up-to-date for the caller.
         self.core.v1.scope(for: LoggingFeature.self)?.eventWriteContext { context, writer in
-            self.queue.async {
-                let userAttributes = self.unsafeAttributes.merging(attributes ?? [:]) { $1 } // prefer message attributes
-                var internalAttributes: [String: Encodable] = [:]
-                let userTags = self.unsafeTags
+            var internalAttributes: [String: Encodable] = [:]
+            let contextAttributes = context.featuresAttributes
 
-                let contextAttributes = context.featuresAttributes
+            if self.rumContextIntegration, let attributes = contextAttributes["rum"] {
+                internalAttributes.merge(attributes.all()) { $1 }
+            }
 
-                if self.rumContextIntegration, let attributes = contextAttributes["rum"] {
-                    internalAttributes.merge(attributes.all()) { $1 }
+            if self.activeSpanIntegration, let attributes = contextAttributes["tracing"] {
+                internalAttributes.merge(attributes.all()) { $1 }
+            }
+
+            let builder = LogEventBuilder(
+                service: self.configuration.service ?? context.service,
+                loggerName: self.configuration.loggerName,
+                sendNetworkInfo: self.configuration.sendNetworkInfo,
+                eventMapper: self.configuration.eventMapper
+            )
+
+            builder.createLogEvent(
+                date: date,
+                level: level,
+                message: message,
+                error: error,
+                attributes: .init(
+                    userAttributes: userAttributes,
+                    internalAttributes: internalAttributes
+                ),
+                tags: tags,
+                context: context,
+                threadName: threadName
+            ) { log in
+                writer.write(value: log)
+
+                guard log.status == .error || log.status == .critical else {
+                    return
                 }
 
-                if self.activeSpanIntegration, let attributes = contextAttributes["tracing"] {
-                    internalAttributes.merge(attributes.all()) { $1 }
-                }
-
-                let builder = LogEventBuilder(
-                    service: self.configuration.service ?? context.service,
-                    loggerName: self.configuration.loggerName,
-                    sendNetworkInfo: self.configuration.sendNetworkInfo,
-                    eventMapper: self.configuration.eventMapper
-                )
-
-                builder.createLogEvent(
-                    date: date,
-                    level: level,
-                    message: message,
-                    error: error,
-                    attributes: .init(
-                        userAttributes: userAttributes,
-                        internalAttributes: internalAttributes
-                    ),
-                    tags: userTags,
-                    context: context,
-                    threadName: threadName
-                ) { log in
-                    writer.write(value: log)
-
-                    guard log.status == .error || log.status == .critical else {
-                        return
-                    }
-
-                    self.core.send(
-                        message: .error(
-                            message: log.error?.message ?? log.message,
-                            baggage: [
-                                "type": log.error?.kind,
-                                "stack": log.error?.stack,
-                                "source": "logger"
-                            ]
-                        )
+                self.core.send(
+                    message: .error(
+                        message: log.error?.message ?? log.message,
+                        baggage: [
+                            "type": log.error?.kind,
+                            "stack": log.error?.stack,
+                            "source": "logger"
+                        ]
                     )
-                }
+                )
             }
         }
     }

--- a/Sources/Datadog/Tracing/Integrations/TracingWithRUMIntegration.swift
+++ b/Sources/Datadog/Tracing/Integrations/TracingWithRUMIntegration.swift
@@ -10,21 +10,7 @@ import Foundation
 internal final class TracingWithRUMIntegration {
     /// The RUM attributes that should be added as Span tags.
     ///
-    /// These attributes are synchronized using a fair and recursive lock.
-    var attribues: [String: Encodable]? {
-        get { synchronize { _attribues } }
-        set { synchronize { _attribues = newValue } }
-    }
-
-    /// Fair and recursive lock.
-    private let lock = NSRecursiveLock()
-
-    /// Unsafe attributes.
-    private var _attribues: [String: Encodable]?
-
-    private func synchronize<T>(_ block: () -> T) -> T {
-        lock.lock()
-        defer { lock.unlock() }
-        return block()
-    }
+    /// These attributes are synchronized using a read-write lock.
+    @_pthread_rwlock
+    var attribues: [String: Encodable]?
 }

--- a/Sources/Datadog/Tracing/Integrations/TracingWithRUMIntegration.swift
+++ b/Sources/Datadog/Tracing/Integrations/TracingWithRUMIntegration.swift
@@ -11,6 +11,6 @@ internal final class TracingWithRUMIntegration {
     /// The RUM attributes that should be added as Span tags.
     ///
     /// These attributes are synchronized using a read-write lock.
-    @_pthread_rwlock
+    @ReadWriteLock
     var attribues: [String: Encodable]?
 }

--- a/Tests/DatadogTests/Datadog/DatadogInternal/ConcurrencyTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/ConcurrencyTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import Datadog
 
 final class ConcurrencyTests: XCTestCase {
-    @_pthread_rwlock
+    @ReadWriteLock
     var value: Int = 0
 
     func testRandomlyCallingValueConcurrentlyDoesNotCrash() {

--- a/Tests/DatadogTests/Datadog/DatadogInternal/ConcurrencyTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/ConcurrencyTests.swift
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+final class ConcurrencyTests: XCTestCase {
+    @_pthread_rwlock
+    var value: Int = 0
+
+    func testRandomlyCallingValueConcurrentlyDoesNotCrash() {
+        // swiftlint:disable opening_brace
+        callConcurrently(
+            closures: [
+                { _ = self.value },
+                { self.value = .mockRandom() },
+                { self._value.mutate { $0 = .mockRandom() } }
+            ],
+            iterations: 1_000
+        )
+        // swiftlint:enable opening_brace
+    }
+}

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -469,6 +469,7 @@ class LoggerTests: XCTestCase {
 
     func testSendingMessageAttributes() throws {
         core.context = .mockAny()
+        core.queue = DispatchQueue(label: "context-queue")
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers()
         core.register(feature: feature)
@@ -503,6 +504,7 @@ class LoggerTests: XCTestCase {
             env: "tests",
             version: "1.2.3"
         )
+        core.queue = DispatchQueue(label: "context-queue")
 
         let feature: LoggingFeature = .mockByRecordingLogMatchers()
         core.register(feature: feature)

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
@@ -21,7 +21,7 @@ internal final class DatadogCoreMock: Flushable {
 
     private var v1Features: [String: Any] = [:]
 
-    @_pthread_rwlock
+    @ReadWriteLock
     var context: DatadogContext {
         didSet { send(message: .context(context)) }
     }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreMock.swift
@@ -26,7 +26,7 @@ internal final class DatadogCoreMock: Flushable {
         didSet { send(message: .context(context)) }
     }
 
-    /// This queue used for invoking Feature scopes.
+    /// This queue is used for invoking Feature scopes.
     var queue: DispatchQueue?
 
     /// Creates a DatadogCore mock.

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -16,7 +16,7 @@ import XCTest
 /// store all events in the `events` property..
 internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureScope {
     /// Current context that will be passed to feature-scopes.
-    @_pthread_rwlock
+    @ReadWriteLock
     var context: DatadogContext {
         didSet { send(message: .context(context)) }
     }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -16,21 +16,9 @@ import XCTest
 /// store all events in the `events` property..
 internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureScope {
     /// Current context that will be passed to feature-scopes.
+    @_pthread_rwlock
     var context: DatadogContext {
-        get { synchronize { _context } }
-        set { synchronize { _context = newValue } }
-    }
-
-    /// ordered/non-recursive lock on the context.
-    private let lock = NSLock()
-    private var _context: DatadogContext {
-        didSet { send(message: .context(_context)) }
-    }
-
-    private func synchronize<T>(_ block: () -> T) -> T {
-        lock.lock()
-        defer { lock.unlock() }
-        return block()
+        didSet { send(message: .context(context)) }
     }
 
     internal let writer = FileWriterMock()
@@ -60,7 +48,7 @@ internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureScope {
         bypassConsentExpectation: XCTestExpectation? = nil,
         messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
     ) {
-        self._context = context
+        self.context = context
         self.expectation = expectation
         self.bypassConsentExpectation = bypassConsentExpectation
         self.messageReceiver = messageReceiver


### PR DESCRIPTION
### What and why?

With the asynchronous aspect of the event write context, logs entries' attributes and tags can become inconsistent. Here an example:
```swift
logger.add(tag: "tag1")
logger.info("info message 1") // This log entry won't include tag1 because the EWC is async
logger.remove(tag: "tag1")
```

We need to capture tags and attributes before opening the EWC.

### How?

In this proposal, I replace the remote logger queue with read-write locks around the attributes and tags. Managing the lock is abstracted behind a `@_pthread_rwlock` property-wrapper. The tags and attributes property are captured on the caller thread before jumping on the EWC.

The POSIX lock has been preferred over `DispatchQueue/barrier` as it's slightly faster on read operation.

### Tests

This issue wasn't catch by unit tests because we rely on the `DatadogCoreMock` which was performing EWC in sync. I'm adding the ability to add a `queue` for async Feature scopes.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
