### PR TITLE
Fix memory usage issues in image capture

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -39,7 +39,10 @@ internal class ImageDataProvider {
                 image = image.withTintColor(tintColor)
             }
 
-            let identifier = "\(image.hash)\(String(describing: tintColor?.hash))"
+            var identifier = image.srIdentifier
+            if let tintColorIdentifier = tintColor?.srIdentifier {
+                identifier += tintColorIdentifier
+            }
             let dataLoadingStaus = cache[identifier]
             switch dataLoadingStaus {
             case .none:
@@ -62,5 +65,17 @@ internal class ImageDataProvider {
 fileprivate extension CGSize {
     static func <= (lhs: CGSize, rhs: CGSize) -> Bool {
         return lhs.width <= rhs.width && lhs.height <= rhs.height
+    }
+}
+
+extension UIImage {
+    var srIdentifier: String {
+        return "\(hash)"
+    }
+}
+
+extension UIColor {
+    var srIdentifier: String {
+        return "\(hash)"
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
@@ -60,6 +60,24 @@ class ImageDataProviderTests: XCTestCase {
         let imageData = try XCTUnwrap(sut.contentBase64String(of: image))
         XCTAssertEqual(imageData.count, 0)
     }
+
+    func test_imageIdentifierConsistency() {
+        var ids = Set<String>()
+        for _ in 0..<100 {
+            if let imageIdentifier = UIImage(named: "dd_logo_v_rgb", in: Bundle.module, compatibleWith: nil)?.srIdentifier {
+                ids.insert(imageIdentifier)
+            }
+        }
+        XCTAssertEqual(ids.count, 1)
+    }
+
+    func test_colorIdentifierConsistency() {
+        var ids = Set<String>()
+        for _ in 0..<100 {
+            ids.insert( UIColor.red.srIdentifier)
+        }
+        XCTAssertEqual(ids.count, 1)
+    }
 }
 
 #if XCODE_BUILD

--- a/DatadogSessionReplay/Tests/Utilities/CacheTests.swift
+++ b/DatadogSessionReplay/Tests/Utilities/CacheTests.swift
@@ -40,6 +40,17 @@ class CacheTests: XCTestCase {
         XCTAssertNil(cache.value(forKey: "one"))
     }
 
+    func test_bytesLimit() {
+        let cache = Cache<String, Int>(dateProvider: {
+            return Date(timeIntervalSinceReferenceDate: 0)
+        }, totalBytesLimit: 1)
+
+        cache.insert(1, forKey: "one", size: 1)
+        cache.insert(1, forKey: "two", size: 1)
+        XCTAssertNil(cache.value(forKey: "one"))
+        XCTAssertNotNil(cache.value(forKey: "two"))
+    }
+
     func test_countLimit() {
         let cache = Cache<String, Int>(maximumEntryCount: 1)
 


### PR DESCRIPTION
### What and why?

Image capture algorithm started to behave funky. It's memory consumption went through the roof.
<img width="491" alt="Screenshot 2023-03-02 at 10 07 50" src="https://user-images.githubusercontent.com/6953112/222398085-31552080-02c1-48b8-83c3-ac90dfd96d69.png">

### How?

Reasons:
- md5 for jpegs generate different values (probably apple's [pngData()](https://developer.apple.com/documentation/uikit/uiimage/1624096-pngdata) is optimised in a way where it doesn't always produce the same bitmap).
- for such image it was running into recursion loading the data each time
- since there was no autorelease pool - memory was never freed in such a loop

Fixes:
- Added cache's max cost (in bytes)
- Removed md5 hash for the time being (we can revisit when needed)
- Added autorelease pool on the `contentBase64String()` to make sure it always frees the memory (even when run in a loop or recursively).

After these changes we are back to stable:
<img width="516" alt="Screenshot 2023-03-02 at 10 06 21" src="https://user-images.githubusercontent.com/6953112/222399541-0a9f9e0b-4989-49e5-b92b-5c91bae1d8d3.png">

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
