### PR TITLE
RUMM-2884 Add `addFeatureFlagEvaluation` method

### DIFF
--- a/Datadog/Example/Scenarios/RUM/ManualInstrumentation/SendRUMFixture2ViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/ManualInstrumentation/SendRUMFixture2ViewController.swift
@@ -12,6 +12,9 @@ internal class SendRUMFixture2ViewController: UIViewController {
 
         rumMonitor.startView(viewController: self, name: "SendRUMFixture2View")
 
+        rumMonitor.addFeatureFlagEvaluation(name: "mock_flag_a", value: false)
+        rumMonitor.addFeatureFlagEvaluation(name: "mock_flag_b", value: "mock_value")
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             rumMonitor.addError(message: "Simulated view error", source: .source)
         }

--- a/Sources/Datadog/DDRUMMonitor.swift
+++ b/Sources/Datadog/DDRUMMonitor.swift
@@ -271,6 +271,16 @@ public class DDRUMMonitor {
         attributes: [AttributeKey: AttributeValue] = [:]
     ) {}
 
+    /// Adds the result of evaluating a feature flag to the view
+    /// Feature flag evaluations are local to the active view and are cleared when the view is stopped
+    /// - Parameters:
+    ///   - name: the name of the feature flag
+    ///   - value: the result of the evaluation
+    public func addFeatureFlagEvaluation(
+        name: String,
+        value: Encodable
+    ) {}
+
     // MARK: - Attributes
 
     /// Adds a custom attribute to all future events sent by the RUM monitor.

--- a/Sources/Datadog/RUM/RUMMonitor/DDNoopRUMMonitor.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/DDNoopRUMMonitor.swift
@@ -184,6 +184,10 @@ internal class DDNoopRUMMonitor: DDRUMMonitor {
         warn()
     }
 
+    override func addFeatureFlagEvaluation(name: String, value: Encodable) {
+        warn()
+    }
+
     override func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
         warn()
     }

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -310,6 +310,24 @@ internal struct RUMAddUserActionCommand: RUMUserActionCommand {
     let name: String
 }
 
+/// Adds that a feature flag has been evaluated to the view
+internal struct RUMAddFeatureFlagEvaluationCommand: RUMCommand {
+    var time: Date
+    var attributes: [AttributeKey: AttributeValue]
+    let canStartBackgroundView = true // yes, we don't want to miss evaluation of flags that may affect background tasks
+    let canStartApplicationLaunchView = true // yes, we don't want to miss evaluation of feature flags during application launch
+    let isUserInteraction = false
+    let name: String
+    let value: Encodable
+
+    init(time: Date, name: String, value: Encodable) {
+        self.time = time
+        self.attributes = [:]
+        self.name = name
+        self.value = value
+    }
+}
+
 // MARK: - RUM Long Task related commands
 
 internal struct RUMAddLongTaskCommand: RUMCommand {

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -577,6 +577,16 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         )
     }
 
+    override public func addFeatureFlagEvaluation(name: String, value: Encodable) {
+        process(
+            command: RUMAddFeatureFlagEvaluationCommand(
+                time: dateProvider.now,
+                name: name,
+                value: value
+            )
+        )
+    }
+
     // MARK: - Attributes
 
     override public func addAttribute(forKey key: AttributeKey, value: AttributeValue) {

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -89,6 +89,8 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view1.errorEvents[0].error.resource?.url, "https://foo.com/resource/2")
         XCTAssertEqual(view1.errorEvents[0].error.resource?.method, .get)
         XCTAssertEqual(view1.errorEvents[0].error.resource?.statusCode, 400)
+        let featureFlags = try XCTUnwrap(view1.viewEvents.last?.featureFlags)
+        XCTAssertEqual(featureFlags.featureFlagsInfo.count, 0)
         RUMSessionMatcher.assertViewWasEventuallyInactive(view1)
 
         let contentReadyTiming = try XCTUnwrap(view1.viewEventMatchers.last?.timing(named: "content-ready"))
@@ -105,8 +107,14 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view2.viewEvents.last?.view.action.count, 0)
         XCTAssertEqual(view2.viewEvents.last?.view.resource.count, 0)
         XCTAssertEqual(view2.viewEvents.last?.view.error.count, 1)
+        let viewFeatureFlags = try XCTUnwrap(view2.viewEvents.last?.featureFlags)
+        XCTAssertEqual((viewFeatureFlags.featureFlagsInfo["mock_flag_a"] as? DDAnyCodable)?.value as? Bool, false)
+        XCTAssertEqual((viewFeatureFlags.featureFlagsInfo["mock_flag_b"] as? DDAnyCodable)?.value as? String, "mock_value")
         XCTAssertEqual(view2.errorEvents[0].error.message, "Simulated view error")
         XCTAssertEqual(view2.errorEvents[0].error.source, .source)
+        let errorFeatureFlags = try XCTUnwrap(view2.errorEvents[0].featureFlags)
+        XCTAssertEqual((errorFeatureFlags.featureFlagsInfo["mock_flag_a"] as? DDAnyCodable)?.value as? Bool, false)
+        XCTAssertEqual((errorFeatureFlags.featureFlagsInfo["mock_flag_b"] as? DDAnyCodable)?.value as? String, "mock_value")
         RUMSessionMatcher.assertViewWasEventuallyInactive(view2)
 
         let view3 = session.viewVisits[2]

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -570,6 +570,30 @@ extension RUMAddLongTaskCommand: AnyMockable, RandomMockable {
     }
 }
 
+extension RUMAddFeatureFlagEvaluationCommand: AnyMockable, RandomMockable {
+    static func mockAny() -> RUMAddFeatureFlagEvaluationCommand { mockWith() }
+
+    static func mockRandom() -> RUMAddFeatureFlagEvaluationCommand {
+        return mockWith(
+            time: .mockRandomInThePast(),
+            name: .mockRandom(),
+            value: String.mockRandom()
+        )
+    }
+
+    static func mockWith(
+        time: Date = .mockAny(),
+        name: String = .mockAny(),
+        value: Encodable = String.mockAny()
+    ) -> RUMAddFeatureFlagEvaluationCommand {
+        return RUMAddFeatureFlagEvaluationCommand(
+            time: time,
+            name: name,
+            value: value
+        )
+    }
+}
+
 // MARK: - RUMCommand Property Mocks
 
 extension RUMInternalErrorSource: RandomMockable {

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -571,9 +571,9 @@ extension RUMAddLongTaskCommand: AnyMockable, RandomMockable {
 }
 
 extension RUMAddFeatureFlagEvaluationCommand: AnyMockable, RandomMockable {
-    static func mockAny() -> RUMAddFeatureFlagEvaluationCommand { mockWith() }
+    public static func mockAny() -> RUMAddFeatureFlagEvaluationCommand { mockWith() }
 
-    static func mockRandom() -> RUMAddFeatureFlagEvaluationCommand {
+    public static func mockRandom() -> RUMAddFeatureFlagEvaluationCommand {
         return mockWith(
             time: .mockRandomInThePast(),
             name: .mockRandom(),

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -864,7 +864,7 @@ class RUMMonitorTests: XCTestCase {
         let flagValue: Bool = .mockRandom()
         monitor.addFeatureFlagEvaluation(name: flagName, value: flagValue)
 
-        let rumEventMatchers = try core.waitAndReturnEvents(of: RUMFeature.self, ofType: RUMViewEvent.self)
+        let rumEventMatchers = core.waitAndReturnEvents(of: RUMFeature.self, ofType: RUMViewEvent.self)
         let lastViewUpdate = try XCTUnwrap(rumEventMatchers.last)
         let flags = try XCTUnwrap(lastViewUpdate.featureFlags)
         XCTAssertEqual(flags.featureFlagsInfo[flagName] as? Bool, flagValue)
@@ -892,7 +892,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.addError(message: .mockAny())
 
         // Then
-        let rumErrorEvents = try core.waitAndReturnEvents(of: RUMFeature.self, ofType: RUMErrorEvent.self)
+        let rumErrorEvents = core.waitAndReturnEvents(of: RUMFeature.self, ofType: RUMErrorEvent.self)
         let lastError = try XCTUnwrap(rumErrorEvents.last)
         let flags = try XCTUnwrap(lastError.featureFlags)
         XCTAssertEqual(flags.featureFlagsInfo[flagName] as? Bool, flagValue)
@@ -919,7 +919,7 @@ class RUMMonitorTests: XCTestCase {
         monitor.startView(viewController: mockSecondView)
 
         // Then
-        let rumEventMatchers = try core.waitAndReturnEvents(of: RUMFeature.self, ofType: RUMViewEvent.self)
+        let rumEventMatchers = core.waitAndReturnEvents(of: RUMFeature.self, ofType: RUMViewEvent.self)
         let lastViewUpdate = try XCTUnwrap(rumEventMatchers.last)
         let flags = try XCTUnwrap(lastViewUpdate.featureFlags)
         XCTAssertEqual(flags.featureFlagsInfo.count, 0)


### PR DESCRIPTION
### What and why?

Add a method to report the result of evaluating a feature flag to a RUM view. These feature flags are subsequently sent on view updates and error updates.

Feature flags are set on view scope, and are discarded when a new view starts.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
