### PR TITLE
REPLAY-1345 Image Scaling Optimisation

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -21,14 +21,14 @@ internal protocol ImageDataProviding {
 internal final class ImageDataProvider: ImageDataProviding {
     private var cache: Cache<String, String>
 
-    private let maxBytesSize: Int
+    private let desiredMaxBytesSize: Int
 
     internal init(
         cache: Cache<String, String> = .init(),
-        maxBytesSize: Int = 10.KB
+        desiredMaxBytesSize: Int = 10.KB
     ) {
         self.cache = cache
-        self.maxBytesSize = maxBytesSize
+        self.desiredMaxBytesSize = desiredMaxBytesSize
     }
 
     func contentBase64String(
@@ -49,7 +49,7 @@ internal final class ImageDataProvider: ImageDataProviding {
                 if #available(iOS 13.0, *), let tintColor = tintColor {
                     image = image.withTintColor(tintColor)
                 }
-                let base64EncodedImage = image.scaledDownToApproximateSize(maxBytesSize).base64EncodedString()
+                let base64EncodedImage = image.scaledDownToApproximateSize(desiredMaxBytesSize).base64EncodedString()
                 cache[identifier, base64EncodedImage.count] = base64EncodedImage
                 return base64EncodedImage
             }

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -25,7 +25,7 @@ internal final class ImageDataProvider: ImageDataProviding {
 
     internal init(
         cache: Cache<String, String> = .init(),
-        desiredMaxBytesSize: Int = 10.KB
+        desiredMaxBytesSize: Int = 15.KB
     ) {
         self.cache = cache
         self.desiredMaxBytesSize = desiredMaxBytesSize

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -25,7 +25,7 @@ internal final class ImageDataProvider: ImageDataProviding {
 
     internal init(
         cache: Cache<String, String> = .init(),
-        maxBytesSize: Int = 15_360 // 10.0 KB
+        maxBytesSize: Int = 10.KB
     ) {
         self.cache = cache
         self.maxBytesSize = maxBytesSize

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/ImageDataProvider.swift
@@ -25,7 +25,7 @@ internal final class ImageDataProvider: ImageDataProviding {
 
     internal init(
         cache: Cache<String, String> = .init(),
-        maxBytesSize: Int = 10_000
+        maxBytesSize: Int = 15_360 // 10.0 KB
     ) {
         self.cache = cache
         self.maxBytesSize = maxBytesSize
@@ -49,12 +49,9 @@ internal final class ImageDataProvider: ImageDataProviding {
                 if #available(iOS 13.0, *), let tintColor = tintColor {
                     image = image.withTintColor(tintColor)
                 }
-                let base64EncodedImage = image.scaledToMaxSize(maxBytesSize).base64EncodedString()
+                let base64EncodedImage = image.scaledDownToApproximateSize(maxBytesSize).base64EncodedString()
                 cache[identifier, base64EncodedImage.count] = base64EncodedImage
                 return base64EncodedImage
-            } else {
-                cache[identifier] = ""
-                return ""
             }
         }
     }
@@ -73,26 +70,6 @@ fileprivate extension CGSize {
 extension UIImage {
     var srIdentifier: String {
         return "\(hash)"
-    }
-
-    func scaledToMaxSize(_ maxSizeInBytes: Int) -> Data {
-        guard let imageData = pngData() else {
-            return Data()
-        }
-        guard imageData.count >= maxSizeInBytes else {
-            return imageData
-        }
-        let percentage: CGFloat = sqrt(CGFloat(maxSizeInBytes) / CGFloat(imageData.count))
-        return scaledImage(by: percentage).pngData() ?? Data()
-    }
-
-    func scaledImage(by percentage: CGFloat) -> UIImage {
-        let newSize = CGSize(width: size.width * percentage, height: size.height * percentage)
-        let format = UIGraphicsImageRendererFormat()
-        let renderer = UIGraphicsImageRenderer(size: newSize, format: format)
-        return renderer.image { context in
-            draw(in: CGRect(origin: .zero, size: newSize))
-        }
     }
 }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIImageViewRecorder.swift
@@ -19,8 +19,12 @@ internal struct UIImageViewRecorder: NodeRecorder {
     }
 
     internal init(
-        tintColorProvider: @escaping (UIImageView) -> UIColor? = { _ in
-            return nil
+        tintColorProvider: @escaping (UIImageView) -> UIColor? = { imageView in
+            if #available(iOS 13.0, *) {
+                return imageView.image?.isSymbolImage == true ? imageView.tintColor : nil
+            } else {
+                return nil
+            }
         },
         shouldRecordImagePredicate: @escaping (UIImageView) -> Bool = { imageView in
             if #available(iOS 13.0, *) {

--- a/DatadogSessionReplay/Sources/Utilities/UIImage+Scaling.swift
+++ b/DatadogSessionReplay/Sources/Utilities/UIImage+Scaling.swift
@@ -20,11 +20,11 @@ extension UIImage {
     ///
     /// Example usage:
     ///
-    /// let originalImage = UIImage(named: "exampleImage")
-    /// let desiredSizeInBytes = 10240 // 10 KB
-    /// if let imageData = originalImage?.scaledDownToApproximateSize(desiredSizeInBytes) {
-    ///     // Use the scaled down image data.
-    /// }
+    ///     let originalImage = UIImage(named: "exampleImage")
+    ///     let desiredSizeInBytes = 10240 // 10 KB
+    ///     if let imageData = originalImage?.scaledDownToApproximateSize(desiredSizeInBytes) {
+    ///         // Use the scaled down image data.
+    ///     }
     func scaledDownToApproximateSize(_ desiredSizeInBytes: Int) -> Data {
         guard let imageData = pngData() else {
             return Data()
@@ -32,7 +32,10 @@ extension UIImage {
         guard imageData.count > desiredSizeInBytes else {
             return imageData
         }
-        var scaledImage = scaledImage(by: sqrt(CGFloat(desiredSizeInBytes) / CGFloat(imageData.count)))
+        // Initial scale is approximatation based on the average side of square for given size ratio.
+        // When running experiments it appeared to be closer to desired scale than using just a size ratio.
+        let initialScale = sqrt(CGFloat(desiredSizeInBytes) / CGFloat(imageData.count))
+        var scaledImage = scaledImage(by: initialScale)
 
         var scale: Double = 1
         let maxIterations = 20

--- a/DatadogSessionReplay/Sources/Utilities/UIImage+Scaling.swift
+++ b/DatadogSessionReplay/Sources/Utilities/UIImage+Scaling.swift
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+extension UIImage {
+    /**
+     Returns a scaled version of the image that is approximately equal to the size specified by the `maxSizeInBytes` parameter.
+     The approximate size is calculated based on the bitmap dimensions of the image,
+     but does not take into account the size of the PNG header or any compression that may be applied.
+
+     - Parameters:
+         - maxSizeInBytes: The maximum size, in bytes, of the scaled image.
+
+     - Returns: The data object containing the scaled image, or an empty data object if the image data cannot be converted to PNG data or if the scaled image cannot be converted to PNG data.
+     */
+    func scaledDownToApproximateSize(_ maxSizeInBytes: Int, _ maxIterations: Int = 20) -> Data {
+        guard let imageData = pngData() else {
+            return Data()
+        }
+        guard imageData.count >= maxSizeInBytes else {
+            return imageData
+        }
+        let percentage: CGFloat = CGFloat(maxSizeInBytes) / CGFloat(imageData.count)
+        var scaledData = scaledImage(by: percentage)?.pngData() ?? Data()
+
+        var iterations = 0, scale: Double = 1
+        while scaledData.count > maxSizeInBytes && iterations < maxIterations {
+            scale *= 0.9
+            let newScaledData = scaledImage(by: scale)?.pngData() ?? Data()
+            if newScaledData.count <= scaledData.count {
+                scaledData = newScaledData
+            }
+            iterations += 1
+        }
+        return scaledData.count < imageData.count ? scaledData : imageData
+    }
+
+    private func scaledImage(by percentage: CGFloat) -> UIImage? {
+        let newSize = CGSize(width: size.width * percentage, height: size.height * percentage)
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 1)
+        draw(in: CGRect(origin: .zero, size: newSize))
+        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return scaledImage
+    }
+}
+

--- a/DatadogSessionReplay/Sources/Utilities/UIImage+Scaling.swift
+++ b/DatadogSessionReplay/Sources/Utilities/UIImage+Scaling.swift
@@ -7,16 +7,24 @@
 import UIKit
 
 extension UIImage {
-    /**
-     Returns a scaled version of the image that is approximately equal to the size specified by the `maxSizeInBytes` parameter.
-     The approximate size is calculated based on the bitmap dimensions of the image,
-     but does not take into account the size of the PNG header or any compression that may be applied.
-
-     - Parameters:
-         - maxSizeInBytes: The maximum size, in bytes, of the scaled image.
-
-     - Returns: The data object containing the scaled image, or an empty data object if the image data cannot be converted to PNG data or if the scaled image cannot be converted to PNG data.
-     */
+    /// Scales down the image to an approximate file size in bytes.
+    ///
+    /// - Parameter desiredSizeInBytes: The target file size in bytes.
+    /// - Returns: A Data object representing the scaled down image as PNG data.
+    ///
+    /// This function takes the desired file size in bytes as input and scales down the image iteratively
+    /// until the resulting PNG data size is less than or equal to the specified target size.
+    ///
+    /// Note: The function will return the original image data if it is already smaller than the desired size,
+    /// or if it fails to generate a smaller image.
+    ///
+    /// Example usage:
+    ///
+    /// let originalImage = UIImage(named: "exampleImage")
+    /// let desiredSizeInBytes = 10240 // 10 KB
+    /// if let imageData = originalImage?.scaledDownToApproximateSize(desiredSizeInBytes) {
+    ///     // Use the scaled down image data.
+    /// }
     func scaledDownToApproximateSize(_ desiredSizeInBytes: Int) -> Data {
         guard let imageData = pngData() else {
             return Data()
@@ -44,6 +52,13 @@ extension UIImage {
         return scaledImageData.count < imageData.count ? scaledImageData : imageData
     }
 
+    /// Scales the image by a given percentage.
+    ///
+    /// - Parameter percentage: The scaling factor to apply, where 1.0 represents the original size.
+    /// - Returns: A UIImage object representing the scaled image, or an empty UIImage if the percentage is less than or equal to zero.
+    ///
+    /// This private helper function takes a CGFloat percentage as input and scales the image accordingly.
+    /// It ensures that the resulting image has a size proportional to the original one, maintaining its aspect ratio.
     private func scaledImage(by percentage: CGFloat) -> UIImage {
         guard percentage > 0 else {
             return UIImage()

--- a/DatadogSessionReplay/Sources/Utilities/UIImage+Scaling.swift
+++ b/DatadogSessionReplay/Sources/Utilities/UIImage+Scaling.swift
@@ -32,7 +32,7 @@ extension UIImage {
         guard imageData.count > desiredSizeInBytes else {
             return imageData
         }
-        var scaledImage = scaledImage(by: CGFloat(desiredSizeInBytes) / CGFloat(imageData.count))
+        var scaledImage = scaledImage(by: sqrt(CGFloat(desiredSizeInBytes) / CGFloat(imageData.count)))
 
         var scale: Double = 1
         let maxIterations = 20

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
@@ -41,16 +41,6 @@ class ImageDataProviderTests: XCTestCase {
         XCTAssertGreaterThan(imageData.count, 0)
     }
 
-    func test_ignoresAboveSize() throws {
-        let sut = ImageDataProvider(
-            maxBytesSize: 1
-        )
-        let image = UIImage(named: "dd_logo_v_rgb", in: Bundle.module, compatibleWith: nil)
-
-        let imageData = try XCTUnwrap(sut.contentBase64String(of: image))
-        XCTAssertEqual(imageData.count, 0)
-    }
-
     func test_imageIdentifierConsistency() {
         var ids = Set<String>()
         for _ in 0..<100 {

--- a/DatadogSessionReplay/Tests/Utilities/UIImage+ScalingTests.swift
+++ b/DatadogSessionReplay/Tests/Utilities/UIImage+ScalingTests.swift
@@ -10,7 +10,6 @@ import XCTest
 
 @available(iOS 13.0, *)
 class UIImageScalingTests: XCTestCase {
-
     var sut: (image: UIImage, pngData: Data) {
         guard let image = UIImage(named: "dd_logo_v_rgb", in: Bundle.module, compatibleWith: nil), let imageData = image.pngData() else {
             XCTFail("Failed to load image")

--- a/DatadogSessionReplay/Tests/Utilities/UIImage+ScalingTests.swift
+++ b/DatadogSessionReplay/Tests/Utilities/UIImage+ScalingTests.swift
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import XCTest
+@testable import DatadogSessionReplay
+
+@available(iOS 13.0, *)
+class UIImageScalingTests: XCTestCase {
+
+    var sut: (image: UIImage, pngData: Data) {
+        guard let image = UIImage(named: "dd_logo_v_rgb", in: Bundle.module, compatibleWith: nil), let imageData = image.pngData() else {
+            XCTFail("Failed to load image")
+            return (UIImage(), Data())
+        }
+        return (image, imageData)
+    }
+
+    func testScaledToApproximateSize_ReturnsOriginalImageData_IfSizeIsSmallerOrEqualToAnticipatedMaxSize() {
+        let dataSize = sut.pngData.count
+        let maxSize = dataSize + 100
+        let scaledData = sut.image.scaledDownToApproximateSize(maxSize)
+        XCTAssertEqual(scaledData, sut.pngData)
+    }
+
+    func testScaledToApproximateSize_ScalesImageToSmallerSize_IfSizeIsLargerThanAnticipatedMaxSize() {
+        let dataSize = sut.pngData.count
+        let maxSize = dataSize - 100
+        let scaledData = sut.image.scaledDownToApproximateSize(maxSize)
+        XCTAssertTrue(scaledData.count < dataSize)
+    }
+}


### PR DESCRIPTION
### What and why?

Adds algorithm for scaling images before generating base64 for session replay.

### How?

Algorithm make initial scale percentage calculation based on desiredSize/ActualSize and after that it performs fixed number of iterations decreasing the size by 10%. It must be done this way due to PNG compression (loss-less) - we can't guarantee that scaled image will be small enough byte size.

As a fallback if scaled image doesn't have smaller byte size than the original image, we will generate base64 of original image (this can happen for very small images).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
