### PR TITLE
RUMM-3065 Fix invalid module interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ test-carthage:
 test-cocoapods:
 		@cd dependency-manager-tests/cocoapods && $(MAKE)
 
+# Tests if current branch ships valid a XCFrameworks project.
+test-xcframeworks:
+		@cd dependency-manager-tests/xcframeworks && $(MAKE)
+
 # Generate RUM data models from rum-events-format JSON Schemas
 rum-models-generate:
 		@echo "⚙️  Generating RUM models..."

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -444,6 +444,34 @@ workflows:
         - cache_level: none
         - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/cocoapods/CPProject.xcworkspace"
         - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/CPProject-tvos-static-tests.html"
+    - script:
+        title: Test XCFrameworks compatibility
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            make test-xcframeworks ci=${CI}
+    - xcode-test:
+        title: Run XCProject iOS tests
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
+        inputs:
+        - scheme: App iOS
+        - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
+        - is_clean_build: 'yes'
+        - cache_level: none
+        - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/xcframeworks/XCProject.xcodeproj"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/XCProject-ios-tests.html"
+    - xcode-test:
+        title: Run XCProject tvOS tests
+        run_if: '{{enveq "DD_RUN_SMOKE_TESTS" "1"}}'
+        inputs:
+        - scheme: App tvOS
+        - destination: platform=tvOS Simulator,name=Apple TV,OS=latest
+        - is_clean_build: 'yes'
+        - cache_level: none
+        - project_path: "$BITRISE_SOURCE_DIR/dependency-manager-tests/xcframeworks/XCProject.xcodeproj"
+        - xcpretty_test_options: --color --report html --output "${BITRISE_DEPLOY_DIR}/XCProject-tvos-tests.html"
 
   run_tools_tests:
     description: |-

--- a/dependency-manager-tests/.gitignore
+++ b/dependency-manager-tests/.gitignore
@@ -18,3 +18,6 @@ xcuserdata
 /cocoapods/**/Pods
 /cocoapods/**/Podfile.lock
 /cocoapods/**/Podfile
+
+# XCFramework test
+/xcframeworks/dd-sdk-ios

--- a/dependency-manager-tests/xcframeworks/App/AppDelegate.swift
+++ b/dependency-manager-tests/xcframeworks/App/AppDelegate.swift
@@ -1,0 +1,23 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+import UIKit
+
+@UIApplicationMain
+internal class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    }
+}

--- a/dependency-manager-tests/xcframeworks/App/Info.plist
+++ b/dependency-manager-tests/xcframeworks/App/Info.plist
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/dependency-manager-tests/xcframeworks/App/SceneDelegate.swift
+++ b/dependency-manager-tests/xcframeworks/App/SceneDelegate.swift
@@ -1,0 +1,37 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+import UIKit
+
+internal class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else {
+            return
+        }
+
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = ViewController()
+        self.window = window
+        window.makeKeyAndVisible()
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+    }
+}

--- a/dependency-manager-tests/xcframeworks/App/ViewController.swift
+++ b/dependency-manager-tests/xcframeworks/App/ViewController.swift
@@ -1,0 +1,52 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+import UIKit
+import Datadog
+import DatadogObjc
+import DatadogCrashReporting
+
+internal class ViewController: UIViewController {
+    private var logger: Logger! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        Datadog.initialize(
+            appContext: .init(),
+            trackingConsent: .granted,
+            configuration: Datadog.Configuration
+                .builderUsing(clientToken: "abc", environment: "tests")
+                .enableCrashReporting(using: DDCrashReportingPlugin())
+                .build()
+        )
+
+        self.logger = Logger.builder
+            .sendLogsToDatadog(false)
+            .printLogsToConsole(true)
+            .build()
+
+        Global.sharedTracer = Tracer.initialize(configuration: .init())
+
+        logger.info("It works")
+
+        // Start span, but never finish it (no upload)
+        _ = Global.sharedTracer.startSpan(operationName: "This too")
+
+        addLabel()
+    }
+
+    private func addLabel() {
+        let label = UILabel()
+        label.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(label)
+
+        label.text = "Testing..."
+        label.textColor = .white
+        label.sizeToFit()
+        label.center = view.center
+    }
+}

--- a/dependency-manager-tests/xcframeworks/AppTests/AppTests.swift
+++ b/dependency-manager-tests/xcframeworks/AppTests/AppTests.swift
@@ -1,0 +1,17 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+import XCTest
+
+@testable import App
+
+class CTProjectTests: XCTestCase {
+    func testCallingLogicThatLoadsSDK() throws {
+        let viewController = ViewController()
+        viewController.viewDidLoad()
+        XCTAssertNotNil(viewController.view)
+    }
+}

--- a/dependency-manager-tests/xcframeworks/AppTests/Info.plist
+++ b/dependency-manager-tests/xcframeworks/AppTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/dependency-manager-tests/xcframeworks/AppUITests/AppUITests.swift
+++ b/dependency-manager-tests/xcframeworks/AppUITests/AppUITests.swift
@@ -1,0 +1,15 @@
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2019-Present Datadog, Inc.
+*/
+
+import XCTest
+
+class CTProjectUITests: XCTestCase {
+    func testDisplayingUI() throws {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssert(app.staticTexts["Testing..."].exists)
+    }
+}

--- a/dependency-manager-tests/xcframeworks/AppUITests/Info.plist
+++ b/dependency-manager-tests/xcframeworks/AppUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/dependency-manager-tests/xcframeworks/Makefile
+++ b/dependency-manager-tests/xcframeworks/Makefile
@@ -1,0 +1,25 @@
+GIT_REFERENCE := $(shell git rev-parse --abbrev-ref HEAD)
+ifneq (${BITRISE_GIT_BRANCH},)
+	GIT_REFERENCE := ${BITRISE_GIT_BRANCH}
+endif
+ifneq (${BITRISE_GIT_TAG},)
+	GIT_REFERENCE := ${BITRISE_GIT_TAG}
+endif
+
+GIT_REMOTE := "https://github.com/DataDog/dd-sdk-ios.git"
+ifneq (${BITRISEIO_PULL_REQUEST_REPOSITORY_URL},)
+	GIT_REMOTE := ${BITRISEIO_PULL_REQUEST_REPOSITORY_URL}
+endif
+
+test:
+		@echo "⚙️  Configuring XCProject with remote branch: '${GIT_REFERENCE}'..."
+		@rm -rf dd-sdk-ios/
+		@git clone --depth 1 --branch ${GIT_REFERENCE} ${GIT_REMOTE}
+		@echo "🧪 Build xcframeworks"
+		@cd dd-sdk-ios && tools/distribution/build-xcframework.sh
+		@echo "🧪 Check if expected frameworks exist in $(PWD)/dd-sdk-ios/build/xcframeworks"
+		@[ -e "dd-sdk-ios/build/xcframeworks/Datadog.xcframework" ] && echo "Datadog.xcframework - OK" || { echo "Datadog.xcframework - missing"; false; }
+		@[ -e "dd-sdk-ios/build/xcframeworks/DatadogObjc.xcframework" ] && echo "DatadogObjc.xcframework - OK" || { echo "DatadogObjc.xcframework - missing"; false; }
+		@[ -e "dd-sdk-ios/build/xcframeworks/DatadogCrashReporting.xcframework" ] && echo "DatadogCrashReporting.xcframework - OK" || { echo "DatadogCrashReporting.xcframework - missing"; false; }
+		@[ -e "dd-sdk-ios/build/xcframeworks/CrashReporter.xcframework" ] && echo "CrashReporter.xcframework - OK" || { echo "CrashReporter.xcframework - missing"; false; }
+		@echo "🧪 SUCCEEDED"

--- a/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.pbxproj
+++ b/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.pbxproj
@@ -12,25 +12,27 @@
 		61C3641D243752A500C4D4E6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3641C243752A500C4D4E6 /* ViewController.swift */; };
 		61C36430243752A600C4D4E6 /* AppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3642F243752A600C4D4E6 /* AppTests.swift */; };
 		61C3643B243752A600C4D4E6 /* AppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3643A243752A600C4D4E6 /* AppUITests.swift */; };
-		9E9D5E8A25F90FC6002F12A0 /* DatadogObjc.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9D5E8625F90FC6002F12A0 /* DatadogObjc.xcframework */; };
-		9E9D5E8B25F90FC6002F12A0 /* DatadogObjc.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9D5E8625F90FC6002F12A0 /* DatadogObjc.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9E9D5E8C25F90FC6002F12A0 /* Datadog.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9D5E8725F90FC6002F12A0 /* Datadog.xcframework */; };
-		9E9D5E8D25F90FC6002F12A0 /* Datadog.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9D5E8725F90FC6002F12A0 /* Datadog.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9EF87B8C26B04E1F00998076 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */; };
-		9EF87B8D26B04E1F00998076 /* CrashReporter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D24C2F7627CCDDAA001365B0 /* DatadogCrashReporting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */; };
 		D290BA1B27CD09740019936D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3641C243752A500C4D4E6 /* ViewController.swift */; };
 		D290BA1C27CD09740019936D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C36418243752A500C4D4E6 /* AppDelegate.swift */; };
 		D290BA1D27CD09740019936D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3641A243752A500C4D4E6 /* SceneDelegate.swift */; };
-		D290BA1F27CD09740019936D /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */; };
-		D290BA2027CD09740019936D /* DatadogCrashReporting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */; };
-		D290BA2127CD09740019936D /* Datadog.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9D5E8725F90FC6002F12A0 /* Datadog.xcframework */; };
-		D290BA2227CD09740019936D /* DatadogObjc.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9D5E8625F90FC6002F12A0 /* DatadogObjc.xcframework */; };
-		D290BA2627CD09740019936D /* CrashReporter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D290BA2827CD09740019936D /* Datadog.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9D5E8725F90FC6002F12A0 /* Datadog.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D290BA2927CD09740019936D /* DatadogObjc.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9E9D5E8625F90FC6002F12A0 /* DatadogObjc.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D290BA3327CD09A20019936D /* AppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3642F243752A600C4D4E6 /* AppTests.swift */; };
 		D290BA3F27CD09C70019936D /* AppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C3643A243752A600C4D4E6 /* AppUITests.swift */; };
+		D2F9244A29A4B9A4006733B2 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244629A4B9A3006733B2 /* CrashReporter.xcframework */; };
+		D2F9244B29A4B9A4006733B2 /* CrashReporter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244629A4B9A3006733B2 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D2F9244C29A4B9A4006733B2 /* Datadog.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244729A4B9A3006733B2 /* Datadog.xcframework */; };
+		D2F9244D29A4B9A4006733B2 /* Datadog.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244729A4B9A3006733B2 /* Datadog.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D2F9244E29A4B9A4006733B2 /* DatadogObjc.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244829A4B9A3006733B2 /* DatadogObjc.xcframework */; };
+		D2F9244F29A4B9A4006733B2 /* DatadogObjc.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244829A4B9A3006733B2 /* DatadogObjc.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D2F9245029A4B9A4006733B2 /* DatadogCrashReporting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244929A4B9A3006733B2 /* DatadogCrashReporting.xcframework */; };
+		D2F9245129A4B9A4006733B2 /* DatadogCrashReporting.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244929A4B9A3006733B2 /* DatadogCrashReporting.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D2F9245329A4B9D8006733B2 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244629A4B9A3006733B2 /* CrashReporter.xcframework */; };
+		D2F9245429A4B9D8006733B2 /* CrashReporter.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244629A4B9A3006733B2 /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D2F9245529A4B9D8006733B2 /* Datadog.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244729A4B9A3006733B2 /* Datadog.xcframework */; };
+		D2F9245629A4B9D8006733B2 /* Datadog.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244729A4B9A3006733B2 /* Datadog.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D2F9245729A4B9D8006733B2 /* DatadogCrashReporting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244929A4B9A3006733B2 /* DatadogCrashReporting.xcframework */; };
+		D2F9245829A4B9D8006733B2 /* DatadogCrashReporting.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244929A4B9A3006733B2 /* DatadogCrashReporting.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D2F9245929A4B9D8006733B2 /* DatadogObjc.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244829A4B9A3006733B2 /* DatadogObjc.xcframework */; };
+		D2F9245A29A4B9D8006733B2 /* DatadogObjc.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D2F9244829A4B9A3006733B2 /* DatadogObjc.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,14 +41,14 @@
 			containerPortal = 61C3640D243752A500C4D4E6 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 61C36414243752A500C4D4E6;
-			remoteInfo = CTProject;
+			remoteInfo = XCProject;
 		};
 		61C36437243752A600C4D4E6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 61C3640D243752A500C4D4E6 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 61C36414243752A500C4D4E6;
-			remoteInfo = CTProject;
+			remoteInfo = XCProject;
 		};
 		D290BA4727CD09EC0019936D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -65,28 +67,30 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		9E9D5E8E25F90FC6002F12A0 /* Embed Frameworks */ = {
+		D2F9245229A4B9A4006733B2 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				9EF87B8D26B04E1F00998076 /* CrashReporter.xcframework in Embed Frameworks */,
-				9E9D5E8D25F90FC6002F12A0 /* Datadog.xcframework in Embed Frameworks */,
-				9E9D5E8B25F90FC6002F12A0 /* DatadogObjc.xcframework in Embed Frameworks */,
+				D2F9244D29A4B9A4006733B2 /* Datadog.xcframework in Embed Frameworks */,
+				D2F9245129A4B9A4006733B2 /* DatadogCrashReporting.xcframework in Embed Frameworks */,
+				D2F9244F29A4B9A4006733B2 /* DatadogObjc.xcframework in Embed Frameworks */,
+				D2F9244B29A4B9A4006733B2 /* CrashReporter.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D290BA2527CD09740019936D /* Embed Frameworks */ = {
+		D2F9245B29A4B9D8006733B2 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D290BA2627CD09740019936D /* CrashReporter.xcframework in Embed Frameworks */,
-				D290BA2827CD09740019936D /* Datadog.xcframework in Embed Frameworks */,
-				D290BA2927CD09740019936D /* DatadogObjc.xcframework in Embed Frameworks */,
+				D2F9245A29A4B9D8006733B2 /* DatadogObjc.xcframework in Embed Frameworks */,
+				D2F9245629A4B9D8006733B2 /* Datadog.xcframework in Embed Frameworks */,
+				D2F9245829A4B9D8006733B2 /* DatadogCrashReporting.xcframework in Embed Frameworks */,
+				D2F9245429A4B9D8006733B2 /* CrashReporter.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -96,8 +100,6 @@
 /* Begin PBXFileReference section */
 		615519322461CDB4002A85CF /* Datadog.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.xcconfig; sourceTree = "<group>"; };
 		615519332461CDB4002A85CF /* Datadog.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Datadog.local.xcconfig; sourceTree = "<group>"; };
-		615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = Carthage/Build/CrashReporter.xcframework; sourceTree = "<group>"; };
-		615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogCrashReporting.xcframework; path = Carthage/Build/DatadogCrashReporting.xcframework; sourceTree = "<group>"; };
 		61C36415243752A500C4D4E6 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		61C36418243752A500C4D4E6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61C3641A243752A500C4D4E6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -109,11 +111,13 @@
 		61C36436243752A600C4D4E6 /* App iOS UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "App iOS UITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		61C3643A243752A600C4D4E6 /* AppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUITests.swift; sourceTree = "<group>"; };
 		61C3643C243752A600C4D4E6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9E9D5E8625F90FC6002F12A0 /* DatadogObjc.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogObjc.xcframework; path = Carthage/Build/DatadogObjc.xcframework; sourceTree = "<group>"; };
-		9E9D5E8725F90FC6002F12A0 /* Datadog.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Datadog.xcframework; path = Carthage/Build/Datadog.xcframework; sourceTree = "<group>"; };
 		D290BA2D27CD09740019936D /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D290BA3927CD09A20019936D /* App tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "App tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D290BA4527CD09C70019936D /* App tvOS UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "App tvOS UITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2F9244629A4B9A3006733B2 /* CrashReporter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CrashReporter.xcframework; path = "dd-sdk-ios/build/xcframeworks/CrashReporter.xcframework"; sourceTree = "<group>"; };
+		D2F9244729A4B9A3006733B2 /* Datadog.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Datadog.xcframework; path = "dd-sdk-ios/build/xcframeworks/Datadog.xcframework"; sourceTree = "<group>"; };
+		D2F9244829A4B9A3006733B2 /* DatadogObjc.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogObjc.xcframework; path = "dd-sdk-ios/build/xcframeworks/DatadogObjc.xcframework"; sourceTree = "<group>"; };
+		D2F9244929A4B9A3006733B2 /* DatadogCrashReporting.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DatadogCrashReporting.xcframework; path = "dd-sdk-ios/build/xcframeworks/DatadogCrashReporting.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,10 +125,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9EF87B8C26B04E1F00998076 /* CrashReporter.xcframework in Frameworks */,
-				D24C2F7627CCDDAA001365B0 /* DatadogCrashReporting.xcframework in Frameworks */,
-				9E9D5E8C25F90FC6002F12A0 /* Datadog.xcframework in Frameworks */,
-				9E9D5E8A25F90FC6002F12A0 /* DatadogObjc.xcframework in Frameworks */,
+				D2F9244C29A4B9A4006733B2 /* Datadog.xcframework in Frameworks */,
+				D2F9245029A4B9A4006733B2 /* DatadogCrashReporting.xcframework in Frameworks */,
+				D2F9244E29A4B9A4006733B2 /* DatadogObjc.xcframework in Frameworks */,
+				D2F9244A29A4B9A4006733B2 /* CrashReporter.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,10 +150,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D290BA1F27CD09740019936D /* CrashReporter.xcframework in Frameworks */,
-				D290BA2027CD09740019936D /* DatadogCrashReporting.xcframework in Frameworks */,
-				D290BA2127CD09740019936D /* Datadog.xcframework in Frameworks */,
-				D290BA2227CD09740019936D /* DatadogObjc.xcframework in Frameworks */,
+				D2F9245929A4B9D8006733B2 /* DatadogObjc.xcframework in Frameworks */,
+				D2F9245529A4B9D8006733B2 /* Datadog.xcframework in Frameworks */,
+				D2F9245729A4B9D8006733B2 /* DatadogCrashReporting.xcframework in Frameworks */,
+				D2F9245329A4B9D8006733B2 /* CrashReporter.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -237,10 +241,10 @@
 		61C364492437547A00C4D4E6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				615D9E6A2604B5B1006DC6D1 /* DatadogCrashReporting.xcframework */,
-				615D9E652604B5AB006DC6D1 /* CrashReporter.xcframework */,
-				9E9D5E8725F90FC6002F12A0 /* Datadog.xcframework */,
-				9E9D5E8625F90FC6002F12A0 /* DatadogObjc.xcframework */,
+				D2F9244929A4B9A3006733B2 /* DatadogCrashReporting.xcframework */,
+				D2F9244629A4B9A3006733B2 /* CrashReporter.xcframework */,
+				D2F9244729A4B9A3006733B2 /* Datadog.xcframework */,
+				D2F9244829A4B9A3006733B2 /* DatadogObjc.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -256,14 +260,14 @@
 				61C36412243752A500C4D4E6 /* Frameworks */,
 				61C36413243752A500C4D4E6 /* Resources */,
 				61C3645C243768FC00C4D4E6 /* ⚙️ Run linter */,
-				9E9D5E8E25F90FC6002F12A0 /* Embed Frameworks */,
+				D2F9245229A4B9A4006733B2 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = "App iOS";
-			productName = CTProject;
+			productName = XCProject;
 			productReference = 61C36415243752A500C4D4E6 /* App.app */;
 			productType = "com.apple.product-type.application";
 		};
@@ -281,7 +285,7 @@
 				61C3642D243752A600C4D4E6 /* PBXTargetDependency */,
 			);
 			name = "App iOS Tests";
-			productName = CTProjectTests;
+			productName = XCProjectTests;
 			productReference = 61C3642B243752A600C4D4E6 /* App iOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
@@ -299,7 +303,7 @@
 				61C36438243752A600C4D4E6 /* PBXTargetDependency */,
 			);
 			name = "App iOS UITests";
-			productName = CTProjectUITests;
+			productName = XCProjectUITests;
 			productReference = 61C36436243752A600C4D4E6 /* App iOS UITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
@@ -311,14 +315,14 @@
 				D290BA1E27CD09740019936D /* Frameworks */,
 				D290BA2327CD09740019936D /* Resources */,
 				D290BA2427CD09740019936D /* ⚙️ Run linter */,
-				D290BA2527CD09740019936D /* Embed Frameworks */,
+				D2F9245B29A4B9D8006733B2 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = "App tvOS";
-			productName = CTProject;
+			productName = XCProject;
 			productReference = D290BA2D27CD09740019936D /* App.app */;
 			productType = "com.apple.product-type.application";
 		};
@@ -336,7 +340,7 @@
 				D290BA4A27CD09F00019936D /* PBXTargetDependency */,
 			);
 			name = "App tvOS Tests";
-			productName = CTProjectTests;
+			productName = XCProjectTests;
 			productReference = D290BA3927CD09A20019936D /* App tvOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
@@ -354,7 +358,7 @@
 				D290BA4827CD09EC0019936D /* PBXTargetDependency */,
 			);
 			name = "App tvOS UITests";
-			productName = CTProjectUITests;
+			productName = XCProjectUITests;
 			productReference = D290BA4527CD09C70019936D /* App tvOS UITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
@@ -387,7 +391,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 61C36410243752A500C4D4E6 /* Build configuration list for PBXProject "CTProject" */;
+			buildConfigurationList = 61C36410243752A500C4D4E6 /* Build configuration list for PBXProject "XCProject" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -707,7 +711,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProject;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProject;
 				PRODUCT_NAME = App;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -724,7 +728,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProject;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProject;
 				PRODUCT_NAME = App;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -743,7 +747,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProjectTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -763,7 +767,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProjectTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -782,11 +786,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProjectUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = CTProject;
+				TEST_TARGET_NAME = XCProject;
 			};
 			name = Debug;
 		};
@@ -801,11 +805,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProjectUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = CTProject;
+				TEST_TARGET_NAME = XCProject;
 			};
 			name = Release;
 		};
@@ -819,7 +823,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProject;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProject;
 				PRODUCT_NAME = App;
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
@@ -836,7 +840,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProject;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProject;
 				PRODUCT_NAME = App;
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
@@ -855,7 +859,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProjectTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
@@ -875,7 +879,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProjectTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProjectTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
@@ -894,7 +898,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProjectUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
@@ -913,7 +917,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.CTProjectUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.datadogqh.XCProjectUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
@@ -924,7 +928,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		61C36410243752A500C4D4E6 /* Build configuration list for PBXProject "CTProject" */ = {
+		61C36410243752A500C4D4E6 /* Build configuration list for PBXProject "XCProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				61C3643D243752A600C4D4E6 /* Debug */,

--- a/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:XCProject.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/xcshareddata/xcschemes/App iOS.xcscheme
+++ b/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/xcshareddata/xcschemes/App iOS.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "61C36414243752A500C4D4E6"
+               BuildableName = "App.app"
+               BlueprintName = "App iOS"
+               ReferencedContainer = "container:XCProject.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "61C3642A243752A600C4D4E6"
+               BuildableName = "App iOS Tests.xctest"
+               BlueprintName = "App iOS Tests"
+               ReferencedContainer = "container:XCProject.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "61C36435243752A600C4D4E6"
+               BuildableName = "App iOS UITests.xctest"
+               BlueprintName = "App iOS UITests"
+               ReferencedContainer = "container:XCProject.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61C36414243752A500C4D4E6"
+            BuildableName = "App.app"
+            BlueprintName = "App iOS"
+            ReferencedContainer = "container:XCProject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "61C36414243752A500C4D4E6"
+            BuildableName = "App.app"
+            BlueprintName = "App iOS"
+            ReferencedContainer = "container:XCProject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/xcshareddata/xcschemes/App tvOS.xcscheme
+++ b/dependency-manager-tests/xcframeworks/XCProject.xcodeproj/xcshareddata/xcschemes/App tvOS.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D290BA1927CD09740019936D"
+               BuildableName = "App.app"
+               BlueprintName = "App tvOS"
+               ReferencedContainer = "container:XCProject.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D290BA2F27CD09A20019936D"
+               BuildableName = "App tvOS Tests.xctest"
+               BlueprintName = "App tvOS Tests"
+               ReferencedContainer = "container:XCProject.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D290BA3B27CD09C70019936D"
+               BuildableName = "App tvOS UITests.xctest"
+               BlueprintName = "App tvOS UITests"
+               ReferencedContainer = "container:XCProject.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D290BA1927CD09740019936D"
+            BuildableName = "App.app"
+            BlueprintName = "App tvOS"
+            ReferencedContainer = "container:XCProject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D290BA1927CD09740019936D"
+            BuildableName = "App.app"
+            BlueprintName = "App tvOS"
+            ReferencedContainer = "container:XCProject.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tools/distribution/build-xcframework.sh
+++ b/tools/distribution/build-xcframework.sh
@@ -48,9 +48,7 @@ function archive {
         -destination "$2" \
         -archivePath "$3" \
         SKIP_INSTALL=NO \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
         ONLY_ACTIVE_ARCH=NO \
-        SKIP_INSTALL=NO \
     | xcpretty
 }
 
@@ -79,7 +77,14 @@ function bundle {
     fi
 
     echo "▸ Create $PRODUCT.xcframework"
-    xcodebuild -create-xcframework ${xcoptions[@]} -output "$XCFRAMEWORK_OUTPUT/$PRODUCT.xcframework"
+
+    # Datadog class conflicts with module name and Swift emits invalid module interface
+    # cf. https://github.com/apple/swift/issues/56573
+    #
+    # Therefore, we cannot provide ABI stability and Library Evolution can't be enabled with
+    # 'BUILD_LIBRARY_FOR_DISTRIBUTION=YES' option, we have to supply '-allow-internal-distribution'
+    # instead.
+    xcodebuild -create-xcframework -allow-internal-distribution ${xcoptions[@]} -output "$XCFRAMEWORK_OUTPUT/$PRODUCT.xcframework"
 }
 
 rm -rf $OUTPUT

--- a/tools/distribution/build-xcframework.sh
+++ b/tools/distribution/build-xcframework.sh
@@ -48,6 +48,7 @@ function archive {
         -destination "$2" \
         -archivePath "$3" \
         SKIP_INSTALL=NO \
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
         ONLY_ACTIVE_ARCH=NO \
     | xcpretty
 }
@@ -81,9 +82,7 @@ function bundle {
     # Datadog class conflicts with module name and Swift emits invalid module interface
     # cf. https://github.com/apple/swift/issues/56573
     #
-    # Therefore, we cannot provide ABI stability and Library Evolution can't be enabled with
-    # 'BUILD_LIBRARY_FOR_DISTRIBUTION=YES' option, we have to supply '-allow-internal-distribution'
-    # instead.
+    # Therefore, we cannot provide ABI stability and we have to supply '-allow-internal-distribution'.
     xcodebuild -create-xcframework -allow-internal-distribution ${xcoptions[@]} -output "$XCFRAMEWORK_OUTPUT/$PRODUCT.xcframework"
 }
 


### PR DESCRIPTION
### What and why?

Datadog class conflicts with module name and Swift emits invalid module interface
cf. https://github.com/apple/swift/issues/56573

Therefore, we cannot provide ABI stability, we have to supply `-allow-internal-distribution`.

### Smoke Test

The `xcframeworks` smoke test is added to `dependency-manager-tests`, it checkouts and build the xcframeworks and try to compile for iOS and tvOS.

Fix #1167 

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [x] Run smoke tests
