### PR TITLE
Stop pinning to .git URL in Package.swift.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter.git", from: "1.11.0"),
+        .package(name: "PLCrashReporter", url: "https://github.com/microsoft/plcrashreporter", from: "1.11.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
### What and why?

When you pin the .git version of a URL in Package.swift, it seems to cause perturbations in the Xcode project of any client. You'll occasionally get diffs where Xcode adds or removes the .git suffix, seemingly at random. I don't know for sure if this fixes it, but it seems to maybe fix it.

### How?

Delete .git pinning from Package.swift. I didn't remove it from a couple of other Package.swift files I found in the project because they seemed to be internal, but I can update them too if it seems important.

I haven't updated the CHANGELOG or filed a ticket. Should I?

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
