### PR TITLE
Fix xcframework GH assets

### DIFF
--- a/tools/distribution/release.py
+++ b/tools/distribution/release.py
@@ -45,12 +45,6 @@ if __name__ == "__main__":
         default=os.environ.get('DD_RELEASE_OVERWRITE_GITHUB') == '1'
     )
     parser.add_argument(
-        "--add-xcode-version-to-github-asset",
-        action='store_true',
-        help="Add Xcode version to the GH Release asset.",
-        default=os.environ.get('DD_ADD_XCODE_VERSION_TO_GITHUB_ASSET') == '1'
-    )
-    parser.add_argument(
         "--dry-run",
         action='store_true',
         help="Run validation but skip publishing.",
@@ -63,7 +57,6 @@ if __name__ == "__main__":
         only_github = True if args.only_github else False
         only_cocoapods = True if args.only_cocoapods else False
         overwrite_github = True if args.overwrite_github else False
-        add_xcode_version_to_github_asset = True if args.add_xcode_version_to_github_asset else False
         dry_run = True if args.dry_run else False
 
         # Validate arguments:
@@ -72,9 +65,6 @@ if __name__ == "__main__":
 
         if only_cocoapods and overwrite_github:
             raise Exception('`--overwrite-github` and `--only-cocoapods` cannot be used together.')
-
-        if only_cocoapods and add_xcode_version_to_github_asset:
-            raise Exception('--add-xcode-version-to-github-asset` and `--only-cocoapods` cannot be used together.')
 
         version = Version(git_tag)
         if not version:
@@ -86,7 +76,6 @@ if __name__ == "__main__":
               f'- DD_RELEASE_ONLY_GITHUB                = {os.environ.get("DD_RELEASE_ONLY_GITHUB")}\n'
               f'- DD_RELEASE_ONLY_COCOAPODS             = {os.environ.get("DD_RELEASE_ONLY_COCOAPODS")}\n'
               f'- DD_RELEASE_OVERWRITE_GITHUB           = {os.environ.get("DD_RELEASE_OVERWRITE_GITHUB")}\n'
-              f'- DD_ADD_XCODE_VERSION_TO_GITHUB_ASSET  = {os.environ.get("DD_ADD_XCODE_VERSION_TO_GITHUB_ASSET")}\n'
               f'- DD_RELEASE_DRY_RUN                    = {os.environ.get("DD_RELEASE_DRY_RUN")}')
 
         print(f'🛠️️ ENV and CLI arguments resolved to:\n'
@@ -94,7 +83,6 @@ if __name__ == "__main__":
               f'- only_github                        = {only_github}\n'
               f'- only_cocoapods                     = {only_cocoapods}\n'
               f'- overwrite_github                   = {overwrite_github}\n'
-              f'- add_xcode_version_to_github_asset  = {add_xcode_version_to_github_asset}\n'
               f'- dry_run                            = {dry_run}.')
 
         print(f'🛠️ Git tag read to version: {version}')
@@ -119,7 +107,7 @@ if __name__ == "__main__":
 
             # Publish GH Release asset:
             if publish_to_gh:
-                gh_asset = GHAsset(add_xcode_version=add_xcode_version_to_github_asset,git_tag=git_tag)
+                gh_asset = GHAsset(git_tag=git_tag)
                 gh_asset.validate()
                 gh_asset.publish(overwrite_existing=overwrite_github, dry_run=dry_run)
 

--- a/tools/distribution/src/utils.py
+++ b/tools/distribution/src/utils.py
@@ -11,7 +11,7 @@ import re
 import os
 import subprocess
 import contextlib
-
+from packaging.version import VERSION_PATTERN
 
 @contextlib.contextmanager
 def remember_cwd():
@@ -71,9 +71,11 @@ def read_sdk_version() -> str:
     Reads SDK version from 'Sources/Datadog/Versioning.swift'.
     """
     file = 'DatadogCore/Sources/Versioning.swift'
-    version_regex = r'^.+\"([0-9]+\.[0-9]+\.[0-9]+[\-a-z0-9]*)\"'  # e.g. 'internal let __sdkVersion = "1.8.0-beta1"'
 
-    versions: [str] = []
+    # https://packaging.pypa.io/en/latest/version.html#packaging.version.VERSION_PATTERN
+    version_regex = re.compile(r'^.+\"' + VERSION_PATTERN + r'\"$', re.VERBOSE | re.IGNORECASE) # e.g. 'internal let __sdkVersion = "1.8.0-beta.1"
+
+    versions: list[str] = []
     with open(file) as version_file:
         for line in version_file.readlines():
             if match := re.match(version_regex, line):


### PR DESCRIPTION
### What and why?

Update GH asset name for pre-build binaries following [Carthage requirements](https://github.com/Carthage/Carthage#archive-prebuilt-frameworks-into-zip-files).

fix #1318

### How?

With v2 and module stability enabled, GH assets will be named `Datadog.xcframework.zip`.
Prior to v2 and since we were not compliant with Carthage, we can always include the Xcode version in the asset name. The `add_xcode_version_to_github_asset` parameter is now unnecessary and has been removed.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
