### PR TITLE
RUMM-2965 [SR] Support `UISlider` elements in session replay

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -9,6 +9,7 @@ import UIKit
 internal enum Fixture: CaseIterable {
     case basicShapes
     case basicTexts
+    case sliders
 
     var menuItemTitle: String {
         switch self {
@@ -16,6 +17,8 @@ internal enum Fixture: CaseIterable {
             return "Basic Shapes"
         case .basicTexts:
             return "Basic Texts"
+        case .sliders:
+            return "Sliders"
         }
     }
 
@@ -25,10 +28,13 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.basic.instantiateViewController(withIdentifier: "Shapes")
         case .basicTexts:
             return UIStoryboard.basic.instantiateViewController(withIdentifier: "Texts")
+        case .sliders:
+            return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Sliders")
         }
     }
 }
 
 internal extension UIStoryboard {
     static var basic: UIStoryboard { UIStoryboard(name: "Basic", bundle: nil) }
+    static var inputElements: UIStoryboard { UIStoryboard(name: "InputElements", bundle: nil) }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="Sliders" id="Y6W-OH-hqX" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Yve-BN-xJl">
+                                <rect key="frame" x="8" y="67" width="377" height="257.33333333333331"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Default" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="58E-a2-QBR">
+                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.25" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="2CT-Qs-j6J">
+                                        <rect key="frame" x="-2" y="28.333333333333329" width="381" height="31"/>
+                                    </slider>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom #1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LCt-iw-0lq">
+                                        <rect key="frame" x="0.0" y="66.333333333333343" width="377" height="20.333333333333329"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="tO8-Zl-4Hg">
+                                        <rect key="frame" x="-2" y="94.666666666666657" width="381" height="31"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="tintColor" red="0.68627450980000004" green="0.32156862749999998" blue="0.87058823529999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </slider>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom #2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qpG-zV-nx4">
+                                        <rect key="frame" x="0.0" y="132.66666666666666" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.75" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="KhM-f4-26g">
+                                        <rect key="frame" x="-2" y="161" width="381" height="31"/>
+                                        <color key="backgroundColor" red="1" green="0.864335344423108" blue="0.51734547555716937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="minimumTrackTintColor" systemColor="systemGreenColor"/>
+                                        <color key="maximumTrackTintColor" name="BAD7E9"/>
+                                        <color key="thumbTintColor" name="AccentColor"/>
+                                    </slider>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6pJ-Hu-FuQ">
+                                        <rect key="frame" x="0.0" y="199" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <slider opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.25" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="lJg-io-KGR">
+                                        <rect key="frame" x="-2" y="227.33333333333331" width="381" height="31"/>
+                                    </slider>
+                                </subviews>
+                            </stackView>
+                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.25" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="lIF-gm-hXc">
+                                <rect key="frame" x="137.66666666666666" y="420" width="118" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="114" id="8Od-mm-XTu"/>
+                                </constraints>
+                            </slider>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Yve-BN-xJl" secondAttribute="trailing" constant="8" id="A6y-1R-Vzh"/>
+                            <constraint firstItem="Yve-BN-xJl" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="8" id="Dlt-zK-kfl"/>
+                            <constraint firstItem="Yve-BN-xJl" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="8" id="MqY-Tj-a8h"/>
+                            <constraint firstItem="lIF-gm-hXc" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="e1K-oQ-CfQ"/>
+                            <constraint firstItem="lIF-gm-hXc" firstAttribute="top" secondItem="Yve-BN-xJl" secondAttribute="bottom" constant="95.670000000000002" id="iwl-qp-6qm"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="138" y="6"/>
+        </scene>
+    </scenes>
+    <resources>
+        <namedColor name="AccentColor">
+            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="BAD7E9">
+            <color red="0.72899997234344482" green="0.84299999475479126" blue="0.91399997472763062" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGreenColor">
+            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		616C37DA299F6913005E0472 /* InputElements.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 616C37D9299F6913005E0472 /* InputElements.storyboard */; };
 		619C49B229952108006B66A6 /* Framer in Frameworks */ = {isa = PBXBuildFile; productRef = 619C49B129952108006B66A6 /* Framer */; };
 		619C49B429952E12006B66A6 /* SnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619C49B329952E12006B66A6 /* SnapshotTestCase.swift */; };
 		619C49B72995512A006B66A6 /* ImageComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619C49B62995512A006B66A6 /* ImageComparison.swift */; };
@@ -36,6 +37,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		616C37D9299F6913005E0472 /* InputElements.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = InputElements.storyboard; sourceTree = "<group>"; };
 		619C49B329952E12006B66A6 /* SnapshotTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestCase.swift; sourceTree = "<group>"; };
 		619C49B62995512A006B66A6 /* ImageComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageComparison.swift; sourceTree = "<group>"; };
 		619C49B8299551F5006B66A6 /* _snapshots_ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = _snapshots_; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 				61B634EA299A5DB3002BEABE /* Fixtures.swift */,
 				61E7DFB8299A5A3E001D7A3A /* Basic.storyboard */,
 				61E7DFBA299A5C9D001D7A3A /* BasicViewControllers.swift */,
+				616C37D9299F6913005E0472 /* InputElements.storyboard */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -236,6 +239,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				616C37DA299F6913005E0472 /* InputElements.storyboard in Resources */,
 				61B3BC572993BE2F0032C78A /* LaunchScreen.storyboard in Resources */,
 				61E7DFB9299A5A3E001D7A3A /* Basic.storyboard in Resources */,
 				61B3BC522993BE2E0032C78A /* Main.storyboard in Resources */,

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -34,4 +34,22 @@ final class SRSnapshotTests: SnapshotTestCase {
             record: recordingMode
         )
     }
+
+    func testSliders() throws {
+        show(fixture: .sliders)
+
+        var image = try takeSnapshot(configuration: .init(privacy: .allowAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
+            record: recordingMode
+        )
+
+        image = try takeSnapshot(configuration: .init(privacy: .maskAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-maskAll-privacy"),
+            record: recordingMode
+        )
+    }
 }

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -170,3 +170,20 @@ internal class WireframesBuilder {
         )
     }
 }
+
+// MARK: - Convenience
+
+internal extension WireframesBuilder {
+    func createShapeWireframe(id: WireframeID, frame: CGRect, attributes: ViewAttributes) -> SRWireframe {
+        return createShapeWireframe(
+            id: id,
+            frame: frame,
+            clip: nil,
+            borderColor: attributes.layerBorderColor,
+            borderWidth: attributes.layerBorderWidth,
+            backgroundColor: attributes.backgroundColor,
+            cornerRadius: attributes.layerCornerRadius,
+            opacity: attributes.alpha
+        )
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGenerator.swift
@@ -11,10 +11,6 @@ import UIKit
 /// It is used to mark `UIViews` which correspond to single wireframe in the replay.
 internal typealias NodeID = Int64
 
-/// Pair of unique IDs of a single view in view-tree hierarchy.
-/// It is used to mark `UIViews` which correspond to two wireframes in the replay.
-internal typealias NodeID2 = (NodeID, NodeID)
-
 /// Manages `NodeIDs` for `UIView` instances.
 ///
 /// Each `UIView` can be assigned one or more unique IDs. All IDs are linked to `UIView` lifespans, so querying
@@ -46,17 +42,17 @@ internal final class NodeIDGenerator {
         }
     }
 
-    /// Returns two `NodeIDs` for given instance of `UIView`.
+    /// Returns multiple `NodeIDs` for given instance of `UIView`.
+    /// - Parameter size: the number of IDs
     /// - Parameter view: the `UIView` object
-    /// - Returns: `NodeIDs` of queried instance
-    func nodeID2(for view: UIView) -> NodeID2 {
-        if let currentID2 = view.nodeID2 {
-            return currentID2
+    /// - Returns: an array with given number of `NodeID` values
+    func nodeIDs(_ size: Int, for view: UIView) -> [NodeID] {
+        if let currentIDs = view.nodeIDs, currentIDs.count == size {
+            return currentIDs
         } else {
-            let id1 = getNextID()
-            let id2 = getNextID()
-            view.nodeID2 = (id1, id2)
-            return (id1, id2)
+            let ids = (0..<size).map { _ in getNextID() }
+            view.nodeIDs = ids
+            return ids
         }
     }
 
@@ -70,7 +66,7 @@ internal final class NodeIDGenerator {
 // MARK: - UIView tagging
 
 fileprivate var associatedNodeIDKey: UInt8 = 1
-fileprivate var associatedNodeID2Key: UInt8 = 2
+fileprivate var associatedNodeIDsKey: UInt8 = 2
 
 private extension UIView {
     var nodeID: NodeID? {
@@ -78,8 +74,8 @@ private extension UIView {
         get { objc_getAssociatedObject(self, &associatedNodeIDKey) as? NodeID }
     }
 
-    var nodeID2: NodeID2? {
-        set { objc_setAssociatedObject(self, &associatedNodeID2Key, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
-        get { objc_getAssociatedObject(self, &associatedNodeID2Key) as? (NodeID, NodeID) }
+    var nodeIDs: [NodeID]? {
+        set { objc_setAssociatedObject(self, &associatedNodeIDsKey, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+        get { objc_getAssociatedObject(self, &associatedNodeIDsKey) as? [NodeID] }
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -21,7 +21,7 @@ internal struct UIImageViewRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        let ids = context.ids.nodeID2(for: imageView)
+        let ids = context.ids.nodeIDs(2, for: imageView)
         let contentFrame: CGRect?
         if let image = imageView.image {
             contentFrame = attributes.frame.contentFrame(
@@ -32,8 +32,8 @@ internal struct UIImageViewRecorder: NodeRecorder {
             contentFrame = nil
         }
         let builder = UIImageViewWireframesBuilder(
-            wireframeID: ids.0,
-            imageWireframeID: ids.1,
+            wireframeID: ids[0],
+            imageWireframeID: ids[1],
             attributes: attributes,
             contentFrame: contentFrame,
             clipsToBounds: imageView.clipsToBounds,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
@@ -1,0 +1,122 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+internal struct UISliderRecorder: NodeRecorder {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        guard let slider = view as? UISlider else {
+            return nil
+        }
+
+        guard attributes.isVisible else {
+            return InvisibleElement.constant
+        }
+
+        let ids = context.ids.nodeIDs(4, for: slider)
+
+        let builder = UISliderWireframesBuilder(
+            wireframeRect: attributes.frame,
+            attributes: attributes,
+            backgroundWireframeID: ids[0],
+            minTrackWireframeID: ids[1],
+            maxTrackWireframeID: ids[2],
+            thumbWireframeID: ids[3],
+            value: (min: slider.minimumValue, max: slider.maximumValue, current: slider.value),
+            isEnabled: slider.isEnabled,
+            minTrackTintColor: slider.minimumTrackTintColor?.cgColor ?? slider.tintColor?.cgColor,
+            maxTrackTintColor: slider.maximumTrackTintColor?.cgColor,
+            thumbTintColor: slider.thumbTintColor?.cgColor
+        )
+        return SpecificElement(wireframesBuilder: builder, recordSubtree: false)
+    }
+}
+
+internal struct UISliderWireframesBuilder: NodeWireframesBuilder {
+    struct SystemDefaults {
+        static let thumbTintColor = UIColor.white.cgColor
+        static let thumbBorderColor = UIColor.lightGray.cgColor
+        static let minTrackColor = UIColor.systemBlue.cgColor
+        static let maxTrackColor = UIColor.lightGray.cgColor
+    }
+
+    var wireframeRect: CGRect
+    let attributes: ViewAttributes
+
+    let backgroundWireframeID: WireframeID
+    let minTrackWireframeID: WireframeID
+    let maxTrackWireframeID: WireframeID
+    let thumbWireframeID: WireframeID
+    let value: (min: Float, max: Float, current: Float)
+    let isEnabled: Bool
+    let minTrackTintColor: CGColor?
+    let maxTrackTintColor: CGColor?
+    let thumbTintColor: CGColor?
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        guard value.max > value.min else {
+            return [] // illegal, should not happen
+        }
+
+        let normalValue = CGFloat((value.current - value.min) / (value.max - value.min)) // normalized, 0 to 1
+        let (left, right) = wireframeRect
+            .divided(atDistance: normalValue * wireframeRect.width, from: .minXEdge)
+
+        // Create thumb wireframe:
+        let radius = wireframeRect.height * 0.5
+        let thumbFrame = CGRect(x: left.maxX, y: left.minY, width: wireframeRect.height, height: wireframeRect.height)
+            .offsetBy(dx: -radius, dy: 0)
+
+        let thumb = builder.createShapeWireframe(
+            id: thumbWireframeID,
+            frame: thumbFrame,
+            borderColor: isEnabled ? SystemDefaults.thumbBorderColor : SystemDefaults.thumbBorderColor.copy(alpha: 0.5),
+            borderWidth: 1,
+            backgroundColor: thumbTintColor ?? SystemDefaults.thumbTintColor,
+            cornerRadius: radius,
+            opacity: attributes.alpha
+        )
+
+        // Create min track wireframe:
+        let leftTrackFrame = left.divided(atDistance: 3, from: .minYEdge)
+            .slice
+            .putInside(left, horizontalAlignment: .left, verticalAlignment: .middle)
+
+        let leftTrack = builder.createShapeWireframe(
+            id: minTrackWireframeID,
+            frame: leftTrackFrame,
+            borderColor: nil,
+            borderWidth: nil,
+            backgroundColor: minTrackTintColor ?? SystemDefaults.minTrackColor,
+            cornerRadius: 0,
+            opacity: isEnabled ? attributes.alpha : 0.5
+        )
+
+        // Create max track wireframe:
+        let rightTrackFrame = right.divided(atDistance: 3, from: .minYEdge)
+            .slice
+            .putInside(right, horizontalAlignment: .left, verticalAlignment: .middle)
+
+        let rightTrack = builder.createShapeWireframe(
+            id: maxTrackWireframeID,
+            frame: rightTrackFrame,
+            borderColor: nil,
+            borderWidth: nil,
+            backgroundColor: maxTrackTintColor ?? SystemDefaults.maxTrackColor,
+            cornerRadius: 0,
+            opacity: isEnabled ? attributes.alpha : 0.5
+        )
+
+        if attributes.hasAnyAppearance {
+            // Create background wireframe only if view declares visible background
+            let backgorund = builder.createShapeWireframe(id: backgroundWireframeID, frame: wireframeRect, attributes: attributes)
+
+            return [backgorund, leftTrack, rightTrack, thumb]
+        } else {
+            return [leftTrack, rightTrack, thumb]
+        }
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
@@ -16,11 +16,11 @@ internal struct UISwitchRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        let (backgroundWireframeID, thumbWireframeID) = context.ids.nodeID2(for: `switch`)
+        let ids = context.ids.nodeIDs(2, for: `switch`)
 
         let builder = UISwitchWireframesBuilder(
-            backgroundWireframeID: backgroundWireframeID,
-            thumbWireframeID: thumbWireframeID,
+            backgroundWireframeID: ids[0],
+            thumbWireframeID: ids[1],
             attributes: attributes,
             isOn: `switch`.isOn,
             thumbTintColor: `switch`.thumbTintColor?.cgColor,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -31,15 +31,7 @@ internal struct UIViewWireframesBuilder: NodeWireframesBuilder {
 
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
         return [
-            builder.createShapeWireframe(
-                id: wireframeID,
-                frame: wireframeRect,
-                borderColor: attributes.layerBorderColor,
-                borderWidth: attributes.layerBorderWidth,
-                backgroundColor: attributes.backgroundColor,
-                cornerRadius: attributes.layerCornerRadius,
-                opacity: attributes.alpha
-            )
+            builder.createShapeWireframe(id: wireframeID, frame: wireframeRect, attributes: attributes)
         ]
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -103,6 +103,7 @@ extension ViewTreeSnapshotBuilder {
                 UITextFieldRecorder(),
                 UITextViewRecorder(),
                 UISwitchRecorder(),
+                UISliderRecorder(),
                 UINavigationBarRecorder(),
                 UITabBarRecorder(),
             ]

--- a/DatadogSessionReplay/Sources/Utilities/CGRectExtensions.swift
+++ b/DatadogSessionReplay/Sources/Utilities/CGRectExtensions.swift
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+
+internal extension CGRect {
+    enum HorizontalAlignment {
+        case left, right, center
+    }
+
+    enum VerticalAlignment {
+        case top, bottom, middle
+    }
+
+    /// Puts this rect inside other rect with given alignment.
+    func putInside(
+        _ other: CGRect,
+        horizontalAlignment: HorizontalAlignment,
+        verticalAlignment: VerticalAlignment
+    ) -> CGRect {
+        var new = self
+
+        switch horizontalAlignment {
+        case .left:     new.origin.x = other.minX
+        case .right:    new.origin.x = other.maxX - new.size.width
+        case .center:   new.origin.x = other.minX + (other.size.width - new.size.width) * 0.5
+        }
+
+        switch verticalAlignment {
+        case .top:      new.origin.y = other.minY
+        case .bottom:   new.origin.y = other.maxY - new.size.height
+        case .middle:   new.origin.y = other.minY + (other.size.height - new.size.height) * 0.5
+        }
+
+        return new
+    }
+}

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeIDGeneratorTests.swift
@@ -10,6 +10,8 @@ import UIKit
 @testable import TestUtilities
 
 class NodeIDGeneratorTests: XCTestCase {
+    private let n: Int = .mockRandom(min: 1, max: 100)
+
     func testAfterIDisRetrievedFirstTime_itAlwaysReturnsTheSameIDForUIViewInstance() {
         // Given
         let view1: UIView = .mockRandom()
@@ -18,31 +20,29 @@ class NodeIDGeneratorTests: XCTestCase {
         // When
         let generator = NodeIDGenerator()
         let id = generator.nodeID(for: view1)
-        let id2 = generator.nodeID2(for: view2)
+        let ids = generator.nodeIDs(n, for: view2)
 
         // Then
         XCTAssertEqual(id, generator.nodeID(for: view1))
-        XCTAssertEqual(id2.0, generator.nodeID2(for: view2).0)
-        XCTAssertEqual(id2.1, generator.nodeID2(for: view2).1)
+        XCTAssertEqual(ids, generator.nodeIDs(n, for: view2))
     }
 
     func testAllIDsAreUnique() {
         // Given
         let viewsWithID: [UIView] = (0..<100).map { _ in UIView(frame: .mockRandom()) }
-        let viewsWithID2: [UIView] = (0..<100).map { _ in UIView(frame: .mockRandom()) }
+        let viewsWithIDs: [UIView] = (0..<100).map { _ in UIView(frame: .mockRandom()) }
 
         // When
         let generator = NodeIDGenerator(currentID: .mockRandom())
         let ids = viewsWithID.map { generator.nodeID(for: $0) }
-        let id2s = viewsWithID2.map { generator.nodeID2(for: $0) }
+        let idNs = viewsWithIDs.map { generator.nodeIDs(n, for: $0) }
 
         // Then
-        let allIDs: Set<NodeID> = zip(ids, id2s).reduce(into: []) { result, ids in
-            result.insert(ids.0)
-            result.insert(ids.1.0)
-            result.insert(ids.1.1)
-        }
-        XCTAssertEqual(allIDs.count, viewsWithID.count + viewsWithID2.count * 2)
+        let singleIDs: Set<NodeID> = ids.reduce(into: []) { result, id in result.insert(id) }
+        let mulitpleIDs: Set<[NodeID]> = idNs.reduce(into: []) { result, ids in result.insert(ids) }
+
+        XCTAssertEqual(singleIDs.count, viewsWithID.count)
+        XCTAssertEqual(mulitpleIDs.map({ Set($0) }).count, viewsWithIDs.count)
     }
 
     func testAfterReachingMaxID_itStartsAgainFromZero() {
@@ -57,5 +57,18 @@ class NodeIDGeneratorTests: XCTestCase {
         XCTAssertEqual(generator.nodeID(for: .mockRandom()), currentID)
         XCTAssertEqual(generator.nodeID(for: .mockRandom()), maxID)
         XCTAssertEqual(generator.nodeID(for: .mockRandom()), 0)
+    }
+
+    func testGivenIDsRetrievedFirstTime_whenQueryingForDifferentSize_itReturnsDistinctIDs() {
+        // Given
+        let view: UIView = .mockRandom()
+        let generator = NodeIDGenerator()
+        let ids1 = generator.nodeIDs(n, for: view)
+
+        // When
+        let ids2 = generator.nodeIDs(.mockRandom(min: 1, max: 100, otherThan: [n]), for: view)
+
+        // Then
+        XCTAssertEqual(Set(ids1).intersection(Set(ids2)), [])
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import TestUtilities
+@testable import DatadogSessionReplay
+
+class UISliderRecorderTests: XCTestCase {
+    private let recorder = UISliderRecorder()
+    private let slider = UISlider()
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenSliderIsNotVisible() throws {
+        // When
+        viewAttributes = .mock(fixture: .invisible)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: slider, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+    }
+
+    func testWhenSliderIsVisible() throws {
+        // Given
+        slider.thumbTintColor = .mockRandom()
+        slider.minimumTrackTintColor = .mockRandom()
+        slider.maximumTrackTintColor = .mockRandom()
+        slider.isEnabled = .mockRandom()
+
+        // When
+        viewAttributes = .mock(fixture: .visible())
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: slider, with: viewAttributes, in: .mockAny()) as? SpecificElement)
+        XCTAssertFalse(semantics.recordSubtree, "Slider's subtree should not be recorded")
+
+        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UISliderWireframesBuilder)
+        XCTAssertEqual(builder.attributes, viewAttributes)
+        XCTAssertEqual(builder.isEnabled, slider.isEnabled)
+        XCTAssertEqual(builder.thumbTintColor, slider.thumbTintColor?.cgColor)
+        XCTAssertEqual(builder.minTrackTintColor, slider.minimumTrackTintColor?.cgColor)
+        XCTAssertEqual(builder.maxTrackTintColor, slider.maximumTrackTintColor?.cgColor)
+    }
+
+    func testWhenViewIsNotOfExpectedType() {
+        // When
+        let view = UITextField()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+    }
+}

--- a/DatadogSessionReplay/Tests/Utilities/CGRectExtensionsTests.swift
+++ b/DatadogSessionReplay/Tests/Utilities/CGRectExtensionsTests.swift
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class CGRectExtensionsTests: XCTestCase {
+    func testPutInside() {
+        // Given
+        let container = CGRect(x: 10, y: 20, width: 100, height: 200)
+        let frame = CGRect(x: .mockRandom(), y: .mockRandom(), width: 40, height: 50)
+
+        // When
+        let insideLT = frame.putInside(container, horizontalAlignment: .left, verticalAlignment: .top)
+        let insideRT = frame.putInside(container, horizontalAlignment: .right, verticalAlignment: .top)
+        let insideCT = frame.putInside(container, horizontalAlignment: .center, verticalAlignment: .top)
+
+        let insideLB = frame.putInside(container, horizontalAlignment: .left, verticalAlignment: .bottom)
+        let insideRB = frame.putInside(container, horizontalAlignment: .right, verticalAlignment: .bottom)
+        let insideCB = frame.putInside(container, horizontalAlignment: .center, verticalAlignment: .bottom)
+
+        let insideLM = frame.putInside(container, horizontalAlignment: .left, verticalAlignment: .middle)
+        let insideRM = frame.putInside(container, horizontalAlignment: .right, verticalAlignment: .middle)
+        let insideCM = frame.putInside(container, horizontalAlignment: .center, verticalAlignment: .middle)
+
+        // Then
+        XCTAssertEqual(insideLT, .init(x: 10, y: 20, width: 40, height: 50))
+        XCTAssertEqual(insideRT, .init(x: 70, y: 20, width: 40, height: 50))
+        XCTAssertEqual(insideCT, .init(x: 40, y: 20, width: 40, height: 50))
+
+        XCTAssertEqual(insideLB, .init(x: 10, y: 170, width: 40, height: 50))
+        XCTAssertEqual(insideRB, .init(x: 70, y: 170, width: 40, height: 50))
+        XCTAssertEqual(insideCB, .init(x: 40, y: 170, width: 40, height: 50))
+
+        XCTAssertEqual(insideLM, .init(x: 10, y: 95, width: 40, height: 50))
+        XCTAssertEqual(insideRM, .init(x: 70, y: 95, width: 40, height: 50))
+        XCTAssertEqual(insideCM, .init(x: 40, y: 95, width: 40, height: 50))
+    }
+}


### PR DESCRIPTION
### What and why?

📦 With this PR we're adding support to `UISlider` elements in session replay.

![testSliders()-maskAll-privacy](https://user-images.githubusercontent.com/2358722/218783902-d868459f-a30a-456e-8c97-86853aa59231.png)

### How?

Regular use of SR framework:
* added `UISliderRecorder` with `UISliderWireframesBuilder`
* added "Sliders" fixture in snapshot tests project.

The slider is constructed with 3 or 4 wireframes:
* 2 wireframes for "min track" and "max track"
* 1 wireframe for the "thumb" element
* 1 optional wireframe if the slider's `UIView` defines visible background

This is the first element that produces more than 2 wireframes, so I had to update the logic of generating `NodeID` (wireframe IDs) for views. Now, the `NodeIDGenerator` can create variadic number of IDs (instead of one or two before).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
