### PR TITLE
RUMM-2950 Fix log attribute forwarding to RUM

### DIFF
--- a/Sources/Datadog/Logging/RemoteLogger.swift
+++ b/Sources/Datadog/Logging/RemoteLogger.swift
@@ -167,7 +167,8 @@ internal final class RemoteLogger: LoggerProtocol {
                         baggage: [
                             "type": log.error?.kind,
                             "stack": log.error?.stack,
-                            "source": "logger"
+                            "source": "logger",
+                            "attributes": userAttributes
                         ]
                     )
                 )

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -101,7 +101,7 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
         self.stack = stack
 
         self.errorSourceType = RUMErrorSourceType.extract(from: &self.attributes)
-        self.isCrash = self.attributes.removeValue(forKey: CrossPlatformAttributes.errorIsCrash) as? Bool
+        self.isCrash = self.attributes.removeValue(forKey: CrossPlatformAttributes.errorIsCrash)?.decoded()
     }
 
     init(

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -66,10 +66,26 @@ internal typealias RUMErrorSourceType = RUMErrorEvent.Error.SourceType
 
 internal extension RUMErrorSourceType {
     static func extract(from attributes: inout [AttributeKey: AttributeValue]) -> Self {
-        return (attributes.removeValue(forKey: CrossPlatformAttributes.errorSourceType) as? String)
+        return (attributes.removeValue(forKey: CrossPlatformAttributes.errorSourceType))
+            .flatMap({
+                $0.decoded()
+            })
             .flatMap {
                 return RUMErrorEvent.Error.SourceType(rawValue: $0)
             } ?? .ios
+    }
+}
+
+internal extension AttributeValue {
+    func decoded<T>() -> T? {
+        switch self {
+        case let codable as DDAnyCodable:
+            return codable.value as? T
+        case let val as T:
+            return val
+        default:
+            return nil
+        }
     }
 }
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -747,23 +747,20 @@ class LoggerTests: XCTestCase {
         ])
 
         // then
-        let rumEventMatchers = try core.waitAndReturnRUMEventMatchers()
-        let rumErrorMatcher1 = rumEventMatchers.first { $0.model(isTypeOf: RUMErrorEvent.self) }
-        let rumErrorMatcher2 = rumEventMatchers.last { $0.model(isTypeOf: RUMErrorEvent.self) }
-        try XCTUnwrap(rumErrorMatcher1).model(ofType: RUMErrorEvent.self) { rumModel in
-            XCTAssertEqual(rumModel.error.message, "error message")
-            XCTAssertEqual(rumModel.error.source, .logger)
-            XCTAssertNil(rumModel.error.stack)
-            // swiftlint:disable:next xct_specific_matcher
-            XCTAssertEqual(rumModel.error.isCrash, false)
-        }
-        try XCTUnwrap(rumErrorMatcher2).model(ofType: RUMErrorEvent.self) { rumModel in
-            XCTAssertEqual(rumModel.error.message, "critical message")
-            XCTAssertEqual(rumModel.error.source, .logger)
-            XCTAssertNil(rumModel.error.stack)
-            // swiftlint:disable:next xct_specific_matcher
-            XCTAssertEqual(rumModel.error.isCrash, true)
-        }
+        let errorEvents = core.waitAndReturnEvents(of: RUMFeature.self, ofType: RUMErrorEvent.self)
+        let error1 = try XCTUnwrap(errorEvents.first)
+        XCTAssertEqual(error1.error.message, "error message")
+        XCTAssertEqual(error1.error.source, .logger)
+        XCTAssertNil(error1.error.stack)
+        // swiftlint:disable:next xct_specific_matcher
+        XCTAssertEqual(error1.error.isCrash, false)
+
+        let error2 = try XCTUnwrap(errorEvents.last)
+        XCTAssertEqual(error2.error.message, "critical message")
+        XCTAssertEqual(error2.error.source, .logger)
+        XCTAssertNil(error2.error.stack)
+        // swiftlint:disable:next xct_specific_matcher
+        XCTAssertEqual(error2.error.isCrash, true)
     }
 
     // MARK: - Integration With Active Span

--- a/Tests/DatadogTests/Datadog/RUM/Integrations/ErrorMessageReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Integrations/ErrorMessageReceiverTests.swift
@@ -75,13 +75,17 @@ class ErrorMessageReceiverTests: XCTestCase {
         defer { Global.rum = DDNoopRUMMonitor() }
 
         // When
+        let mockAttribute: String = .mockRandom()
         core.send(
             message: .error(
                 message: "message-test",
                 baggage: [
                     "type": "type-test",
                     "stack": "stack-test",
-                    "source": "logger"
+                    "source": "logger",
+                    "attributes": [
+                        "any-key": mockAttribute
+                    ]
                 ]
             )
         )
@@ -94,5 +98,7 @@ class ErrorMessageReceiverTests: XCTestCase {
         XCTAssertEqual(event.error.type, "type-test")
         XCTAssertEqual(event.error.stack, "stack-test")
         XCTAssertEqual(event.error.source, .logger)
+        let attributeValue = (event.context?.contextInfo["any-key"] as? DDAnyCodable)?.value as? String
+        XCTAssertEqual(attributeValue, mockAttribute)
     }
 }


### PR DESCRIPTION
### What and why?

When logs started going through the message bus, we accidentally started dropping the additional log attributes. This fixes it so we send the attributes properly. 

Additionally, we need to decode certain values specifically from the cross platform SDKs to ensure they're being set on the RUMErrorModel properly (sourceType and isCrash)

### How?

For now, we're doing "decoding" through a `decode` extension method on AttributeValue. This checks to see if the value is actually `DDAnyCodable` and casts its wrapped value the proper type if it is. Otherwise, it just returns the proper value or nil.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
