### PR TITLE
Fix TracingUUID toString string format

### DIFF
--- a/Sources/Datadog/Tracing/UUIDs/TracingUUID.swift
+++ b/Sources/Datadog/Tracing/UUIDs/TracingUUID.swift
@@ -40,9 +40,9 @@ internal struct TracingUUID: Equatable, Hashable {
         case .hexadecimal:
             return String(rawValue, radix: 16)
         case .hexadecimal16Chars:
-            return String(format: "%016x", rawValue)
+            return String(format: "%016llx", rawValue)
         case .hexadecimal32Chars:
-            return String(format: "%032x", rawValue)
+            return String(format: "%032llx", rawValue)
         }
     }
 }

--- a/Tests/DatadogTests/Datadog/Tracing/UUIDs/TracingUUIDTests.swift
+++ b/Tests/DatadogTests/Datadog/Tracing/UUIDs/TracingUUIDTests.swift
@@ -18,6 +18,26 @@ class UUIDTests: XCTestCase {
         XCTAssertEqual(TracingUUID(rawValue: .max).toString(.hexadecimal), "ffffffffffffffff")
     }
 
+    func testTo16CharHexadecimalStringConversion() {
+        XCTAssertEqual(TracingUUID(rawValue: 0).toString(.hexadecimal16Chars), "0000000000000000")
+        XCTAssertEqual(TracingUUID(rawValue: 1).toString(.hexadecimal16Chars), "0000000000000001")
+        XCTAssertEqual(TracingUUID(rawValue: 15).toString(.hexadecimal16Chars), "000000000000000f")
+        XCTAssertEqual(TracingUUID(rawValue: 16).toString(.hexadecimal16Chars), "0000000000000010")
+        XCTAssertEqual(TracingUUID(rawValue: 123).toString(.hexadecimal16Chars), "000000000000007b")
+        XCTAssertEqual(TracingUUID(rawValue: 123_456).toString(.hexadecimal16Chars), "000000000001e240")
+        XCTAssertEqual(TracingUUID(rawValue: .max).toString(.hexadecimal16Chars), "ffffffffffffffff")
+    }
+
+    func testTo32CharHexadecimalStringConversion() {
+        XCTAssertEqual(TracingUUID(rawValue: 0).toString(.hexadecimal32Chars), "00000000000000000000000000000000")
+        XCTAssertEqual(TracingUUID(rawValue: 1).toString(.hexadecimal32Chars), "00000000000000000000000000000001")
+        XCTAssertEqual(TracingUUID(rawValue: 15).toString(.hexadecimal32Chars), "0000000000000000000000000000000f")
+        XCTAssertEqual(TracingUUID(rawValue: 16).toString(.hexadecimal32Chars), "00000000000000000000000000000010")
+        XCTAssertEqual(TracingUUID(rawValue: 123).toString(.hexadecimal32Chars), "0000000000000000000000000000007b")
+        XCTAssertEqual(TracingUUID(rawValue: 123_456).toString(.hexadecimal32Chars), "0000000000000000000000000001e240")
+        XCTAssertEqual(TracingUUID(rawValue: .max).toString(.hexadecimal32Chars), "0000000000000000ffffffffffffffff")
+    }
+
     func testToDecimalStringConversion() {
         XCTAssertEqual(TracingUUID(rawValue: 0).toString(.decimal), "0")
         XCTAssertEqual(TracingUUID(rawValue: 1).toString(.decimal), "1")


### PR DESCRIPTION
### What and why?
There is a bug in the creation of the `traceparent` of the trace http header.
The type of `TracingUUID.rawValue` is `UInt64`, but it is converted to 32 bits when converted like [format: "%16x"].  
When `trace id : 7242571286695202638`(decimal), the `traceparent` header value is being generated as `[version]-00000000000000000000000063e94f4e-[parent id]-[trace flags]` now.

### How?

Use the `%llx` format when converting strings of type UInt64.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
