### PR TITLE
RUMM-3222 Use targetTimestamp as reference to calculate FPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -462,6 +462,7 @@
 [#1250]: https://github.com/DataDog/dd-sdk-ios/pull/1250
 [#1259]: https://github.com/DataDog/dd-sdk-ios/pull/1259
 [#1264]: https://github.com/DataDog/dd-sdk-ios/pull/1264
+[#1272]: https://github.com/DataDog/dd-sdk-ios/pull/1272
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [BUGFIX] Use targetTimestamp as reference to calculate FPS for variable refresh rate displays. See [#1272][]
+
 # 1.19.0 / 26-04-2023
 - [BUGFIX] Fix view attributes override by action attributes. See [#1250][]
 - [IMPROVEMENT] Add Tracer sampling rate. See [#1259][]
@@ -22,7 +24,7 @@
 # 1.15.0 / 23-01-2023
 
 - [BUGFIX] Fix 'Could not allocate memory' after corrupted TLV. See [#1089][] (Thanks [@cltnschlosser][])
-- [BUGFIX] Fix error count on the view update event following a crash. See [#1145][] 
+- [BUGFIX] Fix error count on the view update event following a crash. See [#1145][]
 
 # 1.14.0 / 20-12-2022
 

--- a/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
@@ -75,10 +75,16 @@ internal class VitalRefreshRateReader: ContinuousVitalReader {
 
         if let lastFrameTimestamp = self.lastFrameTimestamp {
             let currentFrameDuration = provider.currentFrameTimestamp - lastFrameTimestamp
+            guard currentFrameDuration > 0 else {
+                return nil
+            }
             let currentFPS = 1.0 / currentFrameDuration
 
             // ProMotion displays (e.g. iPad Pro and newer iPhone Pro) can have refresh rate higher than 60 FPS.
             if let expectedCurrentFrameDuration = self.nextFrameDuration, provider.maximumDeviceFramesPerSecond > 60 {
+                guard expectedCurrentFrameDuration > 0 else {
+                    return nil
+                }
                 let expectedFPS = 1.0 / expectedCurrentFrameDuration
                 fps = currentFPS * (Self.backendSupportedFrameRate / expectedFPS)
             } else {

--- a/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
@@ -14,6 +14,7 @@ internal class VitalRefreshRateReader: ContinuousVitalReader {
     private var displayLink: CADisplayLink?
     private var lastFrameTimestamp: CFTimeInterval?
     private var nextFrameDuration: CFTimeInterval?
+    private static var backendSupportedFrameRate = 60.0
 
     init(notificationCenter: NotificationCenter = .default) {
         notificationCenter.addObserver(
@@ -79,7 +80,7 @@ internal class VitalRefreshRateReader: ContinuousVitalReader {
             // ProMotion displays (e.g. iPad Pro and newer iPhone Pro) can have refresh rate higher than 60 FPS.
             if let expectedCurrentFrameDuration = self.nextFrameDuration, provider.maximumDeviceFramesPerSecond > 60 {
                 let expectedFPS = 1.0 / expectedCurrentFrameDuration
-                fps = currentFPS * (60.0 / expectedFPS)
+                fps = currentFPS * (Self.backendSupportedFrameRate / expectedFPS)
             } else {
                 fps = currentFPS
             }

--- a/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
@@ -68,7 +68,7 @@ internal class VitalRefreshRateReader: ContinuousVitalReader {
             let currentFPS = 1.0 / currentFrameDuration
 
             // ProMotion displays (e.g. iPad Pro and newer iPhone Pro) can have refresh rate higher than 60 FPS.
-            if let expectedCurrentFrameDuration = self.nextFrameDuration, provider.maximumDeviceFramesPerSecond > 60 {
+            if let expectedCurrentFrameDuration = self.nextFrameDuration, provider.adaptiveFrameRateSupported {
                 guard expectedCurrentFrameDuration > 0 else {
                     return nil
                 }
@@ -139,6 +139,14 @@ internal protocol FrameInfoProvider {
 
     /// Maximum number of frames per second supported by the device
     var maximumDeviceFramesPerSecond: Int { get }
+}
+
+private let adaptiveFrameRateThreshold = 60
+extension FrameInfoProvider {
+    /// `true` if the device supports adaptive frame rate
+    var adaptiveFrameRateSupported: Bool {
+        maximumDeviceFramesPerSecond > adaptiveFrameRateThreshold
+    }
 }
 
 extension CADisplayLink: FrameInfoProvider {

--- a/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
@@ -57,19 +57,6 @@ internal class VitalRefreshRateReader: ContinuousVitalReader {
 
     // MARK: - Internal
 
-    @objc
-    internal func displayTick(link: CADisplayLink) {
-        guard let fps = framesPerSecond(provider: link) else {
-            return
-        }
-
-        for publisher in valuePublishers {
-            publisher.mutateAsync { currentInfo in
-                currentInfo.addSample(fps)
-            }
-        }
-    }
-
     internal func framesPerSecond(provider: FrameInfoProvider) -> Double? {
         var fps: Double? = nil
 
@@ -99,6 +86,19 @@ internal class VitalRefreshRateReader: ContinuousVitalReader {
     }
 
     // MARK: - Private
+
+    @objc
+    private func displayTick(link: CADisplayLink) {
+        guard let fps = framesPerSecond(provider: link) else {
+            return
+        }
+
+        for publisher in valuePublishers {
+            publisher.mutateAsync { currentInfo in
+                currentInfo.addSample(fps)
+            }
+        }
+    }
 
     private func start() {
         guard displayLink == nil else {

--- a/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalRefreshRateReaderTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/RUMVitals/VitalRefreshRateReaderTests.swift
@@ -106,24 +106,24 @@ class VitalRefreshRateReaderTests: XCTestCase {
     */
     func testFramesPerSecond_given60HzFixedRateDisplay() {
         let reader = VitalRefreshRateReader(notificationCenter: mockNotificationCenter)
-        var frameTimestampProvider = FrameTimestampProviderMock()
+        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 60)
 
         // first frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0
-        frameTimestampProvider.nextFrameTimestamp = 0.016
-        let firstFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0
+        frameInfoProvider.nextFrameTimestamp = 0.016
+        let firstFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertNil(firstFps)
 
         // second frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.016
-        frameTimestampProvider.nextFrameTimestamp = 0.032
-        let secondFps = reader.framesPerSecond(provider: frameTimestampProvider)
-        XCTAssertEqual(secondFps, 60)
+        frameInfoProvider.currentFrameTimestamp = 0.016
+        frameInfoProvider.nextFrameTimestamp = 0.032
+        let secondFps = reader.framesPerSecond(provider: frameInfoProvider)
+        XCTAssertEqual(secondFps, 62.5) // fractional value due to low precision of timestamps
 
         // third frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.048
-        let thirdFps = reader.framesPerSecond(provider: frameTimestampProvider)
-        XCTAssertEqual(thirdFps, 30)
+        frameInfoProvider.currentFrameTimestamp = 0.048
+        let thirdFps = reader.framesPerSecond(provider: frameInfoProvider)
+        XCTAssertEqual(thirdFps, 31.25) // fractional value due to low precision of timestamps
     }
 
     /* Rate representation
@@ -134,29 +134,29 @@ class VitalRefreshRateReaderTests: XCTestCase {
     */
     func testFramesPerSecond_given120HzFixedRateDisplay_normalizesTo60Hz() {
         let reader = VitalRefreshRateReader(notificationCenter: mockNotificationCenter)
-        var frameTimestampProvider = FrameTimestampProviderMock()
+        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
 
         // first frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0
-        frameTimestampProvider.nextFrameTimestamp = 0.008
-        let firstFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0
+        frameInfoProvider.nextFrameTimestamp = 0.008
+        let firstFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertNil(firstFps)
 
         // second frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.008
-        frameTimestampProvider.nextFrameTimestamp = 0.016
-        let secondFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0.008
+        frameInfoProvider.nextFrameTimestamp = 0.016
+        let secondFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertEqual(secondFps, 60)
 
         // third frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.016
-        frameTimestampProvider.nextFrameTimestamp = 0.024
-        let thirdFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0.016
+        frameInfoProvider.nextFrameTimestamp = 0.024
+        let thirdFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertEqual(thirdFps, 60)
 
         // fourth frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.032
-        let fourthFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0.032
+        let fourthFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertEqual(fourthFps, 30)
     }
 
@@ -167,29 +167,29 @@ class VitalRefreshRateReaderTests: XCTestCase {
     */
     func testFramesPerSecond_givenAdaptiveSyncDisplay() {
         let reader = VitalRefreshRateReader(notificationCenter: mockNotificationCenter)
-        var frameTimestampProvider = FrameTimestampProviderMock()
+        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
 
         // first frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0
-        frameTimestampProvider.nextFrameTimestamp = 0.008
-        let firstFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0
+        frameInfoProvider.nextFrameTimestamp = 0.008
+        let firstFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertNil(firstFps)
 
         // second frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.008
-        frameTimestampProvider.nextFrameTimestamp = 0.033
-        let secondFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0.008
+        frameInfoProvider.nextFrameTimestamp = 0.033
+        let secondFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertEqual(secondFps, 60)
 
         // third frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.033
-        frameTimestampProvider.nextFrameTimestamp = 0.043
-        let thirdFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0.033
+        frameInfoProvider.nextFrameTimestamp = 0.043
+        let thirdFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertEqual(thirdFps, 60)
 
         // fourth frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.043
-        let fourthFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0.043
+        let fourthFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertEqual(fourthFps, 60)
     }
 
@@ -201,28 +201,29 @@ class VitalRefreshRateReaderTests: XCTestCase {
     */
     func testFramesPerSecond_givenAdaptiveSyncDisplayWithFreezingFrames() {
         let reader = VitalRefreshRateReader(notificationCenter: mockNotificationCenter)
-        var frameTimestampProvider = FrameTimestampProviderMock()
+        var frameInfoProvider = FrameInfoProviderMock(maximumDeviceFramesPerSecond: 120)
 
         // first frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0
-        frameTimestampProvider.nextFrameTimestamp = 0.008
-        let firstFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0
+        frameInfoProvider.nextFrameTimestamp = 0.008
+        let firstFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertNil(firstFps)
 
         // second frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.008
-        frameTimestampProvider.nextFrameTimestamp = 0.033
-        let secondFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0.008
+        frameInfoProvider.nextFrameTimestamp = 0.033
+        let secondFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertEqual(secondFps, 60)
 
         // third frame recorded
-        frameTimestampProvider.currentFrameTimestamp = 0.043
-        let thirdFps = reader.framesPerSecond(provider: frameTimestampProvider)
+        frameInfoProvider.currentFrameTimestamp = 0.043
+        let thirdFps = reader.framesPerSecond(provider: frameInfoProvider)
         XCTAssertEqual(thirdFps, 42.85714285714286)
     }
 }
 
-struct FrameTimestampProviderMock: FrameTimestampProvider {
+struct FrameInfoProviderMock: FrameInfoProvider {
+    var maximumDeviceFramesPerSecond: Int = 60
     var currentFrameTimestamp: CFTimeInterval = 0
     var nextFrameTimestamp: CFTimeInterval = 0
 }


### PR DESCRIPTION
### What and why?

Currently, to find out the FPS of a view, the SDK look for the frame duration and inverses it to get the FPS.

Eg. if the frame duration is 16ms (0.016s), the FPS is 1/0.016 = 60FPS (rounded).

This generally works but when comes to variable refresh rate displays, it becomes an issue. For example, let's say OS has decided to increase the frame duration to 32ms to save battery, the FPS will be 30FPS but that doesn't mean the app is having a poor UI performance. It can very well be that the app is doing nothing.

### How?

`CADisplayLink` has a property called `targetTimestamp` which is the time when the next frame is scheduled to be displayed. This is the time when the frame is actually displayed on the screen. Hence, the SDK uses this property to calculate the expected frame duration and then inverses it to get the FPS.

At the same time, SDK continues to use the old logic to calculate the FPS using the `timestamp` property.

Finally, the SDK normalizes the FPS to 60FPS as Datadog backend only supports 60FPS rate for now described [here](https://www.datadoghq.com/blog/monitor-mobile-vitals-datadog/#slow-rendering).

> The logic for constant refresh rate displays has not changed.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
