### PR TITLE
RUMM-2819 TLV Lenght Limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
 
+- [BUGFIX] Fix 'Could not allocate memory' after corrupted TLV. See [#1089][] (Thanks [@cltnschlosser][])
+
 # 1.14.0 / 20-12-2022
 
-- [IMPROVEMENT] Add a method for sending error attributes on logs as strings[#1051][].
+- [IMPROVEMENT] Add a method for sending error attributes on logs as strings. See [#1051][].
 - [IMPROVEMENT] Add manual Open Telemetry b3 headers injection. See [#1057][]
 - [IMPROVEMENT] Add automatic Open Telemetry b3 headers injection. See [#1061][]
 - [IMPROVEMENT] Add manual and automatic W3C traceparent header injection. See [#1071][]
@@ -423,6 +425,7 @@
 [#1057]: https://github.com/DataDog/dd-sdk-ios/pull/1057
 [#1061]: https://github.com/DataDog/dd-sdk-ios/pull/1061
 [#1071]: https://github.com/DataDog/dd-sdk-ios/pull/1071
+[#1089]: https://github.com/DataDog/dd-sdk-ios/pull/1089
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu
@@ -449,3 +452,4 @@
 [@sdejesusf]: https://github.com/sdejesusF
 [@avdlee]: https://github.com/AvdLee
 [@dfed]: https://github.com/dfed
+[@cltnschlosser]: https://github.com/cltnschlosser

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -24,6 +24,7 @@ internal final class DatadogCore {
     /// The storage r/w GDC queue.
     let readWriteQueue = DispatchQueue(
         label: "com.datadoghq.ios-sdk-read-write",
+        autoreleaseFrequency: .workItem,
         target: .global(qos: .utility)
     )
 

--- a/Sources/Datadog/DatadogCore/Storage/DataBlock.swift
+++ b/Sources/Datadog/DatadogCore/Storage/DataBlock.swift
@@ -149,8 +149,8 @@ internal final class DataBlockReader {
             return Data()
         }
 
-        // Load from stream to data without unnecessary copies
-        var data = Data(repeating: 0, count: length)
+        // Load from stream directly to data without unnecessary copies
+        var data = Data(count: length)
         let count = try data.withUnsafeMutableBytes { (bytes: UnsafeMutableRawBufferPointer) in
             guard let buffer = bytes.assumingMemoryBound(to: UInt8.self).baseAddress else {
                 throw DataBlockError.dataAllocationFailure
@@ -162,7 +162,7 @@ internal final class DataBlockReader {
             throw DataBlockError.readOperationFailed(streamError: stream.streamError)
         }
 
-        if count == 0, stream.streamStatus == .atEnd {
+        if count == 0 {
             throw DataBlockError.endOfStream
         }
 

--- a/Sources/Datadog/DatadogCore/Storage/Files/File.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Files/File.swift
@@ -30,6 +30,9 @@ internal protocol ReadableFile {
     /// Reads the available data in this file.
     func read() throws -> Data
 
+    /// Creates InputStream for reading the available data from this file.
+    func readStream() throws -> InputStream
+
     /// Deletes this file.
     func delete() throws
 }
@@ -129,6 +132,13 @@ internal struct File: WritableFile, ReadableFile {
         return data
     }
 
+    func readStream() throws -> InputStream {
+        guard let stream = InputStream(url: url) else {
+            throw Errors.unableToCreateInputStream
+        }
+        return stream
+    }
+
     func size() throws -> UInt64 {
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         return attributes[.size] as? UInt64 ?? 0
@@ -137,4 +147,8 @@ internal struct File: WritableFile, ReadableFile {
     func delete() throws {
         try FileManager.default.removeItem(at: url)
     }
+}
+
+private enum Errors: Error {
+    case unableToCreateInputStream
 }

--- a/Sources/Datadog/DatadogCore/Storage/FilesOrchestrator.swift
+++ b/Sources/Datadog/DatadogCore/Storage/FilesOrchestrator.swift
@@ -9,11 +9,12 @@ import Foundation
 /// Orchestrates files in a single directory.
 internal class FilesOrchestrator {
     /// Directory where files are stored.
-    private let directory: Directory
+    let directory: Directory
     /// Date provider.
-    private let dateProvider: DateProvider
+    let dateProvider: DateProvider
     /// Performance rules for writing and reading files.
-    private let performance: StoragePerformancePreset
+    let performance: StoragePerformancePreset
+
     /// Name of the last file returned by `getWritableFile()`.
     private var lastWritableFileName: String? = nil
     /// Tracks number of times the file at `lastWritableFileURL` was returned from `getWritableFile()`.
@@ -33,10 +34,6 @@ internal class FilesOrchestrator {
     // MARK: - `WritableFile` orchestration
 
     func getWritableFile(writeSize: UInt64) throws -> WritableFile {
-        if writeSize > performance.maxObjectSize {
-            throw InternalError(description: "data exceeds the maximum size of \(performance.maxObjectSize) bytes.")
-        }
-
         let lastWritableFileOrNil = reuseLastWritableFileIfPossible(writeSize: writeSize)
 
         if let lastWritableFile = lastWritableFileOrNil { // if last writable file can be reused

--- a/Sources/Datadog/DatadogCore/Storage/Reading/FileReader.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Reading/FileReader.swift
@@ -31,7 +31,7 @@ internal final class FileReader: Reader {
         }
 
         do {
-            let events = try decode(data: file.read())
+            let events = try decode(stream: file.readStream())
             return Batch(events: events, file: file)
         } catch {
             DD.telemetry.error("Failed to read data from file", error: error)
@@ -45,10 +45,10 @@ internal final class FileReader: Reader {
     /// consumed and decrypted if encryption is available. Decrypted events are finally joined with
     /// data-format separator.
     ///
-    /// - Parameter data: The data to decode.
+    /// - Parameter stream: The InputStream that provides data to decode.
     /// - Returns: The decoded and formatted data.
-    private func decode(data: Data) throws -> [Data] {
-        let reader = DataBlockReader(data: data)
+    private func decode(stream: InputStream) throws -> [Data] {
+        let reader = DataBlockReader(input: stream)
 
         var failure: String? = nil
         defer {

--- a/Sources/Datadog/DatadogCore/Storage/Reading/FileReader.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Reading/FileReader.swift
@@ -31,7 +31,7 @@ internal final class FileReader: Reader {
         }
 
         do {
-            let events = try decode(stream: file.readStream())
+            let events = try decode(stream: file.stream())
             return Batch(events: events, file: file)
         } catch {
             DD.telemetry.error("Failed to read data from file", error: error)
@@ -48,7 +48,10 @@ internal final class FileReader: Reader {
     /// - Parameter stream: The InputStream that provides data to decode.
     /// - Returns: The decoded and formatted data.
     private func decode(stream: InputStream) throws -> [Data] {
-        let reader = DataBlockReader(input: stream)
+        let reader = DataBlockReader(
+            input: stream,
+            maxBlockLenght: orchestrator.performance.maxObjectSize
+        )
 
         var failure: String? = nil
         defer {

--- a/Sources/Datadog/DatadogCore/Storage/Writing/FileWriter.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Writing/FileWriter.swift
@@ -55,7 +55,9 @@ internal final class FileWriter: Writer {
         return try DataBlock(
             type: .event,
             data: encrypt(data: data)
-        ).serialize()
+        ).serialize(
+            maxLenght: orchestrator.performance.maxObjectSize
+        )
     }
 
     /// Encrypts data if encryption is available.

--- a/Sources/Datadog/DatadogCore/Upload/FeatureUpload.swift
+++ b/Sources/Datadog/DatadogCore/Upload/FeatureUpload.swift
@@ -20,6 +20,7 @@ internal struct FeatureUpload {
     ) {
         let uploadQueue = DispatchQueue(
             label: "com.datadoghq.ios-sdk-\(featureName)-upload",
+            autoreleaseFrequency: .workItem,
             target: .global(qos: .utility)
         )
 

--- a/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
@@ -96,25 +96,48 @@ class DataBlockTests: XCTestCase {
         XCTAssertEqual(block?.data, Data([0xFF, 0xFF]))
     }
 
-    func testDataBlockReader_readsLargeBytesBlock() throws {
-        let data = Data([0x00, 0x00, 0x80, 0x96, 0x98, 0x00]) + Data.mockRepeating(byte: 0xFF, times: 10_000_000) // 10MB
-        let reader = DataBlockReader(data: data)
+    func testDataBlockReader_readsBytesUnderLengthLimit() throws {
+        let data = Data([0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0xFF, 0xFF])
+        let reader = DataBlockReader(data: data, maxBlockLenght: 2)
 
         let block = try reader.next()
         XCTAssertEqual(block?.type, .event)
         XCTAssertEqual(block?.data.first, 0xFF)
-        XCTAssertEqual(block?.data.count, 10_000_000)
+        XCTAssertEqual(block?.data.count, 2)
     }
 
-    func testDataBlockReader_skipsVeryLargeBytesBlock() throws {
-        let data = Data([0x00, 0x00, 0x00, 0x2D, 0x31, 0x01]) + Data.mockRepeating(byte: 0xFF, times: 20_000_000) // 20MB
-        let reader = DataBlockReader(data: data)
+    func testDataBlockReader_skipsExceedingBytesLengthLimit() throws {
+        let data = Data([0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0xFF, 0xFF])
+        let reader = DataBlockReader(data: data, maxBlockLenght: 1)
 
         do {
             _ = try reader.next()
             XCTFail("Expected error to be thrown")
-        } catch DataBlockError.dataLengthExceedsLimit {
+        } catch DataBlockError.bytesLengthExceedsLimit(let limit) where limit == 1 {
             // Expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testDataBlockReader_whenIOErrorHappens_itThrowsWhenReading() throws {
+        temporaryDirectory.create()
+        defer { temporaryDirectory.delete() }
+
+        let file = try temporaryDirectory.createFile(named: "file")
+        try file.delete()
+
+        let stream = try file.stream()
+        let reader = DataBlockReader(input: stream)
+
+        do {
+            _ = try reader.next()
+            XCTFail("Expected error to be thrown")
+        } catch DataBlockError.readOperationFailed(let error) {
+            XCTAssertEqual(
+                (error as? NSError)?.localizedDescription,
+                "The operation couldn’t be completed. No such file or directory"
+            )
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
@@ -105,4 +105,18 @@ class DataBlockTests: XCTestCase {
         XCTAssertEqual(block?.data.first, 0xFF)
         XCTAssertEqual(block?.data.count, 10_000_000)
     }
+
+    func testDataBlockReader_skipsVeryLargeBytesBlock() throws {
+        let data = Data([0x00, 0x00, 0x00, 0x2D, 0x31, 0x01]) + Data.mockRepeating(byte: 0xFF, times: 20_000_000) // 20MB
+        let reader = DataBlockReader(data: data)
+
+        do {
+            _ = try reader.next()
+            XCTFail("Expected error to be thrown")
+        } catch DataBlockError.dataLengthExceedsLimit {
+            // Expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Files/FileTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Files/FileTests.swift
@@ -47,9 +47,17 @@ class FileTests: XCTestCase {
 
     func testItReadsDataFromFile() throws {
         let file = try temporaryDirectory.createFile(named: "file")
-        try file.append(data: "Hello 👋".utf8Data)
+        let data = "Hello 👋".utf8Data
+        try file.append(data: data)
 
-        XCTAssertEqual(try file.read().utf8String, "Hello 👋")
+        let stream = try file.stream()
+        stream.open()
+        defer { stream.close() }
+
+        var bytes = [UInt8](repeating: 0, count: data.count)
+        XCTAssertEqual(stream.read(&bytes, maxLength: data.count), data.count)
+
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Hello 👋")
     }
 
     func testItDeletesFile() throws {
@@ -76,16 +84,6 @@ class FileTests: XCTestCase {
         try file.delete()
 
         XCTAssertThrowsError(try file.append(data: .mock(ofSize: 5))) { error in
-            XCTAssertEqual((error as NSError).localizedDescription, "The file “file” doesn’t exist.")
-        }
-    }
-
-    func testWhenIOExceptionHappens_itThrowsWhenReading() throws {
-        let file = try temporaryDirectory.createFile(named: "file")
-        try file.append(data: .mock(ofSize: 5))
-        try file.delete()
-
-        XCTAssertThrowsError(try file.read()) { error in
             XCTAssertEqual((error as NSError).localizedDescription, "The file “file” doesn’t exist.")
         }
     }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -32,9 +32,9 @@ class FileWriterTests: XCTestCase {
         writer.write(value: ["key3": "value3"])
 
         XCTAssertEqual(try temporaryDirectory.files().count, 1)
-        let data = try temporaryDirectory.files()[0].read()
+        let stream = try temporaryDirectory.files()[0].stream()
 
-        let reader = DataBlockReader(data: data)
+        let reader = DataBlockReader(input: stream)
         var block = try reader.next()
         XCTAssertEqual(block?.type, .event)
         XCTAssertEqual(block?.data, #"{"key1":"value1"}"#.utf8Data)
@@ -69,18 +69,18 @@ class FileWriterTests: XCTestCase {
         writer.write(value: ["key1": "value1"]) // will be written
 
         XCTAssertEqual(try temporaryDirectory.files().count, 1)
-        var reader = try DataBlockReader(data: temporaryDirectory.files()[0].read())
+        var reader = try DataBlockReader(input: temporaryDirectory.files()[0].stream())
         var blocks = try XCTUnwrap(reader.all())
         XCTAssertEqual(blocks.count, 1)
         XCTAssertEqual(blocks[0].data, #"{"key1":"value1"}"#.utf8Data)
 
         writer.write(value: ["key2": "value3 that makes it exceed 23 bytes"]) // will be dropped
 
-        reader = try DataBlockReader(data: temporaryDirectory.files()[0].read())
+        reader = try DataBlockReader(input: temporaryDirectory.files()[0].stream())
         blocks = try XCTUnwrap(reader.all())
         XCTAssertEqual(blocks.count, 1) // same content as before
         XCTAssertEqual(dd.logger.errorLog?.message, "Failed to write data")
-        XCTAssertEqual(dd.logger.errorLog?.error?.message, "data exceeds the maximum size of 23 bytes.")
+        XCTAssertEqual(dd.logger.errorLog?.error?.message, "bytesLengthExceedsLimit(limit: 23)")
     }
 
     func testGivenErrorVerbosity_whenDataCannotBeEncoded_itPrintsError() throws {
@@ -161,8 +161,8 @@ class FileWriterTests: XCTestCase {
 
         XCTAssertEqual(try temporaryDirectory.files().count, 1)
 
-        let data = try temporaryDirectory.files()[0].read()
-        let blocks = try DataBlockReader(data: data).all()
+        let stream = try temporaryDirectory.files()[0].stream()
+        let blocks = try DataBlockReader(input: stream).all()
 
         // Assert that data written is not malformed
         let jsonDecoder = JSONDecoder()
@@ -193,9 +193,9 @@ class FileWriterTests: XCTestCase {
 
         // Then
         XCTAssertEqual(try temporaryDirectory.files().count, 1)
-        let data = try temporaryDirectory.files()[0].read()
+        let stream = try temporaryDirectory.files()[0].stream()
 
-        let reader = DataBlockReader(data: data)
+        let reader = DataBlockReader(input: stream)
         var block = try reader.next()
         XCTAssertEqual(block?.type, .event)
         XCTAssertEqual(block?.data, "foo".utf8Data)

--- a/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/LogOutputs/LogFileOutputTests.swift
@@ -42,8 +42,8 @@ class LogFileOutputTests: XCTestCase {
         output.write(log: log2)
 
         let log1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())
-        let log1FileData = try temporaryDirectory.file(named: log1FileName).read()
-        var reader = DataBlockReader(data: log1FileData)
+        let log1FileStream = try temporaryDirectory.file(named: log1FileName).stream()
+        var reader = DataBlockReader(input: log1FileStream)
         let logBlock1 = try XCTUnwrap(reader.next())
         XCTAssertEqual(logBlock1.type, .event)
 
@@ -52,8 +52,8 @@ class LogFileOutputTests: XCTestCase {
         log1Matcher.assertMessage(equals: "log message 1")
 
         let log2FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
-        let log2FileData = try temporaryDirectory.file(named: log2FileName).read()
-        reader = DataBlockReader(data: log2FileData)
+        let log2FileStream = try temporaryDirectory.file(named: log2FileName).stream()
+        reader = DataBlockReader(input: log2FileStream)
         let logBlock2 = try XCTUnwrap(reader.next())
         XCTAssertEqual(logBlock2.type, .event)
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMEventOutputs/RUMEventFileOutputTests.swift
@@ -44,8 +44,8 @@ class RUMEventFileOutputTests: XCTestCase {
         writer.write(value: event2)
 
         let event1FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC())
-        let event1FileData = try temporaryDirectory.file(named: event1FileName).read()
-        var reader = DataBlockReader(data: event1FileData)
+        let event1FileStream = try temporaryDirectory.file(named: event1FileName).stream()
+        var reader = DataBlockReader(input: event1FileStream)
         let eventBlock1 = try XCTUnwrap(reader.next())
         XCTAssertEqual(eventBlock1.type, .event)
 
@@ -55,8 +55,8 @@ class RUMEventFileOutputTests: XCTestCase {
         XCTAssertEqual(try event1Matcher.model(), expectedDatamodel1)
 
         let event2FileName = fileNameFrom(fileCreationDate: .mockDecember15th2019At10AMUTC(addingTimeInterval: 1))
-        let event2FileData = try temporaryDirectory.file(named: event2FileName).read()
-        reader = DataBlockReader(data: event2FileData)
+        let event2FileStream = try temporaryDirectory.file(named: event2FileName).stream()
+        reader = DataBlockReader(input: event2FileStream)
         let eventBlock2 = try XCTUnwrap(reader.next())
         XCTAssertEqual(eventBlock2.type, .event)
 


### PR DESCRIPTION
### What and why?

Follow up of #1089

Inject object size limit to TLV to protect from 'Could not allocate memory` crash when a TLV gets corrupted.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
