### PR TITLE
RUMM-2582 Async RUM Event Mappers

### DIFF
--- a/Sources/Datadog/Datadog+Internal.swift
+++ b/Sources/Datadog/Datadog+Internal.swift
@@ -56,4 +56,44 @@ extension DatadogExtension where ExtendedType: Datadog.Configuration.Builder {
         type.configuration.logEventMapper = mapper
         return type
     }
+
+    /// Sets a custom async  mapper for `RUMViewEvent`. This can be used to modify view events before they are sent to Datadog.
+    ///
+    /// - Parameter mapper: the mapper
+    public func setRUMViewEventMapper(_ mapper: RUMViewEventMapper) -> ExtendedType {
+        type.configuration.rumViewEventMapper = mapper
+        return type
+    }
+
+    /// Sets a custom async  mapper for `RUMResourceEvent`. This can be used to modify view events before they are sent to Datadog.
+    ///
+    /// - Parameter mapper: the mapper
+    public func setRUMResourceEventMapper(_ mapper: RUMResourceEventMapper) -> ExtendedType {
+        type.configuration.rumResourceEventMapper = mapper
+        return type
+    }
+
+    /// Sets a custom async  mapper for `RUMActionEvent`. This can be used to modify view events before they are sent to Datadog.
+    ///
+    /// - Parameter mapper: the mapper
+    public func setRUMActionEventMapper(_ mapper: RUMActionEventMapper) -> ExtendedType {
+        type.configuration.rumActionEventMapper = mapper
+        return type
+    }
+
+    /// Sets a custom async  mapper for `RUMErrorEvent`. This can be used to modify view events before they are sent to Datadog.
+    ///
+    /// - Parameter mapper: the mapper
+    public func setRUMErrorEventMapper(_ mapper: RUMErrorEventMapper) -> ExtendedType {
+        type.configuration.rumErrorEventMapper = mapper
+        return type
+    }
+
+    /// Sets a custom async  mapper for `RUMLongTaskEvent`. This can be used to modify view events before they are sent to Datadog.
+    ///
+    /// - Parameter mapper: the mapper
+    public func setRUMLongTaskEventMapper(_ mapper: RUMLongTaskEventMapper) -> ExtendedType {
+        type.configuration.rumLongTaskEventMapper = mapper
+        return type
+    }
 }

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -272,11 +272,11 @@ extension Datadog {
         private(set) var rumUIKitViewsPredicate: UIKitRUMViewsPredicate?
         private(set) var rumUIKitUserActionsPredicate: UIKitRUMUserActionsPredicate?
         private(set) var rumLongTaskDurationThreshold: TimeInterval?
-        private(set) var rumViewEventMapper: RUMViewEventMapper?
-        private(set) var rumResourceEventMapper: RUMResourceEventMapper?
-        private(set) var rumActionEventMapper: RUMActionEventMapper?
-        private(set) var rumErrorEventMapper: RUMErrorEventMapper?
-        private(set) var rumLongTaskEventMapper: RUMLongTaskEventMapper?
+        var rumViewEventMapper: RUMViewEventMapper?
+        var rumResourceEventMapper: RUMResourceEventMapper?
+        var rumActionEventMapper: RUMActionEventMapper?
+        var rumErrorEventMapper: RUMErrorEventMapper?
+        var rumLongTaskEventMapper: RUMLongTaskEventMapper?
         private(set) var rumResourceAttributesProvider: URLSessionRUMAttributesProvider?
         private(set) var rumBackgroundEventTrackingEnabled: Bool
         private(set) var rumFrustrationSignalsTrackingEnabled: Bool

--- a/Sources/Datadog/DatadogConfiguration.swift
+++ b/Sources/Datadog/DatadogConfiguration.swift
@@ -719,7 +719,7 @@ extension Datadog {
             ///
             /// Use the `UIKitRUMViewsPredicate` API to ensure upstream consideration or filtering out of `UIViewController`/`RUMView`s.
             public func setRUMViewEventMapper(_ mapper: @escaping (RUMViewEvent) -> RUMViewEvent) -> Builder {
-                configuration.rumViewEventMapper = mapper
+                configuration.rumViewEventMapper = SyncRUMViewEventMapper(mapper)
                 return self
             }
 
@@ -728,7 +728,7 @@ extension Datadog {
             /// The implementation should obtain a mutable version of the `RUMResourceEvent`, modify it and return. Returning `nil` will result
             /// with dropping the RUM Resource event entirely, so it won't be send to Datadog.
             public func setRUMResourceEventMapper(_ mapper: @escaping (RUMResourceEvent) -> RUMResourceEvent?) -> Builder {
-                configuration.rumResourceEventMapper = mapper
+                configuration.rumResourceEventMapper = SyncRUMResourceEventMapper(mapper)
                 return self
             }
 
@@ -737,7 +737,7 @@ extension Datadog {
             /// The implementation should obtain a mutable version of the `RUMActionEvent`, modify it and return. Returning `nil` will result
             /// with dropping the RUM Action event entirely, so it won't be send to Datadog.
             public func setRUMActionEventMapper(_ mapper: @escaping (RUMActionEvent) -> RUMActionEvent?) -> Builder {
-                configuration.rumActionEventMapper = mapper
+                configuration.rumActionEventMapper = SyncRUMActionEventMapper(mapper)
                 return self
             }
 
@@ -746,7 +746,7 @@ extension Datadog {
             /// The implementation should obtain a mutable version of the `RUMErrorEvent`, modify it and return. Returning `nil` will result
             /// with dropping the RUM Error event entirely, so it won't be send to Datadog.
             public func setRUMErrorEventMapper(_ mapper: @escaping (RUMErrorEvent) -> RUMErrorEvent?) -> Builder {
-                configuration.rumErrorEventMapper = mapper
+                configuration.rumErrorEventMapper = SyncRUMErrorEventMapper(mapper)
                 return self
             }
 
@@ -755,7 +755,7 @@ extension Datadog {
             /// The implementation should obtain a mutable version of the `RUMLongTaskEvent`, modify it and return. Returning `nil` will result
             /// with dropping the RUM Long Task event entirely, so it won't be send to Datadog.
             public func setRUMLongTaskEventMapper(_ mapper: @escaping (RUMLongTaskEvent) -> RUMLongTaskEvent?) -> Builder {
-                configuration.rumLongTaskEventMapper = mapper
+                configuration.rumLongTaskEventMapper = SyncRUMLongTaskEventMapper(mapper)
                 return self
             }
 

--- a/Sources/Datadog/DatadogCore/Storage/Files/Directory.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Files/Directory.swift
@@ -95,7 +95,7 @@ internal struct Directory {
         try retry(times: 3, delay: 0.001) {
             try files().forEach { file in
                 let destinationFileURL = destinationDirectory.url.appendingPathComponent(file.name)
-                try? retry(times: 3, delay: 0.0001) {
+                try? retry(times: 3, delay: 0.000_1) {
                     try FileManager.default.moveItem(at: file.url, to: destinationFileURL)
                 }
             }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -14,11 +14,12 @@ internal class RUMEventBuilder {
         self.eventsMapper = eventsMapper
     }
 
-    func build<Event>(from event: Event) -> Event? where Event: RUMSanitizableEvent {
-        guard let transformedEvent = eventsMapper.map(event: event) else {
-            return nil
+    func build<Event>(from event: Event, callback: @escaping (Event?) -> Void) -> Void where Event: RUMSanitizableEvent {
+        eventsMapper.map(event: event) { transformedEvent in
+            guard let transformedEvent = transformedEvent else {
+                return callback(nil)
+            }
+            callback(self.sanitizer.sanitize(event: transformedEvent))
         }
-
-        return sanitizer.sanitize(event: transformedEvent)
     }
 }

--- a/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
+++ b/Sources/Datadog/RUM/RUMEvent/RUMEventBuilder.swift
@@ -14,7 +14,7 @@ internal class RUMEventBuilder {
         self.eventsMapper = eventsMapper
     }
 
-    func build<Event>(from event: Event, callback: @escaping (Event?) -> Void) -> Void where Event: RUMSanitizableEvent {
+    func build<Event>(from event: Event, callback: @escaping (Event?) -> Void) where Event: RUMSanitizableEvent {
         eventsMapper.map(event: event) { transformedEvent in
             guard let transformedEvent = transformedEvent else {
                 return callback(nil)

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -216,9 +216,11 @@ internal class RUMResourceScope: RUMScope {
             )
         )
 
-        if let event = dependencies.eventBuilder.build(from: resourceEvent) {
-            writer.write(value: event)
-            onResourceEventSent()
+        dependencies.eventBuilder.build(from: resourceEvent) { event in
+            if let event = event {
+                writer.write(value: event)
+                self.onResourceEventSent()
+            }
         }
     }
 
@@ -277,9 +279,11 @@ internal class RUMResourceScope: RUMScope {
             )
         )
 
-        if let event = dependencies.eventBuilder.build(from: errorEvent) {
-            writer.write(value: event)
-            onErrorEventSent()
+        dependencies.eventBuilder.build(from: errorEvent) { event in
+            if let event = event {
+                writer.write(value: event)
+                self.onErrorEventSent()
+            }
         }
     }
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -182,9 +182,11 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             )
         )
 
-        if let event = dependencies.eventBuilder.build(from: actionEvent) {
-            writer.write(value: event)
-            onActionEventSent(event)
+        dependencies.eventBuilder.build(from: actionEvent) { event in
+            if let event = event {
+                writer.write(value: event)
+                self.onActionEventSent(event)
+            }
         }
     }
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -320,8 +320,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     // MARK: - Sending RUM Events
 
     private func sendApplicationStartAction(context: DatadogContext, writer: Writer) {
-        actionsCount += 1
-
         var attributes = self.attributes
         var loadingTime: Int64?
 
@@ -390,10 +388,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         dependencies.eventBuilder.build(from: actionEvent) { event in
             if let event = event {
+                self.actionsCount += 1
                 writer.write(value: event)
                 self.needsViewUpdate = true
-            } else {
-                self.actionsCount -= 1
             }
         }
     }
@@ -501,7 +498,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     }
 
     private func sendErrorEvent(on command: RUMAddCurrentViewErrorCommand, context: DatadogContext, writer: Writer) {
-        errorsCount += 1
         attributes.merge(rumCommandAttributes: command.attributes)
 
         let errorEvent = RUMErrorEvent(
@@ -554,10 +550,9 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
 
         dependencies.eventBuilder.build(from: errorEvent) { event in
             if let event = event {
+                self.errorsCount += 1
                 writer.write(value: event)
                 self.needsViewUpdate = true
-            } else {
-                self.errorsCount -= 1
             }
         }
     }

--- a/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
+++ b/Sources/Datadog/RUM/Scrubbing/RUMEventsMapper.swift
@@ -6,11 +6,14 @@
 
 import Foundation
 
-internal protocol RUMViewEventMapper {
+/// A protocol to asynchronously modify `RUMViewEvent`s before they are sent to Datadog.
+///
+/// This protocol is part of the internal interface for Datadog and not meant for public use.
+public protocol RUMViewEventMapper {
     func map(event: RUMViewEvent, callback: @escaping (RUMViewEvent) -> Void)
 }
 
-public class SyncRUMViewEventMapper: RUMViewEventMapper {
+internal class SyncRUMViewEventMapper: RUMViewEventMapper {
     let mapper: (RUMViewEvent) -> RUMViewEvent
 
     init(_ mapper: @escaping (RUMViewEvent) -> RUMViewEvent) {
@@ -22,11 +25,14 @@ public class SyncRUMViewEventMapper: RUMViewEventMapper {
     }
 }
 
-internal protocol RUMErrorEventMapper {
+/// A protocol to asynchronously modify `RUMErrorEvent`s before they are sent to Datadog.
+///
+/// This protocol is part of the internal interface for Datadog and not meant for public use.
+public protocol RUMErrorEventMapper {
     func map(event: RUMErrorEvent, callback: @escaping (RUMErrorEvent?) -> Void)
 }
 
-public class SyncRUMErrorEventMapper: RUMErrorEventMapper {
+internal class SyncRUMErrorEventMapper: RUMErrorEventMapper {
     let mapper: (RUMErrorEvent) -> RUMErrorEvent?
 
     init(_ mapper: @escaping (RUMErrorEvent) -> RUMErrorEvent?) {
@@ -38,11 +44,14 @@ public class SyncRUMErrorEventMapper: RUMErrorEventMapper {
     }
 }
 
-internal protocol RUMResourceEventMapper {
+/// A protocol to asynchronously modify `RUMResourceEvent`s before they are sent to Datadog.
+///
+/// This protocol is part of the internal interface for Datadog and not meant for public use.
+public protocol RUMResourceEventMapper {
     func map(event: RUMResourceEvent, callback: @escaping (RUMResourceEvent?) -> Void)
 }
 
-public class SyncRUMResourceEventMapper: RUMResourceEventMapper {
+internal class SyncRUMResourceEventMapper: RUMResourceEventMapper {
     let mapper: (RUMResourceEvent) -> RUMResourceEvent?
 
     init(_ mapper: @escaping (RUMResourceEvent) -> RUMResourceEvent?) {
@@ -54,11 +63,14 @@ public class SyncRUMResourceEventMapper: RUMResourceEventMapper {
     }
 }
 
-internal protocol RUMActionEventMapper {
+/// A protocol to asynchronously modify `RUMActionEvent`s before they are sent to Datadog.
+///
+/// This protocol is part of the internal interface for Datadog and not meant for public use.
+public protocol RUMActionEventMapper {
     func map(event: RUMActionEvent, callback: @escaping (RUMActionEvent?) -> Void)
 }
 
-public class SyncRUMActionEventMapper: RUMActionEventMapper {
+class SyncRUMActionEventMapper: RUMActionEventMapper {
     let mapper: (RUMActionEvent) -> RUMActionEvent?
 
     init(_ mapper: @escaping (RUMActionEvent) -> RUMActionEvent?) {
@@ -70,11 +82,14 @@ public class SyncRUMActionEventMapper: RUMActionEventMapper {
     }
 }
 
-internal protocol RUMLongTaskEventMapper {
+/// A protocol to asynchronously modify `RUMLongTaskEvent`s before they are sent to Datadog.
+///
+/// This protocol is part of the internal interface for Datadog and not meant for public use.
+public protocol RUMLongTaskEventMapper {
     func map(event: RUMLongTaskEvent, callback: @escaping (RUMLongTaskEvent?) -> Void)
 }
 
-public class SyncRUMLongTaskEventMapper: RUMLongTaskEventMapper {
+internal class SyncRUMLongTaskEventMapper: RUMLongTaskEventMapper {
     let mapper: (RUMLongTaskEvent) -> RUMLongTaskEvent?
 
     init(_ mapper: @escaping (RUMLongTaskEvent) -> RUMLongTaskEvent?) {

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -198,7 +198,6 @@ class DatadogConfigurationBuilderTests: XCTestCase {
 
             wait(for: [viewMappingExpectation, resourceMappingExpectation, actionMappingExpectation, errorMappingExpectation,longTaskMappingExpectation], timeout: 0.1)
 
-
             XCTAssertEqual(configuration.rumResourceAttributesProvider?(.mockAny(), nil, nil, nil) as? [String: String], ["foo": "bar"])
             XCTAssertFalse(configuration.rumBackgroundEventTrackingEnabled)
             XCTAssertFalse(configuration.rumFrustrationSignalsTrackingEnabled)

--- a/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogConfigurationBuilderTests.swift
@@ -165,11 +165,40 @@ class DatadogConfigurationBuilderTests: XCTestCase {
             XCTAssertTrue(configuration.rumUIKitUserActionsPredicate is UIKitRUMUserActionsPredicateMock)
             XCTAssertEqual(configuration.rumLongTaskDurationThreshold, 100.0)
             XCTAssertEqual(configuration.spanEventMapper?(.mockRandom()), mockSpanEvent)
-            XCTAssertEqual(configuration.rumViewEventMapper?(.mockRandom()), mockRUMViewEvent)
-            XCTAssertEqual(configuration.rumResourceEventMapper?(.mockRandom()), mockRUMResourceEvent)
-            XCTAssertEqual(configuration.rumActionEventMapper?(.mockRandom()), mockRUMActionEvent)
-            XCTAssertEqual(configuration.rumErrorEventMapper?(.mockRandom()), mockRUMErrorEvent)
-            XCTAssertEqual(configuration.rumLongTaskEventMapper?(.mockRandom()), mockRUMLongTaskEvent)
+
+            let viewMappingExpectation = XCTestExpectation(description: "View Mapping Callback Called")
+            configuration.rumViewEventMapper?.map(event: .mockRandom()) { event in
+                XCTAssertEqual(event, mockRUMViewEvent)
+                viewMappingExpectation.fulfill()
+            }
+
+            let resourceMappingExpectation = XCTestExpectation(description: "Resource Mapping Callback Called")
+            configuration.rumResourceEventMapper?.map(event: .mockRandom()) { event in
+                XCTAssertEqual(event, mockRUMResourceEvent)
+                resourceMappingExpectation.fulfill()
+            }
+
+            let actionMappingExpectation = XCTestExpectation(description: "Action Mapping Callback Called")
+            configuration.rumActionEventMapper?.map(event: .mockRandom()) { event in
+                XCTAssertEqual(event, mockRUMActionEvent)
+                actionMappingExpectation.fulfill()
+            }
+
+            let errorMappingExpectation = XCTestExpectation(description: "Error Mapping Callback Called")
+            configuration.rumErrorEventMapper?.map(event: .mockRandom()) { event in
+                XCTAssertEqual(event, mockRUMErrorEvent)
+                errorMappingExpectation.fulfill()
+            }
+
+            let longTaskMappingExpectation = XCTestExpectation(description: "LongTask Mapping Callback Called")
+            configuration.rumLongTaskEventMapper?.map(event: .mockRandom()) { event in
+                XCTAssertEqual(event, mockRUMLongTaskEvent)
+                longTaskMappingExpectation.fulfill()
+            }
+
+            wait(for: [viewMappingExpectation, resourceMappingExpectation, actionMappingExpectation, errorMappingExpectation,longTaskMappingExpectation], timeout: 0.1)
+
+
             XCTAssertEqual(configuration.rumResourceAttributesProvider?(.mockAny(), nil, nil, nil) as? [String: String], ["foo": "bar"])
             XCTAssertFalse(configuration.rumBackgroundEventTrackingEnabled)
             XCTAssertFalse(configuration.rumFrustrationSignalsTrackingEnabled)

--- a/Tests/DatadogTests/Datadog/DatadogInternal/Codable/AnyCodableTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/Codable/AnyCodableTests.swift
@@ -84,7 +84,7 @@ class AnyCodableTests: XCTestCase {
 
         XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
         XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
-        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
+        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141_592_653_589_793, accuracy: 0.001)
         XCTAssertEqual(dictionary["string"]?.value as! String, "string")
         XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
         XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
@@ -135,7 +135,7 @@ class AnyCodableTests: XCTestCase {
         let dictionary: [String: Any?] = [
             "boolean": true,
             "integer": 42,
-            "double": 3.141592653589793,
+            "double": 3.141_592_653_589_793,
             "string": "string",
             "stringInterpolation": "string \(injectedValue)",
             "array": [1, 2, 3],

--- a/Tests/DatadogTests/Datadog/DatadogInternal/Codable/AnyDecodableTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/Codable/AnyDecodableTests.swift
@@ -49,7 +49,7 @@ class AnyDecodableTests: XCTestCase {
 
         XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
         XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
-        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
+        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141_592_653_589_793, accuracy: 0.001)
         XCTAssertEqual(dictionary["string"]?.value as! String, "string")
         XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
         XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])

--- a/Tests/DatadogTests/Datadog/DatadogInternal/Codable/AnyEncodableTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/Codable/AnyEncodableTests.swift
@@ -54,7 +54,7 @@ class AnyEncodableTests: XCTestCase {
         let dictionary: [String: Any?] = [
             "boolean": true,
             "integer": 42,
-            "double": 3.141592653589793,
+            "double": 3.141_592_653_589_793,
             "string": "string",
             "array": [1, 2, 3],
             "nested": [
@@ -112,7 +112,7 @@ class AnyEncodableTests: XCTestCase {
             "ushort": 65_535,
             "ulong": 4_294_967_295,
             "ulonglong": 18_446_744_073_709_615,
-            "double": 3.141592653589793,
+            "double": 3.141_592_653_589_793,
         ]
 
         let encoder = JSONEncoder()
@@ -160,7 +160,7 @@ class AnyEncodableTests: XCTestCase {
         let dictionary: [String: Any] = [
             "boolean": "\(true)",
             "integer": "\(42)",
-            "double": "\(3.141592653589793)",
+            "double": "\(3.141_592_653_589_793)",
             "string": "\("string")",
             "array": "\([1, 2, 3])",
         ]

--- a/Tests/DatadogTests/Datadog/Kronos/KronosNTPPacketTests.swift
+++ b/Tests/DatadogTests/Datadog/Kronos/KronosNTPPacketTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class KronosNTPPacketTests: XCTestCase {
     func testToData() {
         var packet = KronosNTPPacket()
-        let data = packet.prepareToSend(transmitTime: 1_463_303_662.776552)
+        let data = packet.prepareToSend(transmitTime: 1_463_303_662.776_552)
         XCTAssertEqual(data, Data(hex: "1b0004fa0001000000010000000000000000000000000000" +
                                        "00000000000000000000000000000000dae2bc6ec6cc1c00")!)
     }
@@ -40,11 +40,11 @@ final class KronosNTPPacketTests: XCTestCase {
         let network = Data(hex: "1c0203e90000065700000a68ada2c09cdae2d084a5a76d5fdae2d3354a529000dae2d32b" +
                                 "b38bab46dae2d32bb38d9e00")!
         let PDU = try? KronosNTPPacket(data: network, destinationTime: 0)
-        XCTAssertEqual(PDU?.rootDelay, 0.0247650146484375)
-        XCTAssertEqual(PDU?.rootDispersion, 0.0406494140625)
+        XCTAssertEqual(PDU?.rootDelay, 0.024_765_014_648_437_5)
+        XCTAssertEqual(PDU?.rootDispersion, 0.040_649_414_062_5)
         XCTAssertEqual(PDU?.clockSource.ID, 2_913_124_508)
-        XCTAssertEqual(PDU?.referenceTime, 1_463_308_804.6470859051)
-        XCTAssertEqual(PDU?.originTime, 1_463_309_493.2903223038)
-        XCTAssertEqual(PDU?.receiveTime, 1_463_309_483.7013499737)
+        XCTAssertEqual(PDU?.referenceTime, 1_463_308_804.647_085_905_1)
+        XCTAssertEqual(PDU?.originTime, 1_463_309_493.290_322_303_8)
+        XCTAssertEqual(PDU?.receiveTime, 1_463_309_483.701_349_973_7)
     }
 }

--- a/Tests/DatadogTests/Datadog/Kronos/KronosTimeStorageTests.swift
+++ b/Tests/DatadogTests/Datadog/Kronos/KronosTimeStorageTests.swift
@@ -33,7 +33,7 @@ class KronosTimeStoragePolicyTests: XCTestCase {
 class KronosTimeStorageTests: XCTestCase {
     func testStoringAndRetrievingTimeFreeze() {
         var storage = KronosTimeStorage(storagePolicy: .standard)
-        let sampleFreeze = KronosTimeFreeze(offset: 5_000.32423)
+        let sampleFreeze = KronosTimeFreeze(offset: 5_000.324_23)
         storage.stableTime = sampleFreeze
 
         let fromDefaults = storage.stableTime
@@ -42,7 +42,7 @@ class KronosTimeStorageTests: XCTestCase {
     }
 
     func testRetrievingTimeFreezeAfterReboot() {
-        let sampleFreeze = KronosTimeFreeze(offset: 5_000.32423)
+        let sampleFreeze = KronosTimeFreeze(offset: 5_000.324_23)
         var storedData = sampleFreeze.toDictionary()
         storedData["Uptime"] = storedData["Uptime"]! + 10
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEvent/RUMEventBuilderTests.swift
@@ -11,42 +11,52 @@ class RUMEventBuilderTests: XCTestCase {
     func testGivenEventBuilderWithEventMapper_whenEventIsModified_itBuildsModifiedEvent() throws {
         let builder = RUMEventBuilder(
             eventsMapper: .mockWith(
-                viewEventMapper: { viewEvent in
+                viewEventMapper: SyncRUMViewEventMapper({ viewEvent in
                     return RUMViewEvent.mockRandom()
-                }
+                })
             )
         )
+        let expectation = XCTestExpectation(description: "Mapper callback called.")
         let originalEventModel = RUMViewEvent.mockRandom()
-        let event = try XCTUnwrap(
-            builder.build(from: RUMViewEvent.mockRandom())
-        )
-        XCTAssertNotEqual(event, originalEventModel)
+        builder.build(from: RUMViewEvent.mockRandom()) { event in
+            XCTAssertNotNil(event)
+            XCTAssertNotEqual(event, originalEventModel)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
     }
 
     func testGivenEventBuilderWithEventMapper_whenEventIsDropped_itBuildsNoEvent() {
         let builder = RUMEventBuilder(
             eventsMapper: .mockWith(
-                resourceEventMapper: { event in
+                resourceEventMapper: SyncRUMResourceEventMapper({ event in
                     return nil
-                }
+                })
             )
         )
-        let event = builder.build(from: RUMResourceEvent.mockRandom())
-        XCTAssertNil(event)
+        let expectation = XCTestExpectation(description: "Mapper callback called.")
+        builder.build(from: RUMResourceEvent.mockRandom()) { event in
+            XCTAssertNil(event)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
     }
 
     func testGivenEventBuilderWithNoEventMapper_whenBuildingAnEvent_itBuildsEventWithOriginalModel() throws {
         let builder = RUMEventBuilder(
             eventsMapper: .mockWith(
-                resourceEventMapper: { event in
+                resourceEventMapper: SyncRUMResourceEventMapper({ event in
                     return event
-                }
+                })
             )
         )
+        let expectation = XCTestExpectation(description: "Mapper callback called.")
         let originalEventModel = RUMResourceEvent.mockRandom()
-        let event = try XCTUnwrap(
-            builder.build(from: originalEventModel)
-        )
-        XCTAssertEqual(event, originalEventModel)
+        builder.build(from: originalEventModel) { event in
+            XCTAssertNotNil(event)
+            XCTAssertEqual(event, originalEventModel)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -34,8 +34,23 @@ class RUMEventFileOutputTests: XCTestCase {
 
         let dataModel1 = RUMDataModelMock(attribute: "foo", context: RUMEventAttributes(contextInfo: ["custom.attribute": "value"]))
         let dataModel2 = RUMDataModelMock(attribute: "bar")
-        let event1 = try XCTUnwrap(builder.build(from: dataModel1))
-        let event2 = try XCTUnwrap(builder.build(from: dataModel2))
+
+        let event1Expectation = XCTestExpectation(description: "Event 1 callback called")
+        let event2Expectation = XCTestExpectation(description: "Event 2 callback called")
+        var event1: RUMDataModelMock?
+        var event2: RUMDataModelMock?
+        builder.build(from: dataModel1) { event in
+            event1 = event
+            event1Expectation.fulfill()
+        }
+        builder.build(from: dataModel2) { event in
+            event2 = event
+            event2Expectation.fulfill()
+        }
+        wait(for: [event1Expectation, event2Expectation], timeout: 0.1)
+
+        event1 = try XCTUnwrap(event1)
+        event2 = try XCTUnwrap(event2)
 
         writer.write(value: event1)
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScopeTests.swift
@@ -852,12 +852,12 @@ class RUMResourceScopeTests: XCTestCase {
         // Given
         let eventBuilder = RUMEventBuilder(
             eventsMapper: RUMEventsMapper.mockWith(
-                errorEventMapper: { event in
+                errorEventMapper: SyncRUMErrorEventMapper({ event in
                     nil
-                },
-                resourceEventMapper: { event in
+                }),
+                resourceEventMapper: SyncRUMResourceEventMapper({ event in
                     nil
-                }
+                })
             )
         )
         let dependencies: RUMScopeDependencies = .mockWith(

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScopeTests.swift
@@ -584,9 +584,9 @@ class RUMUserActionScopeTests: XCTestCase {
         // swiftlint:disable trailing_closure
         let eventBuilder = RUMEventBuilder(
             eventsMapper: .mockWith(
-                actionEventMapper: { event in
+                actionEventMapper: SyncRUMActionEventMapper({ event in
                     nil
-                }
+                })
             )
         )
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -1601,7 +1601,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testGivenViewScopeWithDependentActionsResourcesErrors_whenDroppingEvents_thenCountsAreAdjusted() throws {
         struct ResourceMapperHolder {
-            var resourceEventMapper: RUMResourceEventMapper?
+            var resourceEventMapper: ((RUMResourceEvent) -> RUMResourceEvent?)?
         }
         var resourceMapperHolder = ResourceMapperHolder()
 
@@ -1611,15 +1611,15 @@ class RUMViewScopeTests: XCTestCase {
         // - discards `RUMResourceEvent` from `RUMStartResourceCommand` /resource/1
         let eventBuilder = RUMEventBuilder(
             eventsMapper: .mockWith(
-                errorEventMapper: { event in
+                errorEventMapper: SyncRUMErrorEventMapper({ event in
                     nil
-                },
-                resourceEventMapper: {
+                }),
+                resourceEventMapper: SyncRUMResourceEventMapper({
                     resourceMapperHolder.resourceEventMapper?($0)
-                },
-                actionEventMapper: { event in
+                }),
+                actionEventMapper: SyncRUMActionEventMapper({ event in
                     event.action.type == .applicationStart ? event : nil
-                }
+                })
             )
         )
         let dependencies: RUMScopeDependencies = .mockWith(
@@ -1721,9 +1721,9 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenViewScopeWithDroppingEventsMapper_whenProcessingApplicationStartAction_thenCountIsAdjusted() throws {
         let eventBuilder = RUMEventBuilder(
             eventsMapper: .mockWith(
-                actionEventMapper: { event in
+                actionEventMapper: SyncRUMActionEventMapper({ event in
                     nil
-                }
+                })
             )
         )
         let dependencies: RUMScopeDependencies = .mockWith(

--- a/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Scrubbing/RUMEventsMapperTests.swift
@@ -28,35 +28,79 @@ class RUMEventsMapperTests: XCTestCase {
 
         // Given
         let mapper = RUMEventsMapper(
-            viewEventMapper: { viewEvent in
+            viewEventMapper: SyncRUMViewEventMapper({ viewEvent in
                 XCTAssertEqual(viewEvent, originalViewEvent, "Mapper should be called with the original event.")
                 return modifiedViewEvent
-            },
-            errorEventMapper: { errorEvent in
+            }),
+            errorEventMapper: SyncRUMErrorEventMapper({ errorEvent in
                 XCTAssertEqual(errorEvent, originalErrorEvent, "Mapper should be called with the original event.")
                 return modifiedErrorEvent
-            },
-            resourceEventMapper: { resourceEvent in
+            }),
+            resourceEventMapper: SyncRUMResourceEventMapper({ resourceEvent in
                 XCTAssertEqual(resourceEvent, originalResourceEvent, "Mapper should be called with the original event.")
                 return modifiedResourceEvent
-            },
-            actionEventMapper: { actionEvent in
+            }),
+            actionEventMapper: SyncRUMActionEventMapper({ actionEvent in
                 XCTAssertEqual(actionEvent, originalActionEvent, "Mapper should be called with the original event.")
                 return modifiedActionEvent
-            },
-            longTaskEventMapper: { longTaskEvent in
+            }),
+            longTaskEventMapper: SyncRUMLongTaskEventMapper({ longTaskEvent in
                 XCTAssertEqual(longTaskEvent, originalLongTaskEvent, "Mapper should be called with the original event.")
                 return modifiedLongTaskEvent
-            }
+            })
         )
 
         // When
-        let mappedViewEvent = mapper.map(event: originalViewEvent)
-        let mappedErrorEvent = mapper.map(event: originalErrorEvent)
-        let mappedCrashEvent = mapper.map(event: originalCrashEvent)
-        let mappedResourceEvent = mapper.map(event: originalResourceEvent)
-        let mappedActionEvent = mapper.map(event: originalActionEvent)
-        let mappedLongTaskEvent = mapper.map(event: originalLongTaskEvent)
+        let viewEventExpectation = XCTestExpectation(description: "View Event Mapper Callback called")
+        var mappedViewEvent: RUMViewEvent?
+        mapper.map(event: originalViewEvent) { event in
+            mappedViewEvent = event
+            viewEventExpectation.fulfill()
+        }
+
+        let errorEventExpectation = XCTestExpectation(description: "Error Event Mapper Callback called")
+        var mappedErrorEvent: RUMErrorEvent?
+        mapper.map(event: originalErrorEvent) { event in
+            mappedErrorEvent = event
+            errorEventExpectation.fulfill()
+        }
+
+        let crashEventExpectation = XCTestExpectation(description: "Crash Event Mapper Callback called")
+        var mappedCrashEvent: RUMCrashEvent?
+        mapper.map(event: originalCrashEvent) { event in
+            mappedCrashEvent = event
+            crashEventExpectation.fulfill()
+        }
+
+        let resourceEventExpectation = XCTestExpectation(description: "Resource Event Mapper Callback called")
+        var mappedResourceEvent: RUMResourceEvent?
+        mapper.map(event: originalResourceEvent) { event in
+            mappedResourceEvent = event
+            resourceEventExpectation.fulfill()
+        }
+
+        let actionEventExpectation = XCTestExpectation(description: "Action Event Mapper Callback called")
+        var mappedActionEvent: RUMActionEvent?
+        mapper.map(event: originalActionEvent) { event in
+            mappedActionEvent = event
+            actionEventExpectation.fulfill()
+        }
+
+        let longTaskEventExpectation = XCTestExpectation(description: "Long Task Event Mapper Callback called")
+        var mappedLongTaskEvent: RUMLongTaskEvent?
+        mapper.map(event: originalLongTaskEvent) { event in
+            mappedLongTaskEvent = event
+            longTaskEventExpectation.fulfill()
+        }
+
+        wait(for: [
+            viewEventExpectation,
+            errorEventExpectation,
+            crashEventExpectation,
+            resourceEventExpectation,
+            actionEventExpectation,
+            longTaskEventExpectation
+        ], timeout: 0.1)
 
         // Then
         XCTAssertEqual(try XCTUnwrap(mappedViewEvent), modifiedViewEvent, "Mapper should return modified event.")
@@ -83,30 +127,67 @@ class RUMEventsMapperTests: XCTestCase {
         // Given
         let mapper = RUMEventsMapper(
             viewEventMapper: nil,
-            errorEventMapper: { errorEvent in
+            errorEventMapper: SyncRUMErrorEventMapper({ errorEvent in
                 XCTAssertTrue(errorEvent == originalErrorEvent || errorEvent == originalCrashEvent.model, "Mapper should be called with the original event.")
                 return nil
-            },
-            resourceEventMapper: { resourceEvent in
+            }),
+            resourceEventMapper: SyncRUMResourceEventMapper({ resourceEvent in
                 XCTAssertEqual(resourceEvent, originalResourceEvent, "Mapper should be called with the original event.")
                 return nil
-            },
-            actionEventMapper: { actionEvent in
+            }),
+            actionEventMapper: SyncRUMActionEventMapper({ actionEvent in
                 XCTAssertEqual(actionEvent, originalActionEvent, "Mapper should be called with the original event.")
                 return nil
-            },
-            longTaskEventMapper: { longTaskEvent in
+            }),
+            longTaskEventMapper: SyncRUMLongTaskEventMapper({ longTaskEvent in
                 XCTAssertEqual(longTaskEvent, originalLongTaskEvent, "Mapper should be called with the original event.")
                 return nil
-            }
+            })
         )
 
         // When
-        let mappedErrorEvent = mapper.map(event: originalErrorEvent)
-        let mappedCrashEvent = mapper.map(event: originalCrashEvent)
-        let mappedResourceEvent = mapper.map(event: originalResourceEvent)
-        let mappedActionEvent = mapper.map(event: originalActionEvent)
-        let mappedLongTaskEvent = mapper.map(event: originalLongTaskEvent)
+        let errorEventExpectation = XCTestExpectation(description: "Error Event Mapper Callback called")
+        var mappedErrorEvent: RUMErrorEvent?
+        mapper.map(event: originalErrorEvent) { event in
+            mappedErrorEvent = event
+            errorEventExpectation.fulfill()
+        }
+
+        let crashEventExpectation = XCTestExpectation(description: "Crash Event Mapper Callback called")
+        var mappedCrashEvent: RUMCrashEvent?
+        mapper.map(event: originalCrashEvent) { event in
+            mappedCrashEvent = event
+            crashEventExpectation.fulfill()
+        }
+
+        let resourceEventExpectation = XCTestExpectation(description: "Resource Event Mapper Callback called")
+        var mappedResourceEvent: RUMResourceEvent?
+        mapper.map(event: originalResourceEvent) { event in
+            mappedResourceEvent = event
+            resourceEventExpectation.fulfill()
+        }
+
+        let actionEventExpectation = XCTestExpectation(description: "Action Event Mapper Callback called")
+        var mappedActionEvent: RUMActionEvent?
+        mapper.map(event: originalActionEvent) { event in
+            mappedActionEvent = event
+            actionEventExpectation.fulfill()
+        }
+
+        let longTaskEventExpectation = XCTestExpectation(description: "Long Task Event Mapper Callback called")
+        var mappedLongTaskEvent: RUMLongTaskEvent?
+        mapper.map(event: originalLongTaskEvent) { event in
+            mappedLongTaskEvent = event
+            longTaskEventExpectation.fulfill()
+        }
+
+        wait(for: [
+            errorEventExpectation,
+            crashEventExpectation,
+            resourceEventExpectation,
+            actionEventExpectation,
+            longTaskEventExpectation
+        ], timeout: 0.1)
 
         // Then
         XCTAssertNil(mappedErrorEvent, "Mapper should return nil.")
@@ -134,12 +215,56 @@ class RUMEventsMapperTests: XCTestCase {
         )
 
         // When
-        let mappedViewEvent = mapper.map(event: originalViewEvent)
-        let mappedErrorEvent = mapper.map(event: originalErrorEvent)
-        let mappedCrashEvent = mapper.map(event: originalCrashEvent)
-        let mappedResourceEvent = mapper.map(event: originalResourceEvent)
-        let mappedActionEvent = mapper.map(event: originalActionEvent)
-        let mappedLongTaskEvent = mapper.map(event: originalLongTaskEvent)
+        let viewEventExpectation = XCTestExpectation(description: "View Event Mapper Callback called")
+        var mappedViewEvent: RUMViewEvent?
+        mapper.map(event: originalViewEvent) { event in
+            mappedViewEvent = event
+            viewEventExpectation.fulfill()
+        }
+
+        let errorEventExpectation = XCTestExpectation(description: "Error Event Mapper Callback called")
+        var mappedErrorEvent: RUMErrorEvent?
+        mapper.map(event: originalErrorEvent) { event in
+            mappedErrorEvent = event
+            errorEventExpectation.fulfill()
+        }
+
+        let crashEventExpectation = XCTestExpectation(description: "Crash Event Mapper Callback called")
+        var mappedCrashEvent: RUMCrashEvent?
+        mapper.map(event: originalCrashEvent) { event in
+            mappedCrashEvent = event
+            crashEventExpectation.fulfill()
+        }
+
+        let resourceEventExpectation = XCTestExpectation(description: "Resource Event Mapper Callback called")
+        var mappedResourceEvent: RUMResourceEvent?
+        mapper.map(event: originalResourceEvent) { event in
+            mappedResourceEvent = event
+            resourceEventExpectation.fulfill()
+        }
+
+        let actionEventExpectation = XCTestExpectation(description: "Action Event Mapper Callback called")
+        var mappedActionEvent: RUMActionEvent?
+        mapper.map(event: originalActionEvent) { event in
+            mappedActionEvent = event
+            actionEventExpectation.fulfill()
+        }
+
+        let longTaskEventExpectation = XCTestExpectation(description: "Long Task Event Mapper Callback called")
+        var mappedLongTaskEvent: RUMLongTaskEvent?
+        mapper.map(event: originalLongTaskEvent) { event in
+            mappedLongTaskEvent = event
+            longTaskEventExpectation.fulfill()
+        }
+
+        wait(for: [
+            viewEventExpectation,
+            errorEventExpectation,
+            crashEventExpectation,
+            resourceEventExpectation,
+            actionEventExpectation,
+            longTaskEventExpectation
+        ], timeout: 0.1)
 
         // Then
         XCTAssertEqual(try XCTUnwrap(mappedViewEvent), originalViewEvent, "Mapper should return the original event.")
@@ -161,15 +286,22 @@ class RUMEventsMapperTests: XCTestCase {
         // When
         let mapper = RUMEventsMapper(
             viewEventMapper: nil,
-            errorEventMapper: { _ in nil },
-            resourceEventMapper: { _ in nil },
-            actionEventMapper: { _ in nil },
-            longTaskEventMapper: { _ in nil }
+            errorEventMapper: SyncRUMErrorEventMapper({ _ in nil }),
+            resourceEventMapper: SyncRUMResourceEventMapper({ _ in nil }),
+            actionEventMapper: SyncRUMActionEventMapper({ _ in nil }),
+            longTaskEventMapper: SyncRUMLongTaskEventMapper({ _ in nil })
         )
 
-        let mappedEvent = try XCTUnwrap(mapper.map(event: originalEvent))
+        let callbackExpectation = XCTestExpectation(description: "Mapper callback called")
+        var mappedEvent: UnrecognizedEvent?
+        mapper.map(event: originalEvent) { event in
+            mappedEvent = event
+            callbackExpectation.fulfill()
+        }
+
+        wait(for: [callbackExpectation], timeout: 0.1)
 
         // Then
-        XCTAssertEqual(mappedEvent.value, originalEvent.value)
+        XCTAssertEqual(try XCTUnwrap(mappedEvent).value, originalEvent.value)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -990,18 +990,18 @@ class RUMMonitorTests: XCTestCase {
     func testModifyingEventsBeforeTheyGetSend() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
             configuration: .mockWith(
-                viewEventMapper: { viewEvent in
+                viewEventMapper: SyncRUMViewEventMapper({ viewEvent in
                     var viewEvent = viewEvent
                     viewEvent.view.url = "ModifiedViewURL"
                     viewEvent.view.name = "ModifiedViewName"
                     return viewEvent
-                },
-                resourceEventMapper: { resourceEvent in
+                }),
+                resourceEventMapper: SyncRUMResourceEventMapper({ resourceEvent in
                     var resourceEvent = resourceEvent
                     resourceEvent.resource.url = "https://foo.com?q=modified-resource-url"
                     return resourceEvent
-                },
-                actionEventMapper: { actionEvent in
+                }),
+                actionEventMapper: SyncRUMActionEventMapper({ actionEvent in
                     if actionEvent.action.type == .applicationStart {
                         return nil // drop `.applicationStart` action
                     } else {
@@ -1009,17 +1009,17 @@ class RUMMonitorTests: XCTestCase {
                         actionEvent.action.target?.name = "Modified tap action name"
                         return actionEvent
                     }
-                },
-                errorEventMapper: { errorEvent in
+                }),
+                errorEventMapper: SyncRUMErrorEventMapper({ errorEvent in
                     var errorEvent = errorEvent
                     errorEvent.error.message = "Modified error message"
                     return errorEvent
-                },
-                longTaskEventMapper: { longTaskEvent in
+                }),
+                longTaskEventMapper: SyncRUMLongTaskEventMapper({ longTaskEvent in
                     var mutableLongTaskEvent = longTaskEvent
                     mutableLongTaskEvent.view.name = "ModifiedLongTaskViewName"
                     return mutableLongTaskEvent
-                },
+                }),
                 dateProvider: RelativeDateProvider(startingFrom: Date(), advancingBySeconds: 1)
             )
         )
@@ -1058,12 +1058,12 @@ class RUMMonitorTests: XCTestCase {
     func testDroppingEventsBeforeTheyGetSent() throws {
         let rum: RUMFeature = .mockByRecordingRUMEventMatchers(
             configuration: .mockWith(
-                resourceEventMapper: { _ in nil },
-                actionEventMapper: { event in
+                resourceEventMapper: SyncRUMResourceEventMapper({ _ in nil }),
+                actionEventMapper: SyncRUMActionEventMapper({ event in
                     return event.action.type == .applicationStart ? event : nil
-                },
-                errorEventMapper: { _ in nil },
-                longTaskEventMapper: { _ in nil }
+                }),
+                errorEventMapper: SyncRUMErrorEventMapper({ _ in nil }),
+                longTaskEventMapper: SyncRUMLongTaskEventMapper({ _ in nil })
             )
         )
         core.register(feature: rum)

--- a/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
+++ b/Tests/DatadogTests/Datadog/Utils/SwiftExtensionsTests.swift
@@ -38,11 +38,11 @@ class TimeIntervalExtensionTests: XCTestCase {
         XCTAssertEqual(date15Dec2019.timeIntervalSince1970.toNanoseconds, 1_576_404_000_000_000_000)
 
         // As `TimeInterval` yields sub-millisecond precision this rounds up to the nearest millisecond:
-        let dateAdvanced = date15Dec2019 + 9.999999999
+        let dateAdvanced = date15Dec2019 + 9.999_999_999
         XCTAssertEqual(dateAdvanced.timeIntervalSince1970.toNanoseconds, 1_576_404_010_000_000_000)
 
         // As `TimeInterval` yields sub-millisecond precision this rounds up to the nearest millisecond:
-        let dateAgo = date15Dec2019 - 0.000000001
+        let dateAgo = date15Dec2019 - 0.000_000_001
         XCTAssertEqual(dateAgo.timeIntervalSince1970.toNanoseconds, 1_576_404_000_000_000_000)
 
         let overflownDate = Date(timeIntervalSinceReferenceDate: .greatestFiniteMagnitude)
@@ -62,14 +62,14 @@ class UUIDExtensionTests: XCTestCase {
 
 class IntegerOverflowExtensionTests: XCTestCase {
     func testHappyPath() {
-        let reasonableDouble = Double(1_000.123456)
+        let reasonableDouble = Double(1_000.123_456)
 
         XCTAssertNoThrow(try UInt64(withReportingOverflow: reasonableDouble))
         XCTAssertEqual(try UInt64(withReportingOverflow: reasonableDouble), 1_000)
     }
 
     func testNegative() {
-        let negativeDouble = Double(-1_000.123456)
+        let negativeDouble = Double(-1_000.123_456)
 
         XCTAssertThrowsError(try UInt64(withReportingOverflow: negativeDouble)) { error in
             XCTAssertTrue(error is FixedWidthIntegerError<Double>)
@@ -80,7 +80,7 @@ class IntegerOverflowExtensionTests: XCTestCase {
     }
 
     func testFloat() {
-        let simpleFloat = Float(222.123456)
+        let simpleFloat = Float(222.123_456)
 
         XCTAssertNoThrow(try UInt8(withReportingOverflow: simpleFloat))
         XCTAssertEqual(try UInt8(withReportingOverflow: simpleFloat), 222)

--- a/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDConfigurationTests.swift
@@ -289,11 +289,48 @@ class DDConfigurationTests: XCTestCase {
 
         let configuration = objcBuilder.build().sdkConfiguration
 
-        let redactedSwiftViewEvent = configuration.rumViewEventMapper?(swiftViewEvent)
-        let redactedSwiftResourceEvent = configuration.rumResourceEventMapper?(swiftResourceEvent)
-        let redactedSwiftActionEvent = configuration.rumActionEventMapper?(swiftActionEvent)
-        let redactedSwiftErrorEvent = configuration.rumErrorEventMapper?(swiftErrorEvent)
-        let redactedSwiftLongTaskEvent = configuration.rumLongTaskEventMapper?(swiftLongTaskEvent)
+        let viewEventExpectation = XCTestExpectation(description: "View Event Mapper Callback called")
+        var redactedSwiftViewEvent: RUMViewEvent?
+        configuration.rumViewEventMapper?.map(event: swiftViewEvent) { event in
+            redactedSwiftViewEvent = event
+            viewEventExpectation.fulfill()
+        }
+
+        let errorEventExpectation = XCTestExpectation(description: "Error Event Mapper Callback called")
+        var redactedSwiftErrorEvent: RUMErrorEvent?
+        configuration.rumErrorEventMapper?.map(event: swiftErrorEvent) { event in
+            redactedSwiftErrorEvent = event
+            errorEventExpectation.fulfill()
+        }
+
+        let resourceEventExpectation = XCTestExpectation(description: "Resource Event Mapper Callback called")
+        var redactedSwiftResourceEvent: RUMResourceEvent?
+        configuration.rumResourceEventMapper?.map(event: swiftResourceEvent) { event in
+            redactedSwiftResourceEvent = event
+            resourceEventExpectation.fulfill()
+        }
+
+        let actionEventExpectation = XCTestExpectation(description: "Action Event Mapper Callback called")
+        var redactedSwiftActionEvent: RUMActionEvent?
+        configuration.rumActionEventMapper?.map(event: swiftActionEvent) { event in
+            redactedSwiftActionEvent = event
+            actionEventExpectation.fulfill()
+        }
+
+        let longTaskEventExpectation = XCTestExpectation(description: "Long Task Event Mapper Callback called")
+        var redactedSwiftLongTaskEvent: RUMLongTaskEvent?
+        configuration.rumLongTaskEventMapper?.map(event: swiftLongTaskEvent) { event in
+            redactedSwiftLongTaskEvent = event
+            longTaskEventExpectation.fulfill()
+        }
+
+        wait(for: [
+            viewEventExpectation,
+            errorEventExpectation,
+            resourceEventExpectation,
+            actionEventExpectation,
+            longTaskEventExpectation
+        ], timeout: 0.1)
 
         XCTAssertEqual(redactedSwiftViewEvent?.view.url, "redacted view.url")
         XCTAssertEqual(redactedSwiftResourceEvent?.view.url, "redacted view.url")
@@ -320,10 +357,36 @@ class DDConfigurationTests: XCTestCase {
 
         let configuration = objcBuilder.build().sdkConfiguration
 
-        XCTAssertNil(configuration.rumResourceEventMapper?(.mockRandom()))
-        XCTAssertNil(configuration.rumActionEventMapper?(.mockRandom()))
-        XCTAssertNil(configuration.rumErrorEventMapper?(.mockRandom()))
-        XCTAssertNil(configuration.rumLongTaskEventMapper?(.mockRandom()))
+        let errorEventExpectation = XCTestExpectation(description: "Error Event Mapper Callback called")
+        configuration.rumErrorEventMapper?.map(event: .mockRandom()) { event in
+            XCTAssertNil(event)
+            errorEventExpectation.fulfill()
+        }
+
+        let resourceEventExpectation = XCTestExpectation(description: "Resource Event Mapper Callback called")
+        configuration.rumResourceEventMapper?.map(event: .mockRandom()) { event in
+            XCTAssertNil(event)
+            resourceEventExpectation.fulfill()
+        }
+
+        let actionEventExpectation = XCTestExpectation(description: "Action Event Mapper Callback called")
+        configuration.rumActionEventMapper?.map(event: .mockRandom()) { event in
+            XCTAssertNil(event)
+            actionEventExpectation.fulfill()
+        }
+
+        let longTaskEventExpectation = XCTestExpectation(description: "Long Task Event Mapper Callback called")
+        configuration.rumLongTaskEventMapper?.map(event: .mockRandom()) { event in
+            XCTAssertNil(event)
+            longTaskEventExpectation.fulfill()
+        }
+
+        wait(for: [
+            errorEventExpectation,
+            resourceEventExpectation,
+            actionEventExpectation,
+            longTaskEventExpectation
+        ], timeout: 0.1)
     }
 
     func testDataEncryption() throws {

--- a/session-replay/Tests/DatadogSessionReplayTests/Recorder/Utilties/CGRect+ContentFrameTests.swift
+++ b/session-replay/Tests/DatadogSessionReplayTests/Recorder/Utilties/CGRect+ContentFrameTests.swift
@@ -56,12 +56,12 @@ class CGRectContentFrameTests: XCTestCase {
         let contentSize = CGSize(width: 21, height: 19.5)
         XCTAssertRectsEqual(
             frame.contentFrame(for: contentSize, using: .scaleAspectFit),
-            CGRect(x: 10.0, y: 13.57142857142857, width: 100.0, height: 92.85714285714286),
+            CGRect(x: 10.0, y: 13.571_428_571_428_57, width: 100.0, height: 92.857_142_857_142_86),
             accuracy: accuracy
         )
         XCTAssertRectsEqual(
             frame.contentFrame(for: contentSize, using: .scaleAspectFill),
-            CGRect(x: 6.153846153846146, y: 9.999999999999993, width: 107.69230769230771, height: 100.00000000000001),
+            CGRect(x: 6.153_846_153_846_146, y: 9.999_999_999_999_993, width: 107.692_307_692_307_71, height: 100.000_000_000_000_01),
             accuracy: accuracy
         )
         XCTAssertRectsEqual(


### PR DESCRIPTION
### What and why?

This introduces async event mappers into RUM, similar to those made for the Logging API. 

This allows platforms that require async calls (such as Flutter) to support writing mappers in their native languages.

### How?

Each RUM event has a separate protocol for mapping (RUMXEventMapper) which is public, only so it can be accessed / overridden by our Cross Platform clients.  The Sync versions (SyncRUMXEventMapper) are internal, and are created by the existing public methods for creating RUM event mappers.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
