### PR TITLE
Fix 1st-Party Hosts from Custom Delegate

### DIFF
--- a/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/NetworkInstrumentationFeature.swift
@@ -161,7 +161,7 @@ extension NetworkInstrumentationFeature {
 
     private func firstPartyHosts(for session: URLSession) -> FirstPartyHosts {
         handlers.reduce(.init()) { $0 + $1.firstPartyHosts } +
-            (session.delegate as? DatadogURLSessionDelegate)?.firstPartyHosts
+            (session.delegate as? __URLSessionDelegateProviding)?.ddURLSessionDelegate.firstPartyHosts
     }
 
     private func finish(_ session: URLSession, task: URLSessionTask, interception: URLSessionTaskInterception) {


### PR DESCRIPTION
### What and why?

Fix interception of 1st-party hosts in composite delegate.

### How?

Use `__URLSessionDelegateProviding` for getting 1st-party host instead of `DatadogURLSessionDelegate`.
Add coverage in unit-tests instead of fuzzy integration test.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
