### PR TITLE
REPLAY-1902 Make SR uploader even more eager

### DIFF
--- a/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/PerformancePresetTests.swift
@@ -140,23 +140,35 @@ class PerformancePresetTests: XCTestCase {
     }
 
     func testPresetsUpdate() {
+        // Given
+        let maxFileSizeOverride: UInt64 = .mockRandom()
+        let maxObjectSizeOverride: UInt64 = .mockRandom()
+        let meanFileAgeOverride: TimeInterval = .mockRandom()
+        let uploadDelayOverride: (initial: TimeInterval, range: Range<TimeInterval>, changeRate: Double) = (
+            initial: .mockRandom(),
+            range: (TimeInterval.mockRandom(min: 1, max: 10)..<TimeInterval.mockRandom(min: 11, max: 100)),
+            changeRate: .mockRandom()
+        )
+
+        // When
         let preset = PerformancePreset(batchSize: .mockRandom(), uploadFrequency: .mockRandom(), bundleType: .mockRandom())
         let updatedPreset = preset.updated(
             with: PerformancePresetOverride(
-                maxFileSize: .mockRandom(),
-                maxObjectSize: .mockRandom(),
-                meanFileAge: .mockRandom(),
-                minUploadDelay: .mockRandom()
+                maxFileSize: maxFileSizeOverride,
+                maxObjectSize: maxObjectSizeOverride,
+                meanFileAge: meanFileAgeOverride,
+                uploadDelay: uploadDelayOverride
             )
         )
 
-        XCTAssertNotEqual(preset.maxFileSize, updatedPreset.maxFileSize)
-        XCTAssertNotEqual(preset.maxObjectSize, updatedPreset.maxObjectSize)
-        XCTAssertNotEqual(preset.maxFileAgeForWrite, updatedPreset.maxFileAgeForWrite)
-        XCTAssertNotEqual(preset.minFileAgeForRead, updatedPreset.minFileAgeForRead)
-        XCTAssertNotEqual(preset.initialUploadDelay, updatedPreset.initialUploadDelay)
-        XCTAssertNotEqual(preset.minUploadDelay, updatedPreset.minUploadDelay)
-        XCTAssertNotEqual(preset.maxUploadDelay, updatedPreset.maxUploadDelay)
-        XCTAssertEqual(0.1, updatedPreset.uploadDelayChangeRate)
+        // Then
+        XCTAssertEqual(updatedPreset.maxFileSize, maxFileSizeOverride)
+        XCTAssertEqual(updatedPreset.maxObjectSize, maxObjectSizeOverride)
+        XCTAssertEqual(updatedPreset.maxFileAgeForWrite, meanFileAgeOverride * 0.95, accuracy: 0.01)
+        XCTAssertEqual(updatedPreset.minFileAgeForRead, meanFileAgeOverride * 1.05, accuracy: 0.01)
+        XCTAssertEqual(updatedPreset.initialUploadDelay, uploadDelayOverride.initial)
+        XCTAssertEqual(updatedPreset.minUploadDelay, uploadDelayOverride.range.lowerBound)
+        XCTAssertEqual(updatedPreset.maxUploadDelay, uploadDelayOverride.range.upperBound)
+        XCTAssertEqual(updatedPreset.uploadDelayChangeRate, uploadDelayOverride.changeRate)
     }
 }

--- a/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
+++ b/DatadogCore/Tests/Datadog/DatadogCore/DatadogCoreTests.swift
@@ -212,7 +212,7 @@ class DatadogCoreTests: XCTestCase {
                     maxFileSize: 123,
                     maxObjectSize: 456,
                     meanFileAge: 100,
-                    minUploadDelay: nil
+                    uploadDelay: nil
                 )
             )
         )

--- a/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
+++ b/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
@@ -49,11 +49,12 @@ public struct PerformancePresetOverride {
     ///   - maxObjectSize: The maximum allowed object size in bytes, or `nil` to use the default value from `PerformancePreset`.
     ///   - meanFileAge: The mean age qualifying a file for reuse, or `nil` to use the default value from `PerformancePreset`.
     ///   - minUploadDelay: The mininum interval of data uploads, or `nil` to use the default value from `PerformancePreset`.
+    ///   - uploadDelay: The configuration of time interval for data uploads (initial, minimum, maximum and change rate). Set `nil` to use the default value from `PerformancePreset`.
     public init(
         maxFileSize: UInt64?,
         maxObjectSize: UInt64?,
         meanFileAge: TimeInterval?,
-        minUploadDelay: TimeInterval?
+        uploadDelay: (initial: TimeInterval, range: Range<TimeInterval>, changeRate: Double)?
     ) {
         self.maxFileSize = maxFileSize
         self.maxObjectSize = maxObjectSize
@@ -67,12 +68,11 @@ public struct PerformancePresetOverride {
             self.minFileAgeForRead = nil
         }
 
-        if let minUploadDelay {
-            // Following constants are the same as in `DatadogCore.PerformancePreset`
-            self.initialUploadDelay = minUploadDelay * 5
-            self.minUploadDelay = minUploadDelay
-            self.maxUploadDelay = minUploadDelay * 10
-            self.uploadDelayChangeRate = 0.1
+        if let uploadDelay = uploadDelay {
+            self.initialUploadDelay = uploadDelay.initial
+            self.minUploadDelay = uploadDelay.range.lowerBound
+            self.maxUploadDelay = uploadDelay.range.upperBound
+            self.uploadDelayChangeRate = uploadDelay.changeRate
         } else {
             self.initialUploadDelay = nil
             self.minUploadDelay = nil

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -67,8 +67,12 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
         self.performanceOverride = PerformancePresetOverride(
             maxFileSize: UInt64(10).MB,
             maxObjectSize: UInt64(10).MB,
-            meanFileAge: 5, // equivalent of `batchSize: .small` - see `DatadogCore.PerformancePreset`
-            minUploadDelay: 1 // equivalent of `uploadFrequency: .frequent` - see `DatadogCore.PerformancePreset`
+            meanFileAge: 2, // vs 5s with `batchSize: .small` - see `DatadogCore.PerformancePreset`
+            uploadDelay: (
+                initial: 2, // vs 5s with `uploadFrequency: .frequent`
+                range: 0.6..<6, // vs 1s ..< 10s with `uploadFrequency: .frequent`
+                changeRate: 0.75 // vs 0.1 with `uploadFrequency: .frequent`
+            )
         )
         self.telemetry = telemetry
     }


### PR DESCRIPTION
### What and why?

⏱️ Following on https://github.com/DataDog/dd-sdk-ios/pull/1363, we want to make SR uploader even more eager.

The rationale is to leverage `-beta` and to promote data consistency over uploads performance slightly more. After getting numbers with next observability tasks, we will lower the preset to more optimised one.

### How?

We're leveraging the performance preset override API added earlier. I selected new values by testing in example project - playing smooth scenario and adjusting numbers to achieve relatively short batch buffer.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
