### PR TITLE
RUMM-3222 Don't scale down refresh rate multiple times

### DIFF
--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -42,8 +42,7 @@ internal final class VitalInfoSampler {
     private let maximumRefreshRate: Double
 
     var refreshRate: VitalInfo {
-        let info = refreshRatePublisher.currentValue
-        return info.scaledDown(by: maximumRefreshRate / Constants.normalizedRefreshRate)
+        return refreshRatePublisher.currentValue
     }
 
     private var timer: Timer?


### PR DESCRIPTION
### What and why?

During fixing the variable refresh rate calculation, the normalization was applied during the refresh rate determination phase, but the logic to normalize it again during the reporting was kept which resulted in double normalization.

Eg. First we normalize based on the logic of targetTimestamp and then divide by 2 for 120Hz display.

### How?

Remove second normalization phase during the reporting.

### What and why?

A short description of what changes this PR introduces and why.

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
