### PR TITLE
Remove data race caused by doing sample on rum thread

### DIFF
--- a/Sources/Datadog/RUM/RUMVitals/VitalCPUReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalCPUReader.swift
@@ -11,8 +11,8 @@ import UIKit.UIApplication
 internal class VitalCPUReader: SamplingBasedVitalReader {
     /// host_cpu_load_info_count is 4 (tested in iOS 14.4)
     private static let host_cpu_load_info_count = MemoryLayout<host_cpu_load_info>.stride / MemoryLayout<integer_t>.stride
-    private var totalInactiveTicks: natural_t = 0
-    private var utilizedTicksWhenResigningActive: natural_t? = nil
+    private var totalInactiveTicks: UInt64 = 0
+    private var utilizedTicksWhenResigningActive: UInt64? = nil
 
     init(notificationCenter: NotificationCenter = .default) {
         notificationCenter.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
@@ -44,7 +44,7 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
         }
     }
 
-    private func readUtilizedTicks() -> natural_t? {
+    private func readUtilizedTicks() -> UInt64? {
         // it must be set to host_cpu_load_info_count_size >= host_cpu_load_info_count
         // implementation: https://github.com/opensource-apple/xnu/blob/master/osfmk/kern/host.c#L425
         var host_cpu_load_info_count_size = mach_msg_type_number_t(Self.host_cpu_load_info_count)
@@ -82,6 +82,6 @@ internal class VitalCPUReader: SamplingBasedVitalReader {
          therefore even at the worst-case, precision isn't lost during this conversion below.
          */
         let userTicks = cpuLoadInfo.cpu_ticks.0
-        return userTicks
+        return UInt64(userTicks)
     }
 }

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -63,6 +63,11 @@ internal final class VitalInfoSampler {
         self.refreshRateReader.register(self.refreshRatePublisher)
         self.maximumRefreshRate = maximumRefreshRate
 
+        // Take initial sample
+        RunLoop.main.perform { [weak self] in
+            self?.takeSample()
+        }
+        // Schedule reoccuring samples
         let timer = Timer(
             timeInterval: frequency,
             repeats: true

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -63,7 +63,6 @@ internal final class VitalInfoSampler {
         self.refreshRateReader.register(self.refreshRatePublisher)
         self.maximumRefreshRate = maximumRefreshRate
 
-        takeSample()
         let timer = Timer(
             timeInterval: frequency,
             repeats: true

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -63,16 +63,16 @@ internal final class VitalInfoSampler {
         self.refreshRateReader.register(self.refreshRatePublisher)
         self.maximumRefreshRate = maximumRefreshRate
 
-        // Take initial sample
-        RunLoop.main.perform { [weak self] in
-            self?.takeSample()
-        }
         // Schedule reoccuring samples
         let timer = Timer(
             timeInterval: frequency,
             repeats: true
         ) { [weak self] _ in
             self?.takeSample()
+        }
+        // Take initial sample
+        RunLoop.main.perform {
+            timer.fire()
         }
         // NOTE: RUMM-1280 based on my running Example app
         // non-main run loops don't fire the timer.


### PR DESCRIPTION
### What and why?

Seeing this crash after upgrading from 1.12.1 to 1.15.0:
```
Crashed: com.datadoghq.rum-monitor
0  MyApp                          0x24da04 VitalCPUReader.readVitalData() + 29 (VitalCPUReader.swift:29)
1  MyApp                          0x24db04 protocol witness for SamplingBasedVitalReader.readVitalData() in conformance VitalCPUReader + 4366867204 (<compiler-generated>:4366867204)
2  MyApp                          0x24df7c VitalInfoSampler.takeSample() + 86 (VitalInfoSampler.swift:86)
3  MyApp                          0x20982c specialized VitalInfoSampler.init(cpuReader:memoryReader:refreshRateReader:frequency:maximumRefreshRate:) + 4366587948 (<compiler-generated>:4366587948)
4  MyApp                          0x224808 specialized RUMViewScope.init(isInitialView:parent:dependencies:identity:path:name:attributes:customTimings:startTime:serverTimeOffset:) + 4366698504 (<compiler-generated>:4366698504)
5  MyApp                          0x2083dc RUMSessionScope.startView(on:context:) + 4366582748 (RUMViewScope.swift:4366582748)
6  MyApp                          0x207a10 RUMSessionScope.process(command:context:writer:) + 144 (RUMSessionScope.swift:144)
7  MyApp                          0x18e758 RUMApplicationScope.process(command:context:writer:) + 4366083928 (<compiler-generated>:4366083928)
8  MyApp                          0x1fa8e8 closure #1 in closure #1 in RUMMonitor.process(command:) + 597 (RUMMonitor.swift:597)
9  MyApp                          0x134de0 thunk for @callee_guaranteed () -> () + 4365716960 (<compiler-generated>:4365716960)
10 MyApp                          0x134e00 thunk for @escaping @callee_guaranteed () -> () + 4365716992 (<compiler-generated>:4365716992)
11 libdispatch.dylib              0x647c8 _dispatch_client_callout + 16
12 libdispatch.dylib              0x46b54 _dispatch_lane_barrier_sync_invoke_and_complete + 52
13 MyApp                          0x1fa7bc closure #1 in RUMMonitor.process(command:) + 4366526396 (<compiler-generated>:4366526396)
14 MyApp                          0x1fdc7c partial apply for closure #1 in RUMMonitor.process(command:) + 4366539900 (<compiler-generated>:4366539900)
15 MyApp                          0x1fe540 closure #1 in RUMMonitor.process(command:)partial apply + 4366542144
16 MyApp                          0x12f904 closure #1 in DatadogCoreFeatureScope.eventWriteContext(bypassConsent:forceNewBatch:_:) + 486 (DatadogCore.swift:486)
17 MyApp                          0x12a030 closure #1 in DatadogContextProvider.read(block:) + 105 (DatadogContextProvider.swift:105)
18 MyApp                          0x392b8 thunk for @escaping @callee_guaranteed () -> () + 4364686008 (<compiler-generated>:4364686008)
19 libdispatch.dylib              0x63850 _dispatch_call_block_and_release + 24
20 libdispatch.dylib              0x647c8 _dispatch_client_callout + 16
21 libdispatch.dylib              0x3f854 _dispatch_lane_serial_drain$VARIANT$armv81 + 604
22 libdispatch.dylib              0x402e4 _dispatch_lane_invoke$VARIANT$armv81 + 380
23 libdispatch.dylib              0x4a000 _dispatch_workloop_worker_thread + 612
24 libsystem_pthread.dylib        0x1b50 _pthread_wqthread + 284
25 libsystem_pthread.dylib        0x167c start_wqthread + 8
```

My initial suspicion was integer overflow with the `UInt32`s being used here (`natural_t`), but I tried to reproduce that and I think it would result in a slightly different stacktrace. So then I noticed this comment in `VitalCPUReader`:
```
    // TODO: RUMM-1276 appWillResignActive&appDidBecomeActive are called in main thread
    // IF readVitalData() is called from non-main threads, they must be synchronized
```
And I realized that it's crashing on the rum thread.

### How?

Remove initial sample call that was happening on rum thread.
This passes current unit tests.

Alternatively this call can be moved to `Runloop.main.perform {}`, but that caused a test failure (could just be a test issue), so I went with this approach for now.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration) - Existing tests pass
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
