### PR TITLE
REPLAY-1517 Add unsupported views recorder

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -22,6 +22,7 @@ internal enum Fixture: CaseIterable {
     case timePickersWheels
     case timePickersCompact
     case images
+    case unsupportedViews
 
     var menuItemTitle: String {
         switch self {
@@ -55,6 +56,8 @@ internal enum Fixture: CaseIterable {
             return "Time Picker (compact)"
         case .images:
             return "Images"
+        case .unsupportedViews:
+            return "Unsupported Views"
         }
     }
 
@@ -90,6 +93,8 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.datePickers.instantiateViewController(withIdentifier: "DatePickersCompact") // sharing the same VC with `datePickersCompact`
         case .images:
             return UIStoryboard.images.instantiateViewController(withIdentifier: "Images")
+        case .unsupportedViews:
+            return UIStoryboard.unsupportedViews.instantiateViewController(withIdentifier: "UnsupportedViews")
         }
     }
 }
@@ -99,4 +104,5 @@ internal extension UIStoryboard {
     static var inputElements: UIStoryboard { UIStoryboard(name: "InputElements", bundle: nil) }
     static var datePickers: UIStoryboard { UIStoryboard(name: "InputElements-DatePickers", bundle: nil) }
     static var images: UIStoryboard { UIStoryboard(name: "Images", bundle: nil) }
+    static var unsupportedViews: UIStoryboard { UIStoryboard(name: "UnsupportedViews", bundle: nil) }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/UnsupportedViews.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/UnsupportedViews.storyboard
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Unsupported Views View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="UnsupportedViews" id="Y6W-OH-hqX" customClass="UnsupportedViewsViewController" customModule="SRHost" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="JK3-tS-Vgk">
+                                <rect key="frame" x="16" y="104" width="361" height="4"/>
+                            </progressView>
+                            <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7q1-LL-Wul">
+                                <rect key="frame" x="16" y="169" width="361" height="32"/>
+                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="32" id="UCb-7m-oOs"/>
+                                </constraints>
+                            </webView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UIProgressView" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dIq-0Y-58E">
+                                <rect key="frame" x="16" y="75" width="120" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UIWebView" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YjS-Wb-MaC">
+                                <rect key="frame" x="16" y="140" width="87" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WKWebView" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yq8-JW-BCF">
+                                <rect key="frame" x="16" y="233" width="98" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UIActivityIndiciatorView" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xID-T7-dfx">
+                                <rect key="frame" x="16" y="326" width="180" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="89f-Q3-icO">
+                                <rect key="frame" x="204" y="326.66666666666669" width="20" height="20"/>
+                            </activityIndicatorView>
+                            <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ocn-hX-0nt">
+                                <rect key="frame" x="16" y="262" width="361" height="32"/>
+                                <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="32" id="dPC-Gh-RZQ"/>
+                                </constraints>
+                                <wkWebViewConfiguration key="configuration">
+                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
+                                    <wkPreferences key="preferences"/>
+                                </wkWebViewConfiguration>
+                            </wkWebView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SwiftUI (UIHostingController)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="agd-Ze-rWy">
+                                <rect key="frame" x="16" y="379" width="222" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LM1-im-Xs1">
+                                <rect key="frame" x="16" y="408" width="361" height="64"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="64" id="bSE-ZW-IIl"/>
+                                </constraints>
+                            </containerView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="JK3-tS-Vgk" secondAttribute="trailing" constant="16" id="0rC-Rq-KWb"/>
+                            <constraint firstItem="LM1-im-Xs1" firstAttribute="top" secondItem="agd-Ze-rWy" secondAttribute="bottom" constant="8" id="1CZ-Sy-O4w"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="7q1-LL-Wul" secondAttribute="trailing" constant="16" id="1pp-zp-j0x"/>
+                            <constraint firstItem="YjS-Wb-MaC" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="2rr-8D-ZNq"/>
+                            <constraint firstItem="7q1-LL-Wul" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="3Go-tq-aq1"/>
+                            <constraint firstItem="89f-Q3-icO" firstAttribute="centerY" secondItem="xID-T7-dfx" secondAttribute="centerY" id="6Ig-hu-Fkq"/>
+                            <constraint firstItem="Yq8-JW-BCF" firstAttribute="top" secondItem="7q1-LL-Wul" secondAttribute="bottom" constant="32" id="9uA-hh-xtj"/>
+                            <constraint firstItem="LM1-im-Xs1" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="Cfo-Jk-yrt"/>
+                            <constraint firstItem="dIq-0Y-58E" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="16" id="GSH-KL-ZCl"/>
+                            <constraint firstItem="89f-Q3-icO" firstAttribute="leading" secondItem="xID-T7-dfx" secondAttribute="trailing" constant="8" symbolic="YES" id="IBa-sY-xO8"/>
+                            <constraint firstItem="agd-Ze-rWy" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="Jkg-UA-NOL"/>
+                            <constraint firstItem="JK3-tS-Vgk" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="NVh-ep-RPn"/>
+                            <constraint firstItem="xID-T7-dfx" firstAttribute="top" secondItem="Ocn-hX-0nt" secondAttribute="bottom" constant="32" id="NuX-Ka-6gq"/>
+                            <constraint firstItem="JK3-tS-Vgk" firstAttribute="top" secondItem="dIq-0Y-58E" secondAttribute="bottom" constant="8" id="S9b-c9-Plb"/>
+                            <constraint firstItem="YjS-Wb-MaC" firstAttribute="top" secondItem="JK3-tS-Vgk" secondAttribute="bottom" constant="32" id="SHf-zq-dvQ"/>
+                            <constraint firstItem="Yq8-JW-BCF" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="YCb-jZ-yJd"/>
+                            <constraint firstItem="Ocn-hX-0nt" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="di6-ZT-1cT"/>
+                            <constraint firstItem="dIq-0Y-58E" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="f4y-xv-5xA"/>
+                            <constraint firstItem="7q1-LL-Wul" firstAttribute="top" secondItem="YjS-Wb-MaC" secondAttribute="bottom" constant="8" id="hOM-3e-XhN"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Ocn-hX-0nt" secondAttribute="trailing" constant="16" id="jOi-29-4Nd"/>
+                            <constraint firstItem="xID-T7-dfx" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="kMl-Z3-erC"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="LM1-im-Xs1" secondAttribute="trailing" constant="16" id="kR6-sb-oIj"/>
+                            <constraint firstItem="agd-Ze-rWy" firstAttribute="top" secondItem="xID-T7-dfx" secondAttribute="bottom" constant="32" id="ss7-NQ-jij"/>
+                            <constraint firstItem="Ocn-hX-0nt" firstAttribute="top" secondItem="Yq8-JW-BCF" secondAttribute="bottom" constant="8" symbolic="YES" id="wKz-5m-IxT"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="swiftUIContainer" destination="LM1-im-Xs1" id="xBm-g7-MqQ"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="130.53435114503816" y="-28.169014084507044"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/UnsupportedViewsViewController.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/UnsupportedViewsViewController.swift
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+internal class UnsupportedViewsViewController: UIViewController {
+    
+    @IBOutlet weak var swiftUIContainer: UIView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let hostingController = UIHostingController(rootView: TestView())
+        addChild(hostingController)
+        swiftUIContainer.addSubview(hostingController.view)
+        hostingController.view.frame = swiftUIContainer.bounds
+        hostingController.didMove(toParent: self)
+    }
+}
+
+import SwiftUI
+
+struct TestView: View {
+    var body: some View {
+        VStack {
+            Text("Title")
+                .font(.title)
+
+            Rectangle()
+                .frame(width: 120, height: 16)
+                .foregroundColor(.blue)
+                .cornerRadius(8)
+        }
+    }
+}
+

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/UnsupportedViewsViewController.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/UnsupportedViewsViewController.swift
@@ -23,7 +23,7 @@ internal class UnsupportedViewsViewController: UIViewController {
 
 import SwiftUI
 
-struct TestView: View {
+fileprivate struct TestView: View {
     var body: some View {
         VStack {
             Text("Title")

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		61E7DFB9299A5A3E001D7A3A /* Basic.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61E7DFB8299A5A3E001D7A3A /* Basic.storyboard */; };
 		61E7DFBB299A5C9D001D7A3A /* BasicViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E7DFBA299A5C9D001D7A3A /* BasicViewControllers.swift */; };
 		61EC1A37299CFD7E00224FB6 /* TestUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = 61EC1A36299CFD7E00224FB6 /* TestUtilities */; };
+		A7025BD129E8202E00747BFB /* ImagesViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7025BD029E8202E00747BFB /* ImagesViewControllers.swift */; };
 		A719BC3B29E6A5C600E7B646 /* UnsupportedViews.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A719BC3929E6A4CA00E7B646 /* UnsupportedViews.storyboard */; };
 		A719BC3F29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A719BC3E29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift */; };
 		A797A95029D5958400EE73EB /* Images.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A797A94F29D5958400EE73EB /* Images.storyboard */; };
@@ -62,6 +63,7 @@
 		61E7DFB6299A57A9001D7A3A /* MenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
 		61E7DFB8299A5A3E001D7A3A /* Basic.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Basic.storyboard; sourceTree = "<group>"; };
 		61E7DFBA299A5C9D001D7A3A /* BasicViewControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicViewControllers.swift; sourceTree = "<group>"; };
+		A7025BD029E8202E00747BFB /* ImagesViewControllers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagesViewControllers.swift; sourceTree = "<group>"; };
 		A719BC3929E6A4CA00E7B646 /* UnsupportedViews.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UnsupportedViews.storyboard; sourceTree = "<group>"; };
 		A719BC3E29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedViewsViewController.swift; sourceTree = "<group>"; };
 		A797A94F29D5958400EE73EB /* Images.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Images.storyboard; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 				A797A94F29D5958400EE73EB /* Images.storyboard */,
 				A719BC3929E6A4CA00E7B646 /* UnsupportedViews.storyboard */,
 				A719BC3E29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift */,
+				A7025BD029E8202E00747BFB /* ImagesViewControllers.swift */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -289,6 +292,7 @@
 				61E7DFB7299A57A9001D7A3A /* MenuViewController.swift in Sources */,
 				61B634EB299A5DB3002BEABE /* Fixtures.swift in Sources */,
 				61B3BC4D2993BE2E0032C78A /* SceneDelegate.swift in Sources */,
+				A7025BD129E8202E00747BFB /* ImagesViewControllers.swift in Sources */,
 				61A735AA29A5137400001820 /* InputViewControllers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
@@ -26,7 +26,8 @@
 		61E7DFB9299A5A3E001D7A3A /* Basic.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61E7DFB8299A5A3E001D7A3A /* Basic.storyboard */; };
 		61E7DFBB299A5C9D001D7A3A /* BasicViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E7DFBA299A5C9D001D7A3A /* BasicViewControllers.swift */; };
 		61EC1A37299CFD7E00224FB6 /* TestUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = 61EC1A36299CFD7E00224FB6 /* TestUtilities */; };
-		A77C62F429E4298200AC923B /* ImagesViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77C62F329E4298200AC923B /* ImagesViewControllers.swift */; };
+		A719BC3B29E6A5C600E7B646 /* UnsupportedViews.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A719BC3929E6A4CA00E7B646 /* UnsupportedViews.storyboard */; };
+		A719BC3F29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A719BC3E29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift */; };
 		A797A95029D5958400EE73EB /* Images.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A797A94F29D5958400EE73EB /* Images.storyboard */; };
 		A797A95229D59E7900EE73EB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A797A95129D59E7900EE73EB /* Assets.xcassets */; };
 /* End PBXBuildFile section */
@@ -61,7 +62,8 @@
 		61E7DFB6299A57A9001D7A3A /* MenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
 		61E7DFB8299A5A3E001D7A3A /* Basic.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Basic.storyboard; sourceTree = "<group>"; };
 		61E7DFBA299A5C9D001D7A3A /* BasicViewControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicViewControllers.swift; sourceTree = "<group>"; };
-		A77C62F329E4298200AC923B /* ImagesViewControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesViewControllers.swift; sourceTree = "<group>"; };
+		A719BC3929E6A4CA00E7B646 /* UnsupportedViews.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = UnsupportedViews.storyboard; sourceTree = "<group>"; };
+		A719BC3E29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsupportedViewsViewController.swift; sourceTree = "<group>"; };
 		A797A94F29D5958400EE73EB /* Images.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Images.storyboard; sourceTree = "<group>"; };
 		A797A95129D59E7900EE73EB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -158,7 +160,8 @@
 				61A735A929A5137400001820 /* InputViewControllers.swift */,
 				6196D32329AF7EB2002EACAF /* InputElements-DatePickers.storyboard */,
 				A797A94F29D5958400EE73EB /* Images.storyboard */,
-				A77C62F329E4298200AC923B /* ImagesViewControllers.swift */,
+				A719BC3929E6A4CA00E7B646 /* UnsupportedViews.storyboard */,
+				A719BC3E29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -255,6 +258,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				616C37DA299F6913005E0472 /* InputElements.storyboard in Resources */,
+				A719BC3B29E6A5C600E7B646 /* UnsupportedViews.storyboard in Resources */,
 				61B3BC572993BE2F0032C78A /* LaunchScreen.storyboard in Resources */,
 				61E7DFB9299A5A3E001D7A3A /* Basic.storyboard in Resources */,
 				61B3BC522993BE2E0032C78A /* Main.storyboard in Resources */,
@@ -280,9 +284,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				61B3BC4B2993BE2E0032C78A /* AppDelegate.swift in Sources */,
+				A719BC3F29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift in Sources */,
 				61E7DFBB299A5C9D001D7A3A /* BasicViewControllers.swift in Sources */,
 				61E7DFB7299A57A9001D7A3A /* MenuViewController.swift in Sources */,
-				A77C62F429E4298200AC923B /* ImagesViewControllers.swift in Sources */,
 				61B634EB299A5DB3002BEABE /* Fixtures.swift in Sources */,
 				61B3BC4D2993BE2E0032C78A /* SceneDelegate.swift in Sources */,
 				61A735AA29A5137400001820 /* InputViewControllers.swift in Sources */,

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -210,7 +210,6 @@ final class SRSnapshotTests: SnapshotTestCase {
         let image = try takeSnapshot(configuration: .init(privacy: .allowAll))
         DDAssertSnapshotTest(
             newImage: image,
-
             snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
             record: recordingMode
         )

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -203,4 +203,16 @@ final class SRSnapshotTests: SnapshotTestCase {
             )
         }
     }
+
+    func testUnsupportedView() throws {
+        show(fixture: .unsupportedViews)
+
+        let image = try takeSnapshot(configuration: .init(privacy: .allowAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
+            record: recordingMode
+        )
+    }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
@@ -5,9 +5,11 @@
  */
 
 import UIKit
+import WebKit
 import SwiftUI
 
 internal struct UnsupportedViewRecorder: NodeRecorder {
+    // swiftlint:disable opening_brace
     private let unsupportedViewsPredicates: [(UIView) -> Bool] = [
         {
             if #available(iOS 13.0, *) {
@@ -18,20 +20,24 @@ internal struct UnsupportedViewRecorder: NodeRecorder {
         },
         { $0 is UIProgressView },
         { $0 is UIWebView },
+        { $0 is WKWebView },
         { $0 is UIActivityIndicatorView }
     ]
+    // swiftlint:enable opening_brace
+    
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         guard unsupportedViewsPredicates.reduce(false, { $0 || $1(view) }) else {
             return nil
         }
-
+        guard attributes.isVisible else {
+            return InvisibleElement(subtreeStrategy: .ignore)
+        }
         let builder = UnsupportedViewWireframesBuilder(
             wireframeRect: view.frame,
             wireframeID: context.ids.nodeID(for: view),
             unsupportedClassName: String(describing: type(of: view)),
             attributes: attributes
         )
-
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
         return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+import SwiftUI
+
+internal struct UnsupportedViewRecorder: NodeRecorder {
+    private let unsupportedViewsPredicates: [(UIView) -> Bool] = [
+        {
+            if #available(iOS 13.0, *) {
+                return $0 is (any View)
+            } else {
+                return false
+            }
+        },
+        { $0 is UIProgressView },
+        { $0 is UIWebView },
+        { $0 is UIActivityIndicatorView }
+    ]
+    func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
+        guard unsupportedViewsPredicates.reduce(false, { $0 || $1(view) }) else {
+            return nil
+        }
+
+        let builder = UnsupportedViewWireframesBuilder(
+            wireframeRect: view.frame,
+            wireframeID: context.ids.nodeID(for: view),
+            unsupportedClassName: String(describing: type(of: view)),
+            attributes: attributes
+        )
+
+        let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
+        return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
+    }
+}
+
+internal struct UnsupportedViewWireframesBuilder: NodeWireframesBuilder {
+    let wireframeRect: CGRect
+
+    let wireframeID: WireframeID
+    let unsupportedClassName: String
+    let attributes: ViewAttributes
+
+    func buildWireframes(with builder: WireframesBuilder) -> [SRWireframe] {
+        return [
+            builder.createTextWireframe(
+                id: wireframeID,
+                frame: attributes.frame,
+                text: unsupportedClassName,
+                textFrame: attributes.frame,
+                textAlignment: .init(horizontal: .center, vertical: .center),
+                textColor: UIColor.red.cgColor,
+                borderColor: UIColor.lightGray.cgColor,
+                borderWidth: 1,
+                backgroundColor: UIColor(white: 0, alpha: 0.05).cgColor,
+                cornerRadius: 8
+            )
+        ]
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorder.swift
@@ -29,7 +29,7 @@ internal struct UnsupportedViewRecorder: NodeRecorder {
         let builder = UnsupportedViewWireframesBuilder(
             wireframeRect: view.frame,
             wireframeID: context.ids.nodeID(for: view),
-            unsupportedClassName: String(reflecting: type(of: view)).extractGenericClassNameIfNeeded(),
+            unsupportedClassName: String(reflecting: type(of: view)),
             attributes: attributes
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
@@ -59,16 +59,5 @@ internal struct UnsupportedViewWireframesBuilder: NodeWireframesBuilder {
                 cornerRadius: 4
             )
         ]
-    }
-}
-
-fileprivate extension String {
-    func extractGenericClassNameIfNeeded() -> String {
-        let regex = try? NSRegularExpression(pattern: "<([^>]*)>[^<>]*$", options: [])
-        if let match = regex?.firstMatch(in: self, range: NSRange(startIndex..., in: self)),
-            let range = Range(match.range(at: 1), in: self) {
-            return String(self[range])
-        }
-        return self
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -59,6 +59,7 @@ extension ViewTreeSnapshotBuilder {
 /// An arrays of default node recorders executed for the root view-tree hierarchy.
 internal func createDefaultNodeRecorders() -> [NodeRecorder] {
     return [
+        UnsupportedViewRecorder(),
         UIViewRecorder(),
         UILabelRecorder(),
         UIImageViewRecorder(),

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -12,9 +12,13 @@ import SwiftUI
 @available(iOS 13.0, *)
 class UnsupportedViewRecorderTests: XCTestCase {
     private let recorder = UnsupportedViewRecorder()
-    
-    private let unsupportedViews: [UIView] = [UIProgressView(), UIActivityIndicatorView(), UIWebView(), WKWebView()]
-    private let expectedUnsupportedViewsClassNames = ["UIProgressView", "UIActivityIndicatorView", "UIWebView", "WKWebView"]
+
+    private let unsupportedViews: [UIView] = [
+        UIProgressView(), UIActivityIndicatorView(), UIWebView(), WKWebView(), UIHostingController(rootView: Text("Test")).view
+    ].compactMap { $0 }
+    private let expectedUnsupportedViewsClassNames = [
+        "UIProgressView", "UIActivityIndicatorView", "UIWebView", "WKWebView", "SwiftUI.Text"
+    ]
     private let otherViews = [UILabel(), UIView(), UIImageView(), UIScrollView()]
 
     /// `ViewAttributes` simulating common attributes of the view.

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -17,7 +17,7 @@ class UnsupportedViewRecorderTests: XCTestCase {
         UIProgressView(), UIActivityIndicatorView(), UIWebView(), WKWebView(), UIHostingController(rootView: Text("Test")).view
     ].compactMap { $0 }
     private let expectedUnsupportedViewsClassNames = [
-        "UIProgressView", "UIActivityIndicatorView", "UIWebView", "WKWebView", "SwiftUI.Text"
+        "UIProgressView", "UIActivityIndicatorView", "UIWebView", "WKWebView", "SwiftUI._UIHostingView<SwiftUI.Text>"
     ]
     private let otherViews = [UILabel(), UIView(), UIImageView(), UIScrollView()]
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UnsupportedViewRecorderTests.swift
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import WebKit
+@testable import DatadogSessionReplay
+
+class UnsupportedViewwRecorderTests: XCTestCase {
+    private let recorder = UnsupportedViewRecorder()
+    /// The view under test.
+    private let views = [UIProgressView(), UIActivityIndicatorView(), UIWebView(), WKWebView()]
+    /// `ViewAttributes` simulating common attributes of the view.
+    private var viewAttributes: ViewAttributes = .mockAny()
+
+    func testWhenViewIsNotVisible() throws {
+        // When
+        viewAttributes = .mock(fixture: .invisible)
+
+        // Then
+        try views.forEach { view in
+            let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+            XCTAssertTrue(semantics is InvisibleElement)
+        }
+    }
+
+    func testWhenViewIsVisibleAndHasSomeAppearance() throws {
+        // When
+        viewAttributes = .mock(fixture: .visible(.someAppearance))
+
+        // Then
+        try views.forEach { view in
+            let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+            XCTAssertTrue(semantics is SpecificElement)
+            XCTAssertTrue(semantics.nodes.first?.wireframesBuilder is UnsupportedViewWireframesBuilder)
+        }
+    }
+
+    func testWhenViewIsVisibleButHasNoAppearance() throws {
+        // When
+        viewAttributes = .mock(fixture: .visible(.noAppearance))
+
+        // Then
+        try views.forEach { view in
+            let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: .mockAny()))
+            XCTAssertTrue(semantics is SpecificElement)
+            XCTAssertEqual(semantics.subtreeStrategy, .ignore)
+        }
+    }
+}


### PR DESCRIPTION
### What and why?

Adds special recorder that recognises unsupported views and provides a common placeholder for them.

Snapshot:
![testUnsupportedView()-allowAll-privacy](https://user-images.githubusercontent.com/6953112/231453843-4f37cd96-31e7-4870-a3fb-f6ff4f03e99b.png)

### How?

A brief description of implementation details of this PR.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
