### PR TITLE
RUMM-3349 Add context to crash when there's an active view

### DIFF
--- a/Sources/Datadog/RUM/Integrations/CrashReportReceiver.swift
+++ b/Sources/Datadog/RUM/Integrations/CrashReportReceiver.swift
@@ -326,7 +326,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
             application: .init(id: lastRUMView.application.id),
             ciTest: lastRUMView.ciTest,
             connectivity: lastRUMView.connectivity,
-            context: nil,
+            context: lastRUMView.context,
             date: crashDate.timeIntervalSince1970.toInt64Milliseconds,
             device: lastRUMView.device,
             display: nil,

--- a/Tests/DatadogTests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/Tests/DatadogTests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -498,6 +498,16 @@ class CrashReportReceiverTests: XCTestCase {
             && sendRUMErrorEvent.model.view.id == lastRUMViewEvent.view.id,
             "The `RUMErrorEvent` sent must be linked to the same RUM Session as the last `RUMViewEvent`."
         )
+
+        XCTAssertNotNil(sendRUMErrorEvent.context, "It must contain context details")
+        XCTAssertNotNil(lastRUMViewEvent.context, "It must contain context details")
+
+        DDAssertJSONEqual(
+            AnyEncodable(sendRUMErrorEvent.context?.contextInfo),
+            AnyEncodable(lastRUMViewEvent.context?.contextInfo),
+            "The `RUMErrorEvent` sent must be include the context of the last `RUMViewEvent`."
+        )
+
         XCTAssertTrue(
             sendRUMErrorEvent.model.error.isCrash == true, "The `RUMErrorEvent` sent must be marked as crash."
         )
@@ -656,6 +666,7 @@ class CrashReportReceiverTests: XCTestCase {
             XCTAssertNotNil(sentRUMError.additionalAttributes?[DDError.binaryImages], "It must contain crash details")
             XCTAssertNotNil(sentRUMError.additionalAttributes?[DDError.meta], "It must contain crash details")
             XCTAssertNotNil(sentRUMError.additionalAttributes?[DDError.wasTruncated], "It must contain crash details")
+            XCTAssertNil(sentRUMView.context, "It musn't contain context as there was no last active view")
         }
 
         try test(


### PR DESCRIPTION
### What and why?
We're currently not reporting user set global attributes when collecting a crash. 
This PR addresses this.

### How?

Context reported on the RUM Error created when collecting a crash is extracted from the last active RUM View.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
