### PR TITLE
RUMM-3459 fix: Fix linking telemetry events to RUM session

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		49274907288048B800ECD49B /* InternalTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49274903288048AA00ECD49B /* InternalTelemetryTests.swift */; };
 		61020C2A2757AD91005EEAEA /* BackgroundLocationMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */; };
 		61020C2C2758E853005EEAEA /* DebugBackgroundEventsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */; };
+		610ABD4C2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift */; };
+		610ABD4D2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610ABD4B2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift */; };
 		61112F8E2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */; };
 		61112F8F2A4417D6006FFCA6 /* DDRUM+apiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */; };
 		6111C58225C0081F00F5C4A2 /* RUMDataModels+objc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */; };
@@ -1664,6 +1666,7 @@
 		49274908288048F400ECD49B /* RUMInternalProxyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RUMInternalProxyTests.swift; sourceTree = "<group>"; };
 		61020C292757AD91005EEAEA /* BackgroundLocationMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundLocationMonitor.swift; sourceTree = "<group>"; };
 		61020C2B2758E853005EEAEA /* DebugBackgroundEventsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugBackgroundEventsViewController.swift; sourceTree = "<group>"; };
+		610ABD4B2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryCoreIntegrationTests.swift; sourceTree = "<group>"; };
 		61112F8D2A4417D6006FFCA6 /* DDRUM+apiTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "DDRUM+apiTests.m"; sourceTree = "<group>"; };
 		6111C58125C0081F00F5C4A2 /* RUMDataModels+objc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RUMDataModels+objc.swift"; sourceTree = "<group>"; };
 		61122ECD25B1B74500F9C7F5 /* SpanSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpanSanitizer.swift; sourceTree = "<group>"; };
@@ -2684,6 +2687,22 @@
 			path = BackgroundEvents;
 			sourceTree = "<group>";
 		};
+		610ABD492A69309900AFEA34 /* IntegrationUnitTests */ = {
+			isa = PBXGroup;
+			children = (
+				610ABD4A2A6930AB00AFEA34 /* Public */,
+			);
+			path = IntegrationUnitTests;
+			sourceTree = "<group>";
+		};
+		610ABD4A2A6930AB00AFEA34 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				610ABD4B2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
 		6111543425C993AC007C84C9 /* CrashReporting */ = {
 			isa = PBXGroup;
 			children = (
@@ -2706,6 +2725,7 @@
 			children = (
 				61133B9C2423979B00786299 /* DatadogCore */,
 				9E68FB52244707FD0013A8AA /* DatadogPrivate */,
+				610ABD492A69309900AFEA34 /* IntegrationUnitTests */,
 				61133C122423990D00786299 /* DatadogCoreTests */,
 				61133C082423983800786299 /* DatadogObjc */,
 				D23039A6298D513D001A1FA3 /* DatadogInternal */,
@@ -6432,6 +6452,7 @@
 				D29A9FCE29DDC4BA005C54A4 /* RUMFeatureMocks.swift in Sources */,
 				D2DA23CD298D5EDD00C6C7E6 /* _InternalProxyTests.swift in Sources */,
 				61133C5B2423990D00786299 /* DirectoryTests.swift in Sources */,
+				610ABD4C2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift in Sources */,
 				A79B0F64292BD074008742B3 /* DDOTelHTTPHeadersWriter+apiTests.m in Sources */,
 				D2B3F052282E827700C2B5EE /* DDHTTPHeadersWriter+apiTests.m in Sources */,
 				D20605B92875729E0047275C /* ContextValuePublisherMock.swift in Sources */,
@@ -7273,6 +7294,7 @@
 				D2CB6EE527C520D400A62B57 /* DataUploadConditionsTests.swift in Sources */,
 				D2CB6EE627C520D400A62B57 /* DateFormattingTests.swift in Sources */,
 				D2CB6EE727C520D400A62B57 /* FileTests.swift in Sources */,
+				610ABD4D2A6930CA00AFEA34 /* TelemetryCoreIntegrationTests.swift in Sources */,
 				D2CB6EEA27C520D400A62B57 /* LogMatcher.swift in Sources */,
 				D2CB6EEC27C520D400A62B57 /* CustomObjcViewController.m in Sources */,
 				D2EFA876286E011900F1FAA6 /* DatadogContextProviderTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Public/TelemetryCoreIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Public/TelemetryCoreIntegrationTests.swift
@@ -1,0 +1,137 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import DatadogCore
+import DatadogInternal
+@testable import DatadogRUM
+import TestUtilities
+
+class TelemetryCoreIntegrationTests: XCTestCase {
+    private var core: DatadogCoreProxy! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var telemetry: TelemetryCore! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        core = DatadogCoreProxy()
+        telemetry = TelemetryCore(core: core)
+    }
+
+    override func tearDown() {
+        core.flushAndTearDown()
+        core = nil
+        telemetry = nil
+    }
+
+    func testGivenRUMEnabled_telemetryEventsAreSent() {
+        // Given
+        var config = RUM.Configuration(applicationID: .mockAny())
+        config.telemetrySampleRate = 100
+        RUM.enable(with: config, in: core)
+
+        // When
+        telemetry.debug("Debug Telemetry", attributes: ["debug.attribute": 42])
+        telemetry.error("Error Telemetry")
+
+        // Then
+        let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
+        let errorEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryErrorEvent.self)
+
+        XCTAssertEqual(debugEvents.count, 1)
+        XCTAssertEqual(errorEvents.count, 1)
+
+        let debug = debugEvents[0]
+        XCTAssertEqual(debug.telemetry.message, "Debug Telemetry")
+        DDAssertReflectionEqual(debug.telemetry.telemetryInfo, ["debug.attribute": 42])
+
+        let error = errorEvents[0]
+        XCTAssertEqual(error.telemetry.message, "Error Telemetry")
+    }
+
+    func testGivenRUMEnabled_whenNoViewIsActive_telemetryEventsAreLinkedToSession() throws {
+        // Given & When
+        var config = RUM.Configuration(applicationID: "rum-app-id")
+        config.telemetrySampleRate = 100
+        RUM.enable(with: config, in: core)
+
+        // Then
+        telemetry.debug("Debug Telemetry", attributes: ["debug.attribute": 42])
+        telemetry.error("Error Telemetry")
+
+        let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
+        let errorEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryErrorEvent.self)
+
+        let debug = try XCTUnwrap(debugEvents.first)
+        XCTAssertEqual(debug.application?.id, "rum-app-id")
+        XCTAssertNotNil(debug.session?.id)
+        XCTAssertNil(debug.view?.id)
+        XCTAssertNil(debug.action?.id)
+
+        let error = try XCTUnwrap(errorEvents.first)
+        XCTAssertEqual(error.application?.id, "rum-app-id")
+        XCTAssertNotNil(error.session?.id)
+        XCTAssertNil(error.view?.id)
+        XCTAssertNil(error.action?.id)
+    }
+
+    func testGivenRUMEnabled_whenViewIsActive_telemetryEventsAreLinkedToView() throws {
+        // Given
+        var config = RUM.Configuration(applicationID: "rum-app-id")
+        config.telemetrySampleRate = 100
+        RUM.enable(with: config, in: core)
+
+        // When
+        RUMMonitor.shared(in: core).startView(key: .mockRandom())
+
+        // Then
+        telemetry.debug("Debug Telemetry", attributes: ["debug.attribute": 42])
+        telemetry.error("Error Telemetry")
+
+        let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
+        let errorEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryErrorEvent.self)
+
+        let debug = try XCTUnwrap(debugEvents.first)
+        XCTAssertEqual(debug.application?.id, "rum-app-id")
+        XCTAssertNotNil(debug.session?.id)
+        XCTAssertNotNil(debug.view?.id)
+        XCTAssertNil(debug.action?.id)
+
+        let error = try XCTUnwrap(errorEvents.first)
+        XCTAssertEqual(error.application?.id, "rum-app-id")
+        XCTAssertNotNil(error.session?.id)
+        XCTAssertNotNil(error.view?.id)
+        XCTAssertNil(error.action?.id)
+    }
+
+    func testGivenRUMEnabled_whenActionIsActive_telemetryEventsAreLinkedToAction() throws {
+        // Given
+        var config = RUM.Configuration(applicationID: "rum-app-id")
+        config.telemetrySampleRate = 100
+        RUM.enable(with: config, in: core)
+
+        // When
+        RUMMonitor.shared(in: core).startView(key: .mockRandom())
+        RUMMonitor.shared(in: core).addAction(type: .tap, name: "tap")
+
+        // Then
+        telemetry.debug("Debug Telemetry", attributes: ["debug.attribute": 42])
+        telemetry.error("Error Telemetry")
+
+        let debugEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryDebugEvent.self)
+        let errorEvents = core.waitAndReturnEvents(ofFeature: RUMFeature.name, ofType: TelemetryErrorEvent.self)
+
+        let debug = try XCTUnwrap(debugEvents.first)
+        XCTAssertEqual(debug.application?.id, "rum-app-id")
+        XCTAssertNotNil(debug.session?.id)
+        XCTAssertNotNil(debug.view?.id)
+        XCTAssertNotNil(debug.action?.id)
+
+        let error = try XCTUnwrap(errorEvents.first)
+        XCTAssertEqual(error.application?.id, "rum-app-id")
+        XCTAssertNotNil(error.session?.id)
+        XCTAssertNotNil(error.view?.id)
+        XCTAssertNotNil(error.action?.id)
+    }
+}

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -87,8 +87,8 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
         let date = dateProvider.now
 
         record(event: id, in: core) { context, writer in
-            let rum: [String: String]? = context.featuresAttributes["rum"]?.ids
-
+            let rumAttributes: [String: String?]? = context.featuresAttributes[RUMFeature.name]?.ids
+            let rum = rumAttributes?.compactMapValues { $0 }
             let applicationId = rum?[RUMContextAttributes.IDs.applicationID]
             let sessionId = rum?[RUMContextAttributes.IDs.sessionID]
             let viewId = rum?[RUMContextAttributes.IDs.viewID]
@@ -130,8 +130,8 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
         let date = dateProvider.now
 
         record(event: id, in: core) { context, writer in
-            let attributes: [String: String]? = context.featuresAttributes["rum"]?.ids
-
+            let rumAttributes: [String: String?]? = context.featuresAttributes[RUMFeature.name]?.ids
+            let attributes = rumAttributes?.compactMapValues { $0 }
             let applicationId = attributes?[RUMContextAttributes.IDs.applicationID]
             let sessionId = attributes?[RUMContextAttributes.IDs.sessionID]
             let viewId = attributes?[RUMContextAttributes.IDs.viewID]
@@ -169,7 +169,8 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
         let date = dateProvider.now
 
         self.record(event: "_dd.configuration", in: core) { context, writer in
-            let attributes: [String: String]? = context.featuresAttributes["rum"]?.ids
+            let rumAttributes: [String: String?]? = context.featuresAttributes[RUMFeature.name]?.ids
+            let attributes = rumAttributes?.compactMapValues { $0 }
             let applicationId = attributes?[RUMContextAttributes.IDs.applicationID]
             let sessionId = attributes?[RUMContextAttributes.IDs.sessionID]
             let viewId = attributes?[RUMContextAttributes.IDs.viewID]
@@ -203,7 +204,8 @@ internal final class TelemetryReceiver: FeatureMessageReceiver {
 
         rum.eventWriteContext { context, writer in
             // reset recorded events on session renewal
-            let attributes: [String: String]? = context.featuresAttributes["rum"]?.ids
+            let rumAttributes: [String: String?]? = context.featuresAttributes[RUMFeature.name]?.ids
+            let attributes = rumAttributes?.compactMapValues { $0 }
             let sessionId = attributes?[RUMContextAttributes.IDs.sessionID]
 
             if sessionId != self.currentSessionID {


### PR DESCRIPTION
### What and why?

🐞 This PR fixes broken link between RUM Telemetry events and RUM session.

Without this link we can't make data-driven decisions that include `session_id` querying or distributions.

### How?

Added integration tests for Telemetry feature, which revealed several issues. Fixed one by one.

All problems follow the same pattern of invalid assumption on RUM context retrieval from `FeatureBaggage`. The only non-optional attribute in RUM context is `application.id`, all other (`session.id`, `view.id` and `action.id`) are optional, so:
```swift
// Wrong:
let attributes: [String: String]? = context.featuresAttributes["rum"]?.ids

// Correct:
let attributes: [String: String?]? = context.featuresAttributes["rum"]?.ids
```

In result of wrong assumption, RUM context information was only attached to these telemetry logs that were recorded during full RUM context - meaning all all IDs set, so only when user action on some view was pending.

This problem wasn't surfaced by [existing unit tests](https://github.com/DataDog/dd-sdk-ios/blob/4753d05a6432237d8aa6962307d7de2699794499/DatadogRUM/Tests/Integrations/TelemetryReceiverTests.swift#L87-L94), because they mock the entire context, covering only the "full context" scenario.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
