### PR TITLE
Fix `run_nightly_smoke_and_tools_tests` workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: dependencies xcodeproj-httpservermock templates
+all: dependencies templates
 
 # The release version of `dd-sdk-swift-testing` to use for tests instrumentation.
 DD_SDK_SWIFT_TESTING_VERSION = 2.2.4
@@ -66,11 +66,6 @@ ifeq (${ci}, true)
 		@unzip -q instrumented-tests/DatadogSDKTesting.zip -d instrumented-tests
 		@[ -e "instrumented-tests/DatadogSDKTesting.xcframework" ] && echo "DatadogSDKTesting.xcframework - OK" || { echo "DatadogSDKTesting.xcframework - missing"; exit 1; }
 endif
-
-xcodeproj-httpservermock:
-		@echo "⚙️  Generating 'HTTPServerMock.xcodeproj'..."
-		@cd instrumented-tests/http-server-mock/ && swift package generate-xcodeproj
-		@echo "OK 👌"
 
 xcodeproj-session-replay:
 		@echo "⚙️  Generating 'DatadogSessionReplay.xcodeproj'..."

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -479,20 +479,13 @@ workflows:
         Only ran if 'DD_RUN_TOOLS_TESTS' is '1'.
     steps:
     - script:
-        title: Generate HTTPServerMock.xcodeproj
+        title: Run unit tests for http-server-mock
         run_if: '{{enveq "DD_RUN_TOOLS_TESTS" "1"}}'
         inputs:
         - content: |-
             #!/usr/bin/env bash
             set -e
-            make xcodeproj-httpservermock
-    - xcode-test-mac:
-        title: Run unit tests for HTTPServerMock.xcodeproj - macOS
-        run_if: '{{enveq "DD_RUN_TOOLS_TESTS" "1"}}'
-        inputs:
-        - scheme: HTTPServerMock-Package
-        - destination: platform=OS X,arch=x86_64
-        - project_path: instrumented-tests/http-server-mock/HTTPServerMock.xcodeproj
+            swift test --package-path instrumented-tests/http-server-mock
     - script:
         title: Run unit tests for rum-models-generator
         run_if: '{{enveq "DD_RUN_TOOLS_TESTS" "1"}}'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,7 +15,7 @@ workflows:
             - DD_OVERRIDE_RUN_SR_UNIT_TESTS='1' to run unit tests phase for Session Replay product
             - DD_OVERRIDE_RUN_INTEGRATION_TESTS='1' to run integration tests phase
             - DD_OVERRIDE_RUN_SMOKE_TESTS='1' to run smoke tests phase
-            - DD_OVERRIDE_TOOLS_TESTS='1' to run tools tests phase
+            - DD_OVERRIDE_RUN_TOOLS_TESTS='1' to run tools tests phase
         - a phase is selected on the checklist in the PR description,
         - the PR changes a file which matches phase filter (e.g. changing a file in `Sources/*` will trigger unit tests phase)
     envs:


### PR DESCRIPTION
### What and why?

⛏️ The `run_nightly_smoke_and_tools_tests` was failing on CI in:
```
HTTPServerMockTests
    ✗ testItPullsRecordedRequests, failed - Failed to connect with the server.
    ✗ testItReturnsRecordedRequests, failed - Failed to connect with the server.
    ✓ testWhenPullingRecordedRequestExceedsTimeout_itThrowsAnError (5.200 seconds)
```
causing 3 nightly job failures in a row.

### How?

The problem was in spawning python process from unit tests and reaching timeout in:

```swift
guard let serverProces = runner.waitUntilServerIsReachable() else {
   XCTFail("Failed to connect with the server.")
   return
}
```

As a fix, I'm switching from running `HTTPServerMock` unit tests with generated `*.xcodeproj` (that option is already deprecated in SPM). From now on, we can run them directly using `swift test`. I choose this over Bitrise's `xcode-test` step to reduce our dependency on Bitrise.

To test this fix, I've successfully ran it on CI using `DD_OVERRIDE_RUN_TOOLS_TESTS` ENV override:
```
+---+---------------------------------------------------------------+----------+
| ✓ | Run unit tests for http-server-mock                           | 27.80 sec|
+---+---------------------------------------------------------------+----------+
```

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
