### PR TITLE
Use scaled font when text exceeds bounds of the frame

### DIFF
--- a/DatadogSessionReplay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/DatadogSessionReplay/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -82,11 +82,20 @@ internal class WireframesBuilder {
             )
         }
 
+        var fontSize = Int64(withNoOverflow: font?.pointSize ?? Fallback.fontSize)
+        if let boundingBox = textFrame?.size {
+            let area = boundingBox.width * boundingBox.height
+            let calculatedFontSize = Int64(sqrt(area / CGFloat(text.count)))
+            if calculatedFontSize < fontSize {
+                fontSize = calculatedFontSize
+            }
+        }
+
         // TODO: RUMM-2452 Better recognize the font:
         let textStyle = SRTextStyle(
             color: textColor.flatMap { hexString(from: $0) } ?? Fallback.color,
             family: Fallback.fontFamily,
-            size: Int64(withNoOverflow: font?.pointSize ?? Fallback.fontSize)
+            size: fontSize
         )
 
         let wireframe = SRTextWireframe(


### PR DESCRIPTION
### What and why?

Adds tiny improvement for font scaling when text exceeds the bounds of the frame in order to fix majority of edge cases on the player side with rendering to big fonts. Effects can be watched [here](https://dd.datad0g.com/rum/replay/sessions/9c015e90-171e-4be9-992b-8ee9b338c283?seed=567aaf8c-6d2c-4fad-96d9-32b6548c4877&ts=1675424701418)

### How?

Makes a simply calculation and checks if estimated font size is smaller than the actual font.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
