### PR TITLE
RUMM-3320 [V1] Fix APM local spans not correlating with RUM views

### DIFF
--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/Example iOS.xcscheme
@@ -32,8 +32,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Datadog/Example/AppConfiguration.swift
+++ b/Datadog/Example/AppConfiguration.swift
@@ -63,6 +63,8 @@ struct ExampleAppConfiguration: AppConfiguration {
                 .enableRUM(true)
                 .enableCrashReporting(using: DDCrashReportingPlugin())
                 .trackBackgroundEvents()
+                .trackURLSession()
+                .set(tracingSamplingRate: 100)
         }
 
         return configuration.build()

--- a/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
@@ -39,6 +39,12 @@ private class DebugRUMSessionViewModel: ObservableObject {
     @Published var errorMessage: String = ""
     @Published var resourceKey: String = ""
 
+    @Published var logMessage: String = ""
+    @Published var spanOperationName: String = ""
+    @Published var instrumentedRequestURL: String = "https://api.shopist.io/checkout.json"
+
+    var urlSessions: [URLSession] = []
+
     func startView() {
         guard !viewKey.isEmpty else {
             return
@@ -74,6 +80,10 @@ private class DebugRUMSessionViewModel: ObservableObject {
         )
 
         Global.rum.addUserAction(type: .custom, name: actionName)
+
+        Thread.sleep(forTimeInterval: 0.05)
+        sendSpan()
+
         self.actionName = ""
     }
 
@@ -115,6 +125,45 @@ private class DebugRUMSessionViewModel: ObservableObject {
         self.resourceKey = ""
     }
 
+    func sendLog() {
+        logger.debug(logMessage)
+        logMessage = ""
+    }
+
+    func sendSpan() {
+        let span = Global.sharedTracer.startRootSpan(operationName: spanOperationName, tags: [:])
+        Thread.sleep(forTimeInterval: 0.1)
+        span.finish()
+        spanOperationName = ""
+    }
+
+    func sendPOSTRequest() {
+        guard let url = URL(string: instrumentedRequestURL) else {
+            print("🔥 POST Request not sent - invalid url: \(instrumentedRequestURL)")
+            return
+        }
+        guard let host = url.host else {
+            print("🔥 POST Request not sent - invalid url host: \(instrumentedRequestURL)")
+            return
+        }
+
+        let delegate = DDURLSessionDelegate(additionalFirstPartyHosts: [host])
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        let task = session.dataTask(with: request) { _, _, error in
+            if let error = error {
+                print("🌍🔥 POST \(url) completed with network error: \(error)")
+            } else {
+                print("🌍 POST \(url) sent successfully")
+            }
+        }
+        task.resume()
+
+        urlSessions.append(session) // keep session
+    }
+
     // MARK: - Private
 
     private func modifySessionItem(type: SessionItemType, label: String, change: (inout SessionItem) -> Void) {
@@ -138,40 +187,80 @@ internal struct DebugRUMSessionView: View {
 
     var body: some View {
         VStack() {
-            HStack {
-                FormItemView(
-                    title: "RUM View", placeholder: "view key", accent: .rumViewColor, value: $viewModel.viewKey
-                )
-                Button("START") { viewModel.startView() }
+            Group {
+                Text("RUM Session")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.caption.weight(.bold))
+                Text("Debug RUM Session by creating events manually:")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.caption.weight(.light))
+                HStack {
+                    FormItemView(
+                        title: "RUM View", placeholder: "view key", accent: .rumViewColor, value: $viewModel.viewKey
+                    )
+                    Button("START") { viewModel.startView() }
+                }
+                HStack {
+                    FormItemView(
+                        title: "RUM Action", placeholder: "name", accent: .rumActionColor, value: $viewModel.actionName
+                    )
+                    Button("ADD") { viewModel.addAction() }
+                }
+                HStack {
+                    FormItemView(
+                        title: "RUM Error", placeholder: "message", accent: .rumErrorColor, value: $viewModel.errorMessage
+                    )
+                    Button("ADD") { viewModel.addError() }
+                }
+                HStack {
+                    FormItemView(
+                        title: "RUM Resource", placeholder: "key", accent: .rumResourceColor, value: $viewModel.resourceKey
+                    )
+                    Button("START") { viewModel.startResource() }
+                }
+                Divider()
             }
-            HStack {
-                FormItemView(
-                    title: "RUM Action", placeholder: "name", accent: .rumActionColor, value: $viewModel.actionName
-                )
-                Button("ADD") { viewModel.addAction() }
+            Group {
+                Text("Bundling Logs and Spans")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.caption.weight(.bold))
+                Text("Debug bundling Logs and Spans with RUM Session by sending them manually while the session is active.")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.caption.weight(.light))
+                HStack {
+                    FormItemView(
+                        title: "Log", placeholder: "log message", accent: .gray, value: $viewModel.logMessage
+                    )
+                    Button("Send") { viewModel.sendLog() }
+                }
+                HStack {
+                    FormItemView(
+                        title: "Span", placeholder: "span name", accent: .gray, value: $viewModel.spanOperationName
+                    )
+                    Button("Send") { viewModel.sendSpan() }
+                }
+                Text("Send 1st party request with instrumented URLSession:")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.caption.weight(.light))
+                HStack {
+                    FormItemView(
+                        title: "POST Request", placeholder: "request url", accent: .gray, value: $viewModel.instrumentedRequestURL
+                    )
+                    Button("Send") { viewModel.sendPOSTRequest() }
+                }
+                Divider()
             }
-            HStack {
-                FormItemView(
-                    title: "RUM Error", placeholder: "message", accent: .rumErrorColor, value: $viewModel.errorMessage
-                )
-                Button("ADD") { viewModel.addError() }
+            Group {
+                Text("Current RUM Session:")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.caption.weight(.bold))
+                List(viewModel.sessionItems) { sessionItem in
+                    SessionItemView(item: sessionItem)
+                        .listRowInsets(EdgeInsets())
+                        .padding(4)
+                }
+                .listStyle(PlainListStyle())
             }
-            HStack {
-                FormItemView(
-                    title: "RUM Resource", placeholder: "key", accent: .rumResourceColor, value: $viewModel.resourceKey
-                )
-                Button("START") { viewModel.startResource() }
-            }
-            Divider()
-            Text("RUM Session:")
-                .bold()
-                .font(.footnote)
-            List(viewModel.sessionItems) { sessionItem in
-                SessionItemView(item: sessionItem)
-                    .listRowInsets(EdgeInsets())
-                    .padding(4)
-            }
-            .listStyle(PlainListStyle())
         }
         .buttonStyle(DatadogButtonStyle())
         .padding()

--- a/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
+++ b/Datadog/Example/Debugging/DebugRUMSessionViewController.swift
@@ -81,10 +81,10 @@ private class DebugRUMSessionViewModel: ObservableObject {
 
         Global.rum.addUserAction(type: .custom, name: actionName)
 
-        Thread.sleep(forTimeInterval: 0.05)
-        sendSpan()
-
-        self.actionName = ""
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            self.sendSpan()
+            self.actionName = ""
+        }
     }
 
     func addError() {

--- a/DatadogSessionReplay/Sources/DatadogCoreIntegration/RUMContextReceiver.swift
+++ b/DatadogSessionReplay/Sources/DatadogCoreIntegration/RUMContextReceiver.swift
@@ -11,8 +11,8 @@ import Datadog
 internal struct RUMContext: Decodable, Equatable {
     internal struct IDs: Decodable, Equatable {
         enum CodingKeys: String, CodingKey {
-            case applicationID = "application_id"
-            case sessionID = "session_id"
+            case applicationID = "application.id"
+            case sessionID = "session.id"
             case viewID = "view.id"
         }
         /// Current RUM application ID - standard UUID string, lowecased.

--- a/DatadogSessionReplay/Sources/DatadogCoreIntegration/RUMDependency.swift
+++ b/DatadogSessionReplay/Sources/DatadogCoreIntegration/RUMDependency.swift
@@ -27,7 +27,7 @@ internal enum RUMDependency {
     ///
     /// SR expects:
     /// - `nil` if current RUM session is not sampled,
-    /// - baggage with `application_id`, `session_id` and `view.id` keys if RUM session is sampled.
+    /// - baggage with `application.id`, `session.id` and `view.id` keys if RUM session is sampled.
     static let ids = "ids"
 
     // MARK: Contract from SR to RUM (mirror of `SessionReplayDependency` in RUM):

--- a/DatadogSessionReplay/Tests/DatadogCoreIntegration/RUMContextReceiverTests.swift
+++ b/DatadogSessionReplay/Tests/DatadogCoreIntegration/RUMContextReceiverTests.swift
@@ -17,9 +17,9 @@ class RUMContextReceiverTests: XCTestCase {
         let context = DatadogContext.mockWith(featuresAttributes: [
             RUMDependency.rumBaggageKey: [
                 RUMDependency.ids: [
-                    RUMDependency.IDs.applicationIDKey: "app-id",
-                    RUMDependency.IDs.sessionIDKey: "session-id",
-                    RUMDependency.IDs.viewIDKey: "view-id"
+                    RUMContext.IDs.CodingKeys.applicationID.rawValue: "app-id",
+                    RUMContext.IDs.CodingKeys.sessionID.rawValue: "session-id",
+                    RUMContext.IDs.CodingKeys.viewID.rawValue: "view-id"
                 ],
                 RUMDependency.serverTimeOffsetKey: TimeInterval(123)
             ]
@@ -68,9 +68,9 @@ class RUMContextReceiverTests: XCTestCase {
         let context1 = DatadogContext.mockWith(featuresAttributes: [
             RUMDependency.rumBaggageKey: [
                 RUMDependency.ids: [
-                    RUMDependency.IDs.applicationIDKey: "app-id-1",
-                    RUMDependency.IDs.sessionIDKey: "session-id-1",
-                    RUMDependency.IDs.viewIDKey: "view-id-1"
+                    RUMContext.IDs.CodingKeys.applicationID.rawValue: "app-id-1",
+                    RUMContext.IDs.CodingKeys.sessionID.rawValue: "session-id-1",
+                    RUMContext.IDs.CodingKeys.viewID.rawValue: "view-id-1"
                 ],
                 RUMDependency.serverTimeOffsetKey: TimeInterval(123)
             ]
@@ -79,9 +79,9 @@ class RUMContextReceiverTests: XCTestCase {
         let context2 = DatadogContext.mockWith(featuresAttributes: [
             RUMDependency.rumBaggageKey: [
                 RUMDependency.ids: [
-                    RUMDependency.IDs.applicationIDKey: "app-id-2",
-                    RUMDependency.IDs.sessionIDKey: "session-id-2",
-                    RUMDependency.IDs.viewIDKey: "view-id-2"
+                    RUMContext.IDs.CodingKeys.applicationID.rawValue: "app-id-2",
+                    RUMContext.IDs.CodingKeys.sessionID.rawValue: "session-id-2",
+                    RUMContext.IDs.CodingKeys.viewID.rawValue: "view-id-2"
                 ],
                 RUMDependency.serverTimeOffsetKey: TimeInterval(345)
             ]
@@ -126,13 +126,5 @@ class RUMContextReceiverTests: XCTestCase {
 
         // Then
         XCTAssertTrue(fallbackCalled)
-    }
-}
-
-fileprivate extension RUMDependency {
-    enum IDs {
-        static let applicationIDKey = "application_id"
-        static let sessionIDKey = "session_id"
-        static let viewIDKey = "view.id"
     }
 }

--- a/Sources/Datadog/Logging/Log/LogEventSanitizer.swift
+++ b/Sources/Datadog/Logging/Log/LogEventSanitizer.swift
@@ -13,7 +13,7 @@ internal struct LogEventSanitizer {
         /// If any of those is used by the user, the attribute will be ignored.
         static let reservedAttributeNames: Set<String> = [
             "host", "message", "status", "service", "source", "ddtags",
-            "dd.trace_id", "dd.span_id",
+            "dd.trace_id", "dd.span_id", "application.id", "session.id",
             "application_id", "session_id", "view.id", "user_action.id",
         ]
         /// Allowed first character of a tag name (given as ASCII values ranging from lowercased `a` to `z`) .

--- a/Sources/Datadog/Logging/LoggingV2Configuration.swift
+++ b/Sources/Datadog/Logging/LoggingV2Configuration.swift
@@ -27,6 +27,17 @@ internal func createLoggingConfiguration(
     )
 }
 
+internal func mapInternalAttributeKey(_ originalAttribute: String) -> String {
+    switch originalAttribute {
+    case "application.id":
+        return "application_id"
+    case "session.id":
+        return "session_id"
+    default:
+        return originalAttribute
+    }
+}
+
 /// The Logging URL Request Builder for formatting and configuring the `URLRequest`
 /// to upload logs data.
 internal struct LoggingRequestBuilder: FeatureRequestBuilder {
@@ -286,7 +297,8 @@ internal struct WebViewLogReceiver: FeatureMessageReceiver {
             }
 
             if let baggage: [String: String?] = context.featuresAttributes["rum"]?.ids {
-                event.merge(baggage as [String: Any]) { $1 }
+                let mappedBaggage = Dictionary(uniqueKeysWithValues: baggage.map { key, value in (mapInternalAttributeKey(key), value) })
+                event.merge(mappedBaggage as [String: Any]) { $1 }
             }
 
             writer.write(value: AnyEncodable(event))

--- a/Sources/Datadog/Logging/RemoteLogger.swift
+++ b/Sources/Datadog/Logging/RemoteLogger.swift
@@ -129,7 +129,8 @@ internal final class RemoteLogger: LoggerProtocol {
 
             if self.rumContextIntegration, let attributes: [String: AnyCodable?] = contextAttributes["rum"]?.ids {
                 let attributes = attributes.compactMapValues { $0 }
-                internalAttributes.merge(attributes) { $1 }
+                let mappedAttributes = Dictionary(uniqueKeysWithValues: attributes.map { key, value in (mapInternalAttributeKey(key), value) })
+                internalAttributes.merge(mappedAttributes) { $1 }
             }
 
             if self.activeSpanIntegration, let attributes = contextAttributes["tracing"] {

--- a/Sources/Datadog/RUM/Integrations/RUMContextAttributes.swift
+++ b/Sources/Datadog/RUM/Integrations/RUMContextAttributes.swift
@@ -10,11 +10,11 @@ import Foundation
 internal enum RUMContextAttributes {
     internal enum IDs {
         /// The ID of RUM application (`String`).
-        internal static let applicationID = "application_id"
+        internal static let applicationID = "application.id"
 
         /// The ID of current RUM session (standard UUID `String`, lowercased).
         /// In case the session is rejected (not sampled), RUM context is set to empty (`[:]`) in core.
-        internal static let sessionID = "session_id"
+        internal static let sessionID = "session.id"
 
         /// The ID of current RUM view (standard UUID `String`, lowercased).
         internal static let viewID = "view.id"

--- a/Sources/Datadog/TracerConfiguration.swift
+++ b/Sources/Datadog/TracerConfiguration.swift
@@ -27,7 +27,7 @@ extension Tracer {
         /// - Parameter enabled: `true` by default
         public var bundleWithRUM: Bool
 
-        /// The sampling rate for Traces, as a Float between 0 and 100. Defautl is 100.
+        /// The sampling rate for Traces, as a Float between 0 and 100. Default is 100.
         public var samplingRate: Float
 
         /// Initializes the Datadog Tracer configuration.

--- a/Sources/Datadog/TracerConfiguration.swift
+++ b/Sources/Datadog/TracerConfiguration.swift
@@ -27,7 +27,7 @@ extension Tracer {
         /// - Parameter enabled: `true` by default
         public var bundleWithRUM: Bool
 
-        /// TRhe sampling rate for Traces, as a Float between 0 and 100.
+        /// The sampling rate for Traces, as a Float between 0 and 100. Defautl is 100.
         public var samplingRate: Float
 
         /// Initializes the Datadog Tracer configuration.

--- a/Sources/Datadog/Tracing/Span/SpanEventEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEventEncoder.swift
@@ -243,10 +243,8 @@ internal struct SpanEventEncoder {
         }
 
         try span.tags.forEach {
-            if $0.value != "null" {
-                let metaKey = "meta.\($0.key)"
-                try container.encode($0.value, forKey: DynamicCodingKey(metaKey))
-            }
+            let metaKey = "meta.\($0.key)"
+            try container.encode($0.value, forKey: DynamicCodingKey(metaKey))
         }
     }
 }

--- a/Sources/Datadog/Tracing/Span/SpanEventEncoder.swift
+++ b/Sources/Datadog/Tracing/Span/SpanEventEncoder.swift
@@ -243,8 +243,10 @@ internal struct SpanEventEncoder {
         }
 
         try span.tags.forEach {
-            let metaKey = "meta.\($0.key)"
-            try container.encode($0.value, forKey: DynamicCodingKey(metaKey))
+            if $0.value != "null" {
+                let metaKey = "meta.\($0.key)"
+                try container.encode($0.value, forKey: DynamicCodingKey(metaKey))
+            }
         }
     }
 }

--- a/Sources/Datadog/Tracing/TracingV2Configuration.swift
+++ b/Sources/Datadog/Tracing/TracingV2Configuration.swift
@@ -72,7 +72,7 @@ internal struct TracingMessageReceiver: FeatureMessageReceiver {
     ///
     /// - Parameter context: The updated core context.
     private func update(context: DatadogContext) -> Bool {
-        if let attributes: [String: String] = context.featuresAttributes["rum"]?.ids {
+        if let attributes: [String: String?] = context.featuresAttributes["rum"]?.ids {
             rum.attributes = attributes
             return true
         }

--- a/Sources/Datadog/Tracing/TracingV2Configuration.swift
+++ b/Sources/Datadog/Tracing/TracingV2Configuration.swift
@@ -18,6 +18,21 @@ internal func createTracingConfiguration(intake: URL) -> DatadogFeatureConfigura
     )
 }
 
+internal func mapInternalTags(_ originalTag: String) -> String {
+    switch originalTag {
+    case "application.id":
+        return "_dd.application.id"
+    case "session.id":
+        return "_dd.session.id"
+    case "view.id":
+        return "_dd.view.id"
+    case "user_action.id":
+        return "_dd.action.id"
+    default:
+        return originalTag
+    }
+}
+
 /// The Tracing URL Request Builder for formatting and configuring the `URLRequest`
 /// to upload traces data.
 internal struct TracingRequestBuilder: FeatureRequestBuilder {
@@ -73,7 +88,9 @@ internal struct TracingMessageReceiver: FeatureMessageReceiver {
     /// - Parameter context: The updated core context.
     private func update(context: DatadogContext) -> Bool {
         if let attributes: [String: String?] = context.featuresAttributes["rum"]?.ids {
-            rum.attributes = attributes
+            let mappedAttribues = Dictionary(uniqueKeysWithValues: attributes.map { key, value in (mapInternalTags(key), value) })
+
+            rum.attributes = mappedAttribues
             return true
         }
         return false

--- a/Sources/Datadog/Tracing/TracingV2Configuration.swift
+++ b/Sources/Datadog/Tracing/TracingV2Configuration.swift
@@ -88,6 +88,7 @@ internal struct TracingMessageReceiver: FeatureMessageReceiver {
     /// - Parameter context: The updated core context.
     private func update(context: DatadogContext) -> Bool {
         if let attributes: [String: String?] = context.featuresAttributes["rum"]?.ids {
+            let attributes = attributes.compactMapValues { $0 }
             let mappedAttribues = Dictionary(uniqueKeysWithValues: attributes.map { key, value in (mapInternalTags(key), value) })
 
             rum.attributes = mappedAttribues

--- a/Tests/DatadogTests/Datadog/LoggerTests.swift
+++ b/Tests/DatadogTests/Datadog/LoggerTests.swift
@@ -562,7 +562,7 @@ class LoggerTests: XCTestCase {
 
         logMatchers.forEach {
             $0.assertValue(
-                forKeyPath: RUMContextAttributes.IDs.sessionID,
+                forKeyPath: "application_id",
                 isTypeOf: String.self
             )
         }
@@ -594,17 +594,17 @@ class LoggerTests: XCTestCase {
 
         logMatchers.forEach {
             $0.assertValue(
-                forKeyPath: RUMContextAttributes.IDs.applicationID,
+                forKeyPath: "application_id",
                 equals: rum.configuration.applicationID
             )
 
             $0.assertValue(
-                forKeyPath: RUMContextAttributes.IDs.sessionID,
+                forKeyPath: "session_id",
                 isTypeOf: String.self
             )
 
             $0.assertValue(
-                forKeyPath: RUMContextAttributes.IDs.viewID,
+                forKeyPath: "view.id",
                 isTypeOf: String.self
             )
         }

--- a/Tests/DatadogTests/Datadog/TracerTests.swift
+++ b/Tests/DatadogTests/Datadog/TracerTests.swift
@@ -715,7 +715,7 @@ class TracerTests: XCTestCase {
 //
 //        // then
 //        let spanMatcher = try core.waitAndReturnSpanMatchers()[0]
-//        XCTAssertValidRumUUID(try spanMatcher.meta.custom(keyPath: "meta.\(RUMContextAttributes.IDs.sessionID)"))
+//        XCTAssertValidRumUUID(try spanMatcher.meta.custom(keyPath: "meta._dd.\(RUMContextAttributes.IDs.sessionID)"))
 //    }
 
     // TODO: RUMM-2843 [V2 regression] RUM context is not associated with span started on caller thread
@@ -743,8 +743,8 @@ class TracerTests: XCTestCase {
 //            try spanMatcher.meta.custom(keyPath: "meta.\(RUMContextAttributes.IDs.applicationID)"),
 //            rum.configuration.applicationID
 //        )
-//        XCTAssertValidRumUUID(try spanMatcher.meta.custom(keyPath: "meta.\(RUMContextAttributes.IDs.sessionID)"))
-//        XCTAssertValidRumUUID(try spanMatcher.meta.custom(keyPath: "meta.\(RUMContextAttributes.IDs.viewID)"))
+//        XCTAssertValidRumUUID(try spanMatcher.meta.custom(keyPath: "meta._dd.\(RUMContextAttributes.IDs.sessionID)"))
+//        XCTAssertValidRumUUID(try spanMatcher.meta.custom(keyPath: "meta._dd.\(RUMContextAttributes.IDs.viewID)"))
 //    }
 
     // MARK: - Injecting span context into carrier


### PR DESCRIPTION
### What and why?

APM <-> RUM correlation was not working for local traces due to mismatch in span tag format between the SDK and APM Backend.

fix: https://github.com/DataDog/dd-sdk-ios/issues/1292

### How?

This PR removes the direct use of `RUMContextAttributes` in both Log and Span encoding. 
Instead, a mapping layer is added that transforms keys into the required format for each product. 

On the Example app, changes are made to allow enabling a simple debugging option. It's now possible to single a single log, a single span, and a single traced request on a particular RUM session.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
