### PR TITLE
RUMM-2507 Change ApplicationLaunch view behavior

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example iOS.xcscheme
@@ -32,8 +32,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -15,8 +15,6 @@ internal protocol RUMCommand {
     /// Whether or not receiving this command should start the "Background" view if no view is active
     /// and ``Datadog.Configuration.Builder.trackBackgroundEvents(_:)`` is enabled.
     var canStartBackgroundView: Bool { get }
-    /// Whether or not receiving this command should start the "ApplicationLaunch" view if no view was yet started in current app process.
-    var canStartApplicationLaunchView: Bool { get }
     /// Whether or not this command is considered a user intaraction
     var isUserInteraction: Bool { get }
 }
@@ -27,7 +25,6 @@ internal struct RUMStartViewCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, it should start its own view, not the "Background"
-    let canStartApplicationLaunchView = false // no, it should start its own view, not the "ApplicationLaunch"
     let isUserInteraction = true // a new View means there was a navigation, it's considered a User interaction
 
     /// The value holding stable identity of the RUM View.
@@ -58,7 +55,6 @@ internal struct RUMStopViewCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view
-    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view
     let isUserInteraction = false // a view can be stopped and in most cases should not be considered an interaction (if it's stopped because the user navigate inside the same app, the startView will happen shortly after this)
 
     /// The value holding stable identity of the RUM View.
@@ -69,7 +65,6 @@ internal struct RUMAddCurrentViewErrorCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track errors in "Background" view
-    let canStartApplicationLaunchView = true // yes, we want to track errors in "ApplicationLaunch" view
     let isUserInteraction = false // an error is not an interactive event
 
     /// The error message.
@@ -128,7 +123,6 @@ internal struct RUMAddViewTimingCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, it doesn't make sense to start "Background" view on receiving custom timing, as it will be `0ns` timing
-    let canStartApplicationLaunchView = false // no, it doesn't make sense to start "ApplicationLaunch" view on receiving custom timing, as it will be `0ns` timing
     let isUserInteraction = false // a custom view timing is not an interactive event
 
     /// The name of the timing. It will be used as a JSON key, whereas the value will be the timing duration,
@@ -159,7 +153,6 @@ internal struct RUMStartResourceCommand: RUMResourceCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track resources in "Background" view
-    let canStartApplicationLaunchView = true // yes, we want to track resources in "ApplicationLaunch" view
     let isUserInteraction = false // a resource is not an interactive event
 
     /// Resource url
@@ -177,7 +170,6 @@ internal struct RUMAddResourceMetricsCommand: RUMResourceCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
-    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
     let isUserInteraction = false // an error is not an interactive event
 
     /// Resource metrics.
@@ -189,7 +181,6 @@ internal struct RUMStopResourceCommand: RUMResourceCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
-    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
     let isUserInteraction = false // a resource is not an interactive event
 
     /// A type of the Resource
@@ -205,7 +196,6 @@ internal struct RUMStopResourceWithErrorCommand: RUMResourceCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
-    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartResourceCommand`)
     let isUserInteraction = false // a resource is not an interactive event
 
     /// The error message.
@@ -279,7 +269,6 @@ internal struct RUMStartUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
-    let canStartApplicationLaunchView = true // yes, we want to track actions in "ApplicationLaunch" view (e.g. it makes sense for custom actions)
     let isUserInteraction = true // a user action definitely is a User Interacgion
 
     let actionType: RUMUserActionType
@@ -291,7 +280,6 @@ internal struct RUMStopUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartUserActionCommand`)
-    let canStartApplicationLaunchView = false // no, we don't expect receiving it without an active view (started earlier on `RUMStartUserActionCommand`)
     let isUserInteraction = true // a user action definitely is a User Interacgion
 
     let actionType: RUMUserActionType
@@ -303,7 +291,6 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = true // yes, we want to track actions in "Background" view (e.g. it makes sense for custom actions)
-    let canStartApplicationLaunchView = true // yes, we want to track actions in "ApplicationLaunch" view (e.g. it makes sense for custom actions)
     let isUserInteraction = true // a user action definitely is a User Interacgion
 
     let actionType: RUMUserActionType
@@ -316,7 +303,6 @@ internal struct RUMAddLongTaskCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
     let canStartBackgroundView = false // no, we don't expect receiving long tasks in "Background" view
-    let canStartApplicationLaunchView = true // yes, we want to track long tasks in "ApplicationLaunch" view (e.g. any hitches before presenting first UI)
     let isUserInteraction = false // a long task is not an interactive event
 
     let duration: TimeInterval
@@ -327,7 +313,6 @@ internal struct RUMAddLongTaskCommand: RUMCommand {
 /// RUM Events received from WebView should keep the active session alive, therefore they fire this command to do so. (ref: RUMM-1793)
 internal struct RUMKeepSessionAliveCommand: RUMCommand {
     let canStartBackgroundView = false
-    let canStartApplicationLaunchView = false
     let isUserInteraction = false
     var time: Date
     var attributes: [AttributeKey: AttributeValue]
@@ -337,7 +322,6 @@ internal struct RUMKeepSessionAliveCommand: RUMCommand {
 
 internal struct RUMUpdatePerformanceMetric: RUMCommand {
     let canStartBackgroundView = false
-    let canStartApplicationLaunchView = false
     let isUserInteraction = false
     let metric: PerformanceMetric
     let value: Double

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -68,6 +68,12 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             dependencies: dependencies,
             isReplayBeingRecorded: context.srBaggage?.isReplayBeingRecorded
         )
+
+        if context.applicationStateHistory.currentSnapshot.state != .background {
+            // Immediately start the ApplicationLaunchView for the new session
+            initialSession.startApplicationLaunchView(context: context)
+        }
+        
         sessionScope = initialSession
         sessionScopeDidUpdate(initialSession)
     }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -73,7 +73,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
             // Immediately start the ApplicationLaunchView for the new session
             initialSession.startApplicationLaunchView(context: context)
         }
-        
+
         sessionScope = initialSession
         sessionScopeDidUpdate(initialSession)
     }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -198,7 +198,7 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
            let processStartTime = context.launchTime?.launchDate {
             startTime = processStartTime
         }
-        
+
         viewScopes.append(
             RUMViewScope(
                 shouldSendApplicationLaunch: true,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -150,11 +150,6 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             )
 
             switch handlingRule {
-            case .handleInApplicationLaunchView where command.canStartApplicationLaunchView:
-                // Now that we start the ApplicationLaunchView on creation of the initial session, this shouln't
-                // happen. Send telemetry if it does and start the event anyay.
-                DD.telemetry.error("Creating an ApplicationLaunchView when one should have existed already.")
-                startApplicationLaunchView(context: context)
             case .handleInBackgroundView where command.canStartBackgroundView:
                 startBackgroundView(on: command, context: context)
             default:

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -154,7 +154,6 @@ struct RUMCommandMock: RUMCommand {
     var time = Date()
     var attributes: [AttributeKey: AttributeValue] = [:]
     var canStartBackgroundView = false
-    var canStartApplicationLaunchView = false
     var isUserInteraction = false
 }
 

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -787,7 +787,7 @@ extension RUMViewScope {
     }
 
     static func mockWith(
-        isInitialView: Bool = false,
+        shouldSendApplicationLaunch: Bool = false,
         parent: RUMContextProvider = RUMContextProviderMock(),
         dependencies: RUMScopeDependencies = .mockAny(),
         identity: RUMViewIdentifiable = mockView,
@@ -799,7 +799,7 @@ extension RUMViewScope {
         serverTimeOffset: TimeInterval = .zero
     ) -> RUMViewScope {
         return RUMViewScope(
-            isInitialView: isInitialView,
+            shouldSendApplicationLaunch: shouldSendApplicationLaunch,
             parent: parent,
             dependencies: dependencies,
             identity: identity,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -26,9 +26,17 @@ extension RUMFeature {
 }
 
 extension DatadogCoreProxy {
-    func waitAndReturnRUMEventMatchers(file: StaticString = #file, line: UInt = #line) throws -> [RUMEventMatcher] {
-        return try waitAndReturnEventsData(of: RUMFeature.self)
+    func waitAndReturnRUMEventMatchers(removeApplicationLaunch: Bool = true,
+                                       file: StaticString = #file,
+                                       line: UInt = #line) throws -> [RUMEventMatcher] {
+        var matchers = try waitAndReturnEventsData(of: RUMFeature.self)
             .map { data in try RUMEventMatcher.fromJSONObjectData(data) }
+        if removeApplicationLaunch {
+            matchers = matchers.filter({ matcher in
+                (try? matcher.attribute(forKeyPath: "view.name")) != RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName
+            })
+        }
+        return matchers
     }
 }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -124,7 +124,8 @@ class RUMApplicationScopeTests: XCTestCase {
             writer: writer
         )
 
-        XCTAssertEqual(writer.events(ofType: RUMViewEvent.self).count, 2)
+        // ApplicationLaunch also sends a view event
+        XCTAssertEqual(writer.events(ofType: RUMViewEvent.self).count, 3)
     }
 
     func testWhenSamplingRateIs0_noEventsAreSent() {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -246,12 +246,17 @@ class RUMSessionScopeTests: XCTestCase {
 
     // MARK: - Application Launch Events Tracking
 
-    func testGivenAppInForegroundAndInitialSessionWithNoViewTrackedBefore_whenCommandCanStartApplicationLaunchView_itCreatesAppLaunchScope() {
+    func testGivenAppInForegroundAndInitialSessionWithNoViewTrackedBefore_itCreatesAppLaunchScope() {
         // Given
         let sessionStartTime = Date()
 
         var context = self.context
         context.applicationStateHistory = .mockAppInForeground(since: sessionStartTime) // app in foreground
+        context.launchTime = LaunchTime(
+            launchTime: nil,
+            launchDate: sessionStartTime,
+            isActivePrewarm: false
+        )
 
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: true, // initial session
@@ -339,6 +344,11 @@ class RUMSessionScopeTests: XCTestCase {
 
         var context = self.context
         context.applicationStateHistory = .mockAppInForeground(since: sessionStartTime) // app in foreground
+        context.launchTime = LaunchTime(
+            launchTime: nil,
+            launchDate: sessionStartTime,
+            isActivePrewarm: false
+        )
 
         let scope: RUMSessionScope = .mockWith(
             isInitialSession: true, // initial session

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -31,7 +31,7 @@ class RUMViewScopeTests: XCTestCase {
         let sessionScope: RUMSessionScope = .mockWith(parent: applicationScope)
 
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: sessionScope,
             dependencies: .mockAny(),
             identity: mockView,
@@ -58,7 +58,7 @@ class RUMViewScopeTests: XCTestCase {
         let sessionScope: RUMSessionScope = .mockWith(parent: applicationScope)
 
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: sessionScope,
             dependencies: .mockAny(),
             identity: mockView,
@@ -98,7 +98,7 @@ class RUMViewScopeTests: XCTestCase {
         context.featuresAttributes = .mockSessionReplayAttributes(hasReplay: hasReplay)
 
         let scope = RUMViewScope(
-            isInitialView: true,
+            shouldSendApplicationLaunch: true,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -145,7 +145,7 @@ class RUMViewScopeTests: XCTestCase {
         let customContext: DatadogContext = .mockWith(source: source)
 
         let scope = RUMViewScope(
-            isInitialView: true,
+            shouldSendApplicationLaunch: true,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -180,7 +180,7 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         let scope: RUMViewScope = .mockWith(
-            isInitialView: true,
+            shouldSendApplicationLaunch: true,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -209,7 +209,7 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         let scope: RUMViewScope = .mockWith(
-            isInitialView: true,
+            shouldSendApplicationLaunch: true,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView
@@ -237,7 +237,7 @@ class RUMViewScopeTests: XCTestCase {
 
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
-            isInitialView: true,
+            shouldSendApplicationLaunch: true,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -286,7 +286,7 @@ class RUMViewScopeTests: XCTestCase {
         let customContext: DatadogContext = .mockWith(source: source)
 
         let scope = RUMViewScope(
-            isInitialView: true,
+            shouldSendApplicationLaunch: true,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -310,9 +310,9 @@ class RUMViewScopeTests: XCTestCase {
 
     func testWhenViewIsStarted_itSendsViewUpdateEvent() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
-        let isInitialView: Bool = .mockRandom()
+        let shouldSendApplicationLaunch: Bool = .mockRandom()
         let scope = RUMViewScope(
-            isInitialView: isInitialView,
+            shouldSendApplicationLaunch: shouldSendApplicationLaunch,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -343,7 +343,7 @@ class RUMViewScopeTests: XCTestCase {
         let viewIsActive = try XCTUnwrap(event.view.isActive)
         XCTAssertTrue(viewIsActive)
         XCTAssertEqual(event.view.timeSpent, 1) // Minimum `time_spent of 1 nanosecond
-        XCTAssertEqual(event.view.action.count, isInitialView ? 1 : 0, "It must track application start action only if this is an initial view")
+        XCTAssertEqual(event.view.action.count, shouldSendApplicationLaunch ? 1 : 0, "It must track application start action only if this is an initial view")
         XCTAssertEqual(event.view.error.count, 0)
         XCTAssertEqual(event.view.resource.count, 0)
         XCTAssertEqual(event.dd.documentVersion, 1)
@@ -356,9 +356,9 @@ class RUMViewScopeTests: XCTestCase {
 
     func testWhenViewIsStopped_itSendsViewUpdateEvent_andEndsTheScope() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
-        let isInitialView: Bool = .mockRandom()
+        let shouldSendApplicationLaunch: Bool = .mockRandom()
         let scope = RUMViewScope(
-            isInitialView: isInitialView,
+            shouldSendApplicationLaunch: shouldSendApplicationLaunch,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -408,7 +408,7 @@ class RUMViewScopeTests: XCTestCase {
         let viewIsActive = try XCTUnwrap(event.view.isActive)
         XCTAssertFalse(viewIsActive)
         XCTAssertEqual(event.view.timeSpent, TimeInterval(2).toInt64Nanoseconds)
-        XCTAssertEqual(event.view.action.count, isInitialView ? 1 : 0, "It must track application start action only if this is an initial view")
+        XCTAssertEqual(event.view.action.count, shouldSendApplicationLaunch ? 1 : 0, "It must track application start action only if this is an initial view")
         XCTAssertEqual(event.view.error.count, 0)
         XCTAssertEqual(event.view.resource.count, 0)
         XCTAssertEqual(event.dd.documentVersion, 2)
@@ -424,7 +424,7 @@ class RUMViewScopeTests: XCTestCase {
         let view2 = createMockView(viewControllerClassName: "SecondViewController")
         var currentTime = Date()
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: view1,
@@ -469,7 +469,7 @@ class RUMViewScopeTests: XCTestCase {
     func testWhenTheViewIsStartedAnotherTime_itEndsTheScope() throws {
         var currentTime = Date()
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -514,7 +514,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenMultipleViewScopes_whenSendingViewEvent_eachScopeUsesUniqueViewID() throws {
         func createScope(uri: String, name: String) -> RUMViewScope {
             RUMViewScope(
-                isInitialView: false,
+                shouldSendApplicationLaunch: false,
                 parent: parent,
                 dependencies: .mockAny(),
                 identity: mockView,
@@ -560,7 +560,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testItManagesResourceScopesLifecycle() throws {
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -627,7 +627,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testGivenViewWithPendingResources_whenItGetsStopped_itDoesNotFinishUntilResourcesComplete() throws {
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -704,7 +704,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testItManagesContinuousUserActionScopeLifecycle() throws {
         let scope = RUMViewScope(
-            isInitialView: false,
+            shouldSendApplicationLaunch: false,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -787,7 +787,7 @@ class RUMViewScopeTests: XCTestCase {
     func testItManagesDiscreteUserActionScopeLifecycle() throws {
         var currentTime = Date()
         let scope = RUMViewScope(
-            isInitialView: false,
+            shouldSendApplicationLaunch: false,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -865,7 +865,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenViewWithPendingAction_whenCustomActionIsAdded_itSendsItInstantly() throws {
         var currentTime = Date()
         let scope = RUMViewScope(
-            isInitialView: false,
+            shouldSendApplicationLaunch: false,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -917,7 +917,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenViewWithNoPendingAction_whenCustomActionIsAdded_itSendsItInstantly() throws {
         var currentTime = Date()
         let scope = RUMViewScope(
-            isInitialView: false,
+            shouldSendApplicationLaunch: false,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -964,7 +964,7 @@ class RUMViewScopeTests: XCTestCase {
         // Given
         var currentTime = Date()
         let scope = RUMViewScope(
-            isInitialView: false,
+            shouldSendApplicationLaunch: false,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1027,7 +1027,7 @@ class RUMViewScopeTests: XCTestCase {
 
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1094,7 +1094,7 @@ class RUMViewScopeTests: XCTestCase {
         let customContext: DatadogContext = .mockWith(source: source)
 
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1184,7 +1184,7 @@ class RUMViewScopeTests: XCTestCase {
 
     func testWhenResourceIsFinishedWithError_itSendsViewUpdateEvent() throws {
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1235,7 +1235,7 @@ class RUMViewScopeTests: XCTestCase {
         let startViewDate: Date = .mockDecember15th2019At10AMUTC()
 
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1298,7 +1298,7 @@ class RUMViewScopeTests: XCTestCase {
         let customContext: DatadogContext = .mockWith(source: source)
 
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1338,7 +1338,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenActiveView_whenCustomTimingIsRegistered_itSendsViewUpdateEvent() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1400,7 +1400,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenInactiveView_whenCustomTimingIsRegistered_itDoesNotSendViewUpdateEvent() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1446,7 +1446,7 @@ class RUMViewScopeTests: XCTestCase {
     func testGivenActiveView_whenCustomTimingIsRegistered_itSanitizesCustomTiming() throws {
         var currentTime: Date = .mockDecember15th2019At10AMUTC()
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1511,7 +1511,7 @@ class RUMViewScopeTests: XCTestCase {
 
         // Given
         let scope = RUMViewScope(
-            isInitialView: false,
+            shouldSendApplicationLaunch: false,
             parent: parent,
             dependencies: .mockAny(),
             identity: mockView,
@@ -1627,7 +1627,7 @@ class RUMViewScopeTests: XCTestCase {
         )
 
         let scope = RUMViewScope(
-            isInitialView: true,
+            shouldSendApplicationLaunch: true,
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -1732,7 +1732,7 @@ class RUMViewScopeTests: XCTestCase {
 
         // Given
         let scope = RUMViewScope(
-            isInitialView: true,
+            shouldSendApplicationLaunch: true,
             parent: parent,
             dependencies: dependencies,
             identity: mockView,
@@ -1865,7 +1865,7 @@ class RUMViewScopeTests: XCTestCase {
 
         // Given
         let scope = RUMViewScope(
-            isInitialView: .mockRandom(),
+            shouldSendApplicationLaunch: .mockRandom(),
             parent: parent,
             dependencies: .mockWith(core: core),
             identity: mockView,

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -166,7 +166,6 @@ class RUMViewScopeTests: XCTestCase {
 
     func testWhenViewIsStarted_itSendsViewUpdateEvent() throws {
         let currentTime: Date = .mockDecember15th2019At10AMUTC()
-        let shouldSendApplicationLaunch: Bool = .mockRandom()
         let scope = RUMViewScope(
             shouldSendApplicationLaunch: false,
             parent: parent,

--- a/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDRUMMonitorTests.swift
@@ -213,8 +213,8 @@ class DDRUMMonitorTests: XCTestCase {
         let event2: RUMViewEvent = try viewEvents[1].model()
         XCTAssertEqual(event1.view.name, "SomeView")
         XCTAssertEqual(event2.view.name, "SomeView")
-        XCTAssertEqual(try viewEvents.first?.attribute(forKeyPath: "context.event-attribute1"), "foo1")
-        XCTAssertEqual(try viewEvents.last?.attribute(forKeyPath: "context.event-attribute1"), "foo1")
+        XCTAssertEqual(try viewEvents[0].attribute(forKeyPath: "context.event-attribute1"), "foo1")
+        XCTAssertEqual(try viewEvents[1].attribute(forKeyPath: "context.event-attribute1"), "foo1")
         XCTAssertEqual(try viewEvents.last?.attribute(forKeyPath: "context.event-attribute2"), "foo2")
         XCTAssertNotNil(try? viewEvents.last?.timing(named: "timing"))
     }
@@ -359,18 +359,14 @@ class DDRUMMonitorTests: XCTestCase {
         let rumEventMatchers = try core.waitAndReturnRUMEventMatchers()
 
         let actionEvents = rumEventMatchers.filterRUMEvents(ofType: RUMActionEvent.self)
-        XCTAssertEqual(actionEvents.count, 3)
+        XCTAssertEqual(actionEvents.count, 2)
 
-        let event1Matcher = actionEvents[0]
-        let event1: RUMActionEvent = try event1Matcher.model()
-        XCTAssertEqual(event1.action.type, .applicationStart)
-
-        let event2Matcher = actionEvents[1]
+        let event2Matcher = actionEvents[0]
         let event2: RUMActionEvent = try event2Matcher.model()
         XCTAssertEqual(event2.action.type, .tap)
         XCTAssertEqual(try event2Matcher.attribute(forKeyPath: "context.event-attribute1"), "foo1")
 
-        let event3Matcher = actionEvents[2]
+        let event3Matcher = actionEvents[1]
         let event3: RUMActionEvent = try event3Matcher.model()
         XCTAssertEqual(event3.action.type, .swipe)
         XCTAssertEqual(try event3Matcher.attribute(forKeyPath: "context.event-attribute1"), "foo1")

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -74,6 +74,8 @@ internal class RUMSessionMatcher {
         fileprivate(set) var longTaskEvents: [RUMLongTaskEvent] = []
     }
 
+    let applicationLaunchView: ViewVisit?
+
     /// An array of view visits tracked during this RUM Session.
     /// Each `ViewVisit` is determined by unique `view.id` and groups all RUM events linked to that `view.id`.
     let viewVisits: [ViewVisit]
@@ -199,7 +201,7 @@ internal class RUMSessionMatcher {
         }
 
         // Sort visits by time
-        let visitsEventOrderedByTime = visits.sorted { firstVisit, secondVisit in
+        var visitsEventOrderedByTime = visits.sorted { firstVisit, secondVisit in
             let firstVisitTime = firstVisit.viewEvents[0].date
             let secondVisitTime = secondVisit.viewEvents[0].date
             return firstVisitTime < secondVisitTime
@@ -231,6 +233,14 @@ internal class RUMSessionMatcher {
             }
         }
 
+        if let applicationLaunchIndex = visitsEventOrderedByTime.firstIndex(
+            where: { $0.name == RUMOffViewEventsHandlingRule.Constants.applicationLaunchViewName }
+        ) {
+            self.applicationLaunchView = visitsEventOrderedByTime[applicationLaunchIndex]
+            visitsEventOrderedByTime.remove(at: applicationLaunchIndex)
+        } else {
+            self.applicationLaunchView = nil
+        }
         self.viewVisits = visitsEventOrderedByTime
     }
 }

--- a/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
+++ b/Tests/DatadogTests/Matchers/RUMSessionMatcher.swift
@@ -222,12 +222,6 @@ internal class RUMSessionMatcher {
                     )
                 }
 
-                if index == 0 && !viewIsActive {
-                    throw RUMSessionConsistencyException(
-                        description: "A `RUMSessionMatcher.ViewVisit` can't have a first event with an inactive `View`."
-                    )
-                }
-
                 if viewIsInactive {
                     throw RUMSessionConsistencyException(
                         description: "A `RUMSessionMatcher.ViewVisit` can't have an event after the `View` was marked as inactive."

--- a/docs/rum_collection/data_collected.md
+++ b/docs/rum_collection/data_collected.md
@@ -32,6 +32,12 @@ The following diagram illustrates the RUM event hierarchy:
 
 {{< img src="real_user_monitoring/data_collected/event-hierarchy.png" alt="RUM Event hierarchy" style="width:50%;border:none" >}}
 
+## Application Launch
+
+During initialization the RUM iOS SDK creates a view called "ApplicationLaunch". This view's start time is set to the start of the iOS process, and can be used to track your applicaiton launch time, and will include any logs, actions, and resources made before your first call to `startView`. This view will also have an action, `applicaiton_start`, that spans the entire length of the view, and its duration can be used to time to first view.
+
+In cases where iOS decides to [prewarm your application][4], the ApplicationLaunch view will instead start when the RUM iOS SDK is initialized, and the `application_start` event will not have a duration.
+
 ## Default attributes
 
 RUM collects common attributes for all events and attributes specific to each event by default listed below. You can also choose to enrich your user session data with [additional events][1] to default events specific to your application monitoring and business analytics needs.
@@ -231,3 +237,4 @@ Before data is uploaded to Datadog, it is stored in cleartext in the cache direc
 [1]: https://docs.datadoghq.com/real_user_monitoring/ios/advanced_configuration/#enrich-user-sessions
 [2]: https://docs.datadoghq.com/real_user_monitoring/ios/advanced_configuration/#track-user-sessions
 [3]: https://support.apple.com/guide/security/security-of-runtime-process-sec15bfe098e/web
+[4]: https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence

--- a/docs/rum_collection/data_collected.md
+++ b/docs/rum_collection/data_collected.md
@@ -32,11 +32,13 @@ The following diagram illustrates the RUM event hierarchy:
 
 {{< img src="real_user_monitoring/data_collected/event-hierarchy.png" alt="RUM Event hierarchy" style="width:50%;border:none" >}}
 
-## Application Launch
+## Application launch
 
-During initialization the RUM iOS SDK creates a view called "ApplicationLaunch". This view's start time is set to the start of the iOS process, and can be used to track your applicaiton launch time, and will include any logs, actions, and resources made before your first call to `startView`. This view will also have an action, `applicaiton_start`, that spans the entire length of the view, and its duration can be used to time to first view.
+During initialization, the RUM iOS SDK creates a view called "ApplicationLaunch". This view's start time matches the start of the iOS process, and can be used to track your application launch time.
 
-In cases where iOS decides to [prewarm your application][4], the ApplicationLaunch view will instead start when the RUM iOS SDK is initialized, and the `application_start` event will not have a duration.
+The ApplicationLaunch view includes any logs, actions, and resources created before your first call to `startView`. This view has an action, `application_start`, that spans the entire length of the view. Use the duration of `application_start` to determine time to first view.
+
+In cases where iOS decides to [prewarm your application][4], the ApplicationLaunch view instead starts when the RUM iOS SDK is initialized, and the `application_start` event does not have a duration.
 
 ## Default attributes
 


### PR DESCRIPTION
### What and why?

In order to more accurately track application launch and loading times, we are changing the way the `ApplicationLaunch` view and `application_start` actions work.  

Now, initializing the Datadog SDK with RUM will create the `ApplicationLaunch` view by default, staring at the process launch time. This view can then track any resources, timing, or other events (including user actions) until the first call to `startView`. 

The `application_start` event spans the entire time of the `ApplicationLaunch` view. 

In the event of an active prewarm, the staring time of the `ApplicationLaunch` view is changed to the time the SDK was initialized, and the loading time of the `application_start` event is ignored.

### How?

One big change to the UnitTests here is that now requesting RUM events from the matchers will discard the ApplicationLaunch view, as most tests assume such a view doesn't exist by default. Similarly, the matcher for the Session pulls the ApplicationLaunch view (and all associated events) into its own member, again so that tests that don't expect to see that view still work.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [x] Run smoke tests
