### PR TITLE
[v2] Improve CI Stability

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1304,20 +1304,6 @@
 			remoteGlobalIDString = D20731A429A5279D00ECBF94;
 			remoteInfo = "DatadogLogs tvOS";
 		};
-		D24C9C6D29A7D1D3002057CF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 61133B79242393DE00786299 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D2DA2355298D57AA00C6C7E6;
-			remoteInfo = "DatadogInternal tvOS";
-		};
-		D257956E298ABB7F008A1BE5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 61133B79242393DE00786299 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 61133B81242393DE00786299;
-			remoteInfo = "Datadog iOS";
-		};
 		D25CFA9A29C4F41F00E3A43D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 61133B79242393DE00786299 /* Project object */;
@@ -1429,6 +1415,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = D2DA2355298D57AA00C6C7E6;
 			remoteInfo = "DatadogInternal tvOS";
+		};
+		D2F969FC29FBEC20006C9CBE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D23039A4298D513C001A1FA3;
+			remoteInfo = "DatadogInternal iOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -4898,7 +4891,6 @@
 			);
 			dependencies = (
 				D2A783E329A53414003B03BB /* PBXTargetDependency */,
-				D24C9C6E29A7D1D3002057CF /* PBXTargetDependency */,
 			);
 			name = "DatadogLogs tvOS";
 			productName = DatadogLogs;
@@ -4959,7 +4951,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				D257956F298ABB7F008A1BE5 /* PBXTargetDependency */,
+				D2F969FD29FBEC20006C9CBE /* PBXTargetDependency */,
 			);
 			name = "TestUtilities iOS";
 			productName = TestUtilities;
@@ -7143,16 +7135,6 @@
 			target = D20731A429A5279D00ECBF94 /* DatadogLogs tvOS */;
 			targetProxy = D24C9C4829A7A520002057CF /* PBXContainerItemProxy */;
 		};
-		D24C9C6E29A7D1D3002057CF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D2DA2355298D57AA00C6C7E6 /* DatadogInternal tvOS */;
-			targetProxy = D24C9C6D29A7D1D3002057CF /* PBXContainerItemProxy */;
-		};
-		D257956F298ABB7F008A1BE5 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 61133B81242393DE00786299 /* Datadog iOS */;
-			targetProxy = D257956E298ABB7F008A1BE5 /* PBXContainerItemProxy */;
-		};
 		D25CFA9B29C4F41F00E3A43D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D2C1A53329C4F2DF00946C31 /* DatadogTrace tvOS */;
@@ -7234,6 +7216,11 @@
 			isa = PBXTargetDependency;
 			target = D2DA2355298D57AA00C6C7E6 /* DatadogInternal tvOS */;
 			targetProxy = D2DA23D2298D620F00C6C7E6 /* PBXContainerItemProxy */;
+		};
+		D2F969FD29FBEC20006C9CBE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D23039A4298D513C001A1FA3 /* DatadogInternal iOS */;
+			targetProxy = D2F969FC29FBEC20006C9CBE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -240,23 +240,20 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     // MARK: - URLRequest Interception
 
     func testGivenOpenTracing_whenInterceptingRequests_itInjectsTrace() throws {
-        let notifyInterceptionStart = expectation(description: "Notify interception did start")
-
         // Given
         var request: URLRequest = .mockWith(url: "https://test.com")
         let writer = HTTPHeadersWriter(sampler: .mockKeepAll())
         handler.firstPartyHosts = .init(["test.com": [.datadog]])
-        handler.onInterceptionStart = { _ in notifyInterceptionStart.fulfill() }
 
         // When
         writer.write(traceID: .mock(1), spanID: .mock(2))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
-        let feature = core.get(feature: NetworkInstrumentationFeature.self)
-        feature?.intercept(task: task, additionalFirstPartyHosts: nil)
+        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
+        feature.intercept(task: task, additionalFirstPartyHosts: nil)
+        feature.flush()
 
-        waitForExpectations(timeout: 0.5, handler: nil)
 
         // Then
         let interception = handler.interceptions.first?.value
@@ -265,23 +262,19 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     func testGivenOpenTelemetry_b3single_whenInterceptingRequests_itInjectsTrace() throws {
-        let notifyInterceptionStart = expectation(description: "Notify interception did start")
-
         // Given
         var request: URLRequest = .mockWith(url: "https://test.com")
         let writer = OTelHTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .single)
         handler.firstPartyHosts = .init(["test.com": [.b3]])
-        handler.onInterceptionStart = { _ in notifyInterceptionStart.fulfill() }
 
         // When
         writer.write(traceID: .mock(1), spanID: .mock(2), parentSpanID: .mock(3))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
-        let feature = core.get(feature: NetworkInstrumentationFeature.self)
-        feature?.intercept(task: task, additionalFirstPartyHosts: nil)
-
-        waitForExpectations(timeout: 0.5, handler: nil)
+        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
+        feature.intercept(task: task, additionalFirstPartyHosts: nil)
+        feature.flush()
 
         // Then
         let interception = handler.interceptions.first?.value
@@ -291,23 +284,19 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     func testGivenOpenTelemetry_b3multi_whenInterceptingRequests_itInjectsTrace() throws {
-        let notifyInterceptionStart = expectation(description: "Notify interception did start")
-
         // Given
         var request: URLRequest = .mockWith(url: "https://test.com")
         let writer = OTelHTTPHeadersWriter(sampler: .mockKeepAll(), injectEncoding: .multiple)
         handler.firstPartyHosts = .init(["test.com": [.b3multi]])
-        handler.onInterceptionStart = { _ in notifyInterceptionStart.fulfill() }
 
         // When
         writer.write(traceID: .mock(1), spanID: .mock(2), parentSpanID: .mock(3))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
-        let feature = core.get(feature: NetworkInstrumentationFeature.self)
-        feature?.intercept(task: task, additionalFirstPartyHosts: nil)
-
-        waitForExpectations(timeout: 0.5, handler: nil)
+        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
+        feature.intercept(task: task, additionalFirstPartyHosts: nil)
+        feature.flush()
 
         // Then
         let interception = handler.interceptions.first?.value
@@ -317,23 +306,19 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     }
 
     func testGivenW3C_whenInterceptingRequests_itInjectsTrace() throws {
-        let notifyInterceptionStart = expectation(description: "Notify interception did start")
-
         // Given
         var request: URLRequest = .mockWith(url: "https://test.com")
         let writer = W3CHTTPHeadersWriter(sampler: .mockKeepAll())
         handler.firstPartyHosts = .init(["test.com": [.tracecontext]])
-        handler.onInterceptionStart = { _ in notifyInterceptionStart.fulfill() }
 
         // When
         writer.write(traceID: .mock(1), spanID: .mock(2))
         request.allHTTPHeaderFields = writer.traceHeaderFields
 
         let task: URLSessionTask = .mockWith(request: request, response: .mockAny())
-        let feature = core.get(feature: NetworkInstrumentationFeature.self)
-        feature?.intercept(task: task, additionalFirstPartyHosts: nil)
-
-        waitForExpectations(timeout: 0.5, handler: nil)
+        let feature = try XCTUnwrap(core.get(feature: NetworkInstrumentationFeature.self))
+        feature.intercept(task: task, additionalFirstPartyHosts: nil)
+        feature.flush()
 
         // Then
         let interception = handler.interceptions.first?.value

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -15,7 +15,7 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
     // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
 
         core = SingleFeatureCoreMock()
         handler = URLSessionHandlerMock()

--- a/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/NetworkInstrumentationFeatureTests.swift
@@ -227,10 +227,6 @@ class NetworkInstrumentationFeatureTests: XCTestCase {
 
     func testItOnlyKeepsInstrumentationWhileSDKCoreIsAvailableInMemory() throws {
         // Given
-        var core: DatadogCoreProtocol? = SingleFeatureCoreMock<NetworkInstrumentationFeature>()
-        try core?.register(urlSessionHandler: handler)
-
-        // When
         let delegate = DatadogURLSessionDelegate(in: core)
         // Then
         XCTAssertNotNil(delegate.interceptor)

--- a/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
+++ b/DatadogInternal/Tests/NetworkInstrumentation/URLSessionSwizzlerTests.swift
@@ -15,7 +15,7 @@ class URLSessionSwizzlerTests: XCTestCase {
     // swiftlint:enable implicitly_unwrapped_optional
 
     override func setUpWithError() throws {
-        super.setUp()
+        try super.setUpWithError()
 
         core = SingleFeatureCoreMock()
         handler = URLSessionHandlerMock()

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -61,9 +61,9 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
         let firstPartyBadResourceURL = URL(string: "https://foo.bar")!
 
         // Requesting this third party by the app should create the RUM Resource.
-        let thirdPartyGETResourceURL = URL(string: "https://httpbin.org/get")!
+        let thirdPartyGETResourceURL = URL(string: "https://shopist.io/categories.json")!
         // Requesting this third party by the app should create the RUM Resource.
-        let thirdPartyPOSTResourceURL = URL(string: "https://httpbin.org/post")!
+        let thirdPartyPOSTResourceURL = URL(string: "https://api.shopist.io/checkout.json")!
 
         let app = ExampleApplication()
         app.launchWith(

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -110,12 +110,7 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
         )
 
         // Get RUM Sessions with expected number of View visits and Resources
-        //
-        // RUMM-3151: Timeout of 30s makes the test flaky, increasing to over 30s
-        // allow the session to end. I suspect the view event debounce mechanism
-        // to postpone the end of the session when a resource completes after the
-        // stop of its parent view.
-        let rumRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout * 2) { requests in
+        let rumRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
             try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 

--- a/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -110,7 +110,12 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
         )
 
         // Get RUM Sessions with expected number of View visits and Resources
-        let rumRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout) { requests in
+        //
+        // RUMM-3151: Timeout of 30s makes the test flaky, increasing to over 30s
+        // allow the session to end. I suspect the view event debounce mechanism
+        // to postpone the end of the session when a resource completes after the
+        // stop of its parent view.
+        let rumRequests = try rumServerSession.pullRecordedRequests(timeout: dataDeliveryTimeout * 2) { requests in
             try RUMSessionMatcher.singleSession(from: requests)?.hasEnded() ?? false
         }
 

--- a/IntegrationTests/Runner/Scenarios/URLSession/URLSessionScenarios.swift
+++ b/IntegrationTests/Runner/Scenarios/URLSession/URLSessionScenarios.swift
@@ -214,7 +214,7 @@ class URLSessionBaseScenario: NSObject {
         }
 
         return URLSession(
-            configuration: .default,
+            configuration: .ephemeral,
             delegate: delegate,
             delegateQueue: nil
         )


### PR DESCRIPTION
### What and why?

Fix further flakiness:
1. `NetworkInstrumentationFeatureTests` needs flush of the Feature before assertion.
2. `RUMResourcesScenarioTests` was using an external 3rd party service that we don't own.
3. Bad dependency linking in `DatadogLogs iOS` target 

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
