### PR TITLE
RUMM-2972 [SR] Support `UISegmentedControl` elements in session replay

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -10,6 +10,7 @@ internal enum Fixture: CaseIterable {
     case basicShapes
     case basicTexts
     case sliders
+    case segments
 
     var menuItemTitle: String {
         switch self {
@@ -19,6 +20,8 @@ internal enum Fixture: CaseIterable {
             return "Basic Texts"
         case .sliders:
             return "Sliders"
+        case .segments:
+            return "Segments"
         }
     }
 
@@ -30,6 +33,9 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.basic.instantiateViewController(withIdentifier: "Texts")
         case .sliders:
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Sliders")
+        case .segments:
+            return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Segments")
+
         }
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
@@ -3,6 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -86,8 +87,119 @@
             </objects>
             <point key="canvasLocation" x="138" y="6"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="EM5-Q5-n2I">
+            <objects>
+                <viewController storyboardIdentifier="Segments" id="Uyj-Ig-4Fe" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="yDW-cg-1lR">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DTL-W3-6vG">
+                                <rect key="frame" x="8" y="67" width="377" height="328.66666666666669"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Default - 1st selected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WoK-b0-C37">
+                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="m81-jH-gSH">
+                                        <rect key="frame" x="0.0" y="28.333333333333329" width="377" height="32"/>
+                                        <segments>
+                                            <segment title="First"/>
+                                            <segment title="Second"/>
+                                            <segment title="Third"/>
+                                        </segments>
+                                    </segmentedControl>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Default - 2nd selected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ym8-h6-nyq">
+                                        <rect key="frame" x="0.0" y="67.333333333333343" width="377" height="20.333333333333329"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="tHf-vi-tF8">
+                                        <rect key="frame" x="0.0" y="95.666666666666657" width="377" height="32"/>
+                                        <segments>
+                                            <segment title="First"/>
+                                            <segment title="Second"/>
+                                            <segment title="Third"/>
+                                            <segment title="Fourth"/>
+                                            <segment title="Fifth"/>
+                                        </segments>
+                                    </segmentedControl>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom #1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wqb-y1-cbu">
+                                        <rect key="frame" x="0.0" y="134.66666666666666" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="NAy-1U-Vz5">
+                                        <rect key="frame" x="0.0" y="163" width="377" height="32"/>
+                                        <color key="backgroundColor" systemColor="systemPinkColor"/>
+                                        <segments>
+                                            <segment title="First"/>
+                                            <segment title="Second"/>
+                                            <segment title="Third"/>
+                                            <segment title="Fourth"/>
+                                        </segments>
+                                        <color key="selectedSegmentTintColor" systemColor="systemYellowColor"/>
+                                    </segmentedControl>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom #2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IsM-k7-x69">
+                                        <rect key="frame" x="0.0" y="202" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="3uM-nj-w7l">
+                                        <rect key="frame" x="0.0" y="230.33333333333331" width="377" height="32"/>
+                                        <segments>
+                                            <segment title="">
+                                                <imageReference key="image" image="cloud.fill" catalog="system" symbolScale="small"/>
+                                            </segment>
+                                            <segment title="">
+                                                <imageReference key="image" image="cloud.rain.fill" catalog="system" symbolScale="small"/>
+                                            </segment>
+                                            <segment title="">
+                                                <imageReference key="image" image="sun.max.fill" catalog="system" symbolScale="small"/>
+                                            </segment>
+                                        </segments>
+                                    </segmentedControl>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wgm-YM-pqI">
+                                        <rect key="frame" x="0.0" y="269.33333333333331" width="377" height="20.333333333333314"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="Acx-OW-gag">
+                                        <rect key="frame" x="0.0" y="297.66666666666669" width="377" height="32"/>
+                                        <segments>
+                                            <segment title="First"/>
+                                            <segment title="Second"/>
+                                            <segment title="Third"/>
+                                        </segments>
+                                    </segmentedControl>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="lP8-1i-wOE"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="DTL-W3-6vG" firstAttribute="top" secondItem="lP8-1i-wOE" secondAttribute="top" constant="8" id="8Zz-Qp-Yud"/>
+                            <constraint firstItem="DTL-W3-6vG" firstAttribute="leading" secondItem="lP8-1i-wOE" secondAttribute="leading" constant="8" id="Dvj-Mu-I7k"/>
+                            <constraint firstItem="lP8-1i-wOE" firstAttribute="trailing" secondItem="DTL-W3-6vG" secondAttribute="trailing" constant="8" id="tC2-fJ-owI"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2H1-Mt-tGf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1042" y="6"/>
+        </scene>
     </scenes>
     <resources>
+        <image name="cloud.fill" catalog="system" width="128" height="87"/>
+        <image name="cloud.rain.fill" catalog="system" width="126" height="128"/>
+        <image name="sun.max.fill" catalog="system" width="128" height="125"/>
         <namedColor name="AccentColor">
             <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
@@ -99,6 +211,12 @@
         </systemColor>
         <systemColor name="systemGreenColor">
             <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
@@ -549,7 +549,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ncreated/Framing";
 			requirement = {
-				branch = framer;
+				branch = "ship-framer";
 				kind = branch;
 			};
 		};

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -52,4 +52,22 @@ final class SRSnapshotTests: SnapshotTestCase {
             record: recordingMode
         )
     }
+
+    func testSegments() throws {
+        show(fixture: .segments)
+
+        var image = try takeSnapshot(configuration: .init(privacy: .allowAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
+            record: recordingMode
+        )
+
+        image = try takeSnapshot(configuration: .init(privacy: .maskAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-maskAll-privacy"),
+            record: recordingMode
+        )
+    }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
@@ -62,7 +62,7 @@ private extension SRTextWireframe {
             width: CGFloat(width),
             height: CGFloat(height),
             style: frameStyle(border: border, style: shapeStyle),
-            content: frameContent(text: text, textStyle: textStyle)
+            content: frameContent(text: text, textStyle: textStyle, textPosition: textPosition)
         )
     }
 }
@@ -103,7 +103,7 @@ private func frameStyle(border: SRShapeBorder?, style: SRShapeStyle?) -> Bluepri
     return fs
 }
 
-private func frameContent(text: String, textStyle: SRTextStyle?) -> BlueprintFrameContent {
+private func frameContent(text: String, textStyle: SRTextStyle?, textPosition: SRTextPosition?) -> BlueprintFrameContent {
     var fc = BlueprintFrameContent(
         text: text,
         textColor: .clear,
@@ -113,6 +113,21 @@ private func frameContent(text: String, textStyle: SRTextStyle?) -> BlueprintFra
     if let textStyle = textStyle {
         fc.textColor = UIColor(hexString: textStyle.color)
         fc.font = .systemFont(ofSize: CGFloat(textStyle.size))
+    }
+
+    if let textPosition = textPosition {
+        switch textPosition.alignment?.horizontal {
+        case .left?:    fc.horizontalAlignment = .leading
+        case .center?:  fc.horizontalAlignment = .center
+        case .right?:   fc.horizontalAlignment = .trailing
+        default:        break
+        }
+        switch textPosition.alignment?.vertical {
+        case .top?:     fc.verticalAlignment = .leading
+        case .center?:  fc.verticalAlignment = .center
+        case .bottom?:  fc.verticalAlignment = .trailing
+        default:        break
+        }
     }
 
     return fc

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -87,6 +87,7 @@ internal class WireframesBuilder {
         frame: CGRect,
         text: String,
         textFrame: CGRect? = nil,
+        textAlignment: SRTextPosition.Alignment? = nil,
         clip: SRContentClip? = nil,
         textColor: CGColor? = nil,
         font: UIFont? = nil,
@@ -101,7 +102,7 @@ internal class WireframesBuilder {
 
         if let textFrame = textFrame {
             textPosition = .init(
-                alignment: nil, // TODO: RUMM-2452 Improve text rendering
+                alignment: textAlignment,
                 padding: .init(
                     bottom: Int64(withNoOverflow: frame.maxY - textFrame.maxY),
                     left: Int64(withNoOverflow: textFrame.minX - frame.minX),

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+/// Collection of system colors.
+///
+/// Contextual colors are light- and dark-mode sensitive and must be implemented as computed variables,
+/// so they return different values upon `UIUserInterfaceStyle` change.
+///
+/// For older iOS versions that do not support `UIUserInterfaceStyle`, approximate fallbacks are provided.
+/// See https://gist.github.com/ncreated/35bf4d69d83d1a5ab408ff29a77fc9ff for reference when updating this collection.
+internal enum SystemColors {
+    static let clear: CGColor = UIColor.clear.cgColor
+
+    static var tertiarySystemFill: CGColor {
+        if #available(iOS 13.0, *) {
+            return UIColor.tertiarySystemFill.cgColor
+        } else {
+            // Fallback to iOS 16.2 light mode color:
+            return UIColor(red: 118 / 255, green: 118 / 255, blue: 128 / 255, alpha: 1).cgColor
+        }
+    }
+
+    static var tertiarySystemBackground: CGColor {
+        if #available(iOS 13.0, *) {
+            return UIColor.tertiarySystemBackground.cgColor
+        } else {
+            // Fallback to iOS 16.2 light mode color:
+            return UIColor(red: 255 / 255, green: 255 / 255, blue: 255 / 255, alpha: 1).cgColor
+        }
+    }
+
+    static var secondarySystemFill: CGColor {
+        if #available(iOS 13.0, *) {
+            return UIColor.secondarySystemFill.cgColor
+        } else {
+            // Fallback to iOS 16.2 light mode color:
+            return UIColor(red: 120 / 255, green: 120 / 255, blue: 128 / 255, alpha: 1).cgColor
+        }
+    }
+
+    static var label: CGColor {
+        if #available(iOS 13.0, *) {
+            return UIColor.label.cgColor
+        } else {
+            // Fallback to iOS 16.2 light mode color:
+            return UIColor(red: 0 / 255, green: 0 / 255, blue: 0 / 255, alpha: 1).cgColor
+        }
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
@@ -43,6 +43,15 @@ internal enum SystemColors {
         }
     }
 
+    static var tintColor: CGColor {
+        if #available(iOS 15.0, *) {
+            return UIColor.tintColor.cgColor
+        } else {
+            // Fallback to iOS 16.2 light mode color:
+            return UIColor(red: 0 / 255, green: 122 / 255, blue: 255 / 255, alpha: 1).cgColor
+        }
+    }
+
     static var label: CGColor {
         if #available(iOS 13.0, *) {
             return UIColor.label.cgColor

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -1,0 +1,110 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+internal struct UISegmentRecorder: NodeRecorder {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+        guard let segment = view as? UISegmentedControl else {
+            return nil
+        }
+
+        guard attributes.isVisible else {
+            return InvisibleElement.constant
+        }
+
+        let ids = context.ids.nodeIDs(1 + segment.numberOfSegments, for: segment)
+
+        let builder = UISegmentWireframesBuilder(
+            wireframeRect: attributes.frame,
+            attributes: attributes,
+            textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator,
+            backgroundWireframeID: ids[0],
+            segmentWireframeIDs: Array(ids[1..<ids.count]),
+            segmentTitles: (0..<segment.numberOfSegments).map { segment.titleForSegment(at: $0) },
+            selectedSegmentIndex: context.recorder.privacy == .maskAll ? nil : segment.selectedSegmentIndex,
+            selectedSegmentTintColor: {
+                if #available(iOS 13.0, *) {
+                    return segment.selectedSegmentTintColor
+                } else {
+                    return nil
+                }
+            }()
+        )
+        return SpecificElement(wireframesBuilder: builder, recordSubtree: false)
+    }
+}
+
+internal struct UISegmentWireframesBuilder: NodeWireframesBuilder {
+    private enum Defaults {
+        static let segmentFont: UIFont = .systemFont(ofSize: 14)
+    }
+
+    var wireframeRect: CGRect
+    let attributes: ViewAttributes
+    let textObfuscator: TextObfuscating
+
+    let backgroundWireframeID: WireframeID
+    let segmentWireframeIDs: [WireframeID]
+    let segmentTitles: [String?]
+    /// The index of selected segment or `nil` if privacy masking is applied.
+    let selectedSegmentIndex: Int?
+    let selectedSegmentTintColor: UIColor?
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        let numberOfSegments = segmentWireframeIDs.count
+        guard numberOfSegments > 0, segmentTitles.count == numberOfSegments, (selectedSegmentIndex ?? 0) < numberOfSegments else {
+            return [] // illegal, should not happen
+        }
+
+        // Create background wireframe:
+        let background = builder.createShapeWireframe(
+            id: backgroundWireframeID,
+            frame: wireframeRect,
+            borderColor: nil,
+            borderWidth: nil,
+            backgroundColor: attributes.backgroundColor ?? SystemColors.tertiarySystemFill,
+            cornerRadius: 8,
+            opacity: attributes.alpha
+        )
+
+        // Create segment wireframes:
+        let segmentSize = CGSize(
+            width: wireframeRect.width / CGFloat(numberOfSegments),
+            height: wireframeRect.height * 0.96
+        )
+
+        var segmentRects: [CGRect] = [] // rects for succeeding segments
+        var dividedRect = wireframeRect
+        for _ in (0..<numberOfSegments) {
+            let division = dividedRect.divided(atDistance: segmentSize.width, from: .minXEdge)
+            let segmentRect = division.slice.insetBy(dx: 2, dy: 2)
+            dividedRect = division.remainder
+
+            segmentRects.append(segmentRect)
+        }
+
+        let segments = (0..<numberOfSegments).map { idx in
+            let isSelected = idx == selectedSegmentIndex
+            return builder.createTextWireframe(
+                id: segmentWireframeIDs[idx],
+                frame: segmentRects[idx],
+                text: textObfuscator.mask(text: segmentTitles[idx] ?? ""),
+                textFrame: segmentRects[idx],
+                textAlignment: .init(horizontal: .center, vertical: .center),
+                textColor: SystemColors.label,
+                font: Defaults.segmentFont,
+                borderColor: isSelected ? SystemColors.secondarySystemFill : SystemColors.clear,
+                borderWidth: 1,
+                backgroundColor: isSelected ? (selectedSegmentTintColor?.cgColor ?? SystemColors.tertiarySystemBackground) : SystemColors.clear,
+                cornerRadius: 8,
+                opacity: attributes.alpha
+            )
+        }
+
+        return [background] + segments
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
@@ -36,13 +36,6 @@ internal struct UISliderRecorder: NodeRecorder {
 }
 
 internal struct UISliderWireframesBuilder: NodeWireframesBuilder {
-    struct SystemDefaults {
-        static let thumbTintColor = UIColor.white.cgColor
-        static let thumbBorderColor = UIColor.lightGray.cgColor
-        static let minTrackColor = UIColor.systemBlue.cgColor
-        static let maxTrackColor = UIColor.lightGray.cgColor
-    }
-
     var wireframeRect: CGRect
     let attributes: ViewAttributes
 
@@ -73,9 +66,9 @@ internal struct UISliderWireframesBuilder: NodeWireframesBuilder {
         let thumb = builder.createShapeWireframe(
             id: thumbWireframeID,
             frame: thumbFrame,
-            borderColor: isEnabled ? SystemDefaults.thumbBorderColor : SystemDefaults.thumbBorderColor.copy(alpha: 0.5),
+            borderColor: isEnabled ? SystemColors.secondarySystemFill : SystemColors.tertiarySystemFill,
             borderWidth: 1,
-            backgroundColor: thumbTintColor ?? SystemDefaults.thumbTintColor,
+            backgroundColor: isEnabled ? (thumbTintColor ?? UIColor.white.cgColor) : SystemColors.tertiarySystemBackground,
             cornerRadius: radius,
             opacity: attributes.alpha
         )
@@ -90,7 +83,7 @@ internal struct UISliderWireframesBuilder: NodeWireframesBuilder {
             frame: leftTrackFrame,
             borderColor: nil,
             borderWidth: nil,
-            backgroundColor: minTrackTintColor ?? SystemDefaults.minTrackColor,
+            backgroundColor: minTrackTintColor ?? SystemColors.tintColor,
             cornerRadius: 0,
             opacity: isEnabled ? attributes.alpha : 0.5
         )
@@ -105,7 +98,7 @@ internal struct UISliderWireframesBuilder: NodeWireframesBuilder {
             frame: rightTrackFrame,
             borderColor: nil,
             borderWidth: nil,
-            backgroundColor: maxTrackTintColor ?? SystemDefaults.maxTrackColor,
+            backgroundColor: maxTrackTintColor ?? SystemColors.tertiarySystemFill,
             cornerRadius: 0,
             opacity: isEnabled ? attributes.alpha : 0.5
         )

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -104,6 +104,7 @@ extension ViewTreeSnapshotBuilder {
                 UITextViewRecorder(),
                 UISwitchRecorder(),
                 UISliderRecorder(),
+                UISegmentRecorder(),
                 UINavigationBarRecorder(),
                 UITabBarRecorder(),
             ]

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import TestUtilities
+@testable import DatadogSessionReplay
+
+class UISegmentRecorderTests: XCTestCase {
+    private let recorder = UISegmentRecorder()
+    private let segment = UISegmentedControl(items: ["first", "second", "third"])
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenSegmentIsNotVisible() throws {
+        // When
+        viewAttributes = .mock(fixture: .invisible)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: segment, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+    }
+
+    func testWhenSegmentIsVisible() throws {
+        // Given
+        segment.selectedSegmentIndex = 2
+        if #available(iOS 13.0, *) {
+            segment.selectedSegmentTintColor = .mockRandom()
+        }
+
+        // When
+        viewAttributes = .mock(fixture: .visible())
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: segment, with: viewAttributes, in: .mockAny()) as? SpecificElement)
+        XCTAssertFalse(semantics.recordSubtree, "Segment's subtree should not be recorded")
+
+        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UISegmentWireframesBuilder)
+        XCTAssertEqual(builder.attributes, viewAttributes)
+
+        XCTAssertEqual(builder.segmentTitles, ["first", "second", "third"])
+        XCTAssertEqual(builder.selectedSegmentIndex, 2)
+        if #available(iOS 13.0, *) {
+            XCTAssertEqual(builder.selectedSegmentTintColor, segment.selectedSegmentTintColor)
+        }
+    }
+
+    func testWhenViewIsNotOfExpectedType() {
+        // When
+        let view = UITextField()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+    }
+}


### PR DESCRIPTION
### What and why?

📦 With this PR we're adding support to `UISegmentedControl` elements in session replay.

![segment-light](https://user-images.githubusercontent.com/2358722/220169912-d42952f2-6910-4d5b-82bf-120e2583728d.png)


### How?

- added `UISegmentRecorder` with `UISegmentWireframesBuilder`
- added "Segments" fixture and snapshot tests

The slider is constructed with 1 to many wireframes:
- one _shape_ wireframe for drawing the background of entire control
- separate _text_ wireframes for drawing segment labels
- one more _shape_ wireframe to highlight selected segment.

If privacy mode `.maskAll` is enabled, we obfuscate text and do not build selection wireframe:

![segment-mask](https://user-images.githubusercontent.com/2358722/220170498-a5c21a16-9307-4b35-bcd4-d27f59977e48.png)

I also enhanced the way we deal with system colors by introducing `SystemColors` construct. It acts as a collection of system colors, which are UI mode dependant (return different values for light- and dark-mode on iOS 13+). 

Here, an example of segments in dark mode:

![segment-dark](https://user-images.githubusercontent.com/2358722/220170791-a067e092-97d3-4ee0-b764-653fb43fdb7b.png)


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
