### PR TITLE
Align `swift-tools-version` across all packages

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version: 5.5
 
 import PackageDescription
 

--- a/TestUtilities/Package.swift
+++ b/TestUtilities/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version: 5.7
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 5.5
 
 import PackageDescription
 


### PR DESCRIPTION
### What and why?

📦 Fixing the problem revealed in recent nightly tests failure:

```
xcodebuild: error: Could not resolve package dependencies:
  package 'testutilities' is using Swift tools version 5.7.0 but the installed version is 5.6.0
```

### How?

Following [this post from Apple](https://developer.apple.com/news/?id=2t1chhp3):
> Starting April 25, 2022, iOS, iPadOS, and watchOS apps submitted to the App Store must be built with Xcode 13 (...)

it makes sense to align all our packages with:
```swift
// swift-tools-version: 5.5
```

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
