### PR TITLE
REPLAY-1463 Enable telemetry in Session Replay

### DIFF
--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -38,8 +38,13 @@ internal class SnapshotTestCase: XCTestCase {
         let expectation = self.expectation(description: "Wait for wireframes")
 
         // Set up SR recorder:
-        let processor = Processor(queue: NoQueue(), writer: Writer())
-        let recorder = try Recorder(processor: processor)
+        let processor = Processor(
+            queue: NoQueue(),
+            writer: Writer(),
+            srContextPublisher: SRContextPublisher(core: PassthroughCoreMock()),
+            telemetry: TelemetryMock()
+        )
+        let recorder = try Recorder(processor: processor, telemetry: TelemetryMock())
 
         // Set up wireframes interception :
         var wireframes: [SRWireframe]?

--- a/DatadogSessionReplay/Sources/Feature/RequestBuilder/Multipart/MultipartFormData.swift
+++ b/DatadogSessionReplay/Sources/Feature/RequestBuilder/Multipart/MultipartFormData.swift
@@ -6,8 +6,19 @@
 
 import Foundation
 
+internal protocol MultipartFormDataBuilder {
+    /// The boundary UUID of this multipart form.
+    var boundary: UUID { get }
+    /// Adds a field.
+    mutating func addFormField(name: String, value: String)
+    /// Adds a file.
+    mutating func addFormData(name: String, filename: String, data: Data, mimeType: String)
+    /// Returns the entire multipart body data (as it should be applied to request).
+    var data: Data { get }
+}
+
 /// A helper facilitating creation of `multipart/form-data` body.
-internal struct MultipartFormData {
+internal struct MultipartFormData: MultipartFormDataBuilder {
     let boundary: UUID
     private var body = Data()
 

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -15,9 +15,14 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
 
     // MARK: - Main Components
 
+    /// Orchestrates the process of capturing next snapshots on the main thread.
     let recordingCoordinator: RecordingCoordinator
+    /// Processes each new snapshot on a background thread and transforms it into records.
     let processor: Processing
+    /// Writes records to sdk core.
     let writer: Writing
+    /// Sends telemetry through sdk core.
+    let telemetry: Telemetry
 
     // MARK: - Initialization
 
@@ -26,18 +31,21 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
         configuration: SessionReplay.Configuration
     ) throws {
         let writer = Writer()
+        let telemetry = TelemetryCore(core: core)
 
         let processor = Processor(
             queue: BackgroundAsyncQueue(named: "com.datadoghq.session-replay.processor"),
             writer: writer,
-            srContextPublisher: SRContextPublisher(core: core)
+            srContextPublisher: SRContextPublisher(core: core),
+            telemetry: telemetry
         )
 
         let scheduler = MainThreadScheduler(interval: 0.1)
         let messageReceiver = RUMContextReceiver()
 
         let recorder = try Recorder(
-            processor: processor
+            processor: processor,
+            telemetry: telemetry
         )
         let recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,
@@ -52,12 +60,16 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
         self.recordingCoordinator = recordingCoordinator
         self.processor = processor
         self.writer = writer
-        self.requestBuilder = RequestBuilder(customUploadURL: configuration.customEndpoint)
+        self.requestBuilder = RequestBuilder(
+            customUploadURL: configuration.customEndpoint,
+            telemetry: telemetry
+        )
         self.performanceOverride = PerformancePresetOverride(
             maxFileSize: UInt64(10).MB,
             maxObjectSize: UInt64(10).MB,
             meanFileAge: 5, // equivalent of `batchSize: .small` - see `DatadogCore.PerformancePreset`
             minUploadDelay: 1 // equivalent of `uploadFrequency: .frequent` - see `DatadogCore.PerformancePreset`
         )
+        self.telemetry = telemetry
     }
 }

--- a/DatadogSessionReplay/Sources/Recorder/Recorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Recorder.swift
@@ -58,9 +58,12 @@ internal class Recorder: Recording {
     private let touchSnapshotProducer: TouchSnapshotProducer
     /// Turns view tree snapshots into data models that will be uploaded to SR BE.
     private let snapshotProcessor: Processing
+    /// Sends telemetry through sdk core.
+    private let telemetry: Telemetry
 
     convenience init(
-        processor: Processing
+        processor: Processing,
+        telemetry: Telemetry
     ) throws {
         let windowObserver = KeyWindowObserver()
         let viewTreeSnapshotProducer = WindowViewTreeSnapshotProducer(
@@ -75,7 +78,8 @@ internal class Recorder: Recording {
             uiApplicationSwizzler: try UIApplicationSwizzler(handler: touchSnapshotProducer),
             viewTreeSnapshotProducer: viewTreeSnapshotProducer,
             touchSnapshotProducer: touchSnapshotProducer,
-            snapshotProcessor: processor
+            snapshotProcessor: processor,
+            telemetry: telemetry
         )
     }
 
@@ -83,12 +87,14 @@ internal class Recorder: Recording {
         uiApplicationSwizzler: UIApplicationSwizzler,
         viewTreeSnapshotProducer: ViewTreeSnapshotProducer,
         touchSnapshotProducer: TouchSnapshotProducer,
-        snapshotProcessor: Processing
+        snapshotProcessor: Processing,
+        telemetry: Telemetry
     ) {
         self.uiApplicationSwizzler = uiApplicationSwizzler
         self.viewTreeSnapshotProducer = viewTreeSnapshotProducer
         self.touchSnapshotProducer = touchSnapshotProducer
         self.snapshotProcessor = snapshotProcessor
+        self.telemetry = telemetry
         uiApplicationSwizzler.swizzle()
     }
 
@@ -108,8 +114,8 @@ internal class Recorder: Recording {
             }
             let touchSnapshot = touchSnapshotProducer.takeSnapshot(context: recorderContext)
             snapshotProcessor.process(viewTreeSnapshot: viewTreeSnapshot, touchSnapshot: touchSnapshot)
-        } catch {
-            print("Failed to capture the snapshot: \(error)") // TODO: RUMM-2410 Use `DD.logger` and / or `DD.telemetry`
+        } catch let error {
+            telemetry.error("[SR] Failed to take snapshot", error: DDError(error: error))
         }
     }
 }

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/RequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/RequestBuilderTests.swift
@@ -9,7 +9,6 @@ import DatadogInternal
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 
-// swiftlint:disable empty_xctest_method
 class RequestBuilderTests: XCTestCase {
     private let rumContext: RUMContext = .mockRandom() // all records must reference the same RUM context
     private var mockEvents: [Event] {
@@ -134,7 +133,7 @@ class RequestBuilderTests: XCTestCase {
             var formFiles: [String: (filename: String, data: Data, mimeType: String)] = [:]
             var returnedData: Data = .mockRandom()
 
-            var boundary: UUID = UUID()
+            var boundary = UUID()
             func addFormField(name: String, value: String) { formFields[name] = value }
             func addFormData(name: String, filename: String, data: Data, mimeType: String) {
                 formFiles[name] = (filename: filename, data: data, mimeType: mimeType)
@@ -191,4 +190,3 @@ class RequestBuilderTests: XCTestCase {
         )
     }
 }
-// swiftlint:enable empty_xctest_method

--- a/DatadogSessionReplay/Tests/Feature/RequestBuilder/RequestBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Feature/RequestBuilder/RequestBuilderTests.swift
@@ -5,40 +5,190 @@
  */
 
 import XCTest
-
+import DatadogInternal
 @testable import DatadogSessionReplay
 @testable import TestUtilities
 
 // swiftlint:disable empty_xctest_method
 class RequestBuilderTests: XCTestCase {
-    func testWhenCustomUploadURLIsNotSet_itCreatesRequestsToAppropriateDatadogSite() {
-        // TODO: RUMM-2690
-        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
-        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    private let rumContext: RUMContext = .mockRandom() // all records must reference the same RUM context
+    private var mockEvents: [Event] {
+        let records = [
+            EnrichedRecord(context: .mockWith(rumContext: self.rumContext), records: .mockRandom(count: 5)),
+            EnrichedRecord(context: .mockWith(rumContext: self.rumContext), records: .mockRandom(count: 10)),
+            EnrichedRecord(context: .mockWith(rumContext: self.rumContext), records: .mockRandom(count: 15)),
+        ]
+        return records.map { .mockWith(data: try! JSONEncoder().encode($0)) }
     }
 
-    func testWhenCustomUploadURLIsSet_itCreatesRequestsToCustomURL() {
-        // TODO: RUMM-2690
-        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
-        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    func testItCreatesPOSTRequest() throws {
+        // Given
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockAny())
+
+        // Then
+        XCTAssertEqual(request.httpMethod, "POST")
     }
 
-    func testWhenBatchContainsRecordsFromOneSegment_itCreatesOneRequest() {
-        // TODO: RUMM-2690
-        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
-        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    func testItSetsIntakeURL() {
+        // Given
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+
+        // When
+        func url(for site: DatadogSite) throws -> String {
+            let request = try builder.request(for: mockEvents, with: .mockWith(site: site))
+            return request.url!.absoluteStringWithoutQuery!
+        }
+
+        // Then
+        XCTAssertEqual(try url(for: .us1), "https://session-replay.browser-intake-datadoghq.com/api/v2/replay")
+        XCTAssertEqual(try url(for: .us3), "https://session-replay.browser-intake-us3-datadoghq.com/api/v2/replay")
+        XCTAssertEqual(try url(for: .us5), "https://session-replay.browser-intake-us5-datadoghq.com/api/v2/replay")
+        XCTAssertEqual(try url(for: .eu1), "https://session-replay.browser-intake-datadoghq.eu/api/v2/replay")
+        XCTAssertEqual(try url(for: .ap1), "https://session-replay.browser-intake-datadoghq.eu/api/v2/replay")
+        XCTAssertEqual(try url(for: .us1_fed), "https://session-replay.browser-intake-ddog-gov.com/api/v2/replay")
     }
 
-    func testWhenBatchContainsRecordsFromMultipleSegments_itCreatesMultipleRequests() {
-        // TODO: RUMM-2690
-        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
-        // which is yet not possible as we lack separate, shared module to facilitate tests.
+    func testItSetsCustomIntakeURL() {
+        // Given
+        let randomURL: URL = .mockRandom()
+        let builder = RequestBuilder(customUploadURL: randomURL, telemetry: TelemetryMock())
+
+        // When
+        func url(for site: DatadogSite) throws -> String {
+            let request = try builder.request(for: mockEvents, with: .mockWith(site: site))
+            return request.url!.absoluteStringWithoutQuery!
+        }
+
+        // Then
+        let expectedURL = randomURL.absoluteStringWithoutQuery
+        XCTAssertEqual(try url(for: .us1), expectedURL)
+        XCTAssertEqual(try url(for: .us3), expectedURL)
+        XCTAssertEqual(try url(for: .us5), expectedURL)
+        XCTAssertEqual(try url(for: .eu1), expectedURL)
+        XCTAssertEqual(try url(for: .ap1), expectedURL)
+        XCTAssertEqual(try url(for: .us1_fed), expectedURL)
+    }
+
+    func testItSetsNoQueryParameters() throws {
+        // Given
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+        let context: DatadogContext = .mockRandom()
+
+        // When
+        let request = try builder.request(for: mockEvents, with: context)
+
+        // Then
+        XCTAssertEqual(request.url!.query, nil)
+    }
+
+    func testItSetsHTTPHeaders() throws {
+        let randomApplicationName: String = .mockRandom(among: .alphanumerics)
+        let randomVersion: String = .mockRandom(among: .decimalDigits)
+        let randomSource: String = .mockRandom(among: .alphanumerics)
+        let randomSDKVersion: String = .mockRandom(among: .alphanumerics)
+        let randomClientToken: String = .mockRandom()
+        let randomDeviceName: String = .mockRandom()
+        let randomDeviceOSName: String = .mockRandom()
+        let randomDeviceOSVersion: String = .mockRandom()
+
+        // Given
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+        let context: DatadogContext = .mockWith(
+            clientToken: randomClientToken,
+            version: randomVersion,
+            source: randomSource,
+            sdkVersion: randomSDKVersion,
+            applicationName: randomApplicationName,
+            device: .mockWith(
+                name: randomDeviceName,
+                osName: randomDeviceOSName,
+                osVersion: randomDeviceOSVersion
+            )
+        )
+
+        // When
+        let request = try builder.request(for: mockEvents, with: context)
+
+        // Then
+        let contentType = try XCTUnwrap(request.allHTTPHeaderFields?["Content-Type"])
+        XCTAssertTrue(contentType.matches(regex: #"multipart\/form-data; boundary=([0-9A-Fa-f]{8}(-[0-9A-Fa-f]{4}){3}-[0-9A-Fa-f]{12})"#))
+        XCTAssertEqual(
+            request.allHTTPHeaderFields?["User-Agent"],
+            """
+            \(randomApplicationName)/\(randomVersion) CFNetwork (\(randomDeviceName); \(randomDeviceOSName)/\(randomDeviceOSVersion))
+            """
+        )
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-API-KEY"], randomClientToken)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN"], randomSource)
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-EVP-ORIGIN-VERSION"], randomSDKVersion)
+        XCTAssertNil(request.allHTTPHeaderFields?["Content-Encoding"], "It must us no compression, because multipart file is compressed separately")
+        XCTAssertEqual(request.allHTTPHeaderFields?["DD-REQUEST-ID"]?.matches(regex: .uuidRegex), true)
+    }
+
+    func testItSetsHTTPBodyInExpectedFormat() throws {
+        class MultipartBuilderSpy: MultipartFormDataBuilder {
+            var formFields: [String: String] = [:]
+            var formFiles: [String: (filename: String, data: Data, mimeType: String)] = [:]
+            var returnedData: Data = .mockRandom()
+
+            var boundary: UUID = UUID()
+            func addFormField(name: String, value: String) { formFields[name] = value }
+            func addFormData(name: String, filename: String, data: Data, mimeType: String) {
+                formFiles[name] = (filename: filename, data: data, mimeType: mimeType)
+            }
+            var data: Data { returnedData }
+        }
+
+        // Given
+        let multipartSpy = MultipartBuilderSpy()
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock(), multipartBuilder: multipartSpy)
+
+        // When
+        let request = try builder.request(for: mockEvents, with: .mockWith(source: "ios"))
+
+        // Then
+        let contentType = try XCTUnwrap(request.allHTTPHeaderFields?["Content-Type"])
+        XCTAssertTrue(contentType.matches(regex: "multipart/form-data; boundary=\(multipartSpy.boundary.uuidString)"))
+        XCTAssertEqual(multipartSpy.formFiles["segment"]?.filename, rumContext.ids.sessionID)
+        XCTAssertEqual(multipartSpy.formFiles["segment"]?.mimeType, "application/octet-stream")
+        XCTAssertEqual(multipartSpy.formFields["segment"], rumContext.ids.sessionID)
+        XCTAssertEqual(multipartSpy.formFields["application.id"], rumContext.ids.applicationID)
+        XCTAssertEqual(multipartSpy.formFields["view.id"], rumContext.ids.viewID!)
+        XCTAssertTrue(["true", "false"].contains(multipartSpy.formFields["has_full_snapshot"]!))
+        XCTAssertEqual(multipartSpy.formFields["records_count"], "30")
+        XCTAssertNotNil(multipartSpy.formFields["raw_segment_size"])
+        XCTAssertNotNil(multipartSpy.formFields["start"])
+        XCTAssertNotNil(multipartSpy.formFields["end"])
+        XCTAssertEqual(multipartSpy.formFields["source"], "ios")
     }
 
     func testWhenBatchDataIsMalformed_itThrows() {
-        // TODO: RUMM-2690
-        // Implementing this test requires creating mocks for `DatadogContext` (passed in `FeatureRequestBuilder`),
-        // which is yet not possible as we lack separate, shared module to facilitate tests.
+        // Given
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: TelemetryMock())
+
+        // When, Then
+        XCTAssertThrowsError(try builder.request(for: [.mockWith(data: "abc".utf8Data)], with: .mockAny()))
+    }
+
+    func testWhenSourceIsInvalid_itSendsErrorTelemetry() throws {
+        // Given
+        let telemetry = TelemetryMock()
+        let builder = RequestBuilder(customUploadURL: nil, telemetry: telemetry)
+
+        // When
+        _ = try builder.request(for: mockEvents, with: .mockWith(source: "invalid source"))
+
+        // Then
+        XCTAssertEqual(
+            telemetry.description,
+            """
+            Telemetry logs:
+             - [error] [SR] Could not create segment source from provided string 'invalid source', kind: nil, stack: nil
+            """
+        )
     }
 }
 // swiftlint:enable empty_xctest_method

--- a/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SRDataModelsMocks.swift
@@ -1221,6 +1221,13 @@ internal extension SRRecord {
         default: return nil
         }
     }
+
+    var fullSnapshot: SRFullSnapshotRecord? {
+        switch self {
+        case .fullSnapshotRecord(let value): return value
+        default: return nil
+        }
+    }
 }
 
 extension SRIncrementalSnapshotRecord {

--- a/DatadogSessionReplay/Tests/Mocks/SnapshotProducerMocks.swift
+++ b/DatadogSessionReplay/Tests/Mocks/SnapshotProducerMocks.swift
@@ -10,15 +10,34 @@ import Foundation
 // MARK: - `ViewTreeSnapshotProducer` Mocks
 
 internal class ViewTreeSnapshotProducerMock: ViewTreeSnapshotProducer {
-    /// Succeding snapshots to return for each `takeSnapshot()`.
-    var succeedingSnapshots: [ViewTreeSnapshot]
+    enum TakeSnapshotResult {
+        case snapshot(ViewTreeSnapshot)
+        case error(Error)
+    }
 
-    init(succeedingSnapshots: [ViewTreeSnapshot]) {
-        self.succeedingSnapshots = succeedingSnapshots
+    /// Succeding results for each `takeSnapshot()`.
+    var succeedingResults: [TakeSnapshotResult]
+
+    convenience init(succeedingSnapshots: [ViewTreeSnapshot]) {
+        self.init(succeedingResults: succeedingSnapshots.map { .snapshot($0) })
+    }
+
+    convenience init(succeedingErrors: [Error]) {
+        self.init(succeedingResults: succeedingErrors.map { .error($0) })
+    }
+
+    init(succeedingResults: [TakeSnapshotResult]) {
+        self.succeedingResults = succeedingResults
     }
 
     func takeSnapshot(with context: Recorder.Context) throws -> ViewTreeSnapshot? {
-        return succeedingSnapshots.isEmpty ? nil : succeedingSnapshots.removeFirst()
+        guard let result = succeedingResults.isEmpty ? nil : succeedingResults.removeFirst() else {
+            return nil
+        }
+        switch result {
+        case .snapshot(let snapshot): return snapshot
+        case .error(let error): throw error
+        }
     }
 }
 

--- a/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/ProcessorTests.swift
@@ -29,7 +29,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher)
+        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -61,7 +61,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher)
+        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -108,7 +108,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher)
+        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let view = UIView.mock(withFixture: .visible(.someAppearance))
         view.frame = CGRect(x: 0, y: 0, width: 100, height: 200)
         let rotatedView = UIView.mock(withFixture: .visible(.someAppearance))
@@ -147,7 +147,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher)
+        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When
@@ -201,7 +201,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher)
+        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
 
         // When
         let touchSnapshot = generateTouchSnapshot(startAt: earliestTouchTime, endAt: snapshotTime, numberOfTouches: numberOfTouches)
@@ -246,7 +246,7 @@ class ProcessorTests: XCTestCase {
         // Given
         let core = PassthroughCoreMock()
         let srContextPublisher = SRContextPublisher(core: core)
-        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher)
+        let processor = Processor(queue: NoQueue(), writer: writer, srContextPublisher: srContextPublisher, telemetry: TelemetryMock())
         let viewTree = generateSimpleViewTree()
 
         // When

--- a/DatadogSessionReplay/Tests/Processor/SRDataModelsBuilder/RecordsBuilderTests.swift
+++ b/DatadogSessionReplay/Tests/Processor/SRDataModelsBuilder/RecordsBuilderTests.swift
@@ -1,0 +1,70 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+@testable import DatadogSessionReplay
+
+class RecordsBuilderTests: XCTestCase {
+    func testWhenPreviousAndNextWireframesAreTheSame_itCreatesNoIncrementalSnapshotRecord() {
+        let builder = RecordsBuilder(telemetry: TelemetryMock())
+
+        // Given
+        let wireframes: [SRWireframe] = .mockRandom()
+
+        // When
+        XCTAssertNil(
+            builder.createIncrementalSnapshotRecord(from: .mockAny(), with: wireframes, lastWireframes: wireframes),
+            "If wireframes did not change, it should return no record"
+        )
+    }
+
+    func testWhenPreviousAndNextWireframesAreDifferent_itCreatesIncrementalSnapshotRecord() throws {
+        let builder = RecordsBuilder(telemetry: TelemetryMock())
+
+        // Given
+        let previous: [SRWireframe] = [.mockRandomWith(id: 0), .mockRandomWith(id: 1)]
+        let next: [SRWireframe] = previous + [.mockRandomWith(id: 2)]
+
+        // When
+        let record = builder.createIncrementalSnapshotRecord(from: .mockAny(), with: next, lastWireframes: previous)
+
+        // Then
+        let incrementalRecord = try XCTUnwrap(record?.incrementalSnapshot)
+        guard case .mutationData(let mutations) = incrementalRecord.data else {
+            XCTFail("Expected `mutationData` in incremental record, got \(incrementalRecord.data)")
+            return
+        }
+        XCTAssertTrue(mutations.updates.isEmpty)
+        XCTAssertTrue(mutations.removes.isEmpty)
+        XCTAssertEqual(mutations.adds.count, 1)
+        XCTAssertEqual(mutations.adds[0].previousId, 1)
+        DDAssertReflectionEqual(mutations.adds[0].wireframe, next[2])
+    }
+
+    func testWhenWireframesAreNotConsistent_itFallbacksToFullSnapshotRecordAndSendsErrorTelemetry() throws {
+        let telemetry = TelemetryMock()
+        let builder = RecordsBuilder(telemetry: telemetry)
+
+        // Given
+        let previous: [SRWireframe] = [.shapeWireframe(value: .mockRandomWith(id: 1))]
+        let next: [SRWireframe] = [.textWireframe(value: .mockRandomWith(id: 1))] // illegal: different wireframe type for the same ID
+
+        // When
+        let record = builder.createIncrementalSnapshotRecord(from: .mockAny(), with: next, lastWireframes: previous)
+
+        // Then
+        let fullRecord = try XCTUnwrap(record?.fullSnapshot)
+        DDAssertReflectionEqual(fullRecord.data.wireframes, next)
+        XCTAssertEqual(
+            telemetry.description,
+            """
+            Telemetry logs:
+             - [error] [SR] Failed to create incremental record - typeMismatch, kind: WireframeMutationError, stack: typeMismatch
+            """
+        )
+    }
+}


### PR DESCRIPTION
### What and why?

📦 For observability, this PR enables telemetry logs in Session Replay module.

### How?

Solved all `TODO: send telemetry` left previously due to unavailability of `TelemetryCore` in early development of SR.

Notably, we're enabling 4 telemetry errors:
```
[SR] Could not create segment source from provided string '\(context.source)'
```
```
[SR] Unexpected flow in `Processor`: no previous wireframes and no previous RUM context
```
```
[SR] Failed to create incremental record
```
```
[SR] Failed to take snapshot
```

🎁🏕️ With the full availability of V2, I also filled some gaps in tests coverage. This includes adding missing tests for components that were not covered due to lack of `DatadogInternal` constructs and mocks from `TestUtilities`:
* `SessionReplay: RequestBuilderTests`
* `SessionReplay: RecordsBuilderTests`

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
