### PR TITLE
ci: fix scheme name for nightly unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ venv
 *.pyc
 __pycache__
 *.swp
+.venv

--- a/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
+++ b/DatadogCore/Sources/Core/Storage/Writing/FileWriter.swift
@@ -30,11 +30,11 @@ internal struct FileWriter: Writer {
         do {
             var encoded: Data = .init()
             if let metadata = metadata {
-                let encodedMetadata = try encode(encodable: metadata, blockType: .eventMetadata)
+                let encodedMetadata = try encode(value: metadata, blockType: .eventMetadata)
                 encoded.append(encodedMetadata)
             }
 
-            let encodedValue = try encode(encodable: value, blockType: .event)
+            let encodedValue = try encode(value: value, blockType: .event)
             encoded.append(encodedValue)
 
             // Make sure both event and event metadata are written to the same file.
@@ -62,8 +62,8 @@ internal struct FileWriter: Writer {
     ///
     /// - Parameter event: The value to encode.
     /// - Returns: Data representation of the value.
-    private func encode(encodable: Encodable, blockType: BlockType) throws -> Data {
-        let data = try jsonEncoder.encode(encodable)
+    private func encode<T: Encodable>(value: T, blockType: BlockType) throws -> Data {
+        let data = try jsonEncoder.encode(value)
         return try DataBlock(
             type: blockType,
             data: encrypt(data: data)

--- a/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
+++ b/DatadogInternal/Sources/Storage/PerformancePresetOverride.swift
@@ -59,7 +59,7 @@ public struct PerformancePresetOverride {
         self.maxFileSize = maxFileSize
         self.maxObjectSize = maxObjectSize
 
-        if let meanFileAge {
+        if let meanFileAge = meanFileAge {
             // Following constants are the same as in `DatadogCore.PerformancePreset`
             self.maxFileAgeForWrite = meanFileAge * 0.95 // 5% below the mean age
             self.minFileAgeForRead = meanFileAge * 1.05 //  5% above the mean age

--- a/DatadogRUM/Sources/Feature/RUMViewEventsFilter.swift
+++ b/DatadogRUM/Sources/Feature/RUMViewEventsFilter.swift
@@ -19,7 +19,7 @@ internal struct RUMViewEventsFilter {
         var skipped: [String: [Int64]] = [:]
 
         // reversed is O(1) and no copy because it is view on the original array
-        let filtered = events.reversed().compactMap { event in
+        let filtered: [Event] = events.reversed().compactMap { event in
             guard let metadata = event.metadata else {
                 // If there is no metadata, we can't filter it.
                 return event

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -558,7 +558,7 @@ workflows:
         - environment_key_list: |-
             DD_RELEASE_GIT_TAG
             DD_RELEASE_DRY_RUN
-        
+
   publish_github_asset:
     before_run:
     - _make_dependencies  # install tooling

--- a/tools/nightly-unit-tests/bitrise.yml.src
+++ b/tools/nightly-unit-tests/bitrise.yml.src
@@ -6,7 +6,7 @@ project_type: other
 app:
   envs:
   - PROJECT_PATH: Datadog.xcworkspace
-  - PROJECT_SCHEME: Datadog iOS
+  - PROJECT_SCHEME: DatadogCore iOS
 
 workflows:
   run_all:

--- a/tools/nightly-unit-tests/generate_bitrise_yml.py
+++ b/tools/nightly-unit-tests/generate_bitrise_yml.py
@@ -118,11 +118,6 @@ def generate_bitrise_yml(test_plan: TestPlan, dry_run: bool):
 
     print('\n⚙️ Saving `bitrise.yml`...')
     bitrise_yml.write(path='bitrise.yml')
-
-    print('\n⚙️ `bitrise.yml` content:')
-    saved_bitrise_yml = open('bitrise.yml', 'r')
-    print(saved_bitrise_yml.read())
-
     print('\n⚙️ All good 👍')
 
 

--- a/tools/nightly-unit-tests/generate_bitrise_yml.py
+++ b/tools/nightly-unit-tests/generate_bitrise_yml.py
@@ -118,6 +118,11 @@ def generate_bitrise_yml(test_plan: TestPlan, dry_run: bool):
 
     print('\n⚙️ Saving `bitrise.yml`...')
     bitrise_yml.write(path='bitrise.yml')
+
+    print('\n⚙️ `bitrise.yml` content:')
+    saved_bitrise_yml = open('bitrise.yml', 'r')
+    print(saved_bitrise_yml.read())
+
     print('\n⚙️ All good 👍')
 
 


### PR DESCRIPTION
### What and why?

```
Failed to execute Step:
  command failed with exit status 65 (xcodebuild "-workspace" "/Users/vagrant/git/Datadog.xcworkspace" "-scheme" "Datadog iOS" "test" "-destination" "id=E467E978-443F-4E53-9A7E-C146036E2E69" "-resultBundlePath" "/var/folders/sj/_4jj239s3j33w5w1bdh98yj80000gn/T/XCUITestOutput2480199168/Test-Datadog iOS.xcresult" "-retry-tests-on-failure" "-test-iterations" "2" "-xcconfig" "/var/folders/sj/_4jj239s3j33w5w1bdh98yj80000gn/T/3713649878/temp.xcconfig"):
    xcodebuild: error: The workspace named "Datadog" does not contain a scheme named "Datadog iOS". The "-list" option can be used to find the names of the schemes in the workspace.
```


### How?

`Datadog iOS` no longer exists rather we have `DatadogCore iOS` which currently runs all the targets. Once V2 migration is fully done, we would have to add list of all the targets (given no workspace/project file be there)

Added printing `bitrise.yml` to make CI job easily debuggable.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
