### PR TITLE
Prepare SPM for SessionReplay

### DIFF
--- a/Datadog.xcworkspace/contents.xcworkspacedata
+++ b/Datadog.xcworkspace/contents.xcworkspacedata
@@ -4,13 +4,4 @@
    <FileRef
       location = "group:Datadog/Datadog.xcodeproj">
    </FileRef>
-   <FileRef
-      location = "group:DatadogSessionReplay">
-   </FileRef>
-   <FileRef
-      location = "group:TestUtilities">
-   </FileRef>
-   <FileRef
-      location = "group:instrumented-tests/http-server-mock">
-   </FileRef>
 </Workspace>

--- a/DatadogSDKSessionReplay.podspec
+++ b/DatadogSDKSessionReplay.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
   
   s.source_files = ["DatadogSessionReplay/Sources/**/*.swift"]
-  s.dependency 'DatadogSDK', s.version.to_s
+  s.dependency 'DatadogInternal', s.version.to_s
 end

--- a/DatadogSessionReplay/DatadogInternal
+++ b/DatadogSessionReplay/DatadogInternal
@@ -1,0 +1,1 @@
+../DatadogInternal

--- a/DatadogSessionReplay/Package.swift
+++ b/DatadogSessionReplay/Package.swift
@@ -13,6 +13,10 @@ let package = Package(
             name: "DatadogSessionReplay",
             targets: ["DatadogSessionReplay"]
         ),
+        .library(
+            name: "TestUtilities",
+            targets: ["TestUtilities"]
+        ),
     ],
     targets: [
         .target(

--- a/DatadogSessionReplay/Package.swift
+++ b/DatadogSessionReplay/Package.swift
@@ -14,15 +14,11 @@ let package = Package(
             targets: ["DatadogSessionReplay"]
         ),
     ],
-    dependencies: [
-        .package(name: "Datadog", path: ".."),
-        .package(name: "TestUtilities", path: "../TestUtilities"),
-    ],
     targets: [
         .target(
             name: "DatadogSessionReplay",
             dependencies: [
-                .product(name: "Datadog", package: "Datadog"),
+                .target(name: "DatadogInternal"),
             ],
             path: "Sources"
         ),
@@ -30,9 +26,31 @@ let package = Package(
             name: "DatadogSessionReplayTests",
             dependencies: [
                 .target(name: "DatadogSessionReplay"),
-                .product(name: "TestUtilities", package: "TestUtilities")
+                .target(name: "TestUtilities")
             ],
             path: "Tests"
+        ),
+
+        .target(
+            name: "DatadogInternal",
+            path: "DatadogInternal/Sources"
+        ),
+        .testTarget(
+            name: "DatadogInternalTests",
+            dependencies: [
+                .target(name: "DatadogInternal"),
+                .target(name: "TestUtilities"),
+            ],
+            path: "DatadogInternal/Tests"
+        ),
+
+        .target(
+            name: "TestUtilities",
+            dependencies: [
+                .target(name: "DatadogInternal"),
+            ],
+            path: "TestUtilities",
+            sources: ["Mocks", "Helpers"]
         )
     ]
 )

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcodeproj/project.pbxproj
@@ -25,12 +25,12 @@
 		61E7DFB7299A57A9001D7A3A /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E7DFB6299A57A9001D7A3A /* MenuViewController.swift */; };
 		61E7DFB9299A5A3E001D7A3A /* Basic.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 61E7DFB8299A5A3E001D7A3A /* Basic.storyboard */; };
 		61E7DFBB299A5C9D001D7A3A /* BasicViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E7DFBA299A5C9D001D7A3A /* BasicViewControllers.swift */; };
-		61EC1A37299CFD7E00224FB6 /* TestUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = 61EC1A36299CFD7E00224FB6 /* TestUtilities */; };
 		A7025BD129E8202E00747BFB /* ImagesViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7025BD029E8202E00747BFB /* ImagesViewControllers.swift */; };
 		A719BC3B29E6A5C600E7B646 /* UnsupportedViews.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A719BC3929E6A4CA00E7B646 /* UnsupportedViews.storyboard */; };
 		A719BC3F29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A719BC3E29E6AFCA00E7B646 /* UnsupportedViewsViewController.swift */; };
 		A797A95029D5958400EE73EB /* Images.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A797A94F29D5958400EE73EB /* Images.storyboard */; };
 		A797A95229D59E7900EE73EB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A797A95129D59E7900EE73EB /* Assets.xcassets */; };
+		D2F37BFB2A40A2CF004A28A4 /* TestUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = D2F37BFA2A40A2CF004A28A4 /* TestUtilities */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,7 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				61EC1A37299CFD7E00224FB6 /* TestUtilities in Frameworks */,
+				D2F37BFB2A40A2CF004A28A4 /* TestUtilities in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,7 +208,7 @@
 			);
 			name = SRSnapshotTests;
 			packageProductDependencies = (
-				61EC1A36299CFD7E00224FB6 /* TestUtilities */,
+				D2F37BFA2A40A2CF004A28A4 /* TestUtilities */,
 			);
 			productName = SRSnapshotTests;
 			productReference = 61B3BC622993BEAF0032C78A /* SRSnapshotTests.xctest */;
@@ -597,7 +597,7 @@
 			package = 61C06D5E29D487E7007521D8 /* XCRemoteSwiftPackageReference "Framer" */;
 			productName = Framer;
 		};
-		61EC1A36299CFD7E00224FB6 /* TestUtilities */ = {
+		D2F37BFA2A40A2CF004A28A4 /* TestUtilities */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TestUtilities;
 		};

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcworkspace/contents.xcworkspacedata
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests.xcworkspace/contents.xcworkspacedata
@@ -5,9 +5,6 @@
       location = "group:..">
    </FileRef>
    <FileRef
-      location = "group:../../TestUtilities">
-   </FileRef>
-   <FileRef
       location = "container:SRSnapshotTests.xcodeproj">
    </FileRef>
 </Workspace>

--- a/DatadogSessionReplay/Sources/DatadogCoreIntegration/RUMContextReceiver.swift
+++ b/DatadogSessionReplay/Sources/DatadogCoreIntegration/RUMContextReceiver.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import DatadogInternal
-import Datadog
 
 /// The RUM context received from `DatadogCore`.
 internal struct RUMContext: Decodable, Equatable {

--- a/DatadogSessionReplay/Sources/DatadogCoreIntegration/RequestBuilder/RequestBuilder.swift
+++ b/DatadogSessionReplay/Sources/DatadogCoreIntegration/RequestBuilder/RequestBuilder.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import DatadogInternal
-import Datadog
 
 internal struct RequestBuilder: FeatureRequestBuilder {
     private static let newlineByte = "\n".data(using: .utf8)! // swiftlint:disable:this force_unwrapping

--- a/DatadogSessionReplay/Sources/DatadogCoreIntegration/SRContextPublisher.swift
+++ b/DatadogSessionReplay/Sources/DatadogCoreIntegration/SRContextPublisher.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import DatadogInternal
-import Datadog
 
 /// Publisher that sets Session Replay context for being utilized by other Features.
 internal class SRContextPublisher {

--- a/DatadogSessionReplay/Sources/Drafts/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/Drafts/SessionReplay.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import DatadogInternal
-import Datadog
 
 /// A draft interface for SR Feature initialization.
 /// TODO: RUMM-2268 Design convenient public API

--- a/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import DatadogInternal
-import Datadog
 
 /// A draft of the main SR component (TODO: RUMM-2268 Design convenient public API).
 /// - It conforms to `DatadogFeature` for communicating with `DatadogCore`.

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -5,7 +5,7 @@
  */
 
 import Foundation
-import Datadog
+import DatadogInternal
 
 /// A type managing Session Replay recording.
 internal protocol Recording {

--- a/DatadogSessionReplay/Sources/Writer/Writer.swift
+++ b/DatadogSessionReplay/Sources/Writer/Writer.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import DatadogInternal
-import Datadog
 
 /// A type writing Session Replay records to `DatadogCore`.
 internal protocol Writing {

--- a/DatadogSessionReplay/TestUtilities
+++ b/DatadogSessionReplay/TestUtilities
@@ -1,0 +1,1 @@
+../TestUtilities

--- a/DatadogSessionReplay/Tests/DatadogCoreIntegration/RequestBuilder/RequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogCoreIntegration/RequestBuilder/RequestBuilderTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-import Datadog
+
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 

--- a/DatadogSessionReplay/Tests/Processor/Flattening/NodesFlattenerTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/Flattening/NodesFlattenerTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-import Datadog
+
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 

--- a/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
@@ -5,9 +5,8 @@
  */
 
 import XCTest
-import Datadog
-import TestUtilities
 import DatadogInternal
+import TestUtilities
 
 @testable import DatadogSessionReplay
 

--- a/DatadogSessionReplay/Tests/Writer/SRCompressionTests.swift
+++ b/DatadogSessionReplay/Tests/Writer/SRCompressionTests.swift
@@ -7,7 +7,7 @@
 import zlib
 import XCTest
 import Compression
-@testable import Datadog
+
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 

--- a/DatadogSessionReplay/Tests/Writer/WriterTests.swift
+++ b/DatadogSessionReplay/Tests/Writer/WriterTests.swift
@@ -5,7 +5,7 @@
  */
 
 import XCTest
-import Datadog
+
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 

--- a/DatadogTrace/Sources/Utils/ActiveSpansPool.swift
+++ b/DatadogTrace/Sources/Utils/ActiveSpansPool.swift
@@ -57,7 +57,6 @@ internal class ActiveSpansPool {
         rlock.unlock()
     }
 
-#if DD_SDK_COMPILED_FOR_TESTING
     /// This explicit way of destroying `ActiveSpansPool` was added after noticing RUMM-2904. It is there to keep test coverage
     /// for a scenario of incorret use of `span.setActive()` API. Until RUMM-2904 is fixed, `destroy()` is necessary to not
     /// leak the `core` object memory in tests. It should be removed after fixing the problem.
@@ -68,5 +67,4 @@ internal class ActiveSpansPool {
         contextMap = [:]
         rlock.unlock()
     }
-#endif
 }

--- a/Package.swift
+++ b/Package.swift
@@ -18,26 +18,6 @@ let package = Package(
             targets: ["DatadogObjc"]
         ),
         .library(
-            name: "DatadogDynamic",
-            type: .dynamic,
-            targets: ["Datadog"]
-        ),
-        .library(
-            name: "DatadogDynamicObjc",
-            type: .dynamic,
-            targets: ["DatadogObjc"]
-        ),
-        .library( // TODO: RUMM-2387 Consider removing explicit linkage variants
-            name: "DatadogStatic",
-            type: .static,
-            targets: ["Datadog"]
-        ),
-        .library( // TODO: RUMM-2387 Consider removing explicit linkage variants
-            name: "DatadogStaticObjc",
-            type: .static,
-            targets: ["DatadogObjc"]
-        ),
-        .library(
             name: "DatadogLogs",
             targets: ["DatadogLogs"]
         ),
@@ -57,6 +37,10 @@ let package = Package(
             name: "DatadogWebViewTracking",
             targets: ["DatadogWebViewTracking"]
         ),
+//        .library(
+//            name: "DatadogSessionReplay",
+//            targets: ["DatadogSessionReplay"]
+//        ),
     ],
     dependencies: [
         .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.0"),
@@ -181,9 +165,23 @@ let package = Package(
         ),
 
         .target(
+            name: "DatadogSessionReplay",
+            dependencies: ["DatadogInternal"],
+            path: "DatadogSessionReplay/Sources"
+        ),
+        .testTarget(
+            name: "DatadogSessionReplayTests",
+            dependencies: [
+                .target(name: "DatadogSessionReplay"),
+                .target(name: "TestUtilities"),
+            ],
+            path: "DatadogSessionReplay/Tests"
+        ),
+
+        .target(
             name: "TestUtilities",
             dependencies: [
-                .target(name: "Datadog"),
+                .target(name: "DatadogInternal"),
             ],
             path: "TestUtilities",
             sources: ["Mocks", "Helpers"]

--- a/Package.swift
+++ b/Package.swift
@@ -37,10 +37,6 @@ let package = Package(
             name: "DatadogWebViewTracking",
             targets: ["DatadogWebViewTracking"]
         ),
-//        .library(
-//            name: "DatadogSessionReplay",
-//            targets: ["DatadogSessionReplay"]
-//        ),
     ],
     dependencies: [
         .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.0"),

--- a/Sources/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
+++ b/Sources/DatadogExtensions/Alamofire/DatadogAlamofireExtension.swift
@@ -13,7 +13,7 @@ public class DDEventMonitor: EventMonitor {
     private weak var core: DatadogCoreProtocol?
 
     private var interceptor: URLSessionInterceptor? {
-        let core = self.core ?? defaultDatadogCore
+        let core = self.core ?? CoreRegistry.default
         return URLSessionInterceptor.shared(in: core)
     }
 
@@ -44,7 +44,7 @@ public class DDRequestInterceptor: RequestInterceptor {
     private weak var core: DatadogCoreProtocol?
 
     private var interceptor: URLSessionInterceptor? {
-        let core = self.core ?? defaultDatadogCore
+        let core = self.core ?? CoreRegistry.default
         return URLSessionInterceptor.shared(in: core)
     }
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -243,7 +243,7 @@ workflows:
         title: Run unit tests for Session Replay - iOS Simulator
         run_if: '{{enveq "DD_RUN_SR_UNIT_TESTS" "1"}}'
         inputs:
-        - scheme: DatadogSessionReplay
+        - scheme: DatadogSessionReplay-Package
         - destination: platform=iOS Simulator,name=iPhone 11,OS=latest
         - should_build_before_test: 'no'
         - is_clean_build: 'no'


### PR DESCRIPTION
### What and why?

Prepare repo for including SessionReplay in SPM.

### How?

1. Remove SessionReplay dependency to `Datadog`
2. Add SessionReplay target to main `Package.swift` **without exposing the library**.
3. Fix main SPM tests

In order to keep `SessionReplay/Package.swift` available for development while doing 1. and 2., I've created symbolic links to `DatadogInternal` and `TestUtilities`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [x] Run smoke tests
