### PR TITLE
REPLAY-1892 Sanitize invalid `CGColor` values

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/Utilities/CFType+Safety.swift
+++ b/DatadogSessionReplay/Sources/Recorder/Utilities/CFType+Safety.swift
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import CoreGraphics
+
+/// Sanitizes and validates Core Foundation types.
+///
+/// Verifies if the given `value` is of the expected type specified by `expectedTypeID`.
+/// Returns the value if the type matches; otherwise, returns `nil`.
+///
+/// This method is used to sanitize attributes that can be set dynamically, leveraging the Objective-C runtime. For example:
+///
+/// ```
+/// // If an invalid value is set dynamically (e.g., with User Defined Runtime Attributes in Storyboard):
+/// view.setValue("string value", forKeyPath: "layer.borderColor")
+///
+/// // The following will crash:
+/// let alpha = view.layer.borderColor?.alpha
+///
+/// // Sanitizing it will return `nil` and prevent the crash:
+/// let alpha = sanitize(value: view.layer.borderColor, expectedTypeID: CGColor.typeID)?.alpha
+/// ```
+///
+/// For full context, see: https://github.com/DataDog/dd-sdk-ios/pull/1373
+///
+/// Reference: [CFTypeRef - Core Foundation](https://developer.apple.com/documentation/corefoundation/cftyperef)
+private func sanitize<T: CFTypeRef>(value: T?, expectedTypeID: CFTypeID) -> T? {
+    guard let value = value, CFGetTypeID(value) == expectedTypeID else {
+        return nil
+    }
+    return value
+}
+
+internal extension CGColor {
+    /// Casts receiver to valid `CGColor` object.
+    /// Returns value only if this underlying `CFTypeRef` is of `CGColor.typeID` type.
+    var safeCast: CGColor? { sanitize(value: self, expectedTypeID: CGColor.typeID) }
+}

--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshot.swift
@@ -101,8 +101,8 @@ internal struct ViewAttributes: Equatable {
 extension ViewAttributes {
     init(frameInRootView: CGRect, view: UIView) {
         self.frame = frameInRootView
-        self.backgroundColor = view.backgroundColor?.cgColor
-        self.layerBorderColor = view.layer.borderColor
+        self.backgroundColor = view.backgroundColor?.cgColor.safeCast
+        self.layerBorderColor = view.layer.borderColor?.safeCast
         self.layerBorderWidth = view.layer.borderWidth
         self.layerCornerRadius = view.layer.cornerRadius
         self.alpha = view.alpha

--- a/DatadogSessionReplay/Sources/Utilities/Colors.swift
+++ b/DatadogSessionReplay/Sources/Utilities/Colors.swift
@@ -13,6 +13,13 @@ import UIKit
 ///   - color: the color
 /// - Returns: `#RRGGBBAA` string or `nil` if it cannot be constructed for given `color`.
 internal func hexString(from color: CGColor) -> String? {
+    guard let color = color.safeCast else {
+        // Because `CGColor` is dynamic CF type it is possible to get some other CFTypeRef here.
+        // To avoid crash on sending message to unexpected type, we sanitize here.
+        // For full context, see: https://github.com/DataDog/dd-sdk-ios/pull/1373
+        return nil
+    }
+
     let uiColor = UIColor(cgColor: color) // TODO: RUMM-2250 Check if there's a way without converting to `UIColor`
 
     var r: CGFloat = 0

--- a/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/ViewTreeSnapshotTests.swift
@@ -136,6 +136,18 @@ class ViewAttributesTests: XCTestCase {
         XCTAssertFalse(attributes.isTranslucent)
     }
 
+    func testItSanitizesInvalidRuntimeAttributes() {
+        // Given
+        let view = UIView(frame: .zero)
+        view.setValue("invalid color", forKeyPath: "layer.borderColor")
+
+        // When
+        let attributes = ViewAttributes(frameInRootView: view.frame, view: view)
+
+        // Then
+        XCTAssertNil(attributes.layerBorderColor)
+    }
+
     func testWhenCopy() {
         let view: UIView = .mockRandom()
         let rect: CGRect = .mockRandom()

--- a/DatadogSessionReplay/Tests/Utilities/CFType+SafetyTests.swift
+++ b/DatadogSessionReplay/Tests/Utilities/CFType+SafetyTests.swift
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import XCTest
+@testable import DatadogSessionReplay
+
+class CFTypeSafetyTests: XCTestCase {
+    func testInvalidCGColorValueIsSanitized() {
+        let valid: CGColor = UIColor.red.cgColor
+        XCTAssertEqual(valid, valid.safeCast)
+
+        let string: Any = "invalid CGColor value"
+        let invalid = string as! CGColor
+        XCTAssertNil(invalid.safeCast)
+    }
+}

--- a/DatadogSessionReplay/Tests/Utilities/ColorsTests.swift
+++ b/DatadogSessionReplay/Tests/Utilities/ColorsTests.swift
@@ -72,4 +72,10 @@ class ColorsTests: XCTestCase {
             XCTAssertEqual(expectedHex, actualHex)
         }
     }
+
+    func testWhenConvertingInvalidCGColorRef() {
+        let string: Any = "invalid CGColor value"
+        let color = string as! CGColor
+        XCTAssertNil(hexString(from: color))
+    }
 }


### PR DESCRIPTION
### What and why?

📦 This PR adds a guard logic in SR to prevent it from crashing the app if the assumed value of `view.layer.borderColor` is not a valid [`CGColor`](https://developer.apple.com/documentation/coregraphics/cgcolor) object.

Such situation is likely possible in apps that leverage User Defined Runtime Attributes and do it wrong like in this example:

<img width="25%" alt="Screenshot 2023-07-11 at 14 46 18 (2)" src="https://github.com/DataDog/dd-sdk-ios/assets/2358722/7f9b0540-55ee-4ba4-a841-1098dfec1b4f">

Although the `layer.borderColor` seems to be set properly, at runtime it is resolved to `UIDynamicCatalogSystemColor` at runtime, which isn't compatible with `CGColor`. Calling `layer.borderColor?.alpha` in such case will crash the app. Interestingly, this seems to only impact `view.layer` properties as they use `CG*` types. Setting `view.backgroundColor` this way will work because `UIKit` is smart enough to resolve `UIColor` properly.

We consider this likely and possible, hence we want to prevent SR from causing crashes by adding safety check.

### How?

Added basic check with [`CFGetTypeID(_:)`](https://developer.apple.com/documentation/corefoundation/1521218-cfgettypeid) to guard if the `typeID` of received CGColor is indeed [`CGColor.typeID`](https://developer.apple.com/documentation/coregraphics/cgcolor/1455568-typeid).

The fact that view attribtues are captured in with immutable `ViewAttributes` construct helped to centralise this check. Added second sanity check in the `hexString(from:)` logic, which is the only place where we query assumed `CGColor` objects.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
