### PR TITLE
RUMM-2964 [SR] Support `UIPickerView` elements in session replay

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -11,6 +11,7 @@ internal enum Fixture: CaseIterable {
     case basicTexts
     case sliders
     case segments
+    case pickers
 
     var menuItemTitle: String {
         switch self {
@@ -22,6 +23,8 @@ internal enum Fixture: CaseIterable {
             return "Sliders"
         case .segments:
             return "Segments"
+        case .pickers:
+            return "Pickers"
         }
     }
 
@@ -35,7 +38,8 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Sliders")
         case .segments:
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Segments")
-
+        case .pickers:
+            return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Pickers")
         }
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
@@ -195,6 +195,57 @@
             </objects>
             <point key="canvasLocation" x="1042" y="6"/>
         </scene>
+        <!--Pickers View Controller-->
+        <scene sceneID="zf0-jS-j9h">
+            <objects>
+                <viewController storyboardIdentifier="Pickers" id="pgL-qH-ByZ" customClass="PickersViewController" customModule="SRHost" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="gM5-TU-niJ">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="CZc-U9-Jdq">
+                                <rect key="frame" x="8" y="67.000000000000028" width="377" height="472.66666666666674"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Simple - one wheel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HtK-Qe-ne9">
+                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bsS-D6-XAf">
+                                        <rect key="frame" x="0.0" y="20.333333333333314" width="377" height="216"/>
+                                    </pickerView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customized - multiple wheels" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o3G-Be-Os5">
+                                        <rect key="frame" x="0.0" y="236.33333333333331" width="377" height="20.333333333333314"/>
+                                        <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Smi-UB-4C6">
+                                        <rect key="frame" x="0.0" y="256.66666666666669" width="377" height="216"/>
+                                        <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                    </pickerView>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="yHT-hw-epV"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="yHT-hw-epV" firstAttribute="trailing" secondItem="CZc-U9-Jdq" secondAttribute="trailing" constant="8" id="1Dd-CO-lYY"/>
+                            <constraint firstItem="CZc-U9-Jdq" firstAttribute="top" secondItem="yHT-hw-epV" secondAttribute="top" constant="8" id="FJA-yP-GaU"/>
+                            <constraint firstItem="CZc-U9-Jdq" firstAttribute="leading" secondItem="yHT-hw-epV" secondAttribute="leading" constant="8" id="se3-vK-ph7"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="firstPicker" destination="bsS-D6-XAf" id="AVQ-md-4as"/>
+                        <outlet property="secondPicker" destination="Smi-UB-4C6" id="uVO-Yb-JKA"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="082-Nv-BXt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1892" y="13"/>
+        </scene>
     </scenes>
     <resources>
         <image name="cloud.fill" catalog="system" width="128" height="87"/>
@@ -211,6 +262,9 @@
         </systemColor>
         <systemColor name="systemGreenColor">
             <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemPinkColor">
             <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputViewControllers.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputViewControllers.swift
@@ -1,0 +1,59 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+internal class PickersViewController: UIViewController {
+    private class PickerData: NSObject, UIPickerViewDataSource, UIPickerViewDelegate {
+        var labels: [[String]] = []
+
+        init(labels: [[String]]) {
+            self.labels = labels
+        }
+
+        func numberOfComponents(in pickerView: UIPickerView) -> Int {
+            labels.count
+        }
+
+        func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+            labels[component].count
+        }
+
+        func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+            labels[component][row]
+        }
+
+    }
+
+    private let firstPickerData = PickerData(
+        labels: [
+            ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight"]
+        ]
+    )
+    private let secondPickerData = PickerData(
+        labels: [
+            ["A", "B", "C", "D", "E", "F", "G"],
+            ["One", "Two", "Three", "Four", "Five"],
+            ["First", "Second", "Third", "Fourth", "Fifth"],
+        ]
+    )
+    @IBOutlet weak var firstPicker: UIPickerView!
+    @IBOutlet weak var secondPicker: UIPickerView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        firstPicker.dataSource = firstPickerData
+        firstPicker.delegate = firstPickerData
+        firstPicker.selectRow(3, inComponent: 0, animated: false)
+
+        secondPicker.dataSource = secondPickerData
+        secondPicker.delegate = secondPickerData
+        secondPicker.selectRow(3, inComponent: 0, animated: false)
+        secondPicker.selectRow(0, inComponent: 1, animated: false)
+        secondPicker.selectRow(4, inComponent: 2, animated: false)
+    }
+}

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		619C49B72995512A006B66A6 /* ImageComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619C49B62995512A006B66A6 /* ImageComparison.swift */; };
 		619C49B9299551F5006B66A6 /* _snapshots_ in Resources */ = {isa = PBXBuildFile; fileRef = 619C49B8299551F5006B66A6 /* _snapshots_ */; };
 		619C49BB299639BC006B66A6 /* ImageRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619C49BA299639BC006B66A6 /* ImageRendering.swift */; };
+		61A735AA29A5137400001820 /* InputViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A735A929A5137400001820 /* InputViewControllers.swift */; };
 		61B3BC4B2993BE2E0032C78A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B3BC4A2993BE2E0032C78A /* AppDelegate.swift */; };
 		61B3BC4D2993BE2E0032C78A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B3BC4C2993BE2E0032C78A /* SceneDelegate.swift */; };
 		61B3BC522993BE2E0032C78A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61B3BC502993BE2E0032C78A /* Main.storyboard */; };
@@ -42,6 +43,7 @@
 		619C49B62995512A006B66A6 /* ImageComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageComparison.swift; sourceTree = "<group>"; };
 		619C49B8299551F5006B66A6 /* _snapshots_ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = _snapshots_; sourceTree = "<group>"; };
 		619C49BA299639BC006B66A6 /* ImageRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRendering.swift; sourceTree = "<group>"; };
+		61A735A929A5137400001820 /* InputViewControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputViewControllers.swift; sourceTree = "<group>"; };
 		61B3BC472993BE2E0032C78A /* SRHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SRHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		61B3BC4A2993BE2E0032C78A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		61B3BC4C2993BE2E0032C78A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 				61E7DFB8299A5A3E001D7A3A /* Basic.storyboard */,
 				61E7DFBA299A5C9D001D7A3A /* BasicViewControllers.swift */,
 				616C37D9299F6913005E0472 /* InputElements.storyboard */,
+				61A735A929A5137400001820 /* InputViewControllers.swift */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -266,6 +269,7 @@
 				61E7DFB7299A57A9001D7A3A /* MenuViewController.swift in Sources */,
 				61B634EB299A5DB3002BEABE /* Fixtures.swift in Sources */,
 				61B3BC4D2993BE2E0032C78A /* SceneDelegate.swift in Sources */,
+				61A735AA29A5137400001820 /* InputViewControllers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -70,4 +70,22 @@ final class SRSnapshotTests: SnapshotTestCase {
             record: recordingMode
         )
     }
+
+    func testPickers() throws {
+        show(fixture: .pickers)
+
+        var image = try takeSnapshot(configuration: .init(privacy: .allowAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
+            record: recordingMode
+        )
+
+        image = try takeSnapshot(configuration: .init(privacy: .maskAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-maskAll-privacy"),
+            record: recordingMode
+        )
+    }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
@@ -11,7 +11,7 @@ import Framer
 /// Renders application window into image.
 internal func renderImage(for window: UIWindow) -> UIImage {
     let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
-    return renderer.image { window.layer.render(in: $0.cgContext) }
+    return renderer.image { _ in window.drawHierarchy(in: window.bounds, afterScreenUpdates: true) }
 }
 
 /// Renders wireframes into image.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -31,6 +31,7 @@ internal struct UILabelRecorder: NodeRecorder {
             attributes: attributes,
             text: label.text ?? "",
             textColor: label.textColor?.cgColor,
+            textAlignment: nil,
             font: label.font,
             fontScalingEnabled: label.adjustsFontSizeToFitWidth,
             textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator,
@@ -48,6 +49,8 @@ internal struct UILabelWireframesBuilder: NodeWireframesBuilder {
     let text: String
     /// The color of the text.
     let textColor: CGColor?
+    /// The alignment of the text.
+    var textAlignment: SRTextPosition.Alignment?
     /// The font used by the label.
     let font: UIFont?
     /// Flag that determines if font should be scaled
@@ -64,6 +67,7 @@ internal struct UILabelWireframesBuilder: NodeWireframesBuilder {
                 frame: attributes.frame,
                 text: textObfuscator.mask(text: text),
                 textFrame: wireframeRect,
+                textAlignment: textAlignment,
                 textColor: textColor,
                 font: font,
                 fontScalingEnabled: fontScalingEnabled,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -1,0 +1,116 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+/// Records `UIPickerView` nodes.
+///
+/// The look of picker view in SR is approximated by capturing the text from "selected row" and ignoring all other values on the wheel:
+/// - If the picker defines multiple components, there will be multiple selected values.
+/// - We can't request `picker.dataSource` to receive the value - doing so will result in calling applicaiton code, which could be
+/// dangerous (if the code is faulty) and may significantly slow down the performance (e.g. if the underlying source requires database fetch).
+/// - Similarly, we don't call `picker.delegate` to avoid running application code outside `UIKit's` lifecycle.
+/// - Instead, we infer the value by traversing picker's subtree state and finding texts that are displayed closest to its geometry center.
+/// - If privacy mode is elevated, we don't replace individual characters with "x" letter - instead we change whole options to fixed-width mask value.
+internal struct UIPickerViewRecorder: NodeRecorder {
+    /// Custom text obfuscator for picker option labels.
+    ///
+    /// Unlike the default `TextObfuscator` it doesn't mask each individual character with "x" letter. Instead, it replaces
+    /// whole options with fixed "xxx" string. This elevates the level of privacy, because selected option can not be inferred
+    /// by counting number of characters.
+    private struct PickerOptionTextObfuscator: TextObfuscating {
+        private static let xxx = "xxx"
+        func mask(text: String) -> String { Self.xxx }
+    }
+    /// A sub-tree recorder for capturing shapes nested in picker's view hierarchy.
+    /// It is used to capture the background of selected option.
+    private let selectionRecorder = ViewTreeRecorder(nodeRecorders: [UIViewRecorder()])
+    /// A sub-tree recorder for capturing labels nested in picker's view hierarchy.
+    /// It is used to capture titles for displayed options.
+    private let labelsRecorder = ViewTreeRecorder(nodeRecorders: [UILabelRecorder()])
+
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
+        guard let picker = view as? UIPickerView else {
+            return nil
+        }
+
+        guard attributes.isVisible else {
+            return InvisibleElement.constant
+        }
+
+        // For our "approximation", we render selected option text on top of selection background. However,
+        // in the actual `UIPickerView's` tree their order is opposite (blending is used to make the label
+        // pass through the shape). For that reason, we record both kinds of nodes separately and then reorder
+        // them in returned `.replace(subtreeNodes:)` strategy:
+        let backgroundNodes = recordBackgroundOfSelectedOption(in: picker, using: context)
+        let titleNodes = recordTitlesOfSelectedOption(in: picker, pickerAttributes: attributes, using: context)
+
+        guard attributes.hasAnyAppearance else {
+            // If the root view of `UIPickerView` defines no other appearance (e.g. no custom `.background`), we can
+            // safely ignore it, with only forwarding child nodes to final recording.
+            return InvisibleElement(
+                subtreeStrategy: .replace(subtreeNodes: backgroundNodes + titleNodes)
+            )
+        }
+
+        // Otherwise, we build dedicated wireframes to describe additional appearance coming from picker's root `UIView`:
+        let builder = UIPickerViewWireframesBuilder(
+            wireframeRect: attributes.frame,
+            attributes: attributes,
+            backgroundWireframeID: context.ids.nodeID(for: picker)
+        )
+
+        return SpecificElement(
+            wireframesBuilder: builder,
+            subtreeStrategy: .replace(subtreeNodes: backgroundNodes + titleNodes)
+        )
+    }
+
+    /// Records `UIView` nodes that define background of selected option.
+    private func recordBackgroundOfSelectedOption(in picker: UIPickerView, using context: ViewTreeRecordingContext) -> [Node] {
+        return selectionRecorder.recordNodes(for: picker, in: context)
+    }
+
+    /// Records `UILabel` nodes that hold titles of **selected** options - if picker defines N components, there will be N nodes returned.
+    private func recordTitlesOfSelectedOption(in picker: UIPickerView, pickerAttributes: ViewAttributes, using context: ViewTreeRecordingContext) -> [Node] {
+        var context = context
+        context.textObfuscator = PickerOptionTextObfuscator()
+        context.semanticsOverride = { currentSemantics, label, attributes in
+            // We consider option to be "selected" if it is displayed close enough to picker's geometry center
+            // and its `UILabel` is opaque:
+            let isNearCenter = abs(attributes.frame.midY - pickerAttributes.frame.midY) < 10
+            let isForeground = attributes.alpha == 1
+
+            if isNearCenter && isForeground, var wireframeBuilder = (currentSemantics.wireframesBuilder as? UILabelWireframesBuilder) {
+                // For some reason, the text within `UILabel` is not centered in regular way (with `intrinsicContentSize`), hence
+                // we need to manually center it within produced wireframe. Here we use SR text alignment options to achieve it:
+                var newSemantics = currentSemantics
+                wireframeBuilder.textAlignment = .init(horizontal: .center, vertical: .center)
+                newSemantics.wireframesBuilder = wireframeBuilder
+                return newSemantics
+            } else {
+                return InvisibleElement.constant // this node doesn't describe selected option - ignore it
+            }
+        }
+        return labelsRecorder.recordNodes(for: picker, in: context)
+    }
+}
+
+internal struct UIPickerViewWireframesBuilder: NodeWireframesBuilder {
+    var wireframeRect: CGRect
+    let attributes: ViewAttributes
+    let backgroundWireframeID: WireframeID
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        return [
+            builder.createShapeWireframe(
+                id: backgroundWireframeID,
+                frame: wireframeRect,
+                attributes: attributes
+            )
+        ]
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -22,8 +22,8 @@ internal struct UIPickerViewRecorder: NodeRecorder {
     /// whole options with fixed "xxx" string. This elevates the level of privacy, because selected option can not be inferred
     /// by counting number of characters.
     private struct PickerOptionTextObfuscator: TextObfuscating {
-        private static let xxx = "xxx"
-        func mask(text: String) -> String { Self.xxx }
+        private static let maskedString = "xxx"
+        func mask(text: String) -> String { Self.maskedString }
     }
     /// A sub-tree recorder for capturing shapes nested in picker's view hierarchy.
     /// It is used to capture the background of selected option.

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -12,6 +12,12 @@ internal struct UIViewRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
+        guard attributes.hasAnyAppearance else {
+            // The view has no appearance, but it may contain subviews that bring visual elements, so
+            // we use `InvisibleElement` semantics (to drop it) with `.record` strategy for its subview.
+            return InvisibleElement(subtreeStrategy: .record)
+        }
+
         let builder = UIViewWireframesBuilder(
             wireframeID: context.ids.nodeID(for: view),
             attributes: attributes,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -141,7 +141,7 @@ internal protocol NodeSemantics {
     var subtreeStrategy: NodeSubtreeStrategy { get }
 
     /// A type defining how to build SR wireframes for the UI element this semantic was recorded for.
-    var wireframesBuilder: NodeWireframesBuilder? { get }
+    var wireframesBuilder: NodeWireframesBuilder? { set get }
 }
 
 extension NodeSemantics {
@@ -174,7 +174,7 @@ internal enum NodeSubtreeStrategy {
 /// in view-tree traversal performed in `Recorder` (e.g. working on assumption that is not met).
 internal struct UnknownElement: NodeSemantics {
     static let importance: Int = .min
-    let wireframesBuilder: NodeWireframesBuilder? = nil
+    var wireframesBuilder: NodeWireframesBuilder? = nil
     let subtreeStrategy: NodeSubtreeStrategy = .record
 
     /// Use `UnknownElement.constant` instead.
@@ -189,13 +189,19 @@ internal struct UnknownElement: NodeSemantics {
 /// Nodes with this semantics can be safely ignored in `Recorder` or in `Processor`.
 internal struct InvisibleElement: NodeSemantics {
     static let importance: Int = 0
-    let wireframesBuilder: NodeWireframesBuilder? = nil
-    let subtreeStrategy: NodeSubtreeStrategy = .ignore
+    var wireframesBuilder: NodeWireframesBuilder? = nil
+    let subtreeStrategy: NodeSubtreeStrategy
 
     /// Use `InvisibleElement.constant` instead.
-    private init () {}
+    private init () {
+        self.subtreeStrategy = .ignore
+    }
 
-    /// A constant value of `InvisibleElement` semantics.
+    init(subtreeStrategy: NodeSubtreeStrategy) {
+        self.subtreeStrategy = subtreeStrategy
+    }
+
+    /// A constant value of `InvisibleElement` semantics with `subtreeStrategy: .ignore`.
     static let constant = InvisibleElement()
 }
 
@@ -205,7 +211,7 @@ internal struct InvisibleElement: NodeSemantics {
 /// The view-tree traversal algorithm will continue visiting the subtree of given `UIView` if it has `AmbiguousElement` semantics.
 internal struct AmbiguousElement: NodeSemantics {
     static let importance: Int = 0
-    let wireframesBuilder: NodeWireframesBuilder?
+    var wireframesBuilder: NodeWireframesBuilder?
     let subtreeStrategy: NodeSubtreeStrategy = .record
 }
 
@@ -214,6 +220,6 @@ internal struct AmbiguousElement: NodeSemantics {
 /// "on" / "off" state of `UISwitch` control).
 internal struct SpecificElement: NodeSemantics {
     static let importance: Int = .max
-    let wireframesBuilder: NodeWireframesBuilder?
+    var wireframesBuilder: NodeWireframesBuilder?
     let subtreeStrategy: NodeSubtreeStrategy
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -64,4 +64,5 @@ internal let defaultNodeRecorders: [NodeRecorder] = [
     UISegmentRecorder(),
     UINavigationBarRecorder(),
     UITabBarRecorder(),
+    UIPickerViewRecorder(),
 ]

--- a/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
@@ -98,8 +98,10 @@ class ProcessorTests: XCTestCase {
 
         // Given
         let processor = Processor(queue: NoQueue(), writer: writer)
-        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 200))
-        let rotatedView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        let view = UIView.mock(withFixture: .visible(.someAppearance))
+        view.frame = CGRect(x: 0, y: 0, width: 100, height: 200)
+        let rotatedView = UIView.mock(withFixture: .visible(.someAppearance))
+        rotatedView.frame = CGRect(x: 0, y: 0, width: 200, height: 100)
 
         // When
         let snapshot1 = generateViewTreeSnapshot(for: view, date: time, rumContext: rum)
@@ -224,8 +226,8 @@ class ProcessorTests: XCTestCase {
     }
 
     private func generateSimpleViewTree() -> UIView {
-        let root = UIView.mock(withFixture: .visible(.noAppearance))
-        let child = UIView.mock(withFixture: .visible(.noAppearance))
+        let root = UIView.mock(withFixture: .visible(.someAppearance))
+        let child = UIView.mock(withFixture: .visible(.someAppearance))
         root.addSubview(child)
         return root
     }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
@@ -1,0 +1,60 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class UIPickerViewRecorderTests: XCTestCase {
+    private let recorder = UIPickerViewRecorder()
+    private let picker = UIPickerView()
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenPickerIsNotVisible() throws {
+        // When
+        viewAttributes = .mock(fixture: .invisible)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: picker, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+    }
+
+    func testWhenPickerIsVisibleButHasNoAppearance() throws {
+        // When
+        viewAttributes = .mock(fixture: .visible(.noAppearance))
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: picker, with: viewAttributes, in: .mockAny()) as? InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+        guard case .replace(let nodes) = semantics.subtreeStrategy else {
+            XCTFail("Expected `.replace()` subtreeStrategy, got \(semantics.subtreeStrategy)")
+            return
+        }
+        XCTAssertFalse(nodes.isEmpty)
+    }
+
+    func testWhenPickerIsVisibleAndHasSomeAppearance() throws {
+        // When
+        viewAttributes = .mock(fixture: .visible(.someAppearance))
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: picker, with: viewAttributes, in: .mockAny()) as? SpecificElement)
+        XCTAssertNotNil(semantics.wireframesBuilder)
+        guard case .replace(let nodes) = semantics.subtreeStrategy else {
+            XCTFail("Expected `.replace()` subtreeStrategy, got \(semantics.subtreeStrategy)")
+            return
+        }
+        XCTAssertFalse(nodes.isEmpty)
+    }
+
+    func testWhenViewIsNotOfExpectedType() {
+        // When
+        let view = UITextField()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+    }
+}

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -5,6 +5,7 @@
  */
 
 import XCTest
+import TestUtilities
 @testable import DatadogSessionReplay
 
 class UIViewRecorderTests: XCTestCase {
@@ -34,5 +35,16 @@ class UIViewRecorderTests: XCTestCase {
 
         let builder = try XCTUnwrap(semantics.wireframesBuilder as? UIViewWireframesBuilder)
         XCTAssertEqual(builder.attributes, viewAttributes)
+    }
+
+    func testWhenViewIsVisibleButHasNoAppearance() throws {
+        // When
+        viewAttributes = .mock(fixture: .visible(.noAppearance))
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+        XCTAssertNil(semantics.wireframesBuilder)
+        DDAssertReflectionEqual(semantics.subtreeStrategy, .record)
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR enhances the look of `UIPickerView` elements in session replay. Now we approximate their look by only capturing the text from "selected row" and ignoring all other values on the wheel. To further meet SR goals, if content masking is enabled we erase the values by replacing them with fixed-width `"xxx"` mask.

<table>
<tr><td>With no masking:</td><td>With masking:</td></tr>
<tr>
   <td><img src="https://user-images.githubusercontent.com/2358722/221533190-f65c7f7d-a86f-426a-895c-4c8046b713f6.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/221533979-28e65cee-076f-43d9-b582-eb256c8b997d.png" /></td></tr>
</table>

### How?

This implementation leverages `NodeSubtreeStrategy` concept introduced in #1175. The `UIPickerViewRecorder` uses its own `ViewTreeRecorder` to traverse picker's subtree and returns nodes to parent recorder with `.replace(subtreeNodes:)` strategy. To approximate picker appearance we only need to capture `UILabel` and `UIView` nodes.

Capturing `UILabel` nodes in the context of picker's subtree differs from capturing them in the main recorder. Unlike regular labels, the ones rendered in picker do leverage `intrinsicContentSize` for text positioning. Fortunately, SR data format provides its own means for text positioning, so I was able to achieve desired result by centering the text inside original label's frame.  This required injecting custom configuration to `UILabelRecorder` if used by `UIPickerViewRecorder`. I was able to leverage the concept of `ViewTreeRecordingContext` propagated in parent → child direction. It now supports custom `semanticsOverride` option:
```swift
internal struct ViewTreeRecordingContext {
    var semanticsOverride: ((NodeSemantics, UIView, ViewAttributes) -> NodeSemantics)? = nil
}
```
which allows a parent recorder to alter behaviour of child recorder. It is designed to promote OCP (_"change configuration, not implementation"_) and should let us keep the codebase clean by implementing overrides exactly where they belong (here: we adjusting label recorder from picker recorder's body).

#### Alternative considered

An alternative to recording child labels and views could be reading the selected value through [`UIPickerViewDataSource`](https://developer.apple.com/documentation/uikit/uipickerviewdatasource) and [`UIPickerViewDelegate`](https://developer.apple.com/documentation/uikit/uipickerviewdelegate).  I dropped that option, because calling `dataSource` or `delegate` would mean executing application code outside of `UIKit's` lifecycle. We can't assume or reason about the complexity or consequences of running custom code (e.g. it could sink the performance if data source invokes DB fetch), so it doesn't look like sustainable solution.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
