### PR TITLE
RUMM-3266 fix: use arch conditionals to assert arch specific signal

### DIFF
--- a/IntegrationTests/IntegrationScenarios/Scenarios/CrashReporting/CrashReportingWithRUMScenarioTests.swift
+++ b/IntegrationTests/IntegrationScenarios/Scenarios/CrashReporting/CrashReportingWithRUMScenarioTests.swift
@@ -72,12 +72,10 @@ class CrashReportingWithRUMScenarioTests: IntegrationTests, RUMCommonAsserts {
 
         let crashRUMError = try XCTUnwrap(crashedSession.viewVisits[0].errorEvents.last)
 #if arch(arm64)
-        // On ARM, the crash is caused by `fatalError()`, translates to `SIGTRAP` signal.
-        XCTAssertEqual(crashRUMError.error.message, "Application crash: SIGTRAP (Trace/BPT trap)")
+        XCTAssertEqual(crashRUMError.error.message, "Application crash: SIGTRAP (Trace/BPT trap)", "On ARM, the crash is caused by `fatalError()`, translates to `SIGTRAP` signal.")
         XCTAssertEqual(crashRUMError.error.type, "SIGTRAP (#0)")
 #elseif arch(x86_64)
-        // On x86, the crash is caused by `fatalError()`, translates to `SIGILL` signal.
-        XCTAssertEqual(crashRUMError.error.message, "Application crash: SIGILL (Illegal instruction)")
+        XCTAssertEqual(crashRUMError.error.message, "Application crash: SIGILL (Illegal instruction)", "On x86, the crash is caused by `fatalError()`, translates to `SIGILL` signal.")
         XCTAssertEqual(crashRUMError.error.type, "SIGILL (ILL_ILLOPC)")
 #else
         XCTFail("Unsupported architecture")


### PR DESCRIPTION
### What and why?

On x86 a `fatalError()` results on a SIGILL signal but on an ARM machine it results in a `SIGTRAP`.

Hence, the test case fail on the ARM machine. In order to update the CI to ARM, this needs to be fixed.

### How?

Use preprocessor macros to check the architecture and then use the appropriate signal.

Tested on ARM mac under Rosetta and ARM simulators.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
