### PR TITLE
Make Features `Flushable`

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -504,6 +504,8 @@
 		D240687F27CF982F00C04F44 /* DatadogObjc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; };
 		D240688027CF982F00C04F44 /* DatadogObjc.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61133BF0242397DA00786299 /* DatadogObjc.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D240688627CFA64A00C04F44 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D240688427CFA64A00C04F44 /* LaunchScreen.storyboard */; };
+		D2432CF929EDB22C00D93657 /* Flushable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2432CF829EDB22C00D93657 /* Flushable.swift */; };
+		D2432CFA29EDB22C00D93657 /* Flushable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2432CF829EDB22C00D93657 /* Flushable.swift */; };
 		D243BBC0276C9D640019C857 /* PLCrashReporterIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D243BBBF276C9D640019C857 /* PLCrashReporterIntegrationTests.swift */; };
 		D243BBEC29A614CE000B9CEC /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D243BBEB29A614CE000B9CEC /* Logger.swift */; };
 		D243BBED29A614CE000B9CEC /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D243BBEB29A614CE000B9CEC /* Logger.swift */; };
@@ -1969,6 +1971,7 @@
 		D2375C262954785A00473EA0 /* WebViewLogReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewLogReceiverTests.swift; sourceTree = "<group>"; };
 		D240684D27CE6C9E00C04F44 /* Example tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D240688527CFA64A00C04F44 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D2432CF829EDB22C00D93657 /* Flushable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flushable.swift; sourceTree = "<group>"; };
 		D243BBBF276C9D640019C857 /* PLCrashReporterIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLCrashReporterIntegrationTests.swift; sourceTree = "<group>"; };
 		D243BBEB29A614CE000B9CEC /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		D243BBEE29A61721000B9CEC /* Builder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Builder.swift; sourceTree = "<group>"; };
@@ -4092,6 +4095,7 @@
 			isa = PBXGroup;
 			children = (
 				D23039DB298D5235001A1FA3 /* ReadWriteLock.swift */,
+				D2432CF829EDB22C00D93657 /* Flushable.swift */,
 			);
 			path = Concurrency;
 			sourceTree = "<group>";
@@ -6271,6 +6275,7 @@
 				D2160CE429C0DFEE00FAA9A5 /* MethodSwizzler.swift in Sources */,
 				D2160CC929C0DED100FAA9A5 /* DatadogURLSessionDelegate.swift in Sources */,
 				D2EBEE2929BA160F00B15732 /* HTTPHeadersWriter.swift in Sources */,
+				D2432CF929EDB22C00D93657 /* Flushable.swift in Sources */,
 				D23039F7298D5236001A1FA3 /* AttributesSanitizer.swift in Sources */,
 				D23039EB298D5236001A1FA3 /* DatadogFeature.swift in Sources */,
 				D23039E4298D5236001A1FA3 /* CarrierInfo.swift in Sources */,
@@ -6887,6 +6892,7 @@
 				D2160CE629C0DFEE00FAA9A5 /* MethodSwizzler.swift in Sources */,
 				D2160CCA29C0DED100FAA9A5 /* DatadogURLSessionDelegate.swift in Sources */,
 				D2EBEE3729BA161100B15732 /* HTTPHeadersWriter.swift in Sources */,
+				D2432CFA29EDB22C00D93657 /* Flushable.swift in Sources */,
 				D2DA235D298D57AA00C6C7E6 /* AttributesSanitizer.swift in Sources */,
 				D2DA235E298D57AA00C6C7E6 /* DatadogFeature.swift in Sources */,
 				D2DA235F298D57AA00C6C7E6 /* CarrierInfo.swift in Sources */,

--- a/DatadogInternal/Sources/Concurrency/Flushable.swift
+++ b/DatadogInternal/Sources/Concurrency/Flushable.swift
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+public protocol Flushable {
+    /// Awaits completion of all asynchronous operations.
+    ///
+    /// **blocks the caller thread**
+    func flush()
+}

--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -187,3 +187,12 @@ extension NetworkInstrumentationFeature {
         return reader.read()
     }
 }
+
+extension NetworkInstrumentationFeature: Flushable {
+    /// Awaits completion of all asynchronous operations.
+    ///
+    /// **blocks the caller thread**
+    func flush() {
+        queue.sync { }
+    }
+}

--- a/Sources/Datadog/DatadogCore/Context/DatadogContextProvider.swift
+++ b/Sources/Datadog/DatadogCore/Context/DatadogContextProvider.swift
@@ -160,3 +160,12 @@ internal final class DatadogContextProvider {
     }
 #endif
 }
+
+extension DatadogContextProvider: Flushable {
+    /// Awaits completion of all asynchronous operations.
+    ///
+    /// **blocks the caller thread**
+    func flush() {
+        queue.sync { }
+    }
+}

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -194,35 +194,6 @@ internal final class DatadogCore {
         stores.values.map { $0.upload }
     }
 
-    /// Flushes asynchronous operations related to events write, context and message bus propagation in this instance of the SDK
-    /// with **blocking the caller thread** till their completion.
-    ///
-    /// Upon return, it is safe to assume that all events are stored. No assumption on their upload should be made - to force events upload
-    /// use `flushAndTearDown()` instead.
-    func flush() {
-        // The order of flushing below must be considered cautiously and
-        // follow our design choices around SDK core's threading.
-
-        // The flushing is repeated few times, to make sure that operations spawned from other operations
-        // on these queues are also awaited. Effectively, this is no different than short-time sleep() on current
-        // thread and it has the same drawbacks (including: it might become flaky). Until we find a better solution
-        // this is enough to get consistency in tests - but won't be reliable in any public "deinitialize" API.
-        for _ in 0..<5 {
-            // First, flush bus queue - because messages can lead to obtaining "event write context" (reading
-            // context & performing write) in other Features:
-            messageBusQueue.sync { }
-
-            // Next, flush context queue - because it indicates the entry point to "event write context" and
-            // actual writes dispatched from it:
-            contextProvider.queue.sync { }
-
-            // Last, flush read-write queue - it always comes last, no matter if the write operation is dispatched
-            // from "event write context" started on user thread OR if it happens upon receiving an "event" message
-            // in other Feature:
-            readWriteQueue.sync { }
-        }
-    }
-
     /// Awaits completion of all asynchronous operations, forces uploads (without retrying) and deinitializes
     /// this instance of the SDK. It **blocks the caller thread**.
     ///
@@ -473,5 +444,41 @@ extension DatadogContextProvider {
             self.subscribe(\.applicationStateHistory, to: applicationStatePublisher)
         }
         #endif
+    }
+}
+
+extension DatadogCore: Flushable {
+    /// Flushes asynchronous operations related to events write, context and message bus propagation in this instance of the SDK
+    /// with **blocking the caller thread** till their completion.
+    ///
+    /// Upon return, it is safe to assume that all events are stored. No assumption on their upload should be made - to force events upload
+    /// use `flushAndTearDown()` instead.
+    func flush() {
+        // The order of flushing below must be considered cautiously and
+        // follow our design choices around SDK core's threading.
+
+        let features = features.values.compactMap { $0 as? Flushable }
+
+        // The flushing is repeated few times, to make sure that operations spawned from other operations
+        // on these queues are also awaited. Effectively, this is no different than short-time sleep() on current
+        // thread and it has the same drawbacks (including: it might become flaky). Until we find a better solution
+        // this is enough to get consistency in tests - but won't be reliable in any public "deinitialize" API.
+        for _ in 0..<5 {
+            // First, flush bus queue - because messages can lead to obtaining "event write context" (reading
+            // context & performing write) in other Features:
+            messageBusQueue.sync { }
+
+            // Next, flush flushable Features - finish current data collection to open "event write contexts":
+            features.forEach { $0.flush() }
+
+            // Next, flush context queue - because it indicates the entry point to "event write context" and
+            // actual writes dispatched from it:
+            contextProvider.flush()
+
+            // Last, flush read-write queue - it always comes last, no matter if the write operation is dispatched
+            // from "event write context" started on user thread OR if it happens upon receiving an "event" message
+            // in other Feature:
+            readWriteQueue.sync { }
+        }
     }
 }

--- a/Sources/Datadog/RUM/Feature/DatadogRUMFeature.swift
+++ b/Sources/Datadog/RUM/Feature/DatadogRUMFeature.swift
@@ -74,3 +74,12 @@ internal final class DatadogRUMFeature: DatadogRemoteFeature {
         instrumentation.deinitialize()
     }
 }
+
+extension DatadogRUMFeature: Flushable {
+    /// Awaits completion of all asynchronous operations.
+    ///
+    /// **blocks the caller thread**
+    func flush() {
+        monitor.queue.sync { }
+    }
+}

--- a/Sources/Datadog/RUM/RUMMonitor.swift
+++ b/Sources/Datadog/RUM/RUMMonitor.swift
@@ -154,7 +154,7 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
     /// Attributes associated with every command.
     private var rumAttributes: [AttributeKey: AttributeValue] = [:]
     /// Queue for processing RUM commands off the main thread and providing current RUM context.
-    private let queue = DispatchQueue(
+    internal let queue = DispatchQueue(
         label: "com.datadoghq.rum-monitor",
         target: .global(qos: .userInteractive)
     )
@@ -697,11 +697,4 @@ public class RUMMonitor: DDRUMMonitor, RUMCommandSubscriber {
 
         return mutableCommand
     }
-
-#if DD_SDK_COMPILED_FOR_TESTING
-    /// Blocks the caller thread until (asynchronous) command processing in `RUMMonitor` is completed.
-    public func flush() {
-        queue.sync {}
-    }
-#endif
 }

--- a/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
+++ b/Tests/DatadogTests/Datadog/RUMMonitorTests.swift
@@ -1264,16 +1264,16 @@ class RUMMonitorTests: XCTestCase {
         defer { Global.rum = DDNoopRUMMonitor() }
 
         let monitor = Global.rum.dd
-        monitor.flush()
+        monitor.queue.sync {}
         XCTAssertNil(monitor.debugging)
 
         // when & then
         Datadog.debugRUM = true
-        monitor.flush()
+        monitor.queue.sync {}
         XCTAssertNotNil(monitor.debugging)
 
         Datadog.debugRUM = false
-        monitor.flush()
+        monitor.queue.sync {}
         XCTAssertNil(monitor.debugging)
     }
 


### PR DESCRIPTION
### What and why?

Fix integration tests flakiness by allowing flushing Features.

### How?

Creates a `Flushable` protocol for executing all async operations in a complying implementation. Features implementing `Flushable` will be  flushed with the core they are registered in during tests execution.

A missing flush mechanism in `NetworkInstrumentationFeature` was making Integration Tests flaky.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
