### PR TITLE
RUMM-3277 Prevent sending RUM Error from Cross Platform crash logs

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -1167,6 +1167,8 @@
 		E143CCAF27D236F600F4018A /* CITestIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */; };
 		E179FB4E28F80A6400CC2698 /* PerformanceMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E179FB4D28F80A6400CC2698 /* PerformanceMetric.swift */; };
 		E179FB4F28F80A6400CC2698 /* PerformanceMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = E179FB4D28F80A6400CC2698 /* PerformanceMetric.swift */; };
+		E19BC10E2A0D14EB00540A0F /* RemoteLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19BC10D2A0D14EB00540A0F /* RemoteLoggerTests.swift */; };
+		E19BC10F2A0D14EB00540A0F /* RemoteLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19BC10D2A0D14EB00540A0F /* RemoteLoggerTests.swift */; };
 		E1D202EA24C065CF00D1AF3A /* ActiveSpansPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D202E924C065CF00D1AF3A /* ActiveSpansPool.swift */; };
 		E1D203FD24C1885C00D1AF3A /* ActiveSpansPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D203FB24C1884500D1AF3A /* ActiveSpansPoolTests.swift */; };
 		E1D5AEA724B4D45B007F194B /* Versioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D5AEA624B4D45A007F194B /* Versioning.swift */; };
@@ -2028,6 +2030,7 @@
 		E132727C24B35B5F00952F8B /* TracingStorageBenchmarkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracingStorageBenchmarkTests.swift; sourceTree = "<group>"; };
 		E143CCAE27D236F600F4018A /* CITestIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CITestIntegrationTests.swift; sourceTree = "<group>"; };
 		E179FB4D28F80A6400CC2698 /* PerformanceMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMetric.swift; sourceTree = "<group>"; };
+		E19BC10D2A0D14EB00540A0F /* RemoteLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteLoggerTests.swift; sourceTree = "<group>"; };
 		E1B082CB25641DF9002DB9D2 /* Example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Example.xcconfig; sourceTree = "<group>"; };
 		E1D202E924C065CF00D1AF3A /* ActiveSpansPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpansPool.swift; sourceTree = "<group>"; };
 		E1D203FB24C1884500D1AF3A /* ActiveSpansPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveSpansPoolTests.swift; sourceTree = "<group>"; };
@@ -2684,6 +2687,7 @@
 				61FB222F244E1BE900902D19 /* LoggingFeatureTests.swift */,
 				6194D51B287ECDC00091547D /* ConsoleLoggerTests.swift */,
 				D21C26EA28AFA11E005DD405 /* LogMessageReceiverTests.swift */,
+				E19BC10D2A0D14EB00540A0F /* RemoteLoggerTests.swift */,
 				61FF416125EE5FF400CE35EC /* CrashLogReceiverTests.swift */,
 				D2375C262954785A00473EA0 /* WebViewLogReceiverTests.swift */,
 				61133C3A2423990D00786299 /* Log */,
@@ -5912,6 +5916,7 @@
 				615950EF291C05CC00470E0C /* SessionReplayDependencyTests.swift in Sources */,
 				61122EEE25B1D75B00F9C7F5 /* RUMEventSanitizerTests.swift in Sources */,
 				611F82032563C66100CB9BDB /* UIKitRUMViewsPredicateTests.swift in Sources */,
+				E19BC10E2A0D14EB00540A0F /* RemoteLoggerTests.swift in Sources */,
 				61133C652423990D00786299 /* LogEventBuilderTests.swift in Sources */,
 				61B5E42B26DFC433000B0A5F /* DDNSURLSessionDelegate+apiTests.m in Sources */,
 				61F8CC092469295500FE2908 /* DatadogConfigurationBuilderTests.swift in Sources */,
@@ -6544,6 +6549,7 @@
 				D2CB6F1027C520D400A62B57 /* DDNSURLSessionDelegateTests.swift in Sources */,
 				D2CB6F1227C520D400A62B57 /* LoggerBuilderTests.swift in Sources */,
 				D2079DC9294C91DE00C4D25E /* ReadWriteLockTests.swift in Sources */,
+				E19BC10F2A0D14EB00540A0F /* RemoteLoggerTests.swift in Sources */,
 				D2CB6F1327C520D400A62B57 /* DDConfigurationTests.swift in Sources */,
 				D2CB6F1427C520D400A62B57 /* UUID.swift in Sources */,
 				D2CB6F1527C520D400A62B57 /* URLSessionRUMResourcesHandlerTests.swift in Sources */,

--- a/Sources/Datadog/Core/Attributes/Attributes.swift
+++ b/Sources/Datadog/Core/Attributes/Attributes.swift
@@ -123,4 +123,10 @@ internal struct CrossPlatformAttributes {
     /// configured at the SDK level. This gets displayed on APM's traffic ingestion control page.
     /// Expects `Double` value between `0.0` and `1.0`.
     static let rulePSR = "_dd.rule_psr"
+
+    /// Custom attribute of the log passed from CP SDK. Used in error logs reported by cross platform SDK.
+    /// It flags the error has being fatal for the host application, so we can prevent creating a duplicate RUM error.
+    /// The goal of RUMM-3289 is to create an RFC to get rid of this mechanism.
+    /// Expects `Bool` value.
+    static let errorLogIsCrash = "_dd.error_log.is_crash"
 }

--- a/Sources/Datadog/Logging/RemoteLogger.swift
+++ b/Sources/Datadog/Logging/RemoteLogger.swift
@@ -116,8 +116,10 @@ internal final class RemoteLogger: LoggerProtocol {
 
         // capture current tags and attributes before opening the write event context
         let tags = self.tags
+        var logAttributes = attributes
+        let isCrash = logAttributes?.removeValue(forKey: CrossPlatformAttributes.errorLogIsCrash) as? Bool ?? false
         let userAttributes = self.attributes
-            .merging(attributes ?? [:]) { $1 } // prefer message attributes
+            .merging(logAttributes ?? [:]) { $1 } // prefer message attributes
 
         // SDK context must be requested on the user thread to ensure that it provides values
         // that are up-to-date for the caller.
@@ -157,7 +159,7 @@ internal final class RemoteLogger: LoggerProtocol {
             ) { log in
                 writer.write(value: log)
 
-                guard log.status == .error || log.status == .critical else {
+                guard (log.status == .error || log.status == .critical) && !isCrash else {
                     return
                 }
 

--- a/Tests/DatadogTests/Datadog/Logging/RemoteLoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/Logging/RemoteLoggerTests.swift
@@ -1,0 +1,105 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import Datadog
+
+class RemoteLoggerErrorMessageReceiver: FeatureMessageReceiver {
+    private var errors: [String] = []
+
+    /// Adds RUM Error with given message and stack to current RUM View.
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard
+            case let .error(message, _) = message
+        else {
+            return false
+        }
+
+        self.errors.append(message)
+
+        return true
+    }
+
+    func getErrorMessages() -> [String] {
+        return self.errors
+    }
+}
+
+class RemoteLoggerTests: XCTestCase {
+    func testItSendsErrorAlongWithErrorLog() throws {
+        let errorMessageReceiver = RemoteLoggerErrorMessageReceiver()
+
+        let core = PassthroughCoreMock(
+            expectation: expectation(description: "Send error"),
+            messageReceiver: errorMessageReceiver
+        )
+
+        // Given
+        let logger = RemoteLogger(
+            core: core,
+            configuration: .init(
+                service: "logger.tests",
+                loggerName: "TestLogger",
+                sendNetworkInfo: false,
+                threshold: LogLevel.info,
+                eventMapper: nil,
+                sampler: Sampler(samplingRate: 100.0)
+            ),
+            dateProvider: RelativeDateProvider(
+                using: .mockDecember15th2019At10AMUTC()
+            ),
+            rumContextIntegration: false,
+            activeSpanIntegration: false
+        )
+
+        // When
+        logger.error("Error message")
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let events: [String] = errorMessageReceiver.getErrorMessages()
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first, "Error message")
+    }
+
+    func testItDoesNotSendErrorAlongWithCrossPlatformCrashLog() throws {
+        let errorMessageReceiver = RemoteLoggerErrorMessageReceiver()
+
+        let core = PassthroughCoreMock(
+            expectation: expectation(description: "Send error"),
+            messageReceiver: errorMessageReceiver
+        )
+
+        // Given
+        let logger = RemoteLogger(
+            core: core,
+            configuration: .init(
+                service: "logger.tests",
+                loggerName: "TestLogger",
+                sendNetworkInfo: false,
+                threshold: LogLevel.info,
+                eventMapper: nil,
+                sampler: Sampler(samplingRate: 100.0)
+            ),
+            dateProvider: RelativeDateProvider(
+                using: .mockDecember15th2019At10AMUTC()
+            ),
+            rumContextIntegration: false,
+            activeSpanIntegration: false
+        )
+
+        // When
+        logger.error("Error message", error: nil, attributes: [CrossPlatformAttributes.errorLogIsCrash: true])
+
+        // Then
+        waitForExpectations(timeout: 0.5, handler: nil)
+
+        let events: [String] = errorMessageReceiver.getErrorMessages()
+        XCTAssertEqual(events.count, 0)
+    }
+}


### PR DESCRIPTION
### What and why?

In the case of a Cross Platform crash log, a RUM error is already sent. 
We want to prevent this log from triggering another RUM error, which would be a duplicate.

With the change we only see 1 RUM Error:
![image](https://github.com/DataDog/dd-sdk-ios/assets/8973379/d7e017a0-7f88-4e73-a51f-84deb0f48ff1)


### How?

Look at a cross-platform attribute before creating the log to prevent creating the error.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [x] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
