### PR TITLE
RUMM-2387 Rename Crash Reporting podspec

### DIFF
--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogCrashReporting"
-  s.version      = "1.20.0"
+  s.version      = "1.21.0"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -9,8 +9,9 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Maxime Epain" => "maxime.epain@datadoghq.com"
+    "Maciej Burda" => "maciej.burda@datadoghq.com",
+    "Maxime Epain" => "maxime.epain@datadoghq.com",
+    "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
   s.swift_version      = '5.1'

--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -1,7 +1,6 @@
 Pod::Spec.new do |s|
-  s.name         = "DatadogSDKCrashReporting"
-  s.module_name  = "DatadogCrashReporting"
-  s.version      = "1.21.0"
+  s.name         = "DatadogCrashReporting"
+  s.version      = "1.20.0"
   s.summary      = "Official Datadog Crash Reporting SDK for iOS."
   
   s.homepage     = "https://www.datadoghq.com"
@@ -17,8 +16,6 @@ Pod::Spec.new do |s|
   s.swift_version      = '5.1'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
-
-  s.deprecated_in_favor_of = 'DatadogCrashReporting'
 
   s.source = { :git => 'https://github.com/DataDog/dd-sdk-ios.git', :tag => s.version.to_s }
   s.static_framework = true

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -10,8 +10,9 @@ Pod::Spec.new do |s|
   s.license            = { :type => "Apache", :file => 'LICENSE' }
   s.authors            = { 
     "Maciek Grzybowski" => "maciek.grzybowski@datadoghq.com",
-    "Mert Buran" => "mert.buran@datadoghq.com",
-    "Maxime Epain" => "maxime.epain@datadoghq.com"
+    "Maciej Burda" => "maciej.burda@datadoghq.com",
+    "Maxime Epain" => "maxime.epain@datadoghq.com",
+    "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
   s.swift_version      = '5.1'


### PR DESCRIPTION
### What and why?

Rename `DatadogSDKCrashReporting.podspec` to `DatadogCrashReporting.podspec` and mark `DatadogSDKCrashReporting` as deprecated.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [x] Run smoke tests
