### PR TITLE
RUMM-2964 [SR] Make view-tree recording more customizable

### DIFF
--- a/DatadogSessionReplay/Sources/Processor/Flattening/NodesFlattener.swift
+++ b/DatadogSessionReplay/Sources/Processor/Flattening/NodesFlattener.swift
@@ -7,17 +7,18 @@
 import Foundation
 import CoreGraphics
 
-/// Flattens VTS received from `Recorder` by transforming its tree-structure of nodes into array of nodes.
+/// Flattens VTS received from `Recorder` by removing invisible nodes.
 ///
-/// Flattening includes removal of nodes that are invisible because of being covered by other nodes displayed
-/// closer to the screen surface.
+/// Nodes are invisible if:
+/// - they have no appearance (e.g. nodes denoting container views)
+/// - they are covered by another opaque nodes (displayed closer to the screen surface).
 internal struct NodesFlattener {
     /// This current implementation is greedy and works in `O(n*log(n))`, wheares `O(n)` is possible.
     /// TODO: RUMM-2461 Improve flattening performance.
     func flattenNodes(in snapshot: ViewTreeSnapshot) -> [Node] {
         var flattened: [Node] = []
 
-        dfsVisit(startingFrom: snapshot.root) { nextNode in
+        for nextNode in snapshot.nodes {
             // Skip invisible nodes:
             if !(nextNode.semantics is InvisibleElement) {
                 // When accepting nodes, remove ones that are covered by another opaque node:
@@ -38,12 +39,5 @@ internal struct NodesFlattener {
         }
 
         return flattened
-    }
-
-    private func dfsVisit(startingFrom node: Node, visit: (Node) -> Void) {
-        visit(node)
-        node.children.forEach { child in
-            dfsVisit(startingFrom: child, visit: visit)
-        }
     }
 }

--- a/DatadogSessionReplay/Sources/Processor/Processor.swift
+++ b/DatadogSessionReplay/Sources/Processor/Processor.swift
@@ -29,7 +29,7 @@ internal protocol Processing {
 /// - succeeding records are enriched with their RUM context and written to `DatadogCore`;
 /// - when `DatadogCore` triggers an upload, batched records are deserialized, grouped into SR segments and then uploaded.
 internal class Processor: Processing {
-    /// Flattens VTS received from `Recorder` by transforming its tree-structure into flat array of nodes and removing invisible nodes.
+    /// Flattens VTS received from `Recorder` by removing invisible nodes.
     private let nodesFlattener = NodesFlattener()
     /// Builds SR wireframes to describe UI elements.
     private let wireframesBuilder = WireframesBuilder()

--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/RecordsBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/RecordsBuilder.swift
@@ -17,9 +17,9 @@ internal class RecordsBuilder {
     func createMetaRecord(from snapshot: ViewTreeSnapshot) -> SRRecord {
         let record = SRMetaRecord(
             data: .init(
-                height: Int64(withNoOverflow: snapshot.root.viewAttributes.frame.height),
+                height: Int64(withNoOverflow: snapshot.viewportSize.height),
                 href: nil,
-                width: Int64(withNoOverflow: snapshot.root.viewAttributes.frame.width)
+                width: Int64(withNoOverflow: snapshot.viewportSize.width)
             ),
             timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds
         )
@@ -114,17 +114,15 @@ internal class RecordsBuilder {
         from snapshot: ViewTreeSnapshot,
         lastSnapshot: ViewTreeSnapshot
     ) -> SRRecord? {
-        let lastSize = lastSnapshot.root.viewAttributes.frame.size
-        let currentSize = snapshot.root.viewAttributes.frame.size
-        guard lastSize.aspectRatio != currentSize.aspectRatio else {
+        guard lastSnapshot.viewportSize.aspectRatio != snapshot.viewportSize.aspectRatio else {
             return nil
         }
         return .incrementalSnapshotRecord(
             value: SRIncrementalSnapshotRecord(
                 data: .viewportResizeData(
                     value: .init(
-                        height: Int64(withNoOverflow: currentSize.height),
-                        width: Int64(withNoOverflow: currentSize.width)
+                        height: Int64(withNoOverflow: snapshot.viewportSize.height),
+                        width: Int64(withNoOverflow: snapshot.viewportSize.width)
                     )
                 ),
                 timestamp: snapshot.date.timeIntervalSince1970.toInt64Milliseconds

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/NodeRecorder.swift
@@ -15,9 +15,9 @@ internal protocol NodeRecorder {
     /// - Parameters:
     ///   - view: the `UIView` to determine semantics for
     ///   - attributes: attributes of this view inferred from its base `UIView` interface
-    ///   - context: the context of building current `ViewTreeSnapshot`
+    ///   - context: the context of recording current view-tree
     /// - Returns: the value of `NodeSemantics` or `nil` if the view is a member of view subclass other than the one this recorder is specialised for.
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics?
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics?
 }
 
 /// A type producing SR wireframes.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -12,7 +12,7 @@ internal struct UIImageViewRecorder: NodeRecorder {
     func semantics(
         of view: UIView,
         with attributes: ViewAttributes,
-        in context: ViewTreeSnapshotBuilder.Context
+        in context: ViewTreeRecordingContext
     ) -> NodeSemantics? {
         guard let imageView = view as? UIImageView else {
             return nil

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -41,7 +41,7 @@ internal struct UIImageViewRecorder: NodeRecorder {
             imageTintColor: imageView.tintColor,
             imageDataProvider: imageDataProvider
         )
-        return SpecificElement(wireframesBuilder: builder, recordSubtree: true)
+        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .record)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 internal struct UILabelRecorder: NodeRecorder {
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let label = view as? UILabel else {
             return nil
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -36,7 +36,7 @@ internal struct UILabelRecorder: NodeRecorder {
             textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator,
             wireframeRect: textFrame
         )
-        return SpecificElement(wireframesBuilder: builder, recordSubtree: false)
+        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
@@ -19,7 +19,7 @@ internal struct UINavigationBarRecorder: NodeRecorder {
             color: inferColor(of: navigationBar)
         )
 
-        return SpecificElement(wireframesBuilder: builder, recordSubtree: true)
+        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .record)
     }
 
     private func inferOccupiedFrame(of navigationBar: UINavigationBar, in context: ViewTreeRecordingContext) -> CGRect {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 internal struct UINavigationBarRecorder: NodeRecorder {
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let navigationBar = view as? UINavigationBar else {
             return nil
         }
@@ -22,7 +22,7 @@ internal struct UINavigationBarRecorder: NodeRecorder {
         return SpecificElement(wireframesBuilder: builder, recordSubtree: true)
     }
 
-    private func inferOccupiedFrame(of navigationBar: UINavigationBar, in context: ViewTreeSnapshotBuilder.Context) -> CGRect {
+    private func inferOccupiedFrame(of navigationBar: UINavigationBar, in context: ViewTreeRecordingContext) -> CGRect {
         // TODO: RUMM-2791 Enhance appearance of `UITabBar` and `UINavigationBar` in SR
         var occupiedFrame = navigationBar.frame
         for subview in navigationBar.subviews {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -34,7 +34,7 @@ internal struct UISegmentRecorder: NodeRecorder {
                 }
             }()
         )
-        return SpecificElement(wireframesBuilder: builder, recordSubtree: false)
+        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 internal struct UISegmentRecorder: NodeRecorder {
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let segment = view as? UISegmentedControl else {
             return nil
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
@@ -31,7 +31,7 @@ internal struct UISliderRecorder: NodeRecorder {
             maxTrackTintColor: slider.maximumTrackTintColor?.cgColor,
             thumbTintColor: slider.thumbTintColor?.cgColor
         )
-        return SpecificElement(wireframesBuilder: builder, recordSubtree: false)
+        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 internal struct UISliderRecorder: NodeRecorder {
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let slider = view as? UISlider else {
             return nil
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
@@ -28,7 +28,7 @@ internal struct UISwitchRecorder: NodeRecorder {
             offTintColor: `switch`.tintColor?.cgColor,
             wireframeRect: attributes.frame
         )
-        return SpecificElement(wireframesBuilder: builder, recordSubtree: false)
+        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 internal struct UISwitchRecorder: NodeRecorder {
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let `switch` = view as? UISwitch else {
             return nil
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -18,7 +18,7 @@ internal struct UITabBarRecorder: NodeRecorder {
             attributes: attributes,
             color: inferColor(of: tabBar)
         )
-        return SpecificElement(wireframesBuilder: builder, recordSubtree: true)
+        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .record)
     }
 
     private func inferOccupiedFrame(of tabBar: UITabBar, in context: ViewTreeRecordingContext) -> CGRect {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 internal struct UITabBarRecorder: NodeRecorder {
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let tabBar = view as? UITabBar else {
             return nil
         }
@@ -21,7 +21,7 @@ internal struct UITabBarRecorder: NodeRecorder {
         return SpecificElement(wireframesBuilder: builder, recordSubtree: true)
     }
 
-    private func inferOccupiedFrame(of tabBar: UITabBar, in context: ViewTreeSnapshotBuilder.Context) -> CGRect {
+    private func inferOccupiedFrame(of tabBar: UITabBar, in context: ViewTreeRecordingContext) -> CGRect {
         // TODO: RUMM-2791 Enhance appearance of `UITabBar` and `UINavigationBar` in SR
         var occupiedFrame = tabBar.frame
         for subview in tabBar.subviews {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 internal struct UITextFieldRecorder: NodeRecorder {
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let textField = view as? UITextField else {
             return nil
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -57,7 +57,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
             textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator,
             wireframeRect: textFrame
         )
-        return SpecificElement(wireframesBuilder: builder, recordSubtree: false)
+        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -23,7 +23,7 @@ internal struct UITextViewRecorder: NodeRecorder {
             textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator,
             contentRect: CGRect(origin: textView.contentOffset, size: textView.contentSize)
         )
-        return SpecificElement(wireframesBuilder: builder, recordSubtree: true)
+        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .record)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 internal struct UITextViewRecorder: NodeRecorder {
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let textView = view as? UITextView else {
             return nil
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 internal struct UIViewRecorder: NodeRecorder {
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard attributes.isVisible else {
             return InvisibleElement.constant
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
@@ -1,0 +1,73 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+/// The context of recording subtree hierarchy.
+internal struct ViewTreeRecordingContext {
+    /// The context of the Recorder.
+    let recorder: Recorder.Context
+    /// The coordinate space to convert node positions to.
+    let coordinateSpace: UICoordinateSpace
+    /// Generates stable IDs for traversed views.
+    let ids: NodeIDGenerator
+    /// Masks text in recorded nodes.
+    let textObfuscator: TextObfuscator
+}
+
+internal struct ViewTreeRecorder {
+    /// An array of enabled node recorders.
+    ///
+    /// The order in this this array  should be managed consciously. For each node, the implementation loops
+    /// through `nodeRecorders` and stops on the one that recorded node semantics with highes importance.
+    let nodeRecorders: [NodeRecorder]
+
+    /// Creates `Nodes` for given view and its subtree hierarchy.
+    func recordNodes(for anyView: UIView, in context: ViewTreeRecordingContext) -> [Node] {
+        var nodes: [Node] = []
+        recordRecursively(nodes: &nodes, view: anyView, context: context)
+        return nodes
+    }
+
+    // MARK: - Private
+
+    private func recordRecursively(nodes: inout [Node], view: UIView, context: ViewTreeRecordingContext) {
+        let node = node(for: view, in: context)
+        nodes.append(node)
+
+        if node.semantics.recordSubtree {
+            for subview in view.subviews {
+                recordRecursively(nodes: &nodes, view: subview, context: context)
+            }
+        }
+    }
+
+    private func node(for view: UIView, in context: ViewTreeRecordingContext) -> Node {
+        let attributes = ViewAttributes(
+            frameInRootView: view.convert(view.bounds, to: context.coordinateSpace),
+            view: view
+        )
+
+        var semantics: NodeSemantics = UnknownElement.constant
+
+        for nodeRecorder in nodeRecorders {
+            guard let nextSemantics = nodeRecorder.semantics(of: view, with: attributes, in: context) else {
+                continue
+            }
+
+            if nextSemantics.importance >= semantics.importance {
+                semantics = nextSemantics
+
+                if nextSemantics.importance == .max {
+                    // We know the current semantics is best we can get, so skip querying other `nodeRecorders`:
+                    break
+                }
+            }
+        }
+
+        return Node(viewAttributes: attributes, semantics: semantics)
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorder.swift
@@ -38,10 +38,15 @@ internal struct ViewTreeRecorder {
         let node = node(for: view, in: context)
         nodes.append(node)
 
-        if node.semantics.recordSubtree {
+        switch node.semantics.subtreeStrategy {
+        case .record:
             for subview in view.subviews {
                 recordRecursively(nodes: &nodes, view: subview, context: context)
             }
+        case .replace(let subtreeNodes):
+            nodes.append(contentsOf: subtreeNodes)
+        case .ignore:
+            break
         }
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -20,15 +20,17 @@ internal struct ViewTreeSnapshot {
     let date: Date
     /// The RUM context from the moment of taking this snapshot.
     let rumContext: RUMContext
+    /// The size of a viewport in this snapshot.
+    let viewportSize: CGSize
     /// The node indicating the root view of this snapshot.
-    let root: Node
+    let nodes: [Node]
 }
 
-/// An individual node in `ViewTreeSnapshot`. It abstracts an individual view or part of views hierarchy.
+/// An individual node in `ViewTreeSnapshot`. A `Node` describes a single view - similar: an array of nodes describes
+/// view and its subtree (in depth-first order).
 ///
-/// The `Node` can describe a view by nesting nodes for each of its subviews OR it can abstract the view along with its childs
-/// by merging their information into single node. This stands for the key difference between the hierarchy of native views and
-/// hierarchy of nodes - typically there is significantly less nodes than number of native views they describe.
+/// Typically, to describe certain view-tree we need significantly less nodes than number of views, because some views
+/// are meaningless for session replay (e.g. hidden views or containers with no appearance).
 ///
 /// **Note:** The purpose of this structure is to be lightweight and create minimal overhead when the view-tree
 /// is captured on the main thread (the `Recorder` constantly creates `Nodes` for views residing in the hierarchy).
@@ -38,9 +40,6 @@ internal struct Node {
 
     /// The semantics of this node.
     let semantics: NodeSemantics
-
-    /// Nodes created for subviews of this node's `UIView`.
-    let children: [Node]
 }
 
 /// Attributes of the `UIView` that the node was created for.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -11,27 +11,12 @@ import UIKit
 ///
 /// Note: This builder is used by `Recorder` on the main thread.
 internal struct ViewTreeSnapshotBuilder {
-    /// The context of building current snapshot.
-    struct Context {
-        /// The context of the Recorder.
-        let recorder: Recorder.Context
-        /// The coordinate space to convert node positions to.
-        let coordinateSpace: UICoordinateSpace
-        /// Generates stable IDs for traversed views.
-        let ids: NodeIDGenerator
-        /// Masks text in recorded nodes.
-        let textObfuscator: TextObfuscator
-    }
-
-    /// An array of enabled node recorders.
-    ///
-    /// The order in this this array  should be managed consciously. For each node, the implementation loops
-    /// through `nodeRecorders` and stops on the one that recorded node semantics with highes importance.
-    let nodeRecorders: [NodeRecorder]
+    /// Records subtree of the root view.
+    let viewTreeRecorder: ViewTreeRecorder
     /// Generates stable IDs for traversed views.
-    let idsGenerator = NodeIDGenerator()
+    let idsGenerator: NodeIDGenerator
     /// Masks text in recorded nodes.
-    let textObfuscator = TextObfuscator()
+    let textObfuscator: TextObfuscator
 
     /// Builds the `ViewTreeSnapshot` for given root view.
     ///
@@ -41,73 +26,42 @@ internal struct ViewTreeSnapshotBuilder {
     /// are computed relatively to the `rootView` (e.g. the `x` and `y` position of all descendant nodes  is given
     /// as its position in the root, no matter of nesting level).
     func createSnapshot(of rootView: UIView, with recorderContext: Recorder.Context) -> ViewTreeSnapshot {
-        let builderContext = Context(
+        let context = ViewTreeRecordingContext(
             recorder: recorderContext,
             coordinateSpace: rootView,
             ids: idsGenerator,
             textObfuscator: textObfuscator
         )
-        let viewTreeSnapshot = ViewTreeSnapshot(
+        let snapshot = ViewTreeSnapshot(
             date: recorderContext.date.addingTimeInterval(recorderContext.rumContext.viewServerTimeOffset ?? 0),
             rumContext: recorderContext.rumContext,
-            root: createNode(for: rootView, in: builderContext)
+            viewportSize: rootView.bounds.size,
+            nodes: viewTreeRecorder.recordNodes(for: rootView, in: context)
         )
-        return viewTreeSnapshot
-    }
-
-    /// Takes the native view and creates its `Node` recursively.
-    private func createNode(for anyView: UIView, in context: Context) -> Node {
-        let viewAttributes = ViewAttributes(
-            frameInRootView: anyView.convert(anyView.bounds, to: context.coordinateSpace),
-            view: anyView
-        )
-
-        var semantics: NodeSemantics = UnknownElement.constant
-
-        for nodeRecorder in nodeRecorders {
-            guard let nextSemantics = nodeRecorder.semantics(of: anyView, with: viewAttributes, in: context) else {
-                continue
-            }
-
-            if nextSemantics.importance >= semantics.importance {
-                semantics = nextSemantics
-
-                if nextSemantics.importance == .max {
-                    // We know the current semantics is best we can get, so skip querying other `nodeRecorders`:
-                    break
-                }
-            }
-        }
-
-        return Node(
-            viewAttributes: viewAttributes,
-            semantics: semantics,
-            children: {
-                if semantics.recordSubtree {
-                    return anyView.subviews.map { createNode(for: $0, in: context) }
-                } else {
-                    return []
-                }
-            }()
-        )
+        return snapshot
     }
 }
 
 extension ViewTreeSnapshotBuilder {
     init() {
         self.init(
-            nodeRecorders: [
-                UIViewRecorder(),
-                UILabelRecorder(),
-                UIImageViewRecorder(),
-                UITextFieldRecorder(),
-                UITextViewRecorder(),
-                UISwitchRecorder(),
-                UISliderRecorder(),
-                UISegmentRecorder(),
-                UINavigationBarRecorder(),
-                UITabBarRecorder(),
-            ]
+            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: defaultNodeRecorders),
+            idsGenerator: NodeIDGenerator(),
+            textObfuscator: TextObfuscator()
         )
     }
 }
+
+/// An arrays of default node recorders executed for the root view-tree hierarchy.
+internal let defaultNodeRecorders: [NodeRecorder] = [
+    UIViewRecorder(),
+    UILabelRecorder(),
+    UIImageViewRecorder(),
+    UITextFieldRecorder(),
+    UITextViewRecorder(),
+    UISwitchRecorder(),
+    UISliderRecorder(),
+    UISegmentRecorder(),
+    UINavigationBarRecorder(),
+    UITabBarRecorder(),
+]

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -20,19 +20,22 @@ extension ViewTreeSnapshot: AnyMockable, RandomMockable {
         return ViewTreeSnapshot(
             date: .mockRandom(),
             rumContext: .mockRandom(),
-            root: .mockRandom()
+            viewportSize: .mockRandom(),
+            nodes: .mockRandom(count: .random(in: (5..<50)))
         )
     }
 
     static func mockWith(
         date: Date = .mockAny(),
-        rumContext: RUMContext = .mockRandom(),
-        root: Node = .mockAny()
+        rumContext: RUMContext = .mockAny(),
+        viewportSize: CGSize = .mockAny(),
+        nodes: [Node] = .mockAny()
     ) -> ViewTreeSnapshot {
         return ViewTreeSnapshot(
             date: date,
             rumContext: rumContext,
-            root: root
+            viewportSize: viewportSize,
+            nodes: nodes
         )
     }
 }
@@ -221,37 +224,18 @@ extension Node: AnyMockable, RandomMockable {
 
     static func mockWith(
         viewAttributes: ViewAttributes = .mockAny(),
-        semantics: NodeSemantics = InvisibleElement.constant,
-        children: [Node] = []
+        semantics: NodeSemantics = InvisibleElement.constant
     ) -> Node {
         return .init(
             viewAttributes: viewAttributes,
-            semantics: semantics,
-            children: children
+            semantics: semantics
         )
     }
 
     public static func mockRandom() -> Node {
-        return mockRandom(maxDepth: 4, maxBreadth: 4)
-    }
-
-    static func mockRandom(maxDepth: Int, maxBreadth: Int) -> Node {
-        mockRandom(
-            depth: .random(in: 0..<maxDepth),
-            breadth: .random(in: 0..<maxBreadth)
-        )
-    }
-
-    /// Generates random node.
-    /// - Parameters:
-    ///   - depth: number of levels of nested nodes
-    ///   - breadth: number of child nodes in each nested node (except the last level determined by `depth` which has no childs)
-    /// - Returns: randomized node
-    static func mockRandom(depth: Int, breadth: Int) -> Node {
-        return mockWith(
+        return .init(
             viewAttributes: .mockRandom(),
-            semantics: mockRandomNodeSemantics(),
-            children: depth <= 0 ? [] : (0..<breadth).map { _ in mockRandom(depth: depth - 1, breadth: breadth) }
+            semantics: mockRandomNodeSemantics()
         )
     }
 }
@@ -268,12 +252,12 @@ extension SpecificElement {
     }
 }
 
-extension ViewTreeSnapshotBuilder.Context: AnyMockable, RandomMockable {
-    public static func mockAny() -> ViewTreeSnapshotBuilder.Context {
+extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
+    public static func mockAny() -> ViewTreeRecordingContext {
         return .mockWith()
     }
 
-    public static func mockRandom() -> ViewTreeSnapshotBuilder.Context {
+    public static func mockRandom() -> ViewTreeRecordingContext {
         return .init(
             recorder: .mockRandom(),
             coordinateSpace: UIView.mockRandom(),
@@ -287,13 +271,29 @@ extension ViewTreeSnapshotBuilder.Context: AnyMockable, RandomMockable {
         coordinateSpace: UICoordinateSpace = UIView.mockAny(),
         ids: NodeIDGenerator = NodeIDGenerator(),
         textObfuscator: TextObfuscator = TextObfuscator()
-    ) -> ViewTreeSnapshotBuilder.Context {
+    ) -> ViewTreeRecordingContext {
         return .init(
             recorder: recorder,
             coordinateSpace: coordinateSpace,
             ids: ids,
             textObfuscator: textObfuscator
         )
+    }
+}
+
+class NodeRecorderMock: NodeRecorder {
+    var queriedViews: Set<UIView> = []
+    var queryContexts: [ViewTreeRecordingContext] = []
+    var resultForView: (UIView) -> NodeSemantics?
+
+    init(resultForView: @escaping (UIView) -> NodeSemantics?) {
+        self.resultForView = resultForView
+    }
+
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
+        queriedViews.insert(view)
+        queryContexts.append(context)
+        return resultForView(view)
     }
 }
 

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -195,6 +195,21 @@ struct NOPWireframesBuilderMock: NodeWireframesBuilder {
     }
 }
 
+extension NodeSubtreeStrategy: AnyMockable, RandomMockable {
+    public static func mockAny() -> NodeSubtreeStrategy {
+        return .ignore
+    }
+
+    public static func mockRandom() -> NodeSubtreeStrategy {
+        let all: [NodeSubtreeStrategy] = [
+            .record,
+            .replace(subtreeNodes: [.mockAny()]),
+            .ignore,
+        ]
+        return all.randomElement()!
+    }
+}
+
 func mockAnyNodeSemantics() -> NodeSemantics {
     return InvisibleElement.constant
 }
@@ -204,7 +219,7 @@ func mockRandomNodeSemantics() -> NodeSemantics {
         UnknownElement.constant,
         InvisibleElement.constant,
         AmbiguousElement(wireframesBuilder: NOPWireframesBuilderMock()),
-        SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), recordSubtree: .mockRandom()),
+        SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), subtreeStrategy: .mockRandom()),
     ]
     return all.randomElement()!
 }
@@ -242,12 +257,15 @@ extension Node: AnyMockable, RandomMockable {
 
 extension SpecificElement {
     static func mockAny() -> SpecificElement {
-        SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), recordSubtree: .mockRandom())
+        SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), subtreeStrategy: .mockRandom())
     }
-    static func mock(wireframeRect: CGRect, recordSubtree: Bool = .mockRandom()) -> SpecificElement {
+    static func mock(
+        wireframeRect: CGRect,
+        subtreeStrategy: NodeSubtreeStrategy = .mockRandom()
+    ) -> SpecificElement {
         SpecificElement(
             wireframesBuilder: ShapeWireframesBuilderMock(wireframeRect: wireframeRect),
-            recordSubtree: recordSubtree
+            subtreeStrategy: subtreeStrategy
         )
     }
 }

--- a/DatadogSessionReplay/Tests/Processor/Flattening/NodesFlattenerTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Flattening/NodesFlattenerTests.swift
@@ -28,10 +28,9 @@ class NodesFlattenerTests: XCTestCase {
         )
         let rootNode = Node.mockWith(
             viewAttributes: .mock(fixture: .visible()),
-            semantics: SpecificElement.mock(wireframeRect: bigFrame),
-            children: [invisibleNode, visibleNode]
+            semantics: SpecificElement.mock(wireframeRect: bigFrame)
         )
-        let snapshot = ViewTreeSnapshot.mockWith(root: rootNode)
+        let snapshot = ViewTreeSnapshot.mockWith(nodes: [rootNode, invisibleNode, visibleNode])
         let flattener = NodesFlattener()
 
         // When
@@ -55,10 +54,9 @@ class NodesFlattenerTests: XCTestCase {
         )
         let coveredNode = Node.mockWith(
             viewAttributes: .mockRandom(),
-            semantics: SpecificElement.mock(wireframeRect: frame),
-            children: [coveringNode]
+            semantics: SpecificElement.mock(wireframeRect: frame)
         )
-        let snapshot = ViewTreeSnapshot.mockWith(root: coveredNode)
+        let snapshot = ViewTreeSnapshot.mockWith(nodes: [coveredNode, coveringNode])
         let flattener = NodesFlattener()
 
         // When
@@ -85,18 +83,17 @@ class NodesFlattenerTests: XCTestCase {
             viewAttributes: .mock(fixture: .visible()),
             semantics: SpecificElement.mock(wireframeRect: frame1)
         )
-        let invisibleNode1 = Node.mockWith(viewAttributes: .mock(fixture: .invisible), children: [visibleNode1])
+        let invisibleNode1 = Node.mockWith(viewAttributes: .mock(fixture: .invisible))
         let visibleNode2 = Node.mockWith(
             viewAttributes: .mock(fixture: .visible()),
             semantics: SpecificElement.mock(wireframeRect: frame2)
         )
         let rootNode = Node.mockWith(
             viewAttributes: .mock(fixture: .visible()),
-            semantics: SpecificElement.mock(wireframeRect: rootFrame),
-            children: [invisibleNode1, visibleNode2]
+            semantics: SpecificElement.mock(wireframeRect: rootFrame)
         )
 
-        let snapshot = ViewTreeSnapshot.mockWith(root: rootNode)
+        let snapshot = ViewTreeSnapshot.mockWith(nodes: [rootNode, invisibleNode1, visibleNode1, visibleNode2])
         let flattener = NodesFlattener()
 
         // When
@@ -108,8 +105,10 @@ class NodesFlattenerTests: XCTestCase {
 
     /*
           R
-        / | \
-       V1 V2 V3
+        /   \
+      CN1  CN2
+       |    |
+       CN   CN
     */
     func testFlattenNodes_withMultipleVisibleNodesThatAreCoveredByAnotherNode() {
         // Given
@@ -121,18 +120,14 @@ class NodesFlattenerTests: XCTestCase {
         )
         let coveredNode1 = Node.mockWith(
             viewAttributes: .mockRandom(),
-            semantics: SpecificElement.mock(wireframeRect: frame),
-            children: [coveringNode]
+            semantics: SpecificElement.mock(wireframeRect: frame)
         )
         let coveredNode2 = Node.mockWith(
             viewAttributes: .mockRandom(),
-            semantics: SpecificElement.mock(wireframeRect: frame),
-            children: [coveringNode]
+            semantics: SpecificElement.mock(wireframeRect: frame)
         )
-        let rootNode = Node.mockWith(
-            children: [coveredNode1, coveredNode2, coveringNode]
-        )
-        let snapshot = ViewTreeSnapshot.mockWith(root: rootNode)
+        let rootNode = Node.mockAny()
+        let snapshot = ViewTreeSnapshot.mockWith(nodes: [rootNode, coveredNode1, coveringNode, coveredNode2, coveringNode])
         let flattener = NodesFlattener()
 
         // When
@@ -145,7 +140,7 @@ class NodesFlattenerTests: XCTestCase {
     /*
           R
          / \
-        I   V
+        V1  V2
     */
     func testFlattenNodes_withNodesWithSameFrameAndDifferentAppearances() {
         // Given
@@ -159,8 +154,8 @@ class NodesFlattenerTests: XCTestCase {
             viewAttributes: .mock(fixture: .visible()),
             semantics: SpecificElement.mock(wireframeRect: bigFrame)
         )
-        let rootNode = Node.mockWith(children: [visibleNode1, visibleNode2])
-        let snapshot = ViewTreeSnapshot.mockWith(root: rootNode)
+        let rootNode = Node.mockAny()
+        let snapshot = ViewTreeSnapshot.mockWith(nodes: [rootNode, visibleNode1, visibleNode2])
         let flattener = NodesFlattener()
 
         // When

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 @testable import DatadogSessionReplay
+import TestUtilities
 
 // swiftlint:disable opening_brace
 class UIImageViewRecorderTests: XCTestCase {
@@ -23,7 +24,7 @@ class UIImageViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertFalse(semantics.recordSubtree, "Image view's subtree should not be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Image view's subtree should not be recorded")
     }
 
     func testWhenImageViewHasNoImageAndSomeAppearance() throws {
@@ -34,7 +35,7 @@ class UIImageViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is SpecificElement)
-        XCTAssertTrue(semantics.recordSubtree, "Image view's subtree should be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
 
         let builder = try XCTUnwrap(semantics.wireframesBuilder as? UIImageViewWireframesBuilder)
         XCTAssertEqual(builder.buildWireframes(with: WireframesBuilder()).count, 1)
@@ -48,7 +49,7 @@ class UIImageViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is SpecificElement)
-        XCTAssertTrue(semantics.recordSubtree, "Image view's subtree should be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
 
         let builder = try XCTUnwrap(semantics.wireframesBuilder as? UIImageViewWireframesBuilder)
         XCTAssertEqual(builder.buildWireframes(with: WireframesBuilder()).count, 2)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
@@ -49,7 +49,7 @@ class UILabelRecorderTests: XCTestCase {
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        XCTAssertFalse(semantics.recordSubtree, "Label's subtree should not be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Label's subtree should not be recorded")
 
         let builder = try XCTUnwrap(semantics.wireframesBuilder as? UILabelWireframesBuilder)
         XCTAssertEqual(builder.attributes, viewAttributes)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 @testable import DatadogSessionReplay
+import TestUtilities
 
 class UINavigationBarRecorderTests: XCTestCase {
     private let recorder = UINavigationBarRecorder()
@@ -19,7 +20,7 @@ class UINavigationBarRecorderTests: XCTestCase {
         let semantics = try XCTUnwrap(recorder.semantics(of: navigationBar, with: viewAttributes, in: .mockAny()) as? SpecificElement)
 
         // Then
-        XCTAssertTrue(semantics.recordSubtree, "Navigation Bar's subtree should be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -35,7 +35,7 @@ class UISegmentRecorderTests: XCTestCase {
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: segment, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        XCTAssertFalse(semantics.recordSubtree, "Segment's subtree should not be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Segment's subtree should not be recorded")
 
         let builder = try XCTUnwrap(semantics.wireframesBuilder as? UISegmentWireframesBuilder)
         XCTAssertEqual(builder.attributes, viewAttributes)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
@@ -35,7 +35,7 @@ class UISliderRecorderTests: XCTestCase {
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: slider, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        XCTAssertFalse(semantics.recordSubtree, "Slider's subtree should not be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Slider's subtree should not be recorded")
 
         let builder = try XCTUnwrap(semantics.wireframesBuilder as? UISliderWireframesBuilder)
         XCTAssertEqual(builder.attributes, viewAttributes)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
@@ -37,7 +37,7 @@ class UISwitchRecorderTests: XCTestCase {
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: `switch`, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        XCTAssertFalse(semantics.recordSubtree, "Switch's subtree should not be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Switch's subtree should not be recorded")
 
         let builder = try XCTUnwrap(semantics.wireframesBuilder as? UISwitchWireframesBuilder)
         XCTAssertEqual(builder.attributes, viewAttributes)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 @testable import DatadogSessionReplay
+import TestUtilities
 
 class UITabBarRecorderTests: XCTestCase {
     private let recorder = UITabBarRecorder()
@@ -19,7 +20,7 @@ class UITabBarRecorderTests: XCTestCase {
         let semantics = try XCTUnwrap(recorder.semantics(of: tabBar, with: viewAttributes, in: .mockAny()) as? SpecificElement)
 
         // Then
-        XCTAssertTrue(semantics.recordSubtree, "Tab Bar's subtree should be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "TabBar's subtree should not be recorded")
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -52,7 +52,7 @@ class UITextFieldRecorderTests: XCTestCase {
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        XCTAssertFalse(semantics.recordSubtree, "TextField's subtree should not be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "TextField's subtree should not be recorded")
 
         let builder = try XCTUnwrap(semantics.wireframesBuilder as? UITextFieldWireframesBuilder)
         XCTAssertEqual(builder.text, randomText)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -40,7 +40,7 @@ class UITextViewRecorderTests: XCTestCase {
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: textView, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        XCTAssertTrue(semantics.recordSubtree, "TextView's subtree should be recorded")
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "TextView's subtree should not be recorded")
 
         let builder = try XCTUnwrap(semantics.wireframesBuilder as? UITextViewWireframesBuilder)
         XCTAssertEqual(builder.text, randomText)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -1,0 +1,264 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+@testable import TestUtilities
+
+class ViewTreeRecorderTests: XCTestCase {
+    // MARK: - Querying Node Recorders
+
+    func testItQueriesAllNodeRecorders() {
+        // Given
+        let rootView = UIView(frame: .mockRandom())
+        let childView = UIView(frame: .mockRandom())
+        let grandchildView = UIView(frame: .mockRandom())
+        childView.addSubview(grandchildView)
+        rootView.addSubview(childView)
+
+        // When
+        let recorders: [NodeRecorderMock] = [
+            NodeRecorderMock(resultForView: { _ in nil }),
+            NodeRecorderMock(resultForView: { _ in nil }),
+            NodeRecorderMock(resultForView: { _ in nil }),
+        ]
+        let recorder = ViewTreeRecorder(nodeRecorders: recorders)
+        _ = recorder.recordNodes(for: rootView, in: .mockAny())
+
+        // Then
+        XCTAssertEqual(recorders[0].queriedViews, [rootView, childView, grandchildView])
+        XCTAssertEqual(recorders[1].queriedViews, [rootView, childView, grandchildView])
+        XCTAssertEqual(recorders[2].queriedViews, [rootView, childView, grandchildView])
+    }
+
+    func testItQueriesNodeRecordersInOrderUntilOneFindsBestSemantics() {
+        // Given
+        let view = UIView(frame: .mockRandom())
+
+        let unknownElement = UnknownElement.constant
+        let ambiguousElement = AmbiguousElement(wireframesBuilder: NOPWireframesBuilderMock())
+        let specificElement = SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), recordSubtree: .mockRandom())
+
+        // When
+        let recorders: [NodeRecorderMock] = [
+            NodeRecorderMock(resultForView: { _ in unknownElement }),
+            NodeRecorderMock(resultForView: { _ in ambiguousElement }),
+            NodeRecorderMock(resultForView: { _ in ambiguousElement }),
+            NodeRecorderMock(resultForView: { _ in specificElement }), // here we find best semantics...
+            NodeRecorderMock(resultForView: { _ in specificElement }), // ... so this one should not be queried
+        ]
+        let recorder = ViewTreeRecorder(nodeRecorders: recorders)
+        _ = recorder.recordNodes(for: view, in: .mockAny())
+
+        // Then
+        XCTAssertEqual(recorders[0].queriedViews, [view], "It should be queried as semantics is not known")
+        XCTAssertEqual(recorders[1].queriedViews, [view], "It should be queried as semantics is not known")
+        XCTAssertEqual(recorders[2].queriedViews, [view], "It should be queried as only 'ambiguous' semantics is known")
+        XCTAssertEqual(recorders[3].queriedViews, [view], "It should be queried as only 'ambiguous' semantics is known")
+        XCTAssertEqual(recorders[4].queriedViews, [], "It should NOT be queried as 'specific' semantics is known")
+    }
+
+    // MARK: - Recording Nodes Recursively
+
+    func testItQueriesViewTreeRecursivelyAndReturnsNodesInDFSOrder() {
+        struct MockSemantics: NodeSemantics {
+            static var importance: Int = .mockAny()
+            var recordSubtree: Bool
+            let wireframesBuilder: NodeWireframesBuilder? = nil
+            let debugName: String
+        }
+
+        // Given
+        let rootView = UIView(frame: .mockRandom(minWidth: 1, minHeight: 1))
+        let ambiguousChild = UIView(frame: .mockRandom(minWidth: 1, minHeight: 1))
+        let specificChild1 = UILabel(frame: .mockRandom(minWidth: 1, minHeight: 1))
+        let specificChild2 = UILabel(frame: .mockRandom(minWidth: 1, minHeight: 1))
+        let childOfAmbiguousElement = UIView(frame: .mockAny())
+        let childOfSpecificElement1 = UIView(frame: .mockAny())
+        let childOfSpecificElement2 = UIView(frame: .mockAny())
+
+        ambiguousChild.addSubview(childOfAmbiguousElement)
+        specificChild1.addSubview(childOfSpecificElement1)
+        specificChild2.addSubview(childOfSpecificElement2)
+        rootView.addSubview(ambiguousChild)
+        rootView.addSubview(specificChild1)
+        rootView.addSubview(specificChild2)
+
+        let semanticsByView: [UIView: NodeSemantics] = [
+            rootView: MockSemantics(recordSubtree: true, debugName: "rootView"),
+            ambiguousChild: MockSemantics(recordSubtree: true, debugName: "ambiguousChild"),
+            specificChild1: MockSemantics(recordSubtree: true, debugName: "specificChild1"),
+            specificChild2: MockSemantics(recordSubtree: false, debugName: "specificChild2"),
+            childOfAmbiguousElement: MockSemantics(recordSubtree: true, debugName: "childOfAmbiguousElement"),
+            childOfSpecificElement1: MockSemantics(recordSubtree: true, debugName: "childOfSpecificElement1"),
+            childOfSpecificElement2: MockSemantics(recordSubtree: false, debugName: "childOfSpecificElement2"),
+        ]
+
+        // When
+        let nodeRecorder = NodeRecorderMock(resultForView: { view in semanticsByView[view] })
+        let recorder = ViewTreeRecorder(nodeRecorders: [nodeRecorder])
+        let nodes = recorder.recordNodes(for: rootView, in: .mockRandom())
+
+        // Then
+        let expectedNodes = ["rootView", "ambiguousChild", "childOfAmbiguousElement", "specificChild1", "childOfSpecificElement1", "specificChild2"]
+        let actualNodes = nodes.compactMap { ($0.semantics as? MockSemantics)?.debugName }
+        XCTAssertEqual(expectedNodes, actualNodes)
+
+        XCTAssertTrue(nodeRecorder.queriedViews.contains(rootView))
+        XCTAssertTrue(nodeRecorder.queriedViews.contains(ambiguousChild))
+        XCTAssertTrue(nodeRecorder.queriedViews.contains(specificChild1))
+        XCTAssertTrue(nodeRecorder.queriedViews.contains(specificChild2))
+        XCTAssertTrue(
+            nodeRecorder.queriedViews.contains(childOfAmbiguousElement),
+            "It should query `childOfAmbiguousElement`, because the parent has 'recordSubtree: true' semantics"
+        )
+        XCTAssertTrue(
+            nodeRecorder.queriedViews.contains(childOfSpecificElement1),
+            "It should query `childOfSpecificElement1`, because the parent has 'specific' semantics with `recordSubtree: true`"
+        )
+        XCTAssertFalse(
+            nodeRecorder.queriedViews.contains(childOfSpecificElement2),
+            "It should NOT query `childOfSpecificElement1`, because the parent has 'specific' semantics with `recordSubtree: false`"
+        )
+    }
+
+    // MARK: - Recording Certain Node Semantics
+
+    func testItRecordsInvisibleViews() {
+        // Given
+        let recorder = ViewTreeRecorder(nodeRecorders: defaultNodeRecorders)
+        let views: [UIView] = [
+            UIView.mock(withFixture: .invisible),
+            UILabel.mock(withFixture: .invisible),
+            UIImageView.mock(withFixture: .invisible),
+            UITextField.mock(withFixture: .invisible),
+            UISwitch.mock(withFixture: .invisible),
+        ]
+
+        // When
+        let nodes = views.map { recorder.recordNodes(for: $0, in: .mockRandom()) }
+
+        // Then
+        zip(nodes, views).forEach { nodes, view in
+            XCTAssertTrue(
+                nodes[0].semantics is InvisibleElement,
+                """
+                All invisible members of `UIView` should record `InvisibleElement` semantics as
+                they will not appear in SR anyway. Got \(type(of: nodes[0].semantics)) instead.
+                """
+            )
+        }
+    }
+
+    func testItRecordsViewsWithNoAppearance() {
+        // Given
+        let recorder = ViewTreeRecorder(nodeRecorders: defaultNodeRecorders)
+
+        let view = UIView.mock(withFixture: .visible(.noAppearance))
+        let label = UILabel.mock(withFixture: .visible(.noAppearance))
+        let imageView = UIImageView.mock(withFixture: .visible(.noAppearance))
+        let textField = UITextField.mock(withFixture: .visible(.noAppearance))
+        let `switch` = UISwitch.mock(withFixture: .visible(.noAppearance))
+
+        // When
+        let viewNodes = recorder.recordNodes(for: view, in: .mockRandom())
+        XCTAssertEqual(viewNodes.count, 1)
+        XCTAssertTrue(
+            viewNodes[0].semantics is AmbiguousElement,
+            """
+            Bare `UIView` with no appearance should record `AmbiguousElement` semantics as we don't know
+            if this view is specialised with appearance coming from its superclass.
+            Got \(type(of: viewNodes[0].semantics)) instead.
+            """
+        )
+
+        let labelNodes = recorder.recordNodes(for: label, in: .mockRandom())
+        XCTAssertEqual(labelNodes.count, 1)
+        XCTAssertTrue(
+            labelNodes[0].semantics is InvisibleElement,
+            """
+            `UILabel` with no appearance should record `InvisibleElement` semantics as it
+            won't display anything in SR. Got \(type(of: labelNodes[0].semantics)) instead.
+            """
+        )
+
+        let imageViewNodes = recorder.recordNodes(for: imageView, in: .mockRandom())
+        XCTAssertEqual(imageViewNodes.count, 1)
+        XCTAssertTrue(
+            imageViewNodes[0].semantics is InvisibleElement,
+            """
+            `UIImageView` with no appearance should record `InvisibleElement` semantics as it
+            won't display anything in SR. Got \(type(of: imageViewNodes[0].semantics)) instead.
+            """
+        )
+
+        let textFieldNodes = recorder.recordNodes(for: textField, in: .mockRandom())
+        XCTAssertEqual(textFieldNodes.count, 1)
+        XCTAssertTrue(
+            textFieldNodes[0].semantics is SpecificElement,
+            """
+            `UITextField` with no appearance should still record `SpecificElement` semantics as it
+            has style coming from its internal subtree. Got \(type(of: textFieldNodes[0].semantics)) instead.
+            """
+        )
+
+        let switchNodes = recorder.recordNodes(for: `switch`, in: .mockRandom())
+        XCTAssertEqual(switchNodes.count, 1)
+        XCTAssertTrue(
+            switchNodes[0].semantics is SpecificElement,
+            """
+            `UISwitch` with no appearance should still record `SpecificElement` semantics as it
+            has style coming from its internal subtree. Got \(type(of: switchNodes[0].semantics)) instead.
+            """
+        )
+    }
+
+    func testItRecordsBaseViewWithSomeAppearance() {
+        // Given
+        let recorder = ViewTreeRecorder(nodeRecorders: defaultNodeRecorders)
+        let view = UIView.mock(withFixture: .visible())
+
+        // When
+        let nodes = recorder.recordNodes(for: view, in: .mockRandom())
+
+        // Then
+        XCTAssertTrue(
+            nodes[0].semantics is AmbiguousElement,
+            """
+            Bare `UIView` with no appearance should record `AmbiguousElement` semantics as we don't know
+            if this view is specialised with appearance coming from its superclass.
+            Got \(type(of: nodes[0].semantics)) instead.
+            """
+        )
+    }
+
+    func testItRecordsSpecialisedViewsWithSomeAppearance() {
+        // Given
+        let recorder = ViewTreeRecorder(nodeRecorders: defaultNodeRecorders)
+        let views: [UIView] = [
+            UILabel.mock(withFixture: .visible()),
+            UIImageView.mock(withFixture: .visible()),
+            UITextField.mock(withFixture: .visible()),
+            UISwitch.mock(withFixture: .visible()),
+            UITabBar.mock(withFixture: .visible()),
+            UINavigationBar.mock(withFixture: .visible()),
+        ]
+
+        // When
+        let nodes = views.map { recorder.recordNodes(for: $0, in: .mockRandom()) }
+
+        // Then
+        zip(nodes, views).forEach { nodes, view in
+            XCTAssertTrue(
+                nodes[0].semantics is SpecificElement,
+                """
+                All specialised subclasses of `UIView` should record `SpecificElement` semantics as
+                long as they are visible. Got \(type(of: nodes[0].semantics)) instead.
+                """
+            )
+        }
+    }
+}

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -8,83 +8,18 @@ import XCTest
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 
-private class NodeRecorderMock: NodeRecorder {
-    var queriedViews: Set<UIView> = []
-    var queryContexts: [ViewTreeSnapshotBuilder.Context] = []
-    var resultForView: (UIView) -> NodeSemantics?
-
-    init(resultForView: @escaping (UIView) -> NodeSemantics?) {
-        self.resultForView = resultForView
-    }
-
-    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeSnapshotBuilder.Context) -> NodeSemantics? {
-        queriedViews.insert(view)
-        queryContexts.append(context)
-        return resultForView(view)
-    }
-}
-
 class ViewTreeSnapshotBuilderTests: XCTestCase {
-    // MARK: - Querying Node Recorders
-
-    func testItQueriesAllNodeRecorders() {
-        // Given
-        let rootView = UIView(frame: .mockRandom())
-        let childView = UIView(frame: .mockRandom())
-        let grandchildView = UIView(frame: .mockRandom())
-        childView.addSubview(grandchildView)
-        rootView.addSubview(childView)
-
-        // When
-        let recorders: [NodeRecorderMock] = [
-            NodeRecorderMock(resultForView: { _ in nil }),
-            NodeRecorderMock(resultForView: { _ in nil }),
-            NodeRecorderMock(resultForView: { _ in nil }),
-        ]
-        let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders)
-        _ = builder.createSnapshot(of: rootView, with: .mockRandom())
-
-        // Then
-        XCTAssertEqual(recorders[0].queriedViews, [rootView, childView, grandchildView])
-        XCTAssertEqual(recorders[1].queriedViews, [rootView, childView, grandchildView])
-        XCTAssertEqual(recorders[2].queriedViews, [rootView, childView, grandchildView])
-    }
-
-    // 👀
-    func testItQueriesNodeRecordersInOrderUntilOneFindsBestSemantics() {
-        // Given
-        let view = UIView(frame: .mockRandom())
-
-        let unknownElement = UnknownElement.constant
-        let ambiguousElement = AmbiguousElement(wireframesBuilder: NOPWireframesBuilderMock())
-        let specificElement = SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), recordSubtree: .mockRandom())
-
-        // When
-        let recorders: [NodeRecorderMock] = [
-            NodeRecorderMock(resultForView: { _ in unknownElement }),
-            NodeRecorderMock(resultForView: { _ in ambiguousElement }),
-            NodeRecorderMock(resultForView: { _ in ambiguousElement }),
-            NodeRecorderMock(resultForView: { _ in specificElement }), // here we find best semantics...
-            NodeRecorderMock(resultForView: { _ in specificElement }), // ... so this one should not be queried
-        ]
-        let builder = ViewTreeSnapshotBuilder(nodeRecorders: recorders)
-        _ = builder.createSnapshot(of: view, with: .mockRandom())
-
-        // Then
-        XCTAssertEqual(recorders[0].queriedViews, [view], "It should be queried as semantics is not known")
-        XCTAssertEqual(recorders[1].queriedViews, [view], "It should be queried as semantics is not known")
-        XCTAssertEqual(recorders[2].queriedViews, [view], "It should be queried as only 'ambiguous' semantics is known")
-        XCTAssertEqual(recorders[3].queriedViews, [view], "It should be queried as only 'ambiguous' semantics is known")
-        XCTAssertEqual(recorders[4].queriedViews, [], "It should NOT be queried as 'specific' semantics is known")
-    }
-
     func testWhenQueryingNodeRecorders_itPassesAppropriateContext() throws {
         // Given
         let view = UIView(frame: .mockRandom())
 
         let randomRecorderContext: Recorder.Context = .mockWith()
-        let recorder = NodeRecorderMock(resultForView: { _ in nil })
-        let builder = ViewTreeSnapshotBuilder(nodeRecorders: [recorder])
+        let nodeRecorder = NodeRecorderMock(resultForView: { _ in nil })
+        let builder = ViewTreeSnapshotBuilder(
+            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: [nodeRecorder]),
+            idsGenerator: NodeIDGenerator(),
+            textObfuscator: TextObfuscator()
+        )
 
         // When
         let snapshot = builder.createSnapshot(of: view, with: randomRecorderContext)
@@ -93,217 +28,23 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         XCTAssertEqual(snapshot.date, randomRecorderContext.date)
         XCTAssertEqual(snapshot.rumContext, randomRecorderContext.rumContext)
 
-        let queryContext = try XCTUnwrap(recorder.queryContexts.first)
+        let queryContext = try XCTUnwrap(nodeRecorder.queryContexts.first)
         XCTAssertTrue(queryContext.coordinateSpace === view)
         XCTAssertEqual(queryContext.recorder, randomRecorderContext)
     }
 
-    // MARK: - Recording Nodes Recursively
-
-    func testItQueriesViewTreeRecursively() {
-        // Given
-        let rootView = UIView(frame: .mockRandom(minWidth: 1, minHeight: 1))
-        let ambiguousChild = UIView(frame: .mockRandom(minWidth: 1, minHeight: 1))
-        let specificChild1 = UILabel(frame: .mockRandom(minWidth: 1, minHeight: 1))
-        let specificChild2 = UILabel(frame: .mockRandom(minWidth: 1, minHeight: 1))
-        let childOfAmbiguousElement = UIView(frame: .mockAny())
-        let childOfSpecificElement1 = UIView(frame: .mockAny())
-        let childOfSpecificElement2 = UIView(frame: .mockAny())
-
-        ambiguousChild.addSubview(childOfAmbiguousElement)
-        specificChild1.addSubview(childOfSpecificElement1)
-        specificChild2.addSubview(childOfSpecificElement2)
-        rootView.addSubview(ambiguousChild)
-        rootView.addSubview(specificChild1)
-        rootView.addSubview(specificChild2)
-
-        let ambiguousElement = AmbiguousElement(wireframesBuilder: NOPWireframesBuilderMock())
-        let specificElement1 = SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), recordSubtree: true)
-        let specificElement2 = SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), recordSubtree: false)
-
-        let semanticsByView: [UIView: NodeSemantics] = [
-            rootView: ambiguousElement,
-            ambiguousChild: ambiguousElement,
-            specificChild1: specificElement1,
-            specificChild2: specificElement2,
-            childOfAmbiguousElement: ambiguousElement,
-            childOfSpecificElement1: specificElement1,
-            childOfSpecificElement2: specificElement2,
-        ]
-
-        // When
-        let nodeRecorder = NodeRecorderMock(resultForView: { view in semanticsByView[view] })
-        let builder = ViewTreeSnapshotBuilder(nodeRecorders: [nodeRecorder])
-        let snapshot = builder.createSnapshot(of: rootView, with: .mockRandom())
-
-        // Then
-        XCTAssertTrue(snapshot.root.semantics is AmbiguousElement)
-        XCTAssertEqual(snapshot.root.children.count, 3)
-        XCTAssertTrue(snapshot.root.children[0].semantics is AmbiguousElement)
-        XCTAssertTrue(snapshot.root.children[1].semantics is SpecificElement)
-        XCTAssertTrue(snapshot.root.children[2].semantics is SpecificElement)
-        XCTAssertEqual(snapshot.root.children[0].children.count, 1, "It should record this sub-tree as parent node has 'ambiguous' semantics")
-        XCTAssertEqual(snapshot.root.children[1].children.count, 1, "It should record this sub-tree as parent has 'specific' semantics with `recordSubtree: true`")
-        XCTAssertEqual(snapshot.root.children[2].children.count, 0, "It should NOT record this sub-tree as parent has 'specific' semantics with `recordSubtree: false`")
-
-        XCTAssertTrue(nodeRecorder.queriedViews.contains(rootView))
-        XCTAssertTrue(nodeRecorder.queriedViews.contains(ambiguousChild))
-        XCTAssertTrue(nodeRecorder.queriedViews.contains(specificChild1))
-        XCTAssertTrue(nodeRecorder.queriedViews.contains(specificChild2))
-        XCTAssertTrue(
-            nodeRecorder.queriedViews.contains(childOfAmbiguousElement),
-            "It should query `childOfAmbiguousElement`, because the parent has 'ambiguous' semantics"
-        )
-        XCTAssertTrue(
-            nodeRecorder.queriedViews.contains(childOfSpecificElement1),
-            "It should query `childOfSpecificElement1`, because the parent has 'specific' semantics with `recordSubtree: true`"
-        )
-        XCTAssertFalse(
-            nodeRecorder.queriedViews.contains(childOfSpecificElement2),
-            "It should NOT query `childOfSpecificElement1`, because the parent has 'specific' semantics with `recordSubtree: false`"
-        )
-    }
-
-    // MARK: - Recording Certain Node Semantics
-
-    func testItRecordsInvisibleViews() {
-        // Given
-        let builder = ViewTreeSnapshotBuilder()
-        let views: [UIView] = [
-            UIView.mock(withFixture: .invisible),
-            UILabel.mock(withFixture: .invisible),
-            UIImageView.mock(withFixture: .invisible),
-            UITextField.mock(withFixture: .invisible),
-            UISwitch.mock(withFixture: .invisible),
-        ]
-
-        // When
-        let snapshots = views.map { builder.createSnapshot(of: $0, with: .mockRandom()) }
-
-        // Then
-        zip(snapshots, views).forEach { snapshot, view in
-            XCTAssertTrue(
-                snapshot.root.semantics is InvisibleElement,
-                """
-                All invisible members of `UIView` should record `InvisibleElement` semantics as
-                they will not appear in SR anyway. Got \(type(of: snapshot.root.semantics)) instead.
-                """
-            )
-        }
-    }
-
-    func testItRecordsViewsWithNoAppearance() {
-        // Given
-        let builder = ViewTreeSnapshotBuilder()
-
-        let view = UIView.mock(withFixture: .visible(.noAppearance))
-        let label = UILabel.mock(withFixture: .visible(.noAppearance))
-        let imageView = UIImageView.mock(withFixture: .visible(.noAppearance))
-        let textField = UITextField.mock(withFixture: .visible(.noAppearance))
-        let `switch` = UISwitch.mock(withFixture: .visible(.noAppearance))
-
-        // When
-        let viewSnapshot = builder.createSnapshot(of: view, with: .mockRandom())
-        XCTAssertTrue(
-            viewSnapshot.root.semantics is AmbiguousElement,
-            """
-            Bare `UIView` with no appearance should record `AmbiguousElement` semantics as we don't know
-            if this view is specialised with appearance coming from its superclass.
-            Got \(type(of: viewSnapshot.root.semantics)) instead.
-            """
-        )
-
-        let labelSnapshot = builder.createSnapshot(of: label, with: .mockRandom())
-        XCTAssertTrue(
-            labelSnapshot.root.semantics is InvisibleElement,
-            """
-            `UILabel` with no appearance should record `InvisibleElement` semantics as it
-            won't display anything in SR. Got \(type(of: labelSnapshot.root.semantics)) instead.
-            """
-        )
-
-        let imageViewSnapshot = builder.createSnapshot(of: imageView, with: .mockRandom())
-        XCTAssertTrue(
-            imageViewSnapshot.root.semantics is InvisibleElement,
-            """
-            `UIImageView` with no appearance should record `InvisibleElement` semantics as it
-            won't display anything in SR. Got \(type(of: imageViewSnapshot.root.semantics)) instead.
-            """
-        )
-
-        let textFieldSnapshot = builder.createSnapshot(of: textField, with: .mockRandom())
-        XCTAssertTrue(
-            textFieldSnapshot.root.semantics is SpecificElement,
-            """
-            `UITextField` with no appearance should still record `SpecificElement` semantics as it
-            has style coming from its internal subtree. Got \(type(of: textFieldSnapshot.root.semantics)) instead.
-            """
-        )
-
-        let switchSnapshot = builder.createSnapshot(of: `switch`, with: .mockRandom())
-        XCTAssertTrue(
-            switchSnapshot.root.semantics is SpecificElement,
-            """
-            `UISwitch` with no appearance should still record `SpecificElement` semantics as it
-            has style coming from its internal subtree. Got \(type(of: switchSnapshot.root.semantics)) instead.
-            """
-        )
-    }
-
-    func testItRecordsBaseViewWithSomeAppearance() {
-        // Given
-        let builder = ViewTreeSnapshotBuilder()
-        let view = UIView.mock(withFixture: .visible())
-
-        // When
-        let snapshot = builder.createSnapshot(of: view, with: .mockRandom())
-
-        // Then
-        XCTAssertTrue(
-            snapshot.root.semantics is AmbiguousElement,
-            """
-            Bare `UIView` with no appearance should record `AmbiguousElement` semantics as we don't know
-            if this view is specialised with appearance coming from its superclass.
-            Got \(type(of: snapshot.root.semantics)) instead.
-            """
-        )
-    }
-
-    func testItRecordsSpecialisedViewsWithSomeAppearance() {
-        // Given
-        let builder = ViewTreeSnapshotBuilder()
-        let views: [UIView] = [
-            UILabel.mock(withFixture: .visible()),
-            UIImageView.mock(withFixture: .visible()),
-            UITextField.mock(withFixture: .visible()),
-            UISwitch.mock(withFixture: .visible()),
-            UITabBar.mock(withFixture: .visible()),
-            UINavigationBar.mock(withFixture: .visible()),
-        ]
-
-        // When
-        let snapshots = views.map { builder.createSnapshot(of: $0, with: .mockRandom()) }
-
-        // Then
-        zip(snapshots, views).forEach { snapshot, view in
-            XCTAssertTrue(
-                snapshot.root.semantics is SpecificElement,
-                """
-                All specialised subclasses of `UIView` should record `SpecificElement` semantics as
-                long as they are visible. Got \(type(of: snapshot.root.semantics)) instead.
-                """
-            )
-        }
-    }
-
-    func testItAppliesServerTimeOffsetIsToSnapshot() {
+    func testItAppliesServerTimeOffsetToSnapshot() {
         // Given
         let now = Date()
         let view = UIView(frame: .mockRandom())
+        let nodeRecorder = NodeRecorderMock(resultForView: { _ in nil })
+        let builder = ViewTreeSnapshotBuilder(
+            viewTreeRecorder: ViewTreeRecorder(nodeRecorders: [nodeRecorder]),
+            idsGenerator: NodeIDGenerator(),
+            textObfuscator: TextObfuscator()
+        )
 
         // When
-        let recorder = NodeRecorderMock(resultForView: { _ in nil })
-        let builder = ViewTreeSnapshotBuilder(nodeRecorders: [recorder])
         let snapshot = builder.createSnapshot(of: view, with: .mockWith(date: now, rumContext: .mockWith(serverTimeOffset: 1_000)))
 
         // Then

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -141,7 +141,7 @@ class NodeSemanticsTests: XCTestCase {
         let unknownElement = UnknownElement.constant
         let invisibleElement = InvisibleElement.constant
         let ambiguousElement = AmbiguousElement(wireframesBuilder: nil)
-        let specificElement = SpecificElement(wireframesBuilder: nil, recordSubtree: .mockAny())
+        let specificElement = SpecificElement(wireframesBuilder: nil, subtreeStrategy: .mockAny())
 
         XCTAssertGreaterThan(
             specificElement.importance,
@@ -163,21 +163,24 @@ class NodeSemanticsTests: XCTestCase {
         XCTAssertEqual(specificElement.importance, .max)
     }
 
-    func testRecordSubtree() {
-        XCTAssertTrue(
-            UnknownElement.constant.recordSubtree,
+    func testSubtreeStrategy() {
+        DDAssertReflectionEqual(
+            UnknownElement.constant.subtreeStrategy,
+            .record,
             "Subtree should be recorded for 'unknown' elements as a fallback"
         )
-        XCTAssertFalse(
-            InvisibleElement.constant.recordSubtree,
+        DDAssertReflectionEqual(
+            InvisibleElement.constant.subtreeStrategy,
+            .ignore,
             "Subtree should not be recorded for 'invisible' elements as nothing in it will be visible anyway"
         )
-        XCTAssertTrue(
-            AmbiguousElement(wireframesBuilder: nil).recordSubtree,
+        DDAssertReflectionEqual(
+            AmbiguousElement(wireframesBuilder: nil).subtreeStrategy,
+            .record,
             "Subtree should be recorded for 'ambiguous' elements as it may contain other elements"
         )
 
-        let random: Bool = .mockRandom()
-        XCTAssertEqual(SpecificElement(wireframesBuilder: nil, recordSubtree: random).recordSubtree, random)
+        let random: NodeSubtreeStrategy = .mockRandom()
+        DDAssertReflectionEqual(SpecificElement(wireframesBuilder: nil, subtreeStrategy: random).subtreeStrategy, random)
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR adds more flexibility to the way SR traverses and records subtree hierarchies.

This change will allow each `NodeRecorder` (e.g. `UIViewRecorder` or `UILabelRecorder`) defining their own strategies and will be soon leveraged in `UIPickerViewRecorder` (and later in `UIDatePickerViewRecorder`).

### How?

Before this change, only two strategies existed, denoted by `recordSubtree: Bool` flag. For a given hierarchy, either all subviews were recorded or all could be ignored:

<img width="680" alt="Screenshot 2023-02-23 at 19 18 40" src="https://user-images.githubusercontent.com/2358722/220997477-4532668e-3ccb-44dd-9e96-16bc826178bf.png">

In result, the recorder was visiting following nodes in DFS order:
```
ROOT, A, AA, AB, ABA, ABB, B, C
```

With this PR, we're adding one more strategy, so changing `recordSubtree` boolean into an `enum`:
```swift
internal enum NodeSubtreeStrategy {
    case record // equivalent of `recordSubtree: true`
    case ignore // equivalent of `recordSubtree: false`
    case replace(subtreeNodes: [Node]) // new one ⭐️
}
```
By using the new `.replace(subtreeNodes:)` strategy, certain node recorders (e.g. `UIPickerViewRecorder`) will be able to opt-out from their subtree traversal and instead replace the subtree with its curated `[Node]` information:

<img width="978" alt="Screenshot 2023-02-23 at 19 18 45" src="https://user-images.githubusercontent.com/2358722/220998504-6a5e4e42-2c3f-4a1b-833d-493c969fce4b.png">

```
ROOT, A, AA, AB, ABA, ABB, B, C, CV1, CV2, ..., CVN
```

This will enable code reuse for certain view-tree recorders, meaning:
* the root view-tree recorder could be configured with all node recorders (`UIViewRecorder`, `UILabelRecorder`, `UISwitchRecorder`, `UISliderRecorder`, ...) - as we can expect any node in the root view's hierarchy;
* the `UIViewPickerRecorder` could opt-in only `UILabelRecorder` and `UIViewRecorder` - as we expect only labels and shapes in picker's subtree;
* similar, date-picker recorder would expect texts + shapes, whereas text-field recorder could additionally search for images (to record icons).

Last not least, this required switching from tree-like nodes structure:
```swift
struct ViewTreeSnapshot {
   // ...

   let root: Node
}

struct Node {
   // ...

   let childNodes: [Node]
}
```
to flat array given by DFS-visit order:
```swift
struct ViewTreeSnapshot {
   // ...

   /// Nodes in DFS order.
   let nodes: [Node]
}

struct Node {
   // ...
}
```
The change of data structure should have no impact on the SR performance - nodes were already visited in DFS order, here we just add them to an array while visiting (instead of allocating a graph).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
