### PR TITLE
REPLAY-1339 Support `UITextField` elements in SR

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -13,6 +13,7 @@ internal enum Fixture: CaseIterable {
     case segments
     case pickers
     case switches
+    case textFields
 
     var menuItemTitle: String {
         switch self {
@@ -28,6 +29,8 @@ internal enum Fixture: CaseIterable {
             return "Pickers"
         case .switches:
             return "Switches"
+        case .textFields:
+            return "Text Fields"
         }
     }
 
@@ -45,6 +48,8 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Pickers")
         case .switches:
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Switches")
+        case .textFields:
+            return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "TextFields")
         }
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
@@ -88,6 +88,122 @@
             <point key="canvasLocation" x="138" y="6"/>
         </scene>
         <!--View Controller-->
+        <scene sceneID="7SG-Ig-YgK">
+            <objects>
+                <viewController storyboardIdentifier="TextFields" id="Jf0-qn-anK" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="nob-qf-eI7">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="IEn-Sf-HvM">
+                                <rect key="frame" x="8" y="67" width="377" height="552.33333333333337"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Default (with value)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3uU-aL-MXT">
+                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foo bar" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8Go-nf-cqb">
+                                        <rect key="frame" x="0.0" y="28.333333333333329" width="377" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Default (with placeholder)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="39A-6B-Wot">
+                                        <rect key="frame" x="0.0" y="70.333333333333343" width="377" height="20.333333333333329"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="fizz buzz" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="a4u-id-7wT">
+                                        <rect key="frame" x="0.0" y="98.666666666666657" width="377" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Password (Secure Text Entry)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VMI-1y-b5c">
+                                        <rect key="frame" x="0.0" y="140.66666666666666" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="p4ssw0rd" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qPH-8B-ZFh">
+                                        <rect key="frame" x="0.0" y="169" width="377" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email (textContentType = .emailAddress)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ttw-nr-d6T">
+                                        <rect key="frame" x="0.0" y="211" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="j.doe@example.com" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="c7u-bm-2SR">
+                                        <rect key="frame" x="0.0" y="239.33333333333331" width="377" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" textContentType="email"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Phone no. (textContentType = .telephoneNumber)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IEz-NU-2Bj">
+                                        <rect key="frame" x="0.0" y="281.33333333333331" width="377" height="18"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="+01200000000" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rn0-SO-4R1">
+                                        <rect key="frame" x="0.0" y="307.33333333333331" width="377" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" textContentType="tel"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Default (clear button always visible)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uvb-ej-PYu">
+                                        <rect key="frame" x="0.0" y="349.33333333333331" width="377" height="20.333333333333314"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="bizz bazz" borderStyle="roundedRect" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="4Br-MY-Lqa">
+                                        <rect key="frame" x="0.0" y="377.66666666666669" width="377" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YoQ-B3-Fio">
+                                        <rect key="frame" x="0.0" y="419.66666666666669" width="377" height="20.333333333333314"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="disabled text" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="YaX-lF-HRj">
+                                        <rect key="frame" x="0.0" y="448" width="377" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom #1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s7U-uC-auS">
+                                        <rect key="frame" x="0.0" y="490" width="377" height="20.333333333333314"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="custom text 1" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9ga-bn-yoe">
+                                        <rect key="frame" x="0.0" y="518.33333333333337" width="377" height="34"/>
+                                        <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Pv1-hQ-MV4"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="IEn-Sf-HvM" firstAttribute="leading" secondItem="Pv1-hQ-MV4" secondAttribute="leading" constant="8" id="9pJ-tn-XG8"/>
+                            <constraint firstItem="Pv1-hQ-MV4" firstAttribute="trailing" secondItem="IEn-Sf-HvM" secondAttribute="trailing" constant="8" id="CtW-zm-TRk"/>
+                            <constraint firstItem="IEn-Sf-HvM" firstAttribute="top" secondItem="Pv1-hQ-MV4" secondAttribute="top" constant="8" id="u5q-Qt-PEA"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="mBJ-FW-Es7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="135" y="675"/>
+        </scene>
+        <!--View Controller-->
         <scene sceneID="EM5-Q5-n2I">
             <objects>
                 <viewController storyboardIdentifier="Segments" id="Uyj-Ig-4Fe" sceneMemberID="viewController">

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -106,4 +106,22 @@ final class SRSnapshotTests: SnapshotTestCase {
             record: recordingMode
         )
     }
+
+    func testTextFields() throws {
+        show(fixture: .textFields)
+
+        var image = try takeSnapshot(configuration: .init(privacy: .allowAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
+            record: recordingMode
+        )
+
+        image = try takeSnapshot(configuration: .init(privacy: .maskAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-maskAll-privacy"),
+            record: recordingMode
+        )
+    }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/ImageRendering.swift
@@ -74,8 +74,11 @@ private extension SRImageWireframe {
             y: CGFloat(y),
             width: CGFloat(width),
             height: CGFloat(height),
-            style: frameStyle(border: border, style: shapeStyle),
-            content: .init(text: "IMG", textColor: .black, font: .systemFont(ofSize: 8))
+            style: .init(lineWidth: 1, lineColor: .black, fillColor: .red),
+            annotation: .init(
+                text: "IMG \(width) x \(height)",
+                style: .init(size: .small, position: .top, alignment: .trailing)
+            )
         )
     }
 }

--- a/DatadogSessionReplay/Sources/Processor/Flattening/NodesFlattener.swift
+++ b/DatadogSessionReplay/Sources/Processor/Flattening/NodesFlattener.swift
@@ -19,23 +19,20 @@ internal struct NodesFlattener {
         var flattened: [Node] = []
 
         for nextNode in snapshot.nodes {
-            // Skip invisible nodes:
-            if !(nextNode.semantics is InvisibleElement) {
-                // When accepting nodes, remove ones that are covered by another opaque node:
-                flattened = flattened.compactMap { previousNode in
-                    let previousFrame = previousNode.semantics.wireframesBuilder?.wireframeRect ?? .zero
-                    let nextFrame = nextNode.semantics.wireframesBuilder?.wireframeRect ?? .zero
+            // When accepting nodes, remove ones that are covered by another opaque node:
+            flattened = flattened.compactMap { previousNode in
+                let previousFrame = previousNode.wireframesBuilder.wireframeRect
+                let nextFrame = nextNode.wireframesBuilder.wireframeRect
 
-                    // Drop previous node when:
-                    let dropPreviousNode = nextFrame.contains(previousFrame) // its rect is fully covered by the next node
-                        && nextNode.viewAttributes.hasAnyAppearance // and the next node brings something visual
-                        && !nextNode.viewAttributes.isTranslucent // and the next node is opaque
+                // Drop previous node when:
+                let dropPreviousNode = nextFrame.contains(previousFrame) // its rect is fully covered by the next node
+                    && nextNode.viewAttributes.hasAnyAppearance // and the next node brings something visual
+                    && !nextNode.viewAttributes.isTranslucent // and the next node is opaque
 
-                    return dropPreviousNode ? nil : previousNode
-                }
-
-                flattened.append(nextNode)
+                return dropPreviousNode ? nil : previousNode
             }
+
+            flattened.append(nextNode)
         }
 
         return flattened

--- a/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
+++ b/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
@@ -13,7 +13,7 @@ internal protocol TextObfuscating {
     func mask(text: String) -> String
 }
 
-/// Text obfuscator which replaces all readable characters with `"x"`.
+/// Text obfuscator which replaces all readable characters with space-preserving `"x"` characters.
 internal struct TextObfuscator: TextObfuscating {
     /// The character to mask text with.
     let maskCharacter: UnicodeScalar = "x"
@@ -37,6 +37,17 @@ internal struct TextObfuscator: TextObfuscating {
 
         return masked
     }
+}
+
+/// Text obfuscator which replaces the whole text with fixed-width `"xxx"` mask value.
+///
+/// It should be used **by default** for input elements that bring sensitive information (such as passwords).
+/// It shuold be used for input elements that can't safely use space-preserving masking (such as date pickers, where selection can be still
+/// inferred by counting the number of x-es in the mask).
+internal struct InputTextObfuscator: TextObfuscating {
+    private static let maskedString = "xxx"
+
+    func mask(text: String) -> String { Self.maskedString }
 }
 
 /// Text obfuscator which only returns the original text.

--- a/DatadogSessionReplay/Sources/Processor/Processor.swift
+++ b/DatadogSessionReplay/Sources/Processor/Processor.swift
@@ -66,7 +66,7 @@ internal class Processor: Processing {
     private func processSync(viewTreeSnapshot: ViewTreeSnapshot, touchSnapshot: TouchSnapshot?) {
         let flattenedNodes = nodesFlattener.flattenNodes(in: viewTreeSnapshot)
         let wireframes: [SRWireframe] = flattenedNodes
-            .compactMap { node in node.semantics.wireframesBuilder }
+            .map { node in node.wireframesBuilder }
             .flatMap { nodeBuilder in nodeBuilder.buildWireframes(with: wireframesBuilder) }
 
         #if DEBUG

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/SystemColors.swift
@@ -64,4 +64,13 @@ internal enum SystemColors {
     static var systemGreen: CGColor {
         return UIColor.systemGreen.cgColor
     }
+
+    static var placeholderText: CGColor {
+        if #available(iOS 13.0, *) {
+            return UIColor.placeholderText.cgColor
+        } else {
+            // Fallback to iOS 16.2 light mode color:
+            return UIColor(red: 197 / 255, green: 197 / 255, blue: 197 / 255, alpha: 1).cgColor
+        }
+    }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -41,7 +41,8 @@ internal struct UIImageViewRecorder: NodeRecorder {
             imageTintColor: imageView.tintColor,
             imageDataProvider: imageDataProvider
         )
-        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .record)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .record, nodes: [node])
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -6,9 +6,17 @@
 
 import UIKit
 
-internal struct UILabelRecorder: NodeRecorder {
+internal class UILabelRecorder: NodeRecorder {
+    /// An option for ignoring certain views by this recorder.
+    var dropPredicate: (UILabel, ViewAttributes) -> Bool = { _, _ in false }
+    /// An option for customizing wireframes builder created by this recorder.
+    var builderOverride: (UILabelWireframesBuilder) -> UILabelWireframesBuilder = { $0 }
+
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let label = view as? UILabel else {
+            return nil
+        }
+        if dropPredicate(label, attributes) {
             return nil
         }
 
@@ -37,7 +45,8 @@ internal struct UILabelRecorder: NodeRecorder {
             textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator,
             wireframeRect: textFrame
         )
-        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builderOverride(builder))
+        return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorder.swift
@@ -19,7 +19,8 @@ internal struct UINavigationBarRecorder: NodeRecorder {
             color: inferColor(of: navigationBar)
         )
 
-        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .record)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .record, nodes: [node])
     }
 
     private func inferOccupiedFrame(of navigationBar: UINavigationBar, in context: ViewTreeRecordingContext) -> CGRect {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -16,21 +16,20 @@ import UIKit
 /// - Instead, we infer the value by traversing picker's subtree state and finding texts that are displayed closest to its geometry center.
 /// - If privacy mode is elevated, we don't replace individual characters with "x" letter - instead we change whole options to fixed-width mask value.
 internal struct UIPickerViewRecorder: NodeRecorder {
-    /// Custom text obfuscator for picker option labels.
-    ///
-    /// Unlike the default `TextObfuscator` it doesn't mask each individual character with "x" letter. Instead, it replaces
-    /// whole options with fixed "xxx" string. This elevates the level of privacy, because selected option can not be inferred
-    /// by counting number of characters.
-    private struct PickerOptionTextObfuscator: TextObfuscating {
-        private static let maskedString = "xxx"
-        func mask(text: String) -> String { Self.maskedString }
-    }
-    /// A sub-tree recorder for capturing shapes nested in picker's view hierarchy.
+    /// Records individual labels in picker's subtree.
+    private let labelRecorder: UILabelRecorder
+    /// Records all shapes in picker's subtree.
     /// It is used to capture the background of selected option.
-    private let selectionRecorder = ViewTreeRecorder(nodeRecorders: [UIViewRecorder()])
-    /// A sub-tree recorder for capturing labels nested in picker's view hierarchy.
+    private let selectionRecorder: ViewTreeRecorder
+    /// Records all labels in picker's subtree.
     /// It is used to capture titles for displayed options.
-    private let labelsRecorder = ViewTreeRecorder(nodeRecorders: [UILabelRecorder()])
+    private let labelsRecorder: ViewTreeRecorder
+
+    init() {
+        self.labelRecorder = UILabelRecorder()
+        self.labelsRecorder = ViewTreeRecorder(nodeRecorders: [labelRecorder])
+        self.selectionRecorder = ViewTreeRecorder(nodeRecorders: [UIViewRecorder()])
+    }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let picker = view as? UIPickerView else {
@@ -44,29 +43,24 @@ internal struct UIPickerViewRecorder: NodeRecorder {
         // For our "approximation", we render selected option text on top of selection background. However,
         // in the actual `UIPickerView's` tree their order is opposite (blending is used to make the label
         // pass through the shape). For that reason, we record both kinds of nodes separately and then reorder
-        // them in returned `.replace(subtreeNodes:)` strategy:
+        // them in returned semantics:
         let backgroundNodes = recordBackgroundOfSelectedOption(in: picker, using: context)
         let titleNodes = recordTitlesOfSelectedOption(in: picker, pickerAttributes: attributes, using: context)
 
         guard attributes.hasAnyAppearance else {
             // If the root view of `UIPickerView` defines no other appearance (e.g. no custom `.background`), we can
             // safely ignore it, with only forwarding child nodes to final recording.
-            return InvisibleElement(
-                subtreeStrategy: .replace(subtreeNodes: backgroundNodes + titleNodes)
-            )
+            return SpecificElement(subtreeStrategy: .ignore, nodes: backgroundNodes + titleNodes)
         }
 
-        // Otherwise, we build dedicated wireframes to describe additional appearance coming from picker's root `UIView`:
+        // Otherwise, we build dedicated wireframes to describe extra appearance coming from picker's root `UIView`:
         let builder = UIPickerViewWireframesBuilder(
             wireframeRect: attributes.frame,
             attributes: attributes,
             backgroundWireframeID: context.ids.nodeID(for: picker)
         )
-
-        return SpecificElement(
-            wireframesBuilder: builder,
-            subtreeStrategy: .replace(subtreeNodes: backgroundNodes + titleNodes)
-        )
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .ignore, nodes: [node] + backgroundNodes + titleNodes)
     }
 
     /// Records `UIView` nodes that define background of selected option.
@@ -76,25 +70,23 @@ internal struct UIPickerViewRecorder: NodeRecorder {
 
     /// Records `UILabel` nodes that hold titles of **selected** options - if picker defines N components, there will be N nodes returned.
     private func recordTitlesOfSelectedOption(in picker: UIPickerView, pickerAttributes: ViewAttributes, using context: ViewTreeRecordingContext) -> [Node] {
-        var context = context
-        context.textObfuscator = PickerOptionTextObfuscator()
-        context.semanticsOverride = { currentSemantics, label, attributes in
+        labelRecorder.dropPredicate = { _, labelAttributes in
             // We consider option to be "selected" if it is displayed close enough to picker's geometry center
             // and its `UILabel` is opaque:
-            let isNearCenter = abs(attributes.frame.midY - pickerAttributes.frame.midY) < 10
-            let isForeground = attributes.alpha == 1
-
-            if isNearCenter && isForeground, var wireframeBuilder = (currentSemantics.wireframesBuilder as? UILabelWireframesBuilder) {
-                // For some reason, the text within `UILabel` is not centered in regular way (with `intrinsicContentSize`), hence
-                // we need to manually center it within produced wireframe. Here we use SR text alignment options to achieve it:
-                var newSemantics = currentSemantics
-                wireframeBuilder.textAlignment = .init(horizontal: .center, vertical: .center)
-                newSemantics.wireframesBuilder = wireframeBuilder
-                return newSemantics
-            } else {
-                return InvisibleElement.constant // this node doesn't describe selected option - ignore it
-            }
+            let isNearCenter = abs(labelAttributes.frame.midY - pickerAttributes.frame.midY) < 10
+            let isForeground = labelAttributes.alpha == 1
+            let isSelectedOption = isNearCenter && isForeground
+            return !isSelectedOption // drop other options than selected one
         }
+
+        labelRecorder.builderOverride = { builder in
+            var builder = builder
+            builder.textAlignment = .init(horizontal: .center, vertical: .center)
+            return builder
+        }
+
+        var context = context
+        context.textObfuscator = InputTextObfuscator()
         return labelsRecorder.recordNodes(for: picker, in: context)
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -34,7 +34,8 @@ internal struct UISegmentRecorder: NodeRecorder {
                 }
             }()
         )
-        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorder.swift
@@ -31,7 +31,8 @@ internal struct UISliderRecorder: NodeRecorder {
             maxTrackTintColor: slider.maximumTrackTintColor?.cgColor,
             thumbTintColor: slider.thumbTintColor?.cgColor
         )
-        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorder.swift
@@ -33,7 +33,8 @@ internal struct UISwitchRecorder: NodeRecorder {
             onTintColor: `switch`.onTintColor?.cgColor,
             offTintColor: `switch`.tintColor?.cgColor
         )
-        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorder.swift
@@ -18,7 +18,8 @@ internal struct UITabBarRecorder: NodeRecorder {
             attributes: attributes,
             color: inferColor(of: tabBar)
         )
-        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .record)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .record, nodes: [node])
     }
 
     private func inferOccupiedFrame(of tabBar: UITabBar, in context: ViewTreeRecordingContext) -> CGRect {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -7,6 +7,18 @@
 import UIKit
 
 internal struct UITextFieldRecorder: NodeRecorder {
+    /// `UIViewRecorder` for recording appearance of the text field.
+    private let backgroundViewRecorder: UIViewRecorder
+    /// `UIImageViewRecorder` for recording icons that are displayed in text field.
+    private let iconsRecorder: UIImageViewRecorder
+    private let subtreeRecorder: ViewTreeRecorder
+
+    init() {
+        self.backgroundViewRecorder = UIViewRecorder()
+        self.iconsRecorder = UIImageViewRecorder()
+        self.subtreeRecorder = ViewTreeRecorder(nodeRecorders: [backgroundViewRecorder, iconsRecorder])
+    }
+
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard let textField = view as? UITextField else {
             return nil
@@ -16,104 +28,109 @@ internal struct UITextFieldRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        // TODO: RUMM-2459
-        // Explore other (better) ways of infering text field appearance:
+        // For our "approximation", we render text field's text on top of other TF's appearance.
+        // Here we record both kind of nodes separately and order them respectively in returned semantics:
+        let appearanceNodes = recordAppearance(in: textField, textFieldAttributes: attributes, using: context)
+        if let textNode = recordText(in: textField, attributes: attributes, using: context) {
+            return SpecificElement(subtreeStrategy: .ignore, nodes: appearanceNodes + [textNode])
+        } else {
+            return SpecificElement(subtreeStrategy: .ignore, nodes: appearanceNodes)
+        }
+    }
 
-        var editorProperties: UITextFieldWireframesBuilder.EditorFieldProperties? = nil
-        // Lookup the actual editor field's view in `textField` hierarchy to infer its appearance.
-        // Perhaps this can be do better by infering it from `UITextField` object in RUMM-2459:
-        dfsVisitSubviews(of: textField) { subview in
-            if subview.bounds == textField.bounds {
-                editorProperties = .init(
-                    backgroundColor: subview.backgroundColor?.cgColor,
-                    layerBorderColor: subview.layer.borderColor,
-                    layerBorderWidth: subview.layer.borderWidth,
-                    layerCornerRadius: subview.layer.cornerRadius
-                )
-            }
+    /// Records `UIView` and `UIImageViewRecorder` nodes that define text field's appearance.
+    private func recordAppearance(in textField: UITextField, textFieldAttributes: ViewAttributes, using context: ViewTreeRecordingContext) -> [Node] {
+        backgroundViewRecorder.dropPredicate = { _, viewAttributes in
+            // We consider view to define text field's appearance if it has the same
+            // size as text field:
+            let hasSameSize = textFieldAttributes.frame == viewAttributes.frame
+            let isBackground = hasSameSize && viewAttributes.hasAnyAppearance
+            return !isBackground
         }
 
-        let text: String = {
-            guard let textFieldText = textField.text, !textFieldText.isEmpty else {
-                return textField.placeholder ?? ""
-            }
-            return textFieldText
-        }()
+        return subtreeRecorder.recordNodes(for: textField, in: context)
+    }
 
-        // TODO: RUMM-2459
-        // Enhance text fields rendering by calculating the actual frame of the text:
+    /// Creates node that represents TF's text.
+    /// We cannot use general view-tree traversal solution to find nested labels (`UITextField's` subtree doesn't look that way). Instead, we read
+    /// text information and create arbitrary node with appropriate wireframes builder configuration.
+    private func recordText(in textField: UITextField, attributes: ViewAttributes, using context: ViewTreeRecordingContext) -> Node? {
+        let text: String
+        let isPlaceholder: Bool
+
+        if let fieldText = textField.text, !fieldText.isEmpty {
+            text = fieldText
+            isPlaceholder = false
+        } else if let fieldPlaceholder = textField.placeholder {
+            text = fieldPlaceholder
+            isPlaceholder = true
+        } else {
+            return nil
+        }
+
         let textFrame = attributes.frame
+            .insetBy(dx: 5, dy: 5) // 5 points padding
 
         let builder = UITextFieldWireframesBuilder(
-            wireframeID: context.ids.nodeID(for: textField),
+            wireframeRect: textFrame,
             attributes: attributes,
+            wireframeID: context.ids.nodeID(for: textField),
             text: text,
-            // TODO: RUMM-2459
-            // Is it correct to assume `textField.textColor` for placeholder text?
             textColor: textField.textColor?.cgColor,
+            textAlignment: textField.textAlignment,
+            isPlaceholderText: isPlaceholder,
             font: textField.font,
             fontScalingEnabled: textField.adjustsFontSizeToFitWidth,
-            editor: editorProperties,
-            textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator,
-            wireframeRect: textFrame
+            textObfuscator: textObfuscator(for: textField, in: context)
         )
-        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .ignore)
+        return Node(viewAttributes: attributes, wireframesBuilder: builder)
+    }
+
+    private func textObfuscator(for textField: UITextField, in context: ViewTreeRecordingContext) -> TextObfuscating {
+        if textField.isSecureTextEntry || textField.textContentType == .emailAddress || textField.textContentType == .telephoneNumber {
+            return InputTextObfuscator()
+        }
+
+        return context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator // default one
     }
 }
 
 internal struct UITextFieldWireframesBuilder: NodeWireframesBuilder {
-    let wireframeID: WireframeID
-    /// Attributes of the base `UIView`.
+    let wireframeRect: CGRect
     let attributes: ViewAttributes
-    /// The text inside text field.
+
+    let wireframeID: WireframeID
+
     let text: String
-    /// The color of the text.
     let textColor: CGColor?
-    /// The font used by the text field.
+    let textAlignment: NSTextAlignment
+    let isPlaceholderText: Bool
     let font: UIFont?
-    /// Flag that determines if font should be scaled
     let fontScalingEnabled: Bool
-    /// Properties of the editor field (which is a nested subview in `UITextField`).
-    let editor: EditorFieldProperties?
-    /// Text obfuscator for masking text.
     let textObfuscator: TextObfuscating
 
-    let wireframeRect: CGRect
-
-    struct EditorFieldProperties {
-        /// Editor view's `.backgorundColor`.
-        var backgroundColor: CGColor? = nil
-        /// Editor view's `layer.backgorundColor`.
-        var layerBorderColor: CGColor? = nil
-        /// Editor view's `layer.backgorundColor`.
-        var layerBorderWidth: CGFloat = 0
-        /// Editor view's `layer.cornerRadius`.
-        var layerCornerRadius: CGFloat = 0
-    }
-
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        let horizontalAlignment: SRTextPosition.Alignment.Horizontal? = {
+            switch textAlignment {
+            case .left:     return .left
+            case .center:   return .center
+            case .right:    return .right
+            default:        return nil
+            }
+        }()
+
         return [
             builder.createTextWireframe(
                 id: wireframeID,
-                frame: attributes.frame,
+                frame: wireframeRect,
                 text: textObfuscator.mask(text: text),
                 textFrame: wireframeRect,
-                textColor: textColor,
+                textAlignment: .init(horizontal: horizontalAlignment, vertical: .center),
+                textColor: isPlaceholderText ? SystemColors.placeholderText : textColor,
                 font: font,
                 fontScalingEnabled: fontScalingEnabled,
-                borderColor: editor?.layerBorderColor ?? attributes.layerBorderColor,
-                borderWidth: editor?.layerBorderWidth ?? attributes.layerBorderWidth,
-                backgroundColor: editor?.backgroundColor ?? attributes.backgroundColor,
-                cornerRadius: editor?.layerCornerRadius ?? attributes.layerCornerRadius,
                 opacity: attributes.alpha
             )
         ]
-    }
-}
-
-private func dfsVisitSubviews(of view: UIView, visit: (UIView) -> Void) {
-    view.subviews.forEach { subview in
-        visit(subview)
-        dfsVisitSubviews(of: subview, visit: visit)
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -23,7 +23,8 @@ internal struct UITextViewRecorder: NodeRecorder {
             textObfuscator: context.recorder.privacy == .maskAll ? context.textObfuscator : nopTextObfuscator,
             contentRect: CGRect(origin: textView.contentOffset, size: textView.contentSize)
         )
-        return SpecificElement(wireframesBuilder: builder, subtreeStrategy: .record)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .record, nodes: [node])
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -6,10 +6,16 @@
 
 import UIKit
 
-internal struct UIViewRecorder: NodeRecorder {
+internal class UIViewRecorder: NodeRecorder {
+    /// An option for ignoring certain views by this recorder.
+    var dropPredicate: (UIView, ViewAttributes) -> Bool = { _, _ in false }
+
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard attributes.isVisible else {
             return InvisibleElement.constant
+        }
+        if dropPredicate(view, attributes) {
+            return nil
         }
 
         guard attributes.hasAnyAppearance else {
@@ -23,8 +29,8 @@ internal struct UIViewRecorder: NodeRecorder {
             attributes: attributes,
             wireframeRect: attributes.frame
         )
-
-        return AmbiguousElement(wireframesBuilder: builder)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return AmbiguousElement(nodes: [node])
     }
 }
 

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -201,11 +201,7 @@ extension NodeSubtreeStrategy: AnyMockable, RandomMockable {
     }
 
     public static func mockRandom() -> NodeSubtreeStrategy {
-        let all: [NodeSubtreeStrategy] = [
-            .record,
-            .replace(subtreeNodes: [.mockAny()]),
-            .ignore,
-        ]
+        let all: [NodeSubtreeStrategy] = [.record, .ignore]
         return all.randomElement()!
     }
 }
@@ -218,8 +214,8 @@ func mockRandomNodeSemantics() -> NodeSemantics {
     let all: [NodeSemantics] = [
         UnknownElement.constant,
         InvisibleElement.constant,
-        AmbiguousElement(wireframesBuilder: NOPWireframesBuilderMock()),
-        SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), subtreeStrategy: .mockRandom()),
+        AmbiguousElement(nodes: .mockRandom(count: .mockRandom(min: 1, max: 5))),
+        SpecificElement(subtreeStrategy: .mockRandom(), nodes: .mockRandom(count: .mockRandom(min: 1, max: 5))),
     ]
     return all.randomElement()!
 }
@@ -239,33 +235,34 @@ extension Node: AnyMockable, RandomMockable {
 
     static func mockWith(
         viewAttributes: ViewAttributes = .mockAny(),
-        semantics: NodeSemantics = InvisibleElement.constant
+        wireframesBuilder: NodeWireframesBuilder = NOPWireframesBuilderMock()
     ) -> Node {
         return .init(
             viewAttributes: viewAttributes,
-            semantics: semantics
+            wireframesBuilder: wireframesBuilder
         )
     }
 
     public static func mockRandom() -> Node {
         return .init(
             viewAttributes: .mockRandom(),
-            semantics: mockRandomNodeSemantics()
+            wireframesBuilder: NOPWireframesBuilderMock()
         )
     }
 }
 
 extension SpecificElement {
     static func mockAny() -> SpecificElement {
-        SpecificElement(wireframesBuilder: NOPWireframesBuilderMock(), subtreeStrategy: .mockRandom())
+        SpecificElement(subtreeStrategy: .mockRandom(), nodes: [])
     }
-    static func mock(
-        wireframeRect: CGRect,
-        subtreeStrategy: NodeSubtreeStrategy = .mockRandom()
+
+    static func mockWith(
+        subtreeStrategy: NodeSubtreeStrategy = .mockAny(),
+        nodes: [Node] = .mockAny()
     ) -> SpecificElement {
         SpecificElement(
-            wireframesBuilder: ShapeWireframesBuilderMock(wireframeRect: wireframeRect),
-            subtreeStrategy: subtreeStrategy
+            subtreeStrategy: subtreeStrategy,
+            nodes: nodes
         )
     }
 }

--- a/DatadogSessionReplay/Tests/Processor/Flattening/NodesFlattenerTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Flattening/NodesFlattenerTests.swift
@@ -11,50 +11,20 @@ import Datadog
 
 class NodesFlattenerTests: XCTestCase {
     /*
-          R
-         / \
-        I1  V1
-    */
-    func testFlattenNodes_withInvisibleNode() {
-        // Given
-        let smallFrame: CGRect = .mockRandom(minWidth: 1, maxWidth: 10, minHeight: 1, maxHeight: 10)
-        let bigFrame: CGRect = .mockRandom(minWidth: 11, maxWidth: 100, minHeight: 11, maxHeight: 100)
-        let invisibleNode = Node.mockWith(
-            viewAttributes: .mock(fixture: .invisible)
-        )
-        let visibleNode = Node.mockWith(
-            viewAttributes: .mock(fixture: .visible()),
-            semantics: SpecificElement.mock(wireframeRect: smallFrame)
-        )
-        let rootNode = Node.mockWith(
-            viewAttributes: .mock(fixture: .visible()),
-            semantics: SpecificElement.mock(wireframeRect: bigFrame)
-        )
-        let snapshot = ViewTreeSnapshot.mockWith(nodes: [rootNode, invisibleNode, visibleNode])
-        let flattener = NodesFlattener()
-
-        // When
-        let flattenedNodes = flattener.flattenNodes(in: snapshot)
-
-        // Then
-        DDAssertReflectionEqual(flattenedNodes, [rootNode, visibleNode])
-    }
-
-    /*
         V
         |
         V1
     */
-    func testFlattenNodes_withVisibleNodeThatCoversAnotherNode() {
+    func testFlattenNodes_withNodeThatCoversAnotherNode() {
         // Given
         let frame = CGRect.mockRandom(minWidth: 1, minHeight: 1)
         let coveringNode = Node.mockWith(
             viewAttributes: .mock(fixture: .opaque),
-            semantics: SpecificElement.mock(wireframeRect: frame)
+            wireframesBuilder: ShapeWireframesBuilderMock(wireframeRect: frame)
         )
         let coveredNode = Node.mockWith(
             viewAttributes: .mockRandom(),
-            semantics: SpecificElement.mock(wireframeRect: frame)
+            wireframesBuilder: ShapeWireframesBuilderMock(wireframeRect: frame)
         )
         let snapshot = ViewTreeSnapshot.mockWith(nodes: [coveredNode, coveringNode])
         let flattener = NodesFlattener()
@@ -69,64 +39,31 @@ class NodesFlattenerTests: XCTestCase {
 
     /*
           R
-         / \
-        I1  V2
-       /
-      V1
-    */
-    func testFlattenNodes_withMixedVisibleAndInvisibleNodes() {
-        // Given
-        let frame1: CGRect = .mockRandom(minWidth: 1, maxWidth: 10, minHeight: 1, maxHeight: 10)
-        let frame2: CGRect = .mockRandom(minWidth: 11, maxWidth: 100, minHeight: 11, maxHeight: 100)
-        let rootFrame: CGRect = .mockRandom(minWidth: 101, maxWidth: 1_000, minHeight: 101, maxHeight: 1_000)
-        let visibleNode1 = Node.mockWith(
-            viewAttributes: .mock(fixture: .visible()),
-            semantics: SpecificElement.mock(wireframeRect: frame1)
-        )
-        let invisibleNode1 = Node.mockWith(viewAttributes: .mock(fixture: .invisible))
-        let visibleNode2 = Node.mockWith(
-            viewAttributes: .mock(fixture: .visible()),
-            semantics: SpecificElement.mock(wireframeRect: frame2)
-        )
-        let rootNode = Node.mockWith(
-            viewAttributes: .mock(fixture: .visible()),
-            semantics: SpecificElement.mock(wireframeRect: rootFrame)
-        )
-
-        let snapshot = ViewTreeSnapshot.mockWith(nodes: [rootNode, invisibleNode1, visibleNode1, visibleNode2])
-        let flattener = NodesFlattener()
-
-        // When
-        let flattenedNodes = flattener.flattenNodes(in: snapshot)
-
-        // Then
-        DDAssertReflectionEqual(flattenedNodes, [rootNode, visibleNode1, visibleNode2])
-    }
-
-    /*
-          R
         /   \
       CN1  CN2
        |    |
        CN   CN
     */
-    func testFlattenNodes_withMultipleVisibleNodesThatAreCoveredByAnotherNode() {
+    func testFlattenNodes_withMultipleNodesThatAreCoveredByAnotherNode() {
         // Given
         // set rects
         let frame = CGRect.mockRandom()
         let coveringNode = Node.mockWith(
             viewAttributes: .mock(fixture: .opaque),
-            semantics: SpecificElement.mock(wireframeRect: frame)
+            wireframesBuilder: ShapeWireframesBuilderMock(wireframeRect: frame)
         )
         let coveredNode1 = Node.mockWith(
             viewAttributes: .mockRandom(),
-            semantics: SpecificElement.mock(wireframeRect: frame)
+            wireframesBuilder: ShapeWireframesBuilderMock(wireframeRect: frame)
         )
         let coveredNode2 = Node.mockWith(
             viewAttributes: .mockRandom(),
-            semantics: SpecificElement.mock(wireframeRect: frame)
+            wireframesBuilder: ShapeWireframesBuilderMock(wireframeRect: frame)
         )
-        let rootNode = Node.mockAny()
+        let rootNode = Node.mockWith(
+            viewAttributes: .mockRandom(),
+            wireframesBuilder: ShapeWireframesBuilderMock(wireframeRect: frame)
+        )
         let snapshot = ViewTreeSnapshot.mockWith(nodes: [rootNode, coveredNode1, coveringNode, coveredNode2, coveringNode])
         let flattener = NodesFlattener()
 
@@ -136,32 +73,4 @@ class NodesFlattenerTests: XCTestCase {
         // Then
         DDAssertReflectionEqual(flattenedNodes, [coveringNode])
     }
-
-    /*
-          R
-         / \
-        V1  V2
-    */
-    func testFlattenNodes_withNodesWithSameFrameAndDifferentAppearances() {
-        // Given
-        let smallFrame: CGRect = .mockRandom(minWidth: 1, maxWidth: 10, minHeight: 1, maxHeight: 10)
-        let bigFrame: CGRect = .mockRandom(minWidth: 11, maxWidth: 100, minHeight: 11, maxHeight: 100)
-        let visibleNode1 = Node.mockWith(
-            viewAttributes: .mock(fixture: .visible()),
-            semantics: SpecificElement.mock(wireframeRect: smallFrame)
-        )
-        let visibleNode2 = Node.mockWith(
-            viewAttributes: .mock(fixture: .visible()),
-            semantics: SpecificElement.mock(wireframeRect: bigFrame)
-        )
-        let rootNode = Node.mockAny()
-        let snapshot = ViewTreeSnapshot.mockWith(nodes: [rootNode, visibleNode1, visibleNode2])
-        let flattener = NodesFlattener()
-
-        // When
-        let flattenedNodes = flattener.flattenNodes(in: snapshot)
-
-        // Then
-        DDAssertReflectionEqual(flattenedNodes, [visibleNode1, visibleNode2])
-   }
 }

--- a/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
@@ -49,3 +49,15 @@ class TestObfuscatorTests: XCTestCase {
         XCTAssertEqual(obfuscator.mask(text: "foo 🇮🇹 bar"), "xxx xx xxx")
     }
 }
+
+class InputTextObfuscatorTests: XCTestCase {
+    let obfuscator = InputTextObfuscator()
+
+    func testWhenObfuscatingItAlwaysReplacesTextItWithConstantMask() {
+        let expectedMask = "xxx"
+
+        XCTAssertEqual(obfuscator.mask(text: .mockRandom(among: .alphanumericsAndWhitespace)), expectedMask)
+        XCTAssertEqual(obfuscator.mask(text: .mockRandom(among: .allUnicodes)), expectedMask)
+        XCTAssertEqual(obfuscator.mask(text: .mockRandom(among: .alphanumerics)), expectedMask)
+    }
+}

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorderTests.swift
@@ -24,21 +24,19 @@ class UIImageViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Image view's subtree should not be recorded")
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore)
     }
 
-    func testWhenImageViewHasNoImageAndSomeAppearance() throws {
+    func testWhenImageViewHasNoImageAndHasSomeAppearance() throws {
         // When
         imageView.image = nil
-        viewAttributes = .mock(fixture: .visible())
+        viewAttributes = .mock(fixture: .visible(.someAppearance))
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is SpecificElement)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
-
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UIImageViewWireframesBuilder)
-        XCTAssertEqual(builder.buildWireframes(with: WireframesBuilder()).count, 1)
+        XCTAssertEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
+        XCTAssertTrue(semantics.nodes.first?.wireframesBuilder is UIImageViewWireframesBuilder)
     }
 
     func testWhenImageViewHasImageAndSomeAppearance() throws {
@@ -49,35 +47,8 @@ class UIImageViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is SpecificElement)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
-
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UIImageViewWireframesBuilder)
-        XCTAssertEqual(builder.buildWireframes(with: WireframesBuilder()).count, 2)
-    }
-
-    func testWhenImageViewHasImageOrAppearance() throws {
-        // When
-        oneOf([
-            {
-                self.imageView.image = UIImage()
-                self.viewAttributes = .mock(fixture: .visible())
-            },
-            {
-                self.imageView.image = nil
-                self.viewAttributes = .mock(fixture: .visible())
-            },
-            {
-                self.imageView.image = UIImage()
-                self.viewAttributes = .mock(fixture: .visible(.noAppearance))
-            },
-        ])
-
-        // Then
-        let semantics = try XCTUnwrap(recorder.semantics(of: imageView, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UIImageViewWireframesBuilder)
-        XCTAssertEqual(builder.attributes, viewAttributes)
-        XCTAssertEqual(builder.wireframeRect, viewAttributes.frame)
+        XCTAssertEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
+        XCTAssertTrue(semantics.nodes.first?.wireframesBuilder is UIImageViewWireframesBuilder)
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorderTests.swift
@@ -6,7 +6,6 @@
 
 import XCTest
 @testable import DatadogSessionReplay
-@testable import TestUtilities
 
 // swiftlint:disable opening_brace
 class UILabelRecorderTests: XCTestCase {
@@ -27,7 +26,7 @@ class UILabelRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore)
     }
 
     func testWhenLabelHasTextOrAppearance() throws {
@@ -49,9 +48,9 @@ class UILabelRecorderTests: XCTestCase {
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Label's subtree should not be recorded")
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore, "Label's subtree should not be recorded")
 
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UILabelWireframesBuilder)
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UILabelWireframesBuilder)
         XCTAssertEqual(builder.attributes, viewAttributes)
         XCTAssertEqual(builder.text, label.text ?? "")
         XCTAssertEqual(builder.textColor, label.textColor?.cgColor)
@@ -67,8 +66,8 @@ class UILabelRecorderTests: XCTestCase {
         let semantics2 = try XCTUnwrap(recorder.semantics(of: label, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .allowAll))))
 
         // Then
-        let builder1 = try XCTUnwrap(semantics1.wireframesBuilder as? UILabelWireframesBuilder)
-        let builder2 = try XCTUnwrap(semantics2.wireframesBuilder as? UILabelWireframesBuilder)
+        let builder1 = try XCTUnwrap(semantics1.nodes.first?.wireframesBuilder as? UILabelWireframesBuilder)
+        let builder2 = try XCTUnwrap(semantics2.nodes.first?.wireframesBuilder as? UILabelWireframesBuilder)
         XCTAssertTrue(builder1.textObfuscator is TextObfuscator, "With `.maskAll` privacy the text obfuscator should be used")
         XCTAssertTrue(builder2.textObfuscator is NOPTextObfuscator, "With `.allowAll` privacy the text obfuscator should not be used")
     }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UINavigationBarRecorderTests.swift
@@ -6,7 +6,6 @@
 
 import XCTest
 @testable import DatadogSessionReplay
-import TestUtilities
 
 class UINavigationBarRecorderTests: XCTestCase {
     private let recorder = UINavigationBarRecorder()
@@ -20,7 +19,7 @@ class UINavigationBarRecorderTests: XCTestCase {
         let semantics = try XCTUnwrap(recorder.semantics(of: navigationBar, with: viewAttributes, in: .mockAny()) as? SpecificElement)
 
         // Then
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "Image view's subtree should be recorded")
+        XCTAssertEqual(semantics.subtreeStrategy, .record)
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorderTests.swift
@@ -19,21 +19,6 @@ class UIPickerViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: picker, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
-    }
-
-    func testWhenPickerIsVisibleButHasNoAppearance() throws {
-        // When
-        viewAttributes = .mock(fixture: .visible(.noAppearance))
-
-        // Then
-        let semantics = try XCTUnwrap(recorder.semantics(of: picker, with: viewAttributes, in: .mockAny()) as? InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
-        guard case .replace(let nodes) = semantics.subtreeStrategy else {
-            XCTFail("Expected `.replace()` subtreeStrategy, got \(semantics.subtreeStrategy)")
-            return
-        }
-        XCTAssertFalse(nodes.isEmpty)
     }
 
     func testWhenPickerIsVisibleAndHasSomeAppearance() throws {
@@ -41,13 +26,21 @@ class UIPickerViewRecorderTests: XCTestCase {
         viewAttributes = .mock(fixture: .visible(.someAppearance))
 
         // Then
-        let semantics = try XCTUnwrap(recorder.semantics(of: picker, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        XCTAssertNotNil(semantics.wireframesBuilder)
-        guard case .replace(let nodes) = semantics.subtreeStrategy else {
-            XCTFail("Expected `.replace()` subtreeStrategy, got \(semantics.subtreeStrategy)")
-            return
-        }
-        XCTAssertFalse(nodes.isEmpty)
+        let semantics = try XCTUnwrap(recorder.semantics(of: picker, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore)
+        XCTAssertTrue(semantics.nodes.first?.wireframesBuilder is UIPickerViewWireframesBuilder)
+    }
+
+    func testWhenPickerIsVisibleAndHasNoAppearance() throws {
+        // When
+        viewAttributes = .mock(fixture: .visible(.noAppearance))
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: picker, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore)
+        XCTAssertFalse(semantics.nodes.first?.wireframesBuilder is UIPickerViewWireframesBuilder)
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorderTests.swift
@@ -5,7 +5,6 @@
  */
 
 import XCTest
-@testable import TestUtilities
 @testable import DatadogSessionReplay
 
 class UISegmentRecorderTests: XCTestCase {
@@ -20,7 +19,6 @@ class UISegmentRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: segment, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
     }
 
     func testWhenSegmentIsVisible() throws {
@@ -31,15 +29,15 @@ class UISegmentRecorderTests: XCTestCase {
         }
 
         // When
-        viewAttributes = .mock(fixture: .visible())
+        viewAttributes = .mock(fixture: .visible(.someAppearance))
 
         // Then
-        let semantics = try XCTUnwrap(recorder.semantics(of: segment, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Segment's subtree should not be recorded")
+        let semantics = try XCTUnwrap(recorder.semantics(of: segment, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore)
 
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UISegmentWireframesBuilder)
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UISegmentWireframesBuilder)
         XCTAssertEqual(builder.attributes, viewAttributes)
-
         XCTAssertEqual(builder.segmentTitles, ["first", "second", "third"])
         XCTAssertEqual(builder.selectedSegmentIndex, 2)
         if #available(iOS 13.0, *) {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISliderRecorderTests.swift
@@ -5,7 +5,6 @@
  */
 
 import XCTest
-@testable import TestUtilities
 @testable import DatadogSessionReplay
 
 class UISliderRecorderTests: XCTestCase {
@@ -20,7 +19,6 @@ class UISliderRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: slider, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
     }
 
     func testWhenSliderIsVisible() throws {
@@ -35,9 +33,9 @@ class UISliderRecorderTests: XCTestCase {
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: slider, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Slider's subtree should not be recorded")
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore, "Slider's subtree should not be recorded")
 
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UISliderWireframesBuilder)
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UISliderWireframesBuilder)
         XCTAssertEqual(builder.attributes, viewAttributes)
         XCTAssertEqual(builder.isEnabled, slider.isEnabled)
         XCTAssertEqual(builder.thumbTintColor, slider.thumbTintColor?.cgColor)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISwitchRecorderTests.swift
@@ -5,7 +5,6 @@
  */
 
 import XCTest
-@testable import TestUtilities
 @testable import DatadogSessionReplay
 
 class UISwitchRecorderTests: XCTestCase {
@@ -22,7 +21,6 @@ class UISwitchRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: `switch`, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
     }
 
     func testWhenSwitchIsVisible() throws {
@@ -36,10 +34,11 @@ class UISwitchRecorderTests: XCTestCase {
         viewAttributes = .mock(fixture: .visible())
 
         // Then
-        let semantics = try XCTUnwrap(recorder.semantics(of: `switch`, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "Switch's subtree should not be recorded")
+        let semantics = try XCTUnwrap(recorder.semantics(of: `switch`, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore, "Switch's subtree should not be recorded")
 
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UISwitchWireframesBuilder)
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UISwitchWireframesBuilder)
         XCTAssertEqual(builder.attributes, viewAttributes)
         XCTAssertEqual(builder.isOn, `switch`.isOn)
         XCTAssertEqual(builder.thumbTintColor, `switch`.thumbTintColor?.cgColor)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITabBarRecorderTests.swift
@@ -6,21 +6,20 @@
 
 import XCTest
 @testable import DatadogSessionReplay
-import TestUtilities
 
 class UITabBarRecorderTests: XCTestCase {
     private let recorder = UITabBarRecorder()
 
     func testWhenViewIsOfExpectedType() throws {
-        // Given
+        // When
         let tabBar = UITabBar.mock(withFixture: .allCases.randomElement()!)
         let viewAttributes = ViewAttributes(frameInRootView: tabBar.frame, view: tabBar)
 
-        // When
-        let semantics = try XCTUnwrap(recorder.semantics(of: tabBar, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-
         // Then
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "TabBar's subtree should not be recorded")
+        let semantics = try XCTUnwrap(recorder.semantics(of: tabBar, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .record)
+        XCTAssertTrue(semantics.nodes.first?.wireframesBuilder is UITabBarWireframesBuilder)
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -6,7 +6,6 @@
 
 import XCTest
 @testable import DatadogSessionReplay
-@testable import TestUtilities
 
 // swiftlint:disable opening_brace
 class UITextFieldRecorderTests: XCTestCase {
@@ -23,7 +22,6 @@ class UITextFieldRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
     }
 
     func testWhenTextFieldHasText() throws {
@@ -47,34 +45,47 @@ class UITextFieldRecorderTests: XCTestCase {
                 self.textField.placeholder = .mockRandom()
             },
         ])
-        viewAttributes = .mock(fixture: .visible())
-        textField.layoutSubviews() // force layout (so TF creates its sub-tree)
+        viewAttributes = .mock(fixture: .visible(.someAppearance))
 
         // Then
-        let semantics = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .ignore, "TextField's subtree should not be recorded")
+        let semantics = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore)
 
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UITextFieldWireframesBuilder)
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UITextFieldWireframesBuilder)
         XCTAssertEqual(builder.text, randomText)
         XCTAssertEqual(builder.textColor, textField.textColor?.cgColor)
         XCTAssertEqual(builder.font, textField.font)
-        XCTAssertNotNil(builder.editor)
     }
 
     func testWhenRecordingInDifferentPrivacyModes() throws {
         // Given
-        textField.text = .mockRandom()
+        let textField1 = UITextField(frame: .mockAny())
+        let textField2 = UITextField(frame: .mockAny())
+        let textField3 = UITextField(frame: .mockAny())
+        textField1.text = .mockRandom()
+        textField2.text = .mockRandom()
+        textField3.text = .mockRandom()
+
+        textField2.isSecureTextEntry = true
+        textField3.textContentType = [.telephoneNumber, .emailAddress].randomElement()!
 
         // When
         viewAttributes = .mock(fixture: .visible())
-        let semantics1 = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .maskAll))))
-        let semantics2 = try XCTUnwrap(recorder.semantics(of: textField, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .allowAll))))
+        let semantics1 = try XCTUnwrap(recorder.semantics(of: textField1, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .maskAll))))
+        let semantics2 = try XCTUnwrap(recorder.semantics(of: textField1, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .allowAll))))
+        let semantics3 = try XCTUnwrap(recorder.semantics(of: textField2, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .mockRandom()))))
+        let semantics4 = try XCTUnwrap(recorder.semantics(of: textField3, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .mockRandom()))))
 
         // Then
-        let builder1 = try XCTUnwrap(semantics1.wireframesBuilder as? UITextFieldWireframesBuilder)
-        let builder2 = try XCTUnwrap(semantics2.wireframesBuilder as? UITextFieldWireframesBuilder)
+        let builder1 = try XCTUnwrap(semantics1.nodes.first?.wireframesBuilder as? UITextFieldWireframesBuilder)
+        let builder2 = try XCTUnwrap(semantics2.nodes.first?.wireframesBuilder as? UITextFieldWireframesBuilder)
+        let builder3 = try XCTUnwrap(semantics3.nodes.first?.wireframesBuilder as? UITextFieldWireframesBuilder)
+        let builder4 = try XCTUnwrap(semantics4.nodes.first?.wireframesBuilder as? UITextFieldWireframesBuilder)
         XCTAssertTrue(builder1.textObfuscator is TextObfuscator, "With `.maskAll` privacy the text obfuscator should be used")
         XCTAssertTrue(builder2.textObfuscator is NOPTextObfuscator, "With `.allowAll` privacy the text obfuscator should not be used")
+        XCTAssertTrue(builder3.textObfuscator is InputTextObfuscator, "When `TextField` accepts secure text entry, it should use `InputTextObfuscator`")
+        XCTAssertTrue(builder4.textObfuscator is InputTextObfuscator, "When `TextField` accepts email or tlephone no. entry, it should use `InputTextObfuscator`")
     }
 
     func testWhenViewIsNotOfExpectedType() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -23,7 +23,6 @@ class UITextViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: textView, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
     }
 
     func testWhenTextViewHasText() throws {
@@ -39,10 +38,11 @@ class UITextViewRecorderTests: XCTestCase {
         viewAttributes = .mock(fixture: .visible())
 
         // Then
-        let semantics = try XCTUnwrap(recorder.semantics(of: textView, with: viewAttributes, in: .mockAny()) as? SpecificElement)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .record, "TextView's subtree should not be recorded")
+        let semantics = try XCTUnwrap(recorder.semantics(of: textView, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .record)
 
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UITextViewWireframesBuilder)
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UITextViewWireframesBuilder)
         XCTAssertEqual(builder.text, randomText)
         XCTAssertEqual(builder.textColor, textView.textColor?.cgColor)
         XCTAssertEqual(builder.font, textView.font)
@@ -58,8 +58,8 @@ class UITextViewRecorderTests: XCTestCase {
         let semantics2 = try XCTUnwrap(recorder.semantics(of: textView, with: viewAttributes, in: .mockWith(recorder: .mockWith(privacy: .allowAll))))
 
         // Then
-        let builder1 = try XCTUnwrap(semantics1.wireframesBuilder as? UITextViewWireframesBuilder)
-        let builder2 = try XCTUnwrap(semantics2.wireframesBuilder as? UITextViewWireframesBuilder)
+        let builder1 = try XCTUnwrap(semantics1.nodes.first?.wireframesBuilder as? UITextViewWireframesBuilder)
+        let builder2 = try XCTUnwrap(semantics2.nodes.first?.wireframesBuilder as? UITextViewWireframesBuilder)
         XCTAssertTrue(builder1.textObfuscator is TextObfuscator, "With `.maskAll` privacy the text obfuscator should be used")
         XCTAssertTrue(builder2.textObfuscator is NOPTextObfuscator, "With `.allowAll` privacy the text obfuscator should not be used")
     }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -5,7 +5,6 @@
  */
 
 import XCTest
-import TestUtilities
 @testable import DatadogSessionReplay
 
 class UIViewRecorderTests: XCTestCase {
@@ -22,19 +21,16 @@ class UIViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
     }
 
-    func testWhenViewIsVisible() throws {
+    func testWhenViewIsVisibleAndHasSomeAppearance() throws {
         // When
-        viewAttributes = .mock(fixture: .visible())
+        viewAttributes = .mock(fixture: .visible(.someAppearance))
 
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is AmbiguousElement)
-
-        let builder = try XCTUnwrap(semantics.wireframesBuilder as? UIViewWireframesBuilder)
-        XCTAssertEqual(builder.attributes, viewAttributes)
+        XCTAssertTrue(semantics.nodes.first?.wireframesBuilder is UIViewWireframesBuilder)
     }
 
     func testWhenViewIsVisibleButHasNoAppearance() throws {
@@ -44,7 +40,6 @@ class UIViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is InvisibleElement)
-        XCTAssertNil(semantics.wireframesBuilder)
-        DDAssertReflectionEqual(semantics.subtreeStrategy, .record)
+        XCTAssertEqual(semantics.subtreeStrategy, .record)
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -140,8 +140,8 @@ class NodeSemanticsTests: XCTestCase {
     func testImportance() {
         let unknownElement = UnknownElement.constant
         let invisibleElement = InvisibleElement.constant
-        let ambiguousElement = AmbiguousElement(wireframesBuilder: nil)
-        let specificElement = SpecificElement(wireframesBuilder: nil, subtreeStrategy: .mockAny())
+        let ambiguousElement = AmbiguousElement(nodes: [])
+        let specificElement = SpecificElement(subtreeStrategy: .mockAny(), nodes: [])
 
         XCTAssertGreaterThan(
             specificElement.importance,
@@ -174,13 +174,5 @@ class NodeSemanticsTests: XCTestCase {
             .ignore,
             "Subtree should not be recorded for 'invisible' elements as nothing in it will be visible anyway"
         )
-        DDAssertReflectionEqual(
-            AmbiguousElement(wireframesBuilder: nil).subtreeStrategy,
-            .record,
-            "Subtree should be recorded for 'ambiguous' elements as it may contain other elements"
-        )
-
-        let random: NodeSubtreeStrategy = .mockRandom()
-        DDAssertReflectionEqual(SpecificElement(wireframesBuilder: nil, subtreeStrategy: random).subtreeStrategy, random)
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR enhances the recording of `UITextField` elements in session replay. Its preliminary support was introduced earlier, but here we solve remaining glitches, improve PIIs masking and adjust colors for light and dark mode.

On PIIs masking - following the [SR Privacy Restrictions](https://docs.datadoghq.com/real_user_monitoring/session_replay/privacy_options#privacy-restrictions) now we replace passwords, e-mails and phone numbers with `"xxx"`.

<table>
<tr><td>With no masking:</td><td>With masking:</td></tr>
<tr>
   <td><img src="https://user-images.githubusercontent.com/2358722/222736217-27b25622-9dbb-41de-b71d-af9a59fbd420.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/222736213-5541e8f9-5f9c-4532-ab3d-a6e051ab9df6.png" /></td>
</tr>
<tr>
   <td><img src="https://user-images.githubusercontent.com/2358722/222736201-e7622a55-7920-4d94-8ea5-8af5a7c9aecf.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/222736190-ad2582a9-ece0-49f2-ac0b-ebb6a0b76c59.png" /></td>
</tr>
</table>

### How?

The work done to `UITextFieldRecorder` leverages concepts introduced earlier in https://github.com/DataDog/dd-sdk-ios/pull/1175.

Unfortunately, the `subtreeStrategy: .replace(subtreeNodes:)` turned out to be limiting for text fields situation. Although we now use sub-recorders in `UITextFieldRecorder`:
```swift
/// `UIViewRecorder` for recording appearance of the text field.
private let backgroundViewRecorder: UIViewRecorder
/// `UIImageViewRecorder` for recording icons that are displayed in text field.
private let iconsRecorder: UIImageViewRecorder
```
the actual "text" information isn't available anywhere in TF's subtree. Instead, it is accessible through the root node (`textField.text`) and we can't use the strategy of replacing subtree nodes to replace the root one.

For that reason, I had to do one more iteration on `.subtreeStrategy` concept. What turns out to be sustainable (I made a PoC proving it to work for remaining Input Elements) is changing 1:1 relationship between a `Node` and `NodeSemantics`:
```diff
- node.semantics = <single semantics>
```
into 1:N relationship between `NodeSemantics` and `Node`:
```diff
+ semantics.nodes = <an array of nodes>
```

This works fine for text fields, as now the `UITextFieldRecorder` can return 2 nodes:
```swift
SpecificElementSemantics(nodes: [backgroundNode, textNode])
```

It doesn't change anything to other recorders, although I had to update their unit tests.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
