### PR TITLE
RUMM-2580 Add internal method to access WebEventBridge

### DIFF
--- a/Sources/Datadog/Datadog+Internal.swift
+++ b/Sources/Datadog/Datadog+Internal.swift
@@ -20,6 +20,9 @@ extension Datadog.Configuration.Builder: DatadogInternal {}
 extension DatadogExtension where ExtendedType: Datadog {
     /// Internal telemetry proxy.
     public static var telemetry: _TelemetryProxy { .init() }
+    public static var webEventBridge: _WebEventBridgeProxy {
+        .init(core: defaultDatadogCore)
+    }
 
     /// Changes the `version` used for [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
     public static func set(customVersion: String) {
@@ -45,6 +48,18 @@ public struct _TelemetryProxy {
     /// See Telementry.error
     public func error(id: String, message: String, kind: String?, stack: String?) {
         DD.telemetry.error(id: id, message: message, kind: kind, stack: stack)
+    }
+}
+
+public struct _WebEventBridgeProxy {
+    let bridge: WebEventBridge
+
+    init(core: DatadogCoreProtocol) {
+        bridge = .init(core: core)
+    }
+
+    public func send(_ anyMessage: Any) throws {
+        try bridge.consume(anyMessage)
     }
 }
 


### PR DESCRIPTION
### What and why?

Adds an internal method to assist in WebView bridging.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
