### PR TITLE
RUMM-2902 [SR] Bump version to `1.14.0-sr-beta1`

### DIFF
--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
   s.module_name  = "Datadog"
-  s.version      = "1.14.0"
+  s.version      = "1.14.0-sr-beta1"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKAlamofireExtension.podspec
+++ b/DatadogSDKAlamofireExtension.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKAlamofireExtension"
   s.module_name  = "DatadogAlamofireExtension"
-  s.version      = "1.14.0"
+  s.version      = "1.14.0-sr-beta1"
   s.summary      = "An Official Extensions of Datadog Swift SDK for Alamofire."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKCrashReporting"
   s.module_name  = "DatadogCrashReporting"
-  s.version      = "1.14.0"
+  s.version      = "1.14.0-sr-beta1"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.source_files = "Sources/DatadogCrashReporting/**/*.swift"
-  s.dependency 'DatadogSDK', '1.14.0'
+  s.dependency 'DatadogSDK', '1.14.0-sr-beta1'
   s.dependency 'PLCrashReporter', '~> 1.11.0'
 end

--- a/DatadogSDKObjc.podspec
+++ b/DatadogSDKObjc.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKObjc"
   s.module_name  = "DatadogObjc"
-  s.version      = "1.14.0"
+  s.version      = "1.14.0-sr-beta1"
   s.summary      = "Official Datadog Objective-C SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
 
   s.source_files = "Sources/DatadogObjc/**/*.swift"
-  s.dependency 'DatadogSDK', '1.14.0'
+  s.dependency 'DatadogSDK', '1.14.0-sr-beta1'
 end

--- a/DatadogSDKSessionReplay.podspec
+++ b/DatadogSDKSessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDKSessionReplay"
   s.module_name  = "DatadogSessionReplay"
-  s.version      = "1.14.0"
+  s.version      = "1.14.0-sr-beta1"
   s.summary      = "Official Datadog Session Replay SDK for iOS. This module is currently in beta - contact Datadog to request a try."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ bump:
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKObjc.podspec.src > DatadogSDKObjc.podspec; \
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKAlamofireExtension.podspec.src > DatadogSDKAlamofireExtension.podspec; \
 		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKCrashReporting.podspec.src > DatadogSDKCrashReporting.podspec; \
+		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKSessionReplay.podspec.src > DatadogSDKSessionReplay.podspec; \
 		git add . ; \
 		git commit -m "Bumped version to $$version"; \
-		sed "s/__DATADOG_VERSION__/$$version/g" DatadogSDKSessionReplay.podspec.src > DatadogSDKSessionReplay.podspec; \
 		echo Bumped version to $$version

--- a/Sources/Datadog/Versioning.swift
+++ b/Sources/Datadog/Versioning.swift
@@ -1,3 +1,3 @@
 // GENERATED FILE: Do not edit directly
 
-internal let __sdkVersion = "1.14.0"
+internal let __sdkVersion = "1.14.0-sr-beta1"

--- a/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
+++ b/Tests/DatadogBenchmarkTests/BenchmarkMocks.swift
@@ -24,30 +24,3 @@ struct FeatureRequestBuilderMock: FeatureRequestBuilder {
         return builder.uploadRequest(with: data)
     }
 }
-
-extension DatadogContext: AnyMockable {
-    static func mockAny() -> DatadogContext {
-        .init(
-            site: .us1,
-            clientToken: .mockAny(),
-            service: .mockAny(),
-            env: .mockAny(),
-            version: .mockAny(),
-            variant: nil,
-            source: .mockAny(),
-            sdkVersion: .mockAny(),
-            ciAppOrigin: .mockAny(),
-            serverTimeOffset: .zero,
-            applicationName: .mockAny(),
-            applicationBundleIdentifier: .mockAny(),
-            sdkInitDate: .mockRandomInThePast(),
-            device: DeviceInfo(),
-            userInfo: nil,
-            launchTime: nil,
-            applicationStateHistory: .active(since: Date()),
-            networkConnectionInfo: .unknown,
-            carrierInfo: nil,
-            isLowPowerModeEnabled: false
-        )
-    }
-}


### PR DESCRIPTION
### What and why?

📦 Prepare Session Replay for private `-beta1`.

### How?

This PR targets `session-replay-beta` branch - the one that will be used for shipping updates in private beta. To avoid mistakes in managing this branch, I made it protected on the same rules as `develop`.

Even though it is not necessary, this PR bumps the version in `.podspecs` and `__sdkVersion` in code for versioning clarity:
```diff
- internal let __sdkVersion = "1.14.0"
+ internal let __sdkVersion = "1.14.0-sr-beta1"
```
This will let us distinguish telemetry and data sent from SR private beta.

⚠️ It is expected to run into git conflicts when regular SDK release is made from `develop` branch (and parallel `make bump` is done). However, it will be limited to only version number so its resolution will be easy. I don't think this requires anything fancy to avoid conflicts, as it will only concern releases done during private beta.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
