### PR TITLE
REPLAY-1868 Configure Session Replay uploader to be more eager

### DIFF
--- a/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Drafts/SessionReplayFeature.swift
@@ -62,7 +62,9 @@ internal class SessionReplayFeature: DatadogFeature, SessionReplayController {
         self.requestBuilder = RequestBuilder(customUploadURL: configuration.customUploadURL)
         self.performanceOverride = PerformancePresetOverride(
             maxFileSize: UInt64(10).MB,
-            maxObjectSize: UInt64(10).MB
+            maxObjectSize: UInt64(10).MB,
+            meanFileAge: 5, // equivalent of `batchSize: .small` - see `DatadogCore.PerformancePreset`
+            minUploadDelay: 1 // equivalent of `uploadFrequency: .frequent` - see `DatadogCore.PerformancePreset`
         )
     }
 

--- a/DatadogSessionReplay/Sources/Recorder/WindowObserver/KeyWindowObserver.swift
+++ b/DatadogSessionReplay/Sources/Recorder/WindowObserver/KeyWindowObserver.swift
@@ -17,7 +17,6 @@ internal class KeyWindowObserver: AppWindowObserver {
         if #available(iOS 13.0, tvOS 13.0, *) {
             return findONiOS13AndLater()
         } else {
-            assertionFailure("TODO: RUMM-2409 `AppWindowObserver` isn't yet ready for this version of OS")
             return nil
         }
     }

--- a/Sources/Datadog/Core/PerformancePreset.swift
+++ b/Sources/Datadog/Core/PerformancePreset.swift
@@ -80,12 +80,11 @@ internal extension PerformancePreset {
             }
         }()
 
-        let uploadDelayFactors: (initial: Double, default: Double, min: Double, max: Double, changeRate: Double) = {
+        let uploadDelayFactors: (initial: Double, min: Double, max: Double, changeRate: Double) = {
             switch bundleType {
             case .iOSApp:
                 return (
                     initial: 5,
-                    default: 5,
                     min: 1,
                     max: 10,
                     changeRate: 0.1
@@ -93,7 +92,6 @@ internal extension PerformancePreset {
             case .iOSAppExtension:
                 return (
                     initial: 0.5, // ensures the the first upload is checked quickly after starting the short-lived app extension
-                    default: 3,
                     min: 1,
                     max: 5,
                     changeRate: 0.5 // if batches are found, reduces interval significantly for more uploads in short-lived app extension
@@ -111,7 +109,7 @@ internal extension PerformancePreset {
     init(
         meanFileAge: TimeInterval,
         minUploadDelay: TimeInterval,
-        uploadDelayFactors: (initial: Double, default: Double, min: Double, max: Double, changeRate: Double)
+        uploadDelayFactors: (initial: Double, min: Double, max: Double, changeRate: Double)
     ) {
         self.maxFileSize = UInt64(4).MB
         self.maxDirectorySize = UInt64(512).MB
@@ -126,19 +124,19 @@ internal extension PerformancePreset {
         self.uploadDelayChangeRate = uploadDelayFactors.changeRate
     }
 
-    func updated(with: PerformancePresetOverride) -> PerformancePreset {
+    func updated(with override: PerformancePresetOverride) -> PerformancePreset {
         return PerformancePreset(
-            maxFileSize: with.maxFileSize ?? maxFileSize,
+            maxFileSize: override.maxFileSize ?? maxFileSize,
             maxDirectorySize: maxDirectorySize,
-            maxFileAgeForWrite: maxFileAgeForWrite,
-            minFileAgeForRead: minFileAgeForRead,
+            maxFileAgeForWrite: override.maxFileAgeForWrite ?? maxFileAgeForWrite,
+            minFileAgeForRead: override.minFileAgeForRead ?? minFileAgeForRead,
             maxFileAgeForRead: maxFileAgeForRead,
             maxObjectsInFile: maxObjectsInFile,
-            maxObjectSize: with.maxObjectSize ?? maxObjectSize,
-            initialUploadDelay: initialUploadDelay,
-            minUploadDelay: minUploadDelay,
-            maxUploadDelay: maxUploadDelay,
-            uploadDelayChangeRate: uploadDelayChangeRate
+            maxObjectSize: override.maxObjectSize ?? maxObjectSize,
+            initialUploadDelay: override.initialUploadDelay ?? initialUploadDelay,
+            minUploadDelay: override.minUploadDelay ?? minUploadDelay,
+            maxUploadDelay: override.maxUploadDelay ?? maxUploadDelay,
+            uploadDelayChangeRate: override.uploadDelayChangeRate ?? uploadDelayChangeRate
         )
     }
 }

--- a/Sources/Datadog/DatadogInternal/PerformancePresetOverride.swift
+++ b/Sources/Datadog/DatadogInternal/PerformancePresetOverride.swift
@@ -10,22 +10,74 @@ import Foundation
 /// performance presets by setting optional limits. If the limits are not provided, the default values from
 /// the `PerformancePreset` object will be used.
 public struct PerformancePresetOverride {
-    /// An optional value representing the maximum allowed file size in bytes.
+    /// Overrides the the maximum allowed file size in bytes.
     /// If not provided, the default value from the `PerformancePreset` object is used.
     let maxFileSize: UInt64?
 
-    /// An optional value representing the maximum allowed object size in bytes.
+    /// Overrides the maximum allowed object size in bytes.
     /// If not provided, the default value from the `PerformancePreset` object is used.
     let maxObjectSize: UInt64?
 
-    /// Initializes a new `PerformancePresetOverride` instance with the provided
-    /// maximum file size and maximum object size limits.
+    /// Overrides the maximum age qualifying given file for reuse (in seconds).
+    /// If recently used file is younger than this, it is reused - otherwise: new file is created.
+    let maxFileAgeForWrite: TimeInterval?
+
+    /// Minimum age qualifying given file for upload (in seconds).
+    /// If the file is older than this, it is uploaded (and then deleted if upload succeeded).
+    /// It has an arbitrary offset  (~0.5s) over `maxFileAgeForWrite` to ensure that no upload can start for the file being currently written.
+    let minFileAgeForRead: TimeInterval?
+
+    /// Overrides the initial upload delay (in seconds).
+    /// At runtime, the upload interval starts with `initialUploadDelay` and then ranges from `minUploadDelay` to `maxUploadDelay` depending
+    /// on delivery success or failure.
+    let initialUploadDelay: TimeInterval?
+
+    /// Overrides the mininum  interval of data upload (in seconds).
+    let minUploadDelay: TimeInterval?
+
+    /// Overrides the maximum interval of data upload (in seconds).
+    let maxUploadDelay: TimeInterval?
+
+    /// Overrides the current interval is change on successful upload. Should be less or equal `1.0`.
+    /// E.g: if rate is `0.1` then `delay` will be changed by `delay * 0.1`.
+    let uploadDelayChangeRate: Double?
+
+    /// Initializes a new `PerformancePresetOverride` instance with the provided overrides.
     ///
     /// - Parameters:
     ///   - maxFileSize: The maximum allowed file size in bytes, or `nil` to use the default value from `PerformancePreset`.
     ///   - maxObjectSize: The maximum allowed object size in bytes, or `nil` to use the default value from `PerformancePreset`.
-    public init(maxFileSize: UInt64?, maxObjectSize: UInt64?) {
+    ///   - meanFileAge: The mean age qualifying a file for reuse, or `nil` to use the default value from `PerformancePreset`.
+    ///   - minUploadDelay: The mininum interval of data uploads, or `nil` to use the default value from `PerformancePreset`.
+    public init(
+        maxFileSize: UInt64?,
+        maxObjectSize: UInt64?,
+        meanFileAge: TimeInterval?,
+        minUploadDelay: TimeInterval?
+    ) {
         self.maxFileSize = maxFileSize
         self.maxObjectSize = maxObjectSize
+
+        if let meanFileAge {
+            // Following constants are the same as in `DatadogCore.PerformancePreset`
+            self.maxFileAgeForWrite = meanFileAge * 0.95 // 5% below the mean age
+            self.minFileAgeForRead = meanFileAge * 1.05 //  5% above the mean age
+        } else {
+            self.maxFileAgeForWrite = nil
+            self.minFileAgeForRead = nil
+        }
+
+        if let minUploadDelay {
+            // Following constants are the same as in `DatadogCore.PerformancePreset`
+            self.initialUploadDelay = minUploadDelay * 5
+            self.minUploadDelay = minUploadDelay
+            self.maxUploadDelay = minUploadDelay * 10
+            self.uploadDelayChangeRate = 0.1
+        } else {
+            self.initialUploadDelay = nil
+            self.minUploadDelay = nil
+            self.maxUploadDelay = nil
+            self.uploadDelayChangeRate = nil
+        }
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
@@ -148,6 +148,7 @@ class PerformancePresetTests: XCTestCase {
                 minUploadDelay: .mockRandom()
             )
         )
+
         XCTAssertNotEqual(preset.maxFileSize, updatedPreset.maxFileSize)
         XCTAssertNotEqual(preset.maxObjectSize, updatedPreset.maxObjectSize)
         XCTAssertNotEqual(preset.maxFileAgeForWrite, updatedPreset.maxFileAgeForWrite)
@@ -155,6 +156,6 @@ class PerformancePresetTests: XCTestCase {
         XCTAssertNotEqual(preset.initialUploadDelay, updatedPreset.initialUploadDelay)
         XCTAssertNotEqual(preset.minUploadDelay, updatedPreset.minUploadDelay)
         XCTAssertNotEqual(preset.maxUploadDelay, updatedPreset.maxUploadDelay)
-        XCTAssertNotEqual(preset.uploadDelayChangeRate, updatedPreset.uploadDelayChangeRate)
+        XCTAssertEqual(0.1, updatedPreset.uploadDelayChangeRate)
     }
 }

--- a/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
+++ b/Tests/DatadogTests/Datadog/Core/PerformancePresetTests.swift
@@ -140,8 +140,21 @@ class PerformancePresetTests: XCTestCase {
 
     func testPresetsUpdate() {
         let preset = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .mockRandom(), bundleType: .mockRandom())
-        let updatedPreset = preset.updated(with: PerformancePresetOverride(maxFileSize: .mockRandom(), maxObjectSize: .mockRandom()))
+        let updatedPreset = preset.updated(
+            with: PerformancePresetOverride(
+                maxFileSize: .mockRandom(),
+                maxObjectSize: .mockRandom(),
+                meanFileAge: .mockRandom(),
+                minUploadDelay: .mockRandom()
+            )
+        )
         XCTAssertNotEqual(preset.maxFileSize, updatedPreset.maxFileSize)
         XCTAssertNotEqual(preset.maxObjectSize, updatedPreset.maxObjectSize)
+        XCTAssertNotEqual(preset.maxFileAgeForWrite, updatedPreset.maxFileAgeForWrite)
+        XCTAssertNotEqual(preset.minFileAgeForRead, updatedPreset.minFileAgeForRead)
+        XCTAssertNotEqual(preset.initialUploadDelay, updatedPreset.initialUploadDelay)
+        XCTAssertNotEqual(preset.minUploadDelay, updatedPreset.minUploadDelay)
+        XCTAssertNotEqual(preset.maxUploadDelay, updatedPreset.maxUploadDelay)
+        XCTAssertNotEqual(preset.uploadDelayChangeRate, updatedPreset.uploadDelayChangeRate)
     }
 }

--- a/Tests/DatadogTests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/Tests/DatadogTests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -214,11 +214,18 @@ class DatadogCoreTests: XCTestCase {
         try core.register(
             feature: FeatureMock(
                 name: name,
-                performanceOverride: PerformancePresetOverride(maxFileSize: 123, maxObjectSize: 456)
+                performanceOverride: PerformancePresetOverride(
+                    maxFileSize: 123,
+                    maxObjectSize: 456,
+                    meanFileAge: 100,
+                    minUploadDelay: nil
+                )
             )
         )
         feature = core.v2Features.values.first
         XCTAssertEqual(feature?.storage.authorizedFilesOrchestrator.performance.maxObjectSize, 456)
         XCTAssertEqual(feature?.storage.authorizedFilesOrchestrator.performance.maxFileSize, 123)
+        XCTAssertEqual(feature?.storage.authorizedFilesOrchestrator.performance.maxFileAgeForWrite, 95)
+        XCTAssertEqual(feature?.storage.authorizedFilesOrchestrator.performance.minFileAgeForRead, 105)
     }
 }


### PR DESCRIPTION
### What and why?

📦 This PR tunes the performance of SR uploader, making it more eager. This is to increase reliability of replay uploads.

### How?

The `PerformancePreset` for Session Replay is now overwritten with values that correspond to `uploadFrequency: .fast` and `batchSize: .small` setup.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
