### PR TITLE
REPLAY-1460 Enhance `UIStepper` element masking

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIStepperRecorder.swift
@@ -17,6 +17,7 @@ internal struct UIStepperRecorder: NodeRecorder {
 
         let stepperFrame = CGRect(origin: attributes.frame.origin, size: stepper.intrinsicContentSize)
         let ids = context.ids.nodeIDs(5, for: stepper)
+        let isMasked = context.recorder.privacy == .maskAll
 
         let builder = UIStepperWireframesBuilder(
             wireframeRect: stepperFrame,
@@ -26,8 +27,8 @@ internal struct UIStepperRecorder: NodeRecorder {
             minusWireframeID: ids[2],
             plusHorizontalWireframeID: ids[3],
             plusVerticalWireframeID: ids[4],
-            isMinusEnabled: stepper.value > stepper.minimumValue,
-            isPlusEnabled: stepper.value < stepper.maximumValue
+            isMinusEnabled: isMasked || (stepper.value > stepper.minimumValue),
+            isPlusEnabled: isMasked || (stepper.value < stepper.maximumValue)
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
         return SpecificElement(subtreeStrategy: .ignore, nodes: [node])


### PR DESCRIPTION
### What and why?

📦 This PR enhances masking behaviour for `UIStepper` elements when `.maskAll` policy is set. Now, the MIN and MAX values cannot be inferred as we no longer grey-out their buttons:

<img src="https://user-images.githubusercontent.com/2358722/226681986-d8c79092-5ace-4db8-a80c-058814be2fa9.png" width="50%"/>

### How?

Easy 😎.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
