### PR TITLE
Fix tests compilation issue on Xcode 13.x

### DIFF
--- a/Tests/DatadogTests/Datadog/Logging/LoggingMessageReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LoggingMessageReceiverTests.swift
@@ -249,7 +249,7 @@ class LoggingMessageReceiverTests: XCTestCase {
         )
 
         let received = try XCTUnwrap(core.events.first, "It should send event")
-        try AssertEncodedRepresentationsEqual(received, AnyEncodable(expectedWebLogEvent))
+        try AssertEncodedRepresentationsEqual(AnyEncodable(received), AnyEncodable(expectedWebLogEvent))
     }
 
     func testWhenContextIsUnavailable_itPassesWebviewEventAsIs() throws {
@@ -284,6 +284,6 @@ class LoggingMessageReceiverTests: XCTestCase {
         )
 
         let received = try XCTUnwrap(core.events.first, "It should send event")
-        try AssertEncodedRepresentationsEqual(received, AnyEncodable(expectedWebLogEvent))
+        try AssertEncodedRepresentationsEqual(AnyEncodable(received), AnyEncodable(expectedWebLogEvent))
     }
 }


### PR DESCRIPTION
### What and why?

🧯 Fixes the nightly tests ran on Xcode 13.4.x, macOS 12.4 (Monterey):
```
❌  /Users/vagrant/git/Tests/DatadogTests/Datadog/Logging/LoggingMessageReceiverTests.swift:252:13: protocol 'Encodable' as a type cannot conform to the protocol itself
        try AssertEncodedRepresentationsEqual(received, AnyEncodable(expectedWebLogEvent))
            ^
```

### How?

Xcode 13.4.x is unable to understand `Encodable` value passed as `Encodable` parameter. For that reason, we need to wrap it into new `AnyEncodable`.

Tested on both Xcode `13.4.1` and `14.2` - it works 👍.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
