### PR TITLE
RUMM-2902 [SR] Add `DatadogSDKSessionReplay.podspec`

### DIFF
--- a/DatadogSDKSessionReplay.podspec
+++ b/DatadogSDKSessionReplay.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name         = "DatadogSDKSessionReplay"
+  s.module_name  = "DatadogSessionReplay"
+  s.version      = "1.14.0"
+  s.summary      = "Official Datadog Session Replay SDK for iOS. This module is currently in beta - contact Datadog to request a try."
+  
+  s.homepage     = "https://www.datadoghq.com"
+  s.social_media_url   = "https://twitter.com/datadoghq"
+
+  s.license            = { :type => "Apache", :file => 'LICENSE' }
+  s.authors            = { 
+    "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
+    "Maciej Burda" => "maciej.burda@datadoghq.com",
+    "Maxime Epain" => "maxime.epain@datadoghq.com"
+  }
+
+  s.swift_version      = '5.1'
+  s.ios.deployment_target = '11.0'
+
+  s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
+  
+  s.source_files = ["DatadogSessionReplay/Sources/**/*.swift"]
+  s.dependency 'DatadogSDK', s.version.to_s
+end

--- a/DatadogSDKSessionReplay.podspec.src
+++ b/DatadogSDKSessionReplay.podspec.src
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  s.name         = "DatadogSDKSessionReplay"
+  s.module_name  = "DatadogSessionReplay"
+  s.version      = "__DATADOG_VERSION__"
+  s.summary      = "Official Datadog Session Replay SDK for iOS. This module is currently in beta - contact Datadog to request a try."
+  
+  s.homepage     = "https://www.datadoghq.com"
+  s.social_media_url   = "https://twitter.com/datadoghq"
+
+  s.license            = { :type => "Apache", :file => 'LICENSE' }
+  s.authors            = { 
+    "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
+    "Maciej Burda" => "maciej.burda@datadoghq.com",
+    "Maxime Epain" => "maxime.epain@datadoghq.com"
+  }
+
+  s.swift_version      = '5.1'
+  s.ios.deployment_target = '11.0'
+
+  s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
+  
+  s.source_files = ["DatadogSessionReplay/Sources/**/*.swift"]
+  s.dependency 'DatadogSDK', s.version.to_s
+end

--- a/DatadogSessionReplay/README.md
+++ b/DatadogSessionReplay/README.md
@@ -1,3 +1,3 @@
 # Session Replay
 
-🚧 The Session Replay feature is under construction.
+🚧 The Session Replay feature is currently in beta - contact Datadog to request a try.

--- a/Makefile
+++ b/Makefile
@@ -146,4 +146,5 @@ bump:
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKCrashReporting.podspec.src > DatadogSDKCrashReporting.podspec; \
 		git add . ; \
 		git commit -m "Bumped version to $$version"; \
+		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKSessionReplay.podspec.src > DatadogSDKSessionReplay.podspec; \
 		echo Bumped version to $$version

--- a/dependency-manager-tests/cocoapods/App/ViewController.swift
+++ b/dependency-manager-tests/cocoapods/App/ViewController.swift
@@ -8,10 +8,16 @@ import UIKit
 import Datadog
 import DatadogAlamofireExtension
 import DatadogCrashReporting
+#if os(iOS)
+import DatadogSessionReplay
+#endif
 import Alamofire
 
 internal class ViewController: UIViewController {
     private var logger: Logger! // swiftlint:disable:this implicitly_unwrapped_optional
+    #if os(iOS)
+    private var sessionReplayController: SessionReplayController! // swiftlint:disable:this implicitly_unwrapped_optional
+    #endif
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,6 +47,13 @@ internal class ViewController: UIViewController {
         createInstrumentedAlamofireSession()
 
         addLabel()
+
+        #if os(iOS)
+        sessionReplayController = SessionReplay.initialize(
+            with: SessionReplayConfiguration()
+        )
+        sessionReplayController.start()
+        #endif
     }
 
     private func createInstrumentedAlamofireSession() {

--- a/dependency-manager-tests/cocoapods/Podfile.src
+++ b/dependency-manager-tests/cocoapods/Podfile.src
@@ -7,10 +7,12 @@ abstract_target 'Common' do
   target 'App Dynamic iOS' do
     platform :ios, '13.0'
     use_frameworks!
+    pod 'DatadogSDKSessionReplay', :git => 'GIT_REMOTE', :GIT_REFERENCE
   end
 
   target 'App Static iOS' do
     platform :ios, '13.0'
+    pod 'DatadogSDKSessionReplay', :git => 'GIT_REMOTE', :GIT_REFERENCE
 
     target 'App Static iOS Tests' do
       inherit! :search_paths


### PR DESCRIPTION
### What and why?

📦 This PR adds `DatadogSDKSessionReplay.podspec` so Session Replay can be installed through Cocoapods.

This is to enable early beta of SR. We will be providing this `.podspec` through separate `session-replay-beta` branch, without yet pushing it to `pod trunk` (we want to keep regular SDK releases separate from SR beta updates).

### How?

* added `.podspec`
* updated `dependency-manager-tests/cocoapods` project to run smoke tests for SR installation with Cocoapods

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [x] Run smoke tests
