### PR TITLE
REPLAY-1616 Fix flaky behaviour of `tools/sr-snapshots/Shell` util

### DIFF
--- a/tools/sr-snapshots/Sources/Shell/CommandLine.swift
+++ b/tools/sr-snapshots/Sources/Shell/CommandLine.swift
@@ -6,8 +6,10 @@
 
 import Foundation
 
-public struct CommandLineError: Error, CustomStringConvertible {
-    let result: CommandLineResult
+/// An error thrown when shell command exited with non-zero code.
+public struct CommandError: Error, CustomStringConvertible {
+    /// The full result of command.
+    let result: CommandResult
 
     public var description: String {
         return """
@@ -19,10 +21,10 @@ public struct CommandLineError: Error, CustomStringConvertible {
 }
 
 /// Result of executing shell command.
-public struct CommandLineResult {
-    /// Command's STDOUT value.
+public struct CommandResult {
+    /// Command's STDOUT.
     public let output: String?
-    /// Command's STDERR value.
+    /// Command's STDERR.
     public let error: String?
     /// Exit code of the command.
     public let status: Int32
@@ -31,9 +33,9 @@ public struct CommandLineResult {
 /// Protocol for running command line commands
 public protocol CommandLine {
     /// Executes given shell command.
-    /// - Parameter command: command to run
-    /// - Returns: result of the command
-    func shellResult(_ command: String) throws -> CommandLineResult
+    /// - Parameter command: The command to run.
+    /// - Returns: The result of the command.
+    func shellResult(_ command: String) throws -> CommandResult
 }
 
 public extension CommandLine {
@@ -45,7 +47,7 @@ public extension CommandLine {
     func shell(_ command: String) throws -> String {
         let result = try shellResult(command)
         if result.status != 0 {
-            throw CommandLineError(result: result)
+            throw CommandError(result: result)
         } else if let output = result.output, !output.isEmpty {
             return output
         } else if let error = result.error, !error.isEmpty {

--- a/tools/sr-snapshots/Sources/Shell/ProcessCommandLine.swift
+++ b/tools/sr-snapshots/Sources/Shell/ProcessCommandLine.swift
@@ -29,7 +29,7 @@ public class ProcessCommandLine: CommandLine {
         }
         _ = semaphore.wait(timeout: .distantFuture)
 
-        switch result! {
+        switch result! { // swiftlint:disable:this force_unwrapping
         case .success(let result): return result
         case .failure(let error): throw error
         }
@@ -87,7 +87,7 @@ public class ProcessCommandLine: CommandLine {
                 processGroup.enter()
                 let stdoutFile = stdoutPipe.fileHandleForReading
                 let stdoutReadIO = DispatchIO(type: .stream, fileDescriptor: stdoutFile.fileDescriptor, queue: queue) { _ in
-                    try! stdoutFile.close()
+                    try! stdoutFile.close() // swiftlint:disable:this force_try
                 }
                 stdoutReadIO.read(offset: 0, length: .max, queue: queue) { isDone, chunk, error in
                     stdoutData.append(contentsOf: chunk ?? .empty)
@@ -102,7 +102,7 @@ public class ProcessCommandLine: CommandLine {
                 processGroup.enter()
                 let stderrFile = stderrPipe.fileHandleForReading
                 let stderrReadIO = DispatchIO(type: .stream, fileDescriptor: stderrFile.fileDescriptor, queue: queue) { _ in
-                    try! stderrFile.close()
+                    try! stderrFile.close() // swiftlint:disable:this force_try
                 }
                 stderrReadIO.read(offset: 0, length: .max, queue: queue) { isDone, chunk, error in
                     stderrData.append(contentsOf: chunk ?? .empty)
@@ -117,7 +117,7 @@ public class ProcessCommandLine: CommandLine {
                 // We’ve only entered the group once at this point, so the single leave done by the
                 // termination handler is enough to run the notify block and call the
                 // client’s completion handler.
-                task.terminationHandler!(task)
+                task.terminationHandler!(task) // swiftlint:disable:this force_unwrapping
             }
         }
     }

--- a/tools/sr-snapshots/Sources/Shell/ProcessCommandLine.swift
+++ b/tools/sr-snapshots/Sources/Shell/ProcessCommandLine.swift
@@ -5,96 +5,138 @@
  */
 
 import Foundation
+import Dispatch
 
+/// Runs a child process with capturing standard output and standard error.
+///
+/// Inspired by https://developer.apple.com/forums/thread/690310
 public class ProcessCommandLine: CommandLine {
-    private var output: [String] = []
-    private var error: [String] = []
+    public init() {}
 
-    private let notificationCenter: NotificationCenter
-
-    public init(notificationCenter: NotificationCenter = .default) {
-        self.notificationCenter = notificationCenter
-    }
-
-    @discardableResult
-    public func shellResult(_ command: String) throws -> CommandLineResult {
-        output = []
-        error = []
+    /// Executes given shell command.
+    /// - Parameter command: The command to run.
+    /// - Returns: The result of the command.
+    public func shellResult(_ command: String) throws -> CommandResult {
+        var result: Result<CommandResult, Error>? = nil
+        let queue = DispatchQueue(label: "com.datadoghq.cli-\(UUID().uuidString)")
 
         print("🐚 →   \(command)")
 
-        let outpipe = Pipe()
-        let outfh = outpipe.fileHandleForReading
-        outfh.waitForDataInBackgroundAndNotify()
-        notificationCenter.addObserver(self, selector: #selector(readOutput), name: NSNotification.Name.NSFileHandleDataAvailable, object: outfh)
-
-        let errpipe = Pipe()
-        let errfh = errpipe.fileHandleForReading
-        errfh.waitForDataInBackgroundAndNotify()
-        notificationCenter.addObserver(self, selector: #selector(readError), name: NSNotification.Name.NSFileHandleDataAvailable, object: errfh)
-
-        let task = Process()
-        task.launchPath = "/bin/bash"
-        task.arguments = ["-c", command]
-        task.standardOutput = outpipe
-        task.standardError = errpipe
-        task.launch()
-        task.waitUntilExit()
-
-        if task.isRunning {
-            fatalError()
+        let semaphore = DispatchSemaphore(value: 0)
+        shellWithCompletion(command, on: queue) { callbackResult in
+            result = callbackResult
+            semaphore.signal()
         }
+        _ = semaphore.wait(timeout: .distantFuture)
 
-        return CommandLineResult(
-            output: output.joined(separator: "\n"),
-            error: error.joined(separator: "\n"),
-            status: task.terminationStatus
-        )
+        switch result! {
+        case .success(let result): return result
+        case .failure(let error): throw error
+        }
     }
 
-    @objc
-    private func readOutput(notification: Notification) {
-        guard let handle = notification.object as? FileHandle else {
-            return
-        }
+    internal func shellWithCompletion(
+        _ command: String,
+        on queue: DispatchQueue,
+        completion: @escaping (Result<CommandResult, Error>) -> Void
+    ) {
+        queue.async {
+            let processGroup = DispatchGroup()
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            var stdoutData = Data()
+            var stderrData = Data()
+            var posixError: Error? = nil
 
-        let data = handle.availableData
-        if let str = String(data: data, encoding: .utf8) {
-            if let sanitized = sanitize(line: str) {
-                print(sanitized)
-                output.append(sanitized)
+            let task = Process()
+            task.launchPath = "/bin/bash"
+            task.arguments = ["-c", command]
+            task.standardOutput = stdoutPipe
+            task.standardError = stderrPipe
+
+            processGroup.enter()
+            task.terminationHandler = { _ in
+                // In case the latter `try task.run()` throws, bouncing the group leave()
+                // on queue here ensures it is properly teared down.
+                queue.async { processGroup.leave() }
+            }
+
+            // This runs the supplied block when all three events have completed (task
+            // termination and the end of both STDOUT and STDERR reads).
+            processGroup.notify(queue: queue) {
+                if let error = posixError {
+                    completion(.failure(error))
+                } else {
+                    let result = CommandResult(
+                        stdoutData: stdoutData,
+                        stderrData: stderrData,
+                        terminationStatus: task.terminationStatus
+                    )
+                    completion(.success(result))
+                }
+            }
+
+            do {
+                func posixErr(_ error: Int32) -> Error {
+                    NSError(domain: NSPOSIXErrorDomain, code: Int(error), userInfo: nil)
+                }
+
+                try task.run()
+
+                // Enter the process group and leaver it only after STDOUT buffer is read.
+                processGroup.enter()
+                let stdoutFile = stdoutPipe.fileHandleForReading
+                let stdoutReadIO = DispatchIO(type: .stream, fileDescriptor: stdoutFile.fileDescriptor, queue: queue) { _ in
+                    try! stdoutFile.close()
+                }
+                stdoutReadIO.read(offset: 0, length: .max, queue: queue) { isDone, chunk, error in
+                    stdoutData.append(contentsOf: chunk ?? .empty)
+                    if isDone || error != 0 {
+                        stdoutReadIO.close()
+                        if posixError == nil && error != 0 { posixError = posixErr(error) }
+                        processGroup.leave()
+                    }
+                }
+
+                // Enter the process group and leaver it only after STDERR buffer is read.
+                processGroup.enter()
+                let stderrFile = stderrPipe.fileHandleForReading
+                let stderrReadIO = DispatchIO(type: .stream, fileDescriptor: stderrFile.fileDescriptor, queue: queue) { _ in
+                    try! stderrFile.close()
+                }
+                stderrReadIO.read(offset: 0, length: .max, queue: queue) { isDone, chunk, error in
+                    stderrData.append(contentsOf: chunk ?? .empty)
+                    if isDone || error != 0 {
+                        stderrReadIO.close()
+                        if posixError == nil && error != 0 { posixError = posixErr(error) }
+                        processGroup.leave()
+                    }
+                }
+            } catch {
+                posixError = error
+                // We’ve only entered the group once at this point, so the single leave done by the
+                // termination handler is enough to run the notify block and call the
+                // client’s completion handler.
+                task.terminationHandler!(task)
             }
         }
-
-        handle.waitForDataInBackgroundAndNotify()
     }
+}
 
-    @objc
-    private func readError(notification: Notification) {
-        guard let handle = notification.object as? FileHandle else {
-            return
-        }
-
-        let data = handle.availableData
-        if let str = String(data: data, encoding: .utf8) {
-            if let sanitized = sanitize(line: str) {
-                print(sanitized)
-                error.append(sanitized)
-            }
-        }
-        handle.waitForDataInBackgroundAndNotify()
+private extension CommandResult {
+    init(stdoutData: Data, stderrData: Data, terminationStatus: Int32) {
+        self.output = String(data: stdoutData, encoding: .utf8).flatMap(sanitize(output:))
+        self.error = String(data: stderrData, encoding: .utf8).flatMap(sanitize(output:))
+        self.status = terminationStatus
     }
+}
 
-    /// Removes new lines and trailing spaces from a string
-    private func sanitize(line: String) -> String? {
-        var trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count > 0 else {
-            return nil
-        }
-
-        // replace tabs with space
-        trimmed = trimmed.replacingOccurrences(of: "\t", with: " ")
-
-        return trimmed
+/// Removes new lines and trailing spaces from a string
+private func sanitize(output: String) -> String? {
+    var trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.count > 0 else {
+        return nil
     }
+    trimmed = trimmed.replacingOccurrences(of: "\t", with: " ")
+    return trimmed
 }


### PR DESCRIPTION
### What and why?

🧰 This PR fixes flakiness of earlier introduced shell-wrapper package. The issue was surfaced as flaky test on CI.

The `tools/sr-snapshots/Shell` is a sub-package leveraged by `sr-snapshots` automation. Its main purpose is bringing the convenience of executing shell sub-processes in our tooling.

### How?

The earlier implementation of STDOUT and STDERR capturing was too naive. Learning the lesson from [Running a Child Process with Standard Input and Output](https://developer.apple.com/forums/thread/690310) this PR brings a more solid and versatile solution that could be later utilised as shared/common package for other our tooling.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
