### PR TITLE
REPLAY-1340 Support `UISwitch` elements in session replay

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -12,6 +12,7 @@ internal enum Fixture: CaseIterable {
     case sliders
     case segments
     case pickers
+    case switches
 
     var menuItemTitle: String {
         switch self {
@@ -25,6 +26,8 @@ internal enum Fixture: CaseIterable {
             return "Segments"
         case .pickers:
             return "Pickers"
+        case .switches:
+            return "Switches"
         }
     }
 
@@ -40,6 +43,8 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Segments")
         case .pickers:
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Pickers")
+        case .switches:
+            return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Switches")
         }
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
@@ -203,8 +203,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="CZc-U9-Jdq">
-                                <rect key="frame" x="8" y="67.000000000000028" width="377" height="472.66666666666674"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="CZc-U9-Jdq">
+                                <rect key="frame" x="8" y="67.000000000000028" width="377" height="496.66666666666674"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Simple - one wheel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HtK-Qe-ne9">
                                         <rect key="frame" x="0.0" y="0.0" width="377" height="20.333333333333332"/>
@@ -213,17 +213,17 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bsS-D6-XAf">
-                                        <rect key="frame" x="0.0" y="20.333333333333314" width="377" height="216"/>
+                                        <rect key="frame" x="0.0" y="28.333333333333314" width="377" height="216"/>
                                     </pickerView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customized - multiple wheels" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o3G-Be-Os5">
-                                        <rect key="frame" x="0.0" y="236.33333333333331" width="377" height="20.333333333333314"/>
+                                        <rect key="frame" x="0.0" y="252.33333333333334" width="377" height="20.333333333333343"/>
                                         <color key="backgroundColor" systemColor="systemOrangeColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Smi-UB-4C6">
-                                        <rect key="frame" x="0.0" y="256.66666666666669" width="377" height="216"/>
+                                        <rect key="frame" x="0.0" y="280.66666666666669" width="377" height="216"/>
                                         <color key="backgroundColor" systemColor="systemYellowColor"/>
                                     </pickerView>
                                 </subviews>
@@ -245,6 +245,111 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="082-Nv-BXt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1892" y="13"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="Tnu-GW-onF">
+            <objects>
+                <viewController storyboardIdentifier="Switches" id="fil-XH-ugz" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="P1S-z7-mrf">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="JQC-x6-QsY">
+                                <rect key="frame" x="8" y="67" width="377" height="396"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Default - ON" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b70-44-86b">
+                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bdg-7U-I0i">
+                                        <rect key="frame" x="0.0" y="28.333333333333329" width="379" height="31"/>
+                                    </switch>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Default - OFF" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JPc-Ux-Rll">
+                                        <rect key="frame" x="0.0" y="67.333333333333343" width="377" height="20.333333333333329"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="1bg-1l-H34">
+                                        <rect key="frame" x="0.0" y="95.666666666666657" width="379" height="31"/>
+                                    </switch>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dWv-a0-5cR">
+                                        <rect key="frame" x="0.0" y="134.66666666666666" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jg3-dQ-84B">
+                                        <rect key="frame" x="0.0" y="163" width="379" height="31"/>
+                                    </switch>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom #1 - ON" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eZI-Dj-gL0">
+                                        <rect key="frame" x="0.0" y="202" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dQ9-si-6Bk">
+                                        <rect key="frame" x="0.0" y="230.33333333333331" width="379" height="31"/>
+                                        <color key="onTintColor" systemColor="systemYellowColor"/>
+                                        <color key="thumbTintColor" systemColor="systemPinkColor"/>
+                                    </switch>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom #1  - OFF" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="APo-dW-cPS">
+                                        <rect key="frame" x="0.0" y="269.33333333333331" width="377" height="20.333333333333314"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ZmH-6E-kNq">
+                                        <rect key="frame" x="0.0" y="297.66666666666669" width="379" height="31"/>
+                                        <color key="onTintColor" systemColor="systemYellowColor"/>
+                                        <color key="thumbTintColor" systemColor="systemPinkColor"/>
+                                    </switch>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom #2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q8g-NH-AVw">
+                                        <rect key="frame" x="0.0" y="336.66666666666669" width="377" height="20.333333333333314"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CZH-aq-9sf">
+                                        <rect key="frame" x="0.0" y="365" width="379" height="31"/>
+                                        <color key="backgroundColor" systemColor="systemPurpleColor"/>
+                                    </switch>
+                                </subviews>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Outside of stack view:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oxF-M6-gfF">
+                                <rect key="frame" x="112.66666666666669" y="506.99999999999994" width="168" height="20.333333333333314"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BQK-Z7-w9x">
+                                <rect key="frame" x="172" y="535.33333333333337" width="51" height="31"/>
+                            </switch>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="7Fb-LU-Lfg">
+                                <rect key="frame" x="172" y="574.33333333333337" width="51" height="31"/>
+                            </switch>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="0ZJ-WQ-RPS"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="JQC-x6-QsY" firstAttribute="top" secondItem="0ZJ-WQ-RPS" secondAttribute="top" constant="8" id="22B-he-5sU"/>
+                            <constraint firstItem="0ZJ-WQ-RPS" firstAttribute="trailing" secondItem="JQC-x6-QsY" secondAttribute="trailing" constant="8" id="Jy5-4H-nJj"/>
+                            <constraint firstItem="oxF-M6-gfF" firstAttribute="top" secondItem="JQC-x6-QsY" secondAttribute="bottom" constant="44" id="Ljn-mU-hh5"/>
+                            <constraint firstItem="BQK-Z7-w9x" firstAttribute="centerX" secondItem="P1S-z7-mrf" secondAttribute="centerX" id="U2j-r7-Pv7"/>
+                            <constraint firstItem="oxF-M6-gfF" firstAttribute="centerX" secondItem="P1S-z7-mrf" secondAttribute="centerX" id="Xic-cx-5hr"/>
+                            <constraint firstItem="JQC-x6-QsY" firstAttribute="leading" secondItem="0ZJ-WQ-RPS" secondAttribute="leading" constant="8" id="ejI-5b-jgY"/>
+                            <constraint firstItem="7Fb-LU-Lfg" firstAttribute="top" secondItem="BQK-Z7-w9x" secondAttribute="bottom" constant="8" id="o8S-7F-W3f"/>
+                            <constraint firstItem="7Fb-LU-Lfg" firstAttribute="centerX" secondItem="P1S-z7-mrf" secondAttribute="centerX" id="rin-2q-F7U"/>
+                            <constraint firstItem="BQK-Z7-w9x" firstAttribute="top" secondItem="oxF-M6-gfF" secondAttribute="bottom" constant="8" id="yih-uO-1ht"/>
+                            <constraint firstItem="JQC-x6-QsY" firstAttribute="top" secondItem="0ZJ-WQ-RPS" secondAttribute="top" constant="8" id="zjC-Nt-g8x"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ggg-NW-qTe" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2689" y="32"/>
         </scene>
     </scenes>
     <resources>
@@ -268,6 +373,9 @@
         </systemColor>
         <systemColor name="systemPinkColor">
             <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPurpleColor">
+            <color red="0.68627450980392157" green="0.32156862745098042" blue="0.87058823529411766" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemYellowColor">
             <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -88,4 +88,22 @@ final class SRSnapshotTests: SnapshotTestCase {
             record: recordingMode
         )
     }
+
+    func testSwitches() throws {
+        show(fixture: .switches)
+
+        var image = try takeSnapshot(configuration: .init(privacy: .allowAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
+            record: recordingMode
+        )
+
+        image = try takeSnapshot(configuration: .init(privacy: .maskAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-maskAll-privacy"),
+            record: recordingMode
+        )
+    }
 }

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
@@ -60,4 +60,8 @@ internal enum SystemColors {
             return UIColor(red: 0 / 255, green: 0 / 255, blue: 0 / 255, alpha: 1).cgColor
         }
     }
+
+    static var systemGreen: CGColor {
+        return UIColor.systemGreen.cgColor
+    }
 }

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIKitExtensions.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIKitExtensions.swift
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+internal extension UIView {
+    var usesDarkMode: Bool {
+        if #available(iOS 12.0, *) {
+            return traitCollection.userInterfaceStyle == .dark
+        } else {
+            return false // assume "no"
+        }
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
@@ -16,78 +16,76 @@ internal struct UISwitchRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        let ids = context.ids.nodeIDs(2, for: `switch`)
+        // The actual frame of the switch. It might be different than `view.frame` if displayed in stack view:
+        let switchFrame = CGRect(origin: attributes.frame.origin, size: view.intrinsicContentSize)
+        let ids = context.ids.nodeIDs(3, for: `switch`)
 
         let builder = UISwitchWireframesBuilder(
-            backgroundWireframeID: ids[0],
-            thumbWireframeID: ids[1],
+            wireframeRect: switchFrame,
             attributes: attributes,
+            backgroundWireframeID: ids[0],
+            trackWireframeID: ids[1],
+            thumbWireframeID: ids[2],
+            isEnabled: `switch`.isEnabled,
+            isDarkMode: `switch`.usesDarkMode,
             isOn: `switch`.isOn,
             thumbTintColor: `switch`.thumbTintColor?.cgColor,
             onTintColor: `switch`.onTintColor?.cgColor,
-            offTintColor: `switch`.tintColor?.cgColor,
-            wireframeRect: attributes.frame
+            offTintColor: `switch`.tintColor?.cgColor
         )
         return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
     }
 }
 
 internal struct UISwitchWireframesBuilder: NodeWireframesBuilder {
-    struct SystemDefaults {
-        /// Default color of the thumb.
-        static let thumbTintColor: CGColor = UIColor.white.cgColor
-        /// Default color of the background in "on" state.
-        static let onTintColor: CGColor = UIColor.systemGreen.cgColor
-        /// Default color of the background in "off" state.
-        static let offTintColor: CGColor = UIColor.lightGray.cgColor
-    }
+    let wireframeRect: CGRect
+    let attributes: ViewAttributes
 
     let backgroundWireframeID: WireframeID
+    let trackWireframeID: WireframeID
     let thumbWireframeID: WireframeID
-    /// Attributes of the base `UIView`.
-    let attributes: ViewAttributes
-    /// If the switch is "on" or "off".
+    let isEnabled: Bool
+    let isDarkMode: Bool
     let isOn: Bool
-    /// The custom color of the thumb.
     let thumbTintColor: CGColor?
-    /// The custom color of the background in "on" state.
     let onTintColor: CGColor?
-    /// The custom color of the background in "off" state.
     let offTintColor: CGColor?
 
-    let wireframeRect: CGRect
-
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
-        let radius = attributes.frame.height * 0.5
-        let backgroundColor = isOn ? (onTintColor ?? SystemDefaults.onTintColor) : (offTintColor ?? SystemDefaults.offTintColor)
+        let radius = wireframeRect.height * 0.5
 
-        let background = builder.createShapeWireframe(
-            id: backgroundWireframeID,
+        // Create track wireframe:
+        let trackColor = isOn ? (onTintColor ?? SystemColors.systemGreen) : (offTintColor ?? SystemColors.tertiarySystemFill)
+        let track = builder.createShapeWireframe(
+            id: trackWireframeID,
             frame: wireframeRect,
             borderColor: nil,
             borderWidth: nil,
-            backgroundColor: backgroundColor,
+            backgroundColor: trackColor,
             cornerRadius: radius,
-            opacity: attributes.alpha
+            opacity: isEnabled ? attributes.alpha : 0.5
         )
 
-        let thumbFrame = CGRect(
-            x: wireframeRect.minX + (isOn ? radius : 0.0),
-            y: wireframeRect.minY,
-            width: radius * 2,
-            height: attributes.frame.height
-        )
-
+        // Create thumb wireframe:
+        let thumbContainer = wireframeRect.insetBy(dx: 2, dy: 2)
+        let thumbFrame = CGRect(origin: .zero, size: .init(width: thumbContainer.height, height: thumbContainer.height))
+            .putInside(thumbContainer, horizontalAlignment: isOn ? .right : .left, verticalAlignment: .middle)
         let thumb = builder.createShapeWireframe(
             id: thumbWireframeID,
             frame: thumbFrame,
-            borderColor: nil,
-            borderWidth: nil,
-            backgroundColor: thumbTintColor ?? SystemDefaults.thumbTintColor,
-            cornerRadius: radius,
-            opacity: attributes.alpha
+            borderColor: SystemColors.secondarySystemFill,
+            borderWidth: 1,
+            backgroundColor: thumbTintColor ?? ((isDarkMode && !isEnabled) ? UIColor.gray.cgColor : UIColor.white.cgColor),
+            cornerRadius: radius
         )
 
-        return [background, thumb]
+        // Create background wireframe if the underlying `UIView` has any appearance:
+        if attributes.hasAnyAppearance {
+            let background = builder.createShapeWireframe(id: backgroundWireframeID, frame: attributes.frame, attributes: attributes)
+
+            return [background, track, thumb]
+        } else {
+            return [track, thumb]
+        }
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/UIKitExtensionsTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/UIKitExtensionsTests.swift
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import UIKit
+@testable import DatadogSessionReplay
+
+class UIKitExtensionsTests: XCTestCase {
+    func testUsesDarkMode() {
+        // Given
+        let lightView = UIView.mock(withFixture: .visible(.someAppearance))
+        let darkView = UIView.mock(withFixture: .visible(.someAppearance))
+
+        if #available(iOS 13.0, *) {
+            // When
+            lightView.overrideUserInterfaceStyle = [.light, .unspecified].randomElement()!
+            darkView.overrideUserInterfaceStyle = .dark
+
+            // Then
+            XCTAssertFalse(lightView.usesDarkMode)
+            XCTAssertTrue(darkView.usesDarkMode)
+        } else {
+            XCTAssertFalse(lightView.usesDarkMode)
+            XCTAssertFalse(darkView.usesDarkMode)
+        }
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR enhances the recording of `UISwitch` elements in session replay. Its preliminary support was introduced earlier, but here we solve remaining glitches and adjust the values properly for light and dark mode.

<table>
<tr><td>With no masking:</td><td>With masking:</td></tr>
<tr>
   <td><img src="https://user-images.githubusercontent.com/2358722/221648946-0144a182-b807-42a8-a057-b40c1f63dd1c.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/221648957-6dba34c6-604d-4d18-88e0-dbf7a7153775.png" /></td>
</tr>
<tr>
   <td><img src="https://user-images.githubusercontent.com/2358722/221648962-8281c9ea-490a-456f-af97-97a20c8b31b1.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/221648966-dbda0b8d-e40f-4c84-a54f-8edf7682eb8c.png" /></td>
</tr>
</table>

### How?

A major bug 🐞 fixed in this PR corresponds to recording `UISwitch` views that are positioned inside [`UIStackView`](https://developer.apple.com/documentation/uikit/uistackview). Turned out that if rendered in stack view, the `view.frame` includes the size of the entire stack row - which was stretching the switch wireframe unreastically:

<img width="337" alt="Screenshot 2023-02-27 at 19 20 50" src="https://user-images.githubusercontent.com/2358722/221649970-99a45ba1-ddc7-4e98-93f3-4d691d9e6e47.png">

This problem is solved by using [`intrinsicContentSize `](https://developer.apple.com/documentation/uikit/uiview/1622600-intrinsiccontentsize) for reading the size of element.

Other than this:
- adjusted color values to leverage recently introduced `SystemColors` construct;
- added optional background wireframe to render `switch.backgroundColor` if any is applied.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
