### PR TITLE
REPLAY-1512 UIAlertController support

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Basic.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Basic.storyboard
@@ -118,6 +118,55 @@
             </objects>
             <point key="canvasLocation" x="1117" y="4"/>
         </scene>
+        <!--Popups View Controller-->
+        <scene sceneID="bZC-NI-Lx2">
+            <objects>
+                <viewController storyboardIdentifier="Popups" id="tgf-1d-byI" customClass="PopupsViewController" customModule="SRHost" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="rij-Eo-0BL">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="p6Z-5b-uHi">
+                                <rect key="frame" x="20" y="79" width="353" height="583.33333333333337"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0B3-8T-31k">
+                                        <rect key="frame" x="0.0" y="0.0" width="353" height="36"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                                        <color key="textColor" systemColor="systemIndigoColor"/>
+                                        <color key="highlightedColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Headline" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XcD-TQ-340">
+                                        <rect key="frame" x="0.0" y="56" width="353" height="24"/>
+                                        <color key="backgroundColor" systemColor="systemBrownColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2gH-CT-fic">
+                                        <rect key="frame" x="0.0" y="99.999999999999972" width="353" height="483.33333333333326"/>
+                                        <mutableString key="text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. </mutableString>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="ut1-S9-9ez"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="p6Z-5b-uHi" firstAttribute="leading" secondItem="ut1-S9-9ez" secondAttribute="leading" constant="20" id="CEr-RF-PAI"/>
+                            <constraint firstItem="ut1-S9-9ez" firstAttribute="trailing" secondItem="p6Z-5b-uHi" secondAttribute="trailing" constant="20" id="wIc-hI-ZPk"/>
+                            <constraint firstItem="p6Z-5b-uHi" firstAttribute="top" secondItem="ut1-S9-9ez" secondAttribute="top" constant="20" id="zS0-QE-dep"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="geZ-kh-a5V" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1973" y="4"/>
+        </scene>
     </scenes>
     <resources>
         <namedColor name="EB455F">
@@ -125,6 +174,9 @@
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBrownColor">
+            <color red="0.63529411764705879" green="0.51764705882352946" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGroupedBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -137,9 +189,6 @@
         </systemColor>
         <systemColor name="systemTealColor">
             <color red="0.18823529411764706" green="0.69019607843137254" blue="0.7803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemYellowColor">
-            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/BasicViewControllers.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/BasicViewControllers.swift
@@ -24,8 +24,32 @@ internal class PopupsViewController: UIViewController {
     }
 
     @objc func showAlert() {
-        let alert = UIAlertController(title: "Test", message: "Test", preferredStyle: .alert)
-        alert.addAction(.init(title: "Accept", style: .destructive))
-        present(alert, animated: false)
+        let alertController = UIAlertController(
+            title: "Alert Example",
+            message: "This is an elaborate example of UIAlertController",
+            preferredStyle: .alert
+        )
+
+        alertController.addTextField { (textField) in
+            textField.placeholder = "Enter your name"
+        }
+
+        let confirmAction = UIAlertAction(title: "Confirm", style: .default) { [weak alertController] _ in
+            if let textField = alertController?.textFields?[0], let text = textField.text {
+                print("Name entered: \(text)")
+            }
+        }
+        alertController.addAction(confirmAction)
+
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { (_) in
+            print("Action cancelled")
+        }
+        alertController.addAction(cancelAction)
+
+        let customAction = UIAlertAction(title: "Custom", style: .destructive) { (_) in
+            print("Custom action selected")
+        }
+        alertController.addAction(customAction)
+        present(alertController, animated: false)
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/BasicViewControllers.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/BasicViewControllers.swift
@@ -15,3 +15,17 @@ internal class ShapesViewController: UIViewController {
         yellowView?.layer.borderColor = UIColor.yellow.cgColor
     }
 }
+
+internal class PopupsViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let tap = UITapGestureRecognizer(target: self, action: #selector(showAlert))
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc func showAlert() {
+        let alert = UIAlertController(title: "Test", message: "Test", preferredStyle: .alert)
+        alert.addAction(.init(title: "Accept", style: .destructive))
+        present(alert, animated: false)
+    }
+}

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -22,6 +22,7 @@ internal enum Fixture: CaseIterable {
     case timePickersWheels
     case timePickersCompact
     case images
+    case alert
     case unsupportedViews
 
     var menuItemTitle: String {
@@ -56,6 +57,8 @@ internal enum Fixture: CaseIterable {
             return "Time Picker (compact)"
         case .images:
             return "Images"
+        case .alert:
+            return "Alert"
         case .unsupportedViews:
             return "Unsupported Views"
         }
@@ -95,7 +98,55 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.images.instantiateViewController(withIdentifier: "Images")
         case .unsupportedViews:
             return UIStoryboard.unsupportedViews.instantiateViewController(withIdentifier: "UnsupportedViews")
+        case .alert:
+            return createAlertControler()
         }
+    }
+
+    var presentationStyle: PresentationStyle {
+        switch self {
+        case .alert:
+            return .modal
+        default:
+            return .push
+        }
+    }
+
+    private func createAlertControler() -> UIAlertController {
+        let alertController = UIAlertController(
+            title: "Alert Example",
+            message: "This is an elaborate example of UIAlertController",
+            preferredStyle: .alert
+        )
+
+        alertController.addTextField { (textField) in
+            textField.placeholder = "Enter your name"
+        }
+
+        let confirmAction = UIAlertAction(title: "Confirm", style: .default) { [weak alertController] _ in
+            if let textField = alertController?.textFields?[0], let text = textField.text {
+                print("Name entered: \(text)")
+            }
+        }
+        alertController.addAction(confirmAction)
+
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { (_) in
+            print("Action cancelled")
+        }
+        alertController.addAction(cancelAction)
+
+        let customAction = UIAlertAction(title: "Custom", style: .default) { (_) in
+            print("Custom action selected")
+        }
+        alertController.addAction(customAction)
+        return alertController
+    }
+}
+
+extension Fixture {
+    enum PresentationStyle {
+        case modal
+        case push
     }
 }
 

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -22,7 +22,6 @@ internal enum Fixture: CaseIterable {
     case timePickersWheels
     case timePickersCompact
     case images
-    case alert
     case unsupportedViews
 
     var menuItemTitle: String {
@@ -57,8 +56,6 @@ internal enum Fixture: CaseIterable {
             return "Time Picker (compact)"
         case .images:
             return "Images"
-        case .alert:
-            return "Alert"
         case .unsupportedViews:
             return "Unsupported Views"
         }
@@ -98,55 +95,7 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.images.instantiateViewController(withIdentifier: "Images")
         case .unsupportedViews:
             return UIStoryboard.unsupportedViews.instantiateViewController(withIdentifier: "UnsupportedViews")
-        case .alert:
-            return createAlertControler()
         }
-    }
-
-    var presentationStyle: PresentationStyle {
-        switch self {
-        case .alert:
-            return .modal
-        default:
-            return .push
-        }
-    }
-
-    private func createAlertControler() -> UIAlertController {
-        let alertController = UIAlertController(
-            title: "Alert Example",
-            message: "This is an elaborate example of UIAlertController",
-            preferredStyle: .alert
-        )
-
-        alertController.addTextField { (textField) in
-            textField.placeholder = "Enter your name"
-        }
-
-        let confirmAction = UIAlertAction(title: "Confirm", style: .default) { [weak alertController] _ in
-            if let textField = alertController?.textFields?[0], let text = textField.text {
-                print("Name entered: \(text)")
-            }
-        }
-        alertController.addAction(confirmAction)
-
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { (_) in
-            print("Action cancelled")
-        }
-        alertController.addAction(cancelAction)
-
-        let customAction = UIAlertAction(title: "Custom", style: .default) { (_) in
-            print("Custom action selected")
-        }
-        alertController.addAction(customAction)
-        return alertController
-    }
-}
-
-extension Fixture {
-    enum PresentationStyle {
-        case modal
-        case push
     }
 }
 

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Fixtures.swift
@@ -23,6 +23,7 @@ internal enum Fixture: CaseIterable {
     case timePickersCompact
     case images
     case unsupportedViews
+    case alert
 
     var menuItemTitle: String {
         switch self {
@@ -58,6 +59,8 @@ internal enum Fixture: CaseIterable {
             return "Images"
         case .unsupportedViews:
             return "Unsupported Views"
+        case .alert:
+            return "Alert"
         }
     }
 
@@ -95,6 +98,8 @@ internal enum Fixture: CaseIterable {
             return UIStoryboard.images.instantiateViewController(withIdentifier: "Images")
         case .unsupportedViews:
             return UIStoryboard.unsupportedViews.instantiateViewController(withIdentifier: "UnsupportedViews")
+        case .alert:
+            return UIStoryboard.basic.instantiateViewController(withIdentifier: "Popups")
         }
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/MenuViewController.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/MenuViewController.swift
@@ -33,11 +33,6 @@ internal class MenuViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        let fixture = Fixture.allCases[indexPath.item]
-        if fixture.presentationStyle == .push {
-            show(fixture.instantiateViewController(), sender: self)
-        } else if fixture.presentationStyle == .modal {
-            present(fixture.instantiateViewController(), animated: true)
-        }
+        show(Fixture.allCases[indexPath.item].instantiateViewController(), sender: self)
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/MenuViewController.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/MenuViewController.swift
@@ -33,6 +33,11 @@ internal class MenuViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        show(Fixture.allCases[indexPath.item].instantiateViewController(), sender: self)
+        let fixture = Fixture.allCases[indexPath.item]
+        if fixture.presentationStyle == .push {
+            show(fixture.instantiateViewController(), sender: self)
+        } else if fixture.presentationStyle == .modal {
+            present(fixture.instantiateViewController(), animated: true)
+        }
     }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
@@ -138,9 +138,9 @@
 		61B3BC632993BEAF0032C78A /* SRSnapshotTests */ = {
 			isa = PBXGroup;
 			children = (
-				619C49B8299551F5006B66A6 /* _snapshots_ */,
-				619C49B529955106006B66A6 /* Utils */,
 				61B3BC642993BEAF0032C78A /* SRSnapshotTests.swift */,
+				619C49B529955106006B66A6 /* Utils */,
+				619C49B8299551F5006B66A6 /* _snapshots_ */,
 			);
 			path = SRSnapshotTests;
 			sourceTree = "<group>";

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -204,17 +204,6 @@ final class SRSnapshotTests: SnapshotTestCase {
         }
     }
 
-    func testAlertController() throws {
-        show(fixture: .alert)
-
-        let image = try takeSnapshot(configuration: .init(privacy: .allowAll))
-        DDAssertSnapshotTest(
-            newImage: image,
-            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
-            record: recordingMode
-        )
-    }
-
     func testUnsupportedView() throws {
         show(fixture: .unsupportedViews)
 

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -214,4 +214,19 @@ final class SRSnapshotTests: SnapshotTestCase {
             record: recordingMode
         )
     }
+
+    func testAlert() throws {
+        (show(fixture: .alert) as! PopupsViewController).showAlert()
+
+        wait(seconds: 0.5)
+
+        try forEachPrivacyMode { privacyMode in
+            let image = try takeSnapshot(configuration: .init(privacy: privacyMode))
+            DDAssertSnapshotTest(
+                newImage: image,
+                snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-\(privacyMode)-privacy"),
+                record: recordingMode
+            )
+        }
+    }
 }

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/SRSnapshotTests.swift
@@ -204,6 +204,17 @@ final class SRSnapshotTests: SnapshotTestCase {
         }
     }
 
+    func testAlertController() throws {
+        show(fixture: .alert)
+
+        let image = try takeSnapshot(configuration: .init(privacy: .allowAll))
+        DDAssertSnapshotTest(
+            newImage: image,
+            snapshotLocation: .folder(named: snapshotsFolderName, fileNameSuffix: "-allowAll-privacy"),
+            record: recordingMode
+        )
+    }
+
     func testUnsupportedView() throws {
         show(fixture: .unsupportedViews)
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorder.swift
@@ -17,30 +17,26 @@ internal class UIViewRecorder: NodeRecorder {
     }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
-        let attributesOverride: ViewAttributes
-        if String(reflecting: type(of: view)) == "_UIAlertControllerPhoneTVMacView" {
-            attributesOverride = ViewAttributes(
-                frame: attributes.frame,
-                backgroundColor: SystemColors.systemBackground,
-                layerBorderColor: nil,
-                layerBorderWidth: 0,
-                layerCornerRadius: 16,
-                alpha: 1,
-                isHidden: false,
-                intrinsicContentSize: attributes.intrinsicContentSize
-            )
-        } else {
-            attributesOverride = attributes
+        var attributes = attributes
+        if context.viewControllerContext.isRootView(of: .alert) {
+            attributes = attributes.copy {
+                $0.backgroundColor = SystemColors.systemBackground
+                $0.layerBorderColor = nil
+                $0.layerBorderWidth = 0
+                $0.layerCornerRadius = 16
+                $0.alpha = 1
+                $0.isHidden = false
+            }
         }
 
-        guard attributesOverride.isVisible else {
+        guard attributes.isVisible else {
             return InvisibleElement.constant
         }
-        if let semantics = semanticsOverride(view, attributesOverride) {
+        if let semantics = semanticsOverride(view, attributes) {
             return semantics
         }
 
-        guard attributesOverride.hasAnyAppearance else {
+        guard attributes.hasAnyAppearance else {
             // The view has no appearance, but it may contain subviews that bring visual elements, so
             // we use `InvisibleElement` semantics (to drop it) with `.record` strategy for its subview.
             return InvisibleElement(subtreeStrategy: .record)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewAttributes+Copy.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewAttributes+Copy.swift
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import UIKit
+
+extension ViewAttributes {
+    /// struct copy, lets you overwrite specific variables retaining the value of the rest
+    /// using a closure to set the new values for the copy of the struct
+    func copy(_ build: (inout Builder) -> Void) -> ViewAttributes {
+        var builder = Builder(original: self)
+        build(&builder)
+        return builder.toViewAttributes()
+    }
+
+    struct Builder {
+        var frame: CGRect
+        var backgroundColor: CGColor?
+        var layerBorderColor: CGColor?
+        var layerBorderWidth: CGFloat
+        var layerCornerRadius: CGFloat
+        var alpha: CGFloat
+        var isHidden: Bool
+        var intrinsicContentSize: CGSize
+
+        fileprivate init(original: ViewAttributes) {
+            self.frame = original.frame
+            self.backgroundColor = original.backgroundColor
+            self.layerBorderColor = original.layerBorderColor
+            self.layerBorderWidth = original.layerBorderWidth
+            self.layerCornerRadius = original.layerCornerRadius
+            self.alpha = original.alpha
+            self.isHidden = original.isHidden
+            self.intrinsicContentSize = original.intrinsicContentSize
+        }
+
+        fileprivate func toViewAttributes() -> ViewAttributes {
+            return ViewAttributes(
+                frame: frame,
+                backgroundColor: backgroundColor,
+                layerBorderColor: layerBorderColor,
+                layerBorderWidth: layerBorderWidth,
+                layerCornerRadius: layerCornerRadius,
+                alpha: alpha,
+                isHidden: isHidden,
+                intrinsicContentSize: intrinsicContentSize
+            )
+        }
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -104,7 +104,7 @@ extension ViewAttributes {
         self.layerBorderColor = view.layer.borderColor
         self.layerBorderWidth = view.layer.borderWidth
         self.layerCornerRadius = view.layer.cornerRadius
-        self.alpha = view.alpha
+        self.alpha = ((view.backgroundColor?.cgColor.alpha ?? view.alpha) + view.alpha) / 2
         self.isHidden = view.isHidden
         self.intrinsicContentSize = view.intrinsicContentSize
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -104,7 +104,7 @@ extension ViewAttributes {
         self.layerBorderColor = view.layer.borderColor
         self.layerBorderWidth = view.layer.borderWidth
         self.layerCornerRadius = view.layer.cornerRadius
-        self.alpha = ((view.backgroundColor?.cgColor.alpha ?? view.alpha) + view.alpha) / 2
+        self.alpha = view.alpha
         self.isHidden = view.isHidden
         self.intrinsicContentSize = view.intrinsicContentSize
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -94,7 +94,7 @@ internal struct ViewAttributes: Equatable {
     /// If the view is translucent, meaining if any content underneath it can be seen.
     ///
     /// Example: A view with with blue background of alpha `0.5` is considered "translucent".
-    var isTranslucent: Bool { !isVisible || alpha < 1 }
+    var isTranslucent: Bool { !isVisible || alpha < 1 || backgroundColor?.alpha ?? 0 < 1 }
 }
 
 extension ViewAttributes {

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -150,14 +150,9 @@ extension ViewAttributes: AnyMockable, RandomMockable {
             isHidden = false
             alpha = 1
             frame = .mockRandom(minWidth: 10, minHeight: 10)
-            // some appearance:
-            oneOrMoreOf([
-                {
-                    layerBorderWidth = .mockRandom(min: 1, max: 5)
-                    layerBorderColor = UIColor.mockRandomWith(alpha: .mockRandom(min: 0.1, max: 1)).cgColor
-                },
-                { backgroundColor = UIColor.mockRandomWith(alpha: .mockRandom(min: 0.1, max: 1)).cgColor }
-            ])
+            backgroundColor = UIColor.mockRandomWith(alpha: 1).cgColor
+            layerBorderWidth = .mockRandom(min: 1, max: 5)
+            layerBorderColor = UIColor.mockRandomWith(alpha: .mockRandom(min: 0.1, max: 1)).cgColor
         }
         // swiftlint:enable opening_brace
 

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -315,6 +315,7 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
 class NodeRecorderMock: NodeRecorder {
     var queriedViews: Set<UIView> = []
     var queryContexts: [ViewTreeRecordingContext] = []
+    var queryContextsByView: [UIView: ViewTreeRecordingContext] = [:]
     var resultForView: (UIView) -> NodeSemantics?
 
     init(resultForView: @escaping (UIView) -> NodeSemantics?) {
@@ -324,6 +325,7 @@ class NodeRecorderMock: NodeRecorder {
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {
         queriedViews.insert(view)
         queryContexts.append(context)
+        queryContextsByView[view] = context
         return resultForView(view)
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIViewRecorderTests.swift
@@ -42,4 +42,17 @@ class UIViewRecorderTests: XCTestCase {
         XCTAssertTrue(semantics is InvisibleElement)
         XCTAssertEqual(semantics.subtreeStrategy, .record)
     }
+
+    func testWhenViewIsFromUIAlertController() throws {
+        // When
+        viewAttributes = .mockRandom()
+
+        // Then
+        var context = ViewTreeRecordingContext.mockRandom()
+        context.viewControllerContext.isRootView = true
+        context.viewControllerContext.parentType = .alert
+        let semantics = try XCTUnwrap(recorder.semantics(of: view, with: viewAttributes, in: context))
+        XCTAssertTrue(semantics is AmbiguousElement)
+        XCTAssertEqual(semantics.subtreeStrategy, .record)
+    }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -216,4 +216,15 @@ class ViewTreeRecorderTests: XCTestCase {
             XCTAssertFalse(nodes.isEmpty, "Some nodes should be recorded for \(type(of: view)) when it has some appearance")
         }
     }
+
+    func testItOverridesContextForUIAlertController() {
+        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let view = UIAlertController(title: "", message: "", preferredStyle: .alert).view!
+        // When
+        let context = ViewTreeRecordingContext.mockRandom()
+        let nodes = recorder.recordNodes(for: view, in: context)
+
+        // Then
+        XCTAssertFalse(nodes.isEmpty, "Some nodes should be recorded for \(type(of: view)) when it has some")
+    }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -247,16 +247,20 @@ class ViewTreeRecorderTests: XCTestCase {
             ]
         )
         let view = UIViewController().view!
+        view.addSubview(.mock(withFixture: .visible(.someAppearance)))
         let context = ViewTreeRecordingContext.mockRandom()
 
         // When
         let nodes = recorder.recordNodes(for: view, in: context)
 
         // Then
-        let contextOverride = nodeRecorder.queryContexts.first
-        XCTAssertEqual(contextOverride?.viewControllerContext.isRootView, true)
-        XCTAssertEqual(contextOverride?.viewControllerContext.parentType, .other)
-        XCTAssertTrue(nodes.isEmpty, "No nodes should be recorded for \(type(of: view)) when it's empty UIViewController's view.")
+        let rootViewContext = nodeRecorder.queryContexts.first
+        let childViewContext = nodeRecorder.queryContexts.last
+        XCTAssertEqual(rootViewContext?.viewControllerContext.isRootView, true)
+        XCTAssertEqual(rootViewContext?.viewControllerContext.parentType, .other)
+        XCTAssertEqual(childViewContext?.viewControllerContext.isRootView, false)
+        XCTAssertEqual(childViewContext?.viewControllerContext.parentType, .other)
+        XCTAssertFalse(nodes.isEmpty, "Some nodes should be recorded for view when it has some appearance")
     }
 
     func testItOverridesViewControllerContextForUIView() {

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecorderTests.swift
@@ -218,13 +218,23 @@ class ViewTreeRecorderTests: XCTestCase {
     }
 
     func testItOverridesContextForUIAlertController() {
-        let recorder = ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders())
+        let nodeRecorder = NodeRecorderMock(resultForView: { _ in nil })
+        let recorder = ViewTreeRecorder(
+            nodeRecorders: [
+                UIViewRecorder(),
+                nodeRecorder
+            ]
+        )
         let view = UIAlertController(title: "", message: "", preferredStyle: .alert).view!
-        // When
         let context = ViewTreeRecordingContext.mockRandom()
+
+        // When
         let nodes = recorder.recordNodes(for: view, in: context)
 
         // Then
-        XCTAssertFalse(nodes.isEmpty, "Some nodes should be recorded for \(type(of: view)) when it has some")
+        let contextOverride = nodeRecorder.queryContexts.first
+        XCTAssertEqual(contextOverride?.viewControllerContext.isRootView, true)
+        XCTAssertEqual(contextOverride?.viewControllerContext.parentType, .alert)
+        XCTAssertFalse(nodes.isEmpty, "Some nodes should be recorded for \(type(of: view)) when it's UIAlertController's view.")
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -113,6 +113,7 @@ class ViewAttributesTests: XCTestCase {
             { view.isHidden = true },
             { view.alpha = .mockRandom(min: 0, max: 0.99) },
             { view.frame = .zero },
+            { view.backgroundColor = .mockRandomWith(alpha: .mockRandom(min: 0, max: 0.99))}
         ])
 
         // Then
@@ -128,6 +129,7 @@ class ViewAttributesTests: XCTestCase {
         view.alpha = 1
         view.isHidden = false
         view.frame = .mockRandom(minWidth: 10, minHeight: 10)
+        view.backgroundColor = .mockRandomWith(alpha: 1)
 
         // Then
         let attributes = ViewAttributes(frameInRootView: view.frame, view: view)

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -113,7 +113,7 @@ class ViewAttributesTests: XCTestCase {
             { view.isHidden = true },
             { view.alpha = .mockRandom(min: 0, max: 0.99) },
             { view.frame = .zero },
-            { view.backgroundColor = .mockRandomWith(alpha: .mockRandom(min: 0, max: 0.99))}
+            { view.backgroundColor = .mockRandomWith(alpha: .mockRandom(min: 0, max: 0.99)) }
         ])
 
         // Then

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -133,6 +133,32 @@ class ViewAttributesTests: XCTestCase {
         let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
         XCTAssertFalse(attributes.isTranslucent)
     }
+
+    func testWhenCopy() {
+        let view: UIView = .mockRandom()
+        let rect: CGRect = .mockRandom()
+        let color: CGColor = .mockRandom()
+        let float: CGFloat = .mockRandom()
+        let boolean: Bool = .mockRandom()
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view).copy {
+            $0.frame = rect
+            $0.backgroundColor = color
+            $0.layerBorderColor = color
+            $0.layerBorderWidth = float
+            $0.layerCornerRadius = float
+            $0.alpha = float
+            $0.isHidden = boolean
+            $0.intrinsicContentSize = rect.size
+        }
+        XCTAssertEqual(attributes.frame, rect)
+        XCTAssertEqual(attributes.backgroundColor, color)
+        XCTAssertEqual(attributes.layerBorderColor, color)
+        XCTAssertEqual(attributes.layerBorderWidth, float)
+        XCTAssertEqual(attributes.layerCornerRadius, float)
+        XCTAssertEqual(attributes.alpha, float)
+        XCTAssertEqual(attributes.isHidden, boolean)
+        XCTAssertEqual(attributes.intrinsicContentSize, rect.size)
+    }
 }
 // swiftlint:enable opening_brace
 


### PR DESCRIPTION
### What and why?

Adds proper support for UIAlertController. Without this change recorders don't capture it's background, which doesn't look good.

### How?

It changes `ViewTreeRecordingContext` by adding additional nested `ViewTreeRecordingContext` that carries the type of the view controller and that determines if the view is root view of given view controller. This context knowledge allows us to specify special rules for recording these custom views. Without it we would have to rely on private class type of the view. This approach will be useful in the future for any view controller backed system components.

In this particular instance we override view attributes of the UIAlertController root view to provide consistent background.

![testAlert()-allowAll-privacy](https://user-images.githubusercontent.com/6953112/234845544-11ac5055-b22b-4156-808f-31614d87ad2c.png)
![testAlert()-maskAll-privacy](https://user-images.githubusercontent.com/6953112/234845550-abd42367-5b94-4c2d-895b-15a6098cedfc.png)
![testAlert()-maskUserInput-privacy](https://user-images.githubusercontent.com/6953112/234845552-ce327865-49be-44ca-bac6-8d5a381ea8d1.png)

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
