### PR TITLE
RUMM-2823 [SR] Device orientation change support

### DIFF
--- a/session-replay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/RecordsBuilder.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/RecordsBuilder.swift
@@ -110,5 +110,31 @@ internal class RecordsBuilder {
         }
     }
 
+    func createViewport(
+        from snapshot: ViewTreeSnapshot,
+        lastSnapshot: ViewTreeSnapshot
+    ) -> SRRecord? {
+        let record: SRRecord?
+        let lastSize = lastSnapshot.root.viewAttributes.frame.size
+        let currentSize = snapshot.root.viewAttributes.frame.size
+        if lastSize.aspectRatio != currentSize.aspectRatio {
+            record = .incrementalSnapshotRecord(
+                value: SRIncrementalSnapshotRecord(
+                    data: .viewportResizeData(
+                        value: .init(
+                            height: Int64(withNoOverflow: currentSize.height),
+                            width: Int64(withNoOverflow: currentSize.width)
+                        )
+                    ),
+                    timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
+                )
+            )
+        } else {
+            record = nil
+        }
+        return record
+    }
+
     // TODO: RUMM-2250 Bring other types of records
 }
+

--- a/session-replay/Sources/DatadogSessionReplay/Recorder/Utilities/CGRect+ContentFrame.swift
+++ b/session-replay/Sources/DatadogSessionReplay/Recorder/Utilities/CGRect+ContentFrame.swift
@@ -107,6 +107,13 @@ extension CGRect {
     }
 }
 
+extension CGSize {
+    var aspectRatio: CGFloat {
+        guard width > 0 else { return 0 }
+        return height / width
+    }
+}
+
 fileprivate extension CGSize {
     func scaleAspectFillRect(for contentSize: CGSize) -> CGRect {
         let scale: CGFloat
@@ -127,10 +134,9 @@ fileprivate extension CGSize {
 
     func scaleAspectFitRect(for contentSize: CGSize) -> CGRect {
         let imageAspectRatio = contentSize.height / contentSize.width
-        let frameAspectRatio = height / width
 
         var x, y, width, height: CGFloat
-        if imageAspectRatio > frameAspectRatio {
+        if imageAspectRatio > aspectRatio {
             height = self.height
             width = height / imageAspectRatio
             x = (self.width / 2) - (width / 2)

--- a/session-replay/Tests/DatadogSessionReplayTests/Processor/ProcessorTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Processor/ProcessorTests.swift
@@ -91,6 +91,45 @@ class ProcessorTests: XCTestCase {
         }
     }
 
+    func testWhenOrientationChanges_itWritesRecordsViewportResizeDataSegment() {
+        let time = Date()
+        let rum: RUMContext = .mockRandom()
+
+        // Given
+        let processor = Processor(queue: NoQueue(), writer: writer)
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 200))
+        let rotatedView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+
+        // When
+        let snapshot1 = generateViewTreeSnapshot(for: view, date: time, rumContext: rum)
+        let snapshot2 = generateViewTreeSnapshot(for: rotatedView, date: time.addingTimeInterval(1), rumContext: rum)
+
+        processor.process(viewTreeSnapshot: snapshot1, touchSnapshot: nil)
+        processor.process(viewTreeSnapshot: snapshot2, touchSnapshot: nil)
+
+        // Then
+        let enrichedRecords = writer.records
+        XCTAssertEqual(writer.records.count, 2)
+
+        XCTAssertEqual(enrichedRecords[0].records.count, 3, "Segment must start with 'meta' → 'focus' → 'full snapshot' records")
+        XCTAssertTrue(enrichedRecords[0].records[0].isMetaRecord)
+        XCTAssertTrue(enrichedRecords[0].records[1].isFocusRecord)
+        XCTAssertTrue(enrichedRecords[0].records[2].isFullSnapshotRecord && enrichedRecords[0].hasFullSnapshot)
+
+        XCTAssertEqual(enrichedRecords[1].records.count, 2, "It should follow with two 'incremental snapshot' records")
+        XCTAssertTrue(enrichedRecords[1].records[0].isIncrementalSnapshotRecord)
+        XCTAssertTrue(enrichedRecords[1].records[1].isIncrementalSnapshotRecord)
+
+        if case let .incrementalSnapshotRecord(value: value) = enrichedRecords[1].records[1] {
+            if case let .viewportResizeData(value: data) = value.data {
+                XCTAssertEqual(data.height, 100)
+                XCTAssertEqual(data.width, 200)
+            } else {
+                XCTFail("Record associated data should be `ViewportResizeData`")
+            }
+        }
+    }
+
     func testWhenRUMContextChangesInSucceedingViewTreeSnapshots_itWritesRecordsThatIndicateNextSegments() {
         let time = Date()
         let rum1: RUMContext = .mockRandom()


### PR DESCRIPTION
### What and why?

To fully support orientation change we need to send additional record informing about new size of the screen.

### How?

This PR utilizes `SRIncrementalSnapshotRecord`'s `viewportResizeData` to inform the player about the aspect ratio change.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
