### PR TITLE
RUMM-2688 Add NTP sync to session replay records

### DIFF
--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
@@ -85,10 +85,10 @@ private extension DatadogContext {
 
 private extension FeatureBaggage {
     var rumContext: RUMContext? {
-        guard let applicationID: String = self[RUMDependency.applicationIDKey],
-              let sessionID: String = self[RUMDependency.sessionIDKey],
-              let viewID: String = self[RUMDependency.viewIDKey],
-              let serverTimeOffset: TimeInterval = self[RUMDependency.serverTimeOffset]
+        guard let applicationID: String = self[RUMDependency.ids, type: [String: String].self]?[RUMDependency.IDs.applicationIDKey],
+              let sessionID: String = self[RUMDependency.ids, type: [String: String].self]?[RUMDependency.IDs.sessionIDKey],
+              let viewID: String = self[RUMDependency.ids, type: [String: String].self]?[RUMDependency.IDs.viewIDKey],
+              let serverTimeOffset: TimeInterval = self[RUMDependency.serverTimeOffsetKey]
         else {
             // Current RUM session is not sampled
             return nil

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
@@ -8,15 +8,31 @@ import Foundation
 import Datadog
 
 /// The RUM context received from `DatadogCore`.
-internal struct RUMContext: Equatable {
-    /// Current RUM application ID - standard UUID string, lowecased.
-    let applicationID: String
-    /// Current RUM session ID - standard UUID string, lowecased.
-    let sessionID: String
-    /// Current RUM view ID - standard UUID string, lowecased.
-    let viewID: String
-    /// Current RUM view server time offset (in seconds).
-    let serverTimeOffset: TimeInterval
+internal struct RUMContext: Decodable, Equatable {
+    internal struct IDs: Decodable, Equatable {
+        enum CodingKeys: String, CodingKey {
+            case applicationID = "application_id"
+            case sessionID = "session_id"
+            case viewID = "view.id"
+        }
+        /// Current RUM application ID - standard UUID string, lowecased.
+        let applicationID: String
+        /// Current RUM session ID - standard UUID string, lowecased.
+        let sessionID: String
+        /// Current RUM view ID - standard UUID string, lowecased.
+        let viewID: String
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case ids = "ids"
+        case viewServerTimeOffset = "server_time_offset"
+    }
+
+    /// Wrapper for all RUM related IDs
+    let ids: IDs
+
+    /// Current view related server time offset
+    let viewServerTimeOffset: TimeInterval?
 }
 
 /// An observer notifying on`RUMContext` changes.
@@ -84,21 +100,12 @@ private extension DatadogContext {
 }
 
 private extension FeatureBaggage {
-    var rumContext: RUMContext? {
-        guard let applicationID: String = self[RUMDependency.ids, type: [String: String].self]?[RUMDependency.IDs.applicationIDKey],
-              let sessionID: String = self[RUMDependency.ids, type: [String: String].self]?[RUMDependency.IDs.sessionIDKey],
-              let viewID: String = self[RUMDependency.ids, type: [String: String].self]?[RUMDependency.IDs.viewIDKey],
-              let serverTimeOffset: TimeInterval = self[RUMDependency.serverTimeOffsetKey]
-        else {
-            // Current RUM session is not sampled
-            return nil
-        }
+    var rumContext: RUMContext? { try? unwrap() }
+}
 
-        return RUMContext(
-            applicationID: applicationID,
-            sessionID: sessionID,
-            viewID: viewID,
-            serverTimeOffset: serverTimeOffset
-        )
+extension FeatureBaggage {
+    func unwrap<T>() throws -> T where T: Decodable {
+        let decoder = AnyDecoder()
+        return try decoder.decode(from: attributes)
     }
 }

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMContextReceiver.swift
@@ -15,6 +15,8 @@ internal struct RUMContext: Equatable {
     let sessionID: String
     /// Current RUM view ID - standard UUID string, lowecased.
     let viewID: String
+    /// Current RUM view server time offset (in seconds).
+    let serverTimeOffset: TimeInterval
 }
 
 /// An observer notifying on`RUMContext` changes.
@@ -85,12 +87,18 @@ private extension FeatureBaggage {
     var rumContext: RUMContext? {
         guard let applicationID: String = self[RUMDependency.applicationIDKey],
               let sessionID: String = self[RUMDependency.sessionIDKey],
-              let viewID: String = self[RUMDependency.viewIDKey]
+              let viewID: String = self[RUMDependency.viewIDKey],
+              let serverTimeOffset: TimeInterval = self[RUMDependency.serverTimeOffset]
         else {
             // Current RUM session is not sampled
             return nil
         }
 
-        return RUMContext(applicationID: applicationID, sessionID: sessionID, viewID: viewID)
+        return RUMContext(
+            applicationID: applicationID,
+            sessionID: sessionID,
+            viewID: viewID,
+            serverTimeOffset: serverTimeOffset
+        )
     }
 }

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
@@ -44,4 +44,9 @@ internal struct RUMDependency {
 
     /// The key referencing a `Bool` value that indicates if replay is being recorded.
     static let hasReplay = "has_replay"
+
+    /// The key referencing server time offset of current RUM view used for date correction.
+    ///
+    /// SR expects non-optional value of `TimeInterval`.
+    static let serverTimeOffset = "server_time_offset"
 }

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
@@ -42,7 +42,6 @@ internal enum RUMDependency {
         static let viewIDKey = "view.id"
     }
 
-
     // MARK: Contract from SR to RUM (mirror of `SessionReplayDependency` in RUM):
 
     /// The key referencing SR baggage in `DatadogContext.featuresAttributes`.

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
@@ -18,6 +18,11 @@ internal enum RUMDependency {
     /// - baggage with `ids` and `serverTimeOffsetKey` keys if RUM session is sampled.
     static let rumBaggageKey = "rum"
 
+    /// The key referencing server time offset of current RUM view used for date correction.
+    ///
+    /// SR expects non-optional value of `TimeInterval`.
+    static let serverTimeOffsetKey = "server_time_offset"
+
     /// The key for referencing RUM baggage (RUM context) ids in `DatadogContext.featuresAttributes`.
     ///
     /// SR expects:
@@ -53,9 +58,4 @@ internal enum RUMDependency {
 
     /// The key referencing a `Bool` value that indicates if replay is being recorded.
     static let hasReplay = "has_replay"
-
-    /// The key referencing server time offset of current RUM view used for date correction.
-    ///
-    /// SR expects non-optional value of `TimeInterval`.
-    static let serverTimeOffsetKey = "server_time_offset"
 }

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
@@ -8,30 +8,40 @@ import Foundation
 
 /// Defines dependency between Session Replay (SR) and RUM modules.
 /// It aims at centralizing documentation of contracts between both products.
-internal struct RUMDependency {
+internal enum RUMDependency {
     // MARK: Contract from RUM to SR:
 
     /// The key for referencing RUM baggage (RUM context) in `DatadogContext.featuresAttributes`.
     ///
     /// SR expects:
     /// - empty baggage (`[:]`) if current RUM session is not sampled,
-    /// - baggage with `applicationIDKey`, `sessionIDKey` and `viewIDKey` keys if RUM session is sampled.
+    /// - baggage with `ids` and `serverTimeOffsetKey` keys if RUM session is sampled.
     static let rumBaggageKey = "rum"
 
-    /// The key for referencing RUM application ID inside RUM baggage.
+    /// The key for referencing RUM baggage (RUM context) ids in `DatadogContext.featuresAttributes`.
     ///
-    /// SR expects non-optional value holding lowercased, standard UUID `String`.
-    static let applicationIDKey = "application_id"
+    /// SR expects:
+    /// - `nil` if current RUM session is not sampled,
+    /// - baggage with `applicationIDKey`, `sessionIDKey` and `viewIDKey` keys if RUM session is sampled.
+    static let ids = "ids"
 
-    /// The key for referencing RUM session ID inside RUM baggage.
-    ///
-    /// SR expects non-optional value holding lowercased, standard UUID `String`.
-    static let sessionIDKey = "session_id"
+    internal enum IDs {
+        /// The key for referencing RUM application ID inside RUM baggage.
+        ///
+        /// SR expects non-optional value holding lowercased, standard UUID `String`.
+        static let applicationIDKey = "application_id"
 
-    /// The key for referencing RUM view ID inside RUM baggage.
-    ///
-    /// SR expects non-optional value holding lowercased, standard UUID `String`.
-    static let viewIDKey = "view.id"
+        /// The key for referencing RUM session ID inside RUM baggage.
+        ///
+        /// SR expects non-optional value holding lowercased, standard UUID `String`.
+        static let sessionIDKey = "session_id"
+
+        /// The key for referencing RUM view ID inside RUM baggage.
+        ///
+        /// SR expects non-optional value holding lowercased, standard UUID `String`.
+        static let viewIDKey = "view.id"
+    }
+
 
     // MARK: Contract from SR to RUM (mirror of `SessionReplayDependency` in RUM):
 
@@ -48,5 +58,5 @@ internal struct RUMDependency {
     /// The key referencing server time offset of current RUM view used for date correction.
     ///
     /// SR expects non-optional value of `TimeInterval`.
-    static let serverTimeOffset = "server_time_offset"
+    static let serverTimeOffsetKey = "server_time_offset"
 }

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/DatadogCoreIntegration/RUMDependency.swift
@@ -27,25 +27,8 @@ internal enum RUMDependency {
     ///
     /// SR expects:
     /// - `nil` if current RUM session is not sampled,
-    /// - baggage with `applicationIDKey`, `sessionIDKey` and `viewIDKey` keys if RUM session is sampled.
+    /// - baggage with `application_id`, `session_id` and `view.id` keys if RUM session is sampled.
     static let ids = "ids"
-
-    internal enum IDs {
-        /// The key for referencing RUM application ID inside RUM baggage.
-        ///
-        /// SR expects non-optional value holding lowercased, standard UUID `String`.
-        static let applicationIDKey = "application_id"
-
-        /// The key for referencing RUM session ID inside RUM baggage.
-        ///
-        /// SR expects non-optional value holding lowercased, standard UUID `String`.
-        static let sessionIDKey = "session_id"
-
-        /// The key for referencing RUM view ID inside RUM baggage.
-        ///
-        /// SR expects non-optional value holding lowercased, standard UUID `String`.
-        static let viewIDKey = "view.id"
-    }
 
     // MARK: Contract from SR to RUM (mirror of `SessionReplayDependency` in RUM):
 

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/Recorder.swift
@@ -142,7 +142,7 @@ internal class Recorder: Recording {
                 // There is nothing visible yet (i.e. the key window is not yet ready).
                 return
             }
-            let touchSnapshot = touchSnapshotProducer.takeSnapshot()
+            let touchSnapshot = touchSnapshotProducer.takeSnapshot(context: recorderContext)
             snapshotProcessor.process(viewTreeSnapshot: viewTreeSnapshot, touchSnapshot: touchSnapshot)
         } catch {
             print("Failed to capture the snapshot: \(error)") // TODO: RUMM-2410 Use `DD.logger` and / or `DD.telemetry`

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshot/TouchSnapshot.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshot/TouchSnapshot.swift
@@ -17,7 +17,7 @@ internal struct TouchSnapshot {
         /// Phase of the touch as distinguished in session replay.
         let phase: TouchPhase
         /// A time of recording this touch
-        let date: Date
+        var date: Date
         /// The position of this touch in application window.
         let position: CGPoint
     }

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshotProducer.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshotProducer.swift
@@ -10,5 +10,5 @@ import Foundation
 internal protocol TouchSnapshotProducer {
     /// Produces the snapshot of (touch) interactions that happened since last call to `takeSnapshot()`.
     /// - Returns: the snapshot or `nil` if no new touch information is available
-    func takeSnapshot() -> TouchSnapshot?
+    func takeSnapshot(context: Recorder.Context) -> TouchSnapshot?
 }

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshotProducer.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/TouchSnapshotProducer.swift
@@ -9,6 +9,8 @@ import Foundation
 /// Produces `TouchSnapshots` that describe touch interactions.
 internal protocol TouchSnapshotProducer {
     /// Produces the snapshot of (touch) interactions that happened since last call to `takeSnapshot()`.
+    ///
+    /// - Parameter context: context of the recorder used for sharing common data
     /// - Returns: the snapshot or `nil` if no new touch information is available
     func takeSnapshot(context: Recorder.Context) -> TouchSnapshot?
 }

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducer.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducer.swift
@@ -22,10 +22,12 @@ internal class WindowTouchSnapshotProducer: TouchSnapshotProducer, UIEventHandle
     }
 
     func takeSnapshot(context: Recorder.Context) -> TouchSnapshot? {
-        buffer = buffer.compactMap {
-            var touch = $0
-            touch.date.addTimeInterval(context.rumContext.serverTimeOffset)
-            return touch
+        if let offset = context.rumContext.viewServerTimeOffset {
+            buffer = buffer.compactMap {
+                var touch = $0
+                touch.date.addTimeInterval(offset)
+                return touch
+            }
         }
         guard let firstTouch = buffer.first else {
             return nil

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducer.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducer.swift
@@ -21,7 +21,12 @@ internal class WindowTouchSnapshotProducer: TouchSnapshotProducer, UIEventHandle
         self.windowObserver = windowObserver
     }
 
-    func takeSnapshot() -> TouchSnapshot? {
+    func takeSnapshot(context: Recorder.Context) -> TouchSnapshot? {
+        buffer = buffer.compactMap {
+            var touch = $0
+            touch.date.addTimeInterval(context.rumContext.serverTimeOffset)
+            return touch
+        }
         guard let firstTouch = buffer.first else {
             return nil
         }
@@ -50,7 +55,7 @@ internal class WindowTouchSnapshotProducer: TouchSnapshotProducer, UIEventHandle
                 TouchSnapshot.Touch(
                     id: idsGenerator.touchIdentifier(for: touch),
                     phase: phase,
-                    date: Date(), // TODO: RUMM-2688 Synchronize SR snapshot timestamps with current RUM time (+ NTP offset)
+                    date: Date(),
                     position: touch.location(in: window)
                 )
             )

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -48,7 +48,7 @@ internal struct ViewTreeSnapshotBuilder {
             textObfuscator: textObfuscator
         )
         let viewTreeSnapshot = ViewTreeSnapshot(
-            date: recorderContext.date,
+            date: recorderContext.date.addingTimeInterval(recorderContext.rumContext.serverTimeOffset),
             rumContext: recorderContext.rumContext,
             root: createNode(for: rootView, in: builderContext)
         )

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -48,7 +48,7 @@ internal struct ViewTreeSnapshotBuilder {
             textObfuscator: textObfuscator
         )
         let viewTreeSnapshot = ViewTreeSnapshot(
-            date: recorderContext.date.addingTimeInterval(recorderContext.rumContext.serverTimeOffset),
+            date: recorderContext.date.addingTimeInterval(recorderContext.rumContext.viewServerTimeOffset ?? 0),
             rumContext: recorderContext.rumContext,
             root: createNode(for: rootView, in: builderContext)
         )

--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Writer/Models/EnrichedRecord.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Writer/Models/EnrichedRecord.swift
@@ -43,9 +43,9 @@ internal struct EnrichedRecord: Encodable {
 
     init(rumContext: RUMContext, records: [SRRecord]) {
         self.records = records
-        self.applicationID = rumContext.applicationID
-        self.sessionID = rumContext.sessionID
-        self.viewID = rumContext.viewID
+        self.applicationID = rumContext.ids.applicationID
+        self.sessionID = rumContext.ids.sessionID
+        self.viewID = rumContext.ids.viewID
 
         var hasFullSnapshot = false
         var earliestTimestamp: Int64 = .max

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
@@ -16,10 +16,12 @@ class RUMContextReceiverTests: XCTestCase {
         // Given
         let context = DatadogContext.mockWith(featuresAttributes: [
             RUMDependency.rumBaggageKey: [
-                RUMDependency.applicationIDKey: "app-id",
-                RUMDependency.sessionIDKey: "session-id",
-                RUMDependency.viewIDKey: "view-id",
-                RUMDependency.serverTimeOffset: TimeInterval(123)
+                RUMDependency.ids: [
+                    RUMDependency.IDs.applicationIDKey: "app-id",
+                    RUMDependency.IDs.sessionIDKey: "session-id",
+                    RUMDependency.IDs.viewIDKey: "view-id"
+                ],
+                RUMDependency.serverTimeOffsetKey: TimeInterval(123)
             ]
         ])
         let message = FeatureMessage.context(context)
@@ -65,19 +67,23 @@ class RUMContextReceiverTests: XCTestCase {
         // Given
         let context1 = DatadogContext.mockWith(featuresAttributes: [
             RUMDependency.rumBaggageKey: [
-                RUMDependency.applicationIDKey: "app-id-1",
-                RUMDependency.sessionIDKey: "session-id-1",
-                RUMDependency.viewIDKey: "view-id-1",
-                RUMDependency.serverTimeOffset: TimeInterval(123)
+                RUMDependency.ids: [
+                    RUMDependency.IDs.applicationIDKey: "app-id-1",
+                    RUMDependency.IDs.sessionIDKey: "session-id-1",
+                    RUMDependency.IDs.viewIDKey: "view-id-1"
+                ],
+                RUMDependency.serverTimeOffsetKey: TimeInterval(123)
             ]
         ])
         let message1 = FeatureMessage.context(context1)
         let context2 = DatadogContext.mockWith(featuresAttributes: [
             RUMDependency.rumBaggageKey: [
-                RUMDependency.applicationIDKey: "app-id-2",
-                RUMDependency.sessionIDKey: "session-id-2",
-                RUMDependency.viewIDKey: "view-id-2",
-                RUMDependency.serverTimeOffset: TimeInterval(345)
+                RUMDependency.ids: [
+                    RUMDependency.IDs.applicationIDKey: "app-id-2",
+                    RUMDependency.IDs.sessionIDKey: "session-id-2",
+                    RUMDependency.IDs.viewIDKey: "view-id-2"
+                ],
+                RUMDependency.serverTimeOffsetKey: TimeInterval(345)
             ]
         ])
         let message2 = FeatureMessage.context(context2)
@@ -126,10 +132,12 @@ class RUMContextReceiverTests: XCTestCase {
         // Given
         let context = DatadogContext.mockWith(featuresAttributes: [
             RUMDependency.rumBaggageKey: [
-                RUMDependency.applicationIDKey: "app-id",
-                RUMDependency.sessionIDKey: "session-id",
-                RUMDependency.viewIDKey: "view-id",
-                RUMDependency.serverTimeOffset: TimeInterval(123)
+                RUMDependency.ids: [
+                    RUMDependency.IDs.applicationIDKey: "app-id",
+                    RUMDependency.IDs.sessionIDKey: "session-id",
+                    RUMDependency.IDs.viewIDKey: "view-id"
+                ],
+                RUMDependency.serverTimeOffsetKey: TimeInterval(123)
             ]
         ])
         let message = FeatureMessage.context(context)

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
@@ -105,7 +105,6 @@ class RUMContextReceiverTests: XCTestCase {
         XCTAssertEqual(rumContexts[1].sessionID, "session-id-2")
         XCTAssertEqual(rumContexts[1].viewID, "view-id-2")
         XCTAssertEqual(rumContexts[1].serverTimeOffset, 345)
-
     }
 
     func testWhenMessageDoesntContainRUMBaggage_itCallsFallback() {

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
@@ -128,3 +128,11 @@ class RUMContextReceiverTests: XCTestCase {
         XCTAssertTrue(fallbackCalled)
     }
 }
+
+fileprivate extension RUMDependency {
+    enum IDs {
+        static let applicationIDKey = "application_id"
+        static let sessionIDKey = "session_id"
+        static let viewIDKey = "view.id"
+    }
+}

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
@@ -5,34 +5,154 @@
  */
 
 import XCTest
+import Datadog
 @testable import DatadogSessionReplay
+@testable import TestUtilities
 
-// swiftlint:disable empty_xctest_method
 class RUMContextReceiverTests: XCTestCase {
     private let receiver = RUMContextReceiver()
 
     func testWhenMessageContainsNonEmptyRUMBaggage_itNotifiesRUMContext() {
-        // TODO: RUMM-2690
-        // Implementing this test requires creating partial mocks for `FeatureMessage` and `DatadogContext`,
-        // which is yet not possible as we lack separate, shared module to facilitate tests.
+        // Given
+        let context = DatadogContext.mockWith(featuresAttributes: [
+            RUMDependency.rumBaggageKey: [
+                RUMDependency.applicationIDKey: "app-id",
+                RUMDependency.sessionIDKey: "session-id",
+                RUMDependency.viewIDKey: "view-id",
+                RUMDependency.serverTimeOffset: TimeInterval(123)
+            ]
+        ])
+        let message = FeatureMessage.context(context)
+        let core = PassthroughCoreMock(messageReceiver: receiver)
+
+        // When
+        var rumContext: RUMContext?
+        receiver.observe(on: NoQueue()) { context in
+            rumContext = context
+        }
+        core.send(message: message, sender: core, else: {
+            XCTFail("Fallback shouldn't be called")
+        })
+
+        // Then
+        XCTAssertEqual(rumContext?.applicationID, "app-id")
+        XCTAssertEqual(rumContext?.sessionID, "session-id")
+        XCTAssertEqual(rumContext?.viewID, "view-id")
+        XCTAssertEqual(rumContext?.serverTimeOffset, 123)
     }
 
     func testWhenMessageContainsEmptyRUMBaggage_itNotifiesNoRUMContext() {
-        // TODO: RUMM-2690
-        // Implementing this test requires creating partial mocks for `FeatureMessage` and `DatadogContext`,
-        // which is yet not possible as we lack separate, shared module to facilitate tests.
+        let context = DatadogContext.mockWith(featuresAttributes: [
+            RUMDependency.rumBaggageKey: [:]
+        ])
+        let message = FeatureMessage.context(context)
+        let core = PassthroughCoreMock(messageReceiver: receiver)
+
+        // When
+        var rumContext: RUMContext?
+        receiver.observe(on: NoQueue()) { context in
+            rumContext = context
+        }
+        core.send(message: message, sender: core, else: {
+            XCTFail("Fallback shouldn't be called")
+        })
+
+        // Then
+        XCTAssertNil(rumContext)
     }
 
     func testWhenSucceedingMessagesContainDifferentRUMBaggages_itNotifiesRUMContextChange() {
-        // TODO: RUMM-2690
-        // Implementing this test requires creating partial mocks for `FeatureMessage` and `DatadogContext`,
-        // which is yet not possible as we lack separate, shared module to facilitate tests.
+        // Given
+        let context1 = DatadogContext.mockWith(featuresAttributes: [
+            RUMDependency.rumBaggageKey: [
+                RUMDependency.applicationIDKey: "app-id-1",
+                RUMDependency.sessionIDKey: "session-id-1",
+                RUMDependency.viewIDKey: "view-id-1",
+                RUMDependency.serverTimeOffset: TimeInterval(123)
+            ]
+        ])
+        let message1 = FeatureMessage.context(context1)
+        let context2 = DatadogContext.mockWith(featuresAttributes: [
+            RUMDependency.rumBaggageKey: [
+                RUMDependency.applicationIDKey: "app-id-2",
+                RUMDependency.sessionIDKey: "session-id-2",
+                RUMDependency.viewIDKey: "view-id-2",
+                RUMDependency.serverTimeOffset: TimeInterval(345)
+            ]
+        ])
+        let message2 = FeatureMessage.context(context2)
+        let core = PassthroughCoreMock(messageReceiver: receiver)
+
+        // When
+        var rumContexts = [RUMContext]()
+        receiver.observe(on: NoQueue()) { context in
+            context.flatMap { rumContexts.append($0) }
+        }
+        core.send(message: message1, sender: core, else: {
+            XCTFail("Fallback shouldn't be called")
+        })
+        core.send(message: message2, sender: core, else: {
+            XCTFail("Fallback shouldn't be called")
+        })
+
+        // Then
+        XCTAssertEqual(rumContexts.count, 2)
+        XCTAssertEqual(rumContexts[0].applicationID, "app-id-1")
+        XCTAssertEqual(rumContexts[0].sessionID, "session-id-1")
+        XCTAssertEqual(rumContexts[0].viewID, "view-id-1")
+        XCTAssertEqual(rumContexts[0].serverTimeOffset, 123)
+        XCTAssertEqual(rumContexts[1].applicationID, "app-id-2")
+        XCTAssertEqual(rumContexts[1].sessionID, "session-id-2")
+        XCTAssertEqual(rumContexts[1].viewID, "view-id-2")
+        XCTAssertEqual(rumContexts[1].serverTimeOffset, 345)
+
+    }
+
+    func testWhenMessageDoesntContainRUMBaggage_itCallsFallback() {
+        let context = DatadogContext.mockAny()
+        let message = FeatureMessage.context(context)
+        let core = PassthroughCoreMock(messageReceiver: receiver)
+
+        // When
+        var fallbackCalled = false
+        core.send(message: message, sender: core, else: {
+            fallbackCalled = true
+        })
+
+        // Then
+        XCTAssertTrue(fallbackCalled)
     }
 
     func testWhenSucceedingMessagesContainEqualRUMBaggages_itDoesNotNotifyRUMContextChange() {
-        // TODO: RUMM-2690
-        // Implementing this test requires creating partial mocks for `FeatureMessage` and `DatadogContext`,
-        // which is yet not possible as we lack separate, shared module to facilitate tests.
+        // Given
+        let context = DatadogContext.mockWith(featuresAttributes: [
+            RUMDependency.rumBaggageKey: [
+                RUMDependency.applicationIDKey: "app-id",
+                RUMDependency.sessionIDKey: "session-id",
+                RUMDependency.viewIDKey: "view-id",
+                RUMDependency.serverTimeOffset: TimeInterval(123)
+            ]
+        ])
+        let message = FeatureMessage.context(context)
+        let core = PassthroughCoreMock(messageReceiver: receiver)
+
+        // When
+        var rumContexts = [RUMContext]()
+        receiver.observe(on: NoQueue()) { context in
+            context.flatMap { rumContexts.append($0) }
+        }
+        core.send(message: message, sender: core, else: {
+            XCTFail("Fallback shouldn't be called")
+        })
+        core.send(message: message, sender: core, else: {
+            XCTFail("Fallback shouldn't be called")
+        })
+
+        // Then
+        XCTAssertEqual(rumContexts.count, 1)
+        XCTAssertEqual(rumContexts[0].applicationID, "app-id")
+        XCTAssertEqual(rumContexts[0].sessionID, "session-id")
+        XCTAssertEqual(rumContexts[0].viewID, "view-id")
+        XCTAssertEqual(rumContexts[0].serverTimeOffset, 123)
     }
 }
-// swiftlint:enable empty_xctest_method

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RUMContextReceiverTests.swift
@@ -37,10 +37,10 @@ class RUMContextReceiverTests: XCTestCase {
         })
 
         // Then
-        XCTAssertEqual(rumContext?.applicationID, "app-id")
-        XCTAssertEqual(rumContext?.sessionID, "session-id")
-        XCTAssertEqual(rumContext?.viewID, "view-id")
-        XCTAssertEqual(rumContext?.serverTimeOffset, 123)
+        XCTAssertEqual(rumContext?.ids.applicationID, "app-id")
+        XCTAssertEqual(rumContext?.ids.sessionID, "session-id")
+        XCTAssertEqual(rumContext?.ids.viewID, "view-id")
+        XCTAssertEqual(rumContext?.viewServerTimeOffset, 123)
     }
 
     func testWhenMessageContainsEmptyRUMBaggage_itNotifiesNoRUMContext() {
@@ -103,14 +103,14 @@ class RUMContextReceiverTests: XCTestCase {
 
         // Then
         XCTAssertEqual(rumContexts.count, 2)
-        XCTAssertEqual(rumContexts[0].applicationID, "app-id-1")
-        XCTAssertEqual(rumContexts[0].sessionID, "session-id-1")
-        XCTAssertEqual(rumContexts[0].viewID, "view-id-1")
-        XCTAssertEqual(rumContexts[0].serverTimeOffset, 123)
-        XCTAssertEqual(rumContexts[1].applicationID, "app-id-2")
-        XCTAssertEqual(rumContexts[1].sessionID, "session-id-2")
-        XCTAssertEqual(rumContexts[1].viewID, "view-id-2")
-        XCTAssertEqual(rumContexts[1].serverTimeOffset, 345)
+        XCTAssertEqual(rumContexts[0].ids.applicationID, "app-id-1")
+        XCTAssertEqual(rumContexts[0].ids.sessionID, "session-id-1")
+        XCTAssertEqual(rumContexts[0].ids.viewID, "view-id-1")
+        XCTAssertEqual(rumContexts[0].viewServerTimeOffset, 123)
+        XCTAssertEqual(rumContexts[1].ids.applicationID, "app-id-2")
+        XCTAssertEqual(rumContexts[1].ids.sessionID, "session-id-2")
+        XCTAssertEqual(rumContexts[1].ids.viewID, "view-id-2")
+        XCTAssertEqual(rumContexts[1].viewServerTimeOffset, 345)
     }
 
     func testWhenMessageDoesntContainRUMBaggage_itCallsFallback() {
@@ -126,40 +126,5 @@ class RUMContextReceiverTests: XCTestCase {
 
         // Then
         XCTAssertTrue(fallbackCalled)
-    }
-
-    func testWhenSucceedingMessagesContainEqualRUMBaggages_itDoesNotNotifyRUMContextChange() {
-        // Given
-        let context = DatadogContext.mockWith(featuresAttributes: [
-            RUMDependency.rumBaggageKey: [
-                RUMDependency.ids: [
-                    RUMDependency.IDs.applicationIDKey: "app-id",
-                    RUMDependency.IDs.sessionIDKey: "session-id",
-                    RUMDependency.IDs.viewIDKey: "view-id"
-                ],
-                RUMDependency.serverTimeOffsetKey: TimeInterval(123)
-            ]
-        ])
-        let message = FeatureMessage.context(context)
-        let core = PassthroughCoreMock(messageReceiver: receiver)
-
-        // When
-        var rumContexts = [RUMContext]()
-        receiver.observe(on: NoQueue()) { context in
-            context.flatMap { rumContexts.append($0) }
-        }
-        core.send(message: message, sender: core, else: {
-            XCTFail("Fallback shouldn't be called")
-        })
-        core.send(message: message, sender: core, else: {
-            XCTFail("Fallback shouldn't be called")
-        })
-
-        // Then
-        XCTAssertEqual(rumContexts.count, 1)
-        XCTAssertEqual(rumContexts[0].applicationID, "app-id")
-        XCTAssertEqual(rumContexts[0].sessionID, "session-id")
-        XCTAssertEqual(rumContexts[0].viewID, "view-id")
-        XCTAssertEqual(rumContexts[0].serverTimeOffset, 123)
     }
 }

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
@@ -71,10 +71,12 @@ class SegmentJSONBuilderTests: XCTestCase {
 
     private func generateEnrichedRecordJSONs(for segment: SRSegment) throws -> [EnrichedRecordJSON] {
         let rum = RUMContext(
-            applicationID: segment.application.id,
-            sessionID: segment.session.id,
-            viewID: segment.view.id,
-            serverTimeOffset: 0
+            ids: .init(
+                applicationID: segment.application.id,
+                sessionID: segment.session.id,
+                viewID: segment.view.id
+            ),
+            viewServerTimeOffset: 0
         )
         return try segment.records
             // To make it more challenging for tested `SegmentJSONBuilder`, we chunk records in

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/DatadogCoreIntegration/RequestBuilder/JSON/SegmentJSONBuilderTests.swift
@@ -73,7 +73,8 @@ class SegmentJSONBuilderTests: XCTestCase {
         let rum = RUMContext(
             applicationID: segment.application.id,
             sessionID: segment.session.id,
-            viewID: segment.view.id
+            viewID: segment.view.id,
+            serverTimeOffset: 0
         )
         return try segment.records
             // To make it more challenging for tested `SegmentJSONBuilder`, we chunk records in

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
@@ -314,19 +314,22 @@ extension RUMContext: AnyMockable, RandomMockable {
         return RUMContext(
             applicationID: .mockRandom(),
             sessionID: .mockRandom(),
-            viewID: .mockRandom()
+            viewID: .mockRandom(),
+            serverTimeOffset: .mockRandom()
         )
     }
 
     static func mockWith(
         applicationID: String = .mockAny(),
         sessionID: String = .mockAny(),
-        viewID: String = .mockAny()
+        viewID: String = .mockAny(),
+        serverTimeOffset: TimeInterval = .mockAny()
     ) -> RUMContext {
         return RUMContext(
             applicationID: applicationID,
             sessionID: sessionID,
-            viewID: viewID
+            viewID: viewID,
+            serverTimeOffset: serverTimeOffset
         )
     }
 }

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Mocks/RecorderMocks.swift
@@ -312,10 +312,12 @@ extension RUMContext: AnyMockable, RandomMockable {
 
     public static func mockRandom() -> RUMContext {
         return RUMContext(
-            applicationID: .mockRandom(),
-            sessionID: .mockRandom(),
-            viewID: .mockRandom(),
-            serverTimeOffset: .mockRandom()
+            ids: .init(
+                applicationID: .mockRandom(),
+                sessionID: .mockRandom(),
+                viewID: .mockRandom()
+            ),
+            viewServerTimeOffset: .mockRandom()
         )
     }
 
@@ -326,10 +328,12 @@ extension RUMContext: AnyMockable, RandomMockable {
         serverTimeOffset: TimeInterval = .mockAny()
     ) -> RUMContext {
         return RUMContext(
-            applicationID: applicationID,
-            sessionID: sessionID,
-            viewID: viewID,
-            serverTimeOffset: serverTimeOffset
+            ids: .init(
+                applicationID: applicationID,
+                sessionID: sessionID,
+                viewID: viewID
+            ),
+            viewServerTimeOffset: serverTimeOffset
         )
     }
 }

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Mocks/SnapshotProducerMocks.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Mocks/SnapshotProducerMocks.swift
@@ -42,7 +42,7 @@ internal class TouchSnapshotProducerMock: TouchSnapshotProducer {
         self.succeedingSnapshots = succeedingSnapshots
     }
 
-    func takeSnapshot() -> TouchSnapshot? {
+    func takeSnapshot(context: Recorder.Context) -> TouchSnapshot? {
         return succeedingSnapshots.isEmpty ? nil : succeedingSnapshots.removeFirst()
     }
 }

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Processor/ProcessorTests.swift
@@ -23,7 +23,7 @@ class ProcessorTests: XCTestCase {
 
     func testWhenProcessingFirstViewTreeSnapshot_itWritesRecordsThatIndicateStartOfASegment() throws {
         let time = Date()
-        let rum: RUMContext = .mockRandom()
+        let rum: RUMContext = .mockWith(serverTimeOffset: 0)
 
         // Given
         let processor = Processor(queue: NoQueue(), writer: writer)
@@ -51,7 +51,7 @@ class ProcessorTests: XCTestCase {
 
     func testWhenRUMContextDoesNotChangeInSucceedingViewTreeSnapshots_itWritesRecordsThatContinueCurrentSegment() {
         let time = Date()
-        let rum: RUMContext = .mockRandom()
+        let rum: RUMContext = .mockWith(serverTimeOffset: 0)
 
         // Given
         let processor = Processor(queue: NoQueue(), writer: writer)
@@ -177,7 +177,7 @@ class ProcessorTests: XCTestCase {
         let earliestTouchTime = Date()
         let snapshotTime = earliestTouchTime.addingTimeInterval(5)
         let numberOfTouches = 10
-        let rum: RUMContext = .mockRandom()
+        let rum: RUMContext = .mockWith(serverTimeOffset: 0)
 
         // Given
         let processor = Processor(queue: NoQueue(), writer: writer)

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Processor/ProcessorTests.swift
@@ -37,9 +37,9 @@ class ProcessorTests: XCTestCase {
         XCTAssertEqual(writer.records.count, 1)
 
         let enrichedRecord = try XCTUnwrap(writer.records.first)
-        XCTAssertEqual(enrichedRecord.applicationID, rum.applicationID)
-        XCTAssertEqual(enrichedRecord.sessionID, rum.sessionID)
-        XCTAssertEqual(enrichedRecord.viewID, rum.viewID)
+        XCTAssertEqual(enrichedRecord.applicationID, rum.ids.applicationID)
+        XCTAssertEqual(enrichedRecord.sessionID, rum.ids.sessionID)
+        XCTAssertEqual(enrichedRecord.viewID, rum.ids.viewID)
         XCTAssertEqual(enrichedRecord.earliestTimestamp, time.timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(enrichedRecord.latestTimestamp, time.timeIntervalSince1970.toInt64Milliseconds)
 
@@ -82,9 +82,9 @@ class ProcessorTests: XCTestCase {
         XCTAssertTrue(enrichedRecords[2].records[0].isIncrementalSnapshotRecord)
 
         enrichedRecords.enumerated().forEach { index, enrichedRecord in
-            XCTAssertEqual(enrichedRecord.applicationID, rum.applicationID)
-            XCTAssertEqual(enrichedRecord.sessionID, rum.sessionID)
-            XCTAssertEqual(enrichedRecord.viewID, rum.viewID)
+            XCTAssertEqual(enrichedRecord.applicationID, rum.ids.applicationID)
+            XCTAssertEqual(enrichedRecord.sessionID, rum.ids.sessionID)
+            XCTAssertEqual(enrichedRecord.viewID, rum.ids.viewID)
 
             let expectedTime = time.addingTimeInterval(TimeInterval(index))
             XCTAssertEqual(enrichedRecord.earliestTimestamp, expectedTime.timeIntervalSince1970.toInt64Milliseconds)
@@ -165,9 +165,9 @@ class ProcessorTests: XCTestCase {
         XCTAssertTrue(enrichedRecords[3].records[0].isIncrementalSnapshotRecord)
 
         zip(enrichedRecords, [rum1, rum1, rum2, rum2]).forEach { enrichedRecord, expectedRUM in
-            XCTAssertEqual(enrichedRecord.applicationID, expectedRUM.applicationID)
-            XCTAssertEqual(enrichedRecord.sessionID, expectedRUM.sessionID)
-            XCTAssertEqual(enrichedRecord.viewID, expectedRUM.viewID)
+            XCTAssertEqual(enrichedRecord.applicationID, expectedRUM.ids.applicationID)
+            XCTAssertEqual(enrichedRecord.sessionID, expectedRUM.ids.sessionID)
+            XCTAssertEqual(enrichedRecord.viewID, expectedRUM.ids.viewID)
         }
     }
 
@@ -190,9 +190,9 @@ class ProcessorTests: XCTestCase {
         XCTAssertEqual(writer.records.count, 1)
 
         let enrichedRecord = try XCTUnwrap(writer.records.first)
-        XCTAssertEqual(enrichedRecord.applicationID, rum.applicationID)
-        XCTAssertEqual(enrichedRecord.sessionID, rum.sessionID)
-        XCTAssertEqual(enrichedRecord.viewID, rum.viewID)
+        XCTAssertEqual(enrichedRecord.applicationID, rum.ids.applicationID)
+        XCTAssertEqual(enrichedRecord.sessionID, rum.ids.sessionID)
+        XCTAssertEqual(enrichedRecord.viewID, rum.ids.viewID)
         XCTAssertEqual(enrichedRecord.earliestTimestamp, earliestTouchTime.timeIntervalSince1970.toInt64Milliseconds)
         XCTAssertEqual(enrichedRecord.latestTimestamp, snapshotTime.timeIntervalSince1970.toInt64Milliseconds)
 

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducerTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducerTests.swift
@@ -20,16 +20,18 @@ class WindowTouchSnapshotProducerTests: XCTestCase {
         let touchEvent2 = UITouchEventMock(touches: (0..<10).map { _ in UITouchMock(phase: .moved) })
 
         // Given
-        let producer = WindowTouchSnapshotProducer(windowObserver: mockWindowObserver)
+        let producer = WindowTouchSnapshotProducer(
+            windowObserver: mockWindowObserver
+        )
 
         // When
-        let snapshot1 = producer.takeSnapshot()
+        let snapshot1 = producer.takeSnapshot(context: .mockAny())
         producer.notify_sendEvent(application: mockApplication, event: touchEvent1)
-        let snapshot2 = producer.takeSnapshot()
-        let snapshot3 = producer.takeSnapshot()
+        let snapshot2 = producer.takeSnapshot(context: .mockAny())
+        let snapshot3 = producer.takeSnapshot(context: .mockAny())
         producer.notify_sendEvent(application: mockApplication, event: touchEvent2)
-        let snapshot4 = producer.takeSnapshot()
-        let snapshot5 = producer.takeSnapshot()
+        let snapshot4 = producer.takeSnapshot(context: .mockAny())
+        let snapshot5 = producer.takeSnapshot(context: .mockAny())
 
         // Then
         XCTAssertNil(snapshot1, "Until next touch event is tracked, it should produce no snapshot")
@@ -47,14 +49,16 @@ class WindowTouchSnapshotProducerTests: XCTestCase {
         let touchEvent3 = UITouchEventMock(touches: (0..<15).map { _ in UITouchMock(phase: .moved) })
 
         // Given
-        let producer = WindowTouchSnapshotProducer(windowObserver: mockWindowObserver)
+        let producer = WindowTouchSnapshotProducer(
+            windowObserver: mockWindowObserver
+        )
 
         // When
         producer.notify_sendEvent(application: mockApplication, event: touchEvent1)
         producer.notify_sendEvent(application: mockApplication, event: touchEvent2)
         producer.notify_sendEvent(application: mockApplication, event: touchEvent3)
-        let snapshot1 = producer.takeSnapshot()
-        let snapshot2 = producer.takeSnapshot()
+        let snapshot1 = producer.takeSnapshot(context: .mockAny())
+        let snapshot2 = producer.takeSnapshot(context: .mockAny())
 
         // Then
         XCTAssertNotNil(snapshot1, "After touch event is tracked, it should produce a snapshot")
@@ -68,7 +72,9 @@ class WindowTouchSnapshotProducerTests: XCTestCase {
         let touch3 = UITouchMock()
 
         // Given
-        let producer = WindowTouchSnapshotProducer(windowObserver: mockWindowObserver)
+        let producer = WindowTouchSnapshotProducer(
+            windowObserver: mockWindowObserver
+        )
 
         // When
         touch1.phase = .began
@@ -91,7 +97,7 @@ class WindowTouchSnapshotProducerTests: XCTestCase {
         producer.notify_sendEvent(application: mockApplication, event: UITouchEventMock(touches: [touch3]))
 
         // Then
-        let snapshot = try XCTUnwrap(producer.takeSnapshot())
+        let snapshot = try XCTUnwrap(producer.takeSnapshot(context: .mockAny()))
         XCTAssertEqual(snapshot.touches.count, 9, "It should capture 9 touch informations")
         XCTAssertEqual(Set(snapshot.touches.map { $0.id }).count, 3, "There should be 3 distinct touch identifiers among touch information")
     }

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducerTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducerTests.swift
@@ -111,8 +111,7 @@ class WindowTouchSnapshotProducerTests: XCTestCase {
 
         // When
         producer.notify_sendEvent(application: mockApplication, event: touchEvent1)
-        let snapshot1 = producer.takeSnapshot(context: .mockWith(rumContext: .mockWith(serverTimeOffset: 1000)))
-
+        let snapshot1 = producer.takeSnapshot(context: .mockWith(rumContext: .mockWith(serverTimeOffset: 1_000)))
 
         // Then
         XCTAssertGreaterThan(snapshot1!.date, Date())

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducerTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/TouchSnapshotProducer/WindowTouchSnapshotProducerTests.swift
@@ -101,4 +101,20 @@ class WindowTouchSnapshotProducerTests: XCTestCase {
         XCTAssertEqual(snapshot.touches.count, 9, "It should capture 9 touch informations")
         XCTAssertEqual(Set(snapshot.touches.map { $0.id }).count, 3, "There should be 3 distinct touch identifiers among touch information")
     }
+
+    func testItAppliesServerTimeOffsetIsToSnapshot() {
+        // Given
+        let touchEvent1 = UITouchEventMock(touches: (0..<2).map { _ in UITouchMock(phase: .moved) })
+        let producer = WindowTouchSnapshotProducer(
+            windowObserver: mockWindowObserver
+        )
+
+        // When
+        producer.notify_sendEvent(application: mockApplication, event: touchEvent1)
+        let snapshot1 = producer.takeSnapshot(context: .mockWith(rumContext: .mockWith(serverTimeOffset: 1000)))
+
+
+        // Then
+        XCTAssertGreaterThan(snapshot1!.date, Date())
+    }
 }

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -82,7 +82,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         // Given
         let view = UIView(frame: .mockRandom())
 
-        let randomRecorderContext: Recorder.Context = .mockRandom()
+        let randomRecorderContext: Recorder.Context = .mockWith()
         let recorder = NodeRecorderMock(resultForView: { _ in nil })
         let builder = ViewTreeSnapshotBuilder(nodeRecorders: [recorder])
 

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -304,7 +304,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         // When
         let recorder = NodeRecorderMock(resultForView: { _ in nil })
         let builder = ViewTreeSnapshotBuilder(nodeRecorders: [recorder])
-        let snapshot = builder.createSnapshot(of: view, with: .mockWith(date: now, rumContext: .mockWith(serverTimeOffset: 1000)))
+        let snapshot = builder.createSnapshot(of: view, with: .mockWith(date: now, rumContext: .mockWith(serverTimeOffset: 1_000)))
 
         // Then
         XCTAssertGreaterThan(snapshot.date, now)

--- a/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogSessionReplayTests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -295,4 +295,18 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             )
         }
     }
+
+    func testItAppliesServerTimeOffsetIsToSnapshot() {
+        // Given
+        let now = Date()
+        let view = UIView(frame: .mockRandom())
+
+        // When
+        let recorder = NodeRecorderMock(resultForView: { _ in nil })
+        let builder = ViewTreeSnapshotBuilder(nodeRecorders: [recorder])
+        let snapshot = builder.createSnapshot(of: view, with: .mockWith(date: now, rumContext: .mockWith(serverTimeOffset: 1000)))
+
+        // Then
+        XCTAssertGreaterThan(snapshot.date, now)
+    }
 }

--- a/Sources/Datadog/DatadogInternal/MessageBus/FeatureBaggage.swift
+++ b/Sources/Datadog/DatadogInternal/MessageBus/FeatureBaggage.swift
@@ -44,7 +44,7 @@ import Foundation
 @dynamicMemberLookup
 public struct FeatureBaggage {
     /// The attributes dictionary.
-    private(set) var attributes: [String: Any]
+    public private(set) var attributes: [String: Any]
 
     /// A Boolean value indicating whether the baggage is empty.
     public var isEmpty: Bool {

--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -285,8 +285,8 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
                 event[dateKey] = correctedTimestamp
             }
 
-            if let baggage = context.featuresAttributes["rum"] {
-                event.merge(baggage.attributes) { $1 }
+            if let baggage: [String: String] = context.featuresAttributes["rum"]?.ids {
+                event.merge(baggage) { $1 }
             }
 
             writer.write(value: AnyEncodable(event))

--- a/Sources/Datadog/Logging/RemoteLogger.swift
+++ b/Sources/Datadog/Logging/RemoteLogger.swift
@@ -125,7 +125,7 @@ internal final class RemoteLogger: LoggerProtocol {
             var internalAttributes: [String: Encodable] = [:]
             let contextAttributes = context.featuresAttributes
 
-            if self.rumContextIntegration, let attributes = contextAttributes["rum"] {
+            if self.rumContextIntegration, let attributes: [String: String] = contextAttributes["rum"]?.ids {
                 let attributes = attributes.compactMapValues(AnyEncodable.init)
                 internalAttributes.merge(attributes) { $1 }
             }

--- a/Sources/Datadog/RUM/Integrations/RUMContextAttributes.swift
+++ b/Sources/Datadog/RUM/Integrations/RUMContextAttributes.swift
@@ -20,4 +20,7 @@ internal enum RUMContextAttributes {
 
     /// The ID of current RUM action (standard UUID `String`, lowercased).
     internal static let userActionID = "user_action.id"
+
+    /// Server time offset of current RUM view used for date correction.
+    internal static let serverTimeOffset = "server_time_offset"
 }

--- a/Sources/Datadog/RUM/Integrations/RUMContextAttributes.swift
+++ b/Sources/Datadog/RUM/Integrations/RUMContextAttributes.swift
@@ -8,18 +8,23 @@ import Foundation
 
 /// RUM Attributes shared with other Feature registered in core.
 internal enum RUMContextAttributes {
-    /// The ID of RUM application (`String`).
-    internal static let applicationID = "application_id"
+    internal enum IDs {
+        /// The ID of RUM application (`String`).
+        internal static let applicationID = "application_id"
 
-    /// The ID of current RUM session (standard UUID `String`, lowercased).
-    /// In case the session is rejected (not sampled), RUM context is set to empty (`[:]`) in core.
-    internal static let sessionID = "session_id"
+        /// The ID of current RUM session (standard UUID `String`, lowercased).
+        /// In case the session is rejected (not sampled), RUM context is set to empty (`[:]`) in core.
+        internal static let sessionID = "session_id"
 
-    /// The ID of current RUM view (standard UUID `String`, lowercased).
-    internal static let viewID = "view.id"
+        /// The ID of current RUM view (standard UUID `String`, lowercased).
+        internal static let viewID = "view.id"
 
-    /// The ID of current RUM action (standard UUID `String`, lowercased).
-    internal static let userActionID = "user_action.id"
+        /// The ID of current RUM action (standard UUID `String`, lowercased).
+        internal static let userActionID = "user_action.id"
+    }
+
+    /// Key that aggregates the dictionary of all the RUM context IDs.
+    internal static let ids = "ids"
 
     /// Server time offset of current RUM view used for date correction.
     internal static let serverTimeOffset = "server_time_offset"

--- a/Sources/Datadog/RUM/Integrations/WebViewEventReceiver.swift
+++ b/Sources/Datadog/RUM/Integrations/WebViewEventReceiver.swift
@@ -60,10 +60,9 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
         )
 
         core.v1.scope(for: RUMFeature.self)?.eventWriteContext { context, writer in
-            guard let attributes = context.featuresAttributes["rum"], !attributes.isEmpty else {
+            guard let attributes: [String: String?] = context.featuresAttributes["rum"]?.ids, !attributes.isEmpty else {
                 return writer.write(value: AnyEncodable(event))
             }
-
             var event = event
 
             if let date = event["date"] as? Int {
@@ -73,13 +72,13 @@ internal final class WebViewEventReceiver: FeatureMessageReceiver {
                 event["date"] = correctedDate
             }
 
-            let applicationID = attributes[RUMContextAttributes.applicationID, type: String.self]
+            let applicationID = attributes[RUMContextAttributes.IDs.applicationID]
             if let applicationID = applicationID, var application = event["application"] as? JSON {
                 application["id"] = applicationID
                 event["application"] = application
             }
 
-            let sessionID = attributes[RUMContextAttributes.sessionID, type: String.self]
+            let sessionID = attributes[RUMContextAttributes.IDs.sessionID]
             if let sessionID = sessionID, var session = event["session"] as? JSON {
                 session["id"] = sessionID
                 event["session"] = session

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -54,7 +54,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
     ///
     /// The server time offset is freezed per view scope so all child event time
     /// stay relatives to the scope.
-    private let serverTimeOffset: TimeInterval
+    let serverTimeOffset: TimeInterval
 
     /// Tells if this View is the active one.
     /// `true` for every new started View.

--- a/Sources/Datadog/RUM/RUMTelemetry.swift
+++ b/Sources/Datadog/RUM/RUMTelemetry.swift
@@ -75,12 +75,12 @@ internal final class RUMTelemetry: Telemetry {
         let date = dateProvider.now
 
         record(event: id) { context, writer in
-            let attributes = context.featuresAttributes["rum"]
+            let attributes: [String: String]? = context.featuresAttributes["rum"]?.ids
 
-            let applicationId = attributes?[RUMContextAttributes.applicationID, type: String.self]
-            let sessionId = attributes?[RUMContextAttributes.sessionID, type: String.self]
-            let viewId = attributes?[RUMContextAttributes.viewID, type: String.self]
-            let actionId = attributes?[RUMContextAttributes.userActionID, type: String.self]
+            let applicationId = attributes?[RUMContextAttributes.IDs.applicationID]
+            let sessionId = attributes?[RUMContextAttributes.IDs.sessionID]
+            let viewId = attributes?[RUMContextAttributes.IDs.viewID]
+            let actionId = attributes?[RUMContextAttributes.IDs.userActionID]
 
             let event = TelemetryDebugEvent(
                 dd: .init(),
@@ -115,12 +115,12 @@ internal final class RUMTelemetry: Telemetry {
         let date = dateProvider.now
 
         record(event: id) { context, writer in
-            let attributes = context.featuresAttributes["rum"]
+            let attributes: [String: String]? = context.featuresAttributes["rum"]?.ids
 
-            let applicationId = attributes?[RUMContextAttributes.applicationID, type: String.self]
-            let sessionId = attributes?[RUMContextAttributes.sessionID, type: String.self]
-            let viewId = attributes?[RUMContextAttributes.viewID, type: String.self]
-            let actionId = attributes?[RUMContextAttributes.userActionID, type: String.self]
+            let applicationId = attributes?[RUMContextAttributes.IDs.applicationID]
+            let sessionId = attributes?[RUMContextAttributes.IDs.sessionID]
+            let viewId = attributes?[RUMContextAttributes.IDs.viewID]
+            let actionId = attributes?[RUMContextAttributes.IDs.userActionID]
 
             let event = TelemetryErrorEvent(
                 dd: .init(),
@@ -157,12 +157,12 @@ internal final class RUMTelemetry: Telemetry {
 
         self.delayedDispatcher {
             self.record(event: "_dd.configuration") { context, writer in
-                let attributes = context.featuresAttributes["rum"]
+                let attributes: [String: String]? = context.featuresAttributes["rum"]?.ids
 
-                let applicationId = attributes?[RUMContextAttributes.applicationID, type: String.self]
-                let sessionId = attributes?[RUMContextAttributes.sessionID, type: String.self]
-                let viewId = attributes?[RUMContextAttributes.viewID, type: String.self]
-                let actionId = attributes?[RUMContextAttributes.userActionID, type: String.self]
+                let applicationId = attributes?[RUMContextAttributes.IDs.applicationID]
+                let sessionId = attributes?[RUMContextAttributes.IDs.sessionID]
+                let viewId = attributes?[RUMContextAttributes.IDs.viewID]
+                let actionId = attributes?[RUMContextAttributes.IDs.userActionID]
 
                 var event = TelemetryConfigurationEvent(
                     dd: .init(),
@@ -197,8 +197,8 @@ internal final class RUMTelemetry: Telemetry {
 
         rum.eventWriteContext { context, writer in
             // reset recorded events on session renewal
-            let attributes = context.featuresAttributes["rum"]
-            let sessionId = attributes?[RUMContextAttributes.sessionID, type: String.self]
+            let attributes: [String: String]? = context.featuresAttributes["rum"]?.ids
+            let sessionId = attributes?[RUMContextAttributes.IDs.sessionID]
 
             if sessionId != self.currentSessionID {
                 self.currentSessionID = sessionId

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -613,10 +613,12 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                 }
 
                 return [
-                    RUMContextAttributes.applicationID: context.rumApplicationID,
-                    RUMContextAttributes.sessionID: context.sessionID.rawValue.uuidString.lowercased(),
-                    RUMContextAttributes.viewID: context.activeViewID?.rawValue.uuidString.lowercased(),
-                    RUMContextAttributes.userActionID: context.activeUserActionID?.rawValue.uuidString.lowercased(),
+                    RUMContextAttributes.ids: [
+                        RUMContextAttributes.IDs.applicationID: context.rumApplicationID,
+                        RUMContextAttributes.IDs.sessionID: context.sessionID.rawValue.uuidString.lowercased(),
+                        RUMContextAttributes.IDs.viewID: context.activeViewID?.rawValue.uuidString.lowercased(),
+                        RUMContextAttributes.IDs.userActionID: context.activeUserActionID?.rawValue.uuidString.lowercased(),
+                    ],
                     RUMContextAttributes.serverTimeOffset: self.applicationScope.sessionScope?.viewScopes.last?.serverTimeOffset
                 ]
             }

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -616,7 +616,8 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                     RUMContextAttributes.applicationID: context.rumApplicationID,
                     RUMContextAttributes.sessionID: context.sessionID.rawValue.uuidString.lowercased(),
                     RUMContextAttributes.viewID: context.activeViewID?.rawValue.uuidString.lowercased(),
-                    RUMContextAttributes.userActionID: context.activeUserActionID?.rawValue.uuidString.lowercased()
+                    RUMContextAttributes.userActionID: context.activeUserActionID?.rawValue.uuidString.lowercased(),
+                    RUMContextAttributes.serverTimeOffset: self.applicationScope.sessionScope?.viewScopes.last?.serverTimeOffset
                 ]
             }
         })

--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -204,7 +204,7 @@ public class Tracer: OTTracer {
             combinedTags.merge(userTags) { $1 }
         }
 
-        if let rumTags = rumIntegration?.attribues {
+        if let rumTags = rumIntegration?.attributes {
             combinedTags.merge(rumTags) { $1 }
         }
 

--- a/Sources/Datadog/Tracing/Integrations/TracingWithRUMIntegration.swift
+++ b/Sources/Datadog/Tracing/Integrations/TracingWithRUMIntegration.swift
@@ -12,5 +12,5 @@ internal final class TracingWithRUMIntegration {
     ///
     /// These attributes are synchronized using a read-write lock.
     @ReadWriteLock
-    var attribues: [String: Encodable]?
+    var attributes: [String: Encodable]?
 }

--- a/Sources/Datadog/Tracing/TracingV2Configuration.swift
+++ b/Sources/Datadog/Tracing/TracingV2Configuration.swift
@@ -72,9 +72,10 @@ internal struct TracingMessageReceiver: FeatureMessageReceiver {
     ///
     /// - Parameter context: The updated core context.
     private func update(context: DatadogContext) -> Bool {
-        rum.attribues = context.featuresAttributes["rum"]?
-            .compactMapValues { $0 as? Encodable }
-
-        return true
+        if let attributes: [String: String] = context.featuresAttributes["rum"]?.ids {
+            rum.attributes = attributes
+            return true
+        }
+        return false
     }
 }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -561,19 +561,19 @@ class LoggerTests: XCTestCase {
         // then
         let logMatcher = try core.waitAndReturnLogMatchers()[0]
         logMatcher.assertValue(
-            forKeyPath: RUMContextAttributes.applicationID,
+            forKeyPath: RUMContextAttributes.IDs.applicationID,
             equals: rum.configuration.applicationID
         )
         logMatcher.assertValue(
-            forKeyPath: RUMContextAttributes.sessionID,
+            forKeyPath: RUMContextAttributes.IDs.sessionID,
             isTypeOf: String.self
         )
         logMatcher.assertValue(
-            forKeyPath: RUMContextAttributes.viewID,
+            forKeyPath: RUMContextAttributes.IDs.viewID,
             isTypeOf: String.self
         )
         logMatcher.assertValue(
-            forKeyPath: RUMContextAttributes.userActionID,
+            forKeyPath: RUMContextAttributes.IDs.userActionID,
             isTypeOf: String.self
         )
     }

--- a/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/Log/LogSanitizerTests.swift
@@ -132,10 +132,10 @@ class LogSanitizerTests: XCTestCase {
                 userAttributes: [
                     Tracer.Attributes.traceID: mockValue(),
                     Tracer.Attributes.spanID: mockValue(),
-                    RUMContextAttributes.applicationID: mockValue(),
-                    RUMContextAttributes.sessionID: mockValue(),
-                    RUMContextAttributes.viewID: mockValue(),
-                    RUMContextAttributes.userActionID: mockValue(),
+                    RUMContextAttributes.IDs.applicationID: mockValue(),
+                    RUMContextAttributes.IDs.sessionID: mockValue(),
+                    RUMContextAttributes.IDs.viewID: mockValue(),
+                    RUMContextAttributes.IDs.userActionID: mockValue(),
                     "attribute3": mockValue(),
                 ]
             )

--- a/Tests/DatadogTests/Datadog/Logging/WebViewLogReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/WebViewLogReceiverTests.swift
@@ -49,8 +49,10 @@ class WebViewLogReceiverTests: XCTestCase {
                 serverTimeOffset: 123,
                 featuresAttributes: [
                     "rum": [
-                        RUMContextAttributes.applicationID: "123456",
-                        RUMContextAttributes.sessionID: mockSessionID.uuidString.lowercased()
+                        "ids": [
+                            RUMContextAttributes.IDs.applicationID: "123456",
+                            RUMContextAttributes.IDs.sessionID: mockSessionID.uuidString.lowercased()
+                        ]
                     ]
                 ]
             ),

--- a/Tests/DatadogTests/Datadog/RUM/Integrations/WebViewEventReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Integrations/WebViewEventReceiverTests.swift
@@ -18,8 +18,10 @@ class WebViewEventReceiverTests: XCTestCase {
                 serverTimeOffset: 123,
                 featuresAttributes: [
                     "rum": [
-                        RUMContextAttributes.applicationID: "123456",
-                        RUMContextAttributes.sessionID: "e9796469-c2a1-43d6-b0f6-65c47d33cf5f"
+                        "ids": [
+                            RUMContextAttributes.IDs.applicationID: "123456",
+                            RUMContextAttributes.IDs.sessionID: "e9796469-c2a1-43d6-b0f6-65c47d33cf5f"
+                        ]
                     ]
                 ]
             ),

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -363,7 +363,7 @@ class RUMTelemetryTests: XCTestCase {
                 { telemetry.configuration(configuration: .mockAny()) },
                 {
                     self.core.set(feature: "rum", attributes: {[
-                        "ids": [
+                        RUMContextAttributes.ids: [
                             RUMContextAttributes.IDs.applicationID: String.mockRandom(),
                             RUMContextAttributes.IDs.sessionID: String.mockRandom(),
                             RUMContextAttributes.IDs.viewID: String.mockRandom(),

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -89,10 +89,12 @@ class RUMTelemetryTests: XCTestCase {
         let actionId: String = .mockRandom()
 
         core.set(feature: "rum", attributes: {[
-            RUMContextAttributes.applicationID: applicationId,
-            RUMContextAttributes.sessionID: sessionId,
-            RUMContextAttributes.viewID: viewId,
-            RUMContextAttributes.userActionID: actionId
+            "ids": [
+                RUMContextAttributes.IDs.applicationID: applicationId,
+                RUMContextAttributes.IDs.sessionID: sessionId,
+                RUMContextAttributes.IDs.viewID: viewId,
+                RUMContextAttributes.IDs.userActionID: actionId
+            ]
         ]})
 
         // When
@@ -118,10 +120,12 @@ class RUMTelemetryTests: XCTestCase {
         let actionId: String = .mockRandom()
 
         core.set(feature: "rum", attributes: {[
-            RUMContextAttributes.applicationID: applicationId,
-            RUMContextAttributes.sessionID: sessionId,
-            RUMContextAttributes.viewID: viewId,
-            RUMContextAttributes.userActionID: actionId
+            "ids": [
+                RUMContextAttributes.IDs.applicationID: applicationId,
+                RUMContextAttributes.IDs.sessionID: sessionId,
+                RUMContextAttributes.IDs.viewID: viewId,
+                RUMContextAttributes.IDs.userActionID: actionId
+            ]
         ]})
 
         // When
@@ -267,16 +271,20 @@ class RUMTelemetryTests: XCTestCase {
         let applicationId: String = .mockRandom()
 
         core.set(feature: "rum", attributes: {[
-            RUMContextAttributes.applicationID: applicationId,
-            RUMContextAttributes.sessionID: String.mockRandom()
+            "ids": [
+                RUMContextAttributes.IDs.applicationID: applicationId,
+                RUMContextAttributes.IDs.sessionID: String.mockRandom()
+            ]
         ]})
 
         // When
         telemetry.debug(id: "0", message: "telemetry debug")
 
         core.set(feature: "rum", attributes: {[
-            RUMContextAttributes.applicationID: applicationId,
-            RUMContextAttributes.sessionID: String.mockRandom() // new session
+            "ids": [
+                RUMContextAttributes.IDs.applicationID: applicationId,
+                RUMContextAttributes.IDs.sessionID: String.mockRandom() // new session
+            ]
         ]})
 
         telemetry.debug(id: "0", message: "telemetry debug")
@@ -355,10 +363,12 @@ class RUMTelemetryTests: XCTestCase {
                 { telemetry.configuration(configuration: .mockAny()) },
                 {
                     self.core.set(feature: "rum", attributes: {[
-                        RUMContextAttributes.applicationID: String.mockRandom(),
-                        RUMContextAttributes.sessionID: String.mockRandom(),
-                        RUMContextAttributes.viewID: String.mockRandom(),
-                        RUMContextAttributes.userActionID: String.mockRandom()
+                        "ids": [
+                            RUMContextAttributes.IDs.applicationID: String.mockRandom(),
+                            RUMContextAttributes.IDs.sessionID: String.mockRandom(),
+                            RUMContextAttributes.IDs.viewID: String.mockRandom(),
+                            RUMContextAttributes.IDs.userActionID: String.mockRandom()
+                        ]
                     ]})
                 }
             ],

--- a/Tests/DatadogTests/Datadog/Tracing/TracingMessageReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingMessageReceiverTests.swift
@@ -11,20 +11,20 @@ import XCTest
 class TracingMessageReceiverTests: XCTestCase {
     func testItReceivesRUMContext() throws {
         let core = DatadogCoreProxy(
-            context: .mockWith(featuresAttributes: ["rum": ["key": "value1"]])
+            context: .mockWith(featuresAttributes: ["rum": ["ids": ["key": "value1"]]])
         )
         defer { core.flushAndTearDown() }
 
         // Given
         let receiver = TracingMessageReceiver()
         try core.register(feature: DatadogFeatureMock(messageReceiver: receiver))
-        XCTAssertNil(receiver.rum.attribues, "RUM context should be nil until it is set by RUM")
+        XCTAssertNil(receiver.rum.attributes, "RUM context should be nil until it is set by RUM")
 
         // When
-        core.set(feature: "rum", attributes: { ["key": "value2"] })
+        core.set(feature: "rum", attributes: { ["ids": ["key": "value2"]] })
 
         // Then
         core.flush()
-        XCTAssertEqual(receiver.rum.attribues as? [String: String], ["key": "value2"])
+        XCTAssertEqual(receiver.rum.attributes as? [String: String], ["key": "value2"])
     }
 }

--- a/Tests/DatadogTests/Datadog/WebView/WKUserContentController+DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/WebView/WKUserContentController+DatadogTests.swift
@@ -149,8 +149,10 @@ class WKUserContentController_DatadogTests: XCTestCase {
                 applicationBundleIdentifier: "com.datadoghq.ios-sdk",
                 featuresAttributes: [
                     "rum": [
-                        RUMContextAttributes.sessionID: UUID.nullUUID.uuidString.lowercased(),
-                        RUMContextAttributes.applicationID: String.mockAny()
+                        "ids": [
+                            RUMContextAttributes.IDs.sessionID: UUID.nullUUID.uuidString.lowercased(),
+                            RUMContextAttributes.IDs.applicationID: String.mockAny()
+                        ]
                     ]
                 ]
             )


### PR DESCRIPTION
### What and why?

Shares the server time offset of RUM view with session replay to apply NTP offset on timestamps of records.

### How?

It's passed the same way rum view id was passed and in the `EnrichedRecord` value is subtracted from the timestamp.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
