### PR TITLE
RUMM-3450 feat: include session_sample_rate as part of _dd.configuration blob for all RUM events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [BUGFIX] Do not propagate attributes from Errors and LongTasks to Views.
 - [IMPROVEMENT] Upgrade to PLCrashReporter 1.11.1.
+- [FEATURE] Report session sample rate to the backend with RUM events. See [#1410][]
 
 # 2.0.0 / 31-07-2023
 
@@ -491,6 +492,7 @@ Release `2.0` introduces breaking changes. Follow the [Migration Guide](MIGRATIO
 [#1331]: https://github.com/DataDog/dd-sdk-ios/pull/1331
 [#1328]: https://github.com/DataDog/dd-sdk-ios/pull/1328
 [#1355]: https://github.com/DataDog/dd-sdk-ios/pull/1355
+[#1410]: https://github.com/DataDog/dd-sdk-ios/pull/1410
 [@00fa9a]: https://github.com/00FA9A
 [@britton-earnin]: https://github.com/Britton-Earnin
 [@hengyu]: https://github.com/Hengyu

--- a/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
+++ b/DatadogCore/Tests/Datadog/Mocks/RUMDataModelMocks.swift
@@ -94,6 +94,12 @@ extension RUMOperatingSystem: RandomMockable {
     }
 }
 
+extension RUMViewEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMViewEvent.DD.Configuration {
+        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMViewEvent: RandomMockable {
     public static func mockRandom() -> RUMViewEvent {
         return mockRandomWith()
@@ -108,7 +114,7 @@ extension RUMViewEvent: RandomMockable {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 documentVersion: .mockRandom(),
                 pageStates: nil,
                 replayStats: nil,
@@ -162,6 +168,7 @@ extension RUMViewEvent: RandomMockable {
                         start: .mockRandom()
                     )
                 ],
+                interactionToNextPaint: nil,
                 isActive: viewIsActive,
                 isSlowRendered: .mockRandom(),
                 jsRefreshRate: nil,
@@ -184,12 +191,18 @@ extension RUMViewEvent: RandomMockable {
     }
 }
 
+extension RUMResourceEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMResourceEvent.DD.Configuration {
+        .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMResourceEvent: RandomMockable {
     public static func mockRandom() -> RUMResourceEvent {
         return RUMResourceEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 discarded: nil,
                 rulePsr: nil,
                 session: .init(plan: .plan1),
@@ -244,6 +257,12 @@ extension RUMResourceEvent: RandomMockable {
     }
 }
 
+extension RUMActionEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMActionEvent.DD.Configuration {
+        .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMActionEvent: RandomMockable {
     public static func mockRandom() -> RUMActionEvent {
         return RUMActionEvent(
@@ -257,7 +276,7 @@ extension RUMActionEvent: RandomMockable {
                     )
                 ),
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 session: .init(plan: .plan1)
             ),
             action: .init(
@@ -305,12 +324,18 @@ extension RUMErrorEvent.Error.SourceType: RandomMockable {
     }
 }
 
+extension RUMErrorEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMErrorEvent.DD.Configuration {
+        .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMErrorEvent: RandomMockable {
     public static func mockRandom() -> RUMErrorEvent {
         return RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 session: .init(plan: .plan1)
             ),
             action: .init(id: .mockRandom()),
@@ -376,12 +401,18 @@ extension RUMCrashEvent: RandomMockable {
     }
 }
 
+extension RUMLongTaskEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMLongTaskEvent.DD.Configuration {
+        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMLongTaskEvent: RandomMockable {
     public static func mockRandom() -> RUMLongTaskEvent {
         return RUMLongTaskEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 discarded: nil,
                 session: .init(plan: .plan1)
             ),
@@ -424,6 +455,8 @@ extension TelemetryConfigurationEvent: RandomMockable {
             telemetry: .init(
                 configuration: .init(
                     actionNameAttribute: nil,
+                    allowFallbackToLocalStorage: nil,
+                    allowUntrustedEvents: nil,
                     batchSize: .mockAny(),
                     batchUploadFrequency: .mockAny(),
                     defaultPrivacyLevel: .mockAny(),
@@ -467,6 +500,7 @@ extension TelemetryConfigurationEvent: RandomMockable {
                     useProxy: .mockRandom(),
                     useSecureSessionCookie: nil,
                     useTracing: .mockRandom(),
+                    useWorkerUrl: nil,
                     viewTrackingStrategy: nil
                 )
             ),

--- a/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
+++ b/DatadogCore/Tests/Datadog/RUM/RUMMonitorTests.swift
@@ -1250,6 +1250,60 @@ class RUMMonitorTests: XCTestCase {
         XCTAssertEqual(try resourceEvents[0].attribute(forKeyPath: "context.def"), "789")
     }
 
+    // MARK: - Configuration
+
+    func testRUMEvents_containSessionSampleRate() throws {
+        // Given
+        RUM.enable(with: config, in: core)
+
+        let monitor = RUMMonitor.shared(in: core)
+
+        // When
+        monitor.startView(viewController: mockView)
+        monitor.startAction(type: .scroll, name: .mockAny())
+        monitor.startResource(resourceKey: "/resource/1", request: .mockAny())
+        monitor.startResource(resourceKey: "/resource/2", request: .mockAny())
+        monitor.stopAction(type: .scroll)
+        monitor.stopResource(resourceKey: "/resource/1", response: .mockAny())
+        monitor.stopResourceWithError(resourceKey: "/resource/2", message: .mockAny())
+        monitor.addError(message: .mockAny(), source: .source)
+        monitor._internal?.addLongTask(at: Date(), duration: 1.0)
+        monitor.stopView(viewController: mockView)
+
+        let rumEventMatchers = try core.waitAndReturnRUMEventMatchers()
+
+        // Then
+        let viewEvents = rumEventMatchers.filterRUMEvents(ofType: RUMViewEvent.self)
+        XCTAssertNotEqual(viewEvents.count, 0)
+        for event in viewEvents {
+            XCTAssertEqual(try event.attribute(forKeyPath: "_dd.configuration.session_sample_rate"), config.sessionSampleRate)
+        }
+
+        let actionEvents = rumEventMatchers.filterRUMEvents(ofType: RUMActionEvent.self)
+        XCTAssertNotEqual(actionEvents.count, 0)
+        for event in actionEvents {
+            XCTAssertEqual(try event.attribute(forKeyPath: "_dd.configuration.session_sample_rate"), config.sessionSampleRate)
+        }
+
+        let resourceEvents = rumEventMatchers.filterRUMEvents(ofType: RUMResourceEvent.self)
+        XCTAssertNotEqual(resourceEvents.count, 0)
+        for event in resourceEvents {
+            XCTAssertEqual(try event.attribute(forKeyPath: "_dd.configuration.session_sample_rate"), config.sessionSampleRate)
+        }
+
+        let errorEvents = rumEventMatchers.filterRUMEvents(ofType: RUMErrorEvent.self)
+        XCTAssertNotEqual(errorEvents.count, 0)
+        for event in errorEvents {
+            XCTAssertEqual(try event.attribute(forKeyPath: "_dd.configuration.session_sample_rate"), config.sessionSampleRate)
+        }
+
+        let longTaskEvents = rumEventMatchers.filterRUMEvents(ofType: RUMLongTaskEvent.self)
+        XCTAssertNotEqual(longTaskEvents.count, 0)
+        for event in longTaskEvents {
+            XCTAssertEqual(try event.attribute(forKeyPath: "_dd.configuration.session_sample_rate"), config.sessionSampleRate)
+        }
+    }
+
     // MARK: - Internal attributes
 
     func testHandlingInternalTimestampAttribute() throws {

--- a/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
+++ b/DatadogObjc/Sources/RUM/RUMDataModels+objc.swift
@@ -185,8 +185,8 @@ public class DDRUMActionEventDDConfiguration: NSObject {
         self.root = root
     }
 
-    @objc public var sessionReplaySampleRate: NSNumber {
-        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber
+    @objc public var sessionReplaySampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
 
     @objc public var sessionSampleRate: NSNumber {
@@ -958,8 +958,8 @@ public class DDRUMErrorEventDDConfiguration: NSObject {
         self.root = root
     }
 
-    @objc public var sessionReplaySampleRate: NSNumber {
-        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber
+    @objc public var sessionReplaySampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
 
     @objc public var sessionSampleRate: NSNumber {
@@ -1953,8 +1953,8 @@ public class DDRUMLongTaskEventDDConfiguration: NSObject {
         self.root = root
     }
 
-    @objc public var sessionReplaySampleRate: NSNumber {
-        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber
+    @objc public var sessionReplaySampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
 
     @objc public var sessionSampleRate: NSNumber {
@@ -2603,8 +2603,8 @@ public class DDRUMResourceEventDDConfiguration: NSObject {
         self.root = root
     }
 
-    @objc public var sessionReplaySampleRate: NSNumber {
-        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber
+    @objc public var sessionReplaySampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
 
     @objc public var sessionSampleRate: NSNumber {
@@ -3558,8 +3558,8 @@ public class DDRUMViewEventDDConfiguration: NSObject {
         self.root = root
     }
 
-    @objc public var sessionReplaySampleRate: NSNumber {
-        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber
+    @objc public var sessionReplaySampleRate: NSNumber? {
+        root.swiftModel.dd.configuration!.sessionReplaySampleRate as NSNumber?
     }
 
     @objc public var sessionSampleRate: NSNumber {
@@ -4264,6 +4264,10 @@ public class DDRUMViewEventView: NSObject {
 
     @objc public var inForegroundPeriods: [DDRUMViewEventViewInForegroundPeriods]? {
         root.swiftModel.view.inForegroundPeriods?.map { DDRUMViewEventViewInForegroundPeriods(swiftModel: $0) }
+    }
+
+    @objc public var interactionToNextPaint: NSNumber? {
+        root.swiftModel.view.interactionToNextPaint as NSNumber?
     }
 
     @objc public var isActive: NSNumber? {
@@ -5102,6 +5106,14 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject {
         root.swiftModel.telemetry.configuration.actionNameAttribute
     }
 
+    @objc public var allowFallbackToLocalStorage: NSNumber? {
+        root.swiftModel.telemetry.configuration.allowFallbackToLocalStorage as NSNumber?
+    }
+
+    @objc public var allowUntrustedEvents: NSNumber? {
+        root.swiftModel.telemetry.configuration.allowUntrustedEvents as NSNumber?
+    }
+
     @objc public var batchSize: NSNumber? {
         root.swiftModel.telemetry.configuration.batchSize as NSNumber?
     }
@@ -5310,6 +5322,10 @@ public class DDTelemetryConfigurationEventTelemetryConfiguration: NSObject {
         root.swiftModel.telemetry.configuration.useTracing as NSNumber?
     }
 
+    @objc public var useWorkerUrl: NSNumber? {
+        root.swiftModel.telemetry.configuration.useWorkerUrl as NSNumber?
+    }
+
     @objc public var viewTrackingStrategy: DDTelemetryConfigurationEventTelemetryConfigurationViewTrackingStrategy {
         .init(swift: root.swiftModel.telemetry.configuration.viewTrackingStrategy)
     }
@@ -5434,4 +5450,4 @@ public class DDTelemetryConfigurationEventView: NSObject {
 
 // swiftlint:enable force_unwrapping
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/2b1615693d269368ed91f061103ee98bfecafb00
+// Generated from https://github.com/DataDog/rum-events-format/tree/f21e8badee23a4d3204440d55a5ac7b5d9fadc81

--- a/DatadogRUM/Sources/DataModels/RUMDataModels.swift
+++ b/DatadogRUM/Sources/DataModels/RUMDataModels.swift
@@ -161,7 +161,7 @@ public struct RUMActionEvent: RUMDataModel {
         /// Subset of the SDK configuration options in use during its execution
         public struct Configuration: Codable {
             /// The percentage of sessions with RUM & Session Replay pricing tracked
-            public let sessionReplaySampleRate: Double
+            public let sessionReplaySampleRate: Double?
 
             /// The percentage of sessions tracked
             public let sessionSampleRate: Double
@@ -533,7 +533,7 @@ public struct RUMErrorEvent: RUMDataModel {
         /// Subset of the SDK configuration options in use during its execution
         public struct Configuration: Codable {
             /// The percentage of sessions with RUM & Session Replay pricing tracked
-            public let sessionReplaySampleRate: Double
+            public let sessionReplaySampleRate: Double?
 
             /// The percentage of sessions tracked
             public let sessionSampleRate: Double
@@ -997,7 +997,7 @@ public struct RUMLongTaskEvent: RUMDataModel {
         /// Subset of the SDK configuration options in use during its execution
         public struct Configuration: Codable {
             /// The percentage of sessions with RUM & Session Replay pricing tracked
-            public let sessionReplaySampleRate: Double
+            public let sessionReplaySampleRate: Double?
 
             /// The percentage of sessions tracked
             public let sessionSampleRate: Double
@@ -1284,7 +1284,7 @@ public struct RUMResourceEvent: RUMDataModel {
         /// Subset of the SDK configuration options in use during its execution
         public struct Configuration: Codable {
             /// The percentage of sessions with RUM & Session Replay pricing tracked
-            public let sessionReplaySampleRate: Double
+            public let sessionReplaySampleRate: Double?
 
             /// The percentage of sessions tracked
             public let sessionSampleRate: Double
@@ -1746,7 +1746,7 @@ public struct RUMViewEvent: RUMDataModel {
         /// Subset of the SDK configuration options in use during its execution
         public struct Configuration: Codable {
             /// The percentage of sessions with RUM & Session Replay pricing tracked
-            public let sessionReplaySampleRate: Double
+            public let sessionReplaySampleRate: Double?
 
             /// The percentage of sessions tracked
             public let sessionSampleRate: Double
@@ -2033,6 +2033,9 @@ public struct RUMViewEvent: RUMDataModel {
         /// List of the periods of time the user had the view in foreground (focused in the browser)
         public let inForegroundPeriods: [InForegroundPeriods]?
 
+        /// Longest duration in ns between an interaction and the next paint
+        public let interactionToNextPaint: Int64?
+
         /// Whether the View corresponding to this event is considered active
         public let isActive: Bool?
 
@@ -2105,6 +2108,7 @@ public struct RUMViewEvent: RUMDataModel {
             case frustration = "frustration"
             case id = "id"
             case inForegroundPeriods = "in_foreground_periods"
+            case interactionToNextPaint = "interaction_to_next_paint"
             case isActive = "is_active"
             case isSlowRendered = "is_slow_rendered"
             case jsRefreshRate = "js_refresh_rate"
@@ -2747,6 +2751,12 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Attribute to be used to name actions
             public let actionNameAttribute: String?
 
+            /// Whether it is allowed to use LocalStorage when cookies are not available
+            public let allowFallbackToLocalStorage: Bool?
+
+            /// Whether untrusted events are allowed
+            public let allowUntrustedEvents: Bool?
+
             /// The window duration for batches sent by the SDK (in milliseconds)
             public let batchSize: Int64?
 
@@ -2876,7 +2886,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether local encryption is used
             public let useLocalEncryption: Bool?
 
-            /// Whether a proxy configured is used
+            /// Whether a proxy is used
             public var useProxy: Bool?
 
             /// Whether a secure session cookie is used
@@ -2885,11 +2895,16 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
             /// Whether tracing features are enabled
             public let useTracing: Bool?
 
+            /// Whether the Worker is loaded from an external URL
+            public let useWorkerUrl: Bool?
+
             /// View tracking strategy
             public let viewTrackingStrategy: ViewTrackingStrategy?
 
             enum CodingKeys: String, CodingKey {
                 case actionNameAttribute = "action_name_attribute"
+                case allowFallbackToLocalStorage = "allow_fallback_to_local_storage"
+                case allowUntrustedEvents = "allow_untrusted_events"
                 case batchSize = "batch_size"
                 case batchUploadFrequency = "batch_upload_frequency"
                 case dartVersion = "dart_version"
@@ -2936,6 +2951,7 @@ public struct TelemetryConfigurationEvent: RUMDataModel {
                 case useProxy = "use_proxy"
                 case useSecureSessionCookie = "use_secure_session_cookie"
                 case useTracing = "use_tracing"
+                case useWorkerUrl = "use_worker_url"
                 case viewTrackingStrategy = "view_tracking_strategy"
             }
 
@@ -3309,4 +3325,4 @@ public enum RUMMethod: String, Codable {
     case patch = "PATCH"
 }
 
-// Generated from https://github.com/DataDog/rum-events-format/tree/2b1615693d269368ed91f061103ee98bfecafb00
+// Generated from https://github.com/DataDog/rum-events-format/tree/f21e8badee23a4d3204440d55a5ac7b5d9fadc81

--- a/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/CrashReportReceiver.swift
@@ -325,7 +325,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         let event = RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(self.sessionSampler.samplingRate)),
                 session: .init(plan: .plan1)
             ),
             action: nil,
@@ -378,7 +378,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(self.sessionSampler.samplingRate)),
                 documentVersion: original.dd.documentVersion + 1,
                 pageStates: nil,
                 replayStats: nil,
@@ -420,6 +420,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 frustration: .init(count: 0),
                 id: original.view.id,
                 inForegroundPeriods: original.view.inForegroundPeriods,
+                interactionToNextPaint: nil,
                 isActive: false,
                 isSlowRendered: false,
                 jsRefreshRate: nil,
@@ -455,7 +456,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(self.sessionSampler.samplingRate)),
                 documentVersion: 1,
                 pageStates: nil,
                 replayStats: nil,
@@ -513,6 +514,7 @@ internal struct CrashReportReceiver: FeatureMessageReceiver {
                 frustration: .init(count: 0),
                 id: viewUUID.toRUMDataFormat,
                 inForegroundPeriods: nil,
+                interactionToNextPaint: nil,
                 isActive: false, // we know it won't receive updates
                 isSlowRendered: false,
                 jsRefreshRate: nil,

--- a/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
+++ b/DatadogRUM/Sources/Integrations/TelemetryReceiver.swift
@@ -280,6 +280,8 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
     init(_ configuration: DatadogInternal.ConfigurationTelemetry) {
         self.init(
             actionNameAttribute: nil,
+            allowFallbackToLocalStorage: nil,
+            allowUntrustedEvents: nil,
             batchSize: configuration.batchSize,
             batchUploadFrequency: configuration.batchUploadFrequency,
             dartVersion: configuration.dartVersion,
@@ -324,6 +326,7 @@ private extension TelemetryConfigurationEvent.Telemetry.Configuration {
             useProxy: configuration.useProxy,
             useSecureSessionCookie: nil,
             useTracing: configuration.useTracing,
+            useWorkerUrl: nil,
             viewTrackingStrategy: nil
         )
     }

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMResourceScope.swift
@@ -136,7 +136,7 @@ internal class RUMResourceScope: RUMScope {
         let resourceEvent = RUMResourceEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 discarded: nil,
                 rulePsr: traceSamplingRate,
                 session: .init(plan: .plan1),
@@ -230,7 +230,7 @@ internal class RUMResourceScope: RUMScope {
         let errorEvent = RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 session: .init(plan: .plan1)
             ),
             action: self.context.activeUserActionID.map { rumUUID in

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMUserActionScope.swift
@@ -141,7 +141,7 @@ internal class RUMUserActionScope: RUMScope, RUMContextProvider {
             dd: .init(
                 action: nil,
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 session: .init(plan: .plan1)
             ),
             action: .init(

--- a/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
+++ b/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift
@@ -368,7 +368,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
             dd: .init(
                 action: nil,
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 session: .init(plan: .plan1)
             ),
             action: .init(
@@ -438,7 +438,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let viewEvent = RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 documentVersion: version.toInt64,
                 pageStates: nil,
                 replayStats: .init(
@@ -494,6 +494,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
                 frustration: .init(count: frustrationCount),
                 id: viewUUID.toRUMDataFormat,
                 inForegroundPeriods: nil,
+                interactionToNextPaint: nil,
                 isActive: isActive,
                 isSlowRendered: isSlowRendered ?? false,
                 jsRefreshRate: viewPerformanceMetrics[.jsFrameTimeSeconds]?.asJsRefreshRate(),
@@ -536,7 +537,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let errorEvent = RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 session: .init(plan: .plan1)
             ),
             action: self.context.activeUserActionID.map { rumUUID in
@@ -598,7 +599,7 @@ internal class RUMViewScope: RUMScope, RUMContextProvider {
         let longTaskEvent = RUMLongTaskEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .init(sessionReplaySampleRate: nil, sessionSampleRate: Double(dependencies.sessionSampler.samplingRate)),
                 discarded: nil,
                 session: .init(plan: .plan1)
             ),

--- a/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
+++ b/DatadogRUM/Tests/Mocks/RUMDataModelMocks.swift
@@ -94,6 +94,12 @@ extension RUMOperatingSystem: RandomMockable {
     }
 }
 
+extension RUMViewEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMViewEvent.DD.Configuration {
+        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMViewEvent: RandomMockable {
     public static func mockRandom() -> RUMViewEvent {
         return mockRandomWith()
@@ -108,7 +114,7 @@ extension RUMViewEvent: RandomMockable {
         return RUMViewEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 documentVersion: .mockRandom(),
                 pageStates: nil,
                 replayStats: nil,
@@ -162,6 +168,7 @@ extension RUMViewEvent: RandomMockable {
                         start: .mockRandom()
                     )
                 ],
+                interactionToNextPaint: nil,
                 isActive: viewIsActive,
                 isSlowRendered: .mockRandom(),
                 jsRefreshRate: nil,
@@ -184,12 +191,18 @@ extension RUMViewEvent: RandomMockable {
     }
 }
 
+extension RUMResourceEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMResourceEvent.DD.Configuration {
+        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMResourceEvent: RandomMockable {
     public static func mockRandom() -> RUMResourceEvent {
         return RUMResourceEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 discarded: nil,
                 rulePsr: nil,
                 session: .init(plan: .plan1),
@@ -244,6 +257,12 @@ extension RUMResourceEvent: RandomMockable {
     }
 }
 
+extension RUMActionEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMActionEvent.DD.Configuration {
+        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMActionEvent: RandomMockable {
     public static func mockRandom() -> RUMActionEvent {
         return RUMActionEvent(
@@ -257,7 +276,7 @@ extension RUMActionEvent: RandomMockable {
                     )
                 ),
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 session: .init(plan: .plan1)
             ),
             action: .init(
@@ -305,12 +324,18 @@ extension RUMErrorEvent.Error.SourceType: RandomMockable {
     }
 }
 
+extension RUMErrorEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMErrorEvent.DD.Configuration {
+        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMErrorEvent: RandomMockable {
     public static func mockRandom() -> RUMErrorEvent {
         return RUMErrorEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 session: .init(plan: .plan1)
             ),
             action: .init(id: .mockRandom()),
@@ -376,12 +401,18 @@ extension RUMCrashEvent: RandomMockable {
     }
 }
 
+extension RUMLongTaskEvent.DD.Configuration: RandomMockable {
+    public static func mockRandom() -> RUMLongTaskEvent.DD.Configuration {
+        return .init(sessionReplaySampleRate: .mockRandom(min: 0, max: 100), sessionSampleRate: .mockRandom(min: 0, max: 100))
+    }
+}
+
 extension RUMLongTaskEvent: RandomMockable {
     public static func mockRandom() -> RUMLongTaskEvent {
         return RUMLongTaskEvent(
             dd: .init(
                 browserSdkVersion: nil,
-                configuration: nil,
+                configuration: .mockRandom(),
                 discarded: nil,
                 session: .init(plan: .plan1)
             ),
@@ -424,6 +455,8 @@ extension TelemetryConfigurationEvent: RandomMockable {
             telemetry: .init(
                 configuration: .init(
                     actionNameAttribute: nil,
+                    allowFallbackToLocalStorage: nil,
+                    allowUntrustedEvents: nil,
                     batchSize: .mockAny(),
                     batchUploadFrequency: .mockAny(),
                     defaultPrivacyLevel: .mockAny(),
@@ -467,6 +500,7 @@ extension TelemetryConfigurationEvent: RandomMockable {
                     useProxy: .mockRandom(),
                     useSecureSessionCookie: nil,
                     useTracing: .mockRandom(),
+                    useWorkerUrl: nil,
                     viewTrackingStrategy: nil
                 )
             ),


### PR DESCRIPTION
### What and why?

Configuration reporting.

### How?

- Update the generated models to sync the models. It required for making `sessionReplaySampleRate` optional.
- Whenever a `RUMViewEvent`, `RUMActionEvent`, `RUMResourceEvent`, `RUMErrorEvent` or `RUMLongTaskEvent` is created, it includes configured sampling rate.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [x] Run integration tests
- [ ] Run smoke tests
