### PR TITLE
REPLAY-1610 Align text and appearance masking rules

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Basic.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Basic.storyboard
@@ -78,9 +78,9 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="5e8-XJ-d05">
-                                <rect key="frame" x="20" y="79" width="353" height="617.33333333333337"/>
+                                <rect key="frame" x="20" y="79" width="353" height="686"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nE2-nF-tR0">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labels" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nE2-nF-tR0">
                                         <rect key="frame" x="0.0" y="0.0" width="353" height="36"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
@@ -101,7 +101,7 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Text Views" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="K5s-RK-Xqf">
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Text Views" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="K5s-RK-Xqf">
                                         <rect key="frame" x="0.0" y="281.33333333333331" width="353" height="40"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
@@ -111,8 +111,14 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Editable:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ckm-Kp-yLh">
+                                        <rect key="frame" x="0.0" y="341.33333333333331" width="353" height="14.333333333333314"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="43n-fB-GL1">
-                                        <rect key="frame" x="0.0" y="341.33333333333331" width="353" height="128"/>
+                                        <rect key="frame" x="0.0" y="375.66666666666669" width="353" height="128"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="128" id="Xep-n3-nDX"/>
@@ -122,8 +128,14 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="7DW-74-qEX">
-                                        <rect key="frame" x="0.0" y="489.33333333333337" width="353" height="128"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Non-editable:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFk-Bb-d0Y">
+                                        <rect key="frame" x="0.0" y="523.66666666666663" width="353" height="14.333333333333371"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="7DW-74-qEX">
+                                        <rect key="frame" x="0.0" y="558" width="353" height="128"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="128" id="c5V-bh-7NW"/>

--- a/DatadogSessionReplay/Sources/Drafts/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/Drafts/SessionReplayConfiguration.swift
@@ -26,34 +26,3 @@ public struct SessionReplayConfiguration {
         self.customUploadURL = customUploadURL
     }
 }
-
-/// Session Replay content recording policy.
-/// It describes the way in which sensitive content (e.g. text or images) should be captured.
-public enum SessionReplayPrivacy {
-    /// Record all content as it is.
-    /// When using this option: all text, images and other information will be recorded and presented in the player.
-    case allowAll
-
-    /// Mask all content.
-    /// When using this option: all characters in texts will be replaced with "x", images will be
-    /// replaced with placeholders and other content will be masked accordingly, so the original
-    /// information will not be presented in the player.
-    ///
-    /// This is the default content policy.
-    case maskAll
-
-    /// Mask input elements, but record all other content as it is.
-    /// When uing this option: all user input and selected values (text fields, switches, pickers, segmented controls etc.) will be masked,
-    /// but static text (e.g. in labels) will be not.
-    case maskUserInput
-}
-
-internal extension SessionReplayPrivacy {
-    /// If input elements should be masked in this privacy mode.
-    var shouldMaskInputElements: Bool {
-        switch self {
-        case .maskAll, .maskUserInput: return true
-        case .allowAll: return false
-        }
-    }
-}

--- a/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
+++ b/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
@@ -13,64 +13,10 @@ internal protocol TextObfuscating {
     func mask(text: String) -> String
 }
 
-/// Text obfuscation strategies for different text types.
-internal struct TextObfuscation {
-    /// Text obfuscator that returns original text (no obfuscation).
-    private let nop = NOPTextObfuscator()
-    /// Text obfuscator that replaces each character with `"x"` mask.
-    private let spacePreservingMask = SpacePreservingMaskObfuscator()
-    /// Text obfuscator that replaces whole text with fixed-length `"***"` mask (three asterics).
-    private let fixLengthMask = FixLengthMaskObfuscator()
-
-    /// Returns "Sensitive Text" obfuscator for given `privacyLevel`.
-    ///
-    /// In Session Replay, "Sensitive Text" is:
-    /// - passwords, e-mails and phone numbers marked in a platform-specific way
-    /// - AND other forms of sensitivity in text available to each platform
-    func sensitiveTextObfuscator(for privacyLevel: SessionReplayPrivacy) -> TextObfuscating {
-        return fixLengthMask
-    }
-
-    /// Returns "Input & Option Text" obfuscator for given `privacyLevel`.
-    ///
-    /// In Session Replay, "Input & Option Text" is:
-    /// - a text entered by the user with a keyboard or other text-input device
-    /// - OR a custom (non-generic) value in selection elements
-    func inputAndOptionTextObfuscator(for privacyLevel: SessionReplayPrivacy) -> TextObfuscating {
-        switch privacyLevel {
-        case .allowAll:         return nop
-        case .maskAll:          return fixLengthMask
-        case .maskUserInput:    return fixLengthMask
-        }
-    }
-
-    /// Returns "Static Text" obfuscator for given `privacyLevel`.
-    ///
-    /// In Session Replay, "Static Text" is a text not directly entered by the user.
-    func staticTextObfuscator(for privacyLevel: SessionReplayPrivacy) -> TextObfuscating {
-        switch privacyLevel {
-        case .allowAll:         return nop
-        case .maskAll:          return spacePreservingMask
-        case .maskUserInput:    return nop
-        }
-    }
-
-    /// Returns "Hint Text" obfuscator for given `privacyLevel`.
-    ///
-    /// In Session Replay, "Hint Text" is a static text in editable text elements or option selectors, displayed when there isn't any value set.
-    func hintTextObfuscator(for privacyLevel: SessionReplayPrivacy) -> TextObfuscating {
-        switch privacyLevel {
-        case .allowAll:         return nop
-        case .maskAll:          return fixLengthMask
-        case .maskUserInput:    return nop
-        }
-    }
-}
-
 /// Text obfuscator which replaces all readable characters with space-preserving `"x"` characters.
 internal struct SpacePreservingMaskObfuscator: TextObfuscating {
     /// The character to mask text with.
-    let maskCharacter: UnicodeScalar = "x"
+    private static let maskCharacter: UnicodeScalar = "x"
 
     /// Masks given `text` by replacing all not whitespace characters with `"x"`.
     /// - Parameter text: the text to be masked
@@ -85,7 +31,7 @@ internal struct SpacePreservingMaskObfuscator: TextObfuscating {
             case " ", "\n", "\r", "\t":
                 masked.unicodeScalars.append(nextScalar)
             default:
-                masked.unicodeScalars.append(maskCharacter)
+                masked.unicodeScalars.append(SpacePreservingMaskObfuscator.maskCharacter)
             }
         }
 

--- a/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
+++ b/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
@@ -20,7 +20,7 @@ internal struct TextObfuscation {
     /// Text obfuscator that replaces each character with `"x"` mask.
     private let spacePreservingMask = SpacePreservingMaskObfuscator()
     /// Text obfuscator that replaces whole text with fixed-length `"***"` mask (three asterics).
-    private let fixLegthMask = FixLegthMaskObfuscator()
+    private let fixLengthMask = FixLengthMaskObfuscator()
 
     /// Returns "Sensitive Text" obfuscator for given `privacyLevel`.
     ///
@@ -28,7 +28,7 @@ internal struct TextObfuscation {
     /// - passwords, e-mails and phone numbers marked in a platform-specific way
     /// - AND other forms of sensitivity in text available to each platform
     func sensitiveTextObfuscator(for privacyLevel: SessionReplayPrivacy) -> TextObfuscating {
-        return fixLegthMask
+        return fixLengthMask
     }
 
     /// Returns "Input & Option Text" obfuscator for given `privacyLevel`.
@@ -39,8 +39,8 @@ internal struct TextObfuscation {
     func inputAndOptionTextObfuscator(for privacyLevel: SessionReplayPrivacy) -> TextObfuscating {
         switch privacyLevel {
         case .allowAll:         return nop
-        case .maskAll:          return fixLegthMask
-        case .maskUserInput:    return fixLegthMask
+        case .maskAll:          return fixLengthMask
+        case .maskUserInput:    return fixLengthMask
         }
     }
 
@@ -61,7 +61,7 @@ internal struct TextObfuscation {
     func hintTextObfuscator(for privacyLevel: SessionReplayPrivacy) -> TextObfuscating {
         switch privacyLevel {
         case .allowAll:         return nop
-        case .maskAll:          return fixLegthMask
+        case .maskAll:          return fixLengthMask
         case .maskUserInput:    return nop
         }
     }
@@ -94,7 +94,7 @@ internal struct SpacePreservingMaskObfuscator: TextObfuscating {
 }
 
 /// Text obfuscator which replaces entire text with fix-length `"***"` mask value.
-internal struct FixLegthMaskObfuscator: TextObfuscating {
+internal struct FixLengthMaskObfuscator: TextObfuscating {
     private static let maskedString = "***"
 
     func mask(text: String) -> String { Self.maskedString }

--- a/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
+++ b/DatadogSessionReplay/Sources/Processor/Privacy/TextObfuscator.swift
@@ -19,7 +19,7 @@ internal struct TextObfuscators {
     let nop = NOPTextObfuscator()
     /// Text obfuscator that replaces each character with `"x"` mask.
     let spacePreservingMask = SpacePreservingMaskObfuscator()
-    /// Text obfuscator that replaces whole text with fixed-length `"xxx"` mask (three asterics).
+    /// Text obfuscator that replaces whole text with fixed-length `"***"` mask (three asterics).
     let fixLegthMask = FixLegthMaskObfuscator()
 }
 
@@ -49,9 +49,9 @@ internal struct SpacePreservingMaskObfuscator: TextObfuscating {
     }
 }
 
-/// Text obfuscator which replaces entire text with fix-length `"xxx"` mask value.
+/// Text obfuscator which replaces entire text with fix-length `"***"` mask value.
 internal struct FixLegthMaskObfuscator: TextObfuscating {
-    private static let maskedString = "xxx"
+    private static let maskedString = "***"
 
     func mask(text: String) -> String { Self.maskedString }
 }

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIKitExtensions.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIKitExtensions.swift
@@ -15,3 +15,39 @@ internal extension UIView {
         }
     }
 }
+
+/// Sensitive text content types as defined in Session Replay.
+internal let sensitiveContentTypes: Set<UITextContentType> = {
+    var all: Set<UITextContentType> = [
+        .password,
+        .emailAddress,
+        .telephoneNumber,
+        .addressCity, .addressState, .addressCityAndState, .fullStreetAddress, .streetAddressLine1, .streetAddressLine2, .postalCode,
+        .creditCardNumber
+    ]
+
+    if #available(iOS 12.0, *) {
+        all.formUnion([.newPassword, .oneTimeCode])
+    }
+
+    return all
+}()
+
+internal extension UITextInputTraits {
+    /// Whether or not these input traits describe a "sensitive text" as we define it in Session Replay.
+    ///
+    /// Sensitive texts include:
+    /// - passwords, e-mails, phone numbers, address information, credit card numbers and one-time codes;
+    /// - all texts marked explicitly as secure entry.
+    var isSensitiveText: Bool {
+        if isSecureTextEntry == true {
+            return true
+        }
+
+        if let contentType = textContentType, let contentType = contentType {
+            return sensitiveContentTypes.contains(contentType)
+        }
+
+        return false
+    }
+}

--- a/DatadogSessionReplay/Sources/Recorder/Utilities/UIKitExtensions.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/UIKitExtensions.swift
@@ -34,11 +34,11 @@ internal let sensitiveContentTypes: Set<UITextContentType> = {
 }()
 
 internal extension UITextInputTraits {
-    /// Whether or not these input traits describe a "sensitive text" as we define it in Session Replay.
+    /// Whether or not these input traits describe a "Sensitive Text".
     ///
-    /// Sensitive texts include:
-    /// - passwords, e-mails, phone numbers, address information, credit card numbers and one-time codes;
-    /// - all texts marked explicitly as secure entry.
+    /// In Session Replay, "Sensitive Text" is:
+    /// - passwords, e-mails and phone numbers marked in a platform-specific way
+    /// - AND other forms of sensitivity in text available to each platform
     var isSensitiveText: Bool {
         if isSecureTextEntry == true {
             return true

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -73,11 +73,7 @@ private struct WheelsStyleDatePickerRecorder {
         nodeRecorders: [
             UIPickerViewRecorder(
                 textObfuscator: { context in
-                    switch context.recorder.privacy {
-                    case .allowAll:         return context.textObfuscators.nop
-                    case .maskAll:          return context.textObfuscators.spacePreservingMask
-                    case .maskUserInput:    return context.textObfuscators.spacePreservingMask
-                    }
+                    return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
                 }
             )
         ]
@@ -97,11 +93,7 @@ private struct InlineStyleDatePickerRecorder {
         self.viewRecorder = UIViewRecorder()
         self.labelRecorder = UILabelRecorder(
             textObfuscator: { context in
-                switch context.recorder.privacy {
-                case .allowAll:         return context.textObfuscators.nop
-                case .maskAll:          return context.textObfuscators.spacePreservingMask
-                case .maskUserInput:    return context.textObfuscators.spacePreservingMask
-                }
+                return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
             }
         )
         self.subtreeRecorder = ViewTreeRecorder(
@@ -144,11 +136,7 @@ private struct CompactStyleDatePickerRecorder {
             UIViewRecorder(),
             UILabelRecorder(
                 textObfuscator: { context in
-                    switch context.recorder.privacy {
-                    case .allowAll:         return context.textObfuscators.nop
-                    case .maskAll:          return context.textObfuscators.spacePreservingMask
-                    case .maskUserInput:    return context.textObfuscators.spacePreservingMask
-                    }
+                    return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
                 }
             )
         ]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIDatePickerRecorder.swift
@@ -73,7 +73,7 @@ private struct WheelsStyleDatePickerRecorder {
         nodeRecorders: [
             UIPickerViewRecorder(
                 textObfuscator: { context in
-                    return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
+                    return context.recorder.privacy.staticTextObfuscator
                 }
             )
         ]
@@ -93,7 +93,7 @@ private struct InlineStyleDatePickerRecorder {
         self.viewRecorder = UIViewRecorder()
         self.labelRecorder = UILabelRecorder(
             textObfuscator: { context in
-                return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
+                return context.recorder.privacy.staticTextObfuscator
             }
         )
         self.subtreeRecorder = ViewTreeRecorder(
@@ -136,7 +136,7 @@ private struct CompactStyleDatePickerRecorder {
             UIViewRecorder(),
             UILabelRecorder(
                 textObfuscator: { context in
-                    return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
+                    return context.recorder.privacy.staticTextObfuscator
                 }
             )
         ]

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -14,7 +14,7 @@ internal class UILabelRecorder: NodeRecorder {
     init(
         builderOverride: @escaping (UILabelWireframesBuilder) -> UILabelWireframesBuilder = { $0 },
         textObfuscator: @escaping (ViewTreeRecordingContext) -> TextObfuscating = { context in
-            return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
+            return context.recorder.privacy.staticTextObfuscator
         }
     ) {
         self.builderOverride = builderOverride

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UILabelRecorder.swift
@@ -14,11 +14,7 @@ internal class UILabelRecorder: NodeRecorder {
     init(
         builderOverride: @escaping (UILabelWireframesBuilder) -> UILabelWireframesBuilder = { $0 },
         textObfuscator: @escaping (ViewTreeRecordingContext) -> TextObfuscating = { context in
-            switch context.recorder.privacy {
-            case .allowAll:         return context.textObfuscators.nop
-            case .maskAll:          return context.textObfuscators.spacePreservingMask
-            case .maskUserInput:    return context.textObfuscators.nop
-            }
+            return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
         }
     ) {
         self.builderOverride = builderOverride

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -25,7 +25,7 @@ internal struct UIPickerViewRecorder: NodeRecorder {
 
     init(
         textObfuscator: @escaping (ViewTreeRecordingContext) -> TextObfuscating = { context in
-            return context.textObfuscation.inputAndOptionTextObfuscator(for: context.recorder.privacy)
+            return context.recorder.privacy.inputAndOptionTextObfuscator
         }
     ) {
         self.selectionRecorder = ViewTreeRecorder(nodeRecorders: [UIViewRecorder()])

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UIPickerViewRecorder.swift
@@ -25,11 +25,7 @@ internal struct UIPickerViewRecorder: NodeRecorder {
 
     init(
         textObfuscator: @escaping (ViewTreeRecordingContext) -> TextObfuscating = { context in
-            switch context.recorder.privacy {
-            case .allowAll:         return context.textObfuscators.nop
-            case .maskAll:          return context.textObfuscators.fixLegthMask
-            case .maskUserInput:    return context.textObfuscators.fixLegthMask
-            }
+            return context.textObfuscation.inputAndOptionTextObfuscator(for: context.recorder.privacy)
         }
     ) {
         self.selectionRecorder = ViewTreeRecorder(nodeRecorders: [UIViewRecorder()])

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -10,8 +10,8 @@ internal struct UISegmentRecorder: NodeRecorder {
     var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating = { context in
         switch context.recorder.privacy {
         case .allowAll:         return context.textObfuscators.nop
-        case .maskAll:          return context.textObfuscators.spacePreservingMask
-        case .maskUserInput:    return context.textObfuscators.spacePreservingMask
+        case .maskAll:          return context.textObfuscators.fixLegthMask
+        case .maskUserInput:    return context.textObfuscators.fixLegthMask
         }
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -8,7 +8,7 @@ import UIKit
 
 internal struct UISegmentRecorder: NodeRecorder {
     var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating = { context in
-        return context.textObfuscation.inputAndOptionTextObfuscator(for: context.recorder.privacy)
+        return context.recorder.privacy.inputAndOptionTextObfuscator
     }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -8,11 +8,7 @@ import UIKit
 
 internal struct UISegmentRecorder: NodeRecorder {
     var textObfuscator: (ViewTreeRecordingContext) -> TextObfuscating = { context in
-        switch context.recorder.privacy {
-        case .allowAll:         return context.textObfuscators.nop
-        case .maskAll:          return context.textObfuscators.fixLegthMask
-        case .maskUserInput:    return context.textObfuscators.fixLegthMask
-        }
+        return context.textObfuscation.inputAndOptionTextObfuscator(for: context.recorder.privacy)
     }
 
     func semantics(of view: UIView, with attributes: ViewAttributes, in context: ViewTreeRecordingContext) -> NodeSemantics? {

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -15,19 +15,11 @@ internal struct UITextFieldRecorder: NodeRecorder {
 
     var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isPlaceholder: Bool) -> TextObfuscating = { context, isSensitive, isPlaceholder in
         if isPlaceholder {
-            switch context.recorder.privacy {
-            case .allowAll:         return context.textObfuscators.nop
-            case .maskAll:          return context.textObfuscators.fixLegthMask
-            case .maskUserInput:    return context.textObfuscators.nop
-            }
+            return context.textObfuscation.hintTextObfuscator(for: context.recorder.privacy)
         } else if isSensitive {
-            return context.textObfuscators.fixLegthMask
+            return context.textObfuscation.sensitiveTextObfuscator(for: context.recorder.privacy)
         } else {
-            switch context.recorder.privacy {
-            case .allowAll:         return context.textObfuscators.nop
-            case .maskAll:          return context.textObfuscators.fixLegthMask
-            case .maskUserInput:    return context.textObfuscators.fixLegthMask
-            }
+            return context.textObfuscation.inputAndOptionTextObfuscator(for: context.recorder.privacy)
         }
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -83,8 +83,6 @@ internal struct UITextFieldRecorder: NodeRecorder {
         let textFrame = attributes.frame
             .insetBy(dx: 5, dy: 5) // 5 points padding
 
-        let isSensitiveText = textField.isSecureTextEntry || textField.textContentType == .emailAddress || textField.textContentType == .telephoneNumber
-
         let builder = UITextFieldWireframesBuilder(
             wireframeRect: textFrame,
             attributes: attributes,
@@ -95,7 +93,7 @@ internal struct UITextFieldRecorder: NodeRecorder {
             isPlaceholderText: isPlaceholder,
             font: textField.font,
             fontScalingEnabled: textField.adjustsFontSizeToFitWidth,
-            textObfuscator: textObfuscator(context, isSensitiveText)
+            textObfuscator: textObfuscator(context, textField.isSensitiveText)
         )
         return Node(viewAttributes: attributes, wireframesBuilder: builder)
     }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorder.swift
@@ -15,11 +15,11 @@ internal struct UITextFieldRecorder: NodeRecorder {
 
     var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isPlaceholder: Bool) -> TextObfuscating = { context, isSensitive, isPlaceholder in
         if isPlaceholder {
-            return context.textObfuscation.hintTextObfuscator(for: context.recorder.privacy)
+            return context.recorder.privacy.hintTextObfuscator
         } else if isSensitive {
-            return context.textObfuscation.sensitiveTextObfuscator(for: context.recorder.privacy)
+            return context.recorder.privacy.sensitiveTextObfuscator
         } else {
-            return context.textObfuscation.inputAndOptionTextObfuscator(for: context.recorder.privacy)
+            return context.recorder.privacy.inputAndOptionTextObfuscator
         }
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -9,13 +9,13 @@ import UIKit
 internal struct UITextViewRecorder: NodeRecorder {
     var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isEditable: Bool) -> TextObfuscating = { context, isSensitive, isEditable in
         if isSensitive {
-            return context.textObfuscation.sensitiveTextObfuscator(for: context.recorder.privacy)
+            return context.recorder.privacy.sensitiveTextObfuscator
         }
 
         if isEditable {
-            return context.textObfuscation.inputAndOptionTextObfuscator(for: context.recorder.privacy)
+            return context.recorder.privacy.inputAndOptionTextObfuscator
         } else {
-            return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
+            return context.recorder.privacy.staticTextObfuscator
         }
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -27,8 +27,6 @@ internal struct UITextViewRecorder: NodeRecorder {
             return InvisibleElement.constant
         }
 
-        let isSensitiveText = textView.isSecureTextEntry || textView.textContentType == .emailAddress || textView.textContentType == .telephoneNumber
-
         let builder = UITextViewWireframesBuilder(
             wireframeID: context.ids.nodeID(for: textView),
             attributes: attributes,
@@ -36,7 +34,7 @@ internal struct UITextViewRecorder: NodeRecorder {
             textAlignment: textView.textAlignment,
             textColor: textView.textColor?.cgColor ?? UIColor.black.cgColor,
             font: textView.font,
-            textObfuscator: textObfuscator(context, isSensitiveText),
+            textObfuscator: textObfuscator(context, textView.isSensitiveText),
             contentRect: CGRect(origin: textView.contentOffset, size: textView.contentSize)
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -9,21 +9,13 @@ import UIKit
 internal struct UITextViewRecorder: NodeRecorder {
     var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isEditable: Bool) -> TextObfuscating = { context, isSensitive, isEditable in
         if isSensitive {
-            return context.textObfuscators.fixLegthMask
+            return context.textObfuscation.sensitiveTextObfuscator(for: context.recorder.privacy)
         }
 
         if isEditable {
-            switch context.recorder.privacy {
-            case .allowAll:         return context.textObfuscators.nop
-            case .maskAll:          return context.textObfuscators.fixLegthMask
-            case .maskUserInput:    return context.textObfuscators.fixLegthMask
-            }
+            return context.textObfuscation.inputAndOptionTextObfuscator(for: context.recorder.privacy)
         } else {
-            switch context.recorder.privacy {
-            case .allowAll:         return context.textObfuscators.nop
-            case .maskAll:          return context.textObfuscators.spacePreservingMask
-            case .maskUserInput:    return context.textObfuscators.nop
-            }
+            return context.textObfuscation.staticTextObfuscator(for: context.recorder.privacy)
         }
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorder.swift
@@ -7,15 +7,23 @@
 import UIKit
 
 internal struct UITextViewRecorder: NodeRecorder {
-    var textObfuscator: (ViewTreeRecordingContext, _ isSensitiveText: Bool) -> TextObfuscating = { context, isSensitiveText in
-        if isSensitiveText {
+    var textObfuscator: (ViewTreeRecordingContext, _ isSensitive: Bool, _ isEditable: Bool) -> TextObfuscating = { context, isSensitive, isEditable in
+        if isSensitive {
             return context.textObfuscators.fixLegthMask
         }
 
-        switch context.recorder.privacy {
-        case .allowAll:         return context.textObfuscators.nop
-        case .maskAll:          return context.textObfuscators.spacePreservingMask
-        case .maskUserInput:    return context.textObfuscators.spacePreservingMask
+        if isEditable {
+            switch context.recorder.privacy {
+            case .allowAll:         return context.textObfuscators.nop
+            case .maskAll:          return context.textObfuscators.fixLegthMask
+            case .maskUserInput:    return context.textObfuscators.fixLegthMask
+            }
+        } else {
+            switch context.recorder.privacy {
+            case .allowAll:         return context.textObfuscators.nop
+            case .maskAll:          return context.textObfuscators.spacePreservingMask
+            case .maskUserInput:    return context.textObfuscators.nop
+            }
         }
     }
 
@@ -34,7 +42,7 @@ internal struct UITextViewRecorder: NodeRecorder {
             textAlignment: textView.textAlignment,
             textColor: textView.textColor?.cgColor ?? UIColor.black.cgColor,
             font: textView.font,
-            textObfuscator: textObfuscator(context, textView.isSensitiveText),
+            textObfuscator: textObfuscator(context, textView.isSensitiveText, textView.isEditable),
             contentRect: CGRect(origin: textView.contentOffset, size: textView.contentSize)
         )
         let node = Node(viewAttributes: attributes, wireframesBuilder: builder)

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -21,7 +21,7 @@ internal struct ViewTreeRecordingContext {
     /// Provides base64 image data with a built in caching mechanism.
     let imageDataProvider: ImageDataProviding
     /// Available text obfuscators to use accordingly to current privacy mode.
-    let textObfuscators: TextObfuscators
+    let textObfuscation: TextObfuscation
     /// Variable view controller related context
     var viewControllerContext: ViewControllerContext = .init()
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeRecordingContext.swift
@@ -20,8 +20,6 @@ internal struct ViewTreeRecordingContext {
     let ids: NodeIDGenerator
     /// Provides base64 image data with a built in caching mechanism.
     let imageDataProvider: ImageDataProviding
-    /// Available text obfuscators to use accordingly to current privacy mode.
-    let textObfuscation: TextObfuscation
     /// Variable view controller related context
     var viewControllerContext: ViewControllerContext = .init()
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -17,8 +17,6 @@ internal struct ViewTreeSnapshotBuilder {
     let idsGenerator: NodeIDGenerator
     /// Provides base64 image data with a built in caching mechanism.
     let imageDataProvider: ImageDataProviding
-    /// Text obfuscation strategies for different text types.
-    let textObfuscation: TextObfuscation
 
     /// Builds the `ViewTreeSnapshot` for given root view.
     ///
@@ -32,8 +30,7 @@ internal struct ViewTreeSnapshotBuilder {
             recorder: recorderContext,
             coordinateSpace: rootView,
             ids: idsGenerator,
-            imageDataProvider: imageDataProvider,
-            textObfuscation: textObfuscation
+            imageDataProvider: imageDataProvider
         )
         let snapshot = ViewTreeSnapshot(
             date: recorderContext.date.addingTimeInterval(recorderContext.rumContext.viewServerTimeOffset ?? 0),
@@ -50,8 +47,7 @@ extension ViewTreeSnapshotBuilder {
         self.init(
             viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders()),
             idsGenerator: NodeIDGenerator(),
-            imageDataProvider: ImageDataProvider(),
-            textObfuscation: TextObfuscation()
+            imageDataProvider: ImageDataProvider()
         )
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilder.swift
@@ -17,8 +17,8 @@ internal struct ViewTreeSnapshotBuilder {
     let idsGenerator: NodeIDGenerator
     /// Provides base64 image data with a built in caching mechanism.
     let imageDataProvider: ImageDataProviding
-    /// Available text obfuscators to use by different recorders in response to current privacy mode.
-    let textObfuscators: TextObfuscators
+    /// Text obfuscation strategies for different text types.
+    let textObfuscation: TextObfuscation
 
     /// Builds the `ViewTreeSnapshot` for given root view.
     ///
@@ -33,7 +33,7 @@ internal struct ViewTreeSnapshotBuilder {
             coordinateSpace: rootView,
             ids: idsGenerator,
             imageDataProvider: imageDataProvider,
-            textObfuscators: textObfuscators
+            textObfuscation: textObfuscation
         )
         let snapshot = ViewTreeSnapshot(
             date: recorderContext.date.addingTimeInterval(recorderContext.rumContext.viewServerTimeOffset ?? 0),
@@ -51,7 +51,7 @@ extension ViewTreeSnapshotBuilder {
             viewTreeRecorder: ViewTreeRecorder(nodeRecorders: createDefaultNodeRecorders()),
             idsGenerator: NodeIDGenerator(),
             imageDataProvider: ImageDataProvider(),
-            textObfuscators: TextObfuscators()
+            textObfuscation: TextObfuscation()
         )
     }
 }

--- a/DatadogSessionReplay/Sources/SessionReplayPrivacy.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayPrivacy.swift
@@ -1,0 +1,84 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+/// Session Replay content recording policy.
+/// It describes the way in which sensitive content (e.g. text or images) should be captured.
+public enum SessionReplayPrivacy {
+    /// Record all content as it is.
+    /// When using this option: all text, images and other information will be recorded and presented in the player.
+    case allowAll
+
+    /// Mask all content.
+    /// When using this option: all characters in texts will be replaced with "x", images will be
+    /// replaced with placeholders and other content will be masked accordingly, so the original
+    /// information will not be presented in the player.
+    ///
+    /// This is the default content policy.
+    case maskAll
+
+    /// Mask input elements, but record all other content as it is.
+    /// When uing this option: all user input and selected values (text fields, switches, pickers, segmented controls etc.) will be masked,
+    /// but static text (e.g. in labels) will be not.
+    case maskUserInput
+}
+
+/// Text obfuscation strategies for different text types.
+internal extension SessionReplayPrivacy {
+    /// Returns "Sensitive Text" obfuscator for given `privacyLevel`.
+    ///
+    /// In Session Replay, "Sensitive Text" is:
+    /// - passwords, e-mails and phone numbers marked in a platform-specific way
+    /// - AND other forms of sensitivity in text available to each platform
+    var sensitiveTextObfuscator: TextObfuscating {
+        return FixLengthMaskObfuscator()
+    }
+
+    /// Returns "Input & Option Text" obfuscator for given `privacyLevel`.
+    ///
+    /// In Session Replay, "Input & Option Text" is:
+    /// - a text entered by the user with a keyboard or other text-input device
+    /// - OR a custom (non-generic) value in selection elements
+    var inputAndOptionTextObfuscator: TextObfuscating {
+        switch self {
+        case .allowAll:         return NOPTextObfuscator()
+        case .maskAll:          return FixLengthMaskObfuscator()
+        case .maskUserInput:    return FixLengthMaskObfuscator()
+        }
+    }
+
+    /// Returns "Static Text" obfuscator for given `privacyLevel`.
+    ///
+    /// In Session Replay, "Static Text" is a text not directly entered by the user.
+    var staticTextObfuscator: TextObfuscating {
+        switch self {
+        case .allowAll:         return NOPTextObfuscator()
+        case .maskAll:          return SpacePreservingMaskObfuscator()
+        case .maskUserInput:    return NOPTextObfuscator()
+        }
+    }
+
+    /// Returns "Hint Text" obfuscator for given `privacyLevel`.
+    ///
+    /// In Session Replay, "Hint Text" is a static text in editable text elements or option selectors, displayed when there isn't any value set.
+    var hintTextObfuscator: TextObfuscating {
+        switch self {
+        case .allowAll:         return NOPTextObfuscator()
+        case .maskAll:          return FixLengthMaskObfuscator()
+        case .maskUserInput:    return NOPTextObfuscator()
+        }
+    }
+}
+
+/// Other convenience helpers.
+internal extension SessionReplayPrivacy {
+    /// If input elements should be masked in this privacy mode.
+    var shouldMaskInputElements: Bool {
+        switch self {
+        case .maskAll, .maskUserInput: return true
+        case .allowAll: return false
+        }
+    }
+}

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -286,7 +286,7 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
             coordinateSpace: UIView.mockRandom(),
             ids: NodeIDGenerator(),
             imageDataProvider: mockRandomImageDataProvider(),
-            textObfuscators: TextObfuscators()
+            textObfuscation: TextObfuscation()
         )
     }
 
@@ -295,14 +295,14 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
         coordinateSpace: UICoordinateSpace = UIView.mockAny(),
         ids: NodeIDGenerator = NodeIDGenerator(),
         imageDataProvider: ImageDataProviding = MockImageDataProvider(),
-        textObfuscators: TextObfuscators = TextObfuscators()
+        textObfuscation: TextObfuscation = TextObfuscation()
     ) -> ViewTreeRecordingContext {
         return .init(
             recorder: recorder,
             coordinateSpace: coordinateSpace,
             ids: ids,
             imageDataProvider: imageDataProvider,
-            textObfuscators: textObfuscators
+            textObfuscation: textObfuscation
         )
     }
 }

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -272,7 +272,7 @@ internal class TextObfuscatorMock: TextObfuscating {
 }
 
 internal func mockRandomTextObfuscator() -> TextObfuscating {
-    return [NOPTextObfuscator(), SpacePreservingMaskObfuscator(), FixLegthMaskObfuscator()].randomElement()!
+    return [NOPTextObfuscator(), SpacePreservingMaskObfuscator(), FixLengthMaskObfuscator()].randomElement()!
 }
 
 extension ViewTreeRecordingContext: AnyMockable, RandomMockable {

--- a/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/RecorderMocks.swift
@@ -285,8 +285,7 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
             recorder: .mockRandom(),
             coordinateSpace: UIView.mockRandom(),
             ids: NodeIDGenerator(),
-            imageDataProvider: mockRandomImageDataProvider(),
-            textObfuscation: TextObfuscation()
+            imageDataProvider: mockRandomImageDataProvider()
         )
     }
 
@@ -294,15 +293,13 @@ extension ViewTreeRecordingContext: AnyMockable, RandomMockable {
         recorder: Recorder.Context = .mockAny(),
         coordinateSpace: UICoordinateSpace = UIView.mockAny(),
         ids: NodeIDGenerator = NodeIDGenerator(),
-        imageDataProvider: ImageDataProviding = MockImageDataProvider(),
-        textObfuscation: TextObfuscation = TextObfuscation()
+        imageDataProvider: ImageDataProviding = MockImageDataProvider()
     ) -> ViewTreeRecordingContext {
         return .init(
             recorder: recorder,
             coordinateSpace: coordinateSpace,
             ids: ids,
-            imageDataProvider: imageDataProvider,
-            textObfuscation: textObfuscation
+            imageDataProvider: imageDataProvider
         )
     }
 }

--- a/DatadogSessionReplay/Tests/Mocks/UIKitMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/UIKitMocks.swift
@@ -81,3 +81,27 @@ extension UIView.ContentMode {
         UIView.ContentMode(rawValue: Int.random(in: 0...12)) ?? .scaleToFill
     }
 }
+
+extension UITextContentType: RandomMockable {
+    static var allCases: Set<UITextContentType> {
+        var all: Set<UITextContentType> = [
+            .name, .namePrefix, .givenName, .middleName, .familyName, .nameSuffix, .nickname,
+            .jobTitle, .organizationName, .location, .fullStreetAddress, .streetAddressLine1,
+            .streetAddressLine2, .addressCity, .addressState, .addressCityAndState, .sublocality,
+            .countryName, .postalCode, .telephoneNumber, .emailAddress, .URL, .creditCardNumber,
+            .username, .password
+        ]
+
+        if #available(iOS 15.0, *) {
+            all.formUnion([.shipmentTrackingNumber, .flightNumber, .dateTime])
+        }
+
+        if #available(iOS 12.0, *) {
+            all.formUnion([.newPassword, .oneTimeCode])
+        }
+
+        return all
+    }
+
+    public static func mockRandom() -> UITextContentType { allCases.randomElement()! }
+}

--- a/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
@@ -8,31 +8,6 @@ import XCTest
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 
-class TextObfuscationTests: XCTestCase {
-    let obfuscation = TextObfuscation()
-
-    func testSensitiveTextObfuscation() {
-        XCTAssertTrue(obfuscation.sensitiveTextObfuscator(for: .mockRandom()) is FixLengthMaskObfuscator)
-    }
-
-    func testInputAndOptionTextObfuscation() {
-        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .maskAll) is FixLengthMaskObfuscator)
-        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .maskUserInput) is FixLengthMaskObfuscator)
-    }
-
-    func testStaticTextObfuscation() {
-        XCTAssertTrue(obfuscation.staticTextObfuscator(for: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(obfuscation.staticTextObfuscator(for: .maskAll) is SpacePreservingMaskObfuscator)
-        XCTAssertTrue(obfuscation.staticTextObfuscator(for: .maskUserInput) is NOPTextObfuscator)    }
-
-    func testHintTextObfuscation() {
-        XCTAssertTrue(obfuscation.hintTextObfuscator(for: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(obfuscation.hintTextObfuscator(for: .maskAll) is FixLengthMaskObfuscator)
-        XCTAssertTrue(obfuscation.hintTextObfuscator(for: .maskUserInput) is NOPTextObfuscator)
-    }
-}
-
 class SpacePreservingMaskObfuscatorTests: XCTestCase {
     let obfuscator = SpacePreservingMaskObfuscator()
 

--- a/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
@@ -12,13 +12,13 @@ class TextObfuscationTests: XCTestCase {
     let obfuscation = TextObfuscation()
 
     func testSensitiveTextObfuscation() {
-        XCTAssertTrue(obfuscation.sensitiveTextObfuscator(for: .mockRandom()) is FixLegthMaskObfuscator)
+        XCTAssertTrue(obfuscation.sensitiveTextObfuscator(for: .mockRandom()) is FixLengthMaskObfuscator)
     }
 
     func testInputAndOptionTextObfuscation() {
         XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .maskAll) is FixLegthMaskObfuscator)
-        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .maskUserInput) is FixLegthMaskObfuscator)
+        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .maskAll) is FixLengthMaskObfuscator)
+        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .maskUserInput) is FixLengthMaskObfuscator)
     }
 
     func testStaticTextObfuscation() {
@@ -28,7 +28,7 @@ class TextObfuscationTests: XCTestCase {
 
     func testHintTextObfuscation() {
         XCTAssertTrue(obfuscation.hintTextObfuscator(for: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(obfuscation.hintTextObfuscator(for: .maskAll) is FixLegthMaskObfuscator)
+        XCTAssertTrue(obfuscation.hintTextObfuscator(for: .maskAll) is FixLengthMaskObfuscator)
         XCTAssertTrue(obfuscation.hintTextObfuscator(for: .maskUserInput) is NOPTextObfuscator)
     }
 }
@@ -75,8 +75,8 @@ class SpacePreservingMaskObfuscatorTests: XCTestCase {
     }
 }
 
-class FixLegthMaskObfuscatorTests: XCTestCase {
-    let obfuscator = FixLegthMaskObfuscator()
+class FixLengthMaskObfuscatorTests: XCTestCase {
+    let obfuscator = FixLengthMaskObfuscator()
 
     func testWhenObfuscatingItAlwaysReplacesTextItWithConstantMask() {
         let expectedMask = "***"

--- a/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
@@ -8,6 +8,31 @@ import XCTest
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 
+class TextObfuscationTests: XCTestCase {
+    let obfuscation = TextObfuscation()
+
+    func testSensitiveTextObfuscation() {
+        XCTAssertTrue(obfuscation.sensitiveTextObfuscator(for: .mockRandom()) is FixLegthMaskObfuscator)
+    }
+
+    func testInputAndOptionTextObfuscation() {
+        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .allowAll) is NOPTextObfuscator)
+        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .maskAll) is FixLegthMaskObfuscator)
+        XCTAssertTrue(obfuscation.inputAndOptionTextObfuscator(for: .maskUserInput) is FixLegthMaskObfuscator)
+    }
+
+    func testStaticTextObfuscation() {
+        XCTAssertTrue(obfuscation.staticTextObfuscator(for: .allowAll) is NOPTextObfuscator)
+        XCTAssertTrue(obfuscation.staticTextObfuscator(for: .maskAll) is SpacePreservingMaskObfuscator)
+        XCTAssertTrue(obfuscation.staticTextObfuscator(for: .maskUserInput) is NOPTextObfuscator)    }
+
+    func testHintTextObfuscation() {
+        XCTAssertTrue(obfuscation.hintTextObfuscator(for: .allowAll) is NOPTextObfuscator)
+        XCTAssertTrue(obfuscation.hintTextObfuscator(for: .maskAll) is FixLegthMaskObfuscator)
+        XCTAssertTrue(obfuscation.hintTextObfuscator(for: .maskUserInput) is NOPTextObfuscator)
+    }
+}
+
 class SpacePreservingMaskObfuscatorTests: XCTestCase {
     let obfuscator = SpacePreservingMaskObfuscator()
 

--- a/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Privacy/TextObfuscatorTests.swift
@@ -54,7 +54,7 @@ class FixLegthMaskObfuscatorTests: XCTestCase {
     let obfuscator = FixLegthMaskObfuscator()
 
     func testWhenObfuscatingItAlwaysReplacesTextItWithConstantMask() {
-        let expectedMask = "xxx"
+        let expectedMask = "***"
 
         XCTAssertEqual(obfuscator.mask(text: .mockRandom(among: .alphanumericsAndWhitespace)), expectedMask)
         XCTAssertEqual(obfuscator.mask(text: .mockRandom(among: .allUnicodes)), expectedMask)

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/UIKitExtensionsTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/UIKitExtensionsTests.swift
@@ -7,7 +7,6 @@
 import XCTest
 import UIKit
 @testable import DatadogSessionReplay
-@testable import TestUtilities
 
 class UIKitExtensionsTests: XCTestCase {
     func testUsesDarkMode() {

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/UIKitExtensionsTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/UIKitExtensionsTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 import UIKit
 @testable import DatadogSessionReplay
+@testable import TestUtilities
 
 class UIKitExtensionsTests: XCTestCase {
     func testUsesDarkMode() {
@@ -27,4 +28,33 @@ class UIKitExtensionsTests: XCTestCase {
             XCTAssertFalse(darkView.usesDarkMode)
         }
     }
+
+    // swiftlint:disable opening_brace
+    func testIsSensitiveText() {
+       class Mock: NSObject, UITextInputTraits {
+            var isSecureTextEntry = false
+            var textContentType: UITextContentType! = nil // swiftlint:disable:this implicitly_unwrapped_optional
+        }
+
+        // Given
+        let sensitiveTextMock = Mock()
+        let nonSensitiveTextMock = Mock()
+        let nonSensitiveContentTypes = UITextContentType.allCases.subtracting(sensitiveContentTypes)
+
+        // When
+        oneOrMoreOf([
+            { sensitiveTextMock.isSecureTextEntry = true },
+            { sensitiveTextMock.textContentType = sensitiveContentTypes.randomElement() },
+        ])
+        oneOrMoreOf([
+            { nonSensitiveTextMock.isSecureTextEntry = false },
+            { nonSensitiveTextMock.textContentType = nil },
+            { nonSensitiveTextMock.textContentType = nonSensitiveContentTypes.randomElement() },
+        ])
+
+        // Then
+        XCTAssertTrue(sensitiveTextMock.isSensitiveText)
+        XCTAssertFalse(nonSensitiveTextMock.isSensitiveText)
+    }
+    // swiftlint:enable opening_brace
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -80,7 +80,7 @@ class UITextFieldRecorderTests: XCTestCase {
         }
 
         XCTAssertTrue(try textObfuscator(in: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(try textObfuscator(in: .maskAll) is SpacePreservingMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskAll) is FixLegthMaskObfuscator)
         XCTAssertTrue(try textObfuscator(in: .maskUserInput) is FixLegthMaskObfuscator)
 
         // When
@@ -91,6 +91,15 @@ class UITextFieldRecorderTests: XCTestCase {
 
         // Then
         XCTAssertTrue(try textObfuscator(in: .mockRandom()) is FixLegthMaskObfuscator)
+
+        // When
+        textField.text = nil
+        textField.placeholder = .mockRandom()
+
+        // Then
+        XCTAssertTrue(try textObfuscator(in: .allowAll) is NOPTextObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskAll) is FixLegthMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskUserInput) is NOPTextObfuscator)
     }
 }
 // swiftlint:enable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -84,9 +84,9 @@ class UITextFieldRecorderTests: XCTestCase {
         XCTAssertTrue(try textObfuscator(in: .maskUserInput) is FixLegthMaskObfuscator)
 
         // When
-        oneOf([
+        oneOrMoreOf([
             { self.textField.isSecureTextEntry = true },
-            { self.textField.textContentType = [.telephoneNumber, .emailAddress].randomElement()! },
+            { self.textField.textContentType = sensitiveContentTypes.randomElement() },
         ])
 
         // Then

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextFieldRecorderTests.swift
@@ -80,8 +80,8 @@ class UITextFieldRecorderTests: XCTestCase {
         }
 
         XCTAssertTrue(try textObfuscator(in: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(try textObfuscator(in: .maskAll) is FixLegthMaskObfuscator)
-        XCTAssertTrue(try textObfuscator(in: .maskUserInput) is FixLegthMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskAll) is FixLengthMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskUserInput) is FixLengthMaskObfuscator)
 
         // When
         oneOrMoreOf([
@@ -90,7 +90,7 @@ class UITextFieldRecorderTests: XCTestCase {
         ])
 
         // Then
-        XCTAssertTrue(try textObfuscator(in: .mockRandom()) is FixLegthMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .mockRandom()) is FixLengthMaskObfuscator)
 
         // When
         textField.text = nil
@@ -98,7 +98,7 @@ class UITextFieldRecorderTests: XCTestCase {
 
         // Then
         XCTAssertTrue(try textObfuscator(in: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(try textObfuscator(in: .maskAll) is FixLegthMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskAll) is FixLengthMaskObfuscator)
         XCTAssertTrue(try textObfuscator(in: .maskUserInput) is NOPTextObfuscator)
     }
 }

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -74,10 +74,10 @@ class UITextViewRecorderTests: XCTestCase {
         XCTAssertTrue(try textObfuscator(in: .maskUserInput) is FixLegthMaskObfuscator)
 
         // When
+        textView.isEditable = .mockRandom()
         oneOrMoreOf([
             { self.textView.isSecureTextEntry = true },
             { self.textView.textContentType = sensitiveContentTypes.randomElement() },
-            { self.textView.isEditable = .mockRandom() } // no matter if editable or not
         ])
 
         // Then

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -74,9 +74,9 @@ class UITextViewRecorderTests: XCTestCase {
         XCTAssertTrue(try textObfuscator(in: .maskUserInput) is SpacePreservingMaskObfuscator)
 
         // When
-        oneOf([
+        oneOrMoreOf([
             { self.textView.isSecureTextEntry = true },
-            { self.textView.textContentType = [.telephoneNumber, .emailAddress].randomElement()! },
+            { self.textView.textContentType = sensitiveContentTypes.randomElement() },
         ])
 
         // Then

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -70,8 +70,8 @@ class UITextViewRecorderTests: XCTestCase {
         }
 
         XCTAssertTrue(try textObfuscator(in: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(try textObfuscator(in: .maskAll) is FixLegthMaskObfuscator)
-        XCTAssertTrue(try textObfuscator(in: .maskUserInput) is FixLegthMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskAll) is FixLengthMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskUserInput) is FixLengthMaskObfuscator)
 
         // When
         textView.isEditable = .mockRandom()
@@ -81,7 +81,7 @@ class UITextViewRecorderTests: XCTestCase {
         ])
 
         // Then
-        XCTAssertTrue(try textObfuscator(in: .mockRandom()) is FixLegthMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .mockRandom()) is FixLengthMaskObfuscator)
 
         // When
         textView.isEditable = false

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UITextViewRecorderTests.swift
@@ -70,17 +70,28 @@ class UITextViewRecorderTests: XCTestCase {
         }
 
         XCTAssertTrue(try textObfuscator(in: .allowAll) is NOPTextObfuscator)
-        XCTAssertTrue(try textObfuscator(in: .maskAll) is SpacePreservingMaskObfuscator)
-        XCTAssertTrue(try textObfuscator(in: .maskUserInput) is SpacePreservingMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskAll) is FixLegthMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskUserInput) is FixLegthMaskObfuscator)
 
         // When
         oneOrMoreOf([
             { self.textView.isSecureTextEntry = true },
             { self.textView.textContentType = sensitiveContentTypes.randomElement() },
+            { self.textView.isEditable = .mockRandom() } // no matter if editable or not
         ])
 
         // Then
         XCTAssertTrue(try textObfuscator(in: .mockRandom()) is FixLegthMaskObfuscator)
+
+        // When
+        textView.isEditable = false
+        textView.isSecureTextEntry = false // non-sensitive
+        textView.textContentType = nil // non-sensitive
+
+        // Then
+        XCTAssertTrue(try textObfuscator(in: .allowAll) is NOPTextObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskAll) is SpacePreservingMaskObfuscator)
+        XCTAssertTrue(try textObfuscator(in: .maskUserInput) is NOPTextObfuscator)
     }
 }
 // swiftlint:enable opening_brace

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -18,7 +18,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             viewTreeRecorder: ViewTreeRecorder(nodeRecorders: [nodeRecorder]),
             idsGenerator: NodeIDGenerator(),
             imageDataProvider: MockImageDataProvider(),
-            textObfuscators: TextObfuscators()
+            textObfuscation: TextObfuscation()
         )
 
         // When
@@ -41,7 +41,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
             viewTreeRecorder: ViewTreeRecorder(nodeRecorders: [nodeRecorder]),
             idsGenerator: NodeIDGenerator(),
             imageDataProvider: MockImageDataProvider(),
-            textObfuscators: TextObfuscators()
+            textObfuscation: TextObfuscation()
         )
 
         // When

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotBuilderTests.swift
@@ -17,8 +17,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         let builder = ViewTreeSnapshotBuilder(
             viewTreeRecorder: ViewTreeRecorder(nodeRecorders: [nodeRecorder]),
             idsGenerator: NodeIDGenerator(),
-            imageDataProvider: MockImageDataProvider(),
-            textObfuscation: TextObfuscation()
+            imageDataProvider: MockImageDataProvider()
         )
 
         // When
@@ -40,8 +39,7 @@ class ViewTreeSnapshotBuilderTests: XCTestCase {
         let builder = ViewTreeSnapshotBuilder(
             viewTreeRecorder: ViewTreeRecorder(nodeRecorders: [nodeRecorder]),
             idsGenerator: NodeIDGenerator(),
-            imageDataProvider: MockImageDataProvider(),
-            textObfuscation: TextObfuscation()
+            imageDataProvider: MockImageDataProvider()
         )
 
         // When

--- a/DatadogSessionReplay/Tests/SessionReplayPrivacyTests.swift
+++ b/DatadogSessionReplay/Tests/SessionReplayPrivacyTests.swift
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+@testable import DatadogSessionReplay
+
+class SessionReplayPrivacyTests: XCTestCase {
+    // MARK: - Text obfuscation strategies
+
+    func testSensitiveTextObfuscation() {
+        XCTAssertTrue(SessionReplayPrivacy.allowAll.sensitiveTextObfuscator is FixLengthMaskObfuscator)
+        XCTAssertTrue(SessionReplayPrivacy.maskAll.sensitiveTextObfuscator is FixLengthMaskObfuscator)
+        XCTAssertTrue(SessionReplayPrivacy.maskUserInput.sensitiveTextObfuscator is FixLengthMaskObfuscator)
+    }
+
+    func testInputAndOptionTextObfuscation() {
+        XCTAssertTrue(SessionReplayPrivacy.allowAll.inputAndOptionTextObfuscator is NOPTextObfuscator)
+        XCTAssertTrue(SessionReplayPrivacy.maskAll.inputAndOptionTextObfuscator is FixLengthMaskObfuscator)
+        XCTAssertTrue(SessionReplayPrivacy.maskUserInput.inputAndOptionTextObfuscator is FixLengthMaskObfuscator)
+    }
+
+    func testStaticTextObfuscation() {
+        XCTAssertTrue(SessionReplayPrivacy.allowAll.staticTextObfuscator is NOPTextObfuscator)
+        XCTAssertTrue(SessionReplayPrivacy.maskAll.staticTextObfuscator is SpacePreservingMaskObfuscator)
+        XCTAssertTrue(SessionReplayPrivacy.maskUserInput.staticTextObfuscator is NOPTextObfuscator)    }
+
+    func testHintTextObfuscation() {
+        XCTAssertTrue(SessionReplayPrivacy.allowAll.hintTextObfuscator is NOPTextObfuscator)
+        XCTAssertTrue(SessionReplayPrivacy.maskAll.hintTextObfuscator is FixLengthMaskObfuscator)
+        XCTAssertTrue(SessionReplayPrivacy.maskUserInput.hintTextObfuscator is NOPTextObfuscator)
+    }
+
+    // MARK: - Convenience helpers
+
+    func testShouldMaskInputElements() {
+        XCTAssertFalse(SessionReplayPrivacy.allowAll.shouldMaskInputElements)
+        XCTAssertTrue(SessionReplayPrivacy.maskAll.shouldMaskInputElements)
+        XCTAssertTrue(SessionReplayPrivacy.maskUserInput.shouldMaskInputElements)
+    }
+}


### PR DESCRIPTION
### What and why?

📦 This PR aligns rules of text and appearance masking to what was concluded in [Privacy Options in Mobile SR](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/2945942237/Privacy+Options+in+Mobile+Session+Replay):

<p align="center">
<img width="60%" alt="Screenshot 2023-05-08 at 11 31 55" src="https://user-images.githubusercontent.com/2358722/236789859-a6b8b3a6-f2de-42fd-94c7-5e4a751af054.png">
</p>

### How?

For **text masking**, above configuration is reflected in `SessionReplayPrivacy` extension:
```swift
/// Text masking strategies per type of text.
extension SessionReplayPrivacy {
    var sensitiveTextObfuscator: TextObfuscating
    var inputAndOptionTextObfuscator: TextObfuscating
    var staticTextObfuscator: TextObfuscating
    var hintTextObfuscator: TextObfuscating
}
```
Each node recorder uses `TextObfuscation` to obtain strategy respectively to its text type (e.g. label recorder uses `staticTextObfuscator(for:)`). Same as before, compound recorders can configure child recorders with alternative strategies (e.g. label recorder in picker view recorder uses `inputAndOptionTextObfuscator(for:)`).

For **appearance masking**, we had to update the `UISliderRecorder` (other recorders were fine) so it erases selected value in `.maskAll` and `.maskUserInput` modes:

<table>
<tr><td>`.allowAll`</td><td>`.maskAll`</td><td>`.maskUserInput`</td></tr>
<tr>
   <td><img src="https://user-images.githubusercontent.com/2358722/236792683-b74bdc78-1f98-45cd-8ee2-42ed03d16eab.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/236792687-6e3a70d0-3416-4594-9f41-dcde959a7f51.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/236792691-6309e48d-f8e8-44ef-913f-b7441defbc07.png" /></td>
</tr>
</table>

No changes to **touch interaction masking** - it's already good.

---

This PR alters most of the snapshot files, but due to their number only few representative examples:

<table>
<tr><td>`.allowAll`</td><td>`.maskAll`</td><td>`.maskUserInput`</td></tr>
<tr>
   <td><img src="https://user-images.githubusercontent.com/2358722/236793212-79cac6f0-116c-43de-bc6c-65fee2118a95.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/236793220-a91a2abf-0c37-4657-b3e5-d9bb80bd36f4.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/236793224-bb2b54ec-1fc9-410d-a598-595a79088959.png" /></td>
</tr>
<tr>
   <td><img src="https://user-images.githubusercontent.com/2358722/236793324-d3b9ec6f-cbed-4b48-9c4e-61a64b80c05e.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/236793328-762c0849-c57c-45c6-a452-9fcde64b9207.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/236793332-990a871f-37d6-4dd5-ba54-b2d57b5cb14b.png" /></td>
</tr>
<tr>
   <td><img src="https://user-images.githubusercontent.com/2358722/236793432-2756629b-e277-43c9-b0aa-674a4f931ed8.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/236793440-18739a37-00c8-4408-b6d6-430b82b7e768.png" /></td>
   <td><img src="https://user-images.githubusercontent.com/2358722/236793442-55319b87-ac03-4030-bacc-baea8a2e4c89.png" /></td>
</tr>
</table>

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
