### PR TITLE
Fix develop build issues

### DIFF
--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -24,30 +24,3 @@ struct FeatureRequestBuilderMock: FeatureRequestBuilder {
         return builder.uploadRequest(with: data)
     }
 }
-
-extension DatadogContext: AnyMockable {
-    static func mockAny() -> DatadogContext {
-        .init(
-            site: .us1,
-            clientToken: .mockAny(),
-            service: .mockAny(),
-            env: .mockAny(),
-            version: .mockAny(),
-            variant: nil,
-            source: .mockAny(),
-            sdkVersion: .mockAny(),
-            ciAppOrigin: .mockAny(),
-            serverTimeOffset: .zero,
-            applicationName: .mockAny(),
-            applicationBundleIdentifier: .mockAny(),
-            sdkInitDate: .mockRandomInThePast(),
-            device: DeviceInfo(),
-            userInfo: nil,
-            launchTime: nil,
-            applicationStateHistory: .active(since: Date()),
-            networkConnectionInfo: .unknown,
-            carrierInfo: nil,
-            isLowPowerModeEnabled: false
-        )
-    }
-}


### PR DESCRIPTION
### What and why?

Removes redundant protocol conformance from `DatadogBenchmarkTests`. They are now coming from `TestUtilities`.
