### PR TITLE
Remove span baggage queue

### DIFF
--- a/Sources/Datadog/Tracer.swift
+++ b/Sources/Datadog/Tracer.swift
@@ -175,13 +175,11 @@ public class Tracer: OTTracer {
     }
 
     public func extract(reader: OTFormatReader) -> OTSpanContext? {
-        // TODO: RUMM-385 - make `HTTPHeadersReader` available in public API
-        if let reader = reader as? TracePropagationHeadersExtractor {
-            reader.use(baggageItemQueue: queue)
-            return reader.extract()
-        } else {
+        guard let reader = reader as? TracePropagationHeadersExtractor else {
             return nil
         }
+
+        return reader.extract()
     }
 
     public var activeSpan: OTSpan? {
@@ -195,7 +193,7 @@ public class Tracer: OTTracer {
             traceID: parentSpanContext?.traceID ?? tracingUUIDGenerator.generateUnique(),
             spanID: tracingUUIDGenerator.generateUnique(),
             parentSpanID: parentSpanContext?.spanID,
-            baggageItems: BaggageItems(targetQueue: queue, parentSpanItems: parentSpanContext?.baggageItems)
+            baggageItems: BaggageItems(parent: parentSpanContext?.baggageItems)
         )
     }
 

--- a/Sources/Datadog/Tracing/DDSpan.swift
+++ b/Sources/Datadog/Tracing/DDSpan.swift
@@ -81,17 +81,21 @@ internal class DDSpan: OTSpan {
     }
 
     func setBaggageItem(key: String, value: String) {
-        let isFinished = queue.sync { self.warnIfFinished("setBaggageItem(key:value:)") }
-        if !isFinished {
-            // Baggage items must be accessed outside the `tracer.queue` as it uses that queue for internal sync.
+        queue.sync {
+            if self.warnIfFinished("setBaggageItem(key:value:)") {
+                return
+            }
             ddContext.baggageItems.set(key: key, value: value)
         }
     }
 
     func baggageItem(withKey key: String) -> String? {
-        let isFinished = queue.sync { self.warnIfFinished("baggageItem(withKey:)") }
-        // Baggage items must be accessed outside the `tracer.queue` as it uses that queue for internal sync.
-        return !isFinished ? ddContext.baggageItems.get(key: key) : nil
+        queue.sync {
+            if self.warnIfFinished("baggageItem(withKey:)") {
+                return nil
+            }
+            return ddContext.baggageItems.get(key: key)
+        }
     }
 
     @discardableResult

--- a/Sources/Datadog/Tracing/DDSpanContext.swift
+++ b/Sources/Datadog/Tracing/DDSpanContext.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import DatadogInternal
 
 internal struct DDSpanContext: OTSpanContext {
     /// This span's trace ID.
@@ -31,41 +32,30 @@ internal struct DDSpanContext: OTSpanContext {
 /// unidirectional and recursive, so the grandchild of a span `A` will contain the `A's` baggage items,
 /// but `A` won't contain items of its descendants.
 internal class BaggageItems {
-    /// Queue used to synchronize `unsafeItems` access.
-    private let queue: DispatchQueue
     /// Baggage items of the parent `DDSpan` or`nil` for items of the root span.
     private let parent: BaggageItems?
 
-    /// Unsynchronized baggage items dictionary. Use `queue` to synchronize the access.
-    private var unsafeItems: [String: String] = [:]
+    /// Baggage items dictionary. This property uses a read-write lock.
+    @ReadWriteLock
+    private var items: [String: String] = [:]
 
-    init(targetQueue: DispatchQueue, parentSpanItems: BaggageItems?) {
-        self.queue = DispatchQueue(label: "com.datadoghq.BaggageItem", target: targetQueue)
-        self.parent = parentSpanItems
+    init(parent: BaggageItems? = nil) {
+        self.parent = parent
     }
 
     func set(key: String, value: String) {
-        queue.async { self.unsafeItems[key] = value }
+        items[key] = value
     }
 
     func get(key: String) -> String? {
-        queue.sync { self.unsafeAll[key] }
-    }
-
-    var all: [String: String] {
-        queue.sync { self.unsafeAll }
+        all[key]
     }
 
     /// Returns all baggage items for the span, including its parent items.
-    /// This property is unsafe and should be accessed using `queue`.
-    private var unsafeAll: [String: String] {
-        let parentItems = parent?.unsafeAll ?? [:]
-        let selfItems = unsafeItems
-
-        let allItems = parentItems.merging(selfItems) { _, selfItem -> String in
-            return selfItem
+    var all: [String: String] {
+        guard let parent = parent?.all else {
+            return items
         }
-
-        return allItems
+        return parent.merging(items) { $1 }
     }
 }

--- a/Sources/Datadog/Tracing/Propagation/OpenTelemetry/OTelHTTPHeadersReader.swift
+++ b/Sources/Datadog/Tracing/Propagation/OpenTelemetry/OTelHTTPHeadersReader.swift
@@ -8,21 +8,12 @@ import Foundation
 
 internal class OTelHTTPHeadersReader: OTHTTPHeadersReader, TracePropagationHeadersExtractor {
     private let httpHeaderFields: [String: String]
-    private var baggageItemQueue: DispatchQueue?
 
     init(httpHeaderFields: [String: String]) {
         self.httpHeaderFields = httpHeaderFields
     }
 
-    func use(baggageItemQueue: DispatchQueue) {
-        self.baggageItemQueue = baggageItemQueue
-    }
-
     func extract() -> OTSpanContext? {
-        guard let baggageItemQueue = baggageItemQueue else {
-            return nil
-        }
-
         if let traceIDValue = httpHeaderFields[OTelHTTPHeaders.Multiple.traceIDField],
             let spanIDValue = httpHeaderFields[OTelHTTPHeaders.Multiple.spanIDField],
             let traceID = TracingUUID(traceIDValue, .hexadecimal),
@@ -31,9 +22,11 @@ internal class OTelHTTPHeadersReader: OTHTTPHeadersReader, TracePropagationHeade
                 traceID: traceID,
                 spanID: spanID,
                 parentSpanID: TracingUUID(httpHeaderFields[OTelHTTPHeaders.Multiple.parentSpanIDField], .hexadecimal),
-                baggageItems: BaggageItems(targetQueue: baggageItemQueue, parentSpanItems: nil)
+                baggageItems: BaggageItems()
             )
-        } else if let b3Value = httpHeaderFields[OTelHTTPHeaders.Single.b3Field]?.components(
+        }
+
+        if let b3Value = httpHeaderFields[OTelHTTPHeaders.Single.b3Field]?.components(
                 separatedBy: OTelHTTPHeaders.Constants.b3Separator
             ),
             let traceID = TracingUUID(b3Value[safe: 0], .hexadecimal),
@@ -42,9 +35,10 @@ internal class OTelHTTPHeadersReader: OTHTTPHeadersReader, TracePropagationHeade
                 traceID: traceID,
                 spanID: spanID,
                 parentSpanID: TracingUUID(b3Value[safe: 3], .hexadecimal),
-                baggageItems: BaggageItems(targetQueue: baggageItemQueue, parentSpanItems: nil)
+                baggageItems: BaggageItems()
             )
         }
+
         return nil
     }
 }

--- a/Sources/Datadog/Tracing/Propagation/OpenTracing/HTTPHeadersReader.swift
+++ b/Sources/Datadog/Tracing/Propagation/OpenTracing/HTTPHeadersReader.swift
@@ -8,19 +8,13 @@ import Foundation
 
 internal class HTTPHeadersReader: OTHTTPHeadersReader, TracePropagationHeadersExtractor {
     private let httpHeaderFields: [String: String]
-    private var baggageItemQueue: DispatchQueue?
 
     init(httpHeaderFields: [String: String]) {
         self.httpHeaderFields = httpHeaderFields
     }
 
-    func use(baggageItemQueue: DispatchQueue) {
-        self.baggageItemQueue = baggageItemQueue
-    }
-
     func extract() -> OTSpanContext? {
-        guard let baggageItemQueue = baggageItemQueue,
-              let traceIDValue = httpHeaderFields[TracingHTTPHeaders.traceIDField],
+        guard let traceIDValue = httpHeaderFields[TracingHTTPHeaders.traceIDField],
               let spanIDValue = httpHeaderFields[TracingHTTPHeaders.parentSpanIDField],
               let traceID = TracingUUID(traceIDValue, .decimal),
               let spanID = TracingUUID(spanIDValue, .decimal) else {
@@ -31,7 +25,7 @@ internal class HTTPHeadersReader: OTHTTPHeadersReader, TracePropagationHeadersEx
             traceID: traceID,
             spanID: spanID,
             parentSpanID: nil,
-            baggageItems: BaggageItems(targetQueue: baggageItemQueue, parentSpanItems: nil)
+            baggageItems: BaggageItems()
         )
     }
 }

--- a/Sources/Datadog/Tracing/Propagation/TracePropagationHeadersExtractor.swift
+++ b/Sources/Datadog/Tracing/Propagation/TracePropagationHeadersExtractor.swift
@@ -9,5 +9,4 @@ import Foundation
 /// Interface that defines shared responibilities of HTTP header readers.
 public protocol TracePropagationHeadersExtractor {
     func extract() -> OTSpanContext?
-    func use(baggageItemQueue: DispatchQueue)
 }

--- a/Sources/Datadog/Tracing/Propagation/W3C/W3CHTTPHeadersReader.swift
+++ b/Sources/Datadog/Tracing/Propagation/W3C/W3CHTTPHeadersReader.swift
@@ -8,34 +8,27 @@ import Foundation
 
 internal class W3CHTTPHeadersReader: OTHTTPHeadersReader, TracePropagationHeadersExtractor {
     private let httpHeaderFields: [String: String]
-    private var baggageItemQueue: DispatchQueue?
 
     init(httpHeaderFields: [String: String]) {
         self.httpHeaderFields = httpHeaderFields
     }
 
-    func use(baggageItemQueue: DispatchQueue) {
-        self.baggageItemQueue = baggageItemQueue
-    }
-
     func extract() -> OTSpanContext? {
-        guard let baggageItemQueue = baggageItemQueue else {
-            return nil
-        }
-
-        guard let traceparentValue = httpHeaderFields[W3CHTTPHeaders.traceparent]?.components(
+        guard
+            let traceparentValue = httpHeaderFields[W3CHTTPHeaders.traceparent]?.components(
                 separatedBy: W3CHTTPHeaders.Constants.separator
             ),
             let traceID = TracingUUID(traceparentValue[safe: 1], .hexadecimal),
             let spanID = TracingUUID(traceparentValue[safe: 2], .hexadecimal),
-            traceparentValue[safe: 3] != W3CHTTPHeaders.Constants.unsampledValue else {
+            traceparentValue[safe: 3] != W3CHTTPHeaders.Constants.unsampledValue
+        else {
             return nil
         }
         return DDSpanContext(
             traceID: traceID,
             spanID: spanID,
             parentSpanID: nil,
-            baggageItems: BaggageItems(targetQueue: baggageItemQueue, parentSpanItems: nil)
+            baggageItems: BaggageItems()
         )
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/TracingFeatureMocks.swift
@@ -57,10 +57,7 @@ extension DDSpanContext {
 
 extension BaggageItems {
     static func mockAny() -> BaggageItems {
-        return BaggageItems(
-            targetQueue: DispatchQueue(label: "com.datadoghq.baggage-items"),
-            parentSpanItems: nil
-        )
+        return BaggageItems()
     }
 }
 

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanContextTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanContextTests.swift
@@ -8,10 +8,8 @@ import XCTest
 @testable import Datadog
 
 class DDSpanContextTests: XCTestCase {
-    private let queue = DispatchQueue(label: "com.datadoghq.\(#file)")
-
     func testIteratingOverBaggageItems() {
-        let baggageItems = BaggageItems(targetQueue: queue, parentSpanItems: nil)
+        let baggageItems = BaggageItems(parent: nil)
         baggageItems.set(key: "k1", value: "v1")
         baggageItems.set(key: "k2", value: "v2")
         baggageItems.set(key: "k3", value: "v3")
@@ -38,8 +36,8 @@ class DDSpanContextTests: XCTestCase {
     }
 
     func testChildItemsOverwriteTheParentItems() {
-        let parentBaggageItems = BaggageItems(targetQueue: queue, parentSpanItems: nil)
-        let childBaggageItems = BaggageItems(targetQueue: queue, parentSpanItems: parentBaggageItems)
+        let parentBaggageItems = BaggageItems(parent: nil)
+        let childBaggageItems = BaggageItems(parent: parentBaggageItems)
 
         parentBaggageItems.set(key: "foo", value: "a")
         XCTAssertEqual(parentBaggageItems.all["foo"], "a")
@@ -51,8 +49,8 @@ class DDSpanContextTests: XCTestCase {
     }
 
     func testChildItemsGetParentItems() {
-        let parentBaggageItems = BaggageItems(targetQueue: queue, parentSpanItems: nil)
-        let childBaggageItems = BaggageItems(targetQueue: queue, parentSpanItems: parentBaggageItems)
+        let parentBaggageItems = BaggageItems(parent: nil)
+        let childBaggageItems = BaggageItems(parent: parentBaggageItems)
 
         parentBaggageItems.set(key: "foo", value: "a")
         childBaggageItems.set(key: "bar", value: "b")

--- a/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/DDSpanTests.swift
@@ -122,12 +122,10 @@ class DDSpanTests: XCTestCase {
     }
 
     func testSettingBaggageItems() {
-        let queue = DispatchQueue(label: "com.datadoghq.\(#function)")
-
         // Given
         let span: DDSpan = .mockWith(
             core: PassthroughCoreMock(),
-            context: .mockWith(baggageItems: BaggageItems(targetQueue: queue, parentSpanItems: nil))
+            context: .mockWith(baggageItems: BaggageItems())
         )
         XCTAssertEqual(span.ddContext.baggageItems.all, [:])
 

--- a/Tests/DatadogTests/Datadog/Tracing/Propagation/OTelHTTPHeadersReaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Propagation/OTelHTTPHeadersReaderTests.swift
@@ -10,7 +10,6 @@ import XCTest
 class OTelHTTPHeadersReaderTests: XCTestCase {
     func testOTelHTTPHeadersReaderreadsSingleHeader() {
         let oTelHTTPHeadersReader = OTelHTTPHeadersReader(httpHeaderFields: ["b3": "4d2-929-1-162e"])
-        oTelHTTPHeadersReader.use(baggageItemQueue: .main)
 
         let spanContext = oTelHTTPHeadersReader.extract()?.dd
 
@@ -21,7 +20,6 @@ class OTelHTTPHeadersReaderTests: XCTestCase {
 
     func testOTelHTTPHeadersReaderreadsSingleHeaderWithSampling() {
         let oTelHTTPHeadersReader = OTelHTTPHeadersReader(httpHeaderFields: ["b3": "0"])
-        oTelHTTPHeadersReader.use(baggageItemQueue: .main)
 
         let spanContext = oTelHTTPHeadersReader.extract()?.dd
 
@@ -32,7 +30,6 @@ class OTelHTTPHeadersReaderTests: XCTestCase {
 
     func testOTelHTTPHeadersReaderreadsSingleHeaderWithoutOptionalValues() {
         let oTelHTTPHeadersReader = OTelHTTPHeadersReader(httpHeaderFields: ["b3": "4d2-929"])
-        oTelHTTPHeadersReader.use(baggageItemQueue: .main)
 
         let spanContext = oTelHTTPHeadersReader.extract()?.dd
 
@@ -48,7 +45,6 @@ class OTelHTTPHeadersReaderTests: XCTestCase {
             "X-B3-Sampled": "1",
             "X-B3-ParentSpanId": "162e"
         ])
-        oTelHTTPHeadersReader.use(baggageItemQueue: .main)
 
         let spanContext = oTelHTTPHeadersReader.extract()?.dd
 
@@ -61,7 +57,6 @@ class OTelHTTPHeadersReaderTests: XCTestCase {
         let oTelHTTPHeadersReader = OTelHTTPHeadersReader(httpHeaderFields: [
             "X-B3-Sampled": "0"
         ])
-        oTelHTTPHeadersReader.use(baggageItemQueue: .main)
 
         let spanContext = oTelHTTPHeadersReader.extract()?.dd
 
@@ -75,7 +70,6 @@ class OTelHTTPHeadersReaderTests: XCTestCase {
             "X-B3-TraceId": "4d2",
             "X-B3-SpanId": "929"
         ])
-        oTelHTTPHeadersReader.use(baggageItemQueue: .main)
 
         let spanContext = oTelHTTPHeadersReader.extract()?.dd
 

--- a/Tests/DatadogTests/Datadog/Tracing/Propagation/W3CHTTPHeadersReaderTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/Propagation/W3CHTTPHeadersReaderTests.swift
@@ -10,8 +10,6 @@ import XCTest
 class W3CHTTPHeadersReaderTests: XCTestCase {
     func testW3CHTTPHeadersReaderreadsSingleHeader() {
         let w3cHTTPHeadersReader = W3CHTTPHeadersReader(httpHeaderFields: ["traceparent": "00-4d2-929-01"])
-        w3cHTTPHeadersReader.use(baggageItemQueue: .main)
-
         let spanContext = w3cHTTPHeadersReader.extract()?.dd
 
         XCTAssertEqual(spanContext?.traceID, TracingUUID(rawValue: 1_234))
@@ -21,8 +19,6 @@ class W3CHTTPHeadersReaderTests: XCTestCase {
 
     func testW3CHTTPHeadersReaderreadsSingleHeaderWithSampling() {
         let w3cHTTPHeadersReader = W3CHTTPHeadersReader(httpHeaderFields: ["traceparent": "00-0-0-00"])
-        w3cHTTPHeadersReader.use(baggageItemQueue: .main)
-
         let spanContext = w3cHTTPHeadersReader.extract()?.dd
 
         XCTAssertNil(spanContext?.traceID)


### PR DESCRIPTION
### What and why?

Use lock on `BaggageItems` for thread safety to simplify usage of our various `TracePropagationHeadersExtractor` implementation. This will ease usage of shared trace propagation in the v2 modular architecture.

### How?

Replace the Span `BaggageItems` synchronisation queue with a read-write lock.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
