### PR TITLE
REPLAY-1421 Use better fallback value for fonts

### DIFF
--- a/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
+++ b/DatadogSessionReplay/Sources/Processor/SRDataModelsBuilder/WireframesBuilder.swift
@@ -25,7 +25,10 @@ internal class WireframesBuilder {
         /// The color (solid red) to use when the actual color conversion goes wrong.
         static let color = "#FF0000FF"
         /// The font family to use when the actual one cannot be read.
-        static let fontFamily = "-apple-system, Roboto, Helvetica, Arial"
+        ///
+        /// REPLAY-1421: This definition will promote SF font when running player in Safari, then “BlinkMacSystemFont” in macOS Chrome and
+        /// will ultimately fallback to “Roboto” or any “sans-serif” in other web browsers.
+        static let fontFamily = "-apple-system, BlinkMacSystemFont, 'Roboto', sans-serif"
         /// The font size to use when the actual one cannot be read.
         static let fontSize: CGFloat = 10
     }


### PR DESCRIPTION
### What and why?

📦 Our fonts support in SR is still very limited. No matter of the font configured for certain text elements, we always use single hardcoded value. This PR changes that value to better one according to results observed in the player:

```diff
- static let fontFamily = "-apple-system, Roboto, Helvetica, Arial"
+ static let fontFamily = "-apple-system, BlinkMacSystemFont, 'Roboto', sans-serif"
```

### How?

Just changing the hardcoded value in `WireframesBuilder`.

It doesn't update any tests, because `WireframesBuilder` logic is covered by snapshot tests and snapshots are yet not part of our git workflow (coming soon).

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
