### PR TITLE
Increase error count by 1 on the view update event following a crash

### DIFF
--- a/Sources/Datadog/RUM/Integrations/CrashReportReceiver.swift
+++ b/Sources/Datadog/RUM/Integrations/CrashReportReceiver.swift
@@ -399,7 +399,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 domComplete: original.view.domComplete,
                 domContentLoaded: original.view.domContentLoaded,
                 domInteractive: original.view.domInteractive,
-                error: original.view.error,
+                error: .init(count: original.view.error.count + 1),
                 firstByte: nil,
                 firstContentfulPaint: original.view.firstContentfulPaint,
                 firstInputDelay: original.view.firstInputDelay,

--- a/Tests/DatadogTests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -412,7 +412,7 @@ class CrashReportReceiverTests: XCTestCase {
         )
         XCTAssertEqual(sendRUMViewEvent.view.name, lastRUMViewEvent.view.name)
         XCTAssertEqual(sendRUMViewEvent.view.url, lastRUMViewEvent.view.url)
-        XCTAssertEqual(sendRUMViewEvent.view.error.count, lastRUMViewEvent.view.error.count)
+        XCTAssertEqual(sendRUMViewEvent.view.error.count, lastRUMViewEvent.view.error.count + 1)
         XCTAssertEqual(sendRUMViewEvent.view.resource.count, lastRUMViewEvent.view.resource.count)
         XCTAssertEqual(sendRUMViewEvent.view.action.count, lastRUMViewEvent.view.action.count)
         XCTAssertEqual(
@@ -616,7 +616,7 @@ class CrashReportReceiverTests: XCTestCase {
             XCTAssertTrue(sentRUMView.view.isActive == false, "The view must be marked inactive")
             XCTAssertEqual(sentRUMView.view.name, expectedViewName)
             XCTAssertEqual(sentRUMView.view.url, expectedViewURL)
-            XCTAssertEqual(sentRUMView.view.error.count, 0)
+            XCTAssertEqual(sentRUMView.view.error.count, 1, "The view must increase number of errors by 1")
             XCTAssertEqual(sentRUMView.view.resource.count, 0)
             XCTAssertEqual(sentRUMView.view.action.count, 0)
             XCTAssertEqual(sentRUMView.source, .init(rawValue: randomSource))
@@ -759,7 +759,7 @@ class CrashReportReceiverTests: XCTestCase {
             XCTAssertTrue(sentRUMView.view.isActive == false, "The view must be marked inactive")
             XCTAssertEqual(sentRUMView.view.name, expectedViewName)
             XCTAssertEqual(sentRUMView.view.url, expectedViewURL)
-            XCTAssertEqual(sentRUMView.view.error.count, 0)
+            XCTAssertEqual(sentRUMView.view.error.count, 1, "The view must increase number of errors by 1")
             XCTAssertEqual(sentRUMView.view.resource.count, 0)
             XCTAssertEqual(sentRUMView.view.action.count, 0)
             XCTAssertEqual(


### PR DESCRIPTION
### What and why?
Following a crash, when updating a view with the crash count increase we should also increase the error count. 

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
