### PR TITLE
Fix README link to Alamofire extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See [Datadog iOS RUM Collection](https://docs.datadoghq.com/real_user_monitoring
 
 ### Alamofire
 
-If you use [Alamofire](https://github.com/Alamofire/Alamofire), review the [`DatadogAlamofireExtension` library](Sources/DatadogExtensions/Alamofire/) to learn how to automatically instrument requests with the Datadog iOS SDK.
+If you use [Alamofire](https://github.com/Alamofire/Alamofire), review the [`Datadog Alamofire Extension` library](DatadogExtensions/Alamofire/) to learn how to automatically instrument requests with the Datadog iOS SDK.
 
 ## Contributing
 


### PR DESCRIPTION
### What and why?

Fixes the `README.md` link to Datadog's Alamofire extension.

### How?

A brief description of implementation details of this PR.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
