### PR TITLE
[develop] Improve CI Stability

### DIFF
--- a/Datadog/Example/Scenarios/URLSession/URLSessionScenarios.swift
+++ b/Datadog/Example/Scenarios/URLSession/URLSessionScenarios.swift
@@ -179,7 +179,7 @@ class URLSessionBaseScenario: NSObject {
         }
 
         return URLSession(
-            configuration: .default,
+            configuration: .ephemeral,
             delegate: delegate,
             delegateQueue: nil
         )

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -61,9 +61,9 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
         let firstPartyBadResourceURL = URL(string: "https://foo.bar")!
 
         // Requesting this third party by the app should create the RUM Resource.
-        let thirdPartyGETResourceURL = URL(string: "https://httpbin.org/get")!
+        let thirdPartyGETResourceURL = URL(string: "https://shopist.io/categories.json")!
         // Requesting this third party by the app should create the RUM Resource.
-        let thirdPartyPOSTResourceURL = URL(string: "https://httpbin.org/post")!
+        let thirdPartyPOSTResourceURL = URL(string: "https://api.shopist.io/checkout.json")!
 
         let app = ExampleApplication()
         app.launchWith(


### PR DESCRIPTION
### What and why?

`RUMResourcesScenarioTests` was using `https://httpbin.org` for 3rd party resources. We don't own this service and it could fail to respond in a timely manner.

Using `curl -s https://httpbin.org/get` we can have long response time:
```
    time_namelookup:  0.005084
       time_connect:  0.210384
    time_appconnect:  0.624901
   time_pretransfer:  0.414942
      time_redirect:  0.000000
 time_starttransfer:  31.134719
                    ----------
         time_total:  31.135052
```
This integration test now uses `shopist.io` that we own for 3rd party requests, it can be considered more reliable.

### How?

1. Use `https://shopist.io/categories.json` for GET and `https://api.shopist.io/checkout.json` for POST as 3rd party resources.
2. Use an `.ephemeral` URLSession instance so we don't use local cache and we can get proper metrics.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
