### PR TITLE
RUMM-3327 Add missing fields to Logs for Apple Crash format

### DIFF
--- a/DatadogCore/Tests/Datadog/LoggerTests.swift
+++ b/DatadogCore/Tests/Datadog/LoggerTests.swift
@@ -37,7 +37,12 @@ class LoggerTests: XCTestCase {
             version: "1.0.0",
             sdkVersion: "1.2.3",
             applicationBundleIdentifier: "com.datadoghq.ios-sdk",
-            device: .mockWith(architecture: "testArch")
+            device: .mockWith(
+                name: "testOS",
+                osVersion: "1.0",
+                osBuildNumber: "FFFFFF",
+                architecture: "testArch"
+            )
         )
 
         let feature: LogsFeature = .mockWith(
@@ -53,6 +58,11 @@ class LoggerTests: XCTestCase {
         {
           "status" : "debug",
           "message" : "message",
+          "os": {
+            "build": "FFFFFF",
+            "name": "testOS",
+            "version": "1.0"
+          },
           "service" : "default-service-name",
           "logger.name" : "com.datadoghq.ios-sdk",
           "logger.version": "1.2.3",

--- a/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
+++ b/DatadogCore/Tests/Datadog/Logs/CrashLogReceiverTests.swift
@@ -97,12 +97,19 @@ class CrashLogReceiverTests: XCTestCase {
         )
 
         let mockArchitecture = String.mockRandom()
+        let mockOSName: String = .mockRandom()
+        let mockOSVersion: String = .mockRandom()
+        let mockOSBuild: String = .mockRandom()
+
         let crashContext: CrashContext = .mockWith(
             serverTimeOffset: dateCorrectionOffset,
             service: .mockRandom(),
             env: .mockRandom(),
             version: .mockRandom(),
             device: .mockWith(
+                name: mockOSName,
+                osVersion: mockOSVersion,
+                osBuildNumber: mockOSBuild,
                 architecture: mockArchitecture
             ),
             sdkVersion: .mockRandom(),
@@ -142,6 +149,11 @@ class CrashLogReceiverTests: XCTestCase {
             threadName: nil,
             applicationVersion: crashContext.version,
             dd: .init(device: .init(architecture: mockArchitecture)),
+            os: .init(
+                name: mockOSName,
+                version: mockOSVersion,
+                build: mockOSBuild
+            ),
             userInfo: .init(
                 id: user.id,
                 name: user.name,

--- a/DatadogCore/Tests/Datadog/Mocks/LogsMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/LogsMocks.swift
@@ -101,6 +101,7 @@ extension LogEvent: AnyMockable, RandomMockable {
         threadName: String = .mockAny(),
         applicationVersion: String = .mockAny(),
         dd: LogEvent.Dd = .mockAny(),
+        os: LogEvent.OperatingSystem = .mockAny(),
         userInfo: UserInfo = .mockAny(),
         networkConnectionInfo: NetworkConnectionInfo = .mockAny(),
         mobileCarrierInfo: CarrierInfo? = .mockAny(),
@@ -119,6 +120,7 @@ extension LogEvent: AnyMockable, RandomMockable {
             threadName: threadName,
             applicationVersion: applicationVersion,
             dd: dd,
+            os: os,
             userInfo: userInfo,
             networkConnectionInfo: networkConnectionInfo,
             mobileCarrierInfo: mobileCarrierInfo,
@@ -140,6 +142,7 @@ extension LogEvent: AnyMockable, RandomMockable {
             threadName: .mockRandom(),
             applicationVersion: .mockRandom(),
             dd: .mockRandom(),
+            os: .mockRandom(),
             userInfo: .mockRandom(),
             networkConnectionInfo: .mockRandom(),
             mobileCarrierInfo: .mockRandom(),
@@ -193,6 +196,24 @@ extension LogEvent.Dd: AnyMockable, RandomMockable {
     public static func mockRandom() -> LogEvent.Dd {
         return LogEvent.Dd(
             device: .mockRandom()
+        )
+    }
+}
+
+extension LogEvent.OperatingSystem: AnyMockable, RandomMockable {
+    public static func mockAny() -> Self {
+        .init(
+            name: .mockAny(),
+            version: .mockAny(),
+            build: .mockAny()
+        )
+    }
+
+    public static func mockRandom() -> Self {
+        .init(
+            name: .mockRandom(),
+            version: .mockRandom(),
+            build: .mockRandom()
         )
     }
 }

--- a/DatadogLogs/Sources/Feature/MessageReceivers.swift
+++ b/DatadogLogs/Sources/Feature/MessageReceivers.swift
@@ -230,6 +230,11 @@ internal struct CrashLogReceiver: FeatureMessageReceiver {
             dd: .init(
                 device: .init(architecture: deviceInfo.architecture)
             ),
+            os: .init(
+                name: context.device.name,
+                version: context.device.osVersion,
+                build: context.device.osBuildNumber
+            ),
             userInfo: .init(
                 id: user?.id,
                 name: user?.name,

--- a/DatadogLogs/Sources/Log/LogEventBuilder.swift
+++ b/DatadogLogs/Sources/Log/LogEventBuilder.swift
@@ -73,6 +73,11 @@ internal struct LogEventBuilder {
             dd: LogEvent.Dd(
                 device: LogEvent.DeviceInfo(architecture: context.device.architecture)
             ),
+            os: .init(
+                name: context.device.name,
+                version: context.device.osVersion,
+                build: context.device.osBuildNumber
+            ),
             userInfo: .init(
                 id: userInfo.id,
                 name: userInfo.name,

--- a/DatadogLogs/Sources/Log/LogEventEncoder.swift
+++ b/DatadogLogs/Sources/Log/LogEventEncoder.swift
@@ -26,6 +26,7 @@ public struct LogEvent: Encodable {
         /// Log attributes added internally by the SDK. They are not a subject for sanitization.
         internal let internalAttributes: [String: Encodable]?
     }
+
     public struct UserInfo {
         /// User ID, if any.
         public let id: String?
@@ -36,6 +37,7 @@ public struct LogEvent: Encodable {
         /// User custom attributes, if any.
         public var extraInfo: [String: Encodable]
     }
+
     public struct Error {
         // The Log error kind
         public var kind: String?
@@ -44,21 +46,24 @@ public struct LogEvent: Encodable {
         // The Log error stack
         public var stack: String?
     }
+
     public struct DeviceInfo: Codable {
         // The architecture of the device
         public let architecture: String
-
-        enum CodingKeys: String, CodingKey {
-            case architecture = "architecture"
-        }
     }
-    public struct Dd: Codable {
-        // Device informatino
-        public let device: DeviceInfo
 
-        enum CodingKeys: String, CodingKey {
-            case device = "device"
-        }
+    public struct OperatingSystem: Codable {
+        /// Operating system name, e.g. Android, iOS
+        public let name: String
+        /// Full operating system version, e.g. 8.1.1
+        public let version: String
+        /// Operating system build number, e.g. 15D21
+        public let build: String?
+    }
+
+    public struct Dd: Codable {
+        // Device information
+        public let device: DeviceInfo
     }
 
     /// The log's timestamp
@@ -83,6 +88,8 @@ public struct LogEvent: Encodable {
     public let applicationVersion: String
     /// Datadog specific attributes
     public let dd: Dd
+    /// The associated log error
+    public let os: OperatingSystem
     /// Custom user information configured globally for the SDK.
     public var userInfo: UserInfo
     /// The network connection information from the moment the log was sent.
@@ -110,6 +117,7 @@ internal struct LogEventEncoder {
         case serviceName = "service"
         case environment = "env"
         case tags = "ddtags"
+        case os = "os"
 
         // MARK: - Error
 
@@ -168,6 +176,7 @@ internal struct LogEventEncoder {
         try container.encode(log.status, forKey: .status)
         try container.encode(log.message, forKey: .message)
         try container.encode(log.serviceName, forKey: .serviceName)
+        try container.encode(log.os, forKey: .os)
 
         // Encode log.error properties
         if let someError = log.error {

--- a/DatadogLogs/Sources/Log/LogEventEncoder.swift
+++ b/DatadogLogs/Sources/Log/LogEventEncoder.swift
@@ -20,6 +20,8 @@ public struct LogEvent: Encodable {
         case critical
         case emergency
     }
+
+    /// Custom attributes associated with a the log event.
     public struct Attributes {
         /// Log custom attributes, They are subject for sanitization.
         public var userAttributes: [String: Encodable]
@@ -27,6 +29,7 @@ public struct LogEvent: Encodable {
         internal let internalAttributes: [String: Encodable]?
     }
 
+    /// User information associated with a the log event.
     public struct UserInfo {
         /// User ID, if any.
         public let id: String?
@@ -38,20 +41,23 @@ public struct LogEvent: Encodable {
         public var extraInfo: [String: Encodable]
     }
 
+    /// Error description associated with a log event.
     public struct Error {
-        // The Log error kind
+        /// The Log error kind
         public var kind: String?
-        // The Log error message
+        /// The Log error message
         public var message: String?
-        // The Log error stack
+        /// The Log error stack
         public var stack: String?
     }
 
+    /// Device information.
     public struct DeviceInfo: Codable {
-        // The architecture of the device
+        /// The architecture of the device
         public let architecture: String
     }
 
+    /// Operating System description.
     public struct OperatingSystem: Codable {
         /// Operating system name, e.g. Android, iOS
         public let name: String
@@ -61,8 +67,9 @@ public struct LogEvent: Encodable {
         public let build: String?
     }
 
+    /// Datadog specific attributes.
     public struct Dd: Codable {
-        // Device information
+        /// Device information
         public let device: DeviceInfo
     }
 

--- a/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
+++ b/DatadogLogs/Tests/Log/LogEventBuilderTests.swift
@@ -61,6 +61,7 @@ class LogEventBuilderTests: XCTestCase {
             XCTAssertEqual(log.loggerName, randomLoggerName)
             XCTAssertEqual(log.threadName, randomThreadName)
             XCTAssertEqual(log.dd.device.architecture, randomArchitecture)
+
             expectation.fulfill()
         }
 
@@ -78,11 +79,18 @@ class LogEventBuilderTests: XCTestCase {
         let randomNetworkInfo: NetworkConnectionInfo = .mockRandom()
         let randomCarrierInfo: CarrierInfo = .mockRandom()
         let randomServerOffset: TimeInterval = .mockRandom(min: -10, max: 10)
+        let randomOSVersion: String = .mockRandom()
+        let randomOSBuild: String = .mockRandom()
+
         let randomSDKContext: DatadogContext = .mockWith(
             env: randomEnvironment,
             version: randomApplicationVersion,
             sdkVersion: randomSDKVersion,
             serverTimeOffset: randomServerOffset,
+            device: .mockWith(
+                osVersion: randomOSVersion,
+                osBuildNumber: randomOSBuild
+            ),
             userInfo: randomUserInfo,
             networkConnectionInfo: randomNetworkInfo,
             carrierInfo: randomCarrierInfo
@@ -118,6 +126,8 @@ class LogEventBuilderTests: XCTestCase {
             DDAssertDictionariesEqual(log.userInfo.extraInfo, randomUserInfo.extraInfo)
             XCTAssertEqual(log.networkConnectionInfo, randomNetworkInfo)
             XCTAssertEqual(log.mobileCarrierInfo, randomCarrierInfo)
+            XCTAssertEqual(log.os.version, randomOSVersion)
+            XCTAssertEqual(log.os.build, randomOSBuild)
             expectation.fulfill()
         }
 

--- a/DatadogLogs/Tests/Mocks/LoggingFeatureMocks.swift
+++ b/DatadogLogs/Tests/Mocks/LoggingFeatureMocks.swift
@@ -95,6 +95,7 @@ extension LogEvent: AnyMockable, RandomMockable {
         threadName: String = .mockAny(),
         applicationVersion: String = .mockAny(),
         dd: LogEvent.Dd = .mockAny(),
+        os: LogEvent.OperatingSystem = .mockAny(),
         userInfo: UserInfo = .mockAny(),
         networkConnectionInfo: NetworkConnectionInfo = .mockAny(),
         mobileCarrierInfo: CarrierInfo? = .mockAny(),
@@ -113,6 +114,7 @@ extension LogEvent: AnyMockable, RandomMockable {
             threadName: threadName,
             applicationVersion: applicationVersion,
             dd: dd,
+            os: os,
             userInfo: userInfo,
             networkConnectionInfo: networkConnectionInfo,
             mobileCarrierInfo: mobileCarrierInfo,
@@ -134,6 +136,7 @@ extension LogEvent: AnyMockable, RandomMockable {
             threadName: .mockRandom(),
             applicationVersion: .mockRandom(),
             dd: .mockRandom(),
+            os: .mockRandom(),
             userInfo: .mockRandom(),
             networkConnectionInfo: .mockRandom(),
             mobileCarrierInfo: .mockRandom(),
@@ -201,6 +204,24 @@ extension LogEvent.DeviceInfo: AnyMockable, RandomMockable {
     public static func mockRandom() -> LogEvent.DeviceInfo {
         return LogEvent.DeviceInfo(
             architecture: .mockRandom()
+        )
+    }
+}
+
+extension LogEvent.OperatingSystem: AnyMockable, RandomMockable {
+    public static func mockAny() -> Self {
+        .init(
+            name: .mockAny(),
+            version: .mockAny(),
+            build: .mockAny()
+        )
+    }
+
+    public static func mockRandom() -> Self {
+        .init(
+            name: .mockRandom(),
+            version: .mockRandom(),
+            build: .mockRandom()
         )
     }
 }


### PR DESCRIPTION
### What and why?

Add missing error fields in Logs to enable crash export to Apple format.

### How?

- `os.name`: The OS name.
- `os.version`: The OS version.
- `os.build`: The OS build number.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
