### PR TITLE
RUMM-2821 [V2] Fix SDK core instance leaks, retain cycles and TSAN issues

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -466,6 +466,8 @@
 		61F9CA92251266F7000A5E61 /* RUMNavigationControllerScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA86251266CB000A5E61 /* RUMNavigationControllerScenarioTests.swift */; };
 		61F9CA9F2513978D000A5E61 /* RUMSessionMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA982513977A000A5E61 /* RUMSessionMatcher.swift */; };
 		61F9CABA2513A7F5000A5E61 /* RUMSessionMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F9CA982513977A000A5E61 /* RUMSessionMatcher.swift */; };
+		61FAA16C296F43F500116131 /* DatadogFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FAA16B296F43F500116131 /* DatadogFeatureMocks.swift */; };
+		61FAA16D296F43F500116131 /* DatadogFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FAA16B296F43F500116131 /* DatadogFeatureMocks.swift */; };
 		61FB222D244A21ED00902D19 /* LoggingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */; };
 		61FB2230244E1BE900902D19 /* LoggingFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */; };
 		61FC5F3525CC1898006BB4DE /* CrashContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */; };
@@ -989,7 +991,6 @@
 		D2CB6F4727C520D400A62B57 /* SpanEventBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BD12450F65B00F2C652 /* SpanEventBuilderTests.swift */; };
 		D2CB6F4827C520D400A62B57 /* CrashReportingFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F2723E25C86DA400D54BF8 /* CrashReportingFeatureMocks.swift */; };
 		D2CB6F4927C520D400A62B57 /* CrashLogReceiverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FF416125EE5FF400CE35EC /* CrashLogReceiverTests.swift */; };
-		D2CB6F4B27C520D400A62B57 /* DeleteAllDataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EF788F257E289A00EDCCB3 /* DeleteAllDataMigratorTests.swift */; };
 		D2CB6F4C27C520D400A62B57 /* TracingUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E45BCE2450A6EC00F2C652 /* TracingUUIDTests.swift */; };
 		D2CB6F4D27C520D400A62B57 /* DataUploadStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DA20EF26C40121004AFE6D /* DataUploadStatusTests.swift */; };
 		D2CB6F4F27C520D400A62B57 /* RetryingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6139CD762589FEE3007E8BB7 /* RetryingTests.swift */; };
@@ -1768,6 +1769,7 @@
 		61F9CA7F25125C01000A5E61 /* RUMNCSScreen3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMNCSScreen3ViewController.swift; sourceTree = "<group>"; };
 		61F9CA86251266CB000A5E61 /* RUMNavigationControllerScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMNavigationControllerScenarioTests.swift; sourceTree = "<group>"; };
 		61F9CA982513977A000A5E61 /* RUMSessionMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMSessionMatcher.swift; sourceTree = "<group>"; };
+		61FAA16B296F43F500116131 /* DatadogFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222C244A21ED00902D19 /* LoggingFeatureMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureMocks.swift; sourceTree = "<group>"; };
 		61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingFeatureTests.swift; sourceTree = "<group>"; };
 		61FC5F3425CC1898006BB4DE /* CrashContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashContextProviderTests.swift; sourceTree = "<group>"; };
@@ -4294,6 +4296,7 @@
 				D2553806288AA84F00727FAD /* UploadMock.swift */,
 				D21C26D628A647DB005DD405 /* MessageBusMock.swift */,
 				D234612D28B76C1100055D4C /* FeatureMessageAttributesMock.swift */,
+				61FAA16B296F43F500116131 /* DatadogFeatureMocks.swift */,
 			);
 			path = DatadogInternal;
 			sourceTree = "<group>";
@@ -5733,6 +5736,7 @@
 				6141CE672806B41C00EBB879 /* RUMViewUpdatesThrottlerTests.swift in Sources */,
 				61F3CDAB25121FB500C816E5 /* UIViewControllerSwizzlerTests.swift in Sources */,
 				A728ADA32934DB5000397996 /* W3CHTTPHeadersWriterTests.swift in Sources */,
+				61FAA16C296F43F500116131 /* DatadogFeatureMocks.swift in Sources */,
 				9E989A4225F640D100235FC3 /* AppStateListenerTests.swift in Sources */,
 				D2FB1257292E0F0E005B13F8 /* TrackingConsentPublisherTests.swift in Sources */,
 				D2EFA871286DFF7900F1FAA6 /* DatadogContextMock.swift in Sources */,
@@ -6244,6 +6248,7 @@
 				A79B0F62292BB071008742B3 /* OTelHTTPHeadersReaderTests.swift in Sources */,
 				D2A1EE3C287EECC200D28DFB /* CarrierInfoPublisherTests.swift in Sources */,
 				D2CBC265294217AD00134409 /* AnyCodableTests.swift in Sources */,
+				61FAA16D296F43F500116131 /* DatadogFeatureMocks.swift in Sources */,
 				D2CB6EDD27C520D400A62B57 /* UIApplicationSwizzlerTests.swift in Sources */,
 				D2CB6EDE27C520D400A62B57 /* RUMEventMatcher.swift in Sources */,
 				D2CB6EDF27C520D400A62B57 /* RUMSessionScopeTests.swift in Sources */,

--- a/Sources/Datadog/CrashReporting/Integrations/CrashReportSender.swift
+++ b/Sources/Datadog/CrashReporting/Integrations/CrashReportSender.swift
@@ -32,7 +32,10 @@ internal struct MessageBusSender: CrashReportSender {
     }
 
     /// The core for sending crash report and context.
-    let core: DatadogCoreProtocol
+    ///
+    /// It must be a weak reference to avoid retain cycle (the `CrashReportSender` is held by crash reporting
+    /// integration kept by core).
+    weak var core: DatadogCoreProtocol?
 
     /// Send the crash report et context on the bus of the core.
     ///
@@ -53,14 +56,14 @@ internal struct MessageBusSender: CrashReportSender {
     }
 
     private func sendRUM(baggage: FeatureBaggage) {
-        core.send(
+        core?.send(
             message: .custom(key: MessageKeys.crash, baggage: baggage),
             else: { self.sendLog(baggage: baggage) }
         )
     }
 
     private func sendLog(baggage: FeatureBaggage) {
-        core.send(
+        core?.send(
             message: .custom(key: MessageKeys.crashLog, baggage: baggage),
             else: printError
         )

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -323,7 +323,6 @@ public class Datadog {
         // Reset Globals:
         Global.sharedTracer = DDNoopGlobals.tracer
         Global.rum = DDNoopRUMMonitor()
-        defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self)?.deinitialize()
         DD.telemetry = NOPTelemetry()
 
         // Deinitialize `Datadog`:

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -247,9 +247,13 @@ internal final class DatadogCore {
         feature(RUMInstrumentation.self)?.deinitialize()
         feature(URLSessionAutoInstrumentation.self)?.deinitialize()
 
+        // Deinitialize V2 Integrations (arbitrarily for now, until we make it into `DatadogFeatureIntegration`):
+        integration(named: "crash-reporter", type: CrashReporter.self)?.deinitialize()
+
         // Deallocate all Features and their storage & upload units:
         v1Features = [:]
         v2Features = [:]
+        integrations = [:]
     }
 }
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -216,7 +216,9 @@ internal final class DatadogCore {
         // follow our design choices around SDK core's threading.
 
         // The flushing is repeated few times, to make sure that operations spawned from other operations
-        // on these queues are also awaited.
+        // on these queues are also awaited. Effectively, this is no different than short-time sleep() on current
+        // thread and it has the same drawbacks (including: it might become flaky). Until we find a better solution
+        // this is enough to get consistency in tests - but won't be reliable in any public "deinitialize" API.
         for _ in 0..<5 {
             // First, flush bus queue - because messages can lead to obtaining "event write context" (reading
             // context & performing write) in other Features:

--- a/Sources/Datadog/RUM/RUMTelemetry.swift
+++ b/Sources/Datadog/RUM/RUMTelemetry.swift
@@ -20,7 +20,10 @@ internal final class RUMTelemetry: Telemetry {
     /// Maximium number of telemetry events allowed per user sessions.
     static let maxEventsPerSessions: Int = 100
 
-    let core: DatadogCoreProtocol
+    /// The core for sending telemetry to.
+    /// It must be a weak reference, because `RUMTelemetry` is a global object.
+    private weak var core: DatadogCoreProtocol?
+
     let dateProvider: DateProvider
     var configurationEventMapper: RUMTelemetryConfiguratoinMapper?
     let delayedDispatcher: RUMTelemetryDelayedDispatcher
@@ -186,7 +189,7 @@ internal final class RUMTelemetry: Telemetry {
 
     private func record(event id: String, operation: @escaping (DatadogContext, Writer) -> Void) {
         guard
-            let rum = core.v1.scope(for: RUMFeature.self),
+            let rum = core?.v1.scope(for: RUMFeature.self),
             sampler.sample()
         else {
             return

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -117,7 +117,7 @@ public class Tracer: OTTracer {
             spanEventMapper: tracingFeature.configuration.spanEventMapper,
             tracingUUIDGenerator: tracingFeature.configuration.uuidGenerator,
             dateProvider: tracingFeature.configuration.dateProvider,
-            rumIntegration: tracerConfiguration.bundleWithRUM ? TracingWithRUMIntegration() : nil,
+            rumIntegration: tracerConfiguration.bundleWithRUM ? (tracingFeature.messageReceiver as? TracingMessageReceiver)?.rum : nil,
             loggingIntegration: TracingWithLoggingIntegration(
                 core: core,
                 tracerConfiguration: tracerConfiguration

--- a/Sources/Datadog/Tracing/TracingV2Configuration.swift
+++ b/Sources/Datadog/Tracing/TracingV2Configuration.swift
@@ -51,6 +51,9 @@ internal struct TracingRequestBuilder: FeatureRequestBuilder {
 }
 
 internal struct TracingMessageReceiver: FeatureMessageReceiver {
+    /// Tracks RUM context to be associated with spans.
+    let rum = TracingWithRUMIntegration()
+
     /// Process messages receives from the bus.
     ///
     /// - Parameters:
@@ -69,14 +72,7 @@ internal struct TracingMessageReceiver: FeatureMessageReceiver {
     ///
     /// - Parameter context: The updated core context.
     private func update(context: DatadogContext) -> Bool {
-        guard
-            let tracer = Global.sharedTracer as? Tracer,
-            let integration = tracer.rumIntegration
-        else {
-            return false
-        }
-
-        integration.attribues = context.featuresAttributes["rum"]?.all()
+        rum.attribues = context.featuresAttributes["rum"]?.all()
         return true
     }
 }

--- a/Sources/Datadog/Tracing/Utils/ActiveSpansPool.swift
+++ b/Sources/Datadog/Tracing/Utils/ActiveSpansPool.swift
@@ -56,4 +56,12 @@ internal class ActiveSpansPool {
         contextMap[activityReference.activityId] = nil
         rlock.unlock()
     }
+
+#if DD_SDK_COMPILED_FOR_TESTING
+    func destroy() {
+        rlock.lock()
+        contextMap = [:]
+        rlock.unlock()
+    }
+#endif
 }

--- a/Sources/Datadog/Tracing/Utils/ActiveSpansPool.swift
+++ b/Sources/Datadog/Tracing/Utils/ActiveSpansPool.swift
@@ -58,6 +58,11 @@ internal class ActiveSpansPool {
     }
 
 #if DD_SDK_COMPILED_FOR_TESTING
+    /// This explicit way of destroying `ActiveSpansPool` was added after noticing RUMM-2904. It is there to keep test coverage
+    /// for a scenario of incorret use of `span.setActive()` API. Until RUMM-2904 is fixed, `destroy()` is necessary to not
+    /// leak the `core` object memory in tests. It should be removed after fixing the problem.
+    ///
+    /// TODO: RUMM-2904 Calling `span.setActive()` multiple times introduces retain cycle and leaks `DatadogCore` object
     func destroy() {
         rlock.lock()
         contextMap = [:]

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -29,16 +29,18 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
     }
 
     var instrumentation: URLSessionAutoInstrumentation? {
-        core().v1.feature(URLSessionAutoInstrumentation.self)
+        core?.v1.feature(URLSessionAutoInstrumentation.self)
     }
 
     let firstPartyHosts: FirstPartyHosts
 
-    private let core: () -> DatadogCoreProtocol
+    /// The instance of the SDK core notified by this delegate.
+    /// It must be a weak reference, because `URLSessionDelegate` can last longer than this instance.
+    private weak var core: DatadogCoreProtocol?
 
     @objc
     override public init() {
-        core = { defaultDatadogCore }
+        core = defaultDatadogCore
         firstPartyHosts = .init()
         super.init()
     }
@@ -77,7 +79,7 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
     ///   - additionalFirstPartyHosts: additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
     ///                                passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
     public init(
-        in core: @autoclosure @escaping () -> DatadogCoreProtocol,
+        in core: DatadogCoreProtocol,
         additionalFirstPartyHostsWithHeaderTypes: [String: Set<TracingHeaderType>]
     ) {
         self.core = core

--- a/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
+++ b/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift
@@ -29,24 +29,22 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
     }
 
     var instrumentation: URLSessionAutoInstrumentation? {
-        core?.v1.feature(URLSessionAutoInstrumentation.self)
+        let core = self.core ?? defaultDatadogCore
+        return core.v1.feature(URLSessionAutoInstrumentation.self)
     }
 
     let firstPartyHosts: FirstPartyHosts
 
     /// The instance of the SDK core notified by this delegate.
-    /// It must be a weak reference, because `URLSessionDelegate` can last longer than this instance.
+    /// It must be a weak reference, because `URLSessionDelegate` can last longer than core instance.
+    /// Any `URLSession` will retain its delegate until `.invalidateAndCancel()` is called.
     private weak var core: DatadogCoreProtocol?
 
     @objc
     override public init() {
-        core = defaultDatadogCore
+        core = nil
         firstPartyHosts = .init()
         super.init()
-    }
-
-    public convenience init(in core: DatadogCoreProtocol) {
-        self.init(in: core, additionalFirstPartyHostsWithHeaderTypes: [:])
     }
 
     /// Automatically tracked hosts can be customized per instance with this initializer.
@@ -56,7 +54,10 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
     /// - Parameter additionalFirstPartyHostsWithHeaderTypes: these hosts are tracked **in addition to** what was
     /// passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHostsWithHeaderTypes:)`
     public convenience init(additionalFirstPartyHostsWithHeaderTypes: [String: Set<TracingHeaderType>]) {
-        self.init(in: defaultDatadogCore, additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHostsWithHeaderTypes)
+        self.init(
+            in: nil,
+            additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHostsWithHeaderTypes
+        )
     }
 
     /// Automatically tracked hosts can be customized per instance with this initializer.
@@ -67,20 +68,25 @@ open class DDURLSessionDelegate: NSObject, URLSessionTaskDelegate, URLSessionDat
     /// passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
     @objc
     public convenience init(additionalFirstPartyHosts: Set<String>) {
-        self.init(additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHosts.reduce(into: [:], { partialResult, host in
-            partialResult[host] = [.datadog]
-        }))
+        self.init(
+            in: nil,
+            additionalFirstPartyHostsWithHeaderTypes: additionalFirstPartyHosts.reduce(into: [:], { partialResult, host in
+                partialResult[host] = [.datadog]
+            })
+        )
     }
 
     /// Automatically tracked hosts can be customized per instance with this initializer.
     ///
+    /// **NOTE:** If `trackURLSession(firstPartyHostsWithHeaderTypes:)` is never called, automatic tracking will **not** take place.
+    ///
     /// - Parameters:
-    ///   - core: Datadog SDK core.
-    ///   - additionalFirstPartyHosts: additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
+    ///   - core: Datadog SDK instance (or `nil` to use default SDK instance).
+    ///   - additionalFirstPartyHosts: these hosts are tracked **in addition to** what was
     ///                                passed to `DatadogConfiguration.Builder` via `trackURLSession(firstPartyHosts:)`
     public init(
-        in core: DatadogCoreProtocol,
-        additionalFirstPartyHostsWithHeaderTypes: [String: Set<TracingHeaderType>]
+        in core: DatadogCoreProtocol? = nil,
+        additionalFirstPartyHostsWithHeaderTypes: [String: Set<TracingHeaderType>] = [:]
     ) {
         self.core = core
         self.firstPartyHosts = FirstPartyHosts(additionalFirstPartyHostsWithHeaderTypes)

--- a/Tests/DatadogTests/Datadog/DatadogInternal/FeatureMessageReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogInternal/FeatureMessageReceiverTests.swift
@@ -8,7 +8,17 @@ import XCTest
 @testable import Datadog
 
 class FeatureMessageReceiverTests: XCTestCase {
-    let core = PassthroughCoreMock()
+    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = PassthroughCoreMock()
+    }
+
+    override func tearDown() {
+        core = nil
+        super.tearDown()
+    }
 
     struct TestReceiver: FeatureMessageReceiver {
         let expectation: XCTestExpectation?

--- a/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithLoggingIntegrationTests.swift
+++ b/Tests/DatadogTests/Datadog/FeaturesIntegration/TracingWithLoggingIntegrationTests.swift
@@ -8,9 +8,17 @@ import XCTest
 @testable import Datadog
 
 class TracingWithLoggingIntegrationTests: XCTestCase {
-    private let core = PassthroughCoreMock(
-        messageReceiver: LogMessageReceiver.mockAny()
-    )
+    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = PassthroughCoreMock(messageReceiver: LogMessageReceiver.mockAny())
+    }
+
+    override func tearDown() {
+        core = nil
+        super.tearDown()
+    }
 
     func testSendingLogWithOTMessageField() throws {
         core.expectation = expectation(description: "Send log")

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
@@ -25,6 +25,10 @@ import Foundation
 ///     ```
 ///
 internal class DatadogCoreProxy: DatadogCoreProtocol {
+    /// Counts references to `DatadogCoreProxy` instances, so we can prevent memory
+    /// leaks of SDK core in `DatadogTestsObserver`.
+    static var referenceCount = 0
+
     /// The SDK core managed by this proxy.
     private let core: DatadogCore
 
@@ -43,6 +47,11 @@ internal class DatadogCoreProxy: DatadogCoreProtocol {
             contextProvider: .mockWith(context: context),
             applicationVersion: context.version
         )
+        DatadogCoreProxy.referenceCount += 1
+    }
+
+    deinit {
+        DatadogCoreProxy.referenceCount -= 1
     }
 
     var context: DatadogContext {

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogFeatureMocks.swift
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import Datadog
+
+internal struct DatadogFeatureMock: DatadogFeature {
+    static let featureName = "mock"
+
+    var name: String = DatadogFeatureMock.featureName
+    var requestBuilder: FeatureRequestBuilder = FeatureRequestBuilderMock()
+    var messageReceiver: FeatureMessageReceiver = FeatureMessageReceiverMock()
+}

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/PassthroughCoreMock.swift
@@ -15,6 +15,10 @@ import XCTest
 /// it will always provide a `FeatureScope` with the current context and a `writer` that will
 /// store all events in the `events` property.
 internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureScope {
+    /// Counts references to `PassthroughCoreMock` instances, so we can prevent memory
+    /// leaks of SDK core in `DatadogTestsObserver`.
+    static var referenceCount = 0
+
     /// Current context that will be passed to feature-scopes.
     @ReadWriteLock
     var context: DatadogContext {
@@ -54,6 +58,12 @@ internal final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureScope {
         self.messageReceiver = messageReceiver
 
         messageReceiver.receive(message: .context(context), from: self)
+
+        PassthroughCoreMock.referenceCount += 1
+    }
+
+    deinit {
+        PassthroughCoreMock.referenceCount -= 1
     }
 
     /// no-op

--- a/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Debugging/RUMDebuggingTests.swift
@@ -28,8 +28,8 @@ class RUMDebuggingTests: XCTestCase {
         let debugging = RUMDebugging()
         debugging.debug(applicationScope: applicationScope)
 
-        DispatchQueue.main.async { expectation.fulfill() }
-        waitForExpectations(timeout: 1, handler: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
+        waitForExpectations(timeout: 2, handler: nil)
 
         // then
         let canvas = try XCTUnwrap(
@@ -72,8 +72,8 @@ class RUMDebuggingTests: XCTestCase {
         let debugging = RUMDebugging()
         debugging.debug(applicationScope: applicationScope)
 
-        DispatchQueue.main.async { expectation.fulfill() }
-        waitForExpectations(timeout: 1, handler: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
+        waitForExpectations(timeout: 2, handler: nil)
 
         // then
         let canvas = try XCTUnwrap(

--- a/Tests/DatadogTests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -8,7 +8,17 @@ import XCTest
 @testable import Datadog
 
 class CrashReportReceiverTests: XCTestCase {
-    let core = PassthroughCoreMock()
+    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        core = PassthroughCoreMock()
+    }
+
+    override func tearDown() {
+        core = nil
+        super.tearDown()
+    }
 
     func testReceiveCrashEvent() throws {
         // Given

--- a/Tests/DatadogTests/Datadog/RUM/Integrations/WebViewEventReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Integrations/WebViewEventReceiverTests.swift
@@ -8,20 +8,29 @@ import XCTest
 @testable import Datadog
 
 class WebViewEventReceiverTests: XCTestCase {
-    let core = PassthroughCoreMock(
-        context: .mockWith(
-            serverTimeOffset: 123,
-            featuresAttributes: [
-                "rum": [
-                    RUMContextAttributes.applicationID: "123456",
-                    RUMContextAttributes.sessionID: "e9796469-c2a1-43d6-b0f6-65c47d33cf5f"
-                ]
-            ]
-        ),
-        messageReceiver: WebViewEventReceiver.mockAny()
-    )
+    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
+    private let mockCommandSubscriber = RUMCommandSubscriberMock()
 
-    let mockCommandSubscriber = RUMCommandSubscriberMock()
+    override func setUp() {
+        super.setUp()
+        core = PassthroughCoreMock(
+            context: .mockWith(
+                serverTimeOffset: 123,
+                featuresAttributes: [
+                    "rum": [
+                        RUMContextAttributes.applicationID: "123456",
+                        RUMContextAttributes.sessionID: "e9796469-c2a1-43d6-b0f6-65c47d33cf5f"
+                    ]
+                ]
+            ),
+            messageReceiver: WebViewEventReceiver.mockAny()
+        )
+    }
+
+    override func tearDown() {
+        core = nil
+        super.tearDown()
+    }
 
     func testReceiveEvent() throws {
         // Given

--- a/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Autoinstrumentation/URLSessionTracingHandlerTests.swift
@@ -8,9 +8,7 @@ import XCTest
 @testable import Datadog
 
 class URLSessionTracingHandlerTests: XCTestCase {
-    private let core = PassthroughCoreMock(
-        messageReceiver: LogMessageReceiver.mockAny()
-    )
+    private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional
 
     private let handler = URLSessionTracingHandler(
         appStateListener: AppStateListenerMock(
@@ -23,12 +21,14 @@ class URLSessionTracingHandlerTests: XCTestCase {
     )
 
     override func setUp() {
-        Global.sharedTracer = Tracer.mockWith(core: core)
         super.setUp()
+        core = PassthroughCoreMock(messageReceiver: LogMessageReceiver.mockAny())
+        Global.sharedTracer = Tracer.mockWith(core: core)
     }
 
     override func tearDown() {
         Global.sharedTracer = DDNoopGlobals.tracer
+        core = nil
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/Tracing/TracingMessageReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingMessageReceiverTests.swift
@@ -9,26 +9,22 @@ import XCTest
 @testable import Datadog
 
 class TracingMessageReceiverTests: XCTestCase {
-    func testReceiveRUMContext() throws {
-        // Given
-        let core = PassthroughCoreMock(
-            messageReceiver: TracingMessageReceiver()
+    func testItReceivesRUMContext() throws {
+        let core = DatadogCoreProxy(
+            context: .mockWith(featuresAttributes: ["rum": ["key": "value1"]])
         )
+        defer { core.flushAndTearDown() }
 
-        let integration = TracingWithRUMIntegration()
-        Global.sharedTracer = Tracer.mockWith(
-            core: core,
-            rumIntegration: integration
-        )
-        defer { Global.sharedTracer = DDNoopTracer() }
+        // Given
+        let receiver = TracingMessageReceiver()
+        try core.register(feature: DatadogFeatureMock(messageReceiver: receiver))
+        XCTAssertNil(receiver.rum.attribues, "RUM context should be nil until it is set by RUM")
 
         // When
-        core.context = .mockWith(featuresAttributes: [
-            "rum": ["key": "value"]
-        ])
+        core.set(feature: "rum", attributes: { ["key": "value2"] })
 
         // Then
-        let value = try XCTUnwrap(integration.attribues?["key"] as? String)
-        XCTAssertEqual(value, "value")
+        core.flush()
+        XCTAssertEqual(receiver.rum.attribues as? [String: String], ["key": "value2"])
     }
 }

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegateTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import Datadog
 
 class DDURLSessionDelegateTests: XCTestCase {
-    let core = DatadogCoreProxy()
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
     private let interceptor = URLSessionInterceptorMock()
 
     override func setUpWithError() throws {
@@ -19,11 +19,14 @@ class DDURLSessionDelegateTests: XCTestCase {
         )
 
         instrumentation.enable() // swizzle `URLSession`
+
+        core = DatadogCoreProxy()
         core.register(feature: instrumentation)
     }
 
     override func tearDown() {
         core.flushAndTearDown()
+        core = nil
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
+++ b/Tests/DatadogTests/Datadog/URLSessionAutoInstrumentation/URLSessionSwizzlerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import Datadog
 
 class URLSessionSwizzlerTests: XCTestCase {
-    let core = DatadogCoreProxy()
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
     private let interceptor = URLSessionInterceptorMock()
 
     override func setUpWithError() throws {
@@ -19,11 +19,14 @@ class URLSessionSwizzlerTests: XCTestCase {
         )
 
         instrumentation.enable() // swizzle `URLSession`
+
+        core = DatadogCoreProxy()
         core.register(feature: instrumentation)
     }
 
     override func tearDown() {
         core.flushAndTearDown()
+        core = nil
         super.tearDown()
     }
 

--- a/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
+++ b/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift
@@ -133,6 +133,35 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
             temporaryFeatureDirectories.delete()
             ```
             """
+        ),
+        .init(
+            assert: { DatadogCoreProxy.referenceCount == 0 },
+            problem: "Leaking reference to `DatadogCoreProtocol`",
+            solution: """
+            There should be no remaining reference to `DatadogCoreProtocol` upon each test completion
+            but some instances of `DatadogCoreProxy` are still alive.
+
+            Make sure the instance of `DatadogCoreProxy` is properly managed in test:
+            - it must be allocated on each test start (e.g. in `setUp()` or directly in test)
+            - it must be flushed and deinitialized before test ends with `.flushAndTearDown()`
+            - it must be deallocated before test ends (e.g. in `tearDown()`)
+
+            If all above conditions are met, this failure might indicate a memory leak in the implementation.
+            """
+        ),
+        .init(
+            assert: { PassthroughCoreMock.referenceCount == 0 },
+            problem: "Leaking reference to `DatadogCoreProtocol`",
+            solution: """
+            There should be no remaining reference to `DatadogCoreProtocol` upon each test completion
+            but some instances of `PassthroughCoreMock` are still alive.
+
+            Make sure the instance of `PassthroughCoreMock` is properly managed in test:
+            - it must be allocated on each test test start (e.g. in `setUp()` or directly in test)
+            - it must be deallocated before test ends (e.g. in `tearDown()`)
+
+            If all above conditions are met, this failure might indicate a memory leak in the implementation.
+            """
         )
     ]
 
@@ -150,7 +179,8 @@ internal class DatadogTestsObserver: NSObject, XCTestObservation {
             🐶✋ `DatadogTests` integrity check failure.
 
             `DatadogTestsObserver` found that `\(testCase.name)` breaks \(failedChecks.count) integrity rule(s) which
-            must be fulfilled before and after each unit test:
+            must be fulfilled before and after each unit test. Find potential root cause analysis below and try running
+            surrounding tests in isolation to pinpoint the issue:
             """
             failedChecks.forEach { check in
                 message += """


### PR DESCRIPTION
### What and why?

📦 While trying to stabilise CI tests in #1111 I found more impact of switching them to run on the actual `DatadogCore` instance instead of basic mock. That revealed real problems in current state of V2 migration.

This PR fixes several problems of leaking `DatadogCore` memory. If not addressed, these problems will pop-up in V2 once multiple stand-alone instances of `core` are allowed for customer use.

These issues do not impact V1 nor recent release, as we only provide single, shared instance of `DatadogCore` through singleton model. Even though current V1 uses vast amount of V2 code, there is no chance through V1 API that any customer will step into these problems.

### How?

#### Added `core` reference counting

I added basic `referenceCount` property to available `DatadogCoreProtocol` mocks:
* `PassthroughCoreMock`
* `DatadogCoreProxy`

The `referenceCount` gets incremented in `init()` and decremented from `deinit {}`.

Then, I updated [DatadogTestsObserver](https://github.com/DataDog/dd-sdk-ios/blob/develop/Tests/DatadogTests/TestsObserver/DatadogTestsObserver.swift) to ensure that `referenceCount` is `0` upon completing each test. That revealed several memory leaks and retain cycles, fixed one by one.

#### Did more intensive `flush()`

Another thing was insufficient `flush()` implementation proposed previously in #1111 - while it works in most cases, when repeating some tests 100-1000 times, it still suffers from not awaiting enough operations. I made `flush()` more greedy for now, until we find a better model (that will be necessary for having public "deinitialize" API).

#### Solved 2 TSAN data races

Last, I had to solve following 2 data races in Tracing <> RUM integration, as it was responsible for occasional TSAN crashes:

<img width="1974" alt="Screenshot 2023-01-11 at 18 35 55" src="https://user-images.githubusercontent.com/2358722/212052721-09291945-8293-410d-ba6f-bf164878ed99.png">

---

I've ran this branch 8 times on CI (also with ITAR disabled). It's green even if Bitrise Checks report it wrong (😞).

<img width="724" alt="Screenshot 2023-01-12 at 12 18 02" src="https://user-images.githubusercontent.com/2358722/212053241-92095624-4214-4b3c-ba8a-b40a58ff8921.png">


### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
