### PR TITLE
Re-enable Alamofire Extension

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1874,8 +1874,6 @@
 		A728ADAD2934EB0300397996 /* DDW3CHTTPHeadersWriter+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDW3CHTTPHeadersWriter+apiTests.m"; sourceTree = "<group>"; };
 		A736BA3029D1B6AF00C00966 /* TimeInterval+Convinience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Convinience.swift"; sourceTree = "<group>"; };
 		A736BA3329D1B6E000C00966 /* FixedWidthInteger+Convinience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+Convinience.swift"; sourceTree = "<group>"; };
-		A736BA3729D1B7B600C00966 /* TimeInterval+ConvinienceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ConvinienceTests.swift"; sourceTree = "<group>"; };
-		A736BA3A29D1B7BA00C00966 /* FixedWidthInteger+ConvinienceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FixedWidthInteger+ConvinienceTests.swift"; sourceTree = "<group>"; };
 		A79B0F5A292B7C06008742B3 /* OTelHTTPHeadersWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTelHTTPHeadersWriterTests.swift; sourceTree = "<group>"; };
 		A79B0F5E292BA435008742B3 /* OTelHTTPHeadersWriter+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OTelHTTPHeadersWriter+objc.swift"; sourceTree = "<group>"; };
 		A79B0F60292BB071008742B3 /* OTelHTTPHeadersReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTelHTTPHeadersReaderTests.swift; sourceTree = "<group>"; };
@@ -3837,15 +3835,6 @@
 			path = W3C;
 			sourceTree = "<group>";
 		};
-		A736BA3629D1B7AC00C00966 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				A736BA3729D1B7B600C00966 /* TimeInterval+ConvinienceTests.swift */,
-				A736BA3A29D1B7BA00C00966 /* FixedWidthInteger+ConvinienceTests.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
 		A7F773D929253F5900AC1A62 /* OpenTracing */ = {
 			isa = PBXGroup;
 			children = (
@@ -4338,7 +4327,6 @@
 		D2A783D329A53049003B03BB /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				A736BA3629D1B7AC00C00966 /* Extensions */,
 				D23039D9298D5235001A1FA3 /* DateFormatting.swift */,
 				613C6B8F2768FDDE00870CBF /* Sampler.swift */,
 				D23039DC298D5235001A1FA3 /* DDError.swift */,

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -623,6 +623,8 @@
 		D29294E1291D5ED500F8EFF9 /* ApplicationVersionPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29294DF291D5ECD00F8EFF9 /* ApplicationVersionPublisher.swift */; };
 		D29294E3291D652C00F8EFF9 /* ApplicationVersionPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29294E2291D652900F8EFF9 /* ApplicationVersionPublisherTests.swift */; };
 		D29294E4291D652D00F8EFF9 /* ApplicationVersionPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29294E2291D652900F8EFF9 /* ApplicationVersionPublisherTests.swift */; };
+		D295A16529F299C9007C0E9A /* URLSessionInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D295A16429F299C9007C0E9A /* URLSessionInterceptor.swift */; };
+		D295A16629F299C9007C0E9A /* URLSessionInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D295A16429F299C9007C0E9A /* URLSessionInterceptor.swift */; };
 		D2966C2029CA177000FC6B3C /* DatadogTrace.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2C1A55A29C4F2DF00946C31 /* DatadogTrace.framework */; };
 		D29889C9273413ED00A4D1A9 /* RUMViewsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */; };
 		D29CDD3228211A2200F7DAA5 /* DataBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29CDD3128211A2200F7DAA5 /* DataBlock.swift */; };
@@ -2030,6 +2032,7 @@
 		D28F836A29C9E7A300EF8EA2 /* TracingURLSessionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingURLSessionHandlerTests.swift; sourceTree = "<group>"; };
 		D29294DF291D5ECD00F8EFF9 /* ApplicationVersionPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationVersionPublisher.swift; sourceTree = "<group>"; };
 		D29294E2291D652900F8EFF9 /* ApplicationVersionPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationVersionPublisherTests.swift; sourceTree = "<group>"; };
+		D295A16429F299C9007C0E9A /* URLSessionInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionInterceptor.swift; sourceTree = "<group>"; };
 		D29889C72734136200A4D1A9 /* RUMViewsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMViewsHandlerTests.swift; sourceTree = "<group>"; };
 		D29CDD3128211A2200F7DAA5 /* DataBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataBlock.swift; sourceTree = "<group>"; };
 		D29D5A4C273BF8B400A687C1 /* SwiftUIActionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIActionModifier.swift; sourceTree = "<group>"; };
@@ -3934,6 +3937,7 @@
 		D2160CC029C0DED100FAA9A5 /* URLSession */ = {
 			isa = PBXGroup;
 			children = (
+				D295A16429F299C9007C0E9A /* URLSessionInterceptor.swift */,
 				D2160CC129C0DED100FAA9A5 /* URLSessionTaskInterception.swift */,
 				D2160CC329C0DED100FAA9A5 /* DatadogURLSessionDelegate.swift */,
 				D2160CC429C0DED100FAA9A5 /* URLSessionSwizzler.swift */,
@@ -6325,6 +6329,7 @@
 				D23039EF298D5236001A1FA3 /* FeatureMessage.swift in Sources */,
 				D2160CA029C0DE5700FAA9A5 /* HostsSanitizer.swift in Sources */,
 				D22F06D729DAFD500026CC3C /* FixedWidthInteger+Convenience.swift in Sources */,
+				D295A16529F299C9007C0E9A /* URLSessionInterceptor.swift in Sources */,
 				D23039E5298D5236001A1FA3 /* DateProvider.swift in Sources */,
 				D23039E0298D5235001A1FA3 /* DatadogCoreProtocol.swift in Sources */,
 				D23039FD298D5236001A1FA3 /* DataCompression.swift in Sources */,
@@ -6942,6 +6947,7 @@
 				D2DA237A298D57AA00C6C7E6 /* FeatureMessage.swift in Sources */,
 				D2160CA129C0DE5700FAA9A5 /* HostsSanitizer.swift in Sources */,
 				D22F06D829DAFD500026CC3C /* FixedWidthInteger+Convenience.swift in Sources */,
+				D295A16629F299C9007C0E9A /* URLSessionInterceptor.swift in Sources */,
 				D2DA237B298D57AA00C6C7E6 /* DateProvider.swift in Sources */,
 				D2DA237C298D57AA00C6C7E6 /* DatadogCoreProtocol.swift in Sources */,
 				D2DA237D298D57AA00C6C7E6 /* DataCompression.swift in Sources */,

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog iOS.xcscheme
@@ -170,6 +170,36 @@
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2DA2389298D588800C6C7E6"
+               BuildableName = "DatadogInternalTests iOS.xctest"
+               BlueprintName = "DatadogInternalTests iOS"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D207318229A5226A00ECBF94"
+               BuildableName = "DatadogLogsTests iOS.xctest"
+               BlueprintName = "DatadogLogsTests iOS"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D25EE93A29C4C3C300CE3839"
+               BuildableName = "DatadogTraceTests iOS.xctest"
+               BlueprintName = "DatadogTraceTests iOS"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog tvOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Datadog tvOS.xcscheme
@@ -170,6 +170,36 @@
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2DA23AD298D59DC00C6C7E6"
+               BuildableName = "DatadogInternalTests tvOS.xctest"
+               BlueprintName = "DatadogInternalTests tvOS"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2A783EE29A534F9003B03BB"
+               BuildableName = "DatadogLogsTests tvOS.xctest"
+               BlueprintName = "DatadogLogsTests tvOS"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2C1A55B29C4F2E800946C31"
+               BuildableName = "DatadogTraceTests tvOS.xctest"
+               BlueprintName = "DatadogTraceTests tvOS"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift
@@ -26,17 +26,18 @@ public protocol __URLSessionDelegateProviding: URLSessionDelegate {
 /// All requests made with the `URLSession` instrumented with this delegate will be intercepted by the SDK.
 @objc
 open class DatadogURLSessionDelegate: NSObject, URLSessionDataDelegate {
-    var feature: NetworkInstrumentationFeature? {
+    var interceptor: URLSessionInterceptor? {
         let core = self.core ?? defaultDatadogCore
-        return core.get(feature: NetworkInstrumentationFeature.self)
+        return URLSessionInterceptor.shared(in: core)
     }
 
     /* private */ public let firstPartyHosts: FirstPartyHosts
 
     /// The instance of the SDK core notified by this delegate.
+    /// 
     /// It must be a weak reference, because `URLSessionDelegate` can last longer than core instance.
     /// Any `URLSession` will retain its delegate until `.invalidateAndCancel()` is called.
-    /* private */ public weak var core: DatadogCoreProtocol?
+    private weak var core: DatadogCoreProtocol?
 
     @objc
     override public init() {
@@ -92,17 +93,17 @@ open class DatadogURLSessionDelegate: NSObject, URLSessionDataDelegate {
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        feature?.urlSession(session, task: task, didFinishCollecting: metrics)
+        interceptor?.task(task, didFinishCollecting: metrics)
     }
 
     open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
-        feature?.urlSession(session, dataTask: dataTask, didReceive: data)
+        interceptor?.task(dataTask, didReceive: data)
     }
 
     open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         // NOTE: This delegate method is only called for `URLSessionTasks` created without the completion handler.
-        feature?.urlSession(session, task: task, didCompleteWithError: error)
+        interceptor?.task(task, didCompleteWithError: error)
     }
 }
 

--- a/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionInterceptor.swift
+++ b/DatadogInternal/Sources/NetworkInstrumentation/URLSession/URLSessionInterceptor.swift
@@ -1,0 +1,75 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-2020 Datadog, Inc.
+ */
+
+import Foundation
+
+/// The `URLSession` Interceptor provides methods for injecting distributed-traces
+/// headers into a `URLRequest`and to instrument a `URLURLSessionTask` lifcycle,
+/// from its creation to completion.
+///
+/// Any Feature supporting `URLSession` instrumentation will receive interceptions through
+/// their `DatadogURLSessionHandler` implementation.
+public struct URLSessionInterceptor {
+    let feature: NetworkInstrumentationFeature
+
+    /// Returns the Interceptor registerd in core.
+    ///
+    /// This method will return an interceptor if any `DatadogURLSessionHandler` have been
+    /// registered in the given core.
+    public static func shared(in core: DatadogCoreProtocol = defaultDatadogCore) -> URLSessionInterceptor? {
+        guard let feature = core.get(feature: NetworkInstrumentationFeature.self) else {
+            return nil
+        }
+
+        return URLSessionInterceptor(feature: feature)
+    }
+
+    /// Tells the interceptor to modify a URL request.
+    ///
+    /// - Parameters:
+    ///   - request: The request to intercept.
+    ///   - additionalFirstPartyHosts: Extra hosts to consider in the interception.
+    /// - Returns: The modified request.
+    public func intercept(request: URLRequest, additionalFirstPartyHosts: FirstPartyHosts? = nil) -> URLRequest {
+        feature.intercept(request: request, additionalFirstPartyHosts: additionalFirstPartyHosts)
+    }
+
+    /// Tells the interceptors that a task was created.
+    ///
+    /// - Parameters:
+    ///   - task: The created task.
+    ///   - additionalFirstPartyHosts: Extra hosts to consider in the interception.
+    public func intercept(task: URLSessionTask, additionalFirstPartyHosts: FirstPartyHosts? = nil) {
+        feature.intercept(task: task, additionalFirstPartyHosts: additionalFirstPartyHosts)
+    }
+
+    /// Tells the interceptor that metrics were collected for the given task.
+    ///
+    /// - Parameters:
+    ///   - task: The task whose metrics have been collected.
+    ///   - metrics: The collected metrics.
+    public func task(_ task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        feature.task(task, didFinishCollecting: metrics)
+    }
+
+    /// Tells the interceptor that the task has received some of the expected data.
+    ///
+    /// - Parameters:
+    ///   - task: The data task that provided data.
+    ///   - data: A data object containing the transferred data.
+    public func task(_ task: URLSessionTask, didReceive data: Data) {
+        feature.task(task, didReceive: data)
+    }
+
+    /// Tells the interceptor that the task did complete.
+    ///
+    /// - Parameters:
+    ///   - task: The task that has finished transferring data.
+    ///   - error: If an error occurred, an error object indicating how the transfer failed, otherwise NULL.
+    public func task(_ task: URLSessionTask, didCompleteWithError error: Error?) {
+        feature.task(task, didCompleteWithError: error)
+    }
+}

--- a/DatadogInternal/Tests/Codable/AnyCodableTests.swift
+++ b/DatadogInternal/Tests/Codable/AnyCodableTests.swift
@@ -24,9 +24,9 @@
  */
 
 import XCTest
-import DatadogInternal
 import TestUtilities
-@testable import Datadog
+
+@testable import DatadogInternal
 
 class AnyCodableTests: XCTestCase {
     struct SomeCodable: Codable {

--- a/DatadogInternal/Tests/Codable/AnyCoderTests.swift
+++ b/DatadogInternal/Tests/Codable/AnyCoderTests.swift
@@ -5,9 +5,9 @@
  */
 
 import XCTest
-import DatadogInternal
 import TestUtilities
-@testable import Datadog
+
+@testable import DatadogInternal
 
 private struct CodableObject: Codable, Equatable {
     let id: UUID

--- a/DatadogInternal/Tests/Extensions/TimeInterval+ConvenienceTests.swift
+++ b/DatadogInternal/Tests/Extensions/TimeInterval+ConvenienceTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-@testable import Datadog
+@testable import DatadogInternal
 
 final class TimeIntervalConvenienceTests: XCTestCase {
     func test_Seconds() {

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -347,7 +347,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     func testGivenHandler_whenInterceptingRequests_itDetectFirstPartyHost() throws {
         let notifyInterceptionStart = expectation(description: "Notify interception did start")
-        handler.onInterceptionStart = { _ in notifyInterceptionStart.fulfill() }
         let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
 
         // Given
@@ -358,6 +357,12 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let session = server.getInterceptedURLSession(delegate: delegate)
         let request: URLRequest = .mockWith(url: "https://test.com")
 
+        handler.onInterceptionStart = {
+            // Then
+            XCTAssertTrue($0.isFirstPartyRequest ?? false)
+            notifyInterceptionStart.fulfill()
+        }
+
         // When
         session
             .dataTask(with: request)
@@ -366,11 +371,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 1, handler: nil)
         _ = server.waitAndReturnRequests(count: 1)
-
-        // Then
-        let interception = handler.interceptions.first?.value
-        core.get(feature: NetworkInstrumentationFeature.self)?.flush()
-        XCTAssertTrue(interception?.isFirstPartyRequest ?? false)
     }
 
     func testGivenDelegateSubclass_whenInterceptingRequests_itDetectFirstPartyHost() throws {
@@ -388,6 +388,12 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let session = server.getInterceptedURLSession(delegate: delegate)
         let request: URLRequest = .mockWith(url: "https://test.com")
 
+        handler.onInterceptionStart = {
+            // Then
+            XCTAssertTrue($0.isFirstPartyRequest ?? false)
+            notifyInterceptionStart.fulfill()
+        }
+
         // When
         session
             .dataTask(with: request)
@@ -396,10 +402,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 1, handler: nil)
         _ = server.waitAndReturnRequests(count: 1)
-
-        // Then
-        let interception = handler.interceptions.first?.value
-        XCTAssertTrue(interception?.isFirstPartyRequest ?? false)
     }
 
     func testGivenCompositeDelegate_whenInterceptingRequests_itDetectFirstPartyHost() throws {
@@ -425,6 +427,12 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let session = server.getInterceptedURLSession(delegate: delegate)
         let request: URLRequest = .mockWith(url: "https://test.com")
 
+        handler.onInterceptionStart = {
+            // Then
+            XCTAssertTrue($0.isFirstPartyRequest ?? false)
+            notifyInterceptionStart.fulfill()
+        }
+
         // When
         session
             .dataTask(with: request)
@@ -433,10 +441,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // Then
         waitForExpectations(timeout: 0.5, handler: nil)
         _ = server.waitAndReturnRequests(count: 1)
-
-        // Then
-        let interception = handler.interceptions.first?.value
-        XCTAssertTrue(interception?.isFirstPartyRequest ?? false)
     }
 
     // MARK: - Thread Safety

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -65,12 +65,16 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         handler.onInterceptionComplete = { _ in notifyInterceptionComplete.fulfill() }
 
         // Given
+        let url: URL = .mockAny()
+        handler.firstPartyHosts = .init(
+            hostsWithTracingHeaderTypes: [url.host!: [.datadog]]
+        )
         let delegate = DatadogURLSessionDelegate(in: core)
         let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
         session
-            .dataTask(with: URLRequest.mockAny())
+            .dataTask(with: URLRequest(url: url))
             .resume()
 
         // Then

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -9,13 +9,17 @@ import TestUtilities
 @testable import DatadogInternal
 
 class NetworkInstrumentationFeatureTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
     private var core: SingleFeatureCoreMock<NetworkInstrumentationFeature>! // swiftlint:disable:this implicitly_unwrapped_optional
-    private let handler = URLSessionHandlerMock()
+    private var handler: URLSessionHandlerMock!
+    // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUpWithError() throws {
         super.setUp()
 
         core = SingleFeatureCoreMock()
+        handler = URLSessionHandlerMock()
+
         try core.register(urlSessionHandler: handler)
     }
 
@@ -122,7 +126,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             .resume()
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         _ = server.waitAndReturnRequests(count: 1)
 
         let dateAfterAllRequests = Date()
@@ -198,9 +202,9 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         defer { defaultDatadogCore = NOPDatadogCore() }
 
         // Then
-        XCTAssertNotNil(delegate1.feature)
-        XCTAssertNotNil(delegate2.feature)
-        XCTAssertNotNil(delegate3.feature)
+        XCTAssertNotNil(delegate1.interceptor)
+        XCTAssertNotNil(delegate2.interceptor)
+        XCTAssertNotNil(delegate3.interceptor)
     }
 
     func testItCanBeInitializedAfterInitializingDefaultSDKCore() throws {
@@ -214,9 +218,9 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         let delegate3 = DatadogURLSessionDelegate(additionalFirstPartyHostsWithHeaderTypes: [:])
 
         // Then
-        XCTAssertNotNil(delegate1.feature)
-        XCTAssertNotNil(delegate2.feature)
-        XCTAssertNotNil(delegate3.feature)
+        XCTAssertNotNil(delegate1.interceptor)
+        XCTAssertNotNil(delegate2.interceptor)
+        XCTAssertNotNil(delegate3.interceptor)
     }
 
     func testItOnlyKeepsInstrumentationWhileSDKCoreIsAvailableInMemory() throws {
@@ -227,12 +231,12 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         // When
         let delegate = DatadogURLSessionDelegate(in: core)
         // Then
-        XCTAssertNotNil(delegate.feature)
+        XCTAssertNotNil(delegate.interceptor)
 
         // When (deinitialize core)
         core = nil
         // Then
-        XCTAssertNil(delegate.feature)
+        XCTAssertNil(delegate.interceptor)
     }
 
     // MARK: - URLRequest Interception
@@ -252,7 +256,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
         let feature = core.get(feature: NetworkInstrumentationFeature.self)
-        feature?.urlSession(.mockAny(), didCreateTask: task)
+        feature?.intercept(task: task, additionalFirstPartyHosts: nil)
 
         waitForExpectations(timeout: 0.5, handler: nil)
 
@@ -277,7 +281,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
         let feature = core.get(feature: NetworkInstrumentationFeature.self)
-        feature?.urlSession(.mockAny(), didCreateTask: task)
+        feature?.intercept(task: task, additionalFirstPartyHosts: nil)
 
         waitForExpectations(timeout: 0.5, handler: nil)
 
@@ -303,7 +307,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
         let feature = core.get(feature: NetworkInstrumentationFeature.self)
-        feature?.urlSession(.mockAny(), didCreateTask: task)
+        feature?.intercept(task: task, additionalFirstPartyHosts: nil)
 
         waitForExpectations(timeout: 0.5, handler: nil)
 
@@ -329,7 +333,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
         let feature = core.get(feature: NetworkInstrumentationFeature.self)
-        feature?.urlSession(.mockAny(), didCreateTask: task)
+        feature?.intercept(task: task, additionalFirstPartyHosts: nil)
 
         waitForExpectations(timeout: 0.5, handler: nil)
 
@@ -342,62 +346,69 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     // MARK: - First Party Hosts
 
     func testGivenHandler_whenInterceptingRequests_itDetectFirstPartyHost() throws {
+        let notifyInterceptionStart = expectation(description: "Notify interception did start")
+        handler.onInterceptionStart = { _ in notifyInterceptionStart.fulfill() }
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+
         // Given
-        handler.firstPartyHosts = FirstPartyHosts(hostsWithTracingHeaderTypes: ["test.com": [.datadog]])
-
-        let session = URLSession(
-            configuration: .default,
-            delegate: DatadogURLSessionDelegate(),
-            delegateQueue: nil
+        let delegate = DatadogURLSessionDelegate(
+            in: core,
+            additionalFirstPartyHostsWithHeaderTypes: ["test.com": [.datadog]]
         )
-
-        let task: URLSessionTask = .mockWith(
-            request: .mockWith(url: "https://test.com"),
-            response: .mockAny()
-        )
-
-        let feature = core.get(feature: NetworkInstrumentationFeature.self)
+        let session = server.getInterceptedURLSession(delegate: delegate)
+        let request: URLRequest = .mockWith(url: "https://test.com")
 
         // When
-        feature?.urlSession(session, didCreateTask: task)
+        session
+            .dataTask(with: request)
+            .resume()
 
         // Then
-        feature?.flush()
+        waitForExpectations(timeout: 1, handler: nil)
+        _ = server.waitAndReturnRequests(count: 1)
+
+        // Then
         let interception = handler.interceptions.first?.value
+        core.get(feature: NetworkInstrumentationFeature.self)?.flush()
         XCTAssertTrue(interception?.isFirstPartyRequest ?? false)
     }
 
     func testGivenDelegateSubclass_whenInterceptingRequests_itDetectFirstPartyHost() throws {
+        let notifyInterceptionStart = expectation(description: "Notify interception did start")
+        handler.onInterceptionStart = { _ in notifyInterceptionStart.fulfill() }
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+
         // Given
         class SubclassDelegate: DatadogURLSessionDelegate {}
-        let session = URLSession(
-            configuration: .default,
-            delegate: SubclassDelegate(
-                in: core,
-                additionalFirstPartyHostsWithHeaderTypes: ["test.com": [.datadog]]
-            ),
-            delegateQueue: nil
-        )
 
-        let task: URLSessionTask = .mockWith(
-            request: .mockWith(url: "https://test.com"),
-            response: .mockAny()
+        let delegate = SubclassDelegate(
+            in: core,
+            additionalFirstPartyHostsWithHeaderTypes: ["test.com": [.datadog]]
         )
-
-        let feature = core.get(feature: NetworkInstrumentationFeature.self)
+        let session = server.getInterceptedURLSession(delegate: delegate)
+        let request: URLRequest = .mockWith(url: "https://test.com")
 
         // When
-        feature?.urlSession(session, didCreateTask: task)
+        session
+            .dataTask(with: request)
+            .resume()
 
         // Then
-        feature?.flush()
+        waitForExpectations(timeout: 1, handler: nil)
+        _ = server.waitAndReturnRequests(count: 1)
+
+        // Then
         let interception = handler.interceptions.first?.value
         XCTAssertTrue(interception?.isFirstPartyRequest ?? false)
     }
 
     func testGivenCompositeDelegate_whenInterceptingRequests_itDetectFirstPartyHost() throws {
+        let notifyInterceptionStart = expectation(description: "Notify interception did start")
+        handler.onInterceptionStart = { _ in notifyInterceptionStart.fulfill() }
+        let server = ServerMock(delivery: .success(response: .mockResponseWith(statusCode: 200), data: .mock(ofSize: 10)))
+
         // Given
-        class SubclassDelegate: NSObject, URLSessionDataDelegate, __URLSessionDelegateProviding {
+        class CompositeDelegate: NSObject, URLSessionDataDelegate, __URLSessionDelegateProviding {
             let ddURLSessionDelegate: DatadogURLSessionDelegate
 
             required init(in core: DatadogCoreProtocol) {
@@ -410,24 +421,20 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
             }
         }
 
-        let session = URLSession(
-            configuration: .default,
-            delegate: SubclassDelegate(in: core),
-            delegateQueue: nil
-        )
-
-        let task: URLSessionTask = .mockWith(
-            request: .mockWith(url: "https://test.com"),
-            response: .mockAny()
-        )
-
-        let feature = core.get(feature: NetworkInstrumentationFeature.self)
+        let delegate = CompositeDelegate(in: core)
+        let session = server.getInterceptedURLSession(delegate: delegate)
+        let request: URLRequest = .mockWith(url: "https://test.com")
 
         // When
-        feature?.urlSession(session, didCreateTask: task)
+        session
+            .dataTask(with: request)
+            .resume()
 
         // Then
-        feature?.flush()
+        waitForExpectations(timeout: 0.5, handler: nil)
+        _ = server.waitAndReturnRequests(count: 1)
+
+        // Then
         let interception = handler.interceptions.first?.value
         XCTAssertTrue(interception?.isFirstPartyRequest ?? false)
     }
@@ -437,7 +444,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     func testRandomlyCallingDifferentAPIsConcurrentlyDoesNotCrash() throws {
         let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
 
-        let session = URLSession(configuration: .default, delegate: DatadogURLSessionDelegate(), delegateQueue: nil)
         let requests = [
             URLRequest(url: URL(string: "https://api.first-party.com/v1/endpoint")!),
             URLRequest(url: URL(string: "https://api.third-party.com/v1/endpoint")!),
@@ -449,11 +455,11 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
         callConcurrently(
             closures: [
                 { feature.handlers = [self.handler] },
-                { _ = feature.urlSession(session, intercept: requests.randomElement()!) },
-                { feature.urlSession(session, didCreateTask: tasks.randomElement()!) },
-                { feature.urlSession(session, dataTask: tasks.randomElement()!, didReceive: .mockRandom()) },
-                { feature.urlSession(session, task: tasks.randomElement()!, didFinishCollecting: .mockAny()) },
-                { feature.urlSession(session, task: tasks.randomElement()!, didCompleteWithError: nil) }
+                { _ = feature.intercept(request: requests.randomElement()!, additionalFirstPartyHosts: nil) },
+                { feature.intercept(task: tasks.randomElement()!, additionalFirstPartyHosts: nil) },
+                { feature.task(tasks.randomElement()!, didReceive: .mockRandom()) },
+                { feature.task(tasks.randomElement()!, didFinishCollecting: .mockAny()) },
+                { feature.task(tasks.randomElement()!, didCompleteWithError: nil) }
             ],
             iterations: 50
         )

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
@@ -70,11 +70,15 @@ class URLSessionSwizzlerTests: XCTestCase {
         handler.onInterceptionComplete = { _ in notifyInterceptionComplete.fulfill() }
 
         // Given
+        let url: URL = .mockRandom()
+        handler.firstPartyHosts = .init(
+            hostsWithTracingHeaderTypes: [url.host!: [.datadog]]
+        )
         let delegate = DatadogURLSessionDelegate(in: core)
         let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
-        session.dataTask(with: URLRequest(url: .mockRandom())) { _, _, _ in
+        session.dataTask(with: URLRequest(url: url)) { _, _, _ in
             completionHandlerCalled.fulfill()
         }.resume()
 
@@ -151,11 +155,15 @@ class URLSessionSwizzlerTests: XCTestCase {
         handler.onInterceptionComplete = { _ in notifyInterceptionComplete.fulfill() }
 
         // Given
+        let url: URL = .mockAny()
+        handler.firstPartyHosts = .init(
+            hostsWithTracingHeaderTypes: [url.host!: [.datadog]]
+        )
         let delegate = DatadogURLSessionDelegate(in: core)
         let session = server.getInterceptedURLSession(delegate: delegate)
 
         // When
-        let task = session.dataTask(with: URLRequest(url: .mockAny()))
+        let task = session.dataTask(with: URLRequest(url: url))
         task.resume()
 
         // Then

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
@@ -9,18 +9,23 @@ import TestUtilities
 @testable import DatadogInternal
 
 class URLSessionSwizzlerTests: XCTestCase {
+    // swiftlint:disable implicitly_unwrapped_optional
     private var core: SingleFeatureCoreMock<NetworkInstrumentationFeature>! // swiftlint:disable:this implicitly_unwrapped_optional
-    private let handler = URLSessionHandlerMock()
+    private var handler: URLSessionHandlerMock!
+    // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUpWithError() throws {
         super.setUp()
 
         core = SingleFeatureCoreMock()
+        handler = URLSessionHandlerMock()
+
         try core.register(urlSessionHandler: handler)
     }
 
     override func tearDown() {
         core = nil
+        handler = nil
         super.tearDown()
     }
 

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
@@ -88,14 +88,14 @@ class URLSessionSwizzlerTests: XCTestCase {
         }.resume()
 
         // Then
+        wait(for: [completionHandlerCalled], timeout: 1)
         wait(
             for: [
                 notifyRequestMutation,
                 notifyInterceptionStart,
-                completionHandlerCalled,
                 notifyInterceptionComplete
             ],
-            timeout: 2,
+            timeout: 1,
             enforceOrder: true
         )
 

--- a/DatadogInternal/Tests/Utils/SwiftExtensionsTests.swift
+++ b/DatadogInternal/Tests/Utils/SwiftExtensionsTests.swift
@@ -5,9 +5,8 @@
  */
 
 import XCTest
-import DatadogInternal
 
-@testable import Datadog
+@testable import DatadogInternal
 
 class TimeIntervalExtensionTests: XCTestCase {
     func testTimeIntervalFromMilliseconds() {

--- a/dependency-manager-tests/cocoapods/App/ViewController.swift
+++ b/dependency-manager-tests/cocoapods/App/ViewController.swift
@@ -40,7 +40,7 @@ internal class ViewController: UIViewController {
 
         DatadogTracer.initialize()
 
-        Global.rum = RUMMonitor.initialize()
+        Global.rum = RUMMonitor.shared()
 
         logger.info("It works")
         _ = DatadogTracer.shared().startSpan(operationName: "This too")

--- a/tools/lint/sources.swiftlint.yml
+++ b/tools/lint/sources.swiftlint.yml
@@ -68,6 +68,9 @@ only_rules: # we enable lint rules explicitly - only the ones listed below are a
   - vertical_whitespace_opening_braces
   - void_return
   - xct_specific_matcher
+attributes:
+  always_on_line_above:
+    - "@ReadWriteLock"
 
 custom_rules:
   todo_without_jira: # enforces that all TODO comments must be followed by JIRA reference

--- a/tools/lint/tests.swiftlint.yml
+++ b/tools/lint/tests.swiftlint.yml
@@ -62,6 +62,9 @@ only_rules: # we enable lint rules explicitly - only the ones listed below are a
   - vertical_whitespace_opening_braces
   - void_return
   - xct_specific_matcher
+attributes:
+  always_on_line_above:
+    - "@ReadWriteLock"
 
 custom_rules:
   todo_without_jira: # enforces that all TODO comments must be followed by JIRA reference


### PR DESCRIPTION
### What and why?

The Alamofire extension was broken following #1210 

### How?

Re-introduce the `URLSessionInterceptor` to manually intercept `URLRequest` and `URLSessionTask`. The interceptor will use the `NetworkInstrumentationFeature` to dispatch interception across registered `DatadogURLSessionHandler` (RUM or Tracer).

### Important

- I've noticed that the added module's unit-tests were not run with the main target, and so did not run in CI.
- CocoaPods smoke test was broken following #1227

Both have been fixed in this PR.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [x] Run smoke tests
