### PR TITLE
RUMM-2387 Update CocoaPods specs

### DIFF
--- a/DatadogCrashReporting.podspec
+++ b/DatadogCrashReporting.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
-  s.swift_version      = '5.1'
+  s.swift_version = '5.5'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogInternal.podspec
+++ b/DatadogInternal.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     "Maxime Epain" => "maxime.epain@datadoghq.com"
   }
 
-  s.swift_version      = '5.1'
+  s.swift_version = '5.5'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogLogs.podspec
+++ b/DatadogLogs.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     "Maxime Epain" => "maxime.epain@datadoghq.com"
   }
 
-  s.swift_version      = '5.1'
+  s.swift_version = '5.5'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogRUM.podspec
+++ b/DatadogRUM.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     "Maxime Epain" => "maxime.epain@datadoghq.com"
   }
 
-  s.swift_version      = '5.1'
+  s.swift_version = '5.5'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogSDK.podspec
+++ b/DatadogSDK.podspec
@@ -1,6 +1,5 @@
 Pod::Spec.new do |s|
   s.name         = "DatadogSDK"
-  s.module_name  = "Datadog"
   s.version      = "2.0.0-alpha1"
   s.summary      = "Official Datadog Swift SDK for iOS."
   
@@ -20,11 +19,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '11.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }
-  
-  s.default_subspec = 'Core'
 
-  s.subspec 'Core' do |ss|
-    ss.dependency 'DatadogCore', s.version.to_s
-  end
+  s.deprecated_in_favor_of =
+    'DatadogCore, DatadogLogs, DatadogRUM, DatadogTrace, and DatadogWebViewTracking'
+
+  s.dependency 'DatadogCore', s.version.to_s
+  s.dependency 'DatadogLogs', s.version.to_s
+  s.dependency 'DatadogRUM', s.version.to_s
+  s.dependency 'DatadogTrace', s.version.to_s
+  s.dependency 'DatadogWebViewTracking', s.version.to_s
 
 end

--- a/DatadogSDKCrashReporting.podspec
+++ b/DatadogSDKCrashReporting.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
-  s.swift_version      = '5.1'
+  s.swift_version = '5.5'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogSessionReplay.podspec
+++ b/DatadogSessionReplay.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     "Maxime Epain" => "maxime.epain@datadoghq.com"
   }
 
-  s.swift_version      = '5.1'
+  s.swift_version = '5.5'
   s.ios.deployment_target = '11.0'
 
   s.source = { :git => "https://github.com/DataDog/dd-sdk-ios.git", :tag => s.version.to_s }

--- a/DatadogTrace.podspec
+++ b/DatadogTrace.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     "Maxime Epain" => "maxime.epain@datadoghq.com"
   }
 
-  s.swift_version      = '5.1'
+  s.swift_version = '5.5'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/DatadogWebViewTracking.podspec
+++ b/DatadogWebViewTracking.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     "Ganesh Jangir" => "ganesh.jangir@datadoghq.com"
   }
 
-  s.swift_version      = '5.1'
+  s.swift_version = '5.5'
   s.ios.deployment_target = '11.0'
   s.tvos.deployment_target = '11.0'
 

--- a/IntegrationTests/Podfile
+++ b/IntegrationTests/Podfile
@@ -2,14 +2,13 @@ target 'Runner iOS' do
     platform :ios, '11.0'
 
     pod 'DatadogCore', :path => '..'
-    pod 'DatadogSDKObjc', :path => '..'
-    pod 'DatadogSDKCrashReporting', :path => '..'
-
     pod 'DatadogLogs', :path => '..'
     pod 'DatadogTrace', :path => '..'
     pod 'DatadogRUM', :path => '..'
+    pod 'DatadogCrashReporting', :path => '..'
     pod 'DatadogSessionReplay', :path => '..'
     pod 'DatadogWebViewTracking', :path => '..'
+    pod 'DatadogObjc', :path => '..'
 
     target 'IntegrationScenarios' do
         pod 'DatadogInternal', :path => '..'

--- a/dependency-manager-tests/cocoapods/Podfile.src
+++ b/dependency-manager-tests/cocoapods/Podfile.src
@@ -1,11 +1,12 @@
 abstract_target 'Common' do
   pod 'DatadogInternal', :git => 'GIT_REMOTE', :GIT_REFERENCE
+  pod 'DatadogCore', :git => 'GIT_REMOTE', :GIT_REFERENCE
   pod 'DatadogLogs', :git => 'GIT_REMOTE', :GIT_REFERENCE
   pod 'DatadogTrace', :git => 'GIT_REMOTE', :GIT_REFERENCE
   pod 'DatadogRUM', :git => 'GIT_REMOTE', :GIT_REFERENCE
   pod 'DatadogCore', :git => 'GIT_REMOTE', :GIT_REFERENCE
-  pod 'DatadogSDKAlamofireExtension', :git => 'GIT_REMOTE', :GIT_REFERENCE
-  pod 'DatadogSDKCrashReporting', :git => 'GIT_REMOTE', :GIT_REFERENCE
+  pod 'DatadogAlamofireExtension', :git => 'GIT_REMOTE', :GIT_REFERENCE
+  pod 'DatadogCrashReporting', :git => 'GIT_REMOTE', :GIT_REFERENCE
   pod 'DatadogWebViewTracking', :git => 'GIT_REMOTE', :GIT_REFERENCE
   pod 'Alamofire'
 

--- a/tools/distribution/release.py
+++ b/tools/distribution/release.py
@@ -127,6 +127,13 @@ if __name__ == "__main__":
             if publish_to_cp:
                 podspecs = [
                     CPPodspec(name='DatadogInternal'),
+                    CPPodspec(name='DatadogCore'),
+                    CPPodspec(name='DatadogLogs'),
+                    CPPodspec(name='DatadogTrace'),
+                    CPPodspec(name='DatadogRUM'),
+                    CPPodspec(name='DatadogCrashReporting'),
+                    CPPodspec(name='DatadogWebViewTracking'),
+                    CPPodspec(name='DatadogObjc'),
                     CPPodspec(name='DatadogSDK'),
                     CPPodspec(name='DatadogSDKObjc'),
                     CPPodspec(name='DatadogSDKCrashReporting'),


### PR DESCRIPTION
### What and why?

Update CocoaPods specs for v2 release.

### How?

Mark `DatadogSDK` as deprecated in favor of DatadogCore, DatadogLogs, DatadogRUM, DatadogTrace, and DatadogWebViewTracking

All `DatadogSDK*` podspecs are now marked as deprecated with proper warning when used:

<img width="907" alt="image" src="https://github.com/DataDog/dd-sdk-ios/assets/6815992/b4f823d0-1b6f-4b30-b411-d5b8f36d3fe3">


### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [x] Run smoke tests
