### PR TITLE
RUMM-2786 Create AnyEncoder and AnyDecoder

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1144,6 +1144,12 @@
 		D2CBC26F294395A300134409 /* RUMContextAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CBC26D294395A300134409 /* RUMContextAttributes.swift */; };
 		D2D37DBF2846335F00FB4348 /* DatadogV1CoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D37DBE2846335F00FB4348 /* DatadogV1CoreProtocol.swift */; };
 		D2D37DC02846335F00FB4348 /* DatadogV1CoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D37DBE2846335F00FB4348 /* DatadogV1CoreProtocol.swift */; };
+		D2D9A3CD2966FBCF00562297 /* AnyEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D9A3CB2966FBCF00562297 /* AnyEncoder.swift */; };
+		D2D9A3CE2966FBCF00562297 /* AnyEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D9A3CB2966FBCF00562297 /* AnyEncoder.swift */; };
+		D2D9A3CF2966FBCF00562297 /* AnyDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D9A3CC2966FBCF00562297 /* AnyDecoder.swift */; };
+		D2D9A3D02966FBCF00562297 /* AnyDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D9A3CC2966FBCF00562297 /* AnyDecoder.swift */; };
+		D2D9A3D22966FBE500562297 /* AnyCoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D9A3D12966FBE500562297 /* AnyCoderTests.swift */; };
+		D2D9A3D32966FBE500562297 /* AnyCoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D9A3D12966FBE500562297 /* AnyCoderTests.swift */; };
 		D2DC4BBC27F234D600E4FB96 /* CITestIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11625D727B681D200E428C6 /* CITestIntegration.swift */; };
 		D2DC4BBD27F234E000E4FB96 /* CITestIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */; };
 		D2DC4BF627F484AA00E4FB96 /* DataEncryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */; };
@@ -1987,6 +1993,9 @@
 		D2CBC26A294383F200134409 /* WebViewEventReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewEventReceiver.swift; sourceTree = "<group>"; };
 		D2CBC26D294395A300134409 /* RUMContextAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMContextAttributes.swift; sourceTree = "<group>"; };
 		D2D37DBE2846335F00FB4348 /* DatadogV1CoreProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogV1CoreProtocol.swift; sourceTree = "<group>"; };
+		D2D9A3CB2966FBCF00562297 /* AnyEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyEncoder.swift; sourceTree = "<group>"; };
+		D2D9A3CC2966FBCF00562297 /* AnyDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDecoder.swift; sourceTree = "<group>"; };
+		D2D9A3D12966FBE500562297 /* AnyCoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCoderTests.swift; sourceTree = "<group>"; };
 		D2DC4BF527F484AA00E4FB96 /* DataEncryption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataEncryption.swift; sourceTree = "<group>"; };
 		D2E8D59728C7AB90007E5DE1 /* TracingMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingMessageReceiverTests.swift; sourceTree = "<group>"; };
 		D2EFA867286DA85700F1FAA6 /* DatadogContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogContextProvider.swift; sourceTree = "<group>"; };
@@ -4492,6 +4501,8 @@
 			isa = PBXGroup;
 			children = (
 				D2FB1250292D1D07005B13F8 /* DynamicCodingKey.swift */,
+				D2D9A3CC2966FBCF00562297 /* AnyDecoder.swift */,
+				D2D9A3CB2966FBCF00562297 /* AnyEncoder.swift */,
 				D2CBC2532942007800134409 /* AnyEncodable.swift */,
 				D2CBC2562942008800134409 /* AnyDecodable.swift */,
 				D2CBC2592942009800134409 /* AnyCodable.swift */,
@@ -4502,6 +4513,7 @@
 		D2CBC25C294215BE00134409 /* Codable */ = {
 			isa = PBXGroup;
 			children = (
+				D2D9A3D12966FBE500562297 /* AnyCoderTests.swift */,
 				D2CBC25D294215D900134409 /* AnyEncodableTests.swift */,
 				D2CBC2602942178C00134409 /* AnyDecodableTests.swift */,
 				D2CBC263294217AD00134409 /* AnyCodableTests.swift */,
@@ -5438,6 +5450,7 @@
 				D29CDD3228211A2200F7DAA5 /* DataBlock.swift in Sources */,
 				D2553829288F0B2400727FAD /* LowPowerModePublisher.swift in Sources */,
 				616C0A9E28573DFF00C13264 /* RUMOperatingSystemInfo.swift in Sources */,
+				D2D9A3CD2966FBCF00562297 /* AnyEncoder.swift in Sources */,
 				A7F773DD29253F8B00AC1A62 /* OTelHTTPHeadersWriter.swift in Sources */,
 				61AD4E3824531500006E34EA /* DataFormat.swift in Sources */,
 				D26C49C32889A72B00802B2D /* FeatureRequestBuilder.swift in Sources */,
@@ -5469,6 +5482,7 @@
 				D255382C288F161500727FAD /* BatteryStatus.swift in Sources */,
 				61122EDA25B1BA9700F9C7F5 /* AttributesSanitizer.swift in Sources */,
 				618715F924DC13A100FC0F69 /* RUMDataModelsMapping.swift in Sources */,
+				D2D9A3CF2966FBCF00562297 /* AnyDecoder.swift in Sources */,
 				61C3638524361E9200C4D4E6 /* Globals.swift in Sources */,
 				D20605CB2875A83F0047275C /* ContextValueReader.swift in Sources */,
 				E1D202EA24C065CF00D1AF3A /* ActiveSpansPool.swift in Sources */,
@@ -5625,6 +5639,7 @@
 				617CD0DD24CEDDD300B0B557 /* RUMUserActionScopeTests.swift in Sources */,
 				A79B0F61292BB071008742B3 /* OTelHTTPHeadersReaderTests.swift in Sources */,
 				61B8BA91281812F60068AFF4 /* KronosInternetAddressTests.swift in Sources */,
+				D2D9A3D22966FBE500562297 /* AnyCoderTests.swift in Sources */,
 				D29889C9273413ED00A4D1A9 /* RUMViewsHandlerTests.swift in Sources */,
 				61C5A8A024509C1100DA608C /* Casting+Tracing.swift in Sources */,
 				61133C662423990D00786299 /* LogSanitizerTests.swift in Sources */,
@@ -6148,6 +6163,7 @@
 				D2FB1252292D1D07005B13F8 /* DynamicCodingKey.swift in Sources */,
 				D2CB6E3827C50EAE00A62B57 /* DataFormat.swift in Sources */,
 				D2CB6E3927C50EAE00A62B57 /* JSONEncoder.swift in Sources */,
+				D2D9A3CE2966FBCF00562297 /* AnyEncoder.swift in Sources */,
 				D2CB6E3C27C50EAE00A62B57 /* Retrying.swift in Sources */,
 				D2CB6E3D27C50EAE00A62B57 /* FeaturesConfiguration.swift in Sources */,
 				A793E66B2948C7B1002A195D /* W3CHTTPHeaders.swift in Sources */,
@@ -6179,6 +6195,7 @@
 				D2CB6E4D27C50EAE00A62B57 /* Globals.swift in Sources */,
 				D2CB6E4E27C50EAE00A62B57 /* ActiveSpansPool.swift in Sources */,
 				D2CB6E4F27C50EAE00A62B57 /* AppStateListener.swift in Sources */,
+				D2D9A3D02966FBCF00562297 /* AnyDecoder.swift in Sources */,
 				D2CB6E5027C50EAE00A62B57 /* UIViewControllerHandler.swift in Sources */,
 				D2CB6E5127C50EAE00A62B57 /* Warnings.swift in Sources */,
 				A793E6692948C785002A195D /* W3CHTTPHeadersWriter.swift in Sources */,
@@ -6470,6 +6487,7 @@
 				D2CB6F4627C520D400A62B57 /* CoreMocks.swift in Sources */,
 				D26C49B32886E10E00802B2D /* AppStateHistoryTests.swift in Sources */,
 				D2CB6F4727C520D400A62B57 /* SpanEventBuilderTests.swift in Sources */,
+				D2D9A3D32966FBE500562297 /* AnyCoderTests.swift in Sources */,
 				D2E8D59928C7AD8D007E5DE1 /* TracingMessageReceiverTests.swift in Sources */,
 				D2CB6F4827C520D400A62B57 /* CrashReportingFeatureMocks.swift in Sources */,
 				D2CB6F4927C520D400A62B57 /* CrashLogReceiverTests.swift in Sources */,

--- a/Sources/Datadog/DatadogInternal/Codable/AnyDecoder.swift
+++ b/Sources/Datadog/DatadogInternal/Codable/AnyDecoder.swift
@@ -1,0 +1,858 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An object that decodes instances of a `Any` type.
+///
+/// The example below shows how to decode an instance of a simple `GroceryProduct`
+/// type from a `Any` object. The type adopts `Codable` so that it's decodable using a
+/// `AnyDecoder` instance.
+///
+///     struct GroceryProduct: Codable {
+///         var name: String
+///         var points: Int
+///         var description: String?
+///     }
+///
+///     let dictionary: [String: Any] = [
+///         "name": "Durian",
+///         "points": 600,
+///         "description": "A fruit with a distinctive scent."
+///     ]
+///
+///     let decoder = AnyDecoder()
+///     let product = try decoder.decode(GroceryProduct.self, from: dictionary)
+///
+///     print(product.name) // Prints "Durian"
+///
+open class AnyDecoder {
+    /// Initializes `self`.
+    public init() { }
+
+    /// Decodes a top-level any value to the given type.
+    ///
+    /// - parameter type: The type of the value to decode.
+    /// - parameter object: The object to decode from.
+    /// - returns: A value of the requested type.
+    /// - throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid JSON.
+    /// - throws: An error if any value throws an error during decoding.
+    open func decode<T>(_ type: T.Type = T.self, from any: Any?) throws -> T where T: Decodable {
+        // swiftlint:disable:previous function_default_parameter_at_end
+        let container = _AnyDecoder.SingleValueContainer(any)
+        return try container.decode(T.self)
+    }
+}
+
+// swiftlint:enable closing_brace_whitespace
+// MARK: - Internal Decoder
+private class _AnyDecoder: Decoder {
+    /// The path of coding keys taken to get to this point in decoding.
+    let codingPath: [CodingKey]
+
+    /// The source value.
+    let value: Any?
+
+    /// Any contextual information set by the user for decoding.
+    let userInfo: [CodingUserInfoKey: Any] = [:]
+
+    init(_ value: Any?, path: [CodingKey] = []) {
+        self.value = value
+        codingPath = path
+    }
+
+    /// Returns the data stored in this decoder as represented in a container
+    /// keyed by the given key type.
+    ///
+    /// - parameter type: The key type to use for the container.
+    /// - returns: A keyed decoding container view into this decoder.
+    /// - throws: `DecodingError.typeMismatch` if the encountered stored value is
+    ///   not a keyed container.
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
+        let container = try KeyedContainer<Key>(value, path: codingPath)
+        return KeyedDecodingContainer(container)
+    }
+
+    /// Returns the data stored in this decoder as represented in a container
+    /// appropriate for holding values with no keys.
+    ///
+    /// - returns: An unkeyed container view into this decoder.
+    /// - throws: `DecodingError.typeMismatch` if the encountered stored value is
+    ///   not an unkeyed container.
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        try UnkeyedContainer(value, path: codingPath)
+    }
+
+    /// Returns the data stored in this decoder as represented in a container
+    /// appropriate for holding a single primitive value.
+    ///
+    /// - returns: A single value container view into this decoder.
+    /// - throws: `DecodingError.typeMismatch` if the encountered stored value is
+    ///   not a single value container.
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        SingleValueContainer(value, path: codingPath)
+    }
+
+    /// A type that provides a view into an encoder's storage and is used to hold
+    /// the encoded properties of an encodable type in a keyed manner.
+    struct KeyedContainer<Key>: KeyedDecodingContainerProtocol where Key: CodingKey {
+        /// The path of coding keys taken to get to this point in encoding.
+        let codingPath: [CodingKey]
+
+        /// The source dictionary.
+        let dict: [String: Any?]
+
+        init(_ any: Any?, path: [CodingKey] = []) throws {
+            guard let dict = any as? [String: Any?] else {
+                let context = DecodingError.Context(
+                    codingPath: path,
+                    debugDescription: "Invalid conversion of '\(String(describing: any))' to Dictionary."
+                )
+
+                throw DecodingError.typeMismatch([String: Any?].self, context)
+            }
+
+            self.dict = dict
+            self.codingPath = path
+        }
+
+        /// All the keys the `Decoder` has for this container.
+        ///
+        /// Different keyed containers from the same `Decoder` may return different
+        /// keys here; it is possible to encode with multiple key types which are
+        /// not convertible to one another. This should report all keys present
+        /// which are convertible to the requested type.
+        var allKeys: [Key] {
+            dict.keys.compactMap { Key(stringValue: $0) }
+        }
+
+        /// Returns a Boolean value indicating whether the decoder contains a value
+        /// associated with the given key.
+        ///
+        /// The value associated with `key` may be a null value as appropriate for
+        /// the data format.
+        ///
+        /// - parameter key: The key to search for.
+        /// - returns: Whether the `Decoder` has an entry for the given key.
+        func contains(_ key: Key) -> Bool {
+            dict[key.stringValue] != nil
+        }
+
+        func value(forKey key: Key) throws -> Any? {
+            if let value = dict[key.stringValue] {
+                return value
+            }
+
+            let context = DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "No value associated with key \(key.stringValue)."
+            )
+
+            throw DecodingError.keyNotFound(key, context)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decodeNil(forKey key: Key) throws -> Bool {
+            try nestedSingleValueContainer(forKey: key).decodeNil()
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: String.Type, forKey key: Key) throws -> String {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T: Decodable {
+            try nestedSingleValueContainer(forKey: key).decode(type)
+        }
+
+        /// Returns the data stored for the given key as represented in a container
+        /// keyed by the given key type.
+        ///
+        /// - parameter type: The key type to use for the container.
+        /// - parameter key: The key that the nested container is associated with.
+        /// - returns: A keyed decoding container view into `self`.
+        func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+            let container = try KeyedContainer<NestedKey>(value(forKey: key), path: codingPath + [key])
+            return KeyedDecodingContainer(container)
+        }
+
+        /// Returns the data stored for the given key as represented in an unkeyed
+        /// container.
+        ///
+        /// - parameter key: The key that the nested container is associated with.
+        /// - returns: An unkeyed decoding container view into `self`.
+        func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+            try UnkeyedContainer(value(forKey: key), path: codingPath + [key])
+        }
+
+        /// Returns the data stored for the given key as represented in an single value
+        /// container.
+        ///
+        /// - parameter key: The key that the nested container is associated with.
+        /// - returns: An single value decoding container view into `self`.
+        func nestedSingleValueContainer(forKey key: Key) throws -> SingleValueDecodingContainer {
+            try SingleValueContainer(value(forKey: key), path: codingPath + [key])
+        }
+
+        /// Returns a `Decoder` instance for decoding `super` from the container
+        /// associated with the default `super` key.
+        ///
+        /// Equivalent to calling `superDecoder(forKey:)` with
+        /// `Key(stringValue: "super", intValue: 0)`.
+        ///
+        /// - returns: A new `Decoder` to pass to `super.init(from:)`.
+        func superDecoder() throws -> Decoder {
+            _AnyDecoder(dict, path: codingPath)
+        }
+
+        /// Returns a `Decoder` instance for decoding `super` from the container
+        /// associated with the given key.
+        ///
+        /// - parameter key: The key to decode `super` for.
+        /// - returns: A new `Decoder` to pass to `super.init(from:)`.
+        func superDecoder(forKey key: Key) throws -> Decoder {
+            try _AnyDecoder(value(forKey: key), path: codingPath + [key])
+        }
+    }
+
+    /// A type that provides a view into a decoder's storage and is used to hold
+    /// the encoded properties of a decodable type sequentially, without keys.
+    struct UnkeyedContainer: UnkeyedDecodingContainer {
+        /// The path of coding keys taken to get to this point in decoding.
+        let codingPath: [CodingKey]
+
+        /// The number of elements contained within this container.
+        ///
+        /// If the number of elements is unknown, the value is `nil`.
+        var count: Int? { array.count }
+
+        /// A Boolean value indicating whether there are no more elements left to be
+        /// decoded in the container.
+        var isAtEnd: Bool { currentIndex >= array.count }
+
+        /// The current decoding index of the container (i.e. the index of the next
+        /// element to be decoded.) Incremented after every successful decode call.
+        private(set) var currentIndex: Int = 0
+
+        /// The source array.
+        private let array: [Any?]
+
+        init(_ any: Any?, path: [CodingKey] = []) throws {
+            guard let array = any as? [Any?] else {
+                let context = DecodingError.Context(
+                    codingPath: path,
+                    debugDescription: "Invalid conversion of '\(String(describing: any))' to Array."
+                )
+
+                throw DecodingError.typeMismatch([Any?].self, context)
+            }
+
+            self.array = array
+            self.codingPath = path
+        }
+
+        /// Decodes a null value.
+        ///
+        /// If the value is not null, does not increment currentIndex.
+        ///
+        /// - returns: Whether the encountered value was null.
+        mutating func decodeNil() throws -> Bool {
+            if try nestedSingleValueContainer().decodeNil() {
+                return true
+            }
+
+            currentIndex -= 1
+            return false
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Bool.Type) throws -> Bool {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: String.Type) throws -> String {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Double.Type) throws -> Double {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Float.Type) throws -> Float {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int.Type) throws -> Int {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int8.Type) throws -> Int8 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int16.Type) throws -> Int16 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int32.Type) throws -> Int32 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: Int64.Type) throws -> Int64 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt.Type) throws -> UInt {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        /// Decodes a value of the given type.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - returns: A value of the requested type, if present for the given key
+        ///   and convertible to the requested type.
+        mutating func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+            try nestedSingleValueContainer().decode(type)
+        }
+
+        private mutating func next() throws -> Any? {
+            defer { currentIndex += 1 }
+
+            if isAtEnd {
+                let context = DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Unkeyed container is at end."
+                )
+
+                throw DecodingError.valueNotFound(Any.self, context)
+            }
+
+            return array[currentIndex]
+        }
+
+        /// Decodes a nested container keyed by the given type.
+        ///
+        /// - parameter type: The key type to use for the container.
+        /// - returns: A keyed decoding container view into `self`.
+        mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+            let container = try KeyedContainer<NestedKey>(next(), path: codingPath)
+            return KeyedDecodingContainer(container)
+        }
+
+        /// Decodes an unkeyed nested container.
+        ///
+        /// - returns: An unkeyed decoding container view into `self`.
+        mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+            try UnkeyedContainer(next(), path: codingPath)
+        }
+
+        /// Decodes an single value nested container.
+        ///
+        /// - returns: An unkeyed decoding container view into `self`.
+        mutating func nestedSingleValueContainer() throws -> SingleValueDecodingContainer {
+            try SingleValueContainer(next(), path: codingPath)
+        }
+
+        /// Decodes a nested container and returns a `Decoder` instance for decoding
+        /// `super` from that container.
+        ///
+        /// - returns: A new `Decoder` to pass to `super.init(from:)`.
+        mutating func superDecoder() throws -> Decoder {
+            _AnyDecoder(array, path: codingPath)
+        }
+    }
+
+    /// A container that can support the storage and direct decoding of a single
+    /// nonkeyed value.
+    struct SingleValueContainer: SingleValueDecodingContainer {
+        /// The path of coding keys taken to get to this point in encoding.
+        let codingPath: [CodingKey]
+
+        let value: Any?
+
+        init(_ value: Any?, path: [CodingKey] = []) {
+            self.value = value
+            self.codingPath = path
+        }
+
+        /// Decodes a null value.
+        ///
+        /// - returns: Whether the encountered value was null.
+        func decodeNil() -> Bool {
+            value == nil
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Bool.Type) throws -> Bool {
+            guard let value = value as? Bool else {
+                throw DecodingError.typeMismatch(type, in: self)
+            }
+            return value
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: String.Type) throws -> String {
+            guard let value = value as? String else {
+                throw DecodingError.typeMismatch(type, in: self)
+            }
+            return value
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Double.Type) throws -> Double {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Float.Type) throws -> Float {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int.Type) throws -> Int {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int8.Type) throws -> Int8 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int16.Type) throws -> Int16 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int32.Type) throws -> Int32 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: Int64.Type) throws -> Int64 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt.Type) throws -> UInt {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt8.Type) throws -> UInt8 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt16.Type) throws -> UInt16 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt32.Type) throws -> UInt32 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode(_ type: UInt64.Type) throws -> UInt64 {
+            try value(as: type)
+        }
+
+        /// Decodes a single value of the given type.
+        ///
+        /// - parameter type: The type to decode as.
+        /// - returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+            if let value = value as? T {
+                return value
+            }
+
+            let decoder = _AnyDecoder(value, path: codingPath)
+            return try T(from: decoder)
+        }
+
+        /// Converts value to any `BinaryInteger`.
+        ///
+        /// - Parameter type: The `BinaryInteger` to convert as.
+        /// - Returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        private func value<T>(as type: T.Type) throws -> T where T: BinaryInteger {
+            var value: T?
+            switch self.value {
+            case let source as T: return source
+            case let source as Int: value = T(exactly: source)
+            case let source as Int8: value = T(exactly: source)
+            case let source as Int16: value = T(exactly: source)
+            case let source as Int32: value = T(exactly: source)
+            case let source as Int64: value = T(exactly: source)
+            case let source as UInt: value = T(exactly: source)
+            case let source as UInt8: value = T(exactly: source)
+            case let source as UInt16: value = T(exactly: source)
+            case let source as UInt32: value = T(exactly: source)
+            case let source as UInt64: value = T(exactly: source)
+            default: break
+            }
+
+            guard let value = value else {
+                throw DecodingError.typeMismatch(type, in: self)
+            }
+
+            return value
+        }
+
+        /// Converts value to any `BinaryFloatingPoint`.
+        ///
+        /// - Parameter type: The `BinaryFloatingPoint` to convert as.
+        /// - Returns: A value of the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the value conversion
+        ///   fails.
+        private func value<T>(as type: T.Type) throws -> T where T: BinaryFloatingPoint {
+            if let source = value as? T {
+                return source
+            }
+
+            if let source = value as? Double {
+                return T(source)
+            }
+
+            if let source = value as? Float {
+                return T(source)
+            }
+
+            if let source = try? value(as: Int.self) {
+                return T(source)
+            }
+
+            throw DecodingError.typeMismatch(type, in: self)
+        }
+    }
+}
+
+private extension DecodingError {
+    /// Returns a new `.typeMismatch` error using a constructed coding path and
+    /// the given container.
+    ///
+    /// The coding path for the returned error is the given container's coding
+    /// path.
+    ///
+    /// - param container: The container in which the corrupted data was
+    ///   accessed.
+    /// - param debugDescription: A description of the error to aid in debugging.
+    ///
+    /// - Returns: A new `.typeMismatch` error with the given information.
+    static func typeMismatch(_ type: Any.Type, in container: _AnyDecoder.SingleValueContainer) -> DecodingError {
+        let context = DecodingError.Context(
+            codingPath: container.codingPath,
+            debugDescription: "Invalid conversion of '\(String(describing: container.value))' to \(type)."
+        )
+
+        return .typeMismatch(type, context)
+    }
+}

--- a/Sources/Datadog/DatadogInternal/Codable/AnyEncoder.swift
+++ b/Sources/Datadog/DatadogInternal/Codable/AnyEncoder.swift
@@ -1,0 +1,673 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+/// An object that encodes instances of an `Encodable` type as `Any?`.
+///
+/// The example below shows how to encode an instance of a simple `GroceryProduct`
+/// type to `Any` object. The type adopts `Codable` so that it's encodable as `Any`
+/// using a `AnyEncoder` instance.
+///
+///     struct GroceryProduct: Codable {
+///         var name: String
+///         var points: Int
+///         var description: String?
+///     }
+///
+///     let pear = GroceryProduct(name: "Pear", points: 250, description: "A ripe pear.")
+///
+///     let encoder = AnyEncoder()
+///
+///     let object = try encoder.encode(pear)
+///     print(object as! NSDictionary)
+///
+///     /* Prints:
+///     {
+///         description = "A ripe pear.";
+///         name = Pear;
+///         points = 250;
+///     }
+///     */
+open class AnyEncoder {
+    /// Initializes `self`.
+    public init() { }
+
+    /// Encodes the given top-level value and returns its Any representation.
+    ///
+    /// Depending on the value and its `Encodable` implementation the returned
+    /// encoded value can be `Any`, `[Any?]`, `[String: Any?]`, or `nil`.
+    ///
+    /// - parameter value: The value to encode.
+    /// - returns: An `Any` object containing the value.
+    /// - throws: An error if any value throws an error during encoding.
+    open func encode<T>(_ value: T) throws -> Any? where T: Encodable {
+        let encoder = _AnyEncoder()
+        try value.encode(to: encoder)
+        return encoder.any
+    }
+}
+
+/// A type that can encode values into a native format for external
+/// representation.
+private class _AnyEncoder: Encoder {
+    typealias AnyEncodingStorage = (Any?) -> Void
+
+    /// The path of coding keys taken to get to this point in encoding.
+    let codingPath: [CodingKey]
+
+    /// Any contextual information set by the user for encoding.
+    let userInfo: [CodingUserInfoKey: Any] = [:]
+
+    /// The encoded value.
+    var any: Any?
+
+    init(path: [CodingKey] = []) {
+        codingPath = path
+    }
+
+    /// Returns an encoding container appropriate for holding multiple values
+    /// keyed by the given key type.
+    ///
+    /// You must use only one kind of top-level encoding container. This method
+    /// must not be called after a call to `unkeyedContainer()` or after
+    /// encoding a value through a call to `singleValueContainer()`
+    ///
+    /// - parameter type: The key type to use for the container.
+    /// - returns: A new keyed encoding container.
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+        let container = KeyedContainer<Key>(
+            store: { self.any = $0 },
+            dictionary: any as? [String: Any?],
+            path: codingPath
+        )
+        self.any = container.dictionary
+        return KeyedEncodingContainer(container)
+    }
+
+    /// Returns an encoding container appropriate for holding multiple unkeyed
+    /// values.
+    ///
+    /// You must use only one kind of top-level encoding container. This method
+    /// must not be called after a call to `container(keyedBy:)` or after
+    /// encoding a value through a call to `singleValueContainer()`
+    ///
+    /// - returns: A new empty unkeyed container.
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        let container = UnkeyedContainer(
+            store: { self.any = $0 },
+            array: any as? [Any?],
+            path: codingPath
+        )
+        self.any = container.array
+        return container
+    }
+
+    /// Returns an encoding container appropriate for holding a single primitive
+    /// value.
+    ///
+    /// You must use only one kind of top-level encoding container. This method
+    /// must not be called after a call to `unkeyedContainer()` or
+    /// `container(keyedBy:)`, or after encoding a value through a call to
+    /// `singleValueContainer()`
+    ///
+    /// - returns: A new empty single value container.
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        SingleValueContainer(
+            store: { self.any = $0 },
+            path: codingPath
+        )
+    }
+
+    /// A concrete container that provides a view into an encoder's storage, making
+    /// the encoded properties of an encodable type accessible by keys.
+    class KeyedContainer<Key>: KeyedEncodingContainerProtocol where Key: CodingKey {
+        /// The path of coding keys taken to get to this point in encoding.
+        var codingPath: [CodingKey]
+
+        /// The dictionary of encoded value.
+        var dictionary: [String: Any?]
+
+        /// The storage closure to call with encoded value.
+        let store: AnyEncodingStorage
+
+        /// Creates a keyed container for encoding an `Encodable` object to
+        /// a dictionary of `[String: Any?]`.
+        ///
+        /// - Parameters:
+        ///   - store: The storage closure to call with encoded value.
+        ///   - dictionary: An existing dictionary of any.
+        ///   - path: The path of coding keys taken to get to this point in encoding.
+        init(
+            store: @escaping AnyEncodingStorage,
+            dictionary: [String: Any?]? = nil,
+            path: [CodingKey] = []
+        ) {
+            self.store = store
+            self.dictionary = dictionary ?? [:]
+            self.codingPath = path
+        }
+
+        /// Encodes a null value for the given key.
+        ///
+        /// - parameter key: The key to associate the value with.
+        func encodeNil(forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encodeNil()
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Bool, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: String, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Double, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Float, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int8, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int16, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int32, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: Int64, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt8, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt16, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt32, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode(_ value: UInt64, forKey key: Key) throws {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Encodes the given value for the given key.
+        ///
+        /// - parameter value: The value to encode.
+        /// - parameter key: The key to associate the value with.
+        func encode<T>(_ value: T, forKey key: Key) throws where T: Encodable {
+            try nestedSingleValueContainer(forKey: key).encode(value)
+        }
+
+        /// Stores a keyed encoding container for the given key and returns it.
+        ///
+        /// - parameter keyType: The key type to use for the container.
+        /// - parameter key: The key to encode the container for.
+        /// - returns: A new keyed encoding container.
+        func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+            let container = KeyedContainer<NestedKey>(
+                store: { self.set($0, forKey: key) },
+                path: codingPath + [key]
+            )
+            return KeyedEncodingContainer(container)
+        }
+
+        /// Stores an unkeyed encoding container for the given key and returns it.
+        ///
+        /// - parameter key: The key to encode the container for.
+        /// - returns: A new unkeyed encoding container.
+        func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+            UnkeyedContainer(
+                store: { self.set($0, forKey: key) },
+                path: codingPath + [key]
+            )
+        }
+
+        /// Stores an single value encoding container for the given key and returns it.
+        ///
+        /// - parameter key: The key to encode the container for.
+        /// - returns: A new unkeyed encoding container.
+        func nestedSingleValueContainer(forKey key: Key) -> SingleValueContainer {
+            SingleValueContainer(
+                store: { self.set($0, forKey: key) },
+                path: codingPath + [key]
+            )
+        }
+
+        /// Set the encoded value at the given key.
+        ///
+        /// - Parameters:
+        ///   - any: The encoded value.
+        ///   - key: The key to encode the value for.
+        private func set(_ any: Any?, forKey key: Key) {
+            dictionary[key.stringValue] = any
+            store(dictionary)
+        }
+
+        /// Stores a new nested container for the default `super` key and returns a
+        /// new encoder instance for encoding `super` into that container.
+        ///
+        /// Equivalent to calling `superEncoder(forKey:)` with
+        /// `Key(stringValue: "super", intValue: 0)`.
+        ///
+        /// - returns: A new encoder to pass to `super.encode(to:)`.
+        func superEncoder() -> Encoder {
+            _AnyEncoder(path: codingPath)
+        }
+
+        /// Stores a new nested container for the given key and returns a new encoder
+        /// instance for encoding `super` into that container.
+        ///
+        /// - parameter key: The key to encode `super` for.
+        /// - returns: A new encoder to pass to `super.encode(to:)`.
+        func superEncoder(forKey key: Key) -> Encoder {
+            _AnyEncoder(path: codingPath + [key])
+        }
+    }
+
+    /// A type that provides a view into an encoder's storage and is used to hold
+    /// the encoded properties of an encodable type sequentially, without keys.
+    class UnkeyedContainer: UnkeyedEncodingContainer {
+        /// The path of coding keys taken to get to this point in encoding.
+        let codingPath: [CodingKey]
+
+        /// The number of elements encoded into the container.
+        var count: Int { array.count }
+
+        /// The array of encoded value.
+        var array: [Any?]
+
+        /// The storage closure to call with encoded value.
+        let store: AnyEncodingStorage
+
+        /// Creates a unkeyed container for encoding an `Encodable` object to
+        /// an array of `[Any?]`.
+        ///
+        /// - Parameters:
+        ///   - store: The storage closure to call with encoded value.
+        ///   - array: An existing array of any.
+        ///   - path: The path of coding keys taken to get to this point in encoding.
+        init(
+            store: @escaping AnyEncodingStorage,
+            array: [Any?]? = nil,
+            path: [CodingKey] = []
+        ) {
+            self.store = store
+            self.array = array ?? []
+            self.codingPath = path
+        }
+
+        /// Encodes a null value.
+        func encodeNil() throws {
+            try nestedSingleValueContainer().encodeNil()
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Bool) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: String) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Double) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Float) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        func encode(_ value: Int) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int8) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int16) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int32) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int64) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt8) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt16) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt32) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt64) throws {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes the given value.
+        ///
+        /// - parameter value: The value to encode.
+        func encode<T>(_ value: T) throws where T: Encodable {
+            try nestedSingleValueContainer().encode(value)
+        }
+
+        /// Encodes a nested container keyed by the given type and returns it.
+        ///
+        /// - parameter keyType: The key type to use for the container.
+        /// - returns: A new keyed encoding container.
+        func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+            let container = KeyedContainer<NestedKey>(store: append, path: codingPath)
+            return KeyedEncodingContainer(container)
+        }
+
+        /// Encodes an unkeyed encoding container and returns it.
+        ///
+        /// - returns: A new unkeyed encoding container.
+        func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+            UnkeyedContainer(store: append, path: codingPath)
+        }
+
+        /// Encodes an single value encoding container and returns it.
+        ///
+        /// - returns: A new unkeyed encoding container.
+        func nestedSingleValueContainer() -> SingleValueContainer {
+            SingleValueContainer(store: append, path: codingPath)
+        }
+
+        /// Encodes a nested container and returns an `Encoder` instance for encoding
+        /// `super` into that container.
+        ///
+        /// - returns: A new encoder to pass to `super.encode(to:)`.
+        func superEncoder() -> Encoder {
+            _AnyEncoder(path: codingPath)
+        }
+
+        private func append(_ any: Any?) {
+            array.append(any)
+            store(array)
+        }
+    }
+
+    /// A container that can support the storage and direct encoding of a single
+    /// non-keyed value.
+    struct SingleValueContainer: SingleValueEncodingContainer {
+        /// The path of coding keys taken to get to this point in encoding.
+        let codingPath: [CodingKey]
+
+        /// The storage closure to call with encoded value.
+        let store: AnyEncodingStorage
+
+        /// Creates a single value container for encoding an `Encodable` object to
+        /// `Any?`.
+        ///
+        /// - Parameters:
+        ///   - store: The storage closure to call with encoded value.
+        ///   - path: The path of coding keys taken to get to this point in encoding.
+        init(
+            store: @escaping AnyEncodingStorage,
+            path: [CodingKey] = []
+        ) {
+            self.store = store
+            self.codingPath = path
+        }
+
+        /// Encodes a null value.
+        func encodeNil() throws {
+            store(nil)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Bool) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: String) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Double) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Float) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int8) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int16) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int32) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: Int64) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt8) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt16) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt32) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode(_ value: UInt64) throws {
+            store(value)
+        }
+
+        /// Encodes a single value of the given type.
+        ///
+        /// - parameter value: The value to encode.
+        func encode<T>(_ value: T) throws where T: Encodable {
+            if value is DictionaryEncodable {
+                store(value)
+            } else {
+                let encoder = _AnyEncoder(path: codingPath)
+                try value.encode(to: encoder)
+                store(encoder.any)
+            }
+        }
+    }
+}
+
+/// A shared encodable object will skip encoding when using the `AnyEncoder`.
+///
+/// Making an `Encodable` as shared allow to bypass encoding when the type is
+/// known by multiple parties.
+internal protocol DictionaryEncodable: Encodable { }
+
+extension URL: DictionaryEncodable { }
+extension Date: DictionaryEncodable { }
+extension UUID: DictionaryEncodable { }
+extension Data: DictionaryEncodable { }

--- a/Sources/Datadog/DatadogInternal/Codable/DynamicCodingKey.swift
+++ b/Sources/Datadog/DatadogInternal/Codable/DynamicCodingKey.swift
@@ -41,3 +41,12 @@ import Foundation
         self.stringValue = stringValue
     }
 }
+
+extension DynamicCodingKey: ExpressibleByStringLiteral {
+    /// Creates an instance initialized to the given string value.
+    ///
+    /// - Parameter value: The value of the new instance.
+    init(stringLiteral value: String) {
+        self.init(value)
+    }
+}

--- a/Tests/DatadogTests/Datadog/DatadogInternal/Codable/AnyCoderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/Codable/AnyCoderTests.swift
@@ -1,0 +1,304 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import Datadog
+
+class AnyCoderTests: XCTestCase {
+    struct Object: Codable {
+        let id: UUID
+        let date: Date
+        let url: URL
+        let title: String
+        let null: String?
+        let int: Int?
+        let bool: Bool?
+        let nested: Nested
+        let empty: Empty
+        let array: [AnyCodable?]?
+
+        struct Nested: Codable {
+            let id: UUID
+            let title: String
+        }
+    }
+
+    struct Empty: Codable { }
+
+    let id: UUID = .mockAny()
+
+    lazy var dictionary: [String: Any?] = [
+        "id": id,
+        "date": Date.mockAny(),
+        "url": URL(string: "https://test.com/object/1")!,
+        "title": "Response",
+        "int": UInt64(12_345),
+        "bool": true,
+        "nested": [
+            "id": id,
+            "title": "Nested",
+        ],
+        "empty": [:],
+        "array": [
+            1,
+            "2",
+            3.4,
+            ["five": 5],
+            nil
+        ]
+    ]
+
+    func testObjectDecoding() throws {
+        let decoder = AnyDecoder()
+        let object = try decoder.decode(Object.self, from: dictionary)
+
+        XCTAssertEqual(object.id, id)
+        XCTAssertEqual(object.date, .mockAny())
+        XCTAssertEqual(object.title, "Response")
+        XCTAssertEqual(object.url, URL(string: "https://test.com/object/1"))
+        XCTAssertNotNil(object.nested)
+        XCTAssertEqual(object.nested.id, id)
+        XCTAssertEqual(object.int, 12_345)
+        XCTAssertNil(object.null)
+        XCTAssertTrue(object.bool ?? false)
+        XCTAssertNotNil(object.array)
+        XCTAssertEqual(object.array?.underestimatedCount, 5)
+        XCTAssertEqual(object.array?[0], AnyCodable(1))
+    }
+
+    func testObjectEncoding() throws {
+        let encoder = AnyEncoder()
+        let object = Object(
+            id: id,
+            date: .mockAny(),
+            url: URL(string: "https://test.com/object/1")!,
+            title: "Response",
+            null: nil,
+            int: 12_345,
+            bool: true,
+            nested: .init(id: id, title: "Nested"),
+            empty: Empty(),
+            array: [
+                AnyCodable(1),
+                AnyCodable("2"),
+                AnyCodable(3.4),
+                AnyCodable(["five": 5]),
+                AnyCodable(nil as Any?)
+            ]
+        )
+
+        let dict = try XCTUnwrap(encoder.encode(object) as? [String: Any?])
+
+        XCTAssertEqual(dict["id"] as? UUID, id)
+        XCTAssertEqual(dict["date"] as? Date, .mockAny())
+        XCTAssertEqual(dict["title"] as? String, "Response")
+        XCTAssertEqual(dict["url"] as? URL, URL(string: "https://test.com/object/1"))
+        XCTAssertEqual(dict["int"] as? Int, 12_345)
+        XCTAssertNil(dict["null"] as Any?)
+        XCTAssertTrue(dict["bool"] as? Bool ?? false)
+        let nested = try XCTUnwrap(dict["nested"] as? [String: Any?])
+        XCTAssertEqual(nested["id"] as? UUID, id)
+        XCTAssertEqual(nested["title"] as? String, "Nested")
+        let array = try XCTUnwrap(dict["array"] as? [Any?])
+        XCTAssertEqual(array.count, 5)
+    }
+
+    func testSingleValueEncoding() throws {
+        let encoder = AnyEncoder()
+        XCTAssertTrue(try encoder.encode(true) is Bool)
+        XCTAssertTrue(try encoder.encode("str") is String)
+        XCTAssertTrue(try encoder.encode(Int(1)) is Int)
+        XCTAssertTrue(try encoder.encode(Int8(1)) is Int8)
+        XCTAssertTrue(try encoder.encode(Int16(1)) is Int16)
+        XCTAssertTrue(try encoder.encode(Int32(1)) is Int32)
+        XCTAssertTrue(try encoder.encode(Int64(1)) is Int64)
+        XCTAssertTrue(try encoder.encode(UInt(1)) is UInt)
+        XCTAssertTrue(try encoder.encode(UInt8(1)) is UInt8)
+        XCTAssertTrue(try encoder.encode(UInt16(1)) is UInt16)
+        XCTAssertTrue(try encoder.encode(UInt32(1)) is UInt32)
+        XCTAssertTrue(try encoder.encode(UInt64(1)) is UInt64)
+        XCTAssertTrue(try encoder.encode(Float(1.1)) is Float)
+        XCTAssertTrue(try encoder.encode(Double(1.1)) is Double)
+    }
+
+    func testSingleValueDecoding() throws {
+        let decoder = AnyDecoder()
+        XCTAssertTrue(try decoder.decode(Bool.self, from: true))
+        XCTAssertEqual(try decoder.decode(String.self, from: "str"), "str")
+        XCTAssertEqual(try decoder.decode(Int.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(Int8.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(Int16.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(Int32.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(Int64.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(UInt.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(UInt8.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(UInt16.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(UInt32.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(UInt64.self, from: 1), 1)
+        XCTAssertEqual(try decoder.decode(Float.self, from: Float(1)), 1)
+        XCTAssertEqual(try decoder.decode(Float.self, from: Double(1)), 1)
+        XCTAssertEqual(try decoder.decode(Float.self, from: Int(1)), 1)
+        XCTAssertEqual(try decoder.decode(Double.self, from: Double(1)), 1)
+        XCTAssertEqual(try decoder.decode(Double.self, from: Float(1)), 1)
+        XCTAssertEqual(try decoder.decode(Double.self, from: Int(1)), 1)
+    }
+
+    func testUnkeyedEncoding() throws {
+        let encoder = AnyEncoder()
+
+        struct Foo: Encodable {
+            func encode(to encoder: Encoder) throws {
+                var container1 = encoder.unkeyedContainer()
+                try container1.encodeNil()
+                try container1.encode(true)
+                try container1.encode("str")
+                try container1.encode(Int(1))
+                try container1.encode(Int8(1))
+                try container1.encode(Int16(1))
+                try container1.encode(Int32(1))
+                var container2 = encoder.unkeyedContainer()
+                try container2.encode(Int64(1))
+                try container2.encode(UInt(1))
+                try container2.encode(UInt8(1))
+                try container2.encode(UInt16(1))
+                try container2.encode(UInt32(1))
+                try container2.encode(UInt64(1))
+                try container2.encode(Float(1.1))
+                try container2.encode(Double(1.1))
+            }
+        }
+
+        let array = try XCTUnwrap(try encoder.encode(Foo()) as? [Any?])
+        XCTAssertNil(array[0])
+        XCTAssertTrue(array[1] is Bool)
+        XCTAssertTrue(array[2] is String)
+        XCTAssertTrue(array[3] is Int)
+        XCTAssertTrue(array[4] is Int8)
+        XCTAssertTrue(array[5] is Int16)
+        XCTAssertTrue(array[6] is Int32)
+        XCTAssertTrue(array[7] is Int64)
+        XCTAssertTrue(array[8] is UInt)
+        XCTAssertTrue(array[9] is UInt8)
+        XCTAssertTrue(array[10] is UInt16)
+        XCTAssertTrue(array[11] is UInt32)
+        XCTAssertTrue(array[12] is UInt64)
+        XCTAssertTrue(array[13] is Float)
+        XCTAssertTrue(array[14] is Double)
+    }
+
+    func testUnkeyedDecoding() throws {
+        let decoder = AnyDecoder()
+
+        let array: [Any?] = [
+            nil,
+            true,
+            "str",
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1.1, 1.1
+        ]
+
+        struct Foo: Decodable {
+            init(from decoder: Decoder) throws {
+                var container = try decoder.unkeyedContainer()
+                XCTAssertTrue(try container.decodeNil())
+                XCTAssertTrue(try container.decode(Bool.self))
+                XCTAssertEqual(try container.decode(String.self), "str")
+                XCTAssertEqual(try container.decode(Int.self), 1)
+                XCTAssertEqual(try container.decode(Int8.self), 1)
+                XCTAssertEqual(try container.decode(Int16.self), 1)
+                XCTAssertEqual(try container.decode(Int32.self), 1)
+                XCTAssertEqual(try container.decode(Int64.self), 1)
+                XCTAssertEqual(try container.decode(UInt.self), 1)
+                XCTAssertEqual(try container.decode(UInt8.self), 1)
+                XCTAssertEqual(try container.decode(UInt16.self), 1)
+                XCTAssertEqual(try container.decode(UInt32.self), 1)
+                XCTAssertEqual(try container.decode(UInt64.self), 1)
+                XCTAssertEqual(try container.decode(Float.self), 1.1)
+                XCTAssertEqual(try container.decode(Double.self), 1.1)
+            }
+        }
+
+        XCTAssertNoThrow(try decoder.decode(Foo.self, from: array))
+    }
+
+    func testKeyedEncoding() throws {
+        let encoder = AnyEncoder()
+
+        struct Foo: Encodable {
+            func encode(to encoder: Encoder) throws {
+                var container1 = encoder.container(keyedBy: DynamicCodingKey.self)
+                try container1.encodeNil(forKey: .init("null"))
+                try container1.encode(true, forKey: .init("bool"))
+                try container1.encode("str", forKey: .init("string"))
+                try container1.encode(Int(1), forKey: .init("int"))
+                try container1.encode(Int8(1), forKey: .init("int8"))
+                try container1.encode(Int16(1), forKey: .init("int16"))
+                try container1.encode(Int32(1), forKey: .init("int32"))
+                try container1.encode(Int64(1), forKey: .init("int64"))
+                var container2 = encoder.container(keyedBy: DynamicCodingKey.self)
+                try container2.encode(UInt(1), forKey: .init("uint"))
+                try container2.encode(UInt8(1), forKey: .init("uint8"))
+                try container2.encode(UInt16(1), forKey: .init("uint16"))
+                try container2.encode(UInt32(1), forKey: .init("uint32"))
+                try container2.encode(UInt64(1), forKey: .init("uint64"))
+                try container2.encode(Float(1.1), forKey: .init("float"))
+                try container2.encode(Double(1.1), forKey: .init("double"))
+            }
+        }
+
+        let dictionary = try XCTUnwrap(try encoder.encode(Foo()) as? [String: Any?])
+        XCTAssertNil(try XCTUnwrap(dictionary["null"]))
+        XCTAssertTrue(dictionary["bool"] is Bool)
+        XCTAssertTrue(dictionary["string"] is String)
+        XCTAssertTrue(dictionary["int"] is Int)
+        XCTAssertTrue(dictionary["int8"] is Int8)
+        XCTAssertTrue(dictionary["int16"] is Int16)
+        XCTAssertTrue(dictionary["int32"] is Int32)
+        XCTAssertTrue(dictionary["int64"] is Int64)
+        XCTAssertTrue(dictionary["uint"] is UInt)
+        XCTAssertTrue(dictionary["uint8"] is UInt8)
+        XCTAssertTrue(dictionary["uint16"] is UInt16)
+        XCTAssertTrue(dictionary["uint32"] is UInt32)
+        XCTAssertTrue(dictionary["uint64"] is UInt64)
+        XCTAssertTrue(dictionary["float"] is Float)
+        XCTAssertTrue(dictionary["double"] is Double)
+    }
+
+    func testKeyedDecoding() throws {
+        let decoder = AnyDecoder()
+
+        let dictionary: [String: Any?] = [
+            "null": nil,
+            "bool": true,
+            "string": "str",
+            "integer": 1,
+            "floating": 1.1
+        ]
+
+        struct Foo: Decodable {
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+                XCTAssertTrue(try container.decodeNil(forKey: .init("null")))
+                XCTAssertTrue(try container.decode(Bool.self, forKey: .init("bool")))
+                XCTAssertEqual(try container.decode(String.self, forKey: .init("string")), "str")
+                XCTAssertEqual(try container.decode(Int.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(Int8.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(Int16.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(Int32.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(Int64.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(UInt.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(UInt8.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(UInt16.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(UInt32.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(UInt64.self, forKey: .init("integer")), 1)
+                XCTAssertEqual(try container.decode(Float.self, forKey: .init("floating")), 1.1)
+                XCTAssertEqual(try container.decode(Double.self, forKey: .init("floating")), 1.1)
+            }
+        }
+
+        XCTAssertNoThrow(try decoder.decode(Foo.self, from: dictionary))
+    }
+}


### PR DESCRIPTION
### What and why?

Introduce implementation of `AnyEncoder` and `AnyDecoder` which will allow defragmenting data-types for transfer on the message-bus.

In the following example, a CrashContext is transmitted from the CrashReporting Feature to RUM through the message-bus: 
<img width="802" alt="image" src="https://user-images.githubusercontent.com/6815992/211035165-58b1a04c-741d-47d9-8241-8d875de9f6e2.png">


This implementation will also be useful for the Flutter SDK to replace the dependency to [DictionaryCoder](https://github.com/almazrafi/DictionaryCoder). cc @fuzzybinary 

Usage on the `FeatureBaggage` is done in #1113.

### How?

#### Encoding
The `AnyEncoder` implements the [`Encoder` protocol](https://developer.apple.com/documentation/swift/encoder) and is capable of encoding an `Encodable` object to a `Any`, `[Any?]`, or `[String: Any?]` representation.
It will result in the same `object` as the following snippet, but without having to serialize to `Data`.

```swift
let encoder = JSONEncoder()
let data = try encoder.encode(value)
let object = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
```

#### Decoding
The `AnyDecoder` implements the [`Decoder` protocol](https://developer.apple.com/documentation/swift/decoder) and is capable of decoding a`Decodable` object from an `Any?` representation.
It will result in the same `value` as the following snippet, but without having to serialize to `Data`.
```swift
let decoder = JSONDecoder()
let data = try JSONSerialization.data(withJSONObject: object, options: [])
let value =  try decoder.decode(type, from: data)
```

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
