### PR TITLE
REPLAY-1620 Text view recording improvements

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Basic.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Basic.storyboard
@@ -69,16 +69,16 @@
             </objects>
             <point key="canvasLocation" x="139.69465648854961" y="3.5211267605633805"/>
         </scene>
-        <!--View Controller-->
+        <!--Texts View Controller-->
         <scene sceneID="Ujp-gw-g1R">
             <objects>
-                <viewController storyboardIdentifier="Texts" id="O73-uX-Hhn" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Texts" id="O73-uX-Hhn" customClass="TextsViewController" customModule="SRHost" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="okQ-2i-bM3">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="5e8-XJ-d05">
-                                <rect key="frame" x="20" y="79" width="353" height="261.33333333333331"/>
+                                <rect key="frame" x="20" y="79" width="353" height="617.33333333333337"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nE2-nF-tR0">
                                         <rect key="frame" x="0.0" y="0.0" width="353" height="36"/>
@@ -101,6 +101,38 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Text Views" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="K5s-RK-Xqf">
+                                        <rect key="frame" x="0.0" y="281.33333333333331" width="353" height="40"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="40" id="NlC-Pi-4EJ"/>
+                                        </constraints>
+                                        <color key="textColor" systemColor="labelColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    </textView>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="43n-fB-GL1">
+                                        <rect key="frame" x="0.0" y="341.33333333333331" width="353" height="128"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="128" id="Xep-n3-nDX"/>
+                                        </constraints>
+                                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</string>
+                                        <color key="textColor" systemColor="labelColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    </textView>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="7DW-74-qEX">
+                                        <rect key="frame" x="0.0" y="489.33333333333337" width="353" height="128"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="128" id="c5V-bh-7NW"/>
+                                        </constraints>
+                                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laborissunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                        <color key="textColor" systemColor="labelColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    </textView>
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </stackView>
@@ -113,6 +145,9 @@
                             <constraint firstItem="5e8-XJ-d05" firstAttribute="leading" secondItem="ekV-49-fKi" secondAttribute="leading" constant="20" id="jtP-dO-2uf"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="textView" destination="7DW-74-qEX" id="4hW-de-RPA"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HzZ-cK-pfT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -177,13 +212,16 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="geZ-kh-a5V" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1973" y="4"/>
+            <point key="canvasLocation" x="2117" y="4"/>
         </scene>
     </scenes>
     <resources>
         <namedColor name="EB455F">
             <color red="0.92199999094009399" green="0.27099999785423279" blue="0.37299999594688416" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="labelColor">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/BasicViewControllers.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/BasicViewControllers.swift
@@ -17,6 +17,15 @@ internal class ShapesViewController: UIViewController {
     }
 }
 
+internal class TextsViewController: UIViewController {
+    @IBOutlet weak var textView: UITextView?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        textView?.becomeFirstResponder()
+    }
+}
+
 internal class PopupsViewController: UIViewController {
 
     @IBAction func showSafari() {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -79,6 +79,7 @@ internal struct UITextViewWireframesBuilder: NodeWireframesBuilder {
     }
 
     private var relativeIntersectedRect: CGRect {
+        // UITextView adds additional padding for presented content.
         let padding: CGFloat = 8
         return CGRect(
             x: attributes.frame.origin.x - contentRect.origin.x + padding,

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -40,7 +40,7 @@ internal struct UITextViewRecorder: NodeRecorder {
             contentRect: CGRect(origin: textView.contentOffset, size: textView.contentSize)
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)
-        return SpecificElement(subtreeStrategy: .record, nodes: [node])
+        return SpecificElement(subtreeStrategy: .ignore, nodes: [node])
     }
 }
 
@@ -79,11 +79,12 @@ internal struct UITextViewWireframesBuilder: NodeWireframesBuilder {
     }
 
     private var relativeIntersectedRect: CGRect {
-        CGRect(
-            x: attributes.frame.origin.x - contentRect.origin.x,
-            y: attributes.frame.origin.y - contentRect.origin.y,
-            width: max(contentRect.width, attributes.frame.width),
-            height: max(contentRect.height, attributes.frame.height)
+        let padding: CGFloat = 8
+        return CGRect(
+            x: attributes.frame.origin.x - contentRect.origin.x + padding,
+            y: attributes.frame.origin.y - contentRect.origin.y + padding,
+            width: max(contentRect.width, attributes.frame.width) - padding,
+            height: max(contentRect.height, attributes.frame.height) - padding
         )
     }
 

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -40,7 +40,7 @@ class UITextViewRecorderTests: XCTestCase {
         // Then
         let semantics = try XCTUnwrap(recorder.semantics(of: textView, with: viewAttributes, in: .mockAny()))
         XCTAssertTrue(semantics is SpecificElement)
-        XCTAssertEqual(semantics.subtreeStrategy, .record)
+        XCTAssertEqual(semantics.subtreeStrategy, .ignore)
 
         let builder = try XCTUnwrap(semantics.nodes.first?.wireframesBuilder as? UITextViewWireframesBuilder)
         XCTAssertEqual(builder.text, randomText)


### PR DESCRIPTION
### What and why?

Text view recording behaviour was a little flaky. The biggest problem is with carriage, as we can't fully control the text rendering if was appearing in a wrong place for more complex scenarios.

### How?

This solution adds basic padding to the text view (experimentally selected by looking at rendered text views).
Additionally we now ignore the subtree recording to remove carriage (which is simple UIView).

I added some additonal text views in the basic text snapshot case, making one of them first responder to simulate the appearance of the carriage.

![testBasicTexts()-maskAll-privacy](https://user-images.githubusercontent.com/6953112/236180897-92f44547-28be-43db-8ba8-178d7bad00a3.png)
![testBasicTexts()-maskUserInput-privacy](https://user-images.githubusercontent.com/6953112/236180901-cbd06808-5abb-4ba5-bedc-c5931f91a8fc.png)
![testBasicTexts()-allowAll-privacy](https://user-images.githubusercontent.com/6953112/236180887-c80f9c5f-e452-4a98-bb86-f98f8b44050b.png)

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
