### PR TITLE
RUMM-3237 Fix Application Launch View Creation

### DIFF
--- a/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
+++ b/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMApplicationScope.swift
@@ -48,8 +48,21 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
     // MARK: - RUMScope
 
     func process(command: RUMCommand, context: DatadogContext, writer: Writer) -> Bool {
+        // `RUMSDKInitCommand` forces the creation of the initial session
+        if command is RUMSDKInitCommand {
+            createInitialSession(on: command, context: context, writer: writer)
+            return true
+        }
+
+        // If the application has not been yet activated and no sessions exist
+        // -> create the initial session
         if sessionScopes.isEmpty && !applicationActive {
-            startInitialSession(on: command, context: context, writer: writer)
+            createInitialSession(on: command, context: context, writer: writer)
+        }
+
+        // Create the application launch view on any command
+        if !applicationActive {
+            applicationStart(on: command, context: context, writer: writer)
         }
 
         if activeSession == nil && command.isUserInteraction {
@@ -98,8 +111,7 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
         return refreshedSession
     }
 
-    private func startInitialSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
-        applicationActive = true
+    private func createInitialSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {
         let initialSession = RUMSessionScope(
             isInitialSession: true,
             parent: self,
@@ -110,17 +122,24 @@ internal class RUMApplicationScope: RUMScope, RUMContextProvider {
 
         sessionScopes.append(initialSession)
         sessionScopeDidUpdate(initialSession)
-        if context.applicationStateHistory.currentSnapshot.state != .background {
-            // Immediately start the ApplicationLaunchView for the new session
-            _ = initialSession.process(
-                command: RUMApplicationStartCommand(
-                    time: command.time,
-                    attributes: command.attributes
-                ),
-                context: context,
-                writer: writer
-            )
+    }
+
+    private func applicationStart(on command: RUMCommand, context: DatadogContext, writer: Writer) {
+        applicationActive = true
+
+        guard context.applicationStateHistory.currentSnapshot.state != .background else {
+            return
         }
+
+        // Immediately start the ApplicationLaunchView for the new session
+        _ = process(
+            command: RUMApplicationStartCommand(
+                time: command.time,
+                attributes: command.attributes
+            ),
+            context: context,
+            writer: writer
+        )
     }
 
     private func startNewSession(on command: RUMCommand, context: DatadogContext, writer: Writer) {


### PR DESCRIPTION
### What and why?

#1278 introduced a side effect of creating the 'Application Launch View' at the init of the SDK. This is too early in the process an we need to wait for the first event so it can report the application launch time properly.

### How?

Split the Session creation and the Application activation in the Application Scope:
- The initial Session will be created on `RUMSDKInitCommand` or any other commands.
- The Application Launch View is started (app active) on any other command.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
