### PR TITLE
REPLAY-1869 fix: Fix nightly tests for Session Replay

### DIFF
--- a/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
+++ b/DatadogSessionReplay/Sources/Recorder/ViewTreeSnapshotProducer/ViewTreeSnapshot/NodeRecorders/UISegmentRecorder.swift
@@ -92,7 +92,7 @@ internal struct UISegmentWireframesBuilder: NodeWireframesBuilder {
             segmentRects.append(segmentRect)
         }
 
-        let segments = (0..<numberOfSegments).map { idx in
+        let segments: [SRWireframe] = (0..<numberOfSegments).map { idx in
             let isSelected = idx == selectedSegmentIndex
             return builder.createTextWireframe(
                 id: segmentWireframeIDs[idx],

--- a/DatadogSessionReplay/Sources/Utilities/CGRectExtensions.swift
+++ b/DatadogSessionReplay/Sources/Utilities/CGRectExtensions.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import CoreGraphics
 
 internal extension CGRect {
     enum HorizontalAlignment {

--- a/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
+++ b/DatadogSessionReplay/Tests/Recorder/Utilties/ImageDataProviderTests.swift
@@ -27,7 +27,7 @@ class ImageDataProviderTests: XCTestCase {
     @available(iOS 13.0, *)
     func test_returnsValidString_forSFSymbolIcon() throws {
         let sut = ImageDataProvider()
-        let image = UIImage(systemName: "apple.logo")
+        let image = UIImage(systemName: "square.and.arrow.up")
 
         let imageData = try XCTUnwrap(sut.contentBase64String(of: image))
         XCTAssertGreaterThan(imageData.count, 0)


### PR DESCRIPTION
### What and why?

🧰 The addition of Session Replay to main `.xcworkspace` in #1393 surfaced problems with running SR code in nightly tests.

### How?

* Fixed Xcode 13.4.1 build issues.
* Fixed test that was failing below iOS 16.0.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
