### PR TITLE
Get it compiling on visionOS

### DIFF
--- a/Sources/Datadog/DatadogCore/Context/CarrierInfoPublisher.swift
+++ b/Sources/Datadog/DatadogCore/Context/CarrierInfoPublisher.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-#if os(iOS) && !targetEnvironment(macCatalyst)
+#if os(iOS) && !os(xrOS) && !targetEnvironment(macCatalyst)
 
 import CoreTelephony
 

--- a/Sources/Datadog/DatadogCore/DatadogCore.swift
+++ b/Sources/Datadog/DatadogCore/DatadogCore.swift
@@ -541,7 +541,7 @@ extension DatadogContextProvider {
             assign(reader: SCNetworkReachabilityReader(), to: \.networkConnectionInfo)
         }
 
-        #if os(iOS) && !targetEnvironment(macCatalyst)
+        #if os(iOS) && !os(xrOS) && !targetEnvironment(macCatalyst)
         if #available(iOS 12, *) {
             subscribe(\.carrierInfo, to: iOS12CarrierInfoPublisher())
         } else {

--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -108,7 +108,7 @@ internal class RUMDebugging {
             canvas.addSubview(view)
         }
         if canvas.superview == nil,
-           let someWindow = UIApplication.managedShared?.windows.filter({ $0.isKeyWindow }).first {
+           let someWindow = UIApplication.managedShared?.windows.first(where: { $0.isKeyWindow }) {
             canvas.frame.size = someWindow.bounds.size
             someWindow.addSubview(canvas)
         }

--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -108,7 +108,7 @@ internal class RUMDebugging {
             canvas.addSubview(view)
         }
         if canvas.superview == nil,
-            let someWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first {
+           let someWindow = UIApplication.managedShared?.windows.filter({ $0.isKeyWindow }).first {
             canvas.frame.size = someWindow.bounds.size
             someWindow.addSubview(canvas)
         }

--- a/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
+++ b/Sources/Datadog/RUM/Debugging/RUMDebugging.swift
@@ -35,7 +35,7 @@ internal class RUMDebugging {
 
     // MARK: - Initialization
 
-    #if !os(tvOS)
+    #if !os(tvOS) && !os(xrOS)
     init() {
         DispatchQueue.main.async {
             UIDevice.current.beginGeneratingDeviceOrientationNotifications()
@@ -108,7 +108,7 @@ internal class RUMDebugging {
             canvas.addSubview(view)
         }
         if canvas.superview == nil,
-            let someWindow = UIApplication.managedShared?.keyWindow {
+            let someWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first {
             canvas.frame.size = someWindow.bounds.size
             someWindow.addSubview(canvas)
         }

--- a/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalInfoSampler.swift
@@ -41,12 +41,22 @@ internal final class VitalInfoSampler {
 
     private var timer: Timer?
 
+    private static var maximumFramesPerSecond: Double {
+        get {
+#if os(xrOS)
+            return 120.0
+#else
+            return Double(UIScreen.main.maximumFramesPerSecond)
+#endif
+        }
+    }
+
     init(
         cpuReader: SamplingBasedVitalReader,
         memoryReader: SamplingBasedVitalReader,
         refreshRateReader: ContinuousVitalReader,
         frequency: TimeInterval,
-        maximumRefreshRate: Double = Double(UIScreen.main.maximumFramesPerSecond)
+        maximumRefreshRate: Double = VitalInfoSampler.maximumFramesPerSecond
     ) {
         self.cpuReader = cpuReader
 

--- a/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
+++ b/Sources/Datadog/RUM/RUMVitals/VitalRefreshRateReader.swift
@@ -151,7 +151,11 @@ extension FrameInfoProvider {
 
 extension CADisplayLink: FrameInfoProvider {
     var maximumDeviceFramesPerSecond: Int {
+        #if os(xrOS)
+        120
+        #else
         UIScreen.main.maximumFramesPerSecond
+        #endif
     }
 
     var currentFrameTimestamp: CFTimeInterval {


### PR DESCRIPTION
### What and why?

visionOS SDK beta was recently released and we'd like to test our app instrumented with Datadog

### How?

Basically three things:
- CoreTelephony is unavailable on visionOS, like the simulator, don't use it
- UIScreen is not available on visionOS, so I hardcoded the max framerate to 120 for now (guess based on the description of the max framerate variable docs, "up to 120 FPS")... We should find a better solution to this, but the Apple documentation is just not there yet
- `UIApplication.keyWindow` is long gone, I copied this: https://stackoverflow.com/a/57899013

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
  - Pretty sure this is covered by "it compiles"? Not sure how to do this sorry :(
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
  - No issue, N/A
- [x] Add CHANGELOG entry for user facing changes
  - Shouldn't be any changes for a user?

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
