### PR TITLE
[Chore] Fix nightly unit tests to run on different iOS Simulator each time

### DIFF
--- a/tools/nightly-unit-tests/bitrise.yml.src
+++ b/tools/nightly-unit-tests/bitrise.yml.src
@@ -53,8 +53,7 @@ workflows:
         inputs:
         - project_path: $PROJECT_PATH
         - scheme: $PROJECT_SCHEME
-        - simulator_device: $SIMULATOR_DEVICE
-        - simulator_os_version: $SIMULATOR_OS_VERSION
+        - destination: platform=iOS Simulator,name=$SIMULATOR_DEVICE,OS=$SIMULATOR_OS_VERSION
         - is_clean_build: 'no'
         - test_repetition_mode: 'retry_on_failure'
         - maximum_test_repetitions: 2


### PR DESCRIPTION
### What and why?

🐞 Fixes a problem that caused our nightly unit tests to ran on a single version of iOS Simulator. It is crucial to run them among different simulators, extending our tests coverage to past iOS versions.

### How?

Fixing nightly-generated `bitrise.yml` to use `destination` instead of `simulator_device` and `simulator_os_version` for `xcode-test` step. That change was introduced by Bitrise in https://github.com/bitrise-steplib/steps-xcode-test/pull/185. We [applied it](https://github.com/DataDog/dd-sdk-ios/pull/765#discussion_r812967047) to the main `bitrise.yml` but not to the nightly one.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
