### PR TITLE
RUMM-2987 Use instance name for data persistency

### DIFF
--- a/DatadogCore/Sources/Core/Storage/Directories.swift
+++ b/DatadogCore/Sources/Core/Storage/Directories.swift
@@ -41,10 +41,10 @@ internal extension CoreDirectory {
     /// 
     /// - Parameters:
     ///   - osDirectory: the root OS directory (`/Library/Caches`) to create core directory inside.
-    ///   - clientToken: The core instance client token.
+    ///   - instancenName: The core instance name.
     ///   - site: The cor instance site.
-    init(in osDirectory: Directory, clientToken: String, site: DatadogSite) throws {
-        let sdkInstanceUUID = sha256("\(clientToken)\(site)")
+    init(in osDirectory: Directory, instancenName: String, site: DatadogSite) throws {
+        let sdkInstanceUUID = sha256("\(instancenName)\(site)")
         let path = "com.datadoghq/v2/\(sdkInstanceUUID)"
 
         self.init(

--- a/DatadogCore/Sources/Datadog.swift
+++ b/DatadogCore/Sources/Datadog.swift
@@ -240,7 +240,8 @@ public struct Datadog {
     /// - Parameters:
     ///   - configuration: the SDK configuration.
     ///   - trackingConsent: the initial state of the Data Tracking Consent given by the user of the app.
-    ///   - instanceName: The core instance name.
+    ///   - instanceName:   The core instance name. This value will be used for data persistency and should be
+    ///                     stable between application runs.
     public static func initialize(
         with configuration: Configuration,
         trackingConsent: TrackingConsent,
@@ -299,7 +300,7 @@ public struct Datadog {
         let core = DatadogCore(
             directory: try CoreDirectory(
                 in: Directory.cache(),
-                clientToken: configuration.clientToken,
+                instancenName: instanceName,
                 site: configuration.site
             ),
             dateProvider: configuration.dateProvider,

--- a/DatadogCore/Tests/Datadog/Core/DirectoriesTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/DirectoriesTests.swift
@@ -24,7 +24,7 @@ class DirectoriesTests: XCTestCase {
 
     func testWhenCreatingCoreDirectory_thenItsNameIsUniqueForClientTokenAndSite() throws {
         // Given
-        let fixtures: [(clientToken: String, site: DatadogSite, expectedName: String)] = [
+        let fixtures: [(instancenName: String, site: DatadogSite, expectedName: String)] = [
             ("abcdef", .us1, "d5f91716d9c17bc76cb9931e1f9ff37724a27d4c05f1eb7081f59ea34d44c777"),
             ("abcdef", .us3, "4a2e7e5b459af9976950e85463db2ba1e71500cdd77ead26b41559bf5a372dfb"),
             ("abcdef", .us5, "38028ebbeab2aa980eab9e5a8ee714f93e8118621472697dabe084e6a9c55cd1"),
@@ -40,10 +40,10 @@ class DirectoriesTests: XCTestCase {
         ]
 
         // When
-        let coreDirectories = try fixtures.map { clientToken, site, _ in
+        let coreDirectories = try fixtures.map { instancenName, site, _ in
             try CoreDirectory(
                 in: directory,
-                clientToken: clientToken,
+                instancenName: instancenName,
                 site: site
             )
         }
@@ -54,7 +54,7 @@ class DirectoriesTests: XCTestCase {
             let directoryName = coreDirectory.coreDirectory.url.lastPathComponent
             XCTAssertEqual(directoryName, fixture.expectedName)
             XCTAssertFalse(
-                directoryName.contains(fixture.clientToken),
+                directoryName.contains(fixture.instancenName),
                 "The core directory name must not include client token"
             )
         }
@@ -65,7 +65,7 @@ class DirectoriesTests: XCTestCase {
         let coreDirectories = try (0..<50).map { index in
             try CoreDirectory(
                 in: directory,
-                clientToken: .mockRandom(among: .alphanumerics, length: 31) + "\(index)",
+                instancenName: .mockRandom(among: .alphanumerics, length: 31) + "\(index)",
                 site: .mockRandom()
             )
         }


### PR DESCRIPTION
### What and why?

Use core instance name instead of client-token for persistent dat folder.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
