### PR TITLE
Introduce extra sampling rate of 20% for configuration telemetry events

### DIFF
--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -91,14 +91,16 @@ extension RUMTelemetry {
         dateProvider: DateProvider = SystemDateProvider(),
         configurationEventMapper: RUMTelemetryConfiguratoinMapper? = nil,
         delayedDispatcher: RUMTelemetryDelayedDispatcher? = nil,
-        sampler: Sampler = .init(samplingRate: 100)
+        sampler: Sampler = .init(samplingRate: 100),
+        configurationExtraSampler: Sampler = .init(samplingRate: 100)
     ) -> Self {
         .init(
             in: core,
             dateProvider: dateProvider,
             configurationEventMapper: configurationEventMapper,
             delayedDispatcher: delayedDispatcher,
-            sampler: sampler
+            sampler: sampler,
+            configurationExtraSampler: configurationExtraSampler
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMTelemetryTests.swift
@@ -266,6 +266,22 @@ class RUMTelemetryTests: XCTestCase {
         XCTAssertEqual(events.count, 0)
     }
 
+    func testSampledTelemetry_rejectAllConfiguration() throws {
+        // Given
+        let telemetry: RUMTelemetry = .mockWith(core: core, sampler: .mockKeepAll(), configurationExtraSampler: .mockRejectAll())
+
+        // When
+        // sends 10 telemetry events
+        for _ in 0..<10 {
+            telemetry.configuration(configuration: .mockAny())
+        }
+
+        // Then
+        let eventMatchers = try core.waitAndReturnRUMEventMatchers()
+        let events = try eventMatchers.compactMap(TelemetryDebugEvent.self)
+        XCTAssertEqual(events.count, 0)
+    }
+
     func testSendTelemetry_resetAfterSessionExpire() throws {
         // Given
         let telemetry: RUMTelemetry = .mockAny(in: core)
@@ -304,7 +320,8 @@ class RUMTelemetryTests: XCTestCase {
         let telemetry: RUMTelemetry = .mockWith(
             core: core,
             delayedDispatcher: { block in delayedDispatch = block },
-            sampler: .mockKeepAll()
+            sampler: .mockKeepAll(),
+            configurationExtraSampler: .mockKeepAll()
         )
 
         // When


### PR DESCRIPTION
### What and why?
This change applies extra sampling rate (20%) to the configuration telemetry events on top of the telemetry sampling rate configured.

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
