### PR TITLE
RUMM-3239 Fix RUM Context in Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [BUGFIX] Fix RUM context not being attached to log when no user action exists. See [#1264][]
+
 # 1.18.0 / 19-04-2023
 - [IMPROVEMENT] Add start reason to the session. See [#1247][]
 - [IMPROVEMENT] Add ability to stop the session. See [#1219][]
@@ -452,6 +454,7 @@
 [#1219]: https://github.com/DataDog/dd-sdk-ios/pull/1219
 [#1220]: https://github.com/DataDog/dd-sdk-ios/pull/1220
 [#1247]: https://github.com/DataDog/dd-sdk-ios/pull/1247
+[#1264]: https://github.com/DataDog/dd-sdk-ios/pull/1264
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/Sources/Datadog/Logging/RemoteLogger.swift
+++ b/Sources/Datadog/Logging/RemoteLogger.swift
@@ -125,8 +125,8 @@ internal final class RemoteLogger: LoggerProtocol {
             var internalAttributes: [String: Encodable] = [:]
             let contextAttributes = context.featuresAttributes
 
-            if self.rumContextIntegration, let attributes: [String: String] = contextAttributes["rum"]?.ids {
-                let attributes = attributes.compactMapValues(AnyEncodable.init)
+            if self.rumContextIntegration, let attributes: [String: AnyCodable?] = contextAttributes["rum"]?.ids {
+                let attributes = attributes.compactMapValues { $0 }
                 internalAttributes.merge(attributes) { $1 }
             }
 

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -568,15 +568,12 @@ class LoggerTests: XCTestCase {
                 forKeyPath: RUMContextAttributes.IDs.applicationID,
                 equals: rum.configuration.applicationID
             )
-        }
-        logMatchers.forEach {
+
             $0.assertValue(
                 forKeyPath: RUMContextAttributes.IDs.sessionID,
                 isTypeOf: String.self
             )
-        }
 
-        logMatchers.forEach {
             $0.assertValue(
                 forKeyPath: RUMContextAttributes.IDs.viewID,
                 isTypeOf: String.self


### PR DESCRIPTION
### What and why?

Fix RUM context not being attached to log when no user action exists.

### How?

Allow `nil` values in RUM context.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
