### PR TITLE
Allow `Any` Feature Baggage

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -4041,11 +4041,11 @@
 			isa = PBXGroup;
 			children = (
 				D23039C4298D5235001A1FA3 /* AnyEncoder.swift */,
-				D23039C5298D5235001A1FA3 /* AnyDecodable.swift */,
 				D23039C6298D5235001A1FA3 /* AnyDecoder.swift */,
 				D23039C7298D5235001A1FA3 /* DynamicCodingKey.swift */,
 				D23039C8298D5235001A1FA3 /* AnyCodable.swift */,
 				D23039C9298D5235001A1FA3 /* AnyEncodable.swift */,
+				D23039C5298D5235001A1FA3 /* AnyDecodable.swift */,
 			);
 			path = Codable;
 			sourceTree = "<group>";
@@ -4290,6 +4290,7 @@
 		D2A783D829A530DC003B03BB /* MessageBus */ = {
 			isa = PBXGroup;
 			children = (
+				D2DA239F298D58F300C6C7E6 /* FeatureBaggageTests.swift */,
 				D2DA23A0298D58F400C6C7E6 /* FeatureMessageReceiverTests.swift */,
 			);
 			path = MessageBus;
@@ -4353,7 +4354,6 @@
 			children = (
 				D2DA239D298D58F300C6C7E6 /* AppStateHistoryTests.swift */,
 				D2DA239E298D58F300C6C7E6 /* DeviceInfoTests.swift */,
-				D2DA239F298D58F300C6C7E6 /* FeatureBaggageTests.swift */,
 			);
 			path = Context;
 			sourceTree = "<group>";

--- a/DatadogInternal/Sources/Codable/AnyEncoder.swift
+++ b/DatadogInternal/Sources/Codable/AnyEncoder.swift
@@ -665,7 +665,7 @@ private class _AnyEncoder: Encoder {
 ///
 /// Making an `Encodable` as shared allow to bypass encoding when the type is
 /// known by multiple parties.
-internal protocol DictionaryEncodable: Encodable { }
+public protocol DictionaryEncodable { }
 
 extension URL: DictionaryEncodable { }
 extension Date: DictionaryEncodable { }

--- a/DatadogInternal/Tests/MessageBus/FeatureBaggageTests.swift
+++ b/DatadogInternal/Tests/MessageBus/FeatureBaggageTests.swift
@@ -5,11 +5,19 @@
  */
 
 import XCTest
-import DatadogInternal
+@testable import DatadogInternal
 
 class FeatureBaggageTests: XCTestCase {
     private enum EnumAttribute: String, Codable {
         case test
+    }
+
+    struct SomeEncodable: Encodable {
+        var string: String
+    }
+
+    struct SomeDecodable: Decodable {
+        var string: String
     }
 
     let attributes: FeatureBaggage = [
@@ -45,5 +53,39 @@ class FeatureBaggageTests: XCTestCase {
 
         attributes.int = 2
         XCTAssertEqual(attributes.int, 2)
+    }
+
+    func testSetDecodable() {
+        let value = SomeEncodable(string: "test")
+        let baggage = FeatureBaggage(["key": value])
+
+        var decodable: SomeDecodable? = baggage["key"]
+        XCTAssertEqual(decodable?.string, "test")
+
+        decodable = baggage.key
+        XCTAssertEqual(decodable?.string, "test")
+    }
+
+    func testDecodableBaggage() {
+        let baggage = FeatureBaggage([
+            "key": ["string": "test" as Any]
+        ])
+
+        var decodable: SomeDecodable? = baggage["key"]
+        XCTAssertEqual(decodable?.string, "test")
+
+        decodable = baggage.key
+        XCTAssertEqual(decodable?.string, "test")
+    }
+
+    func testAnyBaggage() {
+        let value = SomeEncodable(string: "test")
+        let baggage = FeatureBaggage(["key": value])
+
+        var decodable: [String: Any]? = baggage["key"]
+        XCTAssertEqual(decodable?["string"] as? String, "test")
+
+        decodable = baggage.key
+        XCTAssertEqual(decodable?["string"] as? String, "test")
     }
 }

--- a/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
+++ b/DatadogInternal/Tests/MessageBus/FeatureMessageReceiverTests.swift
@@ -7,7 +7,6 @@
 import XCTest
 import DatadogInternal
 import TestUtilities
-@testable import Datadog
 
 class FeatureMessageReceiverTests: XCTestCase {
     private var core: PassthroughCoreMock! // swiftlint:disable:this implicitly_unwrapped_optional


### PR DESCRIPTION
### What and why?

The `URLSessionInstrumentation` will require sharing `Foundation` types that are not `Codable` on the message-bus: `HTTPRequest`, `URLResponse`, `Error`, etc ...

The current implementation of `FeatureBaggage` only allow `Codable` which is too restrictive, we need more flexibility to share more types between Features.

### How?

Enable setting and getting `Any` types on the `FeatureBaggage`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
