### PR TITLE
Fix a bug caught by integration test

### DIFF
--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -286,7 +286,7 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
             }
 
             if let baggage: [String: String?] = context.featuresAttributes["rum"]?.ids {
-                event.merge(baggage) { $1 }
+                event.merge(baggage as [String: Any]) { $1 }
             }
 
             writer.write(value: AnyEncodable(event))

--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -285,7 +285,7 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
                 event[dateKey] = correctedTimestamp
             }
 
-            if let baggage: [String: String] = context.featuresAttributes["rum"]?.ids {
+            if let baggage: [String: String?] = context.featuresAttributes["rum"]?.ids {
                 event.merge(baggage) { $1 }
             }
 


### PR DESCRIPTION
### What and why?

There was an issue caught by integration test. It was caused by existence of optional field if the dictionary.

### How?

This PR fixes the type casting to include optional strings. Way to go is to refactor the communication to always use Codable model that describes the contract. Created a ticket to tackle that next week `RUMM-3023`.

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
