### PR TITLE
RUMM-3081 fix invalid cpu ticks per seconds

### DIFF
--- a/Datadog/Example/Scenarios/RUM/MobileVitals/RUMMobileVitalsScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/MobileVitals/RUMMobileVitalsScenario.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ca2-aW-xR8">
-                                <rect key="frame" x="143" y="423" width="128" height="60"/>
+                                <rect key="frame" x="143" y="410" width="128" height="90"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SSx-AL-9bb">
                                         <rect key="frame" x="0.0" y="0.0" width="128" height="30"/>
@@ -32,6 +32,13 @@
                                         <state key="normal" title="Block Main Thread"/>
                                         <connections>
                                             <action selector="blockMainThreadButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="CCI-ts-9al"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6oU-go-pxW" userLabel="Start New View">
+                                        <rect key="frame" x="0.0" y="60" width="128" height="30"/>
+                                        <state key="normal" title="Start New View"/>
+                                        <connections>
+                                            <action selector="startNewViewButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="oCj-5m-88S"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/Datadog/Example/Scenarios/RUM/MobileVitals/RUMMobileVitalsViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/MobileVitals/RUMMobileVitalsViewController.swift
@@ -5,6 +5,7 @@
  */
 
 import UIKit
+import Datadog
 
 final class RUMMobileVitalsViewController: UIViewController {
 
@@ -23,6 +24,13 @@ final class RUMMobileVitalsViewController: UIViewController {
                 break
             }
         }
+    }
+
+    @IBAction func startNewViewButtonTapped(_ sender: Any){
+        print("Start New View button tapped... Starting new view...")
+
+        Global.rum.startView(key: "sample view")
+        Global.rum.stopView(key: "sample view")
     }
 
 }

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -456,7 +456,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             view: .init(
                 action: .init(count: actionsCount.toInt64),
                 cpuTicksCount: cpuInfo?.greatestDiff,
-                cpuTicksPerSecond: cpuInfo?.greatestDiff?.divideIfNotZero(by: Double(timeSpent)),
+                cpuTicksPerSecond: timeSpent > 1.0 ? cpuInfo?.greatestDiff?.divideIfNotZero(by: Double(timeSpent)) : nil,
                 crash: isCrash ? .init(count: 1) : .init(count: 0),
                 cumulativeLayoutShift: nil,
                 customTimings: customTimings.reduce(into: [:]) { acc, element in


### PR DESCRIPTION
### What and why?

When the view lifespan is shorter than a second, the estimation of ticks per second would go through the roof. 
We limit reporting it for views with a time spent greater than one second.