### PR TITLE
Fix data race condition in test

### DIFF
--- a/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/Tests/DatadogTests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -43,6 +43,7 @@ internal class CrashReportingPluginMock: CrashReportingPlugin {
     /// The crash report loaded by this plugin.
     var pendingCrashReport: DDCrashReport?
     /// If the plugin was asked to delete the crash report.
+    @ReadWriteLock
     var hasPurgedCrashReport: Bool?
     /// Custom app state data injected to the plugin.
     var injectedContextData: Data?


### PR DESCRIPTION
### What and why?

Fix data race condition issue in `CrashReportingPluginMock`.

### How?

CI jobs seems to hang when running `testWhenPendingCrashReportIsFound_itIsSentAndPurged`, and by running the test repeatedly we can run into a data-race condition.

The `CrashReportingPluginMock` was missing a lock mechanism.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
