### PR TITLE
Update RUM Schema

### DIFF
--- a/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
+++ b/Sources/Datadog/RUM/DataModels/RUMDataModels.swift
@@ -308,16 +308,12 @@ public struct RUMActionEvent: RUMDataModel {
         /// UUID of the session
         public let id: String
 
-        /// Whether this session is currently active. Set to false to manually stop a session
-        public let isActive: Bool?
-
         /// Type of the session
         public let type: SessionType
 
         enum CodingKeys: String, CodingKey {
             case hasReplay = "has_replay"
             case id = "id"
-            case isActive = "is_active"
             case type = "type"
         }
 
@@ -706,16 +702,12 @@ public struct RUMErrorEvent: RUMDataModel {
         /// UUID of the session
         public let id: String
 
-        /// Whether this session is currently active. Set to false to manually stop a session
-        public let isActive: Bool?
-
         /// Type of the session
         public let type: SessionType
 
         enum CodingKeys: String, CodingKey {
             case hasReplay = "has_replay"
             case id = "id"
-            case isActive = "is_active"
             case type = "type"
         }
 
@@ -971,16 +963,12 @@ public struct RUMLongTaskEvent: RUMDataModel {
         /// UUID of the session
         public let id: String
 
-        /// Whether this session is currently active. Set to false to manually stop a session
-        public let isActive: Bool?
-
         /// Type of the session
         public let type: SessionType
 
         enum CodingKeys: String, CodingKey {
             case hasReplay = "has_replay"
             case id = "id"
-            case isActive = "is_active"
             case type = "type"
         }
 
@@ -1399,16 +1387,12 @@ public struct RUMResourceEvent: RUMDataModel {
         /// UUID of the session
         public let id: String
 
-        /// Whether this session is currently active. Set to false to manually stop a session
-        public let isActive: Bool?
-
         /// Type of the session
         public let type: SessionType
 
         enum CodingKeys: String, CodingKey {
             case hasReplay = "has_replay"
             case id = "id"
-            case isActive = "is_active"
             case type = "type"
         }
 
@@ -1612,6 +1596,9 @@ public struct RUMViewEvent: RUMDataModel {
         /// Whether this session is currently active. Set to false to manually stop a session
         public let isActive: Bool?
 
+        /// The precondition that led to the creation of the session
+        public let startReason: StartReason?
+
         /// Type of the session
         public let type: SessionType
 
@@ -1619,7 +1606,17 @@ public struct RUMViewEvent: RUMDataModel {
             case hasReplay = "has_replay"
             case id = "id"
             case isActive = "is_active"
+            case startReason = "start_reason"
             case type = "type"
+        }
+
+        /// The precondition that led to the creation of the session
+        public enum StartReason: String, Codable {
+            case appStart = "app_start"
+            case inactivityTimeout = "inactivity_timeout"
+            case maxDuration = "max_duration"
+            case stopApi = "stop_api"
+            case backgroundEvent = "background_event"
         }
 
         /// Type of the session
@@ -2977,4 +2974,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/f964339c5f07f476dee5fc6a12b6c1214a40c1da
+// Generated from https://github.com/DataDog/rum-events-format/tree/a45fbc913eb36f3bf0cc37aa1bdbee126104972b

--- a/Sources/Datadog/RUM/Integrations/CrashReportReceiver.swift
+++ b/Sources/Datadog/RUM/Integrations/CrashReportReceiver.swift
@@ -347,7 +347,6 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             session: .init(
                 hasReplay: lastRUMView.session.hasReplay,
                 id: lastRUMView.session.id,
-                isActive: true,
                 type: lastRUMView.ciTest != nil ? .ciTest : .user
             ),
             source: lastRUMView.source?.toErrorEventSource ?? .ios,
@@ -471,6 +470,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 hasReplay: hasReplay,
                 id: sessionUUID.toRUMDataFormat,
                 isActive: true,
+                startReason: nil,
                 type: CITestIntegration.active != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -202,7 +202,6 @@ internal class RUMResourceScope: RUMScope {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: nil,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -263,7 +262,6 @@ internal class RUMResourceScope: RUMScope {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: nil,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -167,7 +167,6 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: nil,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift
@@ -396,7 +396,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: self.context.isSessionActive,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -454,6 +453,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
                 isActive: self.context.isSessionActive,
+                startReason: nil,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -561,7 +561,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: self.context.isSessionActive,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,
@@ -613,7 +612,6 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             session: .init(
                 hasReplay: context.srBaggage?.isReplayBeingRecorded,
                 id: self.context.sessionID.toRUMDataFormat,
-                isActive: self.context.isSessionActive,
                 type: dependencies.ciTest != nil ? .ciTest : .user
             ),
             source: .init(rawValue: context.source) ?? .ios,

--- a/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
+++ b/Sources/DatadogObjc/RUM/RUMDataModels+objc.swift
@@ -666,10 +666,6 @@ public class DDRUMActionEventSession: NSObject {
         root.swiftModel.session.id
     }
 
-    @objc public var isActive: NSNumber? {
-        root.swiftModel.session.isActive as NSNumber?
-    }
-
     @objc public var type: DDRUMActionEventSessionSessionType {
         .init(swift: root.swiftModel.session.type)
     }
@@ -1632,10 +1628,6 @@ public class DDRUMErrorEventSession: NSObject {
         root.swiftModel.session.id
     }
 
-    @objc public var isActive: NSNumber? {
-        root.swiftModel.session.isActive as NSNumber?
-    }
-
     @objc public var type: DDRUMErrorEventSessionSessionType {
         .init(swift: root.swiftModel.session.type)
     }
@@ -2248,10 +2240,6 @@ public class DDRUMLongTaskEventSession: NSObject {
 
     @objc public var id: String {
         root.swiftModel.session.id
-    }
-
-    @objc public var isActive: NSNumber? {
-        root.swiftModel.session.isActive as NSNumber?
     }
 
     @objc public var type: DDRUMLongTaskEventSessionSessionType {
@@ -3185,10 +3173,6 @@ public class DDRUMResourceEventSession: NSObject {
         root.swiftModel.session.id
     }
 
-    @objc public var isActive: NSNumber? {
-        root.swiftModel.session.isActive as NSNumber?
-    }
-
     @objc public var type: DDRUMResourceEventSessionSessionType {
         .init(swift: root.swiftModel.session.type)
     }
@@ -3755,9 +3739,45 @@ public class DDRUMViewEventSession: NSObject {
         root.swiftModel.session.isActive as NSNumber?
     }
 
+    @objc public var startReason: DDRUMViewEventSessionStartReason {
+        .init(swift: root.swiftModel.session.startReason)
+    }
+
     @objc public var type: DDRUMViewEventSessionSessionType {
         .init(swift: root.swiftModel.session.type)
     }
+}
+
+@objc
+public enum DDRUMViewEventSessionStartReason: Int {
+    internal init(swift: RUMViewEvent.Session.StartReason?) {
+        switch swift {
+        case nil: self = .none
+        case .appStart?: self = .appStart
+        case .inactivityTimeout?: self = .inactivityTimeout
+        case .maxDuration?: self = .maxDuration
+        case .stopApi?: self = .stopApi
+        case .backgroundEvent?: self = .backgroundEvent
+        }
+    }
+
+    internal var toSwift: RUMViewEvent.Session.StartReason? {
+        switch self {
+        case .none: return nil
+        case .appStart: return .appStart
+        case .inactivityTimeout: return .inactivityTimeout
+        case .maxDuration: return .maxDuration
+        case .stopApi: return .stopApi
+        case .backgroundEvent: return .backgroundEvent
+        }
+    }
+
+    case none
+    case appStart
+    case inactivityTimeout
+    case maxDuration
+    case stopApi
+    case backgroundEvent
 }
 
 @objc
@@ -5111,4 +5131,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/f964339c5f07f476dee5fc6a12b6c1214a40c1da
+// Generated from https://github.com/DataDog/rum-events-format/tree/a45fbc913eb36f3bf0cc37aa1bdbee126104972b

--- a/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -122,6 +122,7 @@ extension RUMViewEvent: RandomMockable {
                 hasReplay: nil,
                 id: .mockRandom(),
                 isActive: true,
+                startReason: .appStart,
                 type: .user
             ),
             source: .ios,
@@ -220,7 +221,6 @@ extension RUMResourceEvent: RandomMockable {
             session: .init(
                 hasReplay: nil,
                 id: .mockRandom(),
-                isActive: true,
                 type: .user
             ),
             source: .ios,
@@ -274,7 +274,6 @@ extension RUMActionEvent: RandomMockable {
             session: .init(
                 hasReplay: nil,
                 id: .mockRandom(),
-                isActive: nil,
                 type: .user
             ),
             source: .ios,
@@ -338,7 +337,6 @@ extension RUMErrorEvent: RandomMockable {
             session: .init(
                 hasReplay: nil,
                 id: .mockRandom(),
-                isActive: nil,
                 type: .user
             ),
             source: .ios,
@@ -390,7 +388,6 @@ extension RUMLongTaskEvent: RandomMockable {
             session: .init(
                 hasReplay: false,
                 id: .mockRandom(),
-                isActive: true,
                 type: .user
             ),
             source: .ios,


### PR DESCRIPTION
### What and why?

Update the RUM schema to latest, which moves `session.isActive` to only report on View updates and adds `session.startReason`

I'm setting `session.startReason` to nil for now and we'll revisit when we actually add that feature.

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
