### PR TITLE
Fix length typos

### DIFF
--- a/Sources/Datadog/DatadogCore/Storage/DataBlock.swift
+++ b/Sources/Datadog/DatadogCore/Storage/DataBlock.swift
@@ -9,8 +9,8 @@ import Foundation
 /// Block size binary type
 internal typealias BlockSize = UInt32
 
-/// Default max data lenght in block (safety check) - 10 MB
-private let MAX_DATA_LENGHT: UInt64 = 10 * 1_024 * 1_024
+/// Default max data length in block (safety check) - 10 MB
+private let MAX_DATA_LENGTH: UInt64 = 10 * 1_024 * 1_024
 
 /// Block type supported in data stream
 internal enum BlockType: UInt16 {
@@ -37,22 +37,22 @@ internal struct DataBlock {
     /// The data.
     var data: Data
 
-    /// Returns a Data block in Type-Lenght-Value format.
+    /// Returns a Data block in Type-Length-Value format.
     ///
     /// A block follow TLV with bytes aligned such as:
     ///
     ///     +-  2 bytes -+-   4 bytes   -+- n bytes -|
     ///     | block type | data size (n) |    data   |
     ///     +------------+---------------+-----------+
-    /// - Parameter maxLenght: Maximum data lenght of a block.
+    /// - Parameter maxLength: Maximum data length of a block.
     /// - Returns: a data block in TLV.
-    func serialize(maxLenght: UInt64 = MAX_DATA_LENGHT) throws -> Data {
+    func serialize(maxLength: UInt64 = MAX_DATA_LENGTH) throws -> Data {
         var buffer = Data()
         // T
         withUnsafeBytes(of: type.rawValue) { buffer.append(contentsOf: $0) }
         // L
-        guard let length = BlockSize(exactly: data.count), length <= maxLenght else {
-            throw DataBlockError.bytesLengthExceedsLimit(limit: maxLenght)
+        guard let length = BlockSize(exactly: data.count), length <= maxLength else {
+            throw DataBlockError.bytesLengthExceedsLimit(limit: maxLength)
         }
         withUnsafeBytes(of: length) { buffer.append(contentsOf: $0) }
         // V
@@ -69,8 +69,8 @@ internal final class DataBlockReader {
     /// The input data stream.
     private let stream: InputStream
 
-    /// Maximum data lenght of a block.
-    private let maxBlockLenght: UInt64
+    /// Maximum data length of a block.
+    private let maxBlockLength: UInt64
 
     /// Reads block from an input stream.
     ///
@@ -80,9 +80,9 @@ internal final class DataBlockReader {
     /// - Parameter stream: The input stream
     init(
         input stream: InputStream,
-        maxBlockLenght: UInt64 = MAX_DATA_LENGHT
+        maxBlockLength: UInt64 = MAX_DATA_LENGTH
     ) {
-        self.maxBlockLenght = maxBlockLenght
+        self.maxBlockLength = maxBlockLength
         self.stream = stream
         stream.open()
     }
@@ -118,7 +118,7 @@ internal final class DataBlockReader {
     ///
     /// - Throws: `DataBlockError` while reading the input stream.
     /// - Returns: The block sequence found in the input
-    func all(maxDataLenght: UInt64 = MAX_DATA_LENGHT) throws -> [DataBlock] {
+    func all(maxDataLength: UInt64 = MAX_DATA_LENGTH) throws -> [DataBlock] {
         var blocks: [DataBlock] = []
 
         while let block = try next() {
@@ -196,8 +196,8 @@ internal final class DataBlockReader {
         // length.
         // Additionally check that length hasn't been corrupted and
         // we don't try to generate a huge buffer.
-        guard let length = Int(exactly: size), length <= maxBlockLenght else {
-            throw DataBlockError.bytesLengthExceedsLimit(limit: maxBlockLenght)
+        guard let length = Int(exactly: size), length <= maxBlockLength else {
+            throw DataBlockError.bytesLengthExceedsLimit(limit: maxBlockLength)
         }
 
         return try read(length: length)
@@ -214,7 +214,7 @@ extension DataBlockError: CustomStringConvertible {
         case .invalidByteSequence(let expected, let got):
             return "Invalid bytes sequence in DataBlock: expected \(expected) bytes but got \(got)"
         case .bytesLengthExceedsLimit(let limit):
-            return "DataBlock lenght exceeds limit of \(limit) bytes"
+            return "DataBlock length exceeds limit of \(limit) bytes"
         case .dataAllocationFailure:
             return "Allocation failure while reading stream"
         case .endOfStream:

--- a/Sources/Datadog/DatadogCore/Storage/Reading/FileReader.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Reading/FileReader.swift
@@ -50,7 +50,7 @@ internal final class FileReader: Reader {
     private func decode(stream: InputStream) throws -> [Data] {
         let reader = DataBlockReader(
             input: stream,
-            maxBlockLenght: orchestrator.performance.maxObjectSize
+            maxBlockLength: orchestrator.performance.maxObjectSize
         )
 
         var failure: String? = nil

--- a/Sources/Datadog/DatadogCore/Storage/Writing/FileWriter.swift
+++ b/Sources/Datadog/DatadogCore/Storage/Writing/FileWriter.swift
@@ -52,7 +52,7 @@ internal struct FileWriter: Writer {
             type: .event,
             data: encrypt(data: data)
         ).serialize(
-            maxLenght: orchestrator.performance.maxObjectSize
+            maxLength: orchestrator.performance.maxObjectSize
         )
     }
 

--- a/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/DataBlockTests.swift
@@ -98,7 +98,7 @@ class DataBlockTests: XCTestCase {
 
     func testDataBlockReader_readsBytesUnderLengthLimit() throws {
         let data = Data([0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0xFF, 0xFF])
-        let reader = DataBlockReader(data: data, maxBlockLenght: 2)
+        let reader = DataBlockReader(data: data, maxBlockLength: 2)
 
         let block = try reader.next()
         XCTAssertEqual(block?.type, .event)
@@ -108,7 +108,7 @@ class DataBlockTests: XCTestCase {
 
     func testDataBlockReader_skipsExceedingBytesLengthLimit() throws {
         let data = Data([0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0xFF, 0xFF])
-        let reader = DataBlockReader(data: data, maxBlockLenght: 1)
+        let reader = DataBlockReader(data: data, maxBlockLength: 1)
 
         do {
             _ = try reader.next()
@@ -145,11 +145,11 @@ class DataBlockTests: XCTestCase {
 }
 
 private extension DataBlockReader {
-    convenience init(data: Data, maxBlockLenght: UInt64? = nil) {
+    convenience init(data: Data, maxBlockLength: UInt64? = nil) {
         let stream = InputStream(data: data)
 
-        if let maxBlockLenght = maxBlockLenght {
-            self.init(input: stream, maxBlockLenght: maxBlockLenght)
+        if let maxBlockLength = maxBlockLength {
+            self.init(input: stream, maxBlockLength: maxBlockLength)
         } else {
             self.init(input: stream)
         }

--- a/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/Persistence/Writing/FileWriterTests.swift
@@ -119,7 +119,7 @@ class FileWriterTests: XCTestCase {
         blocks = try XCTUnwrap(reader.all())
         XCTAssertEqual(blocks.count, 1) // same content as before
         XCTAssertEqual(dd.logger.errorLog?.message, "Failed to write data")
-        XCTAssertEqual(dd.logger.errorLog?.error?.message, "DataBlock lenght exceeds limit of 23 bytes")
+        XCTAssertEqual(dd.logger.errorLog?.error?.message, "DataBlock length exceeds limit of 23 bytes")
     }
 
     func testGivenErrorVerbosity_whenDataCannotBeEncoded_itPrintsError() throws {


### PR DESCRIPTION
### What and why?

Length typo fixes. [Length vs Lenght](https://word.tips/spelling/length-vs-lenght/).

