### PR TITLE
RUMM-2516 Remove React Native duplicate crashes

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -400,7 +400,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         version += 1
         attributes.merge(rumCommandAttributes: command.attributes)
 
-        let isCrash = (command as? RUMAddCurrentViewErrorCommand)?.isCrash != nil
+        let isCrash = (command as? RUMAddCurrentViewErrorCommand).map { $0.isCrash ?? false } ?? false
         // RUMM-1779 Keep view active as long as we have ongoing resources
         let isActive = isActiveView || !resourceScopes.isEmpty
         // RUMM-2079 `time_spent` can't be lower than 1ns

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -400,6 +400,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         version += 1
         attributes.merge(rumCommandAttributes: command.attributes)
 
+        let isCrash = (command as? RUMAddCurrentViewErrorCommand)?.isCrash != nil
         // RUMM-1779 Keep view active as long as we have ongoing resources
         let isActive = isActiveView || !resourceScopes.isEmpty
         // RUMM-2079 `time_spent` can't be lower than 1ns
@@ -437,7 +438,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 action: .init(count: actionsCount.toInt64),
                 cpuTicksCount: cpuInfo?.greatestDiff,
                 cpuTicksPerSecond: cpuInfo?.greatestDiff?.divideIfNotZero(by: Double(timeSpent)),
-                crash: .init(count: 0),
+                crash: isCrash ? .init(count: 1) : .init(count: 0),
                 cumulativeLayoutShift: nil,
                 customTimings: customTimings.reduce(into: [:]) { acc, element in
                     acc[sanitizeCustomTimingName(customTiming: element.key)] = element.value

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMViewUpdatesThrottler.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMViewUpdatesThrottler.swift
@@ -43,7 +43,7 @@ internal final class RUMViewUpdatesThrottler: RUMViewUpdatesThrottlerType {
 
         sample = sample || event.view.isActive == false // always accept the last event in a view
 
-        sample = sample || event.view.crash?.count ?? 0 > 0 // always accept events if the view has crashed
+        sample = sample || event.view.crash.map { $0.count > 0 } ?? false
 
         if sample {
             lastSampledTimeSpentInNs = event.view.timeSpent

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMViewUpdatesThrottler.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMViewUpdatesThrottler.swift
@@ -43,6 +43,8 @@ internal final class RUMViewUpdatesThrottler: RUMViewUpdatesThrottlerType {
 
         sample = sample || event.view.isActive == false // always accept the last event in a view
 
+        sample = sample || event.view.crash?.count ?? 0 > 0 // always accept events if the view has crashed
+
         if sample {
             lastSampledTimeSpentInNs = event.view.timeSpent
         }

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -110,7 +110,8 @@ extension RUMViewEvent: RandomMockable {
     /// Produces random `RUMViewEvent` with setting given fields to certain values.
     static func mockRandomWith(
         viewIsActive: Bool? = .random(),
-        viewTimeSpent: Int64 = .mockRandom()
+        viewTimeSpent: Int64 = .mockRandom(),
+        crashCount: Int64 = .mockRandom()
     ) -> RUMViewEvent {
         return RUMViewEvent(
             dd: .init(
@@ -140,7 +141,7 @@ extension RUMViewEvent: RandomMockable {
                 action: .init(count: .mockRandom()),
                 cpuTicksCount: .mockRandom(),
                 cpuTicksPerSecond: .mockRandom(),
-                crash: .init(count: .mockRandom()),
+                crash: .init(count: crashCount),
                 cumulativeLayoutShift: .mockRandom(),
                 customTimings: .mockAny(),
                 domComplete: .mockRandom(),

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -1892,4 +1892,50 @@ class RUMViewScopeTests: XCTestCase {
         let rumViewSent = try XCTUnwrap(core.events(ofType: RUMViewEvent.self).last, "It should send view event")
         XCTAssertEqual(viewEvent, rumViewSent, "It must inject sent event to crash context")
     }
+
+    // MARK: Cross-platform crashes
+
+    func testGivenScopeWithViewUpdatesThrottler_whenReceivingCrossPlatformCrash_thenItSendsViewUpdateWithUpdatedCrashCount() throws {
+        let commands: [(Date) -> RUMCommand] = [
+            // receive resource:
+            { date in RUMStartResourceCommand.mockWith(resourceKey: "resource", time: date) }, { date in RUMStopResourceCommand.mockWith(resourceKey: "resource", time: date) },
+            // receive error:
+            { date in RUMAddCurrentViewErrorCommand.mockWithErrorMessage(time: date, attributes: [CrossPlatformAttributes.errorIsCrash: true]) }
+        ]
+        let timeIntervalBetweenCommands = 1.0
+        let simulationDuration = timeIntervalBetweenCommands * Double(commands.count)
+        let samplingDuration = simulationDuration * 0.5 // at least half view updates should be skipped
+
+        // Given
+        let throttler = RUMViewUpdatesThrottler(viewUpdateThreshold: samplingDuration)
+        let sampledWriter = FileWriterMock()
+        let sampledScope: RUMViewScope = .mockWith(
+            parent: parent,
+            dependencies: .mockWith(
+                viewUpdatesThrottlerFactory: { throttler }
+            )
+        )
+
+        // When
+        func send(commands: [(Date) -> RUMCommand], to scope: RUMViewScope, writer: Writer) {
+            var currentTime = scope.viewStartTime
+            commands.forEach { command in
+                currentTime.addTimeInterval(timeIntervalBetweenCommands)
+                _ = scope.process(
+                    command: command(currentTime),
+                    context: context,
+                    writer: writer
+                )
+            }
+        }
+
+        send(commands: commands, to: sampledScope, writer: sampledWriter)
+
+        // Then
+        let viewUpdatesInSampledScope = sampledWriter.events(ofType: RUMViewEvent.self)
+        XCTAssertEqual(viewUpdatesInSampledScope.count, 2, "It should send the first event and the error")
+
+        let actualLastUpdate = try XCTUnwrap(viewUpdatesInSampledScope.last)
+        XCTAssertEqual(actualLastUpdate.view.crash?.count, 1, "It should contain a crash")
+    }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMViewUpdatesThrottlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/Utils/RUMViewUpdatesThrottlerTests.swift
@@ -22,11 +22,13 @@ class RUMViewUpdatesThrottlerTests: XCTestCase {
     func testItRejectsNextEventWhenItArrivesEarlierThanThreshold() {
         let firstEvent: RUMViewEvent = .mockRandomWith(
             viewIsActive: true, // not a final event
-            viewTimeSpent: 0
+            viewTimeSpent: 0,
+            crashCount: 0
         )
         let nextEvent: RUMViewEvent = .mockRandomWith(
             viewIsActive: true, // not a final event
-            viewTimeSpent: randomViewUpdateThreshold.toInt64Nanoseconds - 1
+            viewTimeSpent: randomViewUpdateThreshold.toInt64Nanoseconds - 1,
+            crashCount: 0
         )
 
         XCTAssertTrue(throttler.accept(event: firstEvent), "It should always accepts first event")
@@ -36,11 +38,13 @@ class RUMViewUpdatesThrottlerTests: XCTestCase {
     func testItAcceptsNextEventWhenItArrivesLaterThanThreshold() {
         let firstEvent: RUMViewEvent = .mockRandomWith(
             viewIsActive: true, // not a final event
-            viewTimeSpent: 0
+            viewTimeSpent: 0,
+            crashCount: 0
         )
         let nextEvent: RUMViewEvent = .mockRandomWith(
             viewIsActive: true, // not a final event
-            viewTimeSpent: randomViewUpdateThreshold.toInt64Nanoseconds + 1
+            viewTimeSpent: randomViewUpdateThreshold.toInt64Nanoseconds + 1,
+            crashCount: 0
         )
 
         XCTAssertTrue(throttler.accept(event: firstEvent), "It should always accepts first event")


### PR DESCRIPTION
### What and why?

Better handle cross-platform crashes to make sure:
- the view events are sent after the error
- the native crash, that is a "duplicate" from the js crash, is not sent as we limit the amount of crashes per view to 1.

Result 🎉:
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/8973379/210091019-3f406406-d777-4c5d-bf55-e65fa3a0dcf3.png">

### How?

The event is sent by modifying the `viewEventThrottler` to always accept events when the crash count is 1 - this is my favorite implementation as we keep close to the source of the issue, but I don't know if there will also be side effects if potential events come after that - there should not be so many in any case.

We don't send the duplicate by checking the last view does not contain a crash already.
A nice benefit to this implementation is that if js crash reporting is not enabled but native crash reporting is, we'll get the native crash 👍

### Potential Regression

If a user adds a crash error (can only be done by adding a `_dd.error.is_crash` attribute to the error), but then the app lives on and a distinct native crash happens, the native error won't be reported. Also all events happening in the view after the error won't be recorded.

This could happen if a cross-platform user mistakenly labels an error as a crash, but the application does not actually crash.
On react-native, we could issue a warning to let the user know that now that the app has crashed, it won't be recording any event until a new view is started to prevent this.

It could also be the case if the app uses https://github.com/a7ul/react-native-exception-handler, which will display a screen before restarting the app (useful to let users add more details for instance). 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes -> I think no changelog is needed as it only is a concern for React Native

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
