### PR TITLE
REPLAY-1936 Session Replay Objective-C interface

### DIFF
--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -561,6 +561,8 @@
 		D21C26C628A3B49C005DD405 /* FeatureStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26C428A3B49C005DD405 /* FeatureStorage.swift */; };
 		D21C26D128A64599005DD405 /* MessageBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D028A64599005DD405 /* MessageBusTests.swift */; };
 		D21C26D228A64599005DD405 /* MessageBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21C26D028A64599005DD405 /* MessageBusTests.swift */; };
+		D21D32AD2A8D1DC500DC81E4 /* SessionReplayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D21D32AC2A8D1DC500DC81E4 /* SessionReplayTests.m */; };
+		D21D32AE2A8D1DC500DC81E4 /* DatadogSessionReplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */; platformFilter = ios; };
 		D224430429E9588100274EC7 /* TelemetryReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D214DAA729E54CB4004D0AE8 /* TelemetryReceiver.swift */; };
 		D224430529E9588500274EC7 /* TelemetryReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D214DAA729E54CB4004D0AE8 /* TelemetryReceiver.swift */; };
 		D224430629E95C2C00274EC7 /* MessageBus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D214DAA429E072D7004D0AE8 /* MessageBus.swift */; };
@@ -1568,6 +1570,13 @@
 			remoteGlobalIDString = D23039A4298D513C001A1FA3;
 			remoteInfo = "DatadogInternal iOS";
 		};
+		D21D32AF2A8D1DC500DC81E4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 61133B79242393DE00786299 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6133D1E52A6ED9E100384BEF;
+			remoteInfo = "DatadogSessionReplay iOS";
+		};
 		D22A031A29F7DAA9002C02C6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 61133B79242393DE00786299 /* Project object */;
@@ -2417,6 +2426,8 @@
 		D21C26D628A647DB005DD405 /* MessageBusMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBusMock.swift; sourceTree = "<group>"; };
 		D21C26EA28AFA11E005DD405 /* LogMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogMessageReceiverTests.swift; sourceTree = "<group>"; };
 		D21C26ED28AFB65B005DD405 /* ErrorMessageReceiverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageReceiverTests.swift; sourceTree = "<group>"; };
+		D21D32AA2A8D1DC400DC81E4 /* DatadogSessionReplayTests-Objc.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DatadogSessionReplayTests-Objc.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D21D32AC2A8D1DC500DC81E4 /* SessionReplayTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SessionReplayTests.m; sourceTree = "<group>"; };
 		D224430C29E95D6600274EC7 /* CrashReportReceiverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashReportReceiverTests.swift; sourceTree = "<group>"; };
 		D22743E829DEC9A9001A7EF9 /* RUMDataModelMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUMDataModelMocks.swift; sourceTree = "<group>"; };
 		D22C1F5B271484B400922024 /* LogEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventMapper.swift; sourceTree = "<group>"; };
@@ -2797,6 +2808,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				3C74305C29FBC0480053B80F /* DatadogInternal.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D21D32A72A8D1DC400DC81E4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D21D32AE2A8D1DC500DC81E4 /* DatadogSessionReplay.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3574,6 +3593,7 @@
 				D29A9F3F29DD84AB005C54A4 /* DatadogRUMTests */,
 				61054E012A6EE0A400AAA894 /* DatadogSessionReplay */,
 				61054E022A6EE0DB00AAA894 /* DatadogSessionReplayTests */,
+				D21D32AB2A8D1DC500DC81E4 /* DatadogSessionReplayTests-Objc */,
 				6170DC1325C1864B003AED5C /* DatadogCrashReporting */,
 				6170DC1425C18663003AED5C /* DatadogCrashReportingTests */,
 				3CE11A3B29F7BEE700202522 /* DatadogWebViewTracking */,
@@ -3631,6 +3651,7 @@
 				3CE11A0529F7BE0300202522 /* DatadogWebViewTrackingTests.xctest */,
 				6133D1F52A6ED9E100384BEF /* DatadogSessionReplay.framework */,
 				6133D2082A6EDB7700384BEF /* DatadogSessionReplayTests.xctest */,
+				D21D32AA2A8D1DC400DC81E4 /* DatadogSessionReplayTests-Objc.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -5088,6 +5109,15 @@
 			path = Integrations;
 			sourceTree = "<group>";
 		};
+		D21D32AB2A8D1DC500DC81E4 /* DatadogSessionReplayTests-Objc */ = {
+			isa = PBXGroup;
+			children = (
+				D21D32AC2A8D1DC500DC81E4 /* SessionReplayTests.m */,
+			);
+			name = "DatadogSessionReplayTests-Objc";
+			path = "../DatadogSessionReplay/Tests-Objc";
+			sourceTree = "<group>";
+		};
 		D22C1F5A2714849700922024 /* Scrubbing */ = {
 			isa = PBXGroup;
 			children = (
@@ -6178,6 +6208,24 @@
 			productReference = D20731B429A5279D00ECBF94 /* DatadogLogs.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		D21D32A92A8D1DC400DC81E4 /* DatadogSessionReplayTests-Objc */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D21D32B12A8D1DC500DC81E4 /* Build configuration list for PBXNativeTarget "DatadogSessionReplayTests-Objc" */;
+			buildPhases = (
+				D21D32A62A8D1DC400DC81E4 /* Sources */,
+				D21D32A72A8D1DC400DC81E4 /* Frameworks */,
+				D21D32A82A8D1DC400DC81E4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D21D32B02A8D1DC500DC81E4 /* PBXTargetDependency */,
+			);
+			name = "DatadogSessionReplayTests-Objc";
+			productName = "DatadogSessionReplayTests-Objc";
+			productReference = D21D32AA2A8D1DC400DC81E4 /* DatadogSessionReplayTests-Objc.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		D23039A4298D513C001A1FA3 /* DatadogInternal iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D23039AC298D513D001A1FA3 /* Build configuration list for PBXNativeTarget "DatadogInternal iOS" */;
@@ -6645,6 +6693,9 @@
 					D207318229A5226A00ECBF94 = {
 						CreatedOnToolsVersion = 14.2;
 					};
+					D21D32A92A8D1DC400DC81E4 = {
+						CreatedOnToolsVersion = 14.3.1;
+					};
 					D23039A4298D513C001A1FA3 = {
 						CreatedOnToolsVersion = 14.2;
 						LastSwiftMigration = 1420;
@@ -6724,6 +6775,7 @@
 				3CE11A0429F7BE0300202522 /* DatadogWebViewTrackingTests iOS */,
 				6133D1E52A6ED9E100384BEF /* DatadogSessionReplay iOS */,
 				6133D1F62A6EDB7700384BEF /* DatadogSessionReplayTests iOS */,
+				D21D32A92A8D1DC400DC81E4 /* DatadogSessionReplayTests-Objc */,
 			);
 		};
 /* End PBXProject section */
@@ -6847,6 +6899,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		D20731AF29A5279D00ECBF94 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D21D32A82A8D1DC400DC81E4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -7777,6 +7836,14 @@
 				D20731B629A528DA00ECBF94 /* LogEventBuilder.swift in Sources */,
 				D20731C629A528ED00ECBF94 /* LogOutput.swift in Sources */,
 				D243BBF629A620CC000B9CEC /* MessageReceivers.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D21D32A62A8D1DC400DC81E4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D21D32AD2A8D1DC500DC81E4 /* SessionReplayTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8842,6 +8909,12 @@
 			isa = PBXTargetDependency;
 			target = D23039A4298D513C001A1FA3 /* DatadogInternal iOS */;
 			targetProxy = D207319929A5232A00ECBF94 /* PBXContainerItemProxy */;
+		};
+		D21D32B02A8D1DC500DC81E4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = 6133D1E52A6ED9E100384BEF /* DatadogSessionReplay iOS */;
+			targetProxy = D21D32AF2A8D1DC500DC81E4 /* PBXContainerItemProxy */;
 		};
 		D22A031B29F7DAA9002C02C6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -10604,6 +10677,63 @@
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
+			};
+			name = Integration;
+		};
+		D21D32B22A8D1DC500DC81E4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.datadoghq.DatadogSessionReplayTests-Objc";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D21D32B32A8D1DC500DC81E4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.datadoghq.DatadogSessionReplayTests-Objc";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		D21D32B42A8D1DC500DC81E4 /* Integration */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.datadoghq.DatadogSessionReplayTests-Objc";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Integration;
 		};
@@ -12633,6 +12763,16 @@
 				D20731B129A5279D00ECBF94 /* Debug */,
 				D20731B229A5279D00ECBF94 /* Release */,
 				D20731B329A5279D00ECBF94 /* Integration */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D21D32B12A8D1DC500DC81E4 /* Build configuration list for PBXNativeTarget "DatadogSessionReplayTests-Objc" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D21D32B22A8D1DC500DC81E4 /* Debug */,
+				D21D32B32A8D1DC500DC81E4 /* Release */,
+				D21D32B42A8D1DC500DC81E4 /* Integration */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Datadog/Datadog.xcodeproj/project.pbxproj
+++ b/Datadog/Datadog.xcodeproj/project.pbxproj
@@ -3032,7 +3032,6 @@
 			isa = PBXGroup;
 			children = (
 				61054E3B2A6EE10A00AAA894 /* Feature */,
-				61054E0A2A6EE10A00AAA894 /* Metrics */,
 				61054E482A6EE10A00AAA894 /* Processor */,
 				61054E0D2A6EE10A00AAA894 /* Recorder */,
 				61054E0C2A6EE10A00AAA894 /* SessionReplay.swift */,
@@ -3051,7 +3050,6 @@
 				61054F922A6EE1BA00AAA894 /* Helpers */,
 				61054F7D2A6EE1BA00AAA894 /* Mocks */,
 				61054F4E2A6EE1BA00AAA894 /* Processor */,
-				61054F942A6EE1BA00AAA894 /* Public */,
 				61054F592A6EE1BA00AAA894 /* Recorder */,
 				61054F3D2A6EE1B900AAA894 /* SessionReplayConfigurationTests.swift */,
 				61054F482A6EE1B900AAA894 /* SessionReplayTests.swift */,
@@ -3080,13 +3078,6 @@
 				61054E072A6EE10A00AAA894 /* SRDataModels+UIKit.swift */,
 			);
 			path = Models;
-			sourceTree = "<group>";
-		};
-		61054E0A2A6EE10A00AAA894 /* Metrics */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Metrics;
 			sourceTree = "<group>";
 		};
 		61054E0D2A6EE10A00AAA894 /* Recorder */ = {
@@ -3528,13 +3519,6 @@
 				61054F932A6EE1BA00AAA894 /* XCTAssertRectsEqual.swift */,
 			);
 			path = Helpers;
-			sourceTree = "<group>";
-		};
-		61054F942A6EE1BA00AAA894 /* Public */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Public;
 			sourceTree = "<group>";
 		};
 		610ABD492A69309900AFEA34 /* IntegrationUnitTests */ = {

--- a/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogSessionReplay iOS.xcscheme
+++ b/Datadog/Datadog.xcodeproj/xcshareddata/xcschemes/DatadogSessionReplay iOS.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:Datadog.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D21D32A92A8D1DC400DC81E4"
+               BuildableName = "DatadogSessionReplayTests-Objc.xctest"
+               BlueprintName = "DatadogSessionReplayTests-Objc"
+               ReferencedContainer = "container:Datadog.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -57,6 +67,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6133D1E52A6ED9E100384BEF"
+            BuildableName = "DatadogSessionReplay.framework"
+            BlueprintName = "DatadogSessionReplay iOS"
+            ReferencedContainer = "container:Datadog.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
+++ b/DatadogSessionReplay/SRSnapshotTests/SRSnapshotTests/Utils/SnapshotTestCase.swift
@@ -9,7 +9,7 @@ import TestUtilities
 @testable import DatadogSessionReplay
 @testable import SRHost
 
-private var defaultPrivacyLevel: SessionReplay.Configuration.PrivacyLevel {
+private var defaultPrivacyLevel: PrivacyLevel {
     return SessionReplay.Configuration(replaySampleRate: 100).defaultPrivacyLevel
 }
 
@@ -34,7 +34,7 @@ internal class SnapshotTestCase: XCTestCase {
     }
 
     /// Captures side-by-side snapshot of the app UI and recorded wireframes.
-    func takeSnapshot(with privacyLevel: SessionReplay.Configuration.PrivacyLevel = defaultPrivacyLevel) throws -> UIImage {
+    func takeSnapshot(with privacyLevel: PrivacyLevel = defaultPrivacyLevel) throws -> UIImage {
         let expectation = self.expectation(description: "Wait for wireframes")
 
         // Set up SR recorder:
@@ -95,8 +95,8 @@ internal class SnapshotTestCase: XCTestCase {
         waitForExpectations(timeout: seconds * 2)
     }
 
-    func forEachPrivacyMode(do work: (SessionReplay.Configuration.PrivacyLevel) throws -> Void) rethrows {
-        let modes: [SessionReplay.Configuration.PrivacyLevel] = [.mask, .allow, .maskUserInput]
+    func forEachPrivacyMode(do work: (PrivacyLevel) throws -> Void) rethrows {
+        let modes: [PrivacyLevel] = [.mask, .allow, .maskUserInput]
         try modes.forEach { try work($0) }
     }
 }

--- a/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
+++ b/DatadogSessionReplay/Sources/Feature/SessionReplayFeature.swift
@@ -28,7 +28,9 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
 
     init(
         core: DatadogCoreProtocol,
-        configuration: SessionReplay.Configuration
+        sampleRate: Float,
+        privacy: PrivacyLevel,
+        customEndpoint: URL?
     ) throws {
         let writer = Writer()
         let telemetry = TelemetryCore(core: core)
@@ -49,11 +51,11 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
         )
         let recordingCoordinator = RecordingCoordinator(
             scheduler: scheduler,
-            privacy: configuration.defaultPrivacyLevel,
+            privacy: privacy,
             rumContextObserver: messageReceiver,
             srContextPublisher: SRContextPublisher(core: core),
             recorder: recorder,
-            sampler: Sampler(samplingRate: configuration.debugSDK ? 100 : configuration.replaySampleRate)
+            sampler: Sampler(samplingRate: sampleRate)
         )
 
         self.messageReceiver = messageReceiver
@@ -61,7 +63,7 @@ internal class SessionReplayFeature: DatadogRemoteFeature {
         self.processor = processor
         self.writer = writer
         self.requestBuilder = RequestBuilder(
-            customUploadURL: configuration.customEndpoint,
+            customUploadURL: customEndpoint,
             telemetry: telemetry
         )
         self.performanceOverride = PerformancePresetOverride(

--- a/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
+++ b/DatadogSessionReplay/Sources/Recorder/PrivacyLevel.swift
@@ -4,10 +4,8 @@
  * Copyright 2019-Present Datadog, Inc.
  */
 
-internal typealias PrivacyLevel = SessionReplay.Configuration.PrivacyLevel
-
 /// Text obfuscation strategies for different text types.
-internal extension SessionReplay.Configuration.PrivacyLevel {
+internal extension PrivacyLevel {
     /// Returns "Sensitive Text" obfuscator for given `privacyLevel`.
     ///
     /// In Session Replay, "Sensitive Text" is:
@@ -54,7 +52,7 @@ internal extension SessionReplay.Configuration.PrivacyLevel {
 }
 
 /// Other convenience helpers.
-internal extension SessionReplay.Configuration.PrivacyLevel {
+internal extension PrivacyLevel {
     /// If input elements should be masked in this privacy mode.
     var shouldMaskInputElements: Bool {
         switch self {

--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -43,3 +43,15 @@ public struct SessionReplay {
         sessionReplay.writer.startWriting(to: core)
     }
 }
+
+/// An entry point to Datadog Session Replay feature.
+@objc(DDSessionReplay) @available(swift, obsoleted: 1)
+public final class objc_SessionReplay: NSObject {
+    private override init() { }
+
+    /// Initializes the Datadog Crash Reporter.
+    @objc @available(swift, obsoleted: 1)
+    public static func enable(with configuration: objc_SessionReplayConfiguration) {
+        SessionReplay.enable(with: configuration._swift)
+    }
+}

--- a/DatadogSessionReplay/Sources/SessionReplay.swift
+++ b/DatadogSessionReplay/Sources/SessionReplay.swift
@@ -66,7 +66,7 @@ public final class SessionReplay: NSObject {
         sessionReplay.writer.startWriting(to: core)
     }
 
-    private override init() {
+    override private init() {
         super.init()
     }
 }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -7,67 +7,9 @@
 import Foundation
 import DatadogInternal
 
-extension SessionReplay {
-    /// Session Replay feature configuration.
-    public struct Configuration {
-        /// The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
-        ///
-        /// It must be a number between 0.0 and 100.0, where 0 means no replays will be recorded
-        /// and 100 means all RUM sessions will contain replay.
-        ///
-        /// Note: This sample rate is applied in addition to the RUM sample rate. For example, if RUM uses a sample rate of 80%
-        /// and Session Replay uses a sample rate of 20%, it means that out of all user sessions, 80% will be included in RUM,
-        /// and within those sessions, only 20% will have replays.
-        public var replaySampleRate: Float
-
-        /// Defines the way sensitive content (e.g. text) should be masked.
-        ///
-        /// Default: `.mask`.
-        public var defaultPrivacyLevel: PrivacyLevel
-
-        /// Available privacy levels for content masking.
-        public enum PrivacyLevel {
-            /// Record all content.
-            case allow
-
-            /// Mask all content.
-            case mask
-
-            /// Mask input elements, but record all other content.
-            case maskUserInput
-        }
-
-        /// Custom server url for sending replay data.
-        ///
-        /// Default: `nil`.
-        public var customEndpoint: URL?
-
-        // MARK: - Internal
-
-        internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
-
-        /// Creates Session Replay configuration.
-        ///
-        /// - Parameters:
-        ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
-        ///   - defaultPrivacyLevel: The way sensitive content (e.g. text) should be masked. Default: `.mask`.
-        ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
-        public init(
-            replaySampleRate: Float,
-            defaultPrivacyLevel: PrivacyLevel = .mask,
-            customEndpoint: URL? = nil
-        ) {
-            self.replaySampleRate = replaySampleRate
-            self.defaultPrivacyLevel = defaultPrivacyLevel
-            self.customEndpoint = customEndpoint
-        }
-    }
-}
-
 /// Session Replay feature configuration.
-@objc(DDSessionReplayConfiguration) @available(swift, obsoleted: 1)
-public final class objc_SessionReplayConfiguration: NSObject {
-    public var _swift: SessionReplay.Configuration = .init(replaySampleRate: 0)
+@objc(DDSessionReplayConfiguration)
+public final class SessionReplayConfiguration: NSObject {
 
     /// The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
     ///
@@ -77,26 +19,36 @@ public final class objc_SessionReplayConfiguration: NSObject {
     /// Note: This sample rate is applied in addition to the RUM sample rate. For example, if RUM uses a sample rate of 80%
     /// and Session Replay uses a sample rate of 20%, it means that out of all user sessions, 80% will be included in RUM,
     /// and within those sessions, only 20% will have replays.
-    @objc public var replaySampleRate: Float {
-        set { _swift.replaySampleRate = newValue }
-        get { _swift.replaySampleRate }
-    }
+    @objc public var replaySampleRate: Float
 
     /// Defines the way sensitive content (e.g. text) should be masked.
     ///
     /// Default: `.mask`.
-    @objc @available(swift, obsoleted: 1)
-    public var defaultPrivacyLevel: objc_SessionReplayConfigurationPrivacyLevel {
-        set { _swift.defaultPrivacyLevel = newValue._swift }
-        get { .init(_swift.defaultPrivacyLevel) }
-    }
+    @objc public var defaultPrivacyLevel: PrivacyLevel
 
     /// Custom server url for sending replay data.
     ///
     /// Default: `nil`.
-    @objc public var customEndpoint: URL? {
-        set { _swift.customEndpoint = newValue }
-        get { _swift.customEndpoint }
+    @objc public var customEndpoint: URL?
+
+    internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
+
+    /// Creates Session Replay configuration.
+    ///
+    /// - Parameters:
+    ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
+    ///   - defaultPrivacyLevel: The way sensitive content (e.g. text) should be masked. Default: `.mask`.
+    ///   - customEndpoint: Custom server url for sending replay data. Default: `nil`.
+    @objc
+    public required init(
+        replaySampleRate: Float,
+        defaultPrivacyLevel: PrivacyLevel = .mask,
+        customEndpoint: URL? = nil
+    ) {
+        self.replaySampleRate = replaySampleRate
+        self.defaultPrivacyLevel = defaultPrivacyLevel
+        self.customEndpoint = customEndpoint
+        super.init()
     }
 
     /// Creates Session Replay configuration.
@@ -104,19 +56,17 @@ public final class objc_SessionReplayConfiguration: NSObject {
     /// - Parameters:
     ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
     @objc
-    public required init(
-        replaySampleRate: Float
-    ) {
-        _swift = SessionReplay.Configuration(
-            replaySampleRate: replaySampleRate
+    public convenience init(replaySampleRate: Float) {
+        self.init(
+            replaySampleRate: replaySampleRate,
+            defaultPrivacyLevel: .mask
         )
-        super.init()
     }
 }
 
 /// Available privacy levels for content masking.
-@objc(DDSessionReplayConfigurationPrivacyLevel) @available(swift, obsoleted: 1)
-public enum objc_SessionReplayConfigurationPrivacyLevel: Int {
+@objc(DDSessionReplayConfigurationPrivacyLevel)
+public enum PrivacyLevel: Int {
     /// Record all content.
     case allow
 
@@ -125,21 +75,4 @@ public enum objc_SessionReplayConfigurationPrivacyLevel: Int {
 
     /// Mask input elements, but record all other content.
     case maskUserInput
-
-    public var _swift: SessionReplay.Configuration.PrivacyLevel {
-        switch self {
-        case .allow: return .allow
-        case .mask: return .mask
-        case .maskUserInput: return .maskUserInput
-        default: return .mask
-        }
-    }
-
-    public init(_ swift: SessionReplay.Configuration.PrivacyLevel) {
-        switch swift {
-        case .allow: self = .allow
-        case .mask: self = .mask
-        case .maskUserInput: self = .maskUserInput
-        }
-    }
 }

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -10,7 +10,6 @@ import DatadogInternal
 /// Session Replay feature configuration.
 @objc(DDSessionReplayConfiguration)
 public final class SessionReplayConfiguration: NSObject {
-
     /// The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
     ///
     /// It must be a number between 0.0 and 100.0, where 0 means no replays will be recorded

--- a/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
+++ b/DatadogSessionReplay/Sources/SessionReplayConfiguration.swift
@@ -46,7 +46,8 @@ extension SessionReplay {
 
         internal var debugSDK: Bool = ProcessInfo.processInfo.arguments.contains(LaunchArguments.Debug)
 
-        /// Creates Session Replay configuration
+        /// Creates Session Replay configuration.
+        ///
         /// - Parameters:
         ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
         ///   - defaultPrivacyLevel: The way sensitive content (e.g. text) should be masked. Default: `.mask`.
@@ -59,6 +60,86 @@ extension SessionReplay {
             self.replaySampleRate = replaySampleRate
             self.defaultPrivacyLevel = defaultPrivacyLevel
             self.customEndpoint = customEndpoint
+        }
+    }
+}
+
+/// Session Replay feature configuration.
+@objc(DDSessionReplayConfiguration) @available(swift, obsoleted: 1)
+public final class objc_SessionReplayConfiguration: NSObject {
+    public var _swift: SessionReplay.Configuration = .init(replaySampleRate: 0)
+
+    /// The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
+    ///
+    /// It must be a number between 0.0 and 100.0, where 0 means no replays will be recorded
+    /// and 100 means all RUM sessions will contain replay.
+    ///
+    /// Note: This sample rate is applied in addition to the RUM sample rate. For example, if RUM uses a sample rate of 80%
+    /// and Session Replay uses a sample rate of 20%, it means that out of all user sessions, 80% will be included in RUM,
+    /// and within those sessions, only 20% will have replays.
+    @objc public var replaySampleRate: Float {
+        set { _swift.replaySampleRate = newValue }
+        get { _swift.replaySampleRate }
+    }
+
+    /// Defines the way sensitive content (e.g. text) should be masked.
+    ///
+    /// Default: `.mask`.
+    @objc @available(swift, obsoleted: 1)
+    public var defaultPrivacyLevel: objc_SessionReplayConfigurationPrivacyLevel {
+        set { _swift.defaultPrivacyLevel = newValue._swift }
+        get { .init(_swift.defaultPrivacyLevel) }
+    }
+
+    /// Custom server url for sending replay data.
+    ///
+    /// Default: `nil`.
+    @objc public var customEndpoint: URL? {
+        set { _swift.customEndpoint = newValue }
+        get { _swift.customEndpoint }
+    }
+
+    /// Creates Session Replay configuration.
+    ///
+    /// - Parameters:
+    ///   - replaySampleRate: The sampling rate for Session Replay. It is applied in addition to the RUM session sample rate.
+    @objc
+    public required init(
+        replaySampleRate: Float
+    ) {
+        _swift = SessionReplay.Configuration(
+            replaySampleRate: replaySampleRate
+        )
+        super.init()
+    }
+}
+
+/// Available privacy levels for content masking.
+@objc(DDSessionReplayConfigurationPrivacyLevel) @available(swift, obsoleted: 1)
+public enum objc_SessionReplayConfigurationPrivacyLevel: Int {
+    /// Record all content.
+    case allow
+
+    /// Mask all content.
+    case mask
+
+    /// Mask input elements, but record all other content.
+    case maskUserInput
+
+    public var _swift: SessionReplay.Configuration.PrivacyLevel {
+        switch self {
+        case .allow: return .allow
+        case .mask: return .mask
+        case .maskUserInput: return .maskUserInput
+        default: return .mask
+        }
+    }
+
+    public init(_ swift: SessionReplay.Configuration.PrivacyLevel) {
+        switch swift {
+        case .allow: self = .allow
+        case .mask: self = .mask
+        case .maskUserInput: self = .maskUserInput
         }
     }
 }

--- a/DatadogSessionReplay/Tests-Objc/SessionReplayTests.m
+++ b/DatadogSessionReplay/Tests-Objc/SessionReplayTests.m
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#import <XCTest/XCTest.h>
+
+@import DatadogSessionReplay;
+
+@interface SessionReplayTests : XCTestCase
+@end
+
+@implementation SessionReplayTests
+
+- (void)testConfiguration {
+    DDSessionReplayConfiguration *configuration = [[DDSessionReplayConfiguration alloc] initWithReplaySampleRate:100];
+    configuration.defaultPrivacyLevel = DDSessionReplayConfigurationPrivacyLevelAllow;
+    configuration.customEndpoint = [NSURL new];
+
+    [DDSessionReplay enableWith:configuration];
+}
+
+@end

--- a/Package.swift
+++ b/Package.swift
@@ -178,6 +178,13 @@ let package = Package(
             ],
             path: "DatadogSessionReplay/Tests"
         ),
+        .testTarget(
+            name: "DatadogSessionReplayTests-Objc",
+            dependencies: [
+                .target(name: "DatadogSessionReplay"),
+            ],
+            path: "DatadogSessionReplay/Tests-Objc"
+        ),
 
         .target(
             name: "TestUtilities",


### PR DESCRIPTION
### What and why?

Expose Session Replay to Objective-C.
Fix #1387

### How?

This PR includes 2 proposals:

#### 1. Additional Interface f607fd51f7d21fa7edb4a01445d7ffa7b2398629

Pretty much like the `DatadogObjc` module,`DatadogSessionReplay` will expose specific objects that support interoperability, see the following example:

```swift
@objc(DDSessionReplay) @available(swift, obsoleted: 1)
public final class objc_SessionReplay: NSObject {

    @objc @available(swift, obsoleted: 1)
    public static func enable(with configuration: objc_SessionReplayConfiguration)
}
```

It's using the `@available(swift, obsoleted: 1)` annotation to only expose those to objc.

This solution has 2 main drawbacks:
- Definitions are duplicated.
- The wrappers are **not** testable: we cannot access the inner values from swift.

#### 2. Single Interop Interface 6aadf468d16f4cb713f8d0eae77424b21a74072a

By doing so, we remove the duplication in wrappers and fully leverage Swift/Objective-C interoperability.

It's made possible by the following facts:
- `SessionReplay` is not instantiable and only expose static method.
- `SessionReplayConfiguration` can be mutated freely before enabling the Feature, the instance is never retained.

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [x] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes

### Custom CI job configuration (optional)
- [x] Run unit tests
- [ ] Run integration tests
- [ ] Run smoke tests
