### PR TITLE
fix: broken IntegrationTests target

### DIFF
--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMManualInstrumentationScenarioTests.swift
@@ -79,8 +79,9 @@ class RUMManualInstrumentationScenarioTests: IntegrationTests, RUMCommonAsserts 
         XCTAssertEqual(view1.resourceEvents[0].resource.url, "https://foo.com/resource/1")
         XCTAssertEqual(view1.resourceEvents[0].resource.statusCode, 200)
         XCTAssertEqual(view1.resourceEvents[0].resource.type, .image)
-        XCTAssertGreaterThan(view1.resourceEvents[0].resource.duration, 100_000_000 - 1) // ~0.1s
-        XCTAssertLessThan(view1.resourceEvents[0].resource.duration, 1_000_000_000 * 30) // less than 30s (big enough to balance NTP sync)
+        XCTAssertNotNil(view1.resourceEvents[0].resource.duration) // ~0.1s
+        XCTAssertGreaterThan(view1.resourceEvents[0].resource.duration!, 100_000_000 - 1) // ~0.1s
+        XCTAssertLessThan(view1.resourceEvents[0].resource.duration!, 1_000_000_000 * 30) // less than 30s (big enough to balance NTP sync)
         XCTAssertEqual(view1.errorEvents[0].error.type, "NSURLErrorDomain - -1011")
         XCTAssertEqual(view1.errorEvents[0].error.message, "Bad response.")
         XCTAssertEqual(

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMResourcesScenarioTests.swift
@@ -130,7 +130,8 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
             "RUM Resource should be send for `firstPartyGETResourceURL`"
         )
         XCTAssertEqual(firstPartyResource1.resource.method, .get)
-        XCTAssertGreaterThan(firstPartyResource1.resource.duration, 0)
+        XCTAssertNotNil(firstPartyResource1.resource.duration)
+        XCTAssertGreaterThan(firstPartyResource1.resource.duration!, 0)
 
         XCTAssertNil(firstPartyResource1.dd.traceId, "`firstPartyGETResourceURL` should not be traced")
         XCTAssertNil(firstPartyResource1.dd.spanId, "`firstPartyGETResourceURL` should not be traced")
@@ -141,7 +142,8 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
             "RUM Resource should be send for `firstPartyPOSTResourceURL`"
         )
         XCTAssertEqual(firstPartyResource2.resource.method, .post)
-        XCTAssertGreaterThan(firstPartyResource2.resource.duration, 0)
+        XCTAssertNotNil(firstPartyResource2.resource.duration)
+        XCTAssertGreaterThan(firstPartyResource2.resource.duration!, 0)
         XCTAssertEqual(
             firstPartyResource2.dd.traceId,
             firstPartyPOSTRequestTraceID,
@@ -172,7 +174,8 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
             "RUM Resource should be send for `thirdPartyGETResourceURL`"
         )
         XCTAssertEqual(thirdPartyResource1.resource.method, .get)
-        XCTAssertGreaterThan(thirdPartyResource1.resource.duration, 0)
+        XCTAssertNotNil(thirdPartyResource1.resource.duration)
+        XCTAssertGreaterThan(thirdPartyResource1.resource.duration!, 0)
         XCTAssertNil(thirdPartyResource1.dd.traceId, "3rd party RUM Resources should not be traced")
         XCTAssertNil(thirdPartyResource1.dd.spanId, "3rd party RUM Resources should not be traced")
         XCTAssertNil(thirdPartyResource1.dd.rulePsr, "Not traced resource should not send sample rate")
@@ -182,7 +185,8 @@ class RUMResourcesScenarioTests: IntegrationTests, RUMCommonAsserts {
             "RUM Resource should be send for `thirdPartyPOSTResourceURL`"
         )
         XCTAssertEqual(thirdPartyResource2.resource.method, .post)
-        XCTAssertGreaterThan(thirdPartyResource2.resource.duration, 0)
+        XCTAssertNotNil(thirdPartyResource2.resource.duration)
+        XCTAssertGreaterThan(thirdPartyResource2.resource.duration!, 0)
         XCTAssertNil(thirdPartyResource2.dd.traceId, "3rd party RUM Resources should not be traced")
         XCTAssertNil(thirdPartyResource2.dd.spanId, "3rd party RUM Resources should not be traced")
         XCTAssertNil(thirdPartyResource2.dd.rulePsr, "Not traced resource should not send sample rate")

--- a/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMStopSessionScenarioTests.swift
+++ b/Tests/DatadogIntegrationTests/Scenarios/RUM/RUMStopSessionScenarioTests.swift
@@ -100,8 +100,9 @@ class RUMStopSessionScenarioTests: IntegrationTests, RUMCommonAsserts {
             XCTAssertEqual(view1.resourceEvents[0].resource.url, "https://foo.com/resource/1")
             XCTAssertEqual(view1.resourceEvents[0].resource.statusCode, 200)
             XCTAssertEqual(view1.resourceEvents[0].resource.type, .image)
-            XCTAssertGreaterThan(view1.resourceEvents[0].resource.duration, 100_000_000 - 1) // ~0.1s
-            XCTAssertLessThan(view1.resourceEvents[0].resource.duration, 1_000_000_000 * 30) // less than 30s (big enough to balance NTP sync)
+            XCTAssertNotNil(view1.resourceEvents[0].resource.duration)
+            XCTAssertGreaterThan(view1.resourceEvents[0].resource.duration!, 100_000_000 - 1) // ~0.1s
+            XCTAssertLessThan(view1.resourceEvents[0].resource.duration!, 1_000_000_000 * 30) // less than 30s (big enough to balance NTP sync)
             RUMSessionMatcher.assertViewWasEventuallyInactive(view1)
 
             let view2 = normalSession.viewVisits[1]
@@ -123,8 +124,9 @@ class RUMStopSessionScenarioTests: IntegrationTests, RUMCommonAsserts {
             XCTAssertEqual(view1.resourceEvents[0].resource.url, "https://foo.com/resource/1")
             XCTAssertEqual(view1.resourceEvents[0].resource.statusCode, 200)
             XCTAssertEqual(view1.resourceEvents[0].resource.type, .image)
-            XCTAssertGreaterThan(view1.resourceEvents[0].resource.duration, 100_000_000 - 1) // ~0.1s
-            XCTAssertLessThan(view1.resourceEvents[0].resource.duration, 1_000_000_000 * 30) // less than 30s (big enough to balance NTP sync)
+            XCTAssertNotNil(view1.resourceEvents[0].resource.duration)
+            XCTAssertGreaterThan(view1.resourceEvents[0].resource.duration!, 100_000_000 - 1) // ~0.1s
+            XCTAssertLessThan(view1.resourceEvents[0].resource.duration!, 1_000_000_000 * 30) // less than 30s (big enough to balance NTP sync)
             RUMSessionMatcher.assertViewWasEventuallyInactive(view1)
 
             let view2 = interruptedSession.viewVisits[1]


### PR DESCRIPTION
### What and why?

Since https://github.com/DataDog/dd-sdk-ios/pull/1344 the develop branch `DatadogIntegrationTests` target is broken.

Figured this out after merging develop for https://github.com/DataDog/dd-sdk-ios/pull/1328.

### How?

Adapted tests to new model changes.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
