### PR TITLE
Allow users to manually end a RUM session

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		490D5EC929C9E17E004F969C /* RUMStopSessionScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490D5EC829C9E17E004F969C /* RUMStopSessionScenarioTests.swift */; };
+		490D5ECF29CA0745004F969C /* RUMStopSessionScenario.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 490D5ECB29C9E2D0004F969C /* RUMStopSessionScenario.storyboard */; };
+		490D5ED029CA074A004F969C /* KioskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490D5ECD29CA0738004F969C /* KioskViewController.swift */; };
+		490D5ED329CA08F7004F969C /* KioskSendEventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490D5ED129CA087D004F969C /* KioskSendEventsViewController.swift */; };
+		490D5ED629CA1DD6004F969C /* KioskSendInterruptedEventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490D5ED429CA1D9F004F969C /* KioskSendInterruptedEventsViewController.swift */; };
 		49274906288048B500ECD49B /* InternalTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalTelemetryTests.swift */; };
 		49274907288048B800ECD49B /* InternalTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalTelemetryTests.swift */; };
 		4927490B288048FF00ECD49B /* RUMInternalProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274908288048F400ECD49B /* RUMInternalProxyTests.swift */; };
@@ -1350,6 +1355,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		490D5EC829C9E17E004F969C /* RUMStopSessionScenarioTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMStopSessionScenarioTests.swift; sourceTree = "<group>"; };
+		490D5ECB29C9E2D0004F969C /* RUMStopSessionScenario.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RUMStopSessionScenario.storyboard; sourceTree = "<group>"; };
+		490D5ECD29CA0738004F969C /* KioskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskViewController.swift; sourceTree = "<group>"; };
+		490D5ED129CA087D004F969C /* KioskSendEventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSendEventsViewController.swift; sourceTree = "<group>"; };
+		490D5ED429CA1D9F004F969C /* KioskSendInterruptedEventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KioskSendInterruptedEventsViewController.swift; sourceTree = "<group>"; };
 		49274903288048AA00ECD49B /* InternalTelemetryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalTelemetryTests.swift; sourceTree = "<group>"; };
 		49274908288048F400ECD49B /* RUMInternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMInternalProxyTests.swift; sourceTree = "<group>"; };
 		61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundLocationMonitor.swift; sourceTree = "<group>"; };
@@ -2188,6 +2198,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		490D5ECA29C9E28F004F969C /* StopSessionScenario */ = {
+			isa = PBXGroup;
+			children = (
+				490D5ECB29C9E2D0004F969C /* RUMStopSessionScenario.storyboard */,
+				490D5ECD29CA0738004F969C /* KioskViewController.swift */,
+				490D5ED129CA087D004F969C /* KioskSendEventsViewController.swift */,
+				490D5ED429CA1D9F004F969C /* KioskSendInterruptedEventsViewController.swift */,
+			);
+			path = StopSessionScenario;
+			sourceTree = "<group>";
+		};
 		61020C272757AD63005EEAEA /* BackgroundEvents */ = {
 			isa = PBXGroup;
 			children = (
@@ -2852,14 +2873,15 @@
 			isa = PBXGroup;
 			children = (
 				61D50C532580EF41006038A3 /* RUMScenarios.swift */,
-				9EC2835C26CFF56B00FACF1C /* MobileVitals */,
 				61337037250F84FD00236D58 /* ManualInstrumentation */,
-				61F9CA7725125918000A5E61 /* NavigationControllerAutoInstrumentation */,
-				615AAC34251E34EF00C89EE9 /* TabBarAutoInstrumentation */,
+				9EC2835C26CFF56B00FACF1C /* MobileVitals */,
 				6137E647252DD85400720485 /* ModalViewsAutoInstrumentation */,
-				6193DCA2251B5669009B8011 /* TapActionAutoInstrumentation */,
-				D2791EF32716F16E0046E07A /* SwiftUIInstrumentation */,
+				61F9CA7725125918000A5E61 /* NavigationControllerAutoInstrumentation */,
 				612D8F6725AEE65F000E2E09 /* Scrubbing */,
+				490D5ECA29C9E28F004F969C /* StopSessionScenario */,
+				D2791EF32716F16E0046E07A /* SwiftUIInstrumentation */,
+				615AAC34251E34EF00C89EE9 /* TabBarAutoInstrumentation */,
+				6193DCA2251B5669009B8011 /* TapActionAutoInstrumentation */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -3954,6 +3976,7 @@
 				612D8F8025AF1C74000E2E09 /* RUMScrubbingScenarioTests.swift */,
 				9EC2835926CFEE0B00FACF1C /* RUMMobileVitalsScenarioTests.swift */,
 				D2791EF827170A760046E07A /* RUMSwiftUIScenarioTests.swift */,
+				490D5EC829C9E17E004F969C /* RUMStopSessionScenarioTests.swift */,
 			);
 			path = RUM;
 			sourceTree = "<group>";
@@ -5133,6 +5156,7 @@
 				61337032250F82AE00236D58 /* LoggingManualInstrumentationScenario.storyboard in Resources */,
 				612D8F6925AEE68F000E2E09 /* RUMScrubbingScenario.storyboard in Resources */,
 				D2F5BB36271831C200BDE2A4 /* RUMSwiftUIInstrumentationScenario.storyboard in Resources */,
+				490D5ECF29CA0745004F969C /* RUMStopSessionScenario.storyboard in Resources */,
 				611EA13C2580F77400BC0E56 /* TrackingConsentScenario.storyboard in Resources */,
 				9EA95C1D2791C9BE00F6C1F3 /* WebViewTrackingScenario.storyboard in Resources */,
 				61337039250F852E00236D58 /* RUMManualInstrumentationScenario.storyboard in Resources */,
@@ -5938,6 +5962,7 @@
 				618DCFE124C766F500589570 /* SendRUMFixture2ViewController.swift in Sources */,
 				61441C982461A649003D8BB8 /* DebugTracingViewController.swift in Sources */,
 				9EA95C1E2791C9BE00F6C1F3 /* WebViewScenarios.swift in Sources */,
+				490D5ED329CA08F7004F969C /* KioskSendEventsViewController.swift in Sources */,
 				61F9CA8025125C01000A5E61 /* RUMNCSScreen3ViewController.swift in Sources */,
 				6164AE89252B4ECA000D78C4 /* SendThirdPartyRequestsViewController.swift in Sources */,
 				611EA14225810E1900BC0E56 /* TSHomeViewController.swift in Sources */,
@@ -5946,12 +5971,14 @@
 				61163C37252DDD60007DD5BF /* RUMMVSViewController.swift in Sources */,
 				61441C952461A649003D8BB8 /* ConsoleOutputInterceptor.swift in Sources */,
 				61D50C5A2580EFF3006038A3 /* URLSessionScenarios.swift in Sources */,
+				490D5ED029CA074A004F969C /* KioskViewController.swift in Sources */,
 				618236892710560900125326 /* DebugWebviewViewController.swift in Sources */,
 				614CADCE250FCA0200B93D2D /* TestScenarios.swift in Sources */,
 				6111542525C992F8007C84C9 /* CrashReportingScenarios.swift in Sources */,
 				61F74AF426F20E4600E5F5ED /* DebugCrashReportingWithRUMViewController.swift in Sources */,
 				61441C972461A649003D8BB8 /* UIViewController+KeyboardControlling.swift in Sources */,
 				61098D2B27FEE3F00021237A /* MessagePortChannel.swift in Sources */,
+				490D5ED629CA1DD6004F969C /* KioskSendInterruptedEventsViewController.swift in Sources */,
 				61B9ED1C2461E12000C0DCFF /* SendLogsFixtureViewController.swift in Sources */,
 				6111543F25C996A5007C84C9 /* CrashReportingViewController.swift in Sources */,
 				61B9ED1D2461E12000C0DCFF /* SendTracesFixtureViewController.swift in Sources */,
@@ -6009,6 +6036,7 @@
 				9EA95C212791C9E200F6C1F3 /* WebViewScenarioTest.swift in Sources */,
 				61441C4B24618052003D8BB8 /* SpanMatcher.swift in Sources */,
 				6167ACFD251A22E00012B4D0 /* TracingURLSessionScenarioTests.swift in Sources */,
+				490D5EC929C9E17E004F969C /* RUMStopSessionScenarioTests.swift in Sources */,
 				611EA16625825FB300BC0E56 /* TrackingConsentScenarioTests.swift in Sources */,
 				61F3CD9A2510D8C500C816E5 /* Environment.swift in Sources */,
 				61F9CA9F2513978D000A5E61 /* RUMSessionMatcher.swift in Sources */,

--- a/Datadog/Example/Scenarios/RUM/ManualInstrumentation/RUMManualInstrumentationScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/ManualInstrumentation/RUMManualInstrumentationScenario.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pf8-bf-lC4">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pf8-bf-lC4">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending RUM events... " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SX8-ub-OtU">
-                                <rect key="frame" x="116" y="437.5" width="182.5" height="21"/>
+                                <rect key="frame" x="116.5" y="437.5" width="181.5" height="21"/>
                                 <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -47,7 +48,7 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Zk-BI-nQq">
                                 <rect key="frame" x="107" y="518.5" width="200" height="44"/>
-                                <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="0.47058823529999999" green="0.27058823529999998" blue="0.70980392160000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="CE5-a3-tvy"/>
                                     <constraint firstAttribute="height" constant="44" id="Pp2-Pg-Ujp"/>
@@ -68,7 +69,8 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="sfr-fJ-Afg"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="9Zk-BI-nQq" firstAttribute="centerX" secondItem="NN5-07-h1G" secondAttribute="centerX" id="CbM-JR-3Ix"/>
                             <constraint firstItem="9Zk-BI-nQq" firstAttribute="top" secondItem="0Ll-7g-WYi" secondAttribute="bottom" constant="8" id="H0p-mE-2kE"/>
@@ -77,7 +79,6 @@
                             <constraint firstItem="SX8-ub-OtU" firstAttribute="centerX" secondItem="NN5-07-h1G" secondAttribute="centerX" id="l36-2f-KNu"/>
                             <constraint firstItem="0Ll-7g-WYi" firstAttribute="top" secondItem="SX8-ub-OtU" secondAttribute="bottom" constant="8" id="q6k-4c-XJf"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="sfr-fJ-Afg"/>
                     </view>
                     <navigationItem key="navigationItem" id="jZu-uz-Pcj"/>
                     <connections>
@@ -97,7 +98,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending RUM events... " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ken-2c-0bK">
-                                <rect key="frame" x="116" y="437.5" width="182.5" height="21"/>
+                                <rect key="frame" x="116.5" y="437.5" width="181.5" height="21"/>
                                 <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -126,14 +127,14 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="nHg-xq-2vI"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Tz6-6i-kw5" firstAttribute="centerX" secondItem="Epx-Nl-L0w" secondAttribute="centerX" id="Edn-KE-PZv"/>
                             <constraint firstItem="Tz6-6i-kw5" firstAttribute="top" secondItem="ken-2c-0bK" secondAttribute="bottom" constant="10" id="Mo8-G7-vuP"/>
                             <constraint firstItem="ken-2c-0bK" firstAttribute="centerX" secondItem="Epx-Nl-L0w" secondAttribute="centerX" id="PWg-xS-Nch"/>
                             <constraint firstItem="ken-2c-0bK" firstAttribute="centerY" secondItem="Epx-Nl-L0w" secondAttribute="centerY" id="qpB-Kq-Bah"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="nHg-xq-2vI"/>
                     </view>
                     <navigationItem key="navigationItem" id="uVq-YZ-YVI"/>
                 </viewController>
@@ -150,19 +151,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Sending RUM events... " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QFu-tk-7iM">
-                                <rect key="frame" x="116" y="437.5" width="182.5" height="21"/>
+                                <rect key="frame" x="116.5" y="437.5" width="181.5" height="21"/>
                                 <color key="backgroundColor" red="0.38823529410000002" green="0.17254901959999999" blue="0.65098039220000004" alpha="1" colorSpace="calibratedRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="42g-hj-wb0"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="QFu-tk-7iM" firstAttribute="centerX" secondItem="06R-3w-ldx" secondAttribute="centerX" id="Dua-kk-TFJ"/>
                             <constraint firstItem="QFu-tk-7iM" firstAttribute="centerY" secondItem="06R-3w-ldx" secondAttribute="centerY" id="fLg-Be-JMm"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="42g-hj-wb0"/>
                     </view>
                     <navigationItem key="navigationItem" id="0d3-JV-H2n"/>
                 </viewController>
@@ -175,7 +176,7 @@
             <objects>
                 <navigationController id="pf8-bf-lC4" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Asf-nL-UKR">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -187,4 +188,9 @@
             <point key="canvasLocation" x="-636" y="1233"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
+++ b/Datadog/Example/Scenarios/RUM/RUMScenarios.swift
@@ -251,6 +251,13 @@ final class RUMScrubbingScenario: TestScenario {
     }
 }
 
+
+/// Scenario which starts a navigation controller. Each view controller pushed to this navigation
+/// uses the RUM manual instrumentation API to send RUM events to the server.
+final class RUMStopSessionsScenario: TestScenario {
+    static let storyboardName = "RUMStopSessionScenario"
+}
+
 @available(iOS 13, *)
 /// Scenario which presents `SwiftUI`-based hierarchy and navigates through
 /// its views and view controllers.

--- a/Datadog/Example/Scenarios/RUM/StopSessionScenario/KioskSendEventsViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/StopSessionScenario/KioskSendEventsViewController.swift
@@ -26,10 +26,10 @@ internal class KioskSendEventsViewController: UIViewController {
         rumMonitor.stopView(viewController: self)
     }
 
-    @IBAction func didTapDownloadResourceButton(_ sender: Any) {
+    @IBAction func didTapDownloadResourceButton(_ sender: UIButton) {
         rumMonitor.addUserAction(
             type: .tap,
-            name: (sender as! UIButton).currentTitle!,
+            name: sender.currentTitle!,
             attributes: ["button.description": String(describing: sender)]
         )
 

--- a/Datadog/Example/Scenarios/RUM/StopSessionScenario/KioskSendEventsViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/StopSessionScenario/KioskSendEventsViewController.swift
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import UIKit
+
+internal class KioskSendEventsViewController: UIViewController {
+    @IBOutlet private var doneButton: UIButton!
+
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        doneButton.isHidden = true
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        rumMonitor.startView(viewController: self, name: "KioskSendEvents")
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        rumMonitor.stopView(viewController: self)
+    }
+
+    @IBAction func didTapDownloadResourceButton(_ sender: Any) {
+        rumMonitor.addUserAction(
+            type: .tap,
+            name: (sender as! UIButton).currentTitle!,
+            attributes: ["button.description": String(describing: sender)]
+        )
+
+        let simulatedResourceKey = "/resource/1"
+        let simulatedResourceRequest = URLRequest(url: URL(string: "https://foo.com/resource/1")!)
+        let simulatedResourceLoadingTime: TimeInterval = 0.1
+
+        rumMonitor.startResourceLoading(
+            resourceKey: simulatedResourceKey,
+            request: simulatedResourceRequest
+        )
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + simulatedResourceLoadingTime) {
+            rumMonitor.stopResourceLoading(
+                resourceKey: simulatedResourceKey,
+                response: HTTPURLResponse(
+                    url: simulatedResourceRequest.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "image/png"]
+                )!
+            )
+
+            // Reveal "Done" so UITest can continue
+            self.doneButton.isHidden = false
+        }
+    }
+}

--- a/Datadog/Example/Scenarios/RUM/StopSessionScenario/KioskSendInterruptedEventsViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/StopSessionScenario/KioskSendInterruptedEventsViewController.swift
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import UIKit
+
+internal class KioskSendInterruptedEventsViewController: UIViewController {
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        rumMonitor.startView(viewController: self, name: "KioskSendInterruptedEvents")
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        rumMonitor.stopView(viewController: self)
+    }
+
+    @IBAction func didTapDownloadResourceButton(_ sender: Any) {
+        rumMonitor.addUserAction(
+            type: .tap,
+            name: (sender as! UIButton).currentTitle!,
+            attributes: ["button.description": String(describing: sender)]
+        )
+
+        let simulatedResourceKey = "/resource/1"
+        let simulatedResourceRequest = URLRequest(url: URL(string: "https://foo.com/resource/1")!)
+        // Much longer wait time
+        let simulatedResourceLoadingTime: TimeInterval = 1.0
+
+        rumMonitor.startResourceLoading(
+            resourceKey: simulatedResourceKey,
+            request: simulatedResourceRequest
+        )
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + simulatedResourceLoadingTime) {
+            rumMonitor.stopResourceLoading(
+                resourceKey: simulatedResourceKey,
+                response: HTTPURLResponse(
+                    url: simulatedResourceRequest.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "image/png"]
+                )!
+            )
+        }
+    }
+}

--- a/Datadog/Example/Scenarios/RUM/StopSessionScenario/KioskViewController.swift
+++ b/Datadog/Example/Scenarios/RUM/StopSessionScenario/KioskViewController.swift
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import UIKit
+
+internal class KioskViewController: UIViewController {
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        rumMonitor.startView(viewController: self, name: "KioskViewController")
+
+        // Stop session
+        rumMonitor.stopSession()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        rumMonitor.stopView(viewController: self)
+    }
+}

--- a/Datadog/Example/Scenarios/RUM/StopSessionScenario/RUMStopSessionScenario.storyboard
+++ b/Datadog/Example/Scenarios/RUM/StopSessionScenario/RUMStopSessionScenario.storyboard
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Whx-8v-wwC">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Navigation Controller-->
+        <scene sceneID="f6W-VN-Jvm">
+            <objects>
+                <navigationController id="Whx-8v-wwC" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="aPt-18-zir">
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="HWL-sJ-Uva" kind="relationship" relationship="rootViewController" id="XsD-gR-1RP"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="agX-Li-TUd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="47" y="-55"/>
+        </scene>
+        <!--Kiosk View Controller-->
+        <scene sceneID="2ej-Cn-qUm">
+            <objects>
+                <viewController id="HWL-sJ-Uva" customClass="KioskViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="OnK-cG-SPL">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Kiosk Screen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WqX-pe-Tmj">
+                                <rect key="frame" x="117" y="296" width="159" height="32"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Returning to this screen should stop the current session." textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jmm-JE-B6g">
+                                <rect key="frame" x="8" y="336" width="377" height="20.333333333333314"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="J0F-rs-xxG">
+                                <rect key="frame" x="134" y="409" width="125" height="35"/>
+                                <color key="tintColor" red="0.4720349908" green="0.26942917700000002" blue="0.70946907999999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Start Session"/>
+                                <connections>
+                                    <segue destination="E9R-Yv-ijK" kind="show" id="CYq-bh-AIO"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZEd-cH-nWO">
+                                <rect key="frame" x="89" y="452" width="215" height="35"/>
+                                <color key="tintColor" red="0.4720349908" green="0.26942917700000002" blue="0.70946907999999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Start Interrupted Session"/>
+                                <connections>
+                                    <segue destination="bOA-4i-jjr" kind="show" id="86x-Fq-oKe"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="dZR-XA-RWh"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="WqX-pe-Tmj" firstAttribute="centerX" secondItem="dZR-XA-RWh" secondAttribute="centerX" id="6RY-FX-l32"/>
+                            <constraint firstItem="ZEd-cH-nWO" firstAttribute="top" secondItem="J0F-rs-xxG" secondAttribute="bottom" constant="8" symbolic="YES" id="HPl-oJ-1SI"/>
+                            <constraint firstItem="J0F-rs-xxG" firstAttribute="centerX" secondItem="dZR-XA-RWh" secondAttribute="centerX" id="HQL-ZU-Mna"/>
+                            <constraint firstItem="ZEd-cH-nWO" firstAttribute="centerX" secondItem="dZR-XA-RWh" secondAttribute="centerX" id="MY5-Ac-O3t"/>
+                            <constraint firstItem="J0F-rs-xxG" firstAttribute="top" secondItem="Jmm-JE-B6g" secondAttribute="bottom" constant="52.666666666666686" id="PdS-LR-0ty"/>
+                            <constraint firstItem="Jmm-JE-B6g" firstAttribute="leading" secondItem="dZR-XA-RWh" secondAttribute="leading" constant="8" id="QEm-Df-cjQ"/>
+                            <constraint firstItem="WqX-pe-Tmj" firstAttribute="top" secondItem="dZR-XA-RWh" secondAttribute="top" constant="193" id="SuO-T0-G0b"/>
+                            <constraint firstItem="Jmm-JE-B6g" firstAttribute="top" secondItem="WqX-pe-Tmj" secondAttribute="bottom" constant="8" symbolic="YES" id="WTj-qc-6bE"/>
+                            <constraint firstItem="dZR-XA-RWh" firstAttribute="trailing" secondItem="Jmm-JE-B6g" secondAttribute="trailing" constant="8" id="yTX-mw-f9Y"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="C1w-g1-PnK"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="XA7-1R-Dee" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="925.95419847328242" y="-56.338028169014088"/>
+        </scene>
+        <!--Kiosk Send Events View Controller-->
+        <scene sceneID="cmb-A4-Fwu">
+            <objects>
+                <viewController id="E9R-Yv-ijK" customClass="KioskSendEventsViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Q2Q-l7-ltJ">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sending RUM events..." textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yUZ-w9-mUZ">
+                                <rect key="frame" x="110.33333333333333" y="450" width="172.66666666666669" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vRT-VQ-kyZ">
+                                <rect key="frame" x="108.66666666666669" y="483" width="176" height="35"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Download Resource"/>
+                                <connections>
+                                    <action selector="didTapDownloadResourceButton:" destination="E9R-Yv-ijK" eventType="touchUpInside" id="Sf0-mT-jSL"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ct0-mj-IY6">
+                                <rect key="frame" x="164" y="526" width="65" height="35"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Done"/>
+                                <connections>
+                                    <action selector="didTapDownloadResourceButton:" destination="E9R-Yv-ijK" eventType="touchUpInside" id="9pg-vJ-m5U"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="EKV-93-qOX"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vRT-VQ-kyZ" firstAttribute="top" secondItem="yUZ-w9-mUZ" secondAttribute="bottom" constant="12" id="5Hh-Im-jGa"/>
+                            <constraint firstItem="ct0-mj-IY6" firstAttribute="centerX" secondItem="EKV-93-qOX" secondAttribute="centerX" id="LLs-DU-I2b"/>
+                            <constraint firstItem="yUZ-w9-mUZ" firstAttribute="centerX" secondItem="EKV-93-qOX" secondAttribute="centerX" id="Lyx-zP-OMO"/>
+                            <constraint firstItem="yUZ-w9-mUZ" firstAttribute="centerY" secondItem="EKV-93-qOX" secondAttribute="centerY" id="PbB-ZE-wRk"/>
+                            <constraint firstItem="ct0-mj-IY6" firstAttribute="top" secondItem="vRT-VQ-kyZ" secondAttribute="bottom" constant="8" symbolic="YES" id="Ztb-qb-993"/>
+                            <constraint firstItem="vRT-VQ-kyZ" firstAttribute="centerX" secondItem="EKV-93-qOX" secondAttribute="centerX" id="leV-fT-f2D"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="yXm-oz-zaD"/>
+                    <connections>
+                        <outlet property="doneButton" destination="ct0-mj-IY6" id="vL9-3g-zWQ"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="gfG-vO-mlj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1912" y="-56"/>
+        </scene>
+        <!--Kiosk Send Interrupted Events View Controller-->
+        <scene sceneID="Pcy-80-2t2">
+            <objects>
+                <viewController id="bOA-4i-jjr" customClass="KioskSendInterruptedEventsViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="kmP-j2-UfY">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sending RUM events... but delaying finishing resources." textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OaX-H9-95D">
+                                <rect key="frame" x="8" y="450" width="377" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Grp-kd-Mwq">
+                                <rect key="frame" x="108.66666666666669" y="483" width="176" height="35"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Download Resource"/>
+                                <connections>
+                                    <action selector="didTapDownloadResourceButton:" destination="bOA-4i-jjr" eventType="touchUpInside" id="wY5-mb-InR"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="NdI-FT-Uxm"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Grp-kd-Mwq" firstAttribute="centerX" secondItem="NdI-FT-Uxm" secondAttribute="centerX" id="6xo-XO-2b4"/>
+                            <constraint firstItem="Grp-kd-Mwq" firstAttribute="top" secondItem="OaX-H9-95D" secondAttribute="bottom" constant="12" id="AIQ-sh-tMR"/>
+                            <constraint firstItem="OaX-H9-95D" firstAttribute="centerY" secondItem="NdI-FT-Uxm" secondAttribute="centerY" id="KXa-Zl-Ebs"/>
+                            <constraint firstItem="OaX-H9-95D" firstAttribute="leading" secondItem="NdI-FT-Uxm" secondAttribute="leading" constant="8" id="iYO-fC-e2I"/>
+                            <constraint firstItem="NdI-FT-Uxm" firstAttribute="trailing" secondItem="OaX-H9-95D" secondAttribute="trailing" constant="8" id="wz1-QT-Odv"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="BzF-Oe-YtD"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="cF3-Ns-PMU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1910.6870229007632" y="679.57746478873241"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Sources/Datadog/DDRUMMonitor.swift
+++ b/Sources/Datadog/DDRUMMonitor.swift
@@ -296,6 +296,13 @@ public class DDRUMMonitor {
     /// - Parameter key: key for the attribute that will be removed.
     public func removeAttribute(forKey key: AttributeKey) {}
 
+    // MARK: - Session
+
+    /// Stops the current session.
+    /// A new session will start in response to a call to `startView` or `addUserAction`.
+    /// If the session is started because of a call to `addUserAction`, the last know view is restarted in the new session.
+    public func stopSession() {}
+
     // MARK: - Internal
 
     internal init() {}

--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -308,12 +308,16 @@ public struct RUMActionEvent: RUMDataModel {
         /// UUID of the session
         public let id: String
 
+        /// Whether this session is currently active. Set to false to manually stop a session
+        public let isActive: Bool?
+
         /// Type of the session
         public let type: SessionType
 
         enum CodingKeys: String, CodingKey {
             case hasReplay = "has_replay"
             case id = "id"
+            case isActive = "is_active"
             case type = "type"
         }
 
@@ -702,12 +706,16 @@ public struct RUMErrorEvent: RUMDataModel {
         /// UUID of the session
         public let id: String
 
+        /// Whether this session is currently active. Set to false to manually stop a session
+        public let isActive: Bool?
+
         /// Type of the session
         public let type: SessionType
 
         enum CodingKeys: String, CodingKey {
             case hasReplay = "has_replay"
             case id = "id"
+            case isActive = "is_active"
             case type = "type"
         }
 
@@ -963,12 +971,16 @@ public struct RUMLongTaskEvent: RUMDataModel {
         /// UUID of the session
         public let id: String
 
+        /// Whether this session is currently active. Set to false to manually stop a session
+        public let isActive: Bool?
+
         /// Type of the session
         public let type: SessionType
 
         enum CodingKeys: String, CodingKey {
             case hasReplay = "has_replay"
             case id = "id"
+            case isActive = "is_active"
             case type = "type"
         }
 
@@ -1387,12 +1399,16 @@ public struct RUMResourceEvent: RUMDataModel {
         /// UUID of the session
         public let id: String
 
+        /// Whether this session is currently active. Set to false to manually stop a session
+        public let isActive: Bool?
+
         /// Type of the session
         public let type: SessionType
 
         enum CodingKeys: String, CodingKey {
             case hasReplay = "has_replay"
             case id = "id"
+            case isActive = "is_active"
             case type = "type"
         }
 
@@ -1593,12 +1609,16 @@ public struct RUMViewEvent: RUMDataModel {
         /// UUID of the session
         public let id: String
 
+        /// Whether this session is currently active. Set to false to manually stop a session
+        public let isActive: Bool?
+
         /// Type of the session
         public let type: SessionType
 
         enum CodingKeys: String, CodingKey {
             case hasReplay = "has_replay"
             case id = "id"
+            case isActive = "is_active"
             case type = "type"
         }
 
@@ -2957,4 +2977,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/581880e6d9e9bb51f6c81ecd87bae2923865a2a5
+// Generated from https://github.com/DataDog/rum-events-format/tree/f964339c5f07f476dee5fc6a12b6c1214a40c1da

--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -21,7 +21,7 @@ private struct RUMDebugInfo {
     let views: [View]
 
     init(applicationScope: RUMApplicationScope) {
-        self.views = (applicationScope.sessionScope?.viewScopes ?? [])
+        self.views = (applicationScope.activeSession?.viewScopes ?? [])
             .map { View(scope: $0) }
     }
 }

--- a/Sources/Datadog/RUM/Integrations/CrashReportReceiver.swift
+++ b/Sources/Datadog/RUM/Integrations/CrashReportReceiver.swift
@@ -347,6 +347,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             session: .init(
                 hasReplay: lastRUMView.session.hasReplay,
                 id: lastRUMView.session.id,
+                isActive: true,
                 type: lastRUMView.ciTest != nil ? .ciTest : .user
             ),
             source: lastRUMView.source?.toErrorEventSource ?? .ios,
@@ -469,6 +470,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             session: .init(
                 hasReplay: hasReplay,
                 id: sessionUUID.toRUMDataFormat,
+                isActive: true,
                 type: CITestIntegration.active != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMContext/RUMContext.swift
+++ b/Sources/Datadog/RUM/RUMContext/RUMContext.swift
@@ -11,6 +11,8 @@ internal struct RUMContext {
     let rumApplicationID: String
     /// The ID of current RUM session. May change over time.
     var sessionID: RUMUUID
+    /// Whether the session for this context is currently active
+    var isSessionActive: Bool
 
     /// The ID of currently displayed view.
     var activeViewID: RUMUUID?

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -29,8 +29,8 @@ internal struct RUMApplicationStartCommand: RUMCommand {
 internal struct RUMStopSessionCommand: RUMCommand {
     var time: Date
     var attributes: [AttributeKey: AttributeValue] = [:]
-    var canStartBackgroundView = false // no, stopping a session should not start a backgorund session
-    var isUserInteraction = false
+    let canStartBackgroundView = false // no, stopping a session should not start a backgorund session
+    let isUserInteraction = false
 
     init(time: Date) {
         self.time = time

--- a/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/RUMCommand.swift
@@ -26,6 +26,17 @@ internal struct RUMApplicationStartCommand: RUMCommand {
     var isUserInteraction = false
 }
 
+internal struct RUMStopSessionCommand: RUMCommand {
+    var time: Date
+    var attributes: [AttributeKey: AttributeValue] = [:]
+    var canStartBackgroundView = false // no, stopping a session should not start a backgorund session
+    var isUserInteraction = false
+
+    init(time: Date) {
+        self.time = time
+    }
+}
+
 // MARK: - RUM View related commands
 
 internal struct RUMStartViewCommand: RUMCommand {

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -66,15 +66,18 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         // that need a refresh
         sessionScopes = sessionScopes.compactMap({ scope in
             if scope.process(command: command, context: context, writer: writer) {
-                // Returned true, keep the scope around, it still has work to do.
+                // proccss(command:context:writer) returned true, so keep the scope around
+                // as it it still has work to do.
                 return scope
             }
 
+            // proccss(command:context:writer) returned false, but if the scope is  still active
+            // it means we timed out or expired and we need to refresh the session
             if scope.isActive {
-                // False, but still active means we timed out or expired, refresh the session
                 return refresh(expiredSession: scope, on: command, context: context, writer: writer)
             }
-            // Else, inactive and done processing events, remove
+
+            // Else, an inactive scope is done processing events and can be removed
             return nil
         })
 

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -113,7 +113,12 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     }
 
     private func startSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
-        let session = RUMSessionScope(isInitialSession: false, parent: self, startTime: command.time, dependencies: dependencies, isReplayBeingRecorded: context.srBaggage?.isReplayBeingRecorded
+        let session = RUMSessionScope(
+            isInitialSession: false,
+            parent: self,
+            startTime: command.time,
+            dependencies: dependencies,
+            isReplayBeingRecorded: context.srBaggage?.isReplayBeingRecorded
         )
 
         sessionScopes.append(session)

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -9,6 +9,10 @@ import Foundation
 internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     // MARK: - Child Scopes
 
+    // Whether the applciation is already active. Set to true
+    // when the first session starts.
+    private(set) var appplicationActive: Bool = false
+
     /// Session scope. It gets created with the first event.
     /// Might be re-created later according to session duration constraints.
     private(set) var sessionScope: RUMSessionScope?
@@ -22,6 +26,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         self.context = RUMContext(
             rumApplicationID: dependencies.rumApplicationID,
             sessionID: .nullUUID,
+            isSessionActive: false,
             activeViewID: nil,
             activeViewPath: nil,
             activeViewName: nil,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -202,6 +202,7 @@ internal class RUMResourceScope: RUMScope {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
+                isActive: true,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -262,6 +263,7 @@ internal class RUMResourceScope: RUMScope {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
+                isActive: true,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -202,7 +202,7 @@ internal class RUMResourceScope: RUMScope {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: true,
+                isActive: nil,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -263,7 +263,7 @@ internal class RUMResourceScope: RUMScope {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: true,
+                isActive: nil,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScope.swift
@@ -63,7 +63,8 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
         parent: RUMContextProvider,
         startTime: Date,
         dependencies: RUMScopeDependencies,
-        isReplayBeingRecorded: Bool?
+        isReplayBeingRecorded: Bool?,
+        resumingViewScope: RUMViewScope? = nil
     ) {
         self.parent = parent
         self.dependencies = dependencies
@@ -80,6 +81,24 @@ internal class RUMSessionScope: RUMScope, RUMContextProvider {
             hasTrackedAnyView: false,
             didStartWithReplay: isReplayBeingRecorded
         )
+
+        if let viewScope = resumingViewScope,
+           let viewIdentifiable = viewScope.identity.identifiable {
+            viewScopes.append(
+                RUMViewScope(
+                    isInitialView: false,
+                    parent: self,
+                    dependencies: dependencies,
+                    identity: viewIdentifiable,
+                    path: viewScope.viewPath,
+                    name: viewScope.viewName,
+                    attributes: viewScope.attributes,
+                    customTimings: [:],
+                    startTime: startTime,
+                    serverTimeOffset: viewScope.serverTimeOffset
+                )
+            )
+        }
 
         // Update `CrashContext` with recent RUM session state:
         dependencies.core.send(message: .custom(key: "rum", baggage: [RUMBaggageKeys.sessionState: state]))

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -167,6 +167,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
+                isActive: true,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -167,7 +167,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: true,
+                isActive: nil,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -396,6 +396,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
+                isActive: true,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -452,6 +453,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
+                isActive: true,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -559,6 +561,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
+                isActive: true,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -610,6 +613,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
+                isActive: true,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -168,6 +168,11 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             didReceiveStartCommand = true
             needsViewUpdate = true
 
+        // Session stop
+        case let _ as RUMStopSessionCommand:
+            isActiveView = false
+            needsViewUpdate = true
+
         // View commands
         case let command as RUMStartViewCommand where identity.equals(command.identity):
             if didReceiveStartCommand {

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -396,7 +396,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: true,
+                isActive: self.context.isSessionActive,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -453,7 +453,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: true,
+                isActive: self.context.isSessionActive,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -561,7 +561,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: true,
+                isActive: self.context.isSessionActive,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -613,7 +613,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: true,
+                isActive: self.context.isSessionActive,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -169,7 +169,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             needsViewUpdate = true
 
         // Session stop
-        case let _ as RUMStopSessionCommand:
+        case is RUMStopSessionCommand:
             isActiveView = false
             needsViewUpdate = true
 

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -601,6 +601,12 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         }
     }
 
+    // MARK: - Session
+
+    override public func stopSession() {
+        process(command: RUMStopSessionCommand(time: dateProvider.now))
+    }
+
     // MARK: - Internal
 
     func enableRUMDebugging(_ enabled: Bool) {

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -636,10 +636,11 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         core.set(feature: "rum", attributes: {
             self.queue.sync {
                 let context = self.applicationScope.activeSession?.viewScopes.last?.context ??
-                              self.applicationScope.activeSession?.context ??
-                              self.applicationScope.context
+                                self.applicationScope.activeSession?.context ??
+                                self.applicationScope.context
 
                 guard context.sessionID != .nullUUID else {
+                    // if Session was sampled or not yet started
                     return [:]
                 }
 

--- a/Sources/Datadog/RUMMonitor.swift
+++ b/Sources/Datadog/RUMMonitor.swift
@@ -635,12 +635,11 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
         // update the core context with rum context
         core.set(feature: "rum", attributes: {
             self.queue.sync {
-                let context = self.applicationScope.sessionScope?.viewScopes.last?.context ??
-                                self.applicationScope.sessionScope?.context ??
-                                self.applicationScope.context
+                let context = self.applicationScope.activeSession?.viewScopes.last?.context ??
+                              self.applicationScope.activeSession?.context ??
+                              self.applicationScope.context
 
                 guard context.sessionID != .nullUUID else {
-                    // if Session was sampled or not yet started
                     return [:]
                 }
 
@@ -651,7 +650,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
                         RUMContextAttributes.IDs.viewID: context.activeViewID?.rawValue.uuidString.lowercased(),
                         RUMContextAttributes.IDs.userActionID: context.activeUserActionID?.rawValue.uuidString.lowercased(),
                     ],
-                    RUMContextAttributes.serverTimeOffset: self.applicationScope.sessionScope?.viewScopes.last?.serverTimeOffset
+                    RUMContextAttributes.serverTimeOffset: self.applicationScope.activeSession?.viewScopes.last?.serverTimeOffset
                 ]
             }
         })

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -666,6 +666,10 @@ public class DDRUMActionEventSession: NSObject {
         root.swiftModel.session.id
     }
 
+    @objc public var isActive: NSNumber? {
+        root.swiftModel.session.isActive as NSNumber?
+    }
+
     @objc public var type: DDRUMActionEventSessionSessionType {
         .init(swift: root.swiftModel.session.type)
     }
@@ -1628,6 +1632,10 @@ public class DDRUMErrorEventSession: NSObject {
         root.swiftModel.session.id
     }
 
+    @objc public var isActive: NSNumber? {
+        root.swiftModel.session.isActive as NSNumber?
+    }
+
     @objc public var type: DDRUMErrorEventSessionSessionType {
         .init(swift: root.swiftModel.session.type)
     }
@@ -2240,6 +2248,10 @@ public class DDRUMLongTaskEventSession: NSObject {
 
     @objc public var id: String {
         root.swiftModel.session.id
+    }
+
+    @objc public var isActive: NSNumber? {
+        root.swiftModel.session.isActive as NSNumber?
     }
 
     @objc public var type: DDRUMLongTaskEventSessionSessionType {
@@ -3173,6 +3185,10 @@ public class DDRUMResourceEventSession: NSObject {
         root.swiftModel.session.id
     }
 
+    @objc public var isActive: NSNumber? {
+        root.swiftModel.session.isActive as NSNumber?
+    }
+
     @objc public var type: DDRUMResourceEventSessionSessionType {
         .init(swift: root.swiftModel.session.type)
     }
@@ -3733,6 +3749,10 @@ public class DDRUMViewEventSession: NSObject {
 
     @objc public var id: String {
         root.swiftModel.session.id
+    }
+
+    @objc public var isActive: NSNumber? {
+        root.swiftModel.session.isActive as NSNumber?
     }
 
     @objc public var type: DDRUMViewEventSessionSessionType {
@@ -5091,4 +5111,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/581880e6d9e9bb51f6c81ecd87bae2923865a2a5
+// Generated from https://github.com/DataDog/rum-events-format/tree/f964339c5f07f476dee5fc6a12b6c1214a40c1da

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
@@ -71,7 +71,12 @@ extension RUMSessionMatcher {
         let eventMatchers = try requests
             .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody, eventsPatch: eventsPatch) }
             .filter { event in try event.eventType() != "telemetry" }
-        let sessionMatchers = try RUMSessionMatcher.groupMatchersBySessions(eventMatchers)
+        var sessionMatchers = try RUMSessionMatcher.groupMatchersBySessions(eventMatchers)
+        sessionMatchers.sort {
+            let a = $0.viewVisits.first?.viewEvents.first?.date ?? 0
+            let b = $1.viewVisits.first?.viewEvents.first?.date ?? 0
+            return a < b
+        }
 
         if sessionMatchers.count > maxCount {
             throw Exception(

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMCommonAsserts.swift
@@ -71,12 +71,9 @@ extension RUMSessionMatcher {
         let eventMatchers = try requests
             .flatMap { request in try RUMEventMatcher.fromNewlineSeparatedJSONObjectsData(request.httpBody, eventsPatch: eventsPatch) }
             .filter { event in try event.eventType() != "telemetry" }
-        var sessionMatchers = try RUMSessionMatcher.groupMatchersBySessions(eventMatchers)
-        sessionMatchers.sort {
-            let a = $0.viewVisits.first?.viewEvents.first?.date ?? 0
-            let b = $1.viewVisits.first?.viewEvents.first?.date ?? 0
-            return a < b
-        }
+        let sessionMatchers = try RUMSessionMatcher.groupMatchersBySessions(eventMatchers).sorted(by: {
+            return $0.viewVisits.first?.viewEvents.first?.date ?? 0 < $1.viewVisits.first?.viewEvents.first?.date ?? 0
+        })
 
         if sessionMatchers.count > maxCount {
             throw Exception(

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMStopSessionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMStopSessionScenarioTests.swift
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import Foundation
+import XCTest
+
+class RUMStopSessionKioskScreen: XCUIApplication {
+    func tapStartSession() {
+        buttons["Start Session"].tap()
+    }
+
+    func tapStartInterruptedSession() {
+        buttons["Start Interrupted Session"].tap()
+    }
+}
+
+class RUMSendKioskEventsScreen: XCUIApplication {
+    func back() {
+        navigationBars.buttons["Back"].tap()
+    }
+
+    func tapDownloadResourceAndWait() {
+        buttons["Download Resource"].tap()
+        _ = buttons["Done"].waitForExistence(timeout: 2)
+    }
+}
+
+class RUMSendKioskEventsInterruptedScreen: XCUIApplication {
+    func back() {
+        navigationBars.buttons["Back"].tap()
+    }
+
+    func tapDownloadResource() {
+        buttons["Download Resource"].tap()
+    }
+}
+
+class RUMStopSessionScenarioTests: IntegrationTests, RUMCommonAsserts {
+    func testRUMStopSessionScenario() throws {
+        // Server session recording RUM events send to `HTTPServerMock`.
+        let rumServerSession = server.obtainUniqueRecordingSession()
+
+        let app = ExampleApplication()
+        app.launchWith(
+            testScenarioClassName: "RUMStopSessionsScenario",
+            serverConfiguration: HTTPServerMockConfiguration(
+                rumEndpoint: rumServerSession.recordingURL
+            )
+        )
+
+        let kioskScreen = RUMStopSessionKioskScreen()
+        kioskScreen.tapStartSession()
+        let sendEventsScreen = RUMSendKioskEventsScreen()
+        sendEventsScreen.tapDownloadResourceAndWait()
+        sendEventsScreen.back()
+
+        kioskScreen.tapStartInterruptedSession()
+        let sendInterruptedEventsScreen = RUMSendKioskEventsInterruptedScreen()
+        sendInterruptedEventsScreen.tapDownloadResource()
+        sendInterruptedEventsScreen.back()
+
+        try app.endRUMSession()
+
+        // Get RUM Sessions with expected number of View visits
+        let recordedRUMRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+            // 4th session should only contain the test session ending
+            let sessions = try RUMSessionMatcher.sessions(maxCount: 4, from: requests)
+            // No active views in any session
+            return sessions.count == 4 && sessions.allSatisfy { session in
+                !session.viewVisits.contains(where: { $0.viewEvents.last?.view.isActive == true })
+            }
+        }
+
+        assertRUM(requests: recordedRUMRequests)
+
+        let sessions = try RUMSessionMatcher.sessions(maxCount: 4, from: recordedRUMRequests)
+        do {
+            let appStartSession = sessions[0]
+
+            let launchView = try XCTUnwrap(appStartSession.applicationLaunchView)
+            XCTAssertEqual(launchView.actionEvents[0].action.type, .applicationStart)
+
+            let view1 = appStartSession.viewVisits[0]
+            XCTAssertEqual(view1.name, "KioskViewController")
+            XCTAssertEqual(view1.path, "Example.KioskViewController")
+            XCTAssertEqual(view1.viewEvents.last?.session.isActive, false)
+            RUMSessionMatcher.assertViewWasEventuallyInactive(view1)
+        }
+
+        // Second session sends a resource and ends returning to the KioskViewController
+        do {
+            let normalSession = sessions[1]
+            XCTAssertNil(normalSession.applicationLaunchView)
+
+            let view1 = normalSession.viewVisits[0]
+            XCTAssertTrue(try XCTUnwrap(view1.viewEvents.first?.session.isActive))
+            XCTAssertEqual(view1.name, "KioskSendEvents")
+            XCTAssertEqual(view1.path, "Example.KioskSendEventsViewController")
+            XCTAssertEqual(view1.resourceEvents[0].resource.url, "https://foo.com/resource/1")
+            XCTAssertEqual(view1.resourceEvents[0].resource.statusCode, 200)
+            XCTAssertEqual(view1.resourceEvents[0].resource.type, .image)
+            XCTAssertGreaterThan(view1.resourceEvents[0].resource.duration, 100_000_000 - 1) // ~0.1s
+            XCTAssertLessThan(view1.resourceEvents[0].resource.duration, 1_000_000_000 * 30) // less than 30s (big enough to balance NTP sync)
+            RUMSessionMatcher.assertViewWasEventuallyInactive(view1)
+
+            let view2 = normalSession.viewVisits[1]
+            XCTAssertEqual(view2.name, "KioskViewController")
+            XCTAssertEqual(view2.path, "Example.KioskViewController")
+            XCTAssertEqual(view2.viewEvents.last?.session.isActive, false)
+            RUMSessionMatcher.assertViewWasEventuallyInactive(view2)
+        }
+
+        // Third session, same as the first but longer before completing resources
+        do {
+            let interruptedSession = sessions[2]
+            XCTAssertNil(interruptedSession.applicationLaunchView)
+
+            let view1 = interruptedSession.viewVisits[0]
+            XCTAssertTrue(try XCTUnwrap(view1.viewEvents.first?.session.isActive))
+            XCTAssertEqual(view1.name, "KioskSendInterruptedEvents")
+            XCTAssertEqual(view1.path, "Example.KioskSendInterruptedEventsViewController")
+            XCTAssertEqual(view1.resourceEvents[0].resource.url, "https://foo.com/resource/1")
+            XCTAssertEqual(view1.resourceEvents[0].resource.statusCode, 200)
+            XCTAssertEqual(view1.resourceEvents[0].resource.type, .image)
+            XCTAssertGreaterThan(view1.resourceEvents[0].resource.duration, 100_000_000 - 1) // ~0.1s
+            XCTAssertLessThan(view1.resourceEvents[0].resource.duration, 1_000_000_000 * 30) // less than 30s (big enough to balance NTP sync)
+            RUMSessionMatcher.assertViewWasEventuallyInactive(view1)
+
+            let view2 = interruptedSession.viewVisits[1]
+            XCTAssertEqual(view2.name, "KioskViewController")
+            XCTAssertEqual(view2.path, "Example.KioskViewController")
+            XCTAssertEqual(view2.viewEvents.last?.session.isActive, false)
+            RUMSessionMatcher.assertViewWasEventuallyInactive(view2)
+        }
+    }
+}

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -121,6 +121,7 @@ extension RUMViewEvent: RandomMockable {
             session: .init(
                 hasReplay: nil,
                 id: .mockRandom(),
+                isActive: true,
                 type: .user
             ),
             source: .ios,
@@ -219,6 +220,7 @@ extension RUMResourceEvent: RandomMockable {
             session: .init(
                 hasReplay: nil,
                 id: .mockRandom(),
+                isActive: true,
                 type: .user
             ),
             source: .ios,
@@ -272,6 +274,7 @@ extension RUMActionEvent: RandomMockable {
             session: .init(
                 hasReplay: nil,
                 id: .mockRandom(),
+                isActive: true,
                 type: .user
             ),
             source: .ios,
@@ -335,6 +338,7 @@ extension RUMErrorEvent: RandomMockable {
             session: .init(
                 hasReplay: nil,
                 id: .mockRandom(),
+                isActive: true,
                 type: .user
             ),
             source: .ios,
@@ -383,7 +387,12 @@ extension RUMLongTaskEvent: RandomMockable {
             longTask: .init(duration: .mockRandom(), id: .mockRandom(), isFrozenFrame: .mockRandom()),
             os: .mockRandom(),
             service: .mockRandom(),
-            session: .init(hasReplay: false, id: .mockRandom(), type: .user),
+            session: .init(
+                hasReplay: false,
+                id: .mockRandom(),
+                isActive: true,
+                type: .user
+            ),
             source: .ios,
             synthetics: nil,
             usr: .mockRandom(),

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -274,7 +274,7 @@ extension RUMActionEvent: RandomMockable {
             session: .init(
                 hasReplay: nil,
                 id: .mockRandom(),
-                isActive: true,
+                isActive: nil,
                 type: .user
             ),
             source: .ios,
@@ -338,7 +338,7 @@ extension RUMErrorEvent: RandomMockable {
             session: .init(
                 hasReplay: nil,
                 id: .mockRandom(),
-                isActive: true,
+                isActive: nil,
                 type: .user
             ),
             source: .ios,

--- a/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMFeatureMocks.swift
@@ -149,7 +149,6 @@ struct RUMCommandMock: RUMCommand {
     var time = Date()
     var attributes: [AttributeKey: AttributeValue] = [:]
     var canStartBackgroundView = false
-    var canStartApplicationLaunchView = false
     var isUserInteraction = false
 }
 
@@ -596,6 +595,14 @@ extension RUMAddFeatureFlagEvaluationCommand: AnyMockable, RandomMockable {
     }
 }
 
+extension RUMStopSessionCommand: AnyMockable {
+    public static func mockAny() -> RUMStopSessionCommand { mockWith() }
+
+    static func mockWith(time: Date = .mockAny()) -> RUMStopSessionCommand {
+        return RUMStopSessionCommand(time: time)
+    }
+}
+
 // MARK: - RUMCommand Property Mocks
 
 extension RUMInternalErrorSource: RandomMockable {
@@ -620,6 +627,7 @@ extension RUMContext {
     static func mockWith(
         rumApplicationID: String = .mockAny(),
         sessionID: RUMUUID = .mockRandom(),
+        isSessionActive: Bool = true,
         activeViewID: RUMUUID? = nil,
         activeViewPath: String? = nil,
         activeViewName: String? = nil,
@@ -628,6 +636,7 @@ extension RUMContext {
         return RUMContext(
             rumApplicationID: rumApplicationID,
             sessionID: sessionID,
+            isSessionActive: true,
             activeViewID: activeViewID,
             activeViewPath: activeViewPath,
             activeViewName: activeViewName,

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScopeTests.swift
@@ -40,7 +40,7 @@ class RUMApplicationScopeTests: XCTestCase {
                 onSessionStart: onSessionStart
             )
         )
-        XCTAssertNil(scope.sessionScope)
+        XCTAssertNil(scope.activeSession)
 
         // When
         let command = mockRandomRUMCommand().replacing(time: currentTime.addingTimeInterval(1))
@@ -49,7 +49,7 @@ class RUMApplicationScopeTests: XCTestCase {
         waitForExpectations(timeout: 0.5)
 
         // Then
-        let sessionScope = try XCTUnwrap(scope.sessionScope)
+        let sessionScope = try XCTUnwrap(scope.activeSession)
         XCTAssertTrue(sessionScope.isInitialSession, "Starting the very first view in application must create initial session")
     }
 
@@ -79,7 +79,7 @@ class RUMApplicationScopeTests: XCTestCase {
             writer: writer
         )
 
-        let initialSession = try XCTUnwrap(scope.sessionScope)
+        let initialSession = try XCTUnwrap(scope.activeSession)
 
         // When
         // Push time forward by the max session duration:
@@ -93,7 +93,7 @@ class RUMApplicationScopeTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5)
 
-        let nextSession = try XCTUnwrap(scope.sessionScope)
+        let nextSession = try XCTUnwrap(scope.activeSession)
         XCTAssertNotEqual(initialSession.sessionUUID, nextSession.sessionUUID, "New session must have different id")
         XCTAssertEqual(initialSession.viewScopes.count, nextSession.viewScopes.count, "All view scopes must be transferred to the new session")
 
@@ -180,5 +180,152 @@ class RUMApplicationScopeTests: XCTestCase {
         let halfSessionsCount = 0.5 * Double(simulatedSessionsCount)
         XCTAssertGreaterThan(trackedSessionsCount, halfSessionsCount * 0.8) // -20%
         XCTAssertLessThan(trackedSessionsCount, halfSessionsCount * 1.2) // +20%
+    }
+
+    // MARK: - Stopping and Restarting Sessions
+
+    func testWhenStoppingSession_itHasNoActiveSesssion() throws {
+        // Given
+        var currentTime = Date()
+        let scope = RUMApplicationScope(
+            dependencies: .mockWith(
+                sessionSampler: .mockKeepAll()
+            )
+        )
+
+        let command = mockRandomRUMCommand().replacing(time: currentTime.addingTimeInterval(1))
+        XCTAssertTrue(scope.process(command: command, context: context, writer: writer))
+
+        // When
+        let stopCommand = RUMStopSessionCommand.mockAny()
+        XCTAssertFalse(scope.process(command: stopCommand, context: context, writer: writer))
+
+        // Then
+        XCTAssertNil(scope.activeSession)
+    }
+
+    func testGivenStoppedSession_whenUserActionEvent_itStartsANewSession() throws {
+        // Given
+        var currentTime = Date()
+        let scope = RUMApplicationScope(
+            dependencies: .mockWith(
+                sessionSampler: .mockKeepAll()
+            )
+        )
+        XCTAssertTrue(scope.process(
+            command: RUMCommandMock(time: currentTime.addingTimeInterval(1), isUserInteraction: true),
+            context: context,
+            writer: writer
+        ))
+        XCTAssertFalse(scope.process(
+            command: RUMStopSessionCommand.mockWith(time: currentTime.addingTimeInterval(2)),
+            context: context,
+            writer: writer
+        ))
+        XCTAssertTrue(scope.process(
+            command: RUMCommandMock(time: currentTime.addingTimeInterval(3), isUserInteraction: true),
+            context: context,
+            writer: writer
+        ))
+
+        // Then
+        XCTAssertEqual(scope.sessionScopes.count, 1)
+        XCTAssertNotNil(scope.activeSession)
+    }
+
+    func testGivenStoppedSession_whenNonUserIntaractionEvent_itDoesNotStartANewSession() throws {
+        // Given
+        var currentTime = Date()
+        let scope = RUMApplicationScope(
+            dependencies: .mockWith(
+                sessionSampler: .mockKeepAll()
+            )
+        )
+        XCTAssertTrue(scope.process(
+            command: RUMCommandMock(time: currentTime.addingTimeInterval(1), isUserInteraction: true),
+            context: context,
+            writer: writer
+        ))
+        XCTAssertFalse(scope.process(
+            command: RUMStopSessionCommand.mockWith(time: currentTime.addingTimeInterval(2)),
+            context: context,
+            writer: writer
+        ))
+        XCTAssertFalse(scope.process(
+            command: RUMCommandMock(time: currentTime.addingTimeInterval(3), isUserInteraction: false),
+            context: context,
+            writer: writer
+        ))
+
+        // Then
+        XCTAssertEqual(scope.sessionScopes.count, 0)
+        XCTAssertNil(scope.activeSession)
+    }
+
+    func testGivenStoppedSessionProcessingResources_itCanStayInactive() throws {
+        // Given
+        var currentTime = Date()
+        let scope = RUMApplicationScope(
+            dependencies: .mockWith(
+                sessionSampler: .mockKeepAll()
+            )
+        )
+        XCTAssertTrue(scope.process(
+            command: RUMStartResourceCommand.mockRandom(),
+            context: context,
+            writer: writer
+        ))
+        XCTAssertFalse(scope.process(
+            command: RUMStopSessionCommand.mockWith(time: currentTime.addingTimeInterval(2)),
+            context: context,
+            writer: writer
+        ))
+
+        // Then
+        XCTAssertEqual(scope.sessionScopes.count, 1)
+        XCTAssertNil(scope.activeSession)
+    }
+
+    func testGivenStoppedSessionProcessingResources_itIsRemovedWhenFinished() throws {
+        // Given
+        var currentTime = Date()
+        let scope = RUMApplicationScope(
+            dependencies: .mockWith(
+                sessionSampler: .mockKeepAll()
+            )
+        )
+        let resourceKey = "resources/1"
+        XCTAssertTrue(scope.process(
+            command: RUMStartResourceCommand.mockWith(
+                resourceKey: resourceKey,
+                time: currentTime.addingTimeInterval(1)
+            ),
+            context: context,
+            writer: writer
+        ))
+        let firstSession = scope.activeSession
+        XCTAssertFalse(scope.process(
+            command: RUMStopSessionCommand.mockWith(time: currentTime.addingTimeInterval(2)),
+            context: context,
+            writer: writer
+        ))
+        XCTAssertTrue(scope.process(
+            command: RUMCommandMock(time: currentTime.addingTimeInterval(3), isUserInteraction: true),
+            context: context,
+            writer: writer
+        ))
+        let secondSession = scope.activeSession
+        XCTAssertTrue(scope.process(
+            command: RUMStopResourceCommand.mockWith(
+                resourceKey: resourceKey,
+                time: currentTime.addingTimeInterval(4)
+            ),
+            context: context,
+            writer: writer
+        ))
+
+        // Then
+        XCTAssertEqual(scope.sessionScopes.count, 1)
+        XCTAssertEqual(scope.activeSession?.sessionUUID, secondSession?.sessionUUID)
     }
 }

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -574,11 +574,9 @@ class RUMSessionScopeTests: XCTestCase {
     func testWhenScopeEnded_itDoesNotResetContextNextUpdate() {
         // Given
         var viewResetCallCount = 0
-        var viewEvent: RUMViewEvent? = nil
         let messageReciever = FeatureMessageReceiverMock { message in
             if case let .custom(_, baggage) = message, baggage[RUMBaggageKeys.viewReset, type: Bool.self] == true {
                 viewResetCallCount += 1
-                viewEvent = nil
             }
         }
 

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMSessionScopeTests.swift
@@ -21,6 +21,7 @@ class RUMSessionScopeTests: XCTestCase {
 
         XCTAssertEqual(scope.context.rumApplicationID, "rum-123")
         XCTAssertNotEqual(scope.context.sessionID, .nullUUID)
+        XCTAssertTrue(scope.context.isSessionActive)
         XCTAssertNil(scope.context.activeViewID)
         XCTAssertNil(scope.context.activeViewPath)
         XCTAssertNil(scope.context.activeUserActionID)
@@ -147,7 +148,7 @@ class RUMSessionScopeTests: XCTestCase {
 
         // When
         let commandTime = sessionStartTime.addingTimeInterval(1)
-        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: true, canStartApplicationLaunchView: .mockRandom())
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: true)
         XCTAssertTrue(scope.process(command: command, context: context, writer: writer))
 
         // Then
@@ -183,7 +184,7 @@ class RUMSessionScopeTests: XCTestCase {
 
         // When
         commandTime = commandTime.addingTimeInterval(1)
-        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: true, canStartApplicationLaunchView: .mockRandom())
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: true)
         XCTAssertTrue(scope.process(command: command, context: context, writer: writer))
 
         // Then
@@ -212,7 +213,7 @@ class RUMSessionScopeTests: XCTestCase {
 
         // When
         let commandTime = sessionStartTime.addingTimeInterval(1)
-        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: false, canStartApplicationLaunchView: .mockRandom())
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: false)
         XCTAssertTrue(scope.process(command: command, context: context, writer: writer))
 
         // Then
@@ -238,7 +239,7 @@ class RUMSessionScopeTests: XCTestCase {
 
         // When
         let commandTime = sessionStartTime.addingTimeInterval(1)
-        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: .mockRandom(), canStartApplicationLaunchView: false)
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: .mockRandom())
         XCTAssertTrue(scope.process(command: command, context: context, writer: writer))
 
         // Then
@@ -266,7 +267,7 @@ class RUMSessionScopeTests: XCTestCase {
 
         // When
         let commandTime = sessionStartTime.addingTimeInterval(1)
-        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: .mockRandom(), canStartApplicationLaunchView: true)
+        let command = RUMCommandMock(time: commandTime, canStartBackgroundView: .mockRandom())
         XCTAssertTrue(scope.process(command: command, context: context, writer: writer))
 
         // Then
@@ -409,6 +410,203 @@ class RUMSessionScopeTests: XCTestCase {
         XCTAssertNil(viewEvent, "Crash context must not include rum view event, because there is no active view")
     }
 
+    // MARK: - Stopping Sessions
+
+    func testGivenActiveSession_whenStopSessionEvent_itSetsSessionActiveFalse() {
+        // Given
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: Date()
+        )
+
+        // When
+        let command = RUMStopSessionCommand.mockWith(time: Date())
+
+        let result = scope.process(command: command, context: context, writer: writer)
+
+        // Then
+        XCTAssertFalse(scope.isActive)
+        XCTAssertFalse(result)
+    }
+
+    func testGivenStoppedSession_itUpdatesContext() {
+        // Given
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: Date()
+        )
+        _ = scope.process(command: RUMStopSessionCommand.mockWith(time: Date()), context: context, writer: writer)
+
+        // When
+        let context = scope.context
+
+        XCTAssertFalse(context.isSessionActive)
+    }
+
+    func testGivenActiveSessionWithActiveView_whenStopSessionEvent_itStopsTheActiveView() throws {
+        // Given
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: Date()
+        )
+        _ = scope.process(command: RUMStartViewCommand.mockWith(time: Date()), context: context, writer: writer)
+        let view = try XCTUnwrap(scope.viewScopes.first)
+
+        // When
+        let command = RUMStopSessionCommand.mockWith(time: Date())
+
+        let result = scope.process(command: command, context: context, writer: writer)
+
+        // Then
+        XCTAssertFalse(view.isActiveView)
+        XCTAssertFalse(result)
+    }
+
+    func testWhenSessionScopeHasViewsWithPendingResources_whenStopSetssion_itReturnsTrueFromProcess() throws {
+        // Given
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: Date()
+        )
+        _ = scope.process(command: RUMStartViewCommand.mockWith(time: Date()), context: context, writer: writer)
+        _ = scope.process(command: RUMStartResourceCommand.mockWith(time: Date()), context: context, writer: writer)
+        let view = try XCTUnwrap(scope.viewScopes.first)
+
+        // When
+        let command = RUMStopSessionCommand(time: Date())
+        let result = scope.process(command: command, context: context, writer: writer)
+
+        // Then
+        XCTAssertFalse(scope.isActive)
+        XCTAssertFalse(view.isActiveView)
+        // This still needs to return true because we have pending events
+        XCTAssertTrue(result)
+    }
+
+    func testWhenSessionScopeHasViewsWithPendingResources_itReturnsTrueFromProcessWhenResourcesFinish() throws {
+        // Given
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: Date()
+        )
+        _ = scope.process(command: RUMStartViewCommand.mockWith(time: Date()), context: context, writer: writer)
+        let startResourceCommand = RUMStartResourceCommand.mockWith(time: Date())
+        _ = scope.process(command: startResourceCommand, context: context, writer: writer)
+        _ = scope.process(command: RUMStopSessionCommand.mockWith(time: Date()), context: context, writer: writer)
+
+        // When
+        let command = RUMStopResourceCommand.mockWith(resourceKey: startResourceCommand.resourceKey, time: Date())
+        let result = scope.process(command: command, context: context, writer: writer)
+
+        // Then
+        XCTAssertFalse(scope.isActive)
+        XCTAssertFalse(result)
+    }
+
+    func testWhenScopeEnded_itDoesNotStartNewViews() throws {
+        // Given
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: Date()
+        )
+        _ = scope.process(command: RUMStopSessionCommand.mockWith(time: Date()), context: context, writer: writer)
+
+        // When
+        let command = RUMStartViewCommand.mockWith(time: Date())
+        let result = scope.process(command: command, context: context, writer: writer)
+
+        // Then
+        XCTAssertTrue(scope.viewScopes.isEmpty)
+        XCTAssertFalse(result)
+    }
+
+    func testWhenScopeEnded_itDoesNotCreateAnApplicationLaunchView() {
+        // Note - This should happen because the application context should prevent against
+        // it, but just in case
+        // Given
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: Date()
+        )
+        _ = scope.process(command: RUMStopSessionCommand.mockWith(time: Date()), context: context, writer: writer)
+
+        // When
+        let command = RUMApplicationStartCommand(time: Date(), attributes: [:])
+        let result = scope.process(command: command, context: context, writer: writer)
+
+        // Then
+        XCTAssertTrue(scope.viewScopes.isEmpty)
+        XCTAssertFalse(result)
+    }
+
+    func testWhenScopeEnded_itUpdatesContext() {
+        // Given
+        var viewEvent: RUMViewEvent? = nil
+        let messageReciever = FeatureMessageReceiverMock { message in
+            if case let .custom(_, baggage) = message, let event = baggage[RUMBaggageKeys.viewEvent, type: RUMViewEvent.self] {
+                viewEvent = event
+            } else if case let .custom(_, baggage) = message, baggage[RUMBaggageKeys.viewReset, type: Bool.self] == true {
+                viewEvent = nil
+            }
+        }
+
+        let core = PassthroughCoreMock(
+            context: context,
+            messageReceiver: messageReciever
+        )
+
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: Date(),
+            dependencies: .mockWith(core: core)
+        )
+
+        let command = RUMStartViewCommand.mockWith(time: Date(), identity: mockView)
+        _ = scope.process(command: command, context: context, writer: writer)
+
+        // When
+        _ = scope.process(command: RUMStopSessionCommand.mockWith(time: Date()), context: context, writer: writer)
+
+        // Then
+        XCTAssertNil(viewEvent)
+    }
+
+    func testWhenScopeEnded_itDoesNotResetContextNextUpdate() {
+        // Given
+        var viewResetCallCount = 0
+        var viewEvent: RUMViewEvent? = nil
+        let messageReciever = FeatureMessageReceiverMock { message in
+            if case let .custom(_, baggage) = message, baggage[RUMBaggageKeys.viewReset, type: Bool.self] == true {
+                viewResetCallCount += 1
+                viewEvent = nil
+            }
+        }
+
+        let core = PassthroughCoreMock(
+            context: context,
+            messageReceiver: messageReciever
+        )
+
+        let scope: RUMSessionScope = .mockWith(
+            parent: parent,
+            startTime: Date(),
+            dependencies: .mockWith(core: core)
+        )
+
+        let startViewCommand = RUMStartViewCommand.mockWith(time: Date(), identity: mockView)
+        _ = scope.process(command: startViewCommand, context: context, writer: writer)
+        let startResourceCommand = RUMStartResourceCommand.mockWith(time: Date())
+        _ = scope.process(command: startResourceCommand, context: context, writer: writer)
+
+        // When
+        _ = scope.process(command: RUMStopSessionCommand.mockWith(time: Date()), context: context, writer: writer)
+        let stopResourceCommand = RUMStopResourceCommand.mockWith(resourceKey: startResourceCommand.resourceKey, time: Date())
+        _ = scope.process(command: stopResourceCommand, context: context, writer: writer)
+
+        // Then
+        XCTAssertEqual(viewResetCallCount, 1)
+    }
+
     // MARK: - Usage
 
     func testGivenSessionWithNoActiveScope_whenReceivingRUMCommandOtherThanKeepSessionAliveCommand_itLogsWarning() throws {
@@ -431,7 +629,7 @@ class RUMSessionScopeTests: XCTestCase {
             return dd.logger.warnLog?.message
         }
 
-        let randomCommand = RUMCommandMock(time: Date(), canStartBackgroundView: false, canStartApplicationLaunchView: false)
+        let randomCommand = RUMCommandMock(time: Date(), canStartBackgroundView: false)
         let randomCommandLog = try XCTUnwrap(recordWarningOnReceiving(command: randomCommand))
         XCTAssertEqual(
             randomCommandLog,

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -1606,6 +1606,29 @@ class RUMViewScopeTests: XCTestCase {
         )
     }
 
+    // MARK: - Stopped Session
+
+    func testGivenSession_whenSessionStopped_itSendsViewUpdateWithStopped() {
+        let initialDeviceTime: Date = .mockDecember15th2019At10AMUTC()
+        let initialServerTimeOffset: TimeInterval = 120 // 2 minutes
+        var currentDeviceTime = initialDeviceTime
+
+
+        // Given
+        let scope = RUMViewScope(
+            isInitialView: false,
+            parent: parent,
+            dependencies: .mockAny(),
+            identity: mockView,
+            path: .mockAny(),
+            name: .mockAny(),
+            attributes: [:],
+            customTimings: [:],
+            startTime: initialDeviceTime,
+            serverTimeOffset: initialServerTimeOffset
+        )
+    }
+
     // MARK: - Dates Correction
 
     func testGivenViewStartedWithServerTimeDifference_whenDifferentEventsAreSend_itAppliesTheSameCorrectionToAll() throws {

--- a/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -1608,11 +1608,9 @@ class RUMViewScopeTests: XCTestCase {
 
     // MARK: - Stopped Session
 
-    func testGivenSession_whenSessionStopped_itSendsViewUpdateWithStopped() {
+    func testGivenSession_whenSessionStopped_itSendsViewUpdateWithStopped() throws {
         let initialDeviceTime: Date = .mockDecember15th2019At10AMUTC()
         let initialServerTimeOffset: TimeInterval = 120 // 2 minutes
-        var currentDeviceTime = initialDeviceTime
-
 
         // Given
         let scope = RUMViewScope(
@@ -1627,6 +1625,23 @@ class RUMViewScopeTests: XCTestCase {
             startTime: initialDeviceTime,
             serverTimeOffset: initialServerTimeOffset
         )
+        parent.context.isSessionActive = false
+
+        // When
+        XCTAssertFalse(
+            scope.process(
+                command: RUMStopSessionCommand.mockAny(),
+                context: context,
+                writer: writer
+            )
+        )
+
+        // Then
+        XCTAssertFalse(scope.isActiveView)
+        let events = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self))
+
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.session.isActive, false)
     }
 
     // MARK: - Dates Correction


### PR DESCRIPTION
### What and why?

This adds a method to manually end a RUM session with `stopRumSession`.  This immediately stops the active view and sets the current session to inactive. A new session starts automatically when a user action is sent (`startView` or `addUserAction`).

### How?

First, may RUM events now have a new property: `session.isActive`. This can be null, and is only currently set in RUMViewEvents. The state of this member is pulled from the parent session context.

Second, I've modified `RUMApplicationScope` to support holding multiple `RUMSessionScope`s in a similar way to how Sessions can handle multiple Views until all of their events have been processed.

When a `RUMStopSession` event is received, the Application Scope forwards it to the Session, which marks itself as inactive, then forwards the event to the all views, which mark themselves as inactive and send a ViewUpdate event which captures the session now being inactive.

Provided views have finished processing all of their user actions and resources, the session is removed from available sessions on the ApplicationScope. Otherwise, it sicks around (marked as inactive) until all events are complete.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [x] Run smoke tests
