### PR TITLE
Rename Feature Interfaces

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -599,8 +599,8 @@
 		D24C9C6B29A7D1D3002057CF /* DatadogInternal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DA2385298D57AA00C6C7E6 /* DatadogInternal.framework */; };
 		D24C9C7129A7D57A002057CF /* DirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24C9C7029A7D57A002057CF /* DirectoriesMock.swift */; };
 		D24C9C7229A7D57A002057CF /* DirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24C9C7029A7D57A002057CF /* DirectoriesMock.swift */; };
-		D25085102976E30000E931C3 /* DatadogFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogFeatureMocks.swift */; };
-		D25085112976E30000E931C3 /* DatadogFeatureMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogFeatureMocks.swift */; };
+		D25085102976E30000E931C3 /* DatadogProductMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogProductMocks.swift */; };
+		D25085112976E30000E931C3 /* DatadogProductMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogProductMocks.swift */; };
 		D2553807288AA84F00727FAD /* UploadMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553806288AA84F00727FAD /* UploadMock.swift */; };
 		D2553808288AA84F00727FAD /* UploadMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553806288AA84F00727FAD /* UploadMock.swift */; };
 		D2553826288F0B1A00727FAD /* BatteryStatusPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553825288F0B1A00727FAD /* BatteryStatusPublisher.swift */; };
@@ -1911,7 +1911,7 @@
 		D24C9C5829A7C732002057CF /* DatadogLogsBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogLogsBuilderTests.swift; sourceTree = "<group>"; };
 		D24C9C6629A7CBF0002057CF /* DDErrorMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDErrorMocks.swift; sourceTree = "<group>"; };
 		D24C9C7029A7D57A002057CF /* DirectoriesMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectoriesMock.swift; sourceTree = "<group>"; };
-		D250850F2976E30000E931C3 /* DatadogFeatureMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogFeatureMocks.swift; sourceTree = "<group>"; };
+		D250850F2976E30000E931C3 /* DatadogProductMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogProductMocks.swift; sourceTree = "<group>"; };
 		D2553806288AA84F00727FAD /* UploadMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadMock.swift; sourceTree = "<group>"; };
 		D2553825288F0B1A00727FAD /* BatteryStatusPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatteryStatusPublisher.swift; sourceTree = "<group>"; };
 		D2553828288F0B2300727FAD /* LowPowerModePublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LowPowerModePublisher.swift; sourceTree = "<group>"; };
@@ -3986,6 +3986,7 @@
 				D23039DA298D5235001A1FA3 /* Concurrency */,
 				D23039B2298D5235001A1FA3 /* Context */,
 				D23039B1298D5235001A1FA3 /* DatadogCoreProtocol.swift */,
+				D23039BD298D5235001A1FA3 /* DatadogFeature.swift */,
 				D23039B0298D5235001A1FA3 /* DatadogV1CoreProtocol.swift */,
 				D23039AD298D5234001A1FA3 /* DD.swift */,
 				D23039D6298D5235001A1FA3 /* Extensions */,
@@ -4020,7 +4021,6 @@
 				D23039BA298D5235001A1FA3 /* DatadogContext.swift */,
 				D23039BB298D5235001A1FA3 /* TrackingConsent.swift */,
 				D23039BC298D5235001A1FA3 /* DeviceInfo.swift */,
-				D23039BD298D5235001A1FA3 /* DatadogFeature.swift */,
 				D23039BE298D5235001A1FA3 /* LaunchTime.swift */,
 				D2F8235229915E12003C7E99 /* DatadogSite.swift */,
 			);
@@ -4227,7 +4227,7 @@
 			children = (
 				61A1A44829643254007909E7 /* DatadogCoreProxy.swift */,
 				D2553806288AA84F00727FAD /* UploadMock.swift */,
-				D250850F2976E30000E931C3 /* DatadogFeatureMocks.swift */,
+				D250850F2976E30000E931C3 /* DatadogProductMocks.swift */,
 			);
 			path = DatadogInternal;
 			sourceTree = "<group>";
@@ -5720,7 +5720,7 @@
 				617CD0DD24CEDDD300B0B557 /* RUMUserActionScopeTests.swift in Sources */,
 				A79B0F61292BB071008742B3 /* OTelHTTPHeadersReaderTests.swift in Sources */,
 				61B8BA91281812F60068AFF4 /* KronosInternetAddressTests.swift in Sources */,
-				D25085102976E30000E931C3 /* DatadogFeatureMocks.swift in Sources */,
+				D25085102976E30000E931C3 /* DatadogProductMocks.swift in Sources */,
 				D29889C9273413ED00A4D1A9 /* RUMViewsHandlerTests.swift in Sources */,
 				61C5A8A024509C1100DA608C /* Casting+Tracing.swift in Sources */,
 				616C0AA128573F6300C13264 /* RUMOperatingSystemInfoTests.swift in Sources */,
@@ -6502,7 +6502,7 @@
 				D2CB6F2E27C520D400A62B57 /* RUMCommandTests.swift in Sources */,
 				D2CB6F3027C520D400A62B57 /* DatadogExtensions.swift in Sources */,
 				D2CB6F3227C520D400A62B57 /* JSONDataMatcher.swift in Sources */,
-				D25085112976E30000E931C3 /* DatadogFeatureMocks.swift in Sources */,
+				D25085112976E30000E931C3 /* DatadogProductMocks.swift in Sources */,
 				D2CB6F3327C520D400A62B57 /* FilesOrchestratorTests.swift in Sources */,
 				D236BE2D29521AEA00676E67 /* CrashReportReceiverTests.swift in Sources */,
 				D2FB1258292E0F10005B13F8 /* TrackingConsentPublisherTests.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -599,8 +599,8 @@
 		D24C9C6B29A7D1D3002057CF /* DatadogInternal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DA2385298D57AA00C6C7E6 /* DatadogInternal.framework */; };
 		D24C9C7129A7D57A002057CF /* DirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24C9C7029A7D57A002057CF /* DirectoriesMock.swift */; };
 		D24C9C7229A7D57A002057CF /* DirectoriesMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24C9C7029A7D57A002057CF /* DirectoriesMock.swift */; };
-		D25085102976E30000E931C3 /* DatadogProductMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogProductMocks.swift */; };
-		D25085112976E30000E931C3 /* DatadogProductMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogProductMocks.swift */; };
+		D25085102976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogRemoteFeatureMock.swift */; };
+		D25085112976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D250850F2976E30000E931C3 /* DatadogRemoteFeatureMock.swift */; };
 		D2553807288AA84F00727FAD /* UploadMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553806288AA84F00727FAD /* UploadMock.swift */; };
 		D2553808288AA84F00727FAD /* UploadMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553806288AA84F00727FAD /* UploadMock.swift */; };
 		D2553826288F0B1A00727FAD /* BatteryStatusPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2553825288F0B1A00727FAD /* BatteryStatusPublisher.swift */; };
@@ -1911,7 +1911,7 @@
 		D24C9C5829A7C732002057CF /* DatadogLogsBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogLogsBuilderTests.swift; sourceTree = "<group>"; };
 		D24C9C6629A7CBF0002057CF /* DDErrorMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDErrorMocks.swift; sourceTree = "<group>"; };
 		D24C9C7029A7D57A002057CF /* DirectoriesMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectoriesMock.swift; sourceTree = "<group>"; };
-		D250850F2976E30000E931C3 /* DatadogProductMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogProductMocks.swift; sourceTree = "<group>"; };
+		D250850F2976E30000E931C3 /* DatadogRemoteFeatureMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatadogRemoteFeatureMock.swift; sourceTree = "<group>"; };
 		D2553806288AA84F00727FAD /* UploadMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadMock.swift; sourceTree = "<group>"; };
 		D2553825288F0B1A00727FAD /* BatteryStatusPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatteryStatusPublisher.swift; sourceTree = "<group>"; };
 		D2553828288F0B2300727FAD /* LowPowerModePublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LowPowerModePublisher.swift; sourceTree = "<group>"; };
@@ -4227,7 +4227,7 @@
 			children = (
 				61A1A44829643254007909E7 /* DatadogCoreProxy.swift */,
 				D2553806288AA84F00727FAD /* UploadMock.swift */,
-				D250850F2976E30000E931C3 /* DatadogProductMocks.swift */,
+				D250850F2976E30000E931C3 /* DatadogRemoteFeatureMock.swift */,
 			);
 			path = DatadogInternal;
 			sourceTree = "<group>";
@@ -5720,7 +5720,7 @@
 				617CD0DD24CEDDD300B0B557 /* RUMUserActionScopeTests.swift in Sources */,
 				A79B0F61292BB071008742B3 /* OTelHTTPHeadersReaderTests.swift in Sources */,
 				61B8BA91281812F60068AFF4 /* KronosInternetAddressTests.swift in Sources */,
-				D25085102976E30000E931C3 /* DatadogProductMocks.swift in Sources */,
+				D25085102976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */,
 				D29889C9273413ED00A4D1A9 /* RUMViewsHandlerTests.swift in Sources */,
 				61C5A8A024509C1100DA608C /* Casting+Tracing.swift in Sources */,
 				616C0AA128573F6300C13264 /* RUMOperatingSystemInfoTests.swift in Sources */,
@@ -6502,7 +6502,7 @@
 				D2CB6F2E27C520D400A62B57 /* RUMCommandTests.swift in Sources */,
 				D2CB6F3027C520D400A62B57 /* DatadogExtensions.swift in Sources */,
 				D2CB6F3227C520D400A62B57 /* JSONDataMatcher.swift in Sources */,
-				D25085112976E30000E931C3 /* DatadogProductMocks.swift in Sources */,
+				D25085112976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */,
 				D2CB6F3327C520D400A62B57 /* FilesOrchestratorTests.swift in Sources */,
 				D236BE2D29521AEA00676E67 /* CrashReportReceiverTests.swift in Sources */,
 				D2FB1258292E0F10005B13F8 /* TrackingConsentPublisherTests.swift in Sources */,

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -16,11 +16,11 @@ public var defaultDatadogCore: DatadogCoreProtocol = NOPDatadogCore()
 public protocol DatadogCoreProtocol: AnyObject {
     /// Registers a Feature instance.
     ///
-    /// Feature collects and transfers data to a Datadog Product (e.g. Logs, RUM, ...). Upon registration, the Feature can
-    /// retrieve a `FeatureScope` interface for writing events to the core. The core will store and upload events efficiently
-    /// according to the performance presets defined on initialization.
-    ///
-    /// A Feature can also communicate to other Features by sending messages on the message bus managed by core.
+    /// Feature can interact with the core and other Feature through the message bus. Some specific Features
+    /// complying to `DatadogRemoteFeature` can collects and transfers data to a Datadog Product
+    /// (e.g. Logs, RUM, ...). Upon registration, a Remote Feature can retrieve a `FeatureScope` interface
+    /// for writing events to the core. The core will store and upload events efficiently according to the performance
+    /// presets defined on initialization.
     ///
     /// - Parameter feature: The Feature instance - it will be retained and held by core.
     func register<T>(feature: T) throws where T: DatadogFeature

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -17,7 +17,7 @@ public protocol DatadogCoreProtocol: AnyObject {
     /// Registers a Feature instance.
     ///
     /// Feature can interact with the core and other Feature through the message bus. Some specific Features
-    /// complying to `DatadogRemoteFeature` can collects and transfers data to a Datadog Product
+    /// complying to `DatadogRemoteFeature` can collect and transfer data to a Datadog Product
     /// (e.g. Logs, RUM, ...). Upon registration, a Remote Feature can retrieve a `FeatureScope` interface
     /// for writing events to the core. The core will store and upload events efficiently according to the performance
     /// presets defined on initialization.

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -23,7 +23,7 @@ public protocol DatadogCoreProtocol: AnyObject {
     /// A Feature can also communicate to other Features by sending messages on the message bus managed by core.
     ///
     /// - Parameter feature: The Feature instance - it will be retained and held by core.
-    func register(feature: DatadogFeature) throws
+    func register<T>(feature: T) throws where T: DatadogFeature
 
     /// Retrieves previously registered Feature by its name and type.
     ///
@@ -36,7 +36,7 @@ public protocol DatadogCoreProtocol: AnyObject {
     ///   - name: The Feature's name.
     ///   - type: The Feature instance type.
     /// - Returns: The Feature if any.
-    func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature
+    func get<T>(feature type: T.Type) -> T? where T: DatadogFeature
 
     /// Retrieves a Feature Scope by its name.
     ///
@@ -87,20 +87,6 @@ public protocol DatadogCoreProtocol: AnyObject {
 }
 
 extension DatadogCoreProtocol {
-    /// Retrieves a Feature by its name and type.
-    ///
-    /// A Feature type can be specified as parameter or inferred from the return type:
-    ///
-    ///     let feature = core.feature(named: "foo", type: Foo.self)
-    ///     let feature: Foo? = core.feature(named: "foo")
-    ///
-    /// - Parameters:
-    ///   - name: The Feature's name.
-    /// - Returns: The Feature if any.
-    public func feature<T>(named name: String) -> T? where T: DatadogFeature {
-        feature(named: name, type: T.self)
-    }
-
     /// Sends a message on the bus shared by features registered in this core.
     ///
     /// - Parameters:
@@ -166,9 +152,9 @@ public extension FeatureScope {
 public class NOPDatadogCore: DatadogCoreProtocol {
     public init() { }
     /// no-op
-    public func register(feature: DatadogFeature) throws { }
+    public func register<T>(feature: T) throws where T: DatadogFeature { }
     /// no-op
-    public func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature { nil }
+    public func get<T>(feature type: T.Type) -> T? where T: DatadogFeature { nil }
     /// no-op
     public func scope(for feature: String) -> FeatureScope? { nil }
     /// no-op

--- a/DatadogInternal/Sources/DatadogCoreProtocol.swift
+++ b/DatadogInternal/Sources/DatadogCoreProtocol.swift
@@ -38,29 +38,6 @@ public protocol DatadogCoreProtocol: AnyObject {
     /// - Returns: The Feature if any.
     func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature
 
-    /// Registers a Feature Integration instance.
-    ///
-    /// A Feature Integration collects and transfers data to a local Datadog Feature. An Integration will not store nor upload,
-    /// it will collect data for other Features to consume.
-    ///
-    /// An Integration can commicate to Features via dependency or a communication channel such as the message-bus.
-    ///
-    /// - Parameter integration: The Feature Integration instance.
-    func register(integration: DatadogFeatureIntegration) throws
-
-    /// Retrieves a Feature Integration by its name and type.
-    ///
-    /// A Feature Integration type can be specified as parameter or inferred from the return type:
-    ///
-    ///     let integration = core.integration(named: "foo", type: Foo.self)
-    ///     let integration: Foo? = core.integration(named: "foo")
-    ///
-    /// - Parameters:
-    ///   - name: The Feature Integration's name.
-    ///   - type: The Feature Integration instance type.
-    /// - Returns: The Feature Integration if any.
-    func integration<T>(named name: String, type: T.Type) -> T? where T: DatadogFeatureIntegration
-
     /// Retrieves a Feature Scope by its name.
     ///
     /// Feature Scope collects data to Datadog Product (e.g. Logs, RUM, ...). Upon registration, the Feature retrieves
@@ -122,20 +99,6 @@ extension DatadogCoreProtocol {
     /// - Returns: The Feature if any.
     public func feature<T>(named name: String) -> T? where T: DatadogFeature {
         feature(named: name, type: T.self)
-    }
-
-    /// Retrieves a Feature Integration by its name and type.
-    ///
-    /// A Feature Integration type can be specified as parameter or inferred from the return type:
-    ///
-    ///     let integration = core.integration(named: "foo", type: Foo.self)
-    ///     let integration: Foo? = core.integration(named: "foo")
-    ///
-    /// - Parameters:
-    ///   - name: The Feature Integration's name.
-    /// - Returns: The Feature Integration if any.
-    public func integration<T>(named name: String) -> T? where T: DatadogFeatureIntegration {
-        integration(named: name, type: T.self)
     }
 
     /// Sends a message on the bus shared by features registered in this core.
@@ -206,10 +169,6 @@ public class NOPDatadogCore: DatadogCoreProtocol {
     public func register(feature: DatadogFeature) throws { }
     /// no-op
     public func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature { nil }
-    /// no-op
-    public func register(integration: DatadogFeatureIntegration) throws { }
-    /// no-op
-    public func integration<T>(named name: String, type: T.Type) -> T? where T: DatadogFeatureIntegration { nil }
     /// no-op
     public func scope(for feature: String) -> FeatureScope? { nil }
     /// no-op

--- a/DatadogInternal/Sources/DatadogFeature.swift
+++ b/DatadogInternal/Sources/DatadogFeature.swift
@@ -28,10 +28,7 @@ public struct DatadogFeatureConfiguration {
     }
 }
 
-/// A Datadog Feature that can interact with the core through the message-bus
-///
-/// A Feature **cannot** open a scope to write events, only a `DatadogProduct`
-/// can collect and upload data.
+/// A Datadog Feature that can interact with the core through the message-bus.
 public protocol DatadogFeature {
     /// The feature name.
     static var name: String { get }
@@ -44,9 +41,14 @@ public protocol DatadogFeature {
 }
 
 
-/// A Datadog Product that can store and upload data to its relative product
-/// on the Datadog platform.
-public protocol DatadogProduct: DatadogFeature {
-    /// The URL request builder for uploading data in this Feature.
+/// A Datadog Feature with remote data store.
+public protocol DatadogRemoteFeature: DatadogFeature {
+    /// The URL request builder for uploading data.
+    ///
+    /// The `FeatureRequestBuilder` defines an interface for building a single `URLRequest`
+    /// for a list of data events and the current core context.
+    ///
+    /// A Feature should use this interface for creating requests that needs be sent to its Datadog Intake.
+    /// The request will be transported by `DatadogCore`.
     var requestBuilder: FeatureRequestBuilder { get }
 }

--- a/DatadogInternal/Sources/DatadogFeature.swift
+++ b/DatadogInternal/Sources/DatadogFeature.swift
@@ -28,21 +28,11 @@ public struct DatadogFeatureConfiguration {
     }
 }
 
+/// A Datadog Feature that can interact with the core through the message-bus
+///
+/// A Feature **cannot** open a scope to write events, only a `DatadogProduct`
+/// can collect and upload data.
 public protocol DatadogFeature {
-    /// The feature name.
-    var name: String { get }
-
-    /// The URL request builder for uploading data in this Feature.
-    var requestBuilder: FeatureRequestBuilder { get }
-
-    /// The message bus receiver.
-    ///
-    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
-    /// from a bus that is shared between all Features registered in the core.
-    var messageReceiver: FeatureMessageReceiver { get }
-}
-
-public protocol DatadogFeatureIntegration {
     /// The feature name.
     var name: String { get }
 
@@ -51,4 +41,12 @@ public protocol DatadogFeatureIntegration {
     /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
     /// from a bus that is shared between Features registered in a core.
     var messageReceiver: FeatureMessageReceiver { get }
+}
+
+
+/// A Datadog Product that can store and upload data to its relative product
+/// on the Datadog platform.
+public protocol DatadogProduct: DatadogFeature {
+    /// The URL request builder for uploading data in this Feature.
+    var requestBuilder: FeatureRequestBuilder { get }
 }

--- a/DatadogInternal/Sources/DatadogFeature.swift
+++ b/DatadogInternal/Sources/DatadogFeature.swift
@@ -34,7 +34,7 @@ public struct DatadogFeatureConfiguration {
 /// can collect and upload data.
 public protocol DatadogFeature {
     /// The feature name.
-    var name: String { get }
+    static var name: String { get }
 
     /// The message bus receiver.
     ///

--- a/DatadogLogs/Sources/Builder.swift
+++ b/DatadogLogs/Sources/Builder.swift
@@ -140,7 +140,7 @@ public class Builder {
             )
         }
 
-        guard let feature: DatadogLogsFeature = core.feature(named: logsFeatureName) else {
+        guard let feature = core.get(feature: DatadogLogsFeature.self) else {
             throw ProgrammerError(
                 description: "`Logger.builder.build()` produces a non-functional logger, as the logging feature is disabled."
             )

--- a/DatadogLogs/Sources/Feature/DatadogLogsFeature.swift
+++ b/DatadogLogs/Sources/Feature/DatadogLogsFeature.swift
@@ -9,7 +9,7 @@ import DatadogInternal
 
 internal let logsFeatureName = "logging"
 
-internal struct DatadogLogsFeature: DatadogFeature {
+internal struct DatadogLogsFeature: DatadogProduct {
     let name = logsFeatureName
 
     let requestBuilder: FeatureRequestBuilder

--- a/DatadogLogs/Sources/Feature/DatadogLogsFeature.swift
+++ b/DatadogLogs/Sources/Feature/DatadogLogsFeature.swift
@@ -7,7 +7,7 @@
 import Foundation
 import DatadogInternal
 
-internal struct DatadogLogsFeature: DatadogProduct {
+internal struct DatadogLogsFeature: DatadogRemoteFeature {
     static let name = "logging"
 
     let requestBuilder: FeatureRequestBuilder

--- a/DatadogLogs/Sources/Feature/DatadogLogsFeature.swift
+++ b/DatadogLogs/Sources/Feature/DatadogLogsFeature.swift
@@ -7,10 +7,8 @@
 import Foundation
 import DatadogInternal
 
-internal let logsFeatureName = "logging"
-
 internal struct DatadogLogsFeature: DatadogProduct {
-    let name = logsFeatureName
+    static let name = "logging"
 
     let requestBuilder: FeatureRequestBuilder
 

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -44,7 +44,7 @@ internal struct LogMessageReceiver: FeatureMessageReceiver {
         let userAttributes: [String: AnyCodable] = attributes["userAttributes"] ?? [:]
         let internalAttributes: [String: AnyCodable]? = attributes["internalAttributes"]
 
-        core.scope(for: logsFeatureName)?.eventWriteContext(bypassConsent: false) { context, writer in
+        core.scope(for: DatadogLogsFeature.name)?.eventWriteContext(bypassConsent: false) { context, writer in
             let builder = LogEventBuilder(
                 service: attributes["service"] ?? context.service,
                 loggerName: loggerName,
@@ -189,7 +189,7 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
 
         // crash reporting is considering the user consent from previous session, if an event reached
         // the message bus it means that consent was granted and we can safely bypass current consent.
-        core.v1.scope(for: logsFeatureName)?.eventWriteContext(bypassConsent: true, forceNewBatch: false) { _, writer in
+        core.v1.scope(for: DatadogLogsFeature.name)?.eventWriteContext(bypassConsent: true, forceNewBatch: false) { _, writer in
             writer.write(value: event)
         }
 
@@ -216,7 +216,7 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
         let tagsKey = LogEventEncoder.StaticCodingKeys.tags.rawValue
         let dateKey = LogEventEncoder.StaticCodingKeys.date.rawValue
 
-        core.scope(for: logsFeatureName)?.eventWriteContext { context, writer in
+        core.scope(for: DatadogLogsFeature.name)?.eventWriteContext { context, writer in
             let ddTags = "\(versionKey):\(context.version),\(envKey):\(context.env)"
 
             if let tags = event[tagsKey] as? String, !tags.isEmpty {

--- a/DatadogLogs/Sources/RemoteLogger.swift
+++ b/DatadogLogs/Sources/RemoteLogger.swift
@@ -122,7 +122,7 @@ internal final class RemoteLogger: Logger {
 
         // SDK context must be requested on the user thread to ensure that it provides values
         // that are up-to-date for the caller.
-        self.core.scope(for: logsFeatureName)?.eventWriteContext { context, writer in
+        self.core.scope(for: DatadogLogsFeature.name)?.eventWriteContext { context, writer in
             var internalAttributes: [String: Encodable] = [:]
             let contextAttributes = context.featuresAttributes
 

--- a/DatadogSessionReplay/Sources/Drafts/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Drafts/SessionReplay.swift
@@ -23,8 +23,8 @@ public struct SessionReplay {
             )
             try datadogInstance.register(feature: feature)
 
-            guard let scope = datadogInstance.scope(for: feature.name) else {
-                throw FatalError(description: "Failed to obtain `FeatureScope` for \(feature.name)")
+            guard let scope = datadogInstance.scope(for: SessionReplayFeature.name) else {
+                throw FatalError(description: "Failed to obtain `FeatureScope` for \(SessionReplayFeature.name)")
             }
 
             feature.register(sessionReplayScope: scope)

--- a/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
@@ -17,7 +17,7 @@ import Datadog
 internal class SessionReplayFeature: DatadogProduct, SessionReplayController {
     // MARK: - DatadogFeature
 
-    let name: String = "session-replay"
+    static let name: String = "session-replay"
     let requestBuilder: FeatureRequestBuilder
     let messageReceiver: FeatureMessageReceiver
 

--- a/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
@@ -14,7 +14,7 @@ import Datadog
 ///
 /// An instance of `SessionReplayFeature` is kept by `DatadogCore` but can be also
 /// retained by the user.
-internal class SessionReplayFeature: DatadogProduct, SessionReplayController {
+internal class SessionReplayFeature: DatadogRemoteFeature, SessionReplayController {
     // MARK: - DatadogFeature
 
     static let name: String = "session-replay"

--- a/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
@@ -14,7 +14,7 @@ import Datadog
 ///
 /// An instance of `SessionReplayFeature` is kept by `DatadogCore` but can be also
 /// retained by the user.
-internal class SessionReplayFeature: DatadogFeature, SessionReplayController {
+internal class SessionReplayFeature: DatadogProduct, SessionReplayController {
     // MARK: - DatadogFeature
 
     let name: String = "session-replay"

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -7,7 +7,7 @@
 import Foundation
 import DatadogInternal
 
-/* public */ internal class CrashReporter: DatadogFeatureIntegration {
+/* public */ internal class CrashReporter: DatadogFeature {
     /* public */ let name = "crash-reporter"
 
     /* public */ let messageReceiver: FeatureMessageReceiver

--- a/Sources/Datadog/CrashReporting/CrashReporter.swift
+++ b/Sources/Datadog/CrashReporting/CrashReporter.swift
@@ -8,7 +8,7 @@ import Foundation
 import DatadogInternal
 
 /* public */ internal class CrashReporter: DatadogFeature {
-    /* public */ let name = "crash-reporter"
+    /* public */ static let name = "crash-reporter"
 
     /* public */ let messageReceiver: FeatureMessageReceiver
 

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -281,7 +281,7 @@ public class Datadog {
             let configuration = configuration.crashReporting,
             let reporter = CrashReporter(core: core, configuration: configuration)
         {
-            try core.register(integration: reporter)
+            try core.register(feature: reporter)
             reporter.sendCrashReportIfFound()
         }
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -277,7 +277,7 @@ extension DatadogCore: DatadogCoreProtocol {
     /* public */ func register<T>(feature: T) throws where T: DatadogFeature {
         let featureDirectories = try directory.getFeatureDirectories(forFeatureNamed: T.name)
 
-        if let product = feature as? DatadogProduct {
+        if let product = feature as? DatadogRemoteFeature {
             let storage = FeatureStorage(
                 featureName: T.name,
                 queue: readWriteQueue,

--- a/TestUtilities/Mocks/PassthroughCoreMock.swift
+++ b/TestUtilities/Mocks/PassthroughCoreMock.swift
@@ -79,10 +79,6 @@ public final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureScope {
     /// no-op
     public func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature { nil }
     /// no-op
-    public func register(integration: DatadogFeatureIntegration) throws { }
-    /// no-op
-    public func integration<T>(named name: String, type: T.Type) -> T? where T: DatadogFeatureIntegration { nil }
-    /// no-op
     public func register<T>(feature instance: T?) { }
     /// Returns `nil`
     public func feature<T>(_ type: T.Type) -> T? { nil }

--- a/TestUtilities/Mocks/PassthroughCoreMock.swift
+++ b/TestUtilities/Mocks/PassthroughCoreMock.swift
@@ -74,15 +74,15 @@ public final class PassthroughCoreMock: DatadogV1CoreProtocol, FeatureScope {
         PassthroughCoreMock.referenceCount -= 1
     }
 
+
     /// no-op
-    public func register(feature: DatadogFeature) throws { }
+    public func register<T>(feature: T) throws where T: DatadogFeature { }
     /// no-op
-    public func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature { nil }
+    public func get<T>(feature type: T.Type) -> T? where T: DatadogFeature { nil }
     /// no-op
     public func register<T>(feature instance: T?) { }
-    /// Returns `nil`
+    /// no-op
     public func feature<T>(_ type: T.Type) -> T? { nil }
-
     /// Always returns a feature-scope.
     public func scope<T>(for featureType: T.Type) -> FeatureScope? {
         self

--- a/Tests/DatadogTests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -9,7 +9,7 @@ import TestUtilities
 import DatadogInternal
 @testable import Datadog
 
-private struct FeatureMock: DatadogProduct {
+private struct FeatureMock: DatadogRemoteFeature {
     static let name: String = "mock"
 
     struct Event: Encodable {

--- a/Tests/DatadogTests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -10,11 +10,12 @@ import DatadogInternal
 @testable import Datadog
 
 private struct FeatureMock: DatadogProduct {
+    static let name: String = "mock"
+
     struct Event: Encodable {
         let event: String
     }
 
-    var name: String
     var requestBuilder: FeatureRequestBuilder = FeatureRequestBuilderMock()
     var messageReceiver: FeatureMessageReceiver = FeatureMessageReceiverMock()
 }
@@ -48,8 +49,8 @@ class DatadogCoreTests: XCTestCase {
         defer { core.flushAndTearDown() }
 
         let requestBuilderSpy = FeatureRequestBuilderSpy()
-        try core.register(feature: FeatureMock(name: "mock", requestBuilder: requestBuilderSpy))
-        let scope = try XCTUnwrap(core.scope(for: "mock"))
+        try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
+        let scope = try XCTUnwrap(core.scope(for: FeatureMock.name))
 
         // When
         core.set(trackingConsent: .notGranted)
@@ -97,8 +98,8 @@ class DatadogCoreTests: XCTestCase {
         defer { core.flushAndTearDown() }
 
         let requestBuilderSpy = FeatureRequestBuilderSpy()
-        try core.register(feature: FeatureMock(name: "mock", requestBuilder: requestBuilderSpy))
-        let scope = try XCTUnwrap(core.scope(for: "mock"))
+        try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
+        let scope = try XCTUnwrap(core.scope(for: FeatureMock.name))
 
         // When
         core.set(trackingConsent: .notGranted)
@@ -154,7 +155,7 @@ class DatadogCoreTests: XCTestCase {
         defer { core.flushAndTearDown() }
 
         let requestBuilderSpy = FeatureRequestBuilderSpy()
-        try core.register(feature: FeatureMock(name: "mock", requestBuilder: requestBuilderSpy))
+        try core.register(feature: FeatureMock(requestBuilder: requestBuilderSpy))
         let scope = try XCTUnwrap(core.scope(for: "mock"))
 
         // When

--- a/Tests/DatadogTests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -9,7 +9,7 @@ import TestUtilities
 import DatadogInternal
 @testable import Datadog
 
-private struct FeatureMock: DatadogFeature {
+private struct FeatureMock: DatadogProduct {
     struct Event: Encodable {
         let event: String
     }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -118,85 +118,85 @@ class DatadogTests: XCTestCase {
 
         verify(configuration: defaultBuilder.build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.get(feature: DatadogLogsFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is NOPTelemetry, "When RUM is disabled, telemetry monitor should not be set")
         }
         verify(configuration: rumBuilder.build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.get(feature: DatadogLogsFeature.self))
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is RUMTelemetry, "When RUM is enabled, telemetry monitor should be set")
         }
 
         verify(configuration: defaultBuilder.enableLogging(false).build()) {
             // verify features:
-            XCTAssertNil(defaultDatadogCore.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: DatadogLogsFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
         verify(configuration: rumBuilder.enableLogging(false).build()) {
             // verify features:
-            XCTAssertNil(defaultDatadogCore.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: DatadogLogsFeature.self))
             XCTAssertNotNil(defaultDatadogCore.v1.feature(TracingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is RUMTelemetry)
         }
 
         verify(configuration: defaultBuilder.enableTracing(false).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.get(feature: DatadogLogsFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(TracingFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: CrashReporter.self))
             XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
         verify(configuration: rumBuilder.enableTracing(false).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.get(feature: DatadogLogsFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(TracingFeature.self))
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: CrashReporter.self))
             XCTAssertTrue(DD.telemetry is RUMTelemetry)
         }
 
         verify(configuration: defaultBuilder.enableRUM(true).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.get(feature: DatadogLogsFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature cannot be enabled")
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
         verify(configuration: rumBuilder.enableRUM(false).build()) {
             // verify features:
-            XCTAssertNotNil(defaultDatadogCore.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+            XCTAssertNotNil(defaultDatadogCore.get(feature: DatadogLogsFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.get(feature: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
@@ -242,7 +242,7 @@ class DatadogTests: XCTestCase {
                 .build()
         ) {
             XCTAssertNotNil(
-                defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self),
+                defaultDatadogCore.get(feature: CrashReporter.self),
                 "When only Logging feature is enabled, the Crash Reporter should send crash reports as Logs"
             )
         }
@@ -255,7 +255,7 @@ class DatadogTests: XCTestCase {
                 .build()
         ) {
             XCTAssertNotNil(
-                defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self),
+                defaultDatadogCore.get(feature: CrashReporter.self),
                 "When only RUM feature is enabled, the Crash Reporter should send crash reports as RUM Events"
             )
         }
@@ -268,7 +268,7 @@ class DatadogTests: XCTestCase {
                 .build()
         ) {
             XCTAssertNotNil(
-                defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self),
+                defaultDatadogCore.get(feature: CrashReporter.self),
                 "When both Logging and RUM features are enabled, the Crash Reporter should send crash reports as RUM Events"
             )
         }
@@ -281,7 +281,7 @@ class DatadogTests: XCTestCase {
                 .build()
         ) {
             XCTAssertNil(
-                defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self),
+                defaultDatadogCore.get(feature: CrashReporter.self),
                 "When both Logging and RUM are disabled, Crash Reporter should not be registered"
             )
         }

--- a/Tests/DatadogTests/Datadog/DatadogTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogTests.swift
@@ -122,7 +122,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is NOPTelemetry, "When RUM is disabled, telemetry monitor should not be set")
         }
@@ -132,7 +132,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is RUMTelemetry, "When RUM is enabled, telemetry monitor should be set")
         }
@@ -143,7 +143,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
@@ -154,7 +154,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is RUMTelemetry)
         }
@@ -166,7 +166,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature should be disabled by default")
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
             XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
         verify(configuration: rumBuilder.enableTracing(false).build()) {
@@ -176,7 +176,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `rumBuilder` RUM feature should be enabled by default")
             XCTAssertNotNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
             XCTAssertTrue(DD.telemetry is RUMTelemetry)
         }
 
@@ -186,7 +186,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self), "When using `defaultBuilder` RUM feature cannot be enabled")
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
@@ -196,7 +196,7 @@ class DatadogTests: XCTestCase {
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMFeature.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(RUMInstrumentation.self))
             XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
-            XCTAssertNil(defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self))
+            XCTAssertNil(defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self))
             // verify integrations:
             XCTAssertTrue(DD.telemetry is NOPTelemetry)
         }
@@ -242,7 +242,7 @@ class DatadogTests: XCTestCase {
                 .build()
         ) {
             XCTAssertNotNil(
-                defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self),
+                defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self),
                 "When only Logging feature is enabled, the Crash Reporter should send crash reports as Logs"
             )
         }
@@ -255,7 +255,7 @@ class DatadogTests: XCTestCase {
                 .build()
         ) {
             XCTAssertNotNil(
-                defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self),
+                defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self),
                 "When only RUM feature is enabled, the Crash Reporter should send crash reports as RUM Events"
             )
         }
@@ -268,7 +268,7 @@ class DatadogTests: XCTestCase {
                 .build()
         ) {
             XCTAssertNotNil(
-                defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self),
+                defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self),
                 "When both Logging and RUM features are enabled, the Crash Reporter should send crash reports as RUM Events"
             )
         }
@@ -281,7 +281,7 @@ class DatadogTests: XCTestCase {
                 .build()
         ) {
             XCTAssertNil(
-                defaultDatadogCore.integration(named: "crash-reporter", type: CrashReporter.self),
+                defaultDatadogCore.feature(named: "crash-reporter", type: CrashReporter.self),
                 "When both Logging and RUM are disabled, Crash Reporter should not be registered"
             )
         }

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -885,7 +885,7 @@ class LoggerTests: XCTestCase {
 
         // given
         core.context = .mockAny()
-        XCTAssertNil(core.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+        XCTAssertNil(core.get(feature: DatadogLogsFeature.self))
 
         // when
         let logger = DatadogLogger.builder.build(in: core)

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
@@ -70,14 +70,6 @@ internal class DatadogCoreProxy: DatadogCoreProtocol {
         return core.feature(named: name, type: type)
     }
 
-    func register(integration: DatadogFeatureIntegration) throws {
-        try core.register(integration: integration)
-    }
-
-    func integration<T>(named name: String, type: T.Type) -> T? where T: DatadogFeatureIntegration {
-        return core.integration(named: name, type: type)
-    }
-
     func scope(for feature: String) -> FeatureScope? {
         return core.scope(for: feature).map { scope in
             FeatureScopeProxy(proxy: scope, interceptor: featureScopeInterceptors[feature]!)

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogCoreProxy.swift
@@ -61,13 +61,13 @@ internal class DatadogCoreProxy: DatadogCoreProtocol {
         }
     }
 
-    func register(feature: DatadogFeature) throws {
-        featureScopeInterceptors[feature.name] = FeatureScopeInterceptor()
+    func register<T>(feature: T) throws where T: DatadogFeature {
+        featureScopeInterceptors[T.name] = FeatureScopeInterceptor()
         try core.register(feature: feature)
     }
 
-    func feature<T>(named name: String, type: T.Type) -> T? where T: DatadogFeature {
-        return core.feature(named: name, type: type)
+    func get<T>(feature type: T.Type) -> T? where T: DatadogFeature {
+        return core.get(feature: type)
     }
 
     func scope(for feature: String) -> FeatureScope? {

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogProductMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogProductMocks.swift
@@ -10,9 +10,7 @@ import DatadogInternal
 import Datadog
 
 internal struct DatadogProductMock: DatadogProduct {
-    static let featureName = "mock"
-
-    var name: String = DatadogProductMock.featureName
+    static let name = "mock"
     var requestBuilder: FeatureRequestBuilder = FeatureRequestBuilderMock()
     var messageReceiver: FeatureMessageReceiver = FeatureMessageReceiverMock()
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogProductMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogProductMocks.swift
@@ -9,10 +9,10 @@ import TestUtilities
 import DatadogInternal
 import Datadog
 
-internal struct DatadogFeatureMock: DatadogFeature {
+internal struct DatadogProductMock: DatadogProduct {
     static let featureName = "mock"
 
-    var name: String = DatadogFeatureMock.featureName
+    var name: String = DatadogProductMock.featureName
     var requestBuilder: FeatureRequestBuilder = FeatureRequestBuilderMock()
     var messageReceiver: FeatureMessageReceiver = FeatureMessageReceiverMock()
 }

--- a/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogRemoteFeatureMock.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/DatadogInternal/DatadogRemoteFeatureMock.swift
@@ -9,7 +9,7 @@ import TestUtilities
 import DatadogInternal
 import Datadog
 
-internal struct DatadogProductMock: DatadogProduct {
+internal struct DatadogRemoteFeatureMock: DatadogRemoteFeature {
     static let name = "mock"
     var requestBuilder: FeatureRequestBuilder = FeatureRequestBuilderMock()
     var messageReceiver: FeatureMessageReceiver = FeatureMessageReceiverMock()

--- a/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/LoggingFeatureMocks.swift
@@ -12,7 +12,7 @@ import DatadogInternal
 
 extension DatadogCoreProxy {
     func waitAndReturnLogMatchers(file: StaticString = #file, line: UInt = #line) throws -> [LogMatcher] {
-        return try waitAndReturnEventsData(ofFeature: logsFeatureName)
+        return try waitAndReturnEventsData(ofFeature: DatadogLogsFeature.name)
             .map { data in try LogMatcher.fromJSONObjectData(data) }
     }
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1208,7 +1208,7 @@ class RUMMonitorTests: XCTestCase {
             )
         )
 
-        try core.register(integration: crashReporter)
+        try core.register(feature: crashReporter)
 
         // When
         let monitor = try createTestableRUMMonitor()

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -1124,7 +1124,7 @@ class TracerTests: XCTestCase {
         defer { dd.reset() }
 
         // given
-        XCTAssertNil(core.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+        XCTAssertNil(core.get(feature: DatadogLogsFeature.self))
         core.register(feature: TracingFeature.mockAny())
 
         // when

--- a/Tests/DatadogTests/Datadog/Tracing/TracingMessageReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingMessageReceiverTests.swift
@@ -17,7 +17,7 @@ class TracingMessageReceiverTests: XCTestCase {
 
         // Given
         let receiver = TracingMessageReceiver()
-        try core.register(feature: DatadogFeatureMock(messageReceiver: receiver))
+        try core.register(feature: DatadogProductMock(messageReceiver: receiver))
         XCTAssertNil(receiver.rum.attributes, "RUM context should be nil until it is set by RUM")
 
         // When

--- a/Tests/DatadogTests/Datadog/Tracing/TracingMessageReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/TracingMessageReceiverTests.swift
@@ -17,7 +17,7 @@ class TracingMessageReceiverTests: XCTestCase {
 
         // Given
         let receiver = TracingMessageReceiver()
-        try core.register(feature: DatadogProductMock(messageReceiver: receiver))
+        try core.register(feature: DatadogRemoteFeatureMock(messageReceiver: receiver))
         XCTAssertNil(receiver.rum.attributes, "RUM context should be nil until it is set by RUM")
 
         // When

--- a/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
+++ b/Tests/DatadogTests/DatadogObjc/DDDatadogTests.swift
@@ -47,7 +47,7 @@ class DDDatadogTests: XCTestCase {
         urlSessionInstrumentation?.swizzler.unswizzle()
         Datadog.flushAndDeinitialize()
 
-        XCTAssertNil(defaultDatadogCore.feature(named: logsFeatureName, type: DatadogLogsFeature.self))
+        XCTAssertNil(defaultDatadogCore.get(feature: DatadogLogsFeature.self))
         XCTAssertNil(defaultDatadogCore.v1.feature(URLSessionAutoInstrumentation.self))
     }
 


### PR DESCRIPTION
### What and why?

Update public interface for Feature registration as proposed in **RFC - SDK v2 Public API**.

### How?

```swift
/// A Datadog Feature that can interact with the core through the message-bus.
public protocol DatadogFeature {
    /// The feature name.
    static var name: String { get }

    /// The message bus receiver.
    ///
    /// The `FeatureMessageReceiver` defines an interface for Feature to receive any message
    /// from a bus that is shared between Features registered in a core.
    var messageReceiver: FeatureMessageReceiver { get }
}


/// A Datadog Feature with remote data store.
public protocol DatadogRemoteFeature: DatadogFeature {
    /// The URL request builder for uploading data.
    ///
    /// The `FeatureRequestBuilder` defines an interface for building a single `URLRequest`
    /// for a list of data events and the current core context.
    ///
    /// A Feature should use this interface for creating requests that needs be sent to its Datadog Intake.
    /// The request will be transported by `DatadogCore`.
    var requestBuilder: FeatureRequestBuilder { get }
}

```

The Feature name is now a static var allowing a simplified definition and usage of the `DatadogCoreProtocol`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
