### PR TITLE
REPLAY-1805 image placeholder fixes

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Images.storyboard
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/Images.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -18,15 +18,15 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="dd_logo" translatesAutoresizingMaskIntoConstraints="NO" id="xxq-Cw-MRl">
-                                <rect key="frame" x="156.66666666666666" y="75" width="80" height="80"/>
+                            <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="dd_logo" translatesAutoresizingMaskIntoConstraints="NO" id="xxq-Cw-MRl">
+                                <rect key="frame" x="186.66666666666666" y="107" width="20" height="20"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="80" id="1vb-jA-kiT"/>
-                                    <constraint firstAttribute="width" constant="80" id="KCk-0l-g6b"/>
+                                    <constraint firstAttribute="height" constant="20" id="1vb-jA-kiT"/>
+                                    <constraint firstAttribute="width" constant="20" id="KCk-0l-g6b"/>
                                 </constraints>
                             </imageView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="apple.logo" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KF9-wK-Okh">
-                                <rect key="frame" x="184.66666666666666" y="171.33333333333334" width="24" height="22.333333333333343"/>
+                                <rect key="frame" x="184.66666666666666" y="175.33333333333334" width="24" height="22.333333333333343"/>
                                 <color key="tintColor" systemColor="systemPurpleColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="24" id="QrF-HG-Jtn"/>
@@ -34,7 +34,7 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="zQI-BZ-L2g">
-                                <rect key="frame" x="0.0" y="211" width="393" height="288"/>
+                                <rect key="frame" x="0.0" y="215" width="393" height="288"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="n6y-pj-DAN">
                                         <rect key="frame" x="52.666666666666657" y="0.0" width="288" height="60"/>
@@ -184,7 +184,7 @@
                                 </subviews>
                             </stackView>
                             <tabBar contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="raw-wh-zEy">
-                                <rect key="frame" x="0.0" y="515" width="393" height="49"/>
+                                <rect key="frame" x="0.0" y="519" width="393" height="49"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="49" id="t9n-YU-wtJ"/>
                                 </constraints>
@@ -199,7 +199,7 @@
                                 </items>
                             </tabBar>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ftc-4B-7Pp">
-                                <rect key="frame" x="0.0" y="580" width="393" height="44"/>
+                                <rect key="frame" x="0.0" y="584" width="393" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="4hr-VJ-mh1"/>
                                 </constraints>
@@ -211,14 +211,14 @@
                                 </items>
                             </navigationBar>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vKz-Ut-7bS">
-                                <rect key="frame" x="156.66666666666666" y="640" width="80" height="80"/>
+                                <rect key="frame" x="156.66666666666666" y="644" width="80" height="80"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="80" id="YUK-jg-T8h"/>
                                     <constraint firstAttribute="height" constant="80" id="zPr-qF-VOv"/>
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KxN-zV-mGU">
-                                <rect key="frame" x="252.66666666666666" y="85" width="124.33333333333334" height="60"/>
+                                <rect key="frame" x="254.66666666666666" y="87" width="122.33333333333334" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="HaR-cP-xUI"/>
                                 </constraints>
@@ -233,11 +233,20 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </button>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lus-kO-cFd">
+                                <rect key="frame" x="156.66666666666666" y="738" width="80" height="80"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="80" id="mpr-R0-LJ9"/>
+                                    <constraint firstAttribute="height" constant="80" id="t1B-fG-Ugy"/>
+                                </constraints>
+                            </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="lus-kO-cFd" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="0ds-6f-Hj1"/>
                             <constraint firstItem="vKz-Ut-7bS" firstAttribute="top" secondItem="ftc-4B-7Pp" secondAttribute="bottom" constant="16" id="2KW-Vg-MSH"/>
+                            <constraint firstItem="lus-kO-cFd" firstAttribute="top" secondItem="vKz-Ut-7bS" secondAttribute="bottom" constant="14" id="2Wb-dZ-WYE"/>
                             <constraint firstItem="raw-wh-zEy" firstAttribute="top" secondItem="zQI-BZ-L2g" secondAttribute="bottom" constant="16" id="3Tf-N7-p6F"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="KxN-zV-mGU" secondAttribute="trailing" constant="16" id="Cj8-dU-3FG"/>
                             <constraint firstItem="raw-wh-zEy" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="ET0-BN-qth"/>
@@ -247,17 +256,18 @@
                             <constraint firstItem="ftc-4B-7Pp" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="P5h-A7-U1M"/>
                             <constraint firstItem="zQI-BZ-L2g" firstAttribute="top" secondItem="KF9-wK-Okh" secondAttribute="bottom" constant="16" id="PcY-W5-rVM"/>
                             <constraint firstItem="ftc-4B-7Pp" firstAttribute="top" secondItem="raw-wh-zEy" secondAttribute="bottom" constant="16" id="TIg-KH-e5o"/>
-                            <constraint firstItem="KxN-zV-mGU" firstAttribute="leading" secondItem="xxq-Cw-MRl" secondAttribute="trailing" constant="16" id="VVE-7k-3Tk"/>
+                            <constraint firstItem="KxN-zV-mGU" firstAttribute="leading" secondItem="xxq-Cw-MRl" secondAttribute="trailing" constant="48" id="VVE-7k-3Tk"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="zQI-BZ-L2g" secondAttribute="trailing" id="Wjg-fd-LWW"/>
                             <constraint firstItem="KF9-wK-Okh" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="bah-mp-OGG"/>
-                            <constraint firstItem="KF9-wK-Okh" firstAttribute="top" secondItem="xxq-Cw-MRl" secondAttribute="bottom" constant="16" id="d96-un-7EN"/>
+                            <constraint firstItem="KF9-wK-Okh" firstAttribute="top" secondItem="xxq-Cw-MRl" secondAttribute="bottom" constant="48" id="d96-un-7EN"/>
                             <constraint firstItem="raw-wh-zEy" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="iAJ-aX-zcr"/>
                             <constraint firstItem="vKz-Ut-7bS" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="iGo-IL-Tk7"/>
-                            <constraint firstItem="xxq-Cw-MRl" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="16" id="jIN-YZ-8QX"/>
+                            <constraint firstItem="xxq-Cw-MRl" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="48" id="jIN-YZ-8QX"/>
                             <constraint firstItem="KxN-zV-mGU" firstAttribute="centerY" secondItem="xxq-Cw-MRl" secondAttribute="centerY" id="wlR-Fb-T22"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="contentImageView" destination="lus-kO-cFd" id="Uch-4j-NpS"/>
                         <outlet property="customButton" destination="KxN-zV-mGU" id="zX2-X5-J8J"/>
                         <outlet property="customImageView" destination="vKz-Ut-7bS" id="aJg-Sy-OrB"/>
                         <outlet property="navigationBar" destination="ftc-4B-7Pp" id="Cz6-ki-X2T"/>

--- a/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/ImagesViewControllers.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRHost/Fixtures/ImagesViewControllers.swift
@@ -9,6 +9,7 @@ import UIKit
 internal class ImagesViewController: UIViewController {
     @IBOutlet weak var customButton: UIButton!
     @IBOutlet weak var customImageView: UIImageView!
+    @IBOutlet weak var contentImageView: UIImageView!
     @IBOutlet weak var tabBar: UITabBar!
     @IBOutlet weak var navigationBar: UINavigationBar!
 
@@ -23,6 +24,8 @@ internal class ImagesViewController: UIViewController {
         navigationBar.setBackgroundImage(UIImage(color: color), for: .default)
 
         customImageView.image = UIImage(named: "dd_logo")?.withRenderingMode(.alwaysTemplate)
+
+        contentImageView.image = UIImage(color: color)
     }
 }
 

--- a/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
+++ b/DatadogSessionReplay/Sources/Processor/Diffing/Diff+SRWireframes.swift
@@ -136,6 +136,7 @@ extension SRImageWireframe: MutableWireframe {
                 clip: use(clip, ifDifferentThan: other.clip),
                 height: use(height, ifDifferentThan: other.height),
                 id: id,
+                isEmpty: use(isEmpty, ifDifferentThan: other.isEmpty),
                 mimeType: use(mimeType, ifDifferentThan: other.mimeType),
                 shapeStyle: use(shapeStyle, ifDifferentThan: other.shapeStyle),
                 width: use(width, ifDifferentThan: other.width),


### PR DESCRIPTION
### What and why?

Follow up PR to https://github.com/DataDog/dd-sdk-ios/pull/1326

It fixes clipsToBounds behaviour when image is present.

### How?

Reenabled clipping when image is present + added snapshot tests to cover these scenarios.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
