### PR TITLE
Fix E2ETests build

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		6167AD20251A27CC0012B4D0 /* SendFirstPartyRequestsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167AD1F251A27CC0012B4D0 /* SendFirstPartyRequestsViewController.swift */; };
 		6167C79326665D6900D4CF07 /* E2EUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167C79226665D6900D4CF07 /* E2EUtils.swift */; };
 		6167C7952666622800D4CF07 /* LoggingE2EHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6167C7942666622800D4CF07 /* LoggingE2EHelpers.swift */; };
+		616843C329803FC400EC22EB /* FeatureBaggageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234612D28B76C1100055D4C /* FeatureBaggageMock.swift */; };
 		616B6684259CAE3300968EE8 /* DDGlobalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B6683259CAE3300968EE8 /* DDGlobalTests.swift */; };
 		616B668E259CC28E00968EE8 /* DDRUMMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616B668D259CC28E00968EE8 /* DDRUMMonitorTests.swift */; };
 		616C0A9E28573DFF00C13264 /* RUMOperatingSystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616C0A9D28573DFF00C13264 /* RUMOperatingSystemInfo.swift */; };
@@ -6016,6 +6017,7 @@
 				618F984F265BC905009959F8 /* E2EConfig.swift in Sources */,
 				61216B7B2667A9AE0089DCD1 /* LoggingConfigurationE2ETests.swift in Sources */,
 				A79A544B2971ADC100982BFC /* XCTestCase.swift in Sources */,
+				616843C329803FC400EC22EB /* FeatureBaggageMock.swift in Sources */,
 				A79A54272971ADC100982BFC /* PassthroughCoreMock.swift in Sources */,
 				9E5B6D32270DE9E5002499B8 /* RUMTrackingConsentE2ETests.swift in Sources */,
 				6187A53926FCBE240015D94A /* TracerE2ETests.swift in Sources */,


### PR DESCRIPTION
### What and why?

💊 Fixing E2E tests build:
```
❌  /Users/vagrant/git/TestUtilities/Sources/TestUtilities/Mocks/DatadogContextMock.swift:90:34: referencing static method 'mockRandom()' on 'Dictionary' requires that 'FeatureBaggage' conform to 'RandomMockable'
            featuresAttributes: .mockRandom()
                                 ^
```

### How?

Fixed by including `FeatureBaggageMock` in `E2ETests` target.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
