### PR TITLE
RUMM-2889 Support untracked modals

### DIFF
--- a/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
+++ b/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
@@ -74,7 +74,6 @@ final class RUMModalViewsAutoInstrumentationScenario: TestScenario {
     private class Predicate: UIKitRUMViewsPredicate {
         func rumView(for viewController: UIViewController) -> RUMView? {
             if let viewName = viewController.accessibilityLabel {
-                print(viewName)
                 return .init(name: viewName)
             } else {
                 return nil
@@ -99,8 +98,8 @@ final class RUMUntrackedModalViewsAutoInstrumentationScenario: TestScenario {
         func rumView(for viewController: UIViewController) -> RUMView? {
             if let viewName = viewController.accessibilityLabel {
                 if viewController.modalPresentationStyle == .fullScreen {
-                    if #available(iOS 13, *) {
-                        // Untracked on iOS 13 via isModalInPresentation
+                    if #available(iOS 13, tvOS 13, *) {
+                        // Untracked on iOS/tvOS 13+ via isModalInPresentation
                         return nil
                     } else {
                         return .init(name: viewName, isUntrackedModal: true)

--- a/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
+++ b/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
@@ -74,6 +74,38 @@ final class RUMModalViewsAutoInstrumentationScenario: TestScenario {
     private class Predicate: UIKitRUMViewsPredicate {
         func rumView(for viewController: UIViewController) -> RUMView? {
             if let viewName = viewController.accessibilityLabel {
+                print(viewName)
+                return .init(name: viewName)
+            } else {
+                return nil
+            }
+        }
+    }
+
+    func configureSDK(builder: Datadog.Configuration.Builder) {
+        _ = builder
+            .trackUIKitRUMViews(using: Predicate())
+            .enableLogging(false)
+            .enableTracing(false)
+    }
+}
+
+/// Scenario based on `UINavigationController` hierarchy, which presents different VCs modally.
+/// Tracks view controllers as RUM Views.
+final class RUMUntrackedModalViewsAutoInstrumentationScenario: TestScenario {
+    static var storyboardName: String = "RUMModalViewsAutoInstrumentationScenario"
+
+    private class Predicate: UIKitRUMViewsPredicate {
+        func rumView(for viewController: UIViewController) -> RUMView? {
+            if let viewName = viewController.accessibilityLabel {
+                if viewController.modalPresentationStyle == .fullScreen {
+                    if #available(iOS 13, *) {
+                        // Untracked on iOS 13 via isModalInPresentation
+                        return nil
+                    } else {
+                        return .init(name: viewName, isUntrackedModal: true)
+                    }
+                }
                 return .init(name: viewName)
             } else {
                 return nil

--- a/Sources/Datadog/RUM/Instrumentation/Views/RUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/Instrumentation/Views/RUMViewsHandler.swift
@@ -106,9 +106,7 @@ internal final class RUMViewsHandler {
 
         // Stop the last appearing view of the stack
         if let current = stack.last {
-            if !current.isUntrackedModal {
-                stop(view: current)
-            }
+            stop(view: current)
         }
 
         if !view.isUntrackedModal {
@@ -130,15 +128,11 @@ internal final class RUMViewsHandler {
 
         // Stop and remove the visible view from the stack
         let view = stack.removeLast()
-        if !view.isUntrackedModal {
-            stop(view: view)
-        }
+        stop(view: view)
 
         // Restart the previous view if any.
         if let current = stack.last {
-            if !current.isUntrackedModal {
-                start(view: current)
-            }
+            start(view: current)
         }
     }
 
@@ -150,6 +144,10 @@ internal final class RUMViewsHandler {
                 Make sure `Global.rum = RUMMonitor.initialize()` is called before any view appears.
                 """
             )
+        }
+
+        guard !view.isUntrackedModal else {
+            return
         }
 
         guard let identity = view.identity.identifiable else {
@@ -169,6 +167,10 @@ internal final class RUMViewsHandler {
 
     private func stop(view: View) {
         guard let identity = view.identity.identifiable else {
+            return
+        }
+
+        guard !view.isUntrackedModal else {
             return
         }
 
@@ -212,18 +214,16 @@ extension RUMViewsHandler: UIViewControllerHandler {
                     attributes: rumView.attributes
                 )
             )
-        } else if #available(iOS 13, *) {
-            if viewController.isModalInPresentation {
-                add(
-                    view: .init(
-                        identity: viewController.asRUMViewIdentity(),
-                        name: "RUMUntrackedModal",
-                        path: nil,
-                        isUntrackedModal: true,
-                        attributes: [:]
-                    )
+        } else if #available(iOS 13, *), viewController.isModalInPresentation {
+            add(
+                view: .init(
+                    identity: viewController.asRUMViewIdentity(),
+                    name: "RUMUntrackedModal",
+                    path: nil,
+                    isUntrackedModal: true,
+                    attributes: [:]
                 )
-            }
+            )
         }
     }
 

--- a/Sources/Datadog/RUM/Instrumentation/Views/RUMViewsHandler.swift
+++ b/Sources/Datadog/RUM/Instrumentation/Views/RUMViewsHandler.swift
@@ -214,7 +214,7 @@ extension RUMViewsHandler: UIViewControllerHandler {
                     attributes: rumView.attributes
                 )
             )
-        } else if #available(iOS 13, *), viewController.isModalInPresentation {
+        } else if #available(iOS 13, tvOS 13, *), viewController.isModalInPresentation {
             add(
                 view: .init(
                     identity: viewController.asRUMViewIdentity(),

--- a/Sources/Datadog/RUM/Instrumentation/Views/UIKit/UIKitRUMViewsPredicate.swift
+++ b/Sources/Datadog/RUM/Instrumentation/Views/UIKit/UIKitRUMViewsPredicate.swift
@@ -18,6 +18,11 @@ public struct RUMView {
     /// Additional attributes to associate with the RUM View.
     public var attributes: [AttributeKey: AttributeValue]
 
+    /// Whether this view is modal, but should not be tracked with startView and stopView
+    /// When this is true, the view previous to this one will be stopped, but this one will not be
+    /// started. When this view is dismissed, the previous view will be started.
+    public var isUntrackedModal: Bool
+
     /// Initializes the RUM View description.
     /// - Parameters:
     ///   - path: the RUM View path, appearing as `PATH` in RUM Explorer.
@@ -27,16 +32,19 @@ public struct RUMView {
         self.name = path
         self.path = path
         self.attributes = attributes
+        self.isUntrackedModal = false
     }
 
     /// Initializes the RUM View description.
     /// - Parameters:
     ///   - name: the RUM View name, appearing as `VIEW NAME` in RUM Explorer.
     ///   - attributes: additional attributes to associate with the RUM View.
-    public init(name: String, attributes: [AttributeKey: AttributeValue] = [:]) {
+    ///   - isUntrackedModal: true if this view is modal, but should not call startView / stopView.
+    public init(name: String, attributes: [AttributeKey: AttributeValue] = [:], isUntrackedModal: Bool = false) {
         self.name = name
         self.path = nil // the "VIEW URL" will default to view controller class name
         self.attributes = attributes
+        self.isUntrackedModal = isUntrackedModal
     }
 }
 

--- a/Tests/DatadogTests/Datadog/RUM/Instrumentation/Views/RUMViewsHandlerTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Instrumentation/Views/RUMViewsHandlerTests.swift
@@ -311,7 +311,7 @@ class RUMViewsHandlerTests: XCTestCase {
     }
 
     func testGiveniOS13AppearedView_whenTransitioningToModal_viewDoesStop() throws {
-        if #available(iOS 13, *) {
+        if #available(iOS 13, tvOS 13, *) {
             class Predicate: UIKitRUMViewsPredicate {
                 let untrackedModal: UIViewController
 
@@ -349,7 +349,7 @@ class RUMViewsHandlerTests: XCTestCase {
     }
 
     func testGiveniOS13Modal_whenTransitioningToAppearedView_viewDoesStart() throws {
-        if #available(iOS 13, *) {
+        if #available(iOS 13, tvOS 13, *) {
             class Predicate: UIKitRUMViewsPredicate {
                 let untrackedModal: UIViewController
 


### PR DESCRIPTION
### What and why?

This allows modal views to be "untracked" (not call startView / stopView) when using automatic view tracking. The view disappearing under the modal will still call `stopView`, and will restart when the modal is dismissed.  This is useful for  when a user wants to manually track a view controller that is presented modally, or when a framework (such as Flutter or React Native) wants to take over view reporting.

### How?

Pre iOS 13, users will need to set `isUntrackedModal` on the view they return from the predicate. This will push the view onto the `RUMViewsHandler` stack, but this view will not be started or stopped by the `RUMViewsHandler`.

On iOS 13+, views that are marked with `isModalInPresentation`, but return null from the `rumViewPredicate` are automatically considered to be untracked modals.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
