### PR TITLE
REPLAY-1448 Add support for UIStepper

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -14,6 +14,7 @@ internal enum Fixture: CaseIterable {
     case pickers
     case switches
     case textFields
+    case steppers
 
     var menuItemTitle: String {
         switch self {
@@ -31,6 +32,8 @@ internal enum Fixture: CaseIterable {
             return "Switches"
         case .textFields:
             return "Text Fields"
+        case .steppers:
+            return "Steppers"
         }
     }
 
@@ -50,6 +53,8 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Switches")
         case .textFields:
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "TextFields")
+        case .textFields:
+            return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Steppers")
         }
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -53,7 +53,7 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Switches")
         case .textFields:
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "TextFields")
-        case .textFields:
+        case .steppers:
             return UIStoryboard.inputElements.instantiateViewController(withIdentifier: "Steppers")
         }
     }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
@@ -470,7 +470,7 @@
         <!--View Controller-->
         <scene sceneID="wvK-B5-W4A">
             <objects>
-                <viewController id="THO-zy-oY9" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Steppers" id="THO-zy-oY9" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Pdd-aH-q76">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/InputElements.storyboard
@@ -467,6 +467,82 @@
             </objects>
             <point key="canvasLocation" x="2689" y="32"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="wvK-B5-W4A">
+            <objects>
+                <viewController id="THO-zy-oY9" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Pdd-aH-q76">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="St0-h3-aHe">
+                                <rect key="frame" x="8" y="67" width="377" height="265.33333333333331"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Right Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SXX-XD-0Xa">
+                                        <rect key="frame" x="0.0" y="0.0" width="377" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="9sT-pk-4or">
+                                        <rect key="frame" x="0.0" y="28.333333333333329" width="377" height="32"/>
+                                    </stepper>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Left Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gnd-Cl-hQg">
+                                        <rect key="frame" x="0.0" y="68.333333333333343" width="377" height="20.333333333333329"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" maximumValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="ADD-Eh-qaV">
+                                        <rect key="frame" x="0.0" y="96.666666666666657" width="377" height="32"/>
+                                    </stepper>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Both Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L3Q-TO-dtN">
+                                        <rect key="frame" x="0.0" y="136.66666666666666" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" maximumValue="11" translatesAutoresizingMaskIntoConstraints="NO" id="vfV-UE-h3A">
+                                        <rect key="frame" x="0.0" y="165" width="377" height="32"/>
+                                    </stepper>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Both Disabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ihl-RG-xzx">
+                                        <rect key="frame" x="0.0" y="205" width="377" height="20.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="Q0b-6w-boU">
+                                        <rect key="frame" x="0.0" y="233.33333333333331" width="377" height="32"/>
+                                    </stepper>
+                                </subviews>
+                            </stackView>
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="6oQ-Gf-GXb">
+                                <rect key="frame" x="149.66666666666666" y="396.33333333333331" width="94" height="32"/>
+                            </stepper>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Outside of stack view:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W12-r3-40u">
+                                <rect key="frame" x="112.66666666666669" y="367" width="168" height="20.333333333333314"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="4fy-ha-2IE"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="6oQ-Gf-GXb" firstAttribute="top" secondItem="St0-h3-aHe" secondAttribute="bottom" constant="64" id="CTb-kF-AMF"/>
+                            <constraint firstItem="4fy-ha-2IE" firstAttribute="trailing" secondItem="St0-h3-aHe" secondAttribute="trailing" constant="8" id="EnP-Vo-AFm"/>
+                            <constraint firstItem="6oQ-Gf-GXb" firstAttribute="top" secondItem="W12-r3-40u" secondAttribute="bottom" constant="8.9999999999999432" id="Q0F-qn-HDk"/>
+                            <constraint firstItem="St0-h3-aHe" firstAttribute="top" secondItem="4fy-ha-2IE" secondAttribute="top" constant="8" id="XUH-7Z-iW7"/>
+                            <constraint firstItem="6oQ-Gf-GXb" firstAttribute="centerX" secondItem="4fy-ha-2IE" secondAttribute="centerX" id="cdY-87-IfA"/>
+                            <constraint firstItem="St0-h3-aHe" firstAttribute="leading" secondItem="4fy-ha-2IE" secondAttribute="leading" constant="8" id="diy-hT-7Fa"/>
+                            <constraint firstItem="W12-r3-40u" firstAttribute="centerX" secondItem="6oQ-Gf-GXb" secondAttribute="centerX" id="oed-07-Bh4"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="kah-t2-Kq8" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1063" y="675"/>
+        </scene>
     </scenes>
     <resources>
         <image name="cloud.fill" catalog="system" width="128" height="87"/>

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -126,7 +126,7 @@ final class SRSnapshotTests: SnapshotTestCase {
     }
 
     func testSteppers() throws {
-        show(fixture: .switches)
+        show(fixture: .steppers)
 
         var image = try takeSnapshot(configuration: .init(privacy: .allowAll))
         DDAssertSnapshotTest(

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -124,4 +124,22 @@ final class SRSnapshotTests: SnapshotTestCase {
             record: recordingMode
         )
     }
+
+    func testSteppers() throws {
+        show(fixture: .switches)
+
+        var image = try takeSnapshot(configuration: .init(privacy: .allowAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
+            record: recordingMode
+        )
+
+        image = try takeSnapshot(configuration: .init(privacy: .maskAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-maskAll-privacy"),
+            record: recordingMode
+        )
+    }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -47,56 +47,43 @@ internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
             backgroundColor: SystemColors.tertiarySystemFill,
             cornerRadius: cornerRadius
         )
+        let verticalMargin: CGFloat = 6
         let divider = builder.createShapeWireframe(
             id: ids[1],
             frame: CGRect(
-                origin: CGPoint(x: wireframeRect.origin.x + wireframeRect.size.width / 2, y: wireframeRect.origin.y + 6),
-                size: CGSize(width: 1, height: 20)
-            ),
+                origin: CGPoint(x: 0, y: verticalMargin),
+                size: CGSize(width: 1, height: wireframeRect.size.height - 2 * verticalMargin)
+            ).putInside(wireframeRect, horizontalAlignment: .center, verticalAlignment: .middle),
             backgroundColor: SystemColors.placeholderText
         )
 
-
-        let horizontalElementSize = CGSize(width: 15, height: 1.5)
-        let verticalElementSize = CGSize(width: 1.5, height: 15)
-        let horizontalLeftOffset: CGFloat = wireframeRect.size.width / 4 - horizontalElementSize.width / 2
-        let verticalLeftOffset: CGFloat = horizontalLeftOffset + horizontalElementSize.width / 2 - verticalElementSize.width / 2
-
+        let horizontalElementRect = CGRect(origin: .zero, size: CGSize(width: 14, height: 2))
+        let verticalElementRect = CGRect(origin: .zero, size: CGSize(width: 2, height: 14))
+        let leftButtonFrame = CGRect(
+            origin: wireframeRect.origin,
+            size: CGSize(width: wireframeRect.size.width / 2, height: wireframeRect.size.height)
+        )
+        let rightButtonFrame = CGRect(
+            origin: CGPoint(x: wireframeRect.origin.x + wireframeRect.size.width / 2, y: wireframeRect.origin.y),
+            size: CGSize(width: wireframeRect.size.width / 2, height: wireframeRect.size.height)
+        )
         let minus = builder.createShapeWireframe(
             id: ids[2],
-            frame: CGRect(
-                origin: CGPoint(
-                    x: wireframeRect.origin.x + horizontalLeftOffset,
-                    y: wireframeRect.origin.y + wireframeRect.height / 2 - horizontalElementSize.height
-                ),
-                size: horizontalElementSize
-            ),
+            frame: horizontalElementRect.putInside(leftButtonFrame, horizontalAlignment: .center, verticalAlignment: .middle),
             backgroundColor: isMinusEnabled ? SystemColors.label : SystemColors.placeholderText,
-            cornerRadius: horizontalElementSize.height
+            cornerRadius: horizontalElementRect.size.height
         )
         let plusHorizontal = builder.createShapeWireframe(
             id: ids[3],
-            frame: CGRect(
-                origin: CGPoint(
-                    x: wireframeRect.origin.x + wireframeRect.width / 2 + horizontalLeftOffset - 0.5,
-                    y: wireframeRect.origin.y + wireframeRect.height / 2 - horizontalElementSize.height
-                ),
-                size: horizontalElementSize
-            ),
+            frame: horizontalElementRect.putInside(rightButtonFrame, horizontalAlignment: .center, verticalAlignment: .middle),
             backgroundColor: isPlusEnabled ? SystemColors.label : SystemColors.placeholderText,
-            cornerRadius: horizontalElementSize.height
+            cornerRadius: horizontalElementRect.size.height
         )
         let plusVertical = builder.createShapeWireframe(
             id: ids[4],
-            frame: CGRect(
-                origin: CGPoint(
-                    x: wireframeRect.origin.x + wireframeRect.width / 2 + verticalLeftOffset,
-                    y: wireframeRect.origin.y + wireframeRect.height / 2 - verticalElementSize.height / 2 + 0.5
-                ),
-                size: verticalElementSize
-            ),
+            frame: verticalElementRect.putInside(rightButtonFrame, horizontalAlignment: .center, verticalAlignment: .middle),
             backgroundColor: isPlusEnabled ? SystemColors.label : SystemColors.placeholderText,
-            cornerRadius: verticalElementSize.width
+            cornerRadius: verticalElementRect.size.width
         )
         return [background, divider, minus, plusHorizontal, plusVertical]
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -22,7 +22,9 @@ internal struct UIStepperRecorder: NodeRecorder {
         let builder = UIStepperWireframesBuilder(
             wireframeRect: stepperFrame,
             cornerRadius: stepper.subviews.first?.layer.cornerRadius ?? 0,
-            ids: ids
+            ids: ids,
+            isMinusEnabled: stepper.value > stepper.minimumValue,
+            isPlusEnabled: stepper.value < stepper.maximumValue
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
         return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
@@ -30,9 +32,11 @@ internal struct UIStepperRecorder: NodeRecorder {
 }
 
 internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
-    var wireframeRect: CGRect
-    var cornerRadius: CGFloat
-    var ids: [Int64]
+    let wireframeRect: CGRect
+    let cornerRadius: CGFloat
+    let ids: [Int64]
+    let isMinusEnabled: Bool
+    let isPlusEnabled: Bool
 
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
         let background = builder.createShapeWireframe(
@@ -40,7 +44,7 @@ internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
             frame: wireframeRect,
             borderColor: nil,
             borderWidth: nil,
-            backgroundColor: SystemColors.tertiarySystemBackground,
+            backgroundColor: SystemColors.tertiarySystemFill,
             cornerRadius: cornerRadius
         )
         let divider = builder.createShapeWireframe(
@@ -53,19 +57,19 @@ internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
         )
         let stepButtonFontSize = CGFloat(30)
         let stepButtonSize = CGSize(width: stepButtonFontSize, height: stepButtonFontSize)
-        let stepButtonLeftOffset = wireframeRect.width / 2 - stepButtonSize.width / 2
+        let stepButtonLeftOffset = wireframeRect.width / 4 - stepButtonSize.width / 4
         let minus = builder.createTextWireframe(
             id: ids[2],
             frame: CGRect(
                 origin: CGPoint(
-                    x: wireframeRect.origin.x + stepButtonLeftOffset,
+                    x: wireframeRect.origin.x + stepButtonLeftOffset - 3,
                     y: wireframeRect.origin.y
                 ),
                 size: stepButtonSize
             ),
-            text: "-",
-            textColor: SystemColors.label,
-            font: .systemFont(ofSize: stepButtonFontSize)
+            text: "—",
+            textColor: isMinusEnabled ? SystemColors.label : SystemColors.placeholderText,
+            font: .systemFont(ofSize: 30)
         )
         let plus = builder.createTextWireframe(
             id: ids[3],
@@ -77,7 +81,7 @@ internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
                 size: stepButtonSize
             ),
             text: "+",
-            textColor: SystemColors.label,
+            textColor: isPlusEnabled ? SystemColors.label : SystemColors.placeholderText,
             font: .systemFont(ofSize: stepButtonFontSize)
         )
         return [background, divider, minus, plus]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+internal struct UIStepperRecorder: NodeRecorder {
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
+        guard let slider = view as? UISlider else {
+            return nil
+        }
+        
+        guard attributes.isVisible else {
+            return InvisibleElement.constant
+        }
+        let builder = UIStepperWireframesBuilder(wireframeRect: slider.frame)
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
+    }
+}
+
+internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
+    var wireframeRect: CGRect
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        return []
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -11,7 +11,6 @@ internal struct UIStepperRecorder: NodeRecorder {
         guard let stepper = view as? UIStepper else {
             return nil
         }
-        
         guard attributes.isVisible else {
             return InvisibleElement.constant
         }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -17,7 +17,7 @@ internal struct UIStepperRecorder: NodeRecorder {
         }
 
         let stepperFrame = CGRect(origin: attributes.frame.origin, size: stepper.intrinsicContentSize)
-        let ids = context.ids.nodeIDs(4, for: stepper)
+        let ids = context.ids.nodeIDs(5, for: stepper)
 
         let builder = UIStepperWireframesBuilder(
             wireframeRect: stepperFrame,
@@ -50,40 +50,54 @@ internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
         let divider = builder.createShapeWireframe(
             id: ids[1],
             frame: CGRect(
-                origin: CGPoint(x: wireframeRect.origin.x + 46.5, y: wireframeRect.origin.y + 6),
+                origin: CGPoint(x: wireframeRect.origin.x + wireframeRect.size.width / 2, y: wireframeRect.origin.y + 6),
                 size: CGSize(width: 1, height: 20)
             ),
             backgroundColor: SystemColors.placeholderText
         )
-        let stepButtonFontSize = CGFloat(30)
-        let stepButtonSize = CGSize(width: stepButtonFontSize, height: stepButtonFontSize)
-        let stepButtonLeftOffset = wireframeRect.width / 4 - stepButtonSize.width / 4
-        let minus = builder.createTextWireframe(
+
+
+        let horizontalElementSize = CGSize(width: 15, height: 1.5)
+        let verticalElementSize = CGSize(width: 1.5, height: 15)
+        let horizontalLeftOffset: CGFloat = wireframeRect.size.width / 4 - horizontalElementSize.width / 2
+        let verticalLeftOffset: CGFloat = horizontalLeftOffset + horizontalElementSize.width / 2 - verticalElementSize.width / 2
+
+        let minus = builder.createShapeWireframe(
             id: ids[2],
             frame: CGRect(
                 origin: CGPoint(
-                    x: wireframeRect.origin.x + stepButtonLeftOffset - 3,
-                    y: wireframeRect.origin.y
+                    x: wireframeRect.origin.x + horizontalLeftOffset,
+                    y: wireframeRect.origin.y + wireframeRect.height / 2 - horizontalElementSize.height
                 ),
-                size: stepButtonSize
+                size: horizontalElementSize
             ),
-            text: "—",
-            textColor: isMinusEnabled ? SystemColors.label : SystemColors.placeholderText,
-            font: .systemFont(ofSize: 30)
+            backgroundColor: isMinusEnabled ? SystemColors.label : SystemColors.placeholderText,
+            cornerRadius: horizontalElementSize.height
         )
-        let plus = builder.createTextWireframe(
+        let plusHorizontal = builder.createShapeWireframe(
             id: ids[3],
             frame: CGRect(
                 origin: CGPoint(
-                    x: wireframeRect.origin.x + wireframeRect.width / 2 + stepButtonLeftOffset,
-                    y: wireframeRect.origin.y
+                    x: wireframeRect.origin.x + wireframeRect.width / 2 + horizontalLeftOffset - 0.5,
+                    y: wireframeRect.origin.y + wireframeRect.height / 2 - horizontalElementSize.height
                 ),
-                size: stepButtonSize
+                size: horizontalElementSize
             ),
-            text: "+",
-            textColor: isPlusEnabled ? SystemColors.label : SystemColors.placeholderText,
-            font: .systemFont(ofSize: stepButtonFontSize)
+            backgroundColor: isPlusEnabled ? SystemColors.label : SystemColors.placeholderText,
+            cornerRadius: horizontalElementSize.height
         )
-        return [background, divider, minus, plus]
+        let plusVertical = builder.createShapeWireframe(
+            id: ids[4],
+            frame: CGRect(
+                origin: CGPoint(
+                    x: wireframeRect.origin.x + wireframeRect.width / 2 + verticalLeftOffset,
+                    y: wireframeRect.origin.y + wireframeRect.height / 2 - verticalElementSize.height / 2 + 0.5
+                ),
+                size: verticalElementSize
+            ),
+            backgroundColor: isPlusEnabled ? SystemColors.label : SystemColors.placeholderText,
+            cornerRadius: verticalElementSize.width
+        )
+        return [background, divider, minus, plusHorizontal, plusVertical]
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -8,14 +8,22 @@ import UIKit
 
 internal struct UIStepperRecorder: NodeRecorder {
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
-        guard let slider = view as? UISlider else {
+        guard let stepper = view as? UIStepper else {
             return nil
         }
         
         guard attributes.isVisible else {
             return InvisibleElement.constant
         }
-        let builder = UIStepperWireframesBuilder(wireframeRect: slider.frame)
+
+        let stepperFrame = CGRect(origin: attributes.frame.origin, size: stepper.intrinsicContentSize)
+        let ids = context.ids.nodeIDs(4, for: stepper)
+
+        let builder = UIStepperWireframesBuilder(
+            wireframeRect: stepperFrame,
+            cornerRadius: stepper.subviews.first?.layer.cornerRadius ?? 0,
+            ids: ids
+        )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
         return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
     }
@@ -23,8 +31,55 @@ internal struct UIStepperRecorder: NodeRecorder {
 
 internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
     var wireframeRect: CGRect
+    var cornerRadius: CGFloat
+    var ids: [Int64]
 
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
-        return []
+        let background = builder.createShapeWireframe(
+            id: ids[0],
+            frame: wireframeRect,
+            borderColor: nil,
+            borderWidth: nil,
+            backgroundColor: SystemColors.tertiarySystemBackground,
+            cornerRadius: cornerRadius
+        )
+        let divider = builder.createShapeWireframe(
+            id: ids[1],
+            frame: CGRect(
+                origin: CGPoint(x: wireframeRect.origin.x + 46.5, y: wireframeRect.origin.y + 6),
+                size: CGSize(width: 1, height: 20)
+            ),
+            backgroundColor: SystemColors.placeholderText
+        )
+        let stepButtonFontSize = CGFloat(30)
+        let stepButtonSize = CGSize(width: stepButtonFontSize, height: stepButtonFontSize)
+        let stepButtonLeftOffset = wireframeRect.width / 2 - stepButtonSize.width / 2
+        let minus = builder.createTextWireframe(
+            id: ids[2],
+            frame: CGRect(
+                origin: CGPoint(
+                    x: wireframeRect.origin.x + stepButtonLeftOffset,
+                    y: wireframeRect.origin.y
+                ),
+                size: stepButtonSize
+            ),
+            text: "-",
+            textColor: SystemColors.label,
+            font: .systemFont(ofSize: stepButtonFontSize)
+        )
+        let plus = builder.createTextWireframe(
+            id: ids[3],
+            frame: CGRect(
+                origin: CGPoint(
+                    x: wireframeRect.origin.x + wireframeRect.width / 2 + stepButtonLeftOffset,
+                    y: wireframeRect.origin.y
+                ),
+                size: stepButtonSize
+            ),
+            text: "+",
+            textColor: SystemColors.label,
+            font: .systemFont(ofSize: stepButtonFontSize)
+        )
+        return [background, divider, minus, plus]
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -21,7 +21,11 @@ internal struct UIStepperRecorder: NodeRecorder {
         let builder = UIStepperWireframesBuilder(
             wireframeRect: stepperFrame,
             cornerRadius: stepper.subviews.first?.layer.cornerRadius ?? 0,
-            ids: ids,
+            backgroundWireframeID: ids[0],
+            dividerWireframeID: ids[1],
+            minusWireframeID: ids[2],
+            plusHorizontalWireframeID: ids[3],
+            plusVerticalWireframeID: ids[4],
             isMinusEnabled: stepper.value > stepper.minimumValue,
             isPlusEnabled: stepper.value < stepper.maximumValue
         )
@@ -33,13 +37,17 @@ internal struct UIStepperRecorder: NodeRecorder {
 internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
     let wireframeRect: CGRect
     let cornerRadius: CGFloat
-    let ids: [Int64]
+    let backgroundWireframeID: WireframeID
+    let dividerWireframeID: WireframeID
+    let minusWireframeID: WireframeID
+    let plusHorizontalWireframeID: WireframeID
+    let plusVerticalWireframeID: WireframeID
     let isMinusEnabled: Bool
     let isPlusEnabled: Bool
 
     func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
         let background = builder.createShapeWireframe(
-            id: ids[0],
+            id: backgroundWireframeID,
             frame: wireframeRect,
             borderColor: nil,
             borderWidth: nil,
@@ -48,7 +56,7 @@ internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
         )
         let verticalMargin: CGFloat = 6
         let divider = builder.createShapeWireframe(
-            id: ids[1],
+            id: dividerWireframeID,
             frame: CGRect(
                 origin: CGPoint(x: 0, y: verticalMargin),
                 size: CGSize(width: 1, height: wireframeRect.size.height - 2 * verticalMargin)
@@ -58,28 +66,21 @@ internal struct UIStepperWireframesBuilder: NodeWireframesBuilder {
 
         let horizontalElementRect = CGRect(origin: .zero, size: CGSize(width: 14, height: 2))
         let verticalElementRect = CGRect(origin: .zero, size: CGSize(width: 2, height: 14))
-        let leftButtonFrame = CGRect(
-            origin: wireframeRect.origin,
-            size: CGSize(width: wireframeRect.size.width / 2, height: wireframeRect.size.height)
-        )
-        let rightButtonFrame = CGRect(
-            origin: CGPoint(x: wireframeRect.origin.x + wireframeRect.size.width / 2, y: wireframeRect.origin.y),
-            size: CGSize(width: wireframeRect.size.width / 2, height: wireframeRect.size.height)
-        )
+        let (leftButtonFrame, rightButtonFrame) = wireframeRect.divided(atDistance: wireframeRect.size.width / 2, from: .minXEdge)
         let minus = builder.createShapeWireframe(
-            id: ids[2],
+            id: minusWireframeID,
             frame: horizontalElementRect.putInside(leftButtonFrame, horizontalAlignment: .center, verticalAlignment: .middle),
             backgroundColor: isMinusEnabled ? SystemColors.label : SystemColors.placeholderText,
             cornerRadius: horizontalElementRect.size.height
         )
         let plusHorizontal = builder.createShapeWireframe(
-            id: ids[3],
+            id: plusHorizontalWireframeID,
             frame: horizontalElementRect.putInside(rightButtonFrame, horizontalAlignment: .center, verticalAlignment: .middle),
             backgroundColor: isPlusEnabled ? SystemColors.label : SystemColors.placeholderText,
             cornerRadius: horizontalElementRect.size.height
         )
         let plusVertical = builder.createShapeWireframe(
-            id: ids[4],
+            id: plusVerticalWireframeID,
             frame: verticalElementRect.putInside(rightButtonFrame, horizontalAlignment: .center, verticalAlignment: .middle),
             backgroundColor: isPlusEnabled ? SystemColors.label : SystemColors.placeholderText,
             cornerRadius: verticalElementRect.size.width

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -62,6 +62,7 @@ internal let defaultNodeRecorders: [NodeRecorder] = [
     UISwitchRecorder(),
     UISliderRecorder(),
     UISegmentRecorder(),
+    UIStepperRecorder(),
     UINavigationBarRecorder(),
     UITabBarRecorder(),
     UIPickerViewRecorder(),

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorderTests.swift
@@ -1,0 +1,47 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class UIStepperRecorderTests: XCTestCase {
+    private let recorder = UIStepperRecorder()
+    private let stepper = UIStepper()
+    /// `ViewAttributes` simulating common attributes of switch's `UIView`.
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenStepperIsNotVisible() throws {
+        // When
+        viewAttributes = .mock(fixture: .invisible)
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: stepper, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is InvisibleElement)
+    }
+
+    func testWhenStepperIsVisible() throws {
+        // Given
+        stepper.tintColor = .mockRandom()
+
+        // When
+        viewAttributes = .mock(fixture: .visible())
+
+        // Then
+        let semantics = try XCTUnwrap(recorder.semantics(of: stepper, with: viewAttributes, in: .mockAny()))
+        XCTAssertTrue(semantics is SpecificElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore, "Stepper's subtree should not be recorded")
+
+        let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UIStepperWireframesBuilder)
+    }
+
+    func testWhenViewIsNotOfExpectedType() {
+        // When
+        let view = UITextField()
+
+        // Then
+        XCTAssertNil(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR enhances the recording of `UIStepper` elements in session replay. Its preliminary support was introduced earlier, but here we solve remaining glitches and send frames instead of images for button + and - button icons.

### How?

By adding new recorder for `UIStepper` element that checks it's frame and creates matching wireframes.

![testSteppers()-allowAll-privacy](https://user-images.githubusercontent.com/6953112/223712950-43f98e0a-fdbb-43d7-8a0b-6a652394c7a3.png)
![testSteppers()-allowAll-privacy](https://user-images.githubusercontent.com/6953112/223713758-2049eef6-3b7c-46bc-95d1-80c9b48ca203.png)

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
