### PR TITLE
RUMM-3460 feat: Add "Batch Closed" telemetry

### DIFF
--- a/BenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/LoggingStorageBenchmarkTests.swift
@@ -76,7 +76,7 @@ class LoggingStorageBenchmarkTests: XCTestCase {
             XCTAssertNotNil(batch, "Not enough batch files were created for this benchmark.")
 
             if let batch = batch {
-                reader.markBatchAsRead(batch)
+                reader.markBatchAsRead(batch, reason: .flushed)
             }
         }
     }

--- a/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/RUMStorageBenchmarkTests.swift
@@ -76,7 +76,7 @@ class RUMStorageBenchmarkTests: XCTestCase {
             XCTAssertNotNil(batch, "Not enough batch files were created for this benchmark.")
 
             if let batch = batch {
-                reader.markBatchAsRead(batch)
+                reader.markBatchAsRead(batch, reason: .flushed)
             }
         }
     }

--- a/BenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
+++ b/BenchmarkTests/DataStorage/TracingStorageBenchmarkTests.swift
@@ -76,7 +76,7 @@ class TracingStorageBenchmarkTests: XCTestCase {
             XCTAssertNotNil(batch, "Not enough batch files were created for this benchmark.")
 
             if let batch = batch {
-                reader.markBatchAsRead(batch)
+                reader.markBatchAsRead(batch, reason: .flushed)
             }
         }
     }

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		6134CDB12A691E850061CCD9 /* CoreMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6134CDB02A691E850061CCD9 /* CoreMetricsTests.swift */; };
 		6134CDB22A691E850061CCD9 /* CoreMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6134CDB02A691E850061CCD9 /* CoreMetricsTests.swift */; };
 		61363D9F24D99BAA0084CD6F /* DDErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */; };
+		6136CB4A2A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6136CB492A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift */; };
+		6136CB4B2A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6136CB492A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift */; };
 		6139CD712589FAFD007E8BB7 /* Retrying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6139CD702589FAFD007E8BB7 /* Retrying.swift */; };
 		6139CD772589FEE3007E8BB7 /* RetryingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6139CD762589FEE3007E8BB7 /* RetryingTests.swift */; };
 		613BE0432563FB9E0015216C /* RUMBenchmarkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613BE0422563FB9E0015216C /* RUMBenchmarkTests.swift */; };
@@ -1755,6 +1757,7 @@
 		61345612244756E300E7DA6B /* PerformancePresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformancePresetTests.swift; sourceTree = "<group>"; };
 		6134CDB02A691E850061CCD9 /* CoreMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMetricsTests.swift; sourceTree = "<group>"; };
 		61363D9E24D99BAA0084CD6F /* DDErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDErrorTests.swift; sourceTree = "<group>"; };
+		6136CB492A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FilesOrchestrator+MetricsTests.swift"; sourceTree = "<group>"; };
 		61378BA72555329E00F28837 /* DatadogTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogTests.xcconfig; sourceTree = "<group>"; };
 		61378BB22555337900F28837 /* DatadogSDKTesting.local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DatadogSDKTesting.local.xcconfig; sourceTree = "<group>"; };
 		6139CD702589FAFD007E8BB7 /* Retrying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Retrying.swift; sourceTree = "<group>"; };
@@ -3049,6 +3052,7 @@
 			children = (
 				3C0D5DDF2A543DAE00446CF9 /* EventGeneratorTests.swift */,
 				61133C2A2423990D00786299 /* FilesOrchestratorTests.swift */,
+				6136CB492A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift */,
 				D2B3F0432823EE8300C2B5EE /* DataBlockTests.swift */,
 				619E16D42577C11B00B2516B /* Writing */,
 				619E16D52577C12100B2516B /* Reading */,
@@ -6412,6 +6416,7 @@
 				617B954224BF4E7600E6F443 /* RUMMonitorConfigurationTests.swift in Sources */,
 				61F9CABA2513A7F5000A5E61 /* RUMSessionMatcher.swift in Sources */,
 				3C0D5DE22A543DC400446CF9 /* EventGeneratorTests.swift in Sources */,
+				6136CB4A2A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift in Sources */,
 				61C3638324361BE200C4D4E6 /* DatadogPrivateMocks.swift in Sources */,
 				D26C49AF2886DC7B00802B2D /* ApplicationStatePublisherTests.swift in Sources */,
 				6147989C2A459E2B0095CB02 /* DDTrace+apiTests.m in Sources */,
@@ -7376,6 +7381,7 @@
 				D2CB6F2C27C520D400A62B57 /* JSONEncoderTests.swift in Sources */,
 				D2CB6F3027C520D400A62B57 /* DatadogExtensions.swift in Sources */,
 				D2CB6F3227C520D400A62B57 /* JSONDataMatcher.swift in Sources */,
+				6136CB4B2A69C29C00AC265D /* FilesOrchestrator+MetricsTests.swift in Sources */,
 				D25085112976E30000E931C3 /* DatadogRemoteFeatureMock.swift in Sources */,
 				D2CB6F3327C520D400A62B57 /* FilesOrchestratorTests.swift in Sources */,
 				D2FB1258292E0F10005B13F8 /* TrackingConsentPublisherTests.swift in Sources */,

--- a/Datadog/IntegrationUnitTests/Internal/CoreMetricsIntegrationTests.swift
+++ b/Datadog/IntegrationUnitTests/Internal/CoreMetricsIntegrationTests.swift
@@ -12,9 +12,9 @@ import XCTest
 
 class CoreMetricsIntegrationTests: XCTestCase {
     func testResolvingTrackValueFromFeatureName() {
-        XCTAssertEqual(BatchDeletedMetric.trackValue(for: RUMFeature.name), "rum")
-        XCTAssertEqual(BatchDeletedMetric.trackValue(for: TraceFeature.name), "trace")
-        XCTAssertEqual(BatchDeletedMetric.trackValue(for: LogsFeature.name), "logs")
+        XCTAssertEqual(BatchMetric.trackValue(for: RUMFeature.name), "rum")
+        XCTAssertEqual(BatchMetric.trackValue(for: TraceFeature.name), "trace")
+        XCTAssertEqual(BatchMetric.trackValue(for: LogsFeature.name), "logs")
         // TODO: REPLAY-1869 Assert `sr` track name after Session Replay is available for integration testing
     }
 }

--- a/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
+++ b/DatadogCore/Sources/Core/Storage/FeatureStorage.swift
@@ -110,7 +110,13 @@ extension FeatureStorage {
             directory: directories.authorized,
             performance: performance,
             dateProvider: dateProvider,
-            metricsData: .init(featureName: featureName, uploaderPerformance: performance)
+            metricsData: {
+                guard let trackName = BatchMetric.trackValue(for: featureName) else {
+                    DD.logger.error("Can't determine track name for feature named '\(featureName)'")
+                    return nil
+                }
+                return FilesOrchestrator.MetricsData(trackName: trackName, uploaderPerformance: performance)
+            }()
         )
         let unauthorizedFilesOrchestrator = FilesOrchestrator(
             directory: directories.unauthorized,

--- a/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
+++ b/DatadogCore/Sources/Core/Storage/FilesOrchestrator.swift
@@ -29,14 +29,17 @@ internal class FilesOrchestrator: FilesOrchestratorType {
 
     /// Name of the last file returned by `getWritableFile()`.
     private var lastWritableFileName: String? = nil
-    /// Tracks number of times the file at `lastWritableFileURL` was returned from `getWritableFile()`.
+    /// Tracks number of times the last file was returned from `getWritableFile(writeSize:)`.
     /// This should correspond with number of objects stored in file, assuming that majority of writes succeed (the difference is negligible).
-    private var lastWritableFileUsesCount: Int = 0
+    private var lastWritableFileObjectsCount: UInt64 = 0
+    /// Tracks the size of last writable file by accumulating the total `writeSize:` requested in `getWritableFile(writeSize:)`
+    /// This is approximated value as it assumes that all requested writes succed. The actual difference should be negligible.
+    private var lastWritableFileApproximatedSize: UInt64 = 0
 
     /// Extra information for metrics set from this orchestrator.
     struct MetricsData {
-        /// The name of the `DatadogRemoteFeature` that uses this orchestrator.
-        let featureName: String
+        /// The name of the track reported for this orchestrator.
+        let trackName: String
         /// The preset for uploader performance in this feature to include in metric.
         let uploaderPerformance: UploadPerformancePreset
     }
@@ -67,7 +70,10 @@ internal class FilesOrchestrator: FilesOrchestratorType {
     /// - Returns: `WritableFile` capable of writing data of given size
     func getNewWritableFile(writeSize: UInt64) throws -> WritableFile {
         try validate(writeSize: writeSize)
-        return try createNewWritableFile()
+        if let closedBatchName = lastWritableFileName {
+            sendBatchClosedMetric(fileName: closedBatchName, forcedNew: true)
+        }
+        return try createNewWritableFile(writeSize: writeSize)
     }
 
     /// Returns writable file accordingly to default heuristic of creating and reusing files.
@@ -78,10 +84,14 @@ internal class FilesOrchestrator: FilesOrchestratorType {
         try validate(writeSize: writeSize)
 
         if let lastWritableFile = reuseLastWritableFileIfPossible(writeSize: writeSize) { // if last writable file can be reused
-            lastWritableFileUsesCount += 1
+            lastWritableFileObjectsCount += 1
+            lastWritableFileApproximatedSize += writeSize
             return lastWritableFile
         } else {
-            return try createNewWritableFile()
+            if let closedBatchName = lastWritableFileName {
+                sendBatchClosedMetric(fileName: closedBatchName, forcedNew: false)
+            }
+            return try createNewWritableFile(writeSize: writeSize)
         }
     }
 
@@ -91,7 +101,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
         }
     }
 
-    private func createNewWritableFile() throws -> WritableFile {
+    private func createNewWritableFile(writeSize: UInt64) throws -> WritableFile {
         // NOTE: RUMM-610 Because purging files directory is a memory-expensive operation, do it only when a new file
         // is created (we assume here that this won't happen too often). In details, this is to avoid over-allocating
         // internal `_FileCache` and `_NSFastEnumerationEnumerator` objects in downstream `FileManager` routines.
@@ -102,7 +112,8 @@ internal class FilesOrchestrator: FilesOrchestratorType {
         let newFileName = fileNameFrom(fileCreationDate: dateProvider.now)
         let newFile = try directory.createFile(named: newFileName)
         lastWritableFileName = newFile.name
-        lastWritableFileUsesCount = 1
+        lastWritableFileObjectsCount = 1
+        lastWritableFileApproximatedSize = writeSize
         return newFile
     }
 
@@ -119,7 +130,7 @@ internal class FilesOrchestrator: FilesOrchestratorType {
 
                 let fileIsRecentEnough = lastFileAge <= performance.maxFileAgeForWrite
                 let fileHasRoomForMore = (try lastFile.size() + writeSize) <= performance.maxFileSize
-                let fileCanBeUsedMoreTimes = (lastWritableFileUsesCount + 1) <= performance.maxObjectsInFile
+                let fileCanBeUsedMoreTimes = (lastWritableFileObjectsCount + 1) <= performance.maxObjectsInFile
 
                 if fileIsRecentEnough && fileHasRoomForMore && fileCanBeUsedMoreTimes {
                     return lastFile
@@ -226,18 +237,14 @@ internal class FilesOrchestrator: FilesOrchestratorType {
         guard let metricsData = metricsData, deletionReason.includeInMetric else {
             return // do not track metrics for this orchestrator or deletion reason
         }
-        guard let trackValue = BatchDeletedMetric.trackValue(for: metricsData.featureName) else {
-            DD.logger.error("Can't determine track name for feature named '\(metricsData.featureName)'")
-            return
-        }
 
         let batchAge = dateProvider.now.timeIntervalSince(fileCreationDateFrom(fileName: batchFile.name))
 
         DD.telemetry.metric(
             name: BatchDeletedMetric.name,
             attributes: [
-                BatchDeletedMetric.typeKey: BatchDeletedMetric.typeValue,
-                BatchDeletedMetric.trackKey: trackValue,
+                BatchMetric.typeKey: BatchDeletedMetric.typeValue,
+                BatchMetric.trackKey: metricsData.trackName,
                 BatchDeletedMetric.uploaderDelayKey: [
                     BatchDeletedMetric.uploaderDelayMinKey: metricsData.uploaderPerformance.minUploadDelay.toMilliseconds,
                     BatchDeletedMetric.uploaderDelayMaxKey: metricsData.uploaderPerformance.maxUploadDelay.toMilliseconds,
@@ -246,6 +253,31 @@ internal class FilesOrchestrator: FilesOrchestratorType {
                 BatchDeletedMetric.batchAgeKey: batchAge.toMilliseconds,
                 BatchDeletedMetric.batchRemovalReasonKey: deletionReason.asString,
                 BatchDeletedMetric.inBackgroundKey: false,
+            ]
+        )
+    }
+
+    /// Sends "Batch Closed" telemetry log.
+    /// - Parameters:
+    ///   - fileName: The name of the batch that was closed.
+    ///   - forcedNew: If the batch was closed due to default heuristic or because a new batch was forced by feature.
+    private func sendBatchClosedMetric(fileName: String, forcedNew: Bool) {
+        guard let metricsData = metricsData else {
+            return // do not track metrics for this orchestrator
+        }
+
+        let batchDuration = dateProvider.now.timeIntervalSince(fileCreationDateFrom(fileName: fileName))
+
+        DD.telemetry.metric(
+            name: BatchClosedMetric.name,
+            attributes: [
+                BatchMetric.typeKey: BatchClosedMetric.typeValue,
+                BatchMetric.trackKey: metricsData.trackName,
+                BatchClosedMetric.uploaderWindowKey: performance.uploaderWindow.toMilliseconds,
+                BatchClosedMetric.batchSizeKey: lastWritableFileApproximatedSize,
+                BatchClosedMetric.batchEventsCountKey: lastWritableFileObjectsCount,
+                BatchClosedMetric.batchDurationKey: batchDuration.toMilliseconds,
+                BatchClosedMetric.forcedNewKey: forcedNew
             ]
         )
     }

--- a/DatadogCore/Sources/Utils/CoreMetrics.swift
+++ b/DatadogCore/Sources/Utils/CoreMetrics.swift
@@ -6,17 +6,10 @@
 
 import Foundation
 
-/// Definition of "Batch Deleted" telemetry.
-internal enum BatchDeletedMetric {
-    /// The name of this metric, included in telemetry log.
-    /// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
-    static let name = "Batch Deleted"
-
+/// Common definitions for batch telemetries.
+internal enum BatchMetric {
     /// Metric type key.
     static let typeKey = "metric_type"
-    /// Metric type value.
-    static let typeValue = "batch deleted"
-
     /// Track name key
     static let trackKey = "track"
     /// Track name value.
@@ -30,7 +23,15 @@ internal enum BatchDeletedMetric {
         default:                return nil
         }
     }
+}
 
+/// Definition of "Batch Deleted" telemetry.
+internal enum BatchDeletedMetric {
+    /// The name of this metric, included in telemetry log.
+    /// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
+    static let name = "Batch Deleted"
+    /// Metric type value.
+    static let typeValue = "batch deleted"
     /// The key for uploader's delay options.
     static let uploaderDelayKey = "uploader_delay"
     /// The min delay of uploads for this track (in ms).
@@ -91,4 +92,24 @@ internal enum BatchDeletedMetric {
             }
         }
     }
+}
+
+/// Definition of "Batch Closed" telemetry.
+internal enum BatchClosedMetric {
+    /// The name of this metric, included in telemetry log.
+    /// Note: the "[Mobile Metric]" prefix is added when sending this telemetry in RUM.
+    static let name = "Batch Closed"
+    /// Metric type value.
+    static let typeValue = "batch closed"
+    /// The default duration since last write (in ms) after which the uploader considers the file to be "ready for upload".
+    static let uploaderWindowKey = "uploader_window"
+
+    /// The size of batch at closing (in bytes).
+    static let batchSizeKey = "batch_size"
+    /// The number of events written to this batch before closing.
+    static let batchEventsCountKey = "batch_events_count"
+    /// The duration from batch creation to batch closing (in ms).
+    static let batchDurationKey = "batch_duration"
+    /// If the batch was closed by core or after new batch was forced by the feature.
+    static let forcedNewKey = "forced_new"
 }

--- a/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
+++ b/DatadogCore/Tests/Datadog/Core/Persistence/FilesOrchestrator+MetricsTests.swift
@@ -1,0 +1,192 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import XCTest
+import TestUtilities
+import DatadogInternal
+@testable import DatadogCore
+
+class FilesOrchestrator_MetricsTests: XCTestCase {
+    private var dd: DDMock<CoreLoggerMock, TelemetryMock>! // swiftlint:disable:this implicitly_unwrapped_optional
+    private let telemetry = TelemetryMock()
+    private let dateProvider = RelativeDateProvider(using: .mockDecember15th2019At10AMUTC())
+    private var storage: StoragePerformanceMock! // swiftlint:disable:this implicitly_unwrapped_optional
+    private var upload: UploadPerformanceMock! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    override func setUp() {
+        super.setUp()
+        dd = DD.mockWith(telemetry: telemetry)
+        CreateTemporaryDirectory()
+
+        let performance: PerformancePreset = .mockRandom()
+        storage = StoragePerformanceMock(other: performance)
+        upload = UploadPerformanceMock(other: performance)
+    }
+
+    override func tearDown() {
+        DeleteTemporaryDirectory()
+        dd.reset()
+        super.tearDown()
+    }
+
+    private func createOrchestrator() -> FilesOrchestrator {
+        return FilesOrchestrator(
+            directory: Directory(url: temporaryDirectory),
+            performance: PerformancePreset.combining(storagePerformance: storage, uploadPerformance: upload),
+            dateProvider: dateProvider,
+            metricsData: .init(trackName: "track name", uploaderPerformance: upload)
+        )
+    }
+
+    // MARK: - "Batch Deleted" Metric
+
+    func testWhenReadableFileIsDeleted_itSendsBatchDeletedMetric() throws {
+        // Given
+        let orchestrator = createOrchestrator()
+        let file = try XCTUnwrap(orchestrator.getWritableFile(writeSize: 1) as? ReadableFile)
+        let expectedBatchAge = storage.minFileAgeForRead + 1
+
+        // When:
+        // - wait and delete the file
+        dateProvider.advance(bySeconds: expectedBatchAge)
+        orchestrator.delete(readableFile: file, deletionReason: .intakeCode(responseCode: 202))
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
+        DDAssertReflectionEqual(metric.attributes, [
+            "metric_type": "batch deleted",
+            "track": "track name",
+            "uploader_delay": [
+                "min": upload.minUploadDelay.toMilliseconds,
+                "max": upload.maxUploadDelay.toMilliseconds
+            ],
+            "uploader_window": storage.uploaderWindow.toMilliseconds,
+            "in_background": false,
+            "batch_age": expectedBatchAge.toMilliseconds,
+            "batch_removal_reason": "intake-code-202",
+        ])
+    }
+
+    func testWhenObsoleteFileIsDeleted_itSendsBatchDeletedMetric() throws {
+        // Given:
+        // - request some batch to be created
+        let orchestrator = createOrchestrator()
+        _ = try orchestrator.getWritableFile(writeSize: 1)
+
+        // When:
+        // - wait more than batch obsolescence limit
+        // - then request readable file, which should trigger obsolete files deletion
+        dateProvider.advance(bySeconds: storage.maxFileAgeForRead + 1)
+        _ = orchestrator.getReadableFile()
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
+        DDAssertReflectionEqual(metric.attributes, [
+            "metric_type": "batch deleted",
+            "track": "track name",
+            "uploader_delay": [
+                "min": upload.minUploadDelay.toMilliseconds,
+                "max": upload.maxUploadDelay.toMilliseconds
+            ],
+            "uploader_window": storage.uploaderWindow.toMilliseconds,
+            "in_background": false,
+            "batch_age": (storage.maxFileAgeForRead + 1).toMilliseconds,
+            "batch_removal_reason": "obsolete",
+        ])
+    }
+
+    func testWhenDirectoryIsPurged_itSendsBatchDeletedMetrics() throws {
+        // Given: some batch
+        // - request batch to be created
+        // - write more data than allowed directory size limit
+        storage.maxDirectorySize = 10 // 10 bytes
+        let orchestrator = createOrchestrator()
+        let file = try orchestrator.getWritableFile(writeSize: storage.maxDirectorySize + 1)
+        try file.append(data: .mockRandom(ofSize: storage.maxDirectorySize + 1))
+        let expectedBatchAge = storage.minFileAgeForRead + 1
+
+        // When:
+        // - then request new batch, which triggers directory purging
+        dateProvider.advance(bySeconds: expectedBatchAge)
+        _ = try orchestrator.getNewWritableFile(writeSize: 1)
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Deleted"))
+        DDAssertReflectionEqual(metric.attributes, [
+            "metric_type": "batch deleted",
+            "track": "track name",
+            "uploader_delay": [
+                "min": upload.minUploadDelay.toMilliseconds,
+                "max": upload.maxUploadDelay.toMilliseconds
+            ],
+            "uploader_window": storage.uploaderWindow.toMilliseconds,
+            "in_background": false,
+            "batch_age": expectedBatchAge.toMilliseconds,
+            "batch_removal_reason": "purged",
+        ])
+    }
+
+    // MARK: - "Batch Closed" Metric
+
+    func testWhenNewBatchIsStarted_itSendsBatchClosedMetric() throws {
+        // Given
+        // - request batch to be created
+        // - request few writes on that batch
+        let orchestrator = createOrchestrator()
+        let expectedWrites: [UInt64] = [10, 5, 2]
+        try expectedWrites.forEach { writeSize in
+            _ = try orchestrator.getWritableFile(writeSize: writeSize)
+        }
+
+        // When
+        // - wait more than allowed batch age for writes, so next batch request will create another batch
+        // - then request another batch, which will close the previous one
+        dateProvider.advance(bySeconds: (storage.maxFileAgeForWrite + 1))
+        _ = try orchestrator.getWritableFile(writeSize: 1)
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Closed"))
+        DDAssertReflectionEqual(metric.attributes, [
+            "metric_type": "batch closed",
+            "track": "track name",
+            "uploader_window": storage.uploaderWindow.toMilliseconds,
+            "batch_size": expectedWrites.reduce(0, +),
+            "batch_events_count": expectedWrites.count,
+            "batch_duration": (storage.maxFileAgeForWrite + 1).toMilliseconds,
+            "forced_new": false
+        ])
+    }
+
+    func testWhenNewBatchIsForced_itSendsBatchClosedMetric() throws {
+        // Given
+        // - request batch to be created
+        // - request few writes on that batch
+        let orchestrator = createOrchestrator()
+        let expectedWrites: [UInt64] = [10, 5, 2]
+        try expectedWrites.forEach { writeSize in
+            _ = try orchestrator.getWritableFile(writeSize: writeSize)
+        }
+        let expectedBatchDuration = storage.maxFileAgeForWrite - 1
+
+        // When
+        // - wait less than allowed batch age for writes
+        // - then request new batch, which closes the previous one
+        dateProvider.advance(bySeconds: expectedBatchDuration)
+        _ = try orchestrator.getNewWritableFile(writeSize: 1)
+
+        // Then
+        let metric = try XCTUnwrap(telemetry.messages.firstMetric(named: "Batch Closed"))
+        DDAssertReflectionEqual(metric.attributes, [
+            "metric_type": "batch closed",
+            "track": "track name",
+            "uploader_window": storage.uploaderWindow.toMilliseconds,
+            "batch_size": expectedWrites.reduce(0, +),
+            "batch_events_count": expectedWrites.count,
+            "batch_duration": expectedBatchDuration.toMilliseconds,
+            "forced_new": true
+        ])
+    }
+}

--- a/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/CoreMocks.swift
@@ -98,13 +98,13 @@ class ServerDateProviderMock: ServerDateProvider {
 // MARK: - PerformancePreset Mocks
 
 struct StoragePerformanceMock: StoragePerformancePreset {
-    let maxFileSize: UInt64
-    let maxDirectorySize: UInt64
-    let maxFileAgeForWrite: TimeInterval
-    let minFileAgeForRead: TimeInterval
-    let maxFileAgeForRead: TimeInterval
-    let maxObjectsInFile: Int
-    let maxObjectSize: UInt64
+    var maxFileSize: UInt64
+    var maxDirectorySize: UInt64
+    var maxFileAgeForWrite: TimeInterval
+    var minFileAgeForRead: TimeInterval
+    var maxFileAgeForRead: TimeInterval
+    var maxObjectsInFile: Int
+    var maxObjectSize: UInt64
 
     static let noOp = StoragePerformanceMock(
         maxFileSize: 0,
@@ -137,11 +137,23 @@ struct StoragePerformanceMock: StoragePerformancePreset {
     )
 }
 
+extension StoragePerformanceMock {
+    init(other: StoragePerformancePreset) {
+        maxFileSize = other.maxFileSize
+        maxDirectorySize = other.maxDirectorySize
+        maxFileAgeForWrite = other.maxFileAgeForWrite
+        minFileAgeForRead = other.minFileAgeForRead
+        maxFileAgeForRead = other.maxFileAgeForRead
+        maxObjectsInFile = other.maxObjectsInFile
+        maxObjectSize = other.maxObjectSize
+    }
+}
+
 struct UploadPerformanceMock: UploadPerformancePreset {
-    let initialUploadDelay: TimeInterval
-    let minUploadDelay: TimeInterval
-    let maxUploadDelay: TimeInterval
-    let uploadDelayChangeRate: Double
+    var initialUploadDelay: TimeInterval
+    var minUploadDelay: TimeInterval
+    var maxUploadDelay: TimeInterval
+    var uploadDelayChangeRate: Double
 
     static let noOp = UploadPerformanceMock(
         initialUploadDelay: .distantFuture,
@@ -165,6 +177,15 @@ struct UploadPerformanceMock: UploadPerformancePreset {
         maxUploadDelay: 60,
         uploadDelayChangeRate: 60 / 0.05
     )
+}
+
+extension UploadPerformanceMock {
+    init(other: UploadPerformancePreset) {
+        initialUploadDelay = other.initialUploadDelay
+        minUploadDelay = other.minUploadDelay
+        maxUploadDelay = other.maxUploadDelay
+        uploadDelayChangeRate = other.uploadDelayChangeRate
+    }
 }
 
 extension BundleType: AnyMockable, RandomMockable {

--- a/TestUtilities/Mocks/TelemetryMocks.swift
+++ b/TestUtilities/Mocks/TelemetryMocks.swift
@@ -80,6 +80,23 @@ public class TelemetryMock: Telemetry, CustomStringConvertible {
     }
 }
 
+public extension Array where Element == TelemetryMessage {
+    /// Returns properties of the first metric message of given name.
+    func firstMetric(named metricName: String) -> (name: String, attributes: [String: Encodable])? {
+        return compactMap({ $0.asMetric }).filter({ $0.name == metricName }).first
+    }
+}
+
+public extension TelemetryMessage {
+    /// Extracts metric attributes if this is metric message.
+    var asMetric: (name: String, attributes: [String: Encodable])? {
+        guard case let .metric(metricName, metricAttributes) = self else {
+            return nil
+        }
+        return (name: metricName, attributes: metricAttributes)
+    }
+}
+
 extension DD {
     /// Syntactic sugar for patching the `dd` bundle by replacing `logger`.
     ///


### PR DESCRIPTION
### What and why?

📦⏱️ Adding "Batch Closed" metric.

See (internal) [RFC Batching & Upload Observability](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3076063377/RFC+-+Batching+Upload+Observability).

### How?

Leveraged metrics API added earlier in #1384.

With this PR, I'm adding full unit tests coverage for both metrics creation in `FilesOrchestrator`.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
