### PR TITLE
[RUMM-2997] Send a crash to both RUM and Logging features

### DIFF
--- a/Sources/Datadog/CrashReporting/Integrations/CrashReportSender.swift
+++ b/Sources/Datadog/CrashReporting/Integrations/CrashReportSender.swift
@@ -21,14 +21,8 @@ internal struct MessageBusSender: CrashReportSender {
         /// The key for a crash message.
         ///
         /// Use this key when the crash should be reported
-        /// as a RUM event.
+        /// as a RUM and a Logs event.
         static let crash = "crash"
-
-        /// The key for a crash log message.
-        ///
-        /// Use this key when the crash should be reported
-        /// as a log event.
-        static let crashLog = "crash-log"
     }
 
     /// The core for sending crash report and context.
@@ -47,14 +41,7 @@ internal struct MessageBusSender: CrashReportSender {
             return
         }
 
-        sendRUM(
-            baggage: [
-                "report": report,
-                "context": context
-            ]
-        )
-
-        sendLog(
+        sendCrash(
             baggage: [
                 "report": report,
                 "context": context
@@ -62,31 +49,18 @@ internal struct MessageBusSender: CrashReportSender {
         )
     }
 
-    private func sendRUM(baggage: FeatureBaggage) {
+    private func sendCrash(baggage: FeatureBaggage) {
         core?.send(
             message: .custom(key: MessageKeys.crash, baggage: baggage),
             else: {
                 DD.logger.warn(
             """
-            RUM Feature is not enabled. Will not send crash as RUM Error.
-            Make sure `.enableRUM(true)`when initializing Datadog SDK.
+            In order to use Crash Reporting, RUM or Logging feature must be enabled.
+            Make sure `.enableRUM(true)` or `.enableLogging(true)` are configured
+            when initializing Datadog SDK.
             """
             )
             }
         )
-    }
-
-    private func sendLog(baggage: FeatureBaggage) {
-        core?.send(
-            message: .custom(key: MessageKeys.crashLog, baggage: baggage),
-            else: {
-                DD.logger.warn(
-            """
-            Logging Feature is not enabled. Will not send crash as Log Error.
-            Make sure `.enableLogging(true)`when initializing Datadog SDK.
-            """
-            )
-            }
-            )
     }
 }

--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -67,7 +67,7 @@ internal enum LoggingMessageKeys {
     static let log = "log"
 
     /// The key references a crash message.
-    static let crash = "crash-log"
+    static let crash = "crash"
 
     /// The key references a browser log message.
     static let browserLog = "browser-log"

--- a/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
+++ b/Tests/DatadogTests/Datadog/CrashReporting/CrashReporterTests.swift
@@ -46,13 +46,13 @@ class CrashReporterTests: XCTestCase {
         XCTAssertTrue(plugin.hasPurgedCrashReport == true, "It should ask to purge the crash report")
     }
 
-    func testWhenPendingCrashReportIsFound_itIsSentBothToRumAndLogs() throws {
-        let expectation = self.expectation(description: "`CrashReportSender` sends the crash report to both features")
+    func testWhenPendingCrashReportIsFound_itIsSentToRumFeature() throws {
+        let expectation = self.expectation(description: "`CrashReportSender` sends the crash report to RUM feature")
         let crashContext: CrashContext = .mockRandom()
         let crashReport: DDCrashReport = .mockRandomWith(context: crashContext)
-        let crashMessageReceiver = CrashMessageReceiverMock()
+        let rumCrashReceiver = RUMCrashReceiverMock()
 
-        let core = PassthroughCoreMock(messageReceiver: crashMessageReceiver)
+        let core = PassthroughCoreMock(messageReceiver: rumCrashReceiver)
 
         let plugin = CrashReportingPluginMock()
 
@@ -74,17 +74,38 @@ class CrashReporterTests: XCTestCase {
 
         waitForExpectations(timeout: 0.5, handler: nil)
 
-        let sentRumBaggage = crashMessageReceiver.rumBaggage
-        let sentLogBaggage = crashMessageReceiver.logsBaggage
+        XCTAssert(!rumCrashReceiver.receivedBaggage.isEmpty, "RUM baggage must not be empty")
+    }
 
-        XCTAssert(!sentRumBaggage.isEmpty, "RUM baggage must not be empty")
-        XCTAssert(!sentLogBaggage.isEmpty, "Log baggage must not be empty")
+    func testWhenPendingCrashReportIsFound_itIsSentToLogsFeature() throws {
+        let expectation = self.expectation(description: "`CrashReportSender` sends the crash report to Logs feature")
+        let crashContext: CrashContext = .mockRandom()
+        let crashReport: DDCrashReport = .mockRandomWith(context: crashContext)
+        let logsCrashReceiver = LogsCrashReceiverMock()
 
-        DDAssertDictionariesEqual(
-            sentRumBaggage.attributes,
-            sentLogBaggage.attributes,
-            "RUM and logs baggage should be equal"
+        let core = PassthroughCoreMock(messageReceiver: logsCrashReceiver)
+
+        let plugin = CrashReportingPluginMock()
+
+        // Given
+        plugin.pendingCrashReport = crashReport
+        plugin.injectedContextData = crashContext.data
+
+        // When
+        let crashReporter = CrashReporter(
+            crashReportingPlugin: plugin,
+            crashContextProvider: CrashContextProviderMock(),
+            sender: MessageBusSender(core: core),
+            messageReceiver: NOPFeatureMessageReceiver()
         )
+
+        //Then
+        plugin.didReadPendingCrashReport = { expectation.fulfill() }
+        crashReporter.sendCrashReportIfFound()
+
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        XCTAssert(!logsCrashReceiver.receivedBaggage.isEmpty, "Logs baggage must not be empty")
     }
 
     func testWhenPendingCrashReportIsNotFound_itDoesNothing() {
@@ -274,7 +295,7 @@ class CrashReporterTests: XCTestCase {
 
     // MARK: - Usage
 
-    func testGivenNoRegisteredCrashReportReceiver_whenPendingCrashReportIsFound_itPrintsError() {
+    func testGivenNoRegisteredCrashReportReceiver_whenPendingCrashReportIsFound_itPrintsWarning() {
         let expectation = self.expectation(description: "`plugin` checks the crash report")
 
         let dd = DD.mockWith(logger: CoreLoggerMock())
@@ -304,13 +325,9 @@ class CrashReporterTests: XCTestCase {
         let logs = dd.logger.warnLogs
 
         XCTAssert(logs.contains(where: { $0.message == """
-            Logging Feature is not enabled. Will not send crash as Log Error.
-            Make sure `.enableLogging(true)`when initializing Datadog SDK.
-            """ }))
-
-        XCTAssert(logs.contains(where: { $0.message == """
-            RUM Feature is not enabled. Will not send crash as RUM Error.
-            Make sure `.enableRUM(true)`when initializing Datadog SDK.
+            In order to use Crash Reporting, RUM or Logging feature must be enabled.
+            Make sure `.enableRUM(true)` or `.enableLogging(true)` are configured
+            when initializing Datadog SDK.
             """ }))
     }
 }

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -87,6 +87,24 @@ class CrashReportSenderMock: CrashReportSender {
     var didSendCrashReport: (() -> Void)?
 }
 
+class CrashMessageReceiverMock: FeatureMessageReceiver {
+    var rumBaggage: FeatureBaggage = [:]
+    var logsBaggage: FeatureBaggage = [:]
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        switch message {
+        case .custom(let key, let attributes) where key == "crash-log":
+            logsBaggage = attributes
+            return true
+        case .custom(let key, let attributes) where key == "crash":
+            rumBaggage = attributes
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 extension CrashContext {
     static func mockAny() -> CrashContext {
         return mockWith()

--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -87,17 +87,27 @@ class CrashReportSenderMock: CrashReportSender {
     var didSendCrashReport: (() -> Void)?
 }
 
-class CrashMessageReceiverMock: FeatureMessageReceiver {
-    var rumBaggage: FeatureBaggage = [:]
-    var logsBaggage: FeatureBaggage = [:]
+class RUMCrashReceiverMock: FeatureMessageReceiver {
+    var receivedBaggage: FeatureBaggage = [:]
 
     func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
         switch message {
-        case .custom(let key, let attributes) where key == "crash-log":
-            logsBaggage = attributes
+        case .custom(let key, let attributes) where key == CrashReportReceiver.MessageKeys.crash:
+            receivedBaggage = attributes
             return true
-        case .custom(let key, let attributes) where key == "crash":
-            rumBaggage = attributes
+        default:
+            return false
+        }
+    }
+}
+
+class LogsCrashReceiverMock: FeatureMessageReceiver {
+    var receivedBaggage: FeatureBaggage = [:]
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        switch message {
+        case .custom(let key, let attributes) where key == LoggingMessageKeys.crash:
+            receivedBaggage = attributes
             return true
         default:
             return false


### PR DESCRIPTION
### What and why?

Sends crash information both to Logs and RUM Features, as opposed to only RUM if both features are enabled.
Adopted a logging strategy similar to Android.  

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
