### PR TITLE
RUMM-2782 Flush Context Queue

### DIFF
--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -331,6 +331,10 @@ public class Datadog {
     internal static func internalFlushAndDeinitialize() {
         assert(Datadog.isInitialized, "SDK must be first initialized.")
 
+        // Flush the context provider's work items
+        let core = defaultDatadogCore as? DatadogCore
+        core?.contextProvider.queue.sync(flags: .barrier) { }
+
         // Tear down and deinitialize all features:
         let logging = defaultDatadogCore.v1.feature(LoggingFeature.self)
         let tracing = defaultDatadogCore.v1.feature(TracingFeature.self)

--- a/Sources/Datadog/DatadogCore/Context/DatadogContextProvider.swift
+++ b/Sources/Datadog/DatadogCore/Context/DatadogContextProvider.swift
@@ -47,7 +47,7 @@ internal final class DatadogContextProvider {
     ///
     /// Concurrent queue is used for performant reads, `.barrier` must be used
     /// to make writes exclusive.
-    private let queue = DispatchQueue(
+    internal let queue = DispatchQueue(
         label: "com.datadoghq.core-context",
         qos: .utility
     )


### PR DESCRIPTION
### What and why?

When running E2E tests, we invoke `flushAndDeinitialize` to send all events to the intake. But after introducing the Core Context Provider, some work items could still be waiting on its queue after flushing. We should for wait all execution when flushing.

### How?

Perform a `sync` on the context provider queue.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
