### PR TITLE
RUMM-3162 Add missing fields RUM for Apple Crash format

### DIFF
--- a/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
@@ -86,8 +86,8 @@ class CrashLogReceiverTests: XCTestCase {
             ],
             meta: .init(
                 incidentIdentifier: "incident-identifier",
-                processName: "process-name",
-                parentProcess: "parent-process",
+                process: "process [1]",
+                parentProcess: "parent-process [0]",
                 path: "process/path",
                 codeType: "arch",
                 exceptionType: "EXCEPTION_TYPE",

--- a/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CrashReportingFeatureMocks.swift
@@ -226,7 +226,7 @@ internal extension DDCrashReport.Meta {
     static func mockAny() -> DDCrashReport.Meta {
         return DDCrashReport.Meta(
             incidentIdentifier: nil,
-            processName: nil,
+            process: nil,
             parentProcess: nil,
             path: nil,
             codeType: nil,

--- a/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/Integrations/CrashReportReceiverTests.swift
@@ -455,8 +455,8 @@ class CrashReportReceiverTests: XCTestCase {
             ],
             meta: .init(
                 incidentIdentifier: "incident-identifier",
-                processName: "process-name",
-                parentProcess: "parent-process",
+                process: "process [1]",
+                parentProcess: "parent-process [0]",
                 path: "process/path",
                 codeType: "arch",
                 exceptionType: "EXCEPTION_TYPE",

--- a/DatadogCrashReporting/Sources/CrashReportingPlugin.swift
+++ b/DatadogCrashReporting/Sources/CrashReportingPlugin.swift
@@ -83,7 +83,7 @@ internal class DDCrashReport: NSObject, Codable {
         /// A client-generated 16-byte UUID of the incident.
         let incidentIdentifier: String?
         /// The name of the crashed process.
-        let processName: String?
+        let process: String?
         /// Parent process information.
         let parentProcess: String?
         /// The location of the executable on disk.
@@ -97,7 +97,7 @@ internal class DDCrashReport: NSObject, Codable {
 
         init(
             incidentIdentifier: String?,
-            processName: String?,
+            process: String?,
             parentProcess: String?,
             path: String?,
             codeType: String?,
@@ -105,7 +105,7 @@ internal class DDCrashReport: NSObject, Codable {
             exceptionCodes: String?
         ) {
             self.incidentIdentifier = incidentIdentifier
-            self.processName = processName
+            self.process = process
             self.parentProcess = parentProcess
             self.path = path
             self.codeType = codeType
@@ -115,7 +115,7 @@ internal class DDCrashReport: NSObject, Codable {
 
         enum CodingKeys: String, CodingKey {
             case incidentIdentifier = "incident_identifier"
-            case processName = "process"
+            case process = "process"
             case parentProcess = "parent_process"
             case path = "path"
             case codeType = "code_type"

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/CrashReport.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/CrashReport.swift
@@ -42,6 +42,8 @@ internal struct SystemInfo {
 internal struct CrashedProcessInfo {
     /// The name of the process.
     var processName: String?
+    /// The process ID.
+    var processID: UInt
     /// The path to the process executable.
     var processPath: String?
     /// The parent process ID.
@@ -175,6 +177,7 @@ extension CrashedProcessInfo {
         }
 
         self.processName = processInfo.processName
+        self.processID = processInfo.processID
         self.processPath = processInfo.processPath
         self.parentProcessID = processInfo.parentProcessID
         self.parentProcessName = processInfo.parentProcessName

--- a/DatadogCrashReporting/Sources/PLCrashReporterIntegration/DDCrashReportExporter.swift
+++ b/DatadogCrashReporting/Sources/PLCrashReporterIntegration/DDCrashReportExporter.swift
@@ -176,14 +176,12 @@ internal struct DDCrashReportExporter {
     // MARK: - Exporting meta information
 
     private func formattedMeta(for crashReport: CrashReport) -> DDCrashReport.Meta {
-        var parentProcessDescription: String? = nil
+        let process = crashReport.processInfo.map { info in
+            info.processName.map { "\($0) [\(info.processID)]" } ?? "[\(info.processID)]"
+        }
 
-        if let processInfo = crashReport.processInfo {
-            if let parentProcessName = processInfo.parentProcessName {
-                parentProcessDescription = "\(parentProcessName) [\(processInfo.parentProcessID)]"
-            } else {
-                parentProcessDescription = "[\(processInfo.parentProcessID)]"
-            }
+        let parentProcess = crashReport.processInfo.map { info in
+            info.parentProcessName.map { "\($0) [\(info.parentProcessID)]" } ?? "[\(info.parentProcessID)]"
         }
 
         let anyBinaryImageWithKnownArchitecture = crashReport.binaryImages.first { $0.codeType?.architectureName != nil }
@@ -191,8 +189,8 @@ internal struct DDCrashReportExporter {
 
         return .init(
             incidentIdentifier: crashReport.incidentIdentifier,
-            processName: crashReport.processInfo?.processName,
-            parentProcess: parentProcessDescription,
+            process: process,
+            parentProcess: parentProcess,
             path: crashReport.processInfo?.processPath,
             codeType: cpuArchitecture,
             exceptionType: crashReport.signalInfo?.name,

--- a/DatadogCrashReporting/Tests/Mocks.swift
+++ b/DatadogCrashReporting/Tests/Mocks.swift
@@ -59,7 +59,7 @@ internal extension DDCrashReport {
             binaryImages: [],
             meta: .init(
                 incidentIdentifier: "any",
-                processName: "any",
+                process: "any",
                 parentProcess: "any",
                 path: "any",
                 codeType: "any",
@@ -217,12 +217,14 @@ extension CrashReport {
 extension CrashedProcessInfo {
     static func mockWith(
         processName: String? = nil,
+        processID: UInt = 1,
         processPath: String? = nil,
         parentProcessID: UInt = 0,
         parentProcessName: String? = nil
     ) -> CrashedProcessInfo {
         return CrashedProcessInfo(
             processName: processName,
+            processID: processID,
             processPath: processPath,
             parentProcessID: parentProcessID,
             parentProcessName: parentProcessName

--- a/DatadogCrashReporting/Tests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
+++ b/DatadogCrashReporting/Tests/PLCrashReporterIntegration/DDCrashReportExporterTests.swift
@@ -358,10 +358,23 @@ class DDCrashReportExporterTests: XCTestCase {
         XCTAssertEqual(exporter.export(crashReport).meta.incidentIdentifier, randomIdentifier)
     }
 
-    func testExportingProcessName() {
+    func testExportingProcess() {
         let randomName: String = .mockRandom()
-        crashReport.processInfo = .mockWith(processName: randomName)
-        XCTAssertEqual(exporter.export(crashReport).meta.processName, randomName)
+        let randomID: UInt = .mockRandom()
+        crashReport.processInfo = .mockWith(
+            processName: randomName,
+            processID: randomID
+        )
+        XCTAssertEqual(exporter.export(crashReport).meta.process, "\(randomName) [\(randomID)]")
+    }
+
+    func testExportingProcessID() {
+        let randomID: UInt = .mockRandom()
+        crashReport.processInfo = .mockWith(
+            processName: nil,
+            processID: randomID
+        )
+        XCTAssertEqual(exporter.export(crashReport).meta.process, "[\(randomID)]")
     }
 
     func testExportingParentProcess() {

--- a/DatadogInternal/Sources/Context/DeviceInfo.swift
+++ b/DatadogInternal/Sources/Context/DeviceInfo.swift
@@ -25,6 +25,9 @@ public struct DeviceInfo: Codable, Equatable, DictionaryEncodable {
     /// The version of the operating system, e.g. "15.4.1".
     public let osVersion: String
 
+    /// The build numer of the operating system, e.g.  "15D21" or "13D20".
+    public let osBuildNumber: String?
+
     /// The architecture of the device
     public let architecture: String
 
@@ -33,6 +36,7 @@ public struct DeviceInfo: Codable, Equatable, DictionaryEncodable {
         model: String,
         osName: String,
         osVersion: String,
+        osBuildNumber: String?,
         architecture: String
     ) {
         self.brand = "Apple"
@@ -40,6 +44,7 @@ public struct DeviceInfo: Codable, Equatable, DictionaryEncodable {
         self.model = model
         self.osName = osName
         self.osVersion = osVersion
+        self.osBuildNumber = osBuildNumber
         self.architecture = architecture
     }
 }
@@ -50,25 +55,6 @@ import UIKit
 import MachO
 
 extension DeviceInfo {
-    /// Creates device info based on UIKit description.
-    ///
-    /// - Parameters:
-    ///   - model: The model name.
-    ///   - device: The `UIDevice` description.
-    public init(
-        model: String,
-        device: UIDevice,
-        architecture: String
-    ) {
-        self.init(
-            name: device.model,
-            model: model,
-            osName: device.systemName,
-            osVersion: device.systemVersion,
-            architecture: architecture
-        )
-    }
-
     /// Creates device info based on UIKit description.
     ///
     /// - Parameters:
@@ -83,13 +69,17 @@ extension DeviceInfo {
             architecture = String(utf8String: archInfo.name) ?? "unknown"
         }
 
+        let build = try? Sysctl.osVersion()
+
         #if !targetEnvironment(simulator)
+        let model = try? Sysctl.model()
         // Real iOS device
         self.init(
             name: device.model,
-            model: (try? Sysctl.getModel()) ?? device.model,
+            model: model ?? device.model,
             osName: device.systemName,
             osVersion: device.systemVersion,
+            osBuildNumber: build,
             architecture: architecture
         )
         #else
@@ -100,6 +90,7 @@ extension DeviceInfo {
             model: "\(model) Simulator",
             osName: device.systemName,
             osVersion: device.systemVersion,
+            osBuildNumber: build,
             architecture: architecture
         )
         #endif

--- a/DatadogInternal/Sources/Context/Sysctl.swift
+++ b/DatadogInternal/Sources/Context/Sysctl.swift
@@ -63,11 +63,16 @@ internal struct Sysctl {
 
     /// e.g. "MacPro4,1" or "iPhone8,1"
     /// NOTE: this is *corrected* on iOS devices to fetch hw.machine
-    static func getModel() throws -> String {
+    static func model() throws -> String {
         #if os(iOS) && !arch(x86_64) && !arch(i386) // iOS device && not Simulator
             return try Sysctl.string(for: [CTL_HW, HW_MACHINE])
         #else
             return try Sysctl.string(for: [CTL_HW, HW_MODEL])
         #endif
+    }
+
+    /// e.g. "15D21" or "13D20"
+    static func osVersion() throws -> String {
+        try Sysctl.string(for: [CTL_KERN, KERN_OSVERSION])
     }
 }

--- a/DatadogInternal/Tests/Context/DeviceInfoTests.swift
+++ b/DatadogInternal/Tests/Context/DeviceInfoTests.swift
@@ -14,23 +14,22 @@ class DeviceInfoTests: XCTestCase {
         let randomModel: String = .mockRandom()
         let randomOSName: String = .mockRandom()
         let randomOSVersion: String = .mockRandom()
-        let randomArchitecutre: String = .mockRandom()
-
         let info = DeviceInfo(
-            model: randomModel,
+            processInfo: ProcessInfoMock(environment: [
+                "SIMULATOR_MODEL_IDENTIFIER": randomModel
+            ]),
             device: UIDeviceMock(
                 model: randomUIDeviceModel,
                 systemName: randomOSName,
                 systemVersion: randomOSVersion
-            ),
-            architecture: randomArchitecutre
+            )
         )
 
         XCTAssertEqual(info.brand, "Apple")
         XCTAssertEqual(info.name, randomUIDeviceModel)
-        XCTAssertEqual(info.model, randomModel)
+        XCTAssertEqual(info.model, "\(randomModel) Simulator")
         XCTAssertEqual(info.osName, randomOSName)
         XCTAssertEqual(info.osVersion, randomOSVersion)
-        XCTAssertEqual(info.architecture, randomArchitecutre)
+        XCTAssertNotNil(info.osBuildNumber)
     }
 }

--- a/DatadogRUM/Sources/RUMEvent/RUMOperatingSystemInfo.swift
+++ b/DatadogRUM/Sources/RUMEvent/RUMOperatingSystemInfo.swift
@@ -15,7 +15,7 @@ extension RUMOperatingSystem {
     init(device: DeviceInfo) {
         self.name = device.osName
         self.version = device.osVersion
+        self.build = device.osBuildNumber
         self.versionMajor = device.osVersion.split(separator: ".").first.map { String($0) } ?? device.osVersion
-        self.build = nil
     }
 }

--- a/DatadogRUM/Tests/RUMEvent/RUMOperatingSystemInfoTests.swift
+++ b/DatadogRUM/Tests/RUMEvent/RUMOperatingSystemInfoTests.swift
@@ -11,13 +11,19 @@ class RUMOperatingSystemInfoTests: XCTestCase {
     func testItSetsOSNameAndVersion() {
         let randomOSName: String = .mockRandom()
         let randomOSVersion: String = .mockRandom()
+        let randomOSBuild: String = .mockRandom()
 
         let info = RUMOperatingSystem(
-            device: .mockWith(osName: randomOSName, osVersion: randomOSVersion)
+            device: .mockWith(
+                osName: randomOSName,
+                osVersion: randomOSVersion,
+                osBuildNumber: randomOSBuild
+            )
         )
 
         XCTAssertEqual(info.name, randomOSName)
         XCTAssertEqual(info.version, randomOSVersion)
+        XCTAssertEqual(info.build, randomOSBuild)
     }
 
     func testItInfersOSMajorVersion() {

--- a/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
+++ b/DatadogRUM/Tests/RUMMonitor/Scopes/RUMViewScopeTests.swift
@@ -15,7 +15,9 @@ class RUMViewScopeTests: XCTestCase {
         service: "test-service",
         device: .mockWith(
             name: "device-name",
-            osName: "device-os"
+            osName: "device-os",
+            osVersion: "os-version",
+            osBuildNumber: "os-build"
         ),
         networkConnectionInfo: nil,
         carrierInfo: nil
@@ -232,6 +234,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.service, "test-service")
         XCTAssertEqual(event.device?.name, "device-name")
         XCTAssertEqual(event.os?.name, "device-os")
+        XCTAssertEqual(event.os?.version, "os-version")
+        XCTAssertEqual(event.os?.build, "os-build")
         XCTAssertEqual(event.dd.replayStats?.recordsCount, 1)
     }
 
@@ -309,6 +313,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.service, "test-service")
         XCTAssertEqual(event.device?.name, "device-name")
         XCTAssertEqual(event.os?.name, "device-os")
+        XCTAssertEqual(event.os?.version, "os-version")
+        XCTAssertEqual(event.os?.build, "os-build")
     }
 
     func testWhenViewIsStopped_itSendsViewUpdateEvent_andEndsTheScope() throws {
@@ -374,6 +380,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.service, "test-service")
         XCTAssertEqual(event.device?.name, "device-name")
         XCTAssertEqual(event.os?.name, "device-os")
+        XCTAssertEqual(event.os?.version, "os-version")
+        XCTAssertEqual(event.os?.build, "os-build")
     }
 
     func testWhenAnotherViewIsStarted_itEndsTheScope() throws {
@@ -869,6 +877,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(firstActionEvent.service, "test-service")
         XCTAssertEqual(firstActionEvent.device?.name, "device-name")
         XCTAssertEqual(firstActionEvent.os?.name, "device-os")
+        XCTAssertEqual(firstActionEvent.os?.version, "os-version")
+        XCTAssertEqual(firstActionEvent.os?.build, "os-build")
     }
 
     func testGivenViewWithNoPendingAction_whenCustomActionIsAdded_itSendsItInstantly() throws {
@@ -915,6 +925,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(firstActionEvent.service, "test-service")
         XCTAssertEqual(firstActionEvent.device?.name, "device-name")
         XCTAssertEqual(firstActionEvent.os?.name, "device-os")
+        XCTAssertEqual(firstActionEvent.os?.version, "os-version")
+        XCTAssertEqual(firstActionEvent.os?.build, "os-build")
     }
 
     func testWhenDiscreteUserActionHasFrustration_itSendsFrustrationCount() throws {
@@ -1039,6 +1051,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(error.service, "test-service")
         XCTAssertEqual(error.device?.name, "device-name")
         XCTAssertEqual(error.os?.name, "device-os")
+        XCTAssertEqual(error.os?.version, "os-version")
+        XCTAssertEqual(error.os?.build, "os-build")
 
         let viewUpdate = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
         XCTAssertEqual(viewUpdate.view.error.count, 1)
@@ -1243,6 +1257,8 @@ class RUMViewScopeTests: XCTestCase {
         XCTAssertEqual(event.service, "test-service")
         XCTAssertEqual(event.device?.name, "device-name")
         XCTAssertEqual(event.os?.name, "device-os")
+        XCTAssertEqual(event.os?.version, "os-version")
+        XCTAssertEqual(event.os?.build, "os-build")
 
         let viewUpdate = try XCTUnwrap(writer.events(ofType: RUMViewEvent.self).last)
         XCTAssertEqual(viewUpdate.view.longTask?.count, 1)

--- a/TestUtilities/Mocks/DatadogContextMock.swift
+++ b/TestUtilities/Mocks/DatadogContextMock.swift
@@ -111,6 +111,7 @@ extension DeviceInfo {
         model: String = .mockAny(),
         osName: String = .mockAny(),
         osVersion: String = .mockAny(),
+        osBuildNumber: String = .mockAny(),
         architecture: String = .mockAny()
     ) -> DeviceInfo {
         return .init(
@@ -118,6 +119,7 @@ extension DeviceInfo {
             model: model,
             osName: osName,
             osVersion: osVersion,
+            osBuildNumber: osBuildNumber,
             architecture: architecture
         )
     }
@@ -128,6 +130,7 @@ extension DeviceInfo {
             model: .mockRandom(),
             osName: .mockRandom(),
             osVersion: .mockRandom(),
+            osBuildNumber: .mockRandom(),
             architecture: .mockRandom()
         )
     }

--- a/TestUtilities/Mocks/FoundationMocks.swift
+++ b/TestUtilities/Mocks/FoundationMocks.swift
@@ -567,16 +567,25 @@ extension URLRequest: AnyMockable {
 
 public class ProcessInfoMock: ProcessInfo {
     private var _isLowPowerModeEnabled: Bool
+    private var _environment: [String: String]
     private var _arguments: [String]
 
-    public init(isLowPowerModeEnabled: Bool = .mockAny(), arguments: [String] = []) {
+    public init(
+        isLowPowerModeEnabled: Bool = .mockAny(),
+        environment: [String: String] = [:],
+        arguments: [String] = []
+    ) {
         _isLowPowerModeEnabled = isLowPowerModeEnabled
+        _environment = environment
         _arguments = arguments
     }
 
     public override var isLowPowerModeEnabled: Bool { _isLowPowerModeEnabled }
 
+    public override var environment: [String : String] { _environment }
+
     public override var arguments: [String] { _arguments }
+
 }
 
 // MARK: - URLSession


### PR DESCRIPTION
### What and why?

Add missing error fields in RUM to enable crash export to Apple format.

### How?

- `os.build`: The OS build number.
- `error.meta.process`: Add the process ID: `process_name [process_id]`

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
