### PR TITLE
Change initial sample collecting

### DIFF
--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -63,6 +63,10 @@ internal final class VitalInfoSampler {
         self.refreshRateReader.register(self.refreshRatePublisher)
         self.maximumRefreshRate = maximumRefreshRate
 
+        // Take initial sample
+        RunLoop.main.perform(inModes: [.common]) { [weak self] in
+            self?.takeSample()
+        }
         // Schedule reoccuring samples
         let timer = Timer(
             timeInterval: frequency,
@@ -70,13 +74,6 @@ internal final class VitalInfoSampler {
         ) { [weak self] _ in
             self?.takeSample()
         }
-        // Take initial sample
-        RunLoop.main.perform {
-            timer.fire()
-        }
-        // NOTE: RUMM-1280 based on my running Example app
-        // non-main run loops don't fire the timer.
-        // Although i can't catch this in unit tests
         RunLoop.main.add(timer, forMode: .common)
         self.timer = timer
     }


### PR DESCRIPTION
### What and why?

Potential fix for crash https://github.com/DataDog/dd-sdk-ios/issues/1213

Chain of events:
1. Issue from @cltnschlosser mentioning the problem crashes: https://github.com/DataDog/dd-sdk-ios/issues/1091
2. @cltnschlosser opened a pull request fixing the issue: https://github.com/DataDog/dd-sdk-ios/pull/1177
3. Tests were failing on CI, so we changed the way initial sample is taken in this commit: https://github.com/DataDog/dd-sdk-ios/pull/1177/commits/24382bed85cc5c67de50d952d31605a3696e968e
4. This change made the app crash in a different way, which was reported here: https://github.com/DataDog/dd-sdk-ios/issues/1213
5. We opened this PR to fix the issue and created a JIRA ticket to investigate threading in the rum-monitors scopes.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
